### PR TITLE
[OSHI] Add bytesRead and bytesWritten to OSProcess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 .project
 .settings
 .classpath
+.idea
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.3 (in progress)
 ================
 * Your contribution here.
+* [#262](https://github.com/dblock/oshi/pull/262): Add bytesRead and bytesWritten to OSProcess - [@plamenko](https://github.com/plamenko).
 
 3.2 (9/1/2016)
 ================

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/Libc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/Libc.java
@@ -115,4 +115,13 @@ public interface Libc extends Library {
      *         of the contents.
      */
     int readlink(String path, Pointer buf, int bufsize);
+
+    /**
+     * Returns the number of bytes in a memory page, where "page" is a
+     * fixed-length block, the unit for memory allocation and file
+     * mapping performed by mmap(2).
+     *
+     * @return the memory page size
+     */
+    int getpagesize();
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
@@ -55,6 +55,9 @@ public interface SystemB extends com.sun.jna.platform.mac.SystemB {
     int MNT_NOWAIT = 0x0010;
     int MNT_DWAIT = 0x0100;
 
+    // resource.h
+    int RUSAGE_INFO_V2 = 2;
+
     class ProcTaskAllInfo extends Structure {
         public ProcBsdInfo pbsd;
         public ProcTaskInfo ptinfo;
@@ -124,6 +127,37 @@ public interface SystemB extends com.sun.jna.platform.mac.SystemB {
                     "pti_total_system", "pti_threads_user", "pti_threads_system", "pti_policy", "pti_faults",
                     "pti_pageins", "pti_cow_faults", "pti_messages_sent", "pti_messages_received", "pti_syscalls_mach",
                     "pti_syscalls_unix", "pti_csw", "pti_threadnum", "pti_numrunning", "pti_priority" });
+        }
+    }
+
+    class RUsageInfoV2 extends Structure {
+        public byte[] ri_uuid = new byte[16];
+        public long ri_user_time;
+        public long ri_system_time;
+        public long ri_pkg_idle_wkups;
+        public long ri_interrupt_wkups;
+        public long ri_pageins;
+        public long ri_wired_size;
+        public long ri_resident_size;
+        public long ri_phys_footprint;
+        public long ri_proc_start_abstime;
+        public long ri_proc_exit_abstime;
+        public long ri_child_user_time;
+        public long ri_child_system_time;
+        public long ri_child_pkg_idle_wkups;
+        public long ri_child_interrupt_wkups;
+        public long ri_child_pageins;
+        public long ri_child_elapsed_abstime;
+        public long ri_diskio_bytesread;
+        public long ri_diskio_byteswritten;
+
+        @Override
+        protected List getFieldOrder() {
+            return Arrays.asList(new String[] { "ri_uuid", "ri_user_time", "ri_system_time", "ri_pkg_idle_wkups",
+                    "ri_interrupt_wkups", "ri_pageins", "ri_wired_size", "ri_resident_size", "ri_phys_footprint",
+                    "ri_proc_start_abstime", "ri_proc_exit_abstime", "ri_child_user_time", "ri_child_system_time",
+                    "ri_child_pkg_idle_wkups", "ri_child_interrupt_wkups", "ri_child_pageins",
+                    "ri_child_elapsed_abstime", "ri_diskio_bytesread", "ri_diskio_byteswritten" });
         }
     }
 
@@ -386,6 +420,19 @@ public interface SystemB extends com.sun.jna.platform.mac.SystemB {
      *         otherwise
      */
     int proc_pidpath(int pid, Pointer buffer, int buffersize);
+
+    /**
+     * Return resource usage information for the given pid, which can be a live process or a zombie.
+     *
+     * @param pid
+     *            the process identifier
+     * @param flavor
+     *            the type of information requested
+     * @param buffer
+     *            holds results
+     * @returns 0 on success; or -1 on failure, with errno set to indicate the specific error.
+     */
+    int proc_pid_rusage(int pid, int flavor, RUsageInfoV2 buffer);
 
     /**
      * The getfsstat() function returns information about all mounted file

--- a/oshi-core/src/main/java/oshi/software/common/AbstractProcess.java
+++ b/oshi-core/src/main/java/oshi/software/common/AbstractProcess.java
@@ -30,7 +30,7 @@ import oshi.software.os.OSProcess;
  */
 public class AbstractProcess implements OSProcess {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     protected String name;
     protected String path;
@@ -45,6 +45,8 @@ public class AbstractProcess implements OSProcess {
     protected long userTime;
     protected long startTime;
     protected long upTime;
+    protected long bytesRead;
+    protected long bytesWritten;
 
     /**
      * {@inheritDoc}
@@ -151,5 +153,21 @@ public class AbstractProcess implements OSProcess {
     @Override
     public long getStartTime() {
         return this.startTime;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getBytesRead() {
+        return bytesRead;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getBytesWritten() {
+        return bytesWritten;
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/OSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSProcess.java
@@ -151,4 +151,14 @@ public interface OSProcess extends Serializable {
      *         since January 1, 1970.
      */
     long getStartTime();
+
+    /**
+     * @return Returns the number of bytes the process has read from disk.
+     */
+    long getBytesRead();
+
+    /**
+     * @return Returns the number of bytes the process has written to disk.
+     */
+    long getBytesWritten();
 }

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -21,6 +21,7 @@ package oshi.software.os.linux;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,12 +57,27 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
 
     protected String codeName;
 
+    // Resident Set Size is given as number of pages the process has in real memory.
+    // To get the actual size in bytes we need to multiply that with page size.
+    private final int memoryPageSize;
+
     public LinuxOperatingSystem() {
         this.manufacturer = "GNU/Linux";
         setFamilyFromReleaseFiles();
         // The above call may also populate versionId and codeName
         // to pass to version constructor
         this.version = new LinuxOSVersionInfoEx(this.versionId, this.codeName);
+        this.memoryPageSize = getMemoryPageSize();
+    }
+
+    private static int getMemoryPageSize() {
+        try {
+            return Libc.INSTANCE.getpagesize();
+        } catch (UnsatisfiedLinkError | NoClassDefFoundError e) {
+            LOG.error("Failed to get the memory page size.", e);
+        }
+        // default to 4K if the above call fails
+        return 4096;
     }
 
     /**
@@ -105,7 +121,9 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         if (size > 0) {
             path = buf.getString(0).substring(0, size);
         }
-        return new LinuxProcess(split[1].replaceFirst("\\(", "").replace(")", ""), // name
+        Map<String, String> io = FileUtil.getKeyValueMapFromFile(String.format("/proc/%d/io", pid), ":");
+        return new LinuxProcess(
+                split[1].replaceFirst("\\(", "").replace(")", ""), // name
                 // See man proc for how to parse /proc/[pid]/stat
                 path, // path
                 split[2].charAt(0), // state, one of RSDZTW
@@ -114,12 +132,15 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
                 ParseUtil.parseIntOrDefault(split[19], 0), // thread count
                 ParseUtil.parseIntOrDefault(split[17], 0), // priority
                 ParseUtil.parseLongOrDefault(split[22], 0L), // VSZ
-                ParseUtil.parseLongOrDefault(split[23], 0L), // RSS
+                ParseUtil.parseLongOrDefault(split[23], 0L) * memoryPageSize, // RSS pages * page_size
                 // The below values are in jiffies
                 ParseUtil.parseLongOrDefault(split[14], 0L), // kernelTime
                 ParseUtil.parseLongOrDefault(split[13], 0L), // userTime
                 ParseUtil.parseLongOrDefault(split[21], 0L), // startTime (after
                                                              // uptime)
+                // See man proc for how to parse /proc/[pid]/io
+                ParseUtil.parseLongOrDefault(io.getOrDefault("read_bytes", ""), 0L),
+                ParseUtil.parseLongOrDefault(io.getOrDefault("write_bytes", ""), 0L),
                 System.currentTimeMillis() //
         );
     }

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxProcess.java
@@ -61,7 +61,7 @@ public class LinuxProcess extends AbstractProcess {
 
     public LinuxProcess(String name, String path, char state, int processID, int parentProcessID, int threadCount,
             int priority, long virtualSize, long residentSetSize, long kernelTime, long userTime, long startTime,
-            long now) {
+            long bytesRead, long bytesWritten, long now) {
         this.name = name;
         this.path = path;
         switch (state) {
@@ -94,6 +94,8 @@ public class LinuxProcess extends AbstractProcess {
         this.userTime = userTime * 1000L / hz;
         this.startTime = bootTime + startTime * 1000L / hz;
         this.upTime = now - this.startTime;
+        this.bytesRead = bytesRead;
+        this.bytesWritten = bytesWritten;
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSVersionInfoEx.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSVersionInfoEx.java
@@ -31,16 +31,23 @@ public class MacOSVersionInfoEx extends AbstractOSVersionInfoEx {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacOSVersionInfoEx.class);
 
+    private int osxVersionNumber = -1;
+
     public MacOSVersionInfoEx() {
         setVersion(System.getProperty("os.version"));
         setCodeName(parseCodeName());
         setBuildNumber(SysctlUtil.sysctl("kern.osversion", ""));
     }
 
+    public int getOsxVersionNumber() {
+        return osxVersionNumber;
+    }
+
     private String parseCodeName() {
         String[] versionSplit = getVersion().split("\\.");
         if (versionSplit.length > 1 && versionSplit[0].equals("10")) {
-            switch (ParseUtil.parseIntOrDefault(versionSplit[1], -1)) {
+            osxVersionNumber = ParseUtil.parseIntOrDefault(versionSplit[1], -1);
+            switch (osxVersionNumber) {
             // MacOS
             case 12:
                 return "Sierra";

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacProcess.java
@@ -31,7 +31,7 @@ import oshi.software.os.OSProcess;
  */
 public class MacProcess extends AbstractProcess {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
     /*
      * OS X States:
      */
@@ -45,7 +45,7 @@ public class MacProcess extends AbstractProcess {
 
     public MacProcess(String name, String path, int osXState, int processID, int parentProcessID, int threadCount,
             int priority, long virtualSize, long residentSetSize, long kernelTime, long userTime, long startTime,
-            long now) {
+            long now, long bytesRead, long bytesWritten) {
         this.name = name;
         this.path = path;
         switch (osXState) {
@@ -81,6 +81,8 @@ public class MacProcess extends AbstractProcess {
         this.userTime = userTime;
         this.startTime = startTime;
         this.upTime = now - startTime;
+        this.bytesRead = bytesRead;
+        this.bytesWritten = bytesWritten;
     }
 
 }

--- a/oshi-core/src/main/java/oshi/util/FileUtil.java
+++ b/oshi-core/src/main/java/oshi/util/FileUtil.java
@@ -24,7 +24,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -156,5 +158,27 @@ public class FileUtil {
             return read.get(0).split("\\s+");
         }
         return new String[0];
+    }
+
+    /**
+     * Read a file and return a map of string keys to string values contained
+     * therein. Intended primarily for Linux /proc/[pid]/io
+     * @param filename
+     *            The file to read
+     * @return The map contained in the file, if any; otherwise empty map
+     */
+    public static Map<String, String> getKeyValueMapFromFile(
+            String filename,
+            String separator) {
+        Map<String, String> map = new HashMap<>();
+        LOG.debug("Reading file {}", filename);
+        List<String> lines = FileUtil.readFile(filename, false);
+        for (String line : lines) {
+            String[] parts = line.split(separator);
+            if (parts.length == 2) {
+                map.put(parts[0], parts[1].trim());
+            }
+        }
+        return map;
     }
 }

--- a/oshi-core/src/test/java/oshi/util/FileUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/FileUtilTest.java
@@ -20,7 +20,9 @@ package oshi.util;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -35,6 +37,7 @@ public class FileUtilTest {
     private static String THISCLASS = "src/test/java/oshi/util/FileUtilTest.java";
     private static String INT_FILE = "src/test/resources/test.integer.txt";
     private static String STRING_FILE = "src/test/resources/test.string.txt";
+    private static String PROCIO_FILE = "src/test/resources/test.procio.txt";
     private static String NO_FILE = "does/not/exist";
 
     /**
@@ -84,5 +87,22 @@ public class FileUtilTest {
 
         assertEquals(5, FileUtil.getSplitFromFile(STRING_FILE).length);
         assertEquals(0, FileUtil.getSplitFromFile(NO_FILE).length);
+    }
+
+    @Test
+    public void testReadProcIo() {
+        Map<String, String> expected = new HashMap<>();
+        expected.put("rchar", "124788352");
+        expected.put("wchar", "124802481");
+        expected.put("syscr", "135");
+        expected.put("syscw", "1547");
+        expected.put("read_bytes", "40304640");
+        expected.put("write_bytes", "124780544");
+        expected.put("cancelled_write_bytes", "42");
+        Map<String, String> actual = FileUtil.getKeyValueMapFromFile(PROCIO_FILE, ":");
+        assertEquals(expected.size(), actual.size());
+        for (String key : expected.keySet()) {
+            assertEquals(expected.get(key), actual.get(key));
+        }
     }
 }

--- a/oshi-core/src/test/resources/test.procio.txt
+++ b/oshi-core/src/test/resources/test.procio.txt
@@ -1,0 +1,7 @@
+rchar: 124788352
+wchar: 124802481
+syscr: 135
+syscw: 1547
+read_bytes: 40304640
+write_bytes: 124780544
+cancelled_write_bytes: 42

--- a/oshi-dist/pom.xml
+++ b/oshi-dist/pom.xml
@@ -33,6 +33,7 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<appendAssemblyId>false</appendAssemblyId>
+					<tarLongFileMode>posix</tarLongFileMode>
 					<descriptors>
 						<descriptor>src/assembly/assembly.xml</descriptor>
 					</descriptors>

--- a/oshi-json/src/main/java/oshi/json/software/os/OSProcess.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/OSProcess.java
@@ -119,4 +119,14 @@ public interface OSProcess extends OshiJsonObject {
      *         since January 1, 1970.
      */
     long getStartTime();
+
+    /**
+     * @return Returns the number of bytes the process has read from disk.
+     */
+    long getBytesRead();
+
+    /**
+     * @return Returns the number of bytes the process has written to disk.
+     */
+    long getBytesWritten();
 }

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/OSProcessImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/OSProcessImpl.java
@@ -36,7 +36,7 @@ import oshi.software.os.OSProcess.State;
  */
 public class OSProcessImpl extends AbstractOshiJsonObject implements OSProcess {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private transient JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
@@ -161,6 +161,22 @@ public class OSProcessImpl extends AbstractOshiJsonObject implements OSProcess {
      * {@inheritDoc}
      */
     @Override
+    public long getBytesRead() {
+        return this.osProcess.getBytesRead();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getBytesWritten() {
+        return this.osProcess.getBytesWritten();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JsonObject toJSON(Properties properties) {
         JsonObjectBuilder json = NullAwareJsonObjectBuilder.wrap(this.jsonFactory.createObjectBuilder());
         if (PropertiesUtil.getBoolean(properties, "operatingSystem.processes.name")) {
@@ -201,6 +217,12 @@ public class OSProcessImpl extends AbstractOshiJsonObject implements OSProcess {
         }
         if (PropertiesUtil.getBoolean(properties, "operatingSystem.processes.startTime")) {
             json.add("startTime", getStartTime());
+        }
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.processes.bytesRead")) {
+            json.add("bytesRead", getBytesRead());
+        }
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.processes.bytesWritten")) {
+            json.add("bytesWritten", getBytesWritten());
         }
         return json.build();
     }

--- a/oshi-json/src/test/resources/oshi.json.properties
+++ b/oshi-json/src/test/resources/oshi.json.properties
@@ -68,6 +68,8 @@
 #    operatingSystem.processes.userTime                  = false
 #    operatingSystem.processes.upTime                    = false
 #    operatingSystem.processes.startTime                 = false
+#    operatingSystem.processes.bytesRead                 = false
+#    operatingSystem.processes.bytesWritten              = false
 
 ############################
 # HARDWARE


### PR DESCRIPTION
Summary:
This change adds bytesRead and bytesWritten fields to OSProcess.
An implementation is provided for MacProcess which uses `proc_pid_rusage(pid, RUSAGE_INFO_V2, ...)`.
Note that RUSAGE_INFO_V2 is only available on MacOSX 10.9+.

Test Plan:
Successfully obtained process io stats on MacOSX 10.10 and 10.11.
Verified that `mvn test` succeeds.