### PR TITLE
Corrected the way the number of CPU is calculated, apparently the old

### DIFF
--- a/src/main/java/oshi/software/os/mac/MacHardwareAbstractionLayer.java
+++ b/src/main/java/oshi/software/os/mac/MacHardwareAbstractionLayer.java
@@ -31,7 +31,7 @@ public class MacHardwareAbstractionLayer implements HardwareAbstractionLayer {
 		if (_processors == null) {
 			List<Processor> processors = new ArrayList<Processor>();
 			int nbCPU = new Integer(
-					ExecutingCommand.getFirstAnswer("sysctl -n hw.availcpu"));
+					ExecutingCommand.getFirstAnswer("sysctl -n hw.logicalcpu"));
 			for (int i = 0; i < nbCPU; i++)
 				processors.add(new CentralProcessor());
 			


### PR DESCRIPTION
method is not working anymore on Yosemite...
