### PR TITLE
Fixed test in Windows environment

### DIFF
--- a/oshi-core/src/test/java/oshi/util/ExecutingCommandTest.java
+++ b/oshi-core/src/test/java/oshi/util/ExecutingCommandTest.java
@@ -24,13 +24,15 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 
 import org.junit.Test;
+import oshi.PlatformEnum;
+import oshi.SystemInfo;
 
 /**
  * Test command line and returning the result of execution.
  */
 public class ExecutingCommandTest {
 
-    private static final String ECHO = System.getProperty("os.name").startsWith("Windows") ? "cmd.exe /C echo Test" : "echo Test";
+    private static final String ECHO = SystemInfo.getCurrentPlatformEnum().equals(PlatformEnum.WINDOWS) ? "cmd.exe /C echo Test" : "echo Test";
     private static final String BAD_COMMAND = "noOSshouldHaveACommandNamedThis";
 
     @Test

--- a/oshi-core/src/test/java/oshi/util/ExecutingCommandTest.java
+++ b/oshi-core/src/test/java/oshi/util/ExecutingCommandTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
  */
 public class ExecutingCommandTest {
 
-    private static final String ECHO = "echo Test";
+    private static final String ECHO = System.getProperty("os.name").startsWith("Windows") ? "cmd.exe /C echo Test" : "echo Test";
     private static final String BAD_COMMAND = "noOSshouldHaveACommandNamedThis";
 
     @Test


### PR DESCRIPTION
Rationale: this test doesn't work on Windows because `echo` is an internal command of cmd.exe