### PR TITLE
Site and License adjustments

### DIFF
--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/dblock/oshi)
+
+    Copyright (c) 2010 - 2016 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/dblock/oshi/graphs/contributors
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/oshi-core/src/site/site.xml
+++ b/oshi-core/src/site/site.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/dblock/oshi)
+
+    Copyright (c) 2010 - 2016 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/dblock/oshi/graphs/contributors
+
+-->
+<project xmlns="http://maven.apache.org/DECORATION/1.7.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="${project.name}"
+	xsi:schemaLocation="http://maven.apache.org/DECORATION/1.7.0 http://maven.apache.org/xsd/decoration-1.7.0.xsd">
+	<skin>
+		<groupId>org.apache.maven.skins</groupId>
+		<artifactId>maven-fluido-skin</artifactId>
+		<version>1.5</version>
+	</skin>
+	<custom>
+		<fluidoSkin>
+			<topBarEnabled>true</topBarEnabled>
+			<sideBarEnabled>true</sideBarEnabled>
+		</fluidoSkin>
+	</custom>
+	<body>
+		<links>
+			<item name="oshi" href="http://github.com/dblock/oshi" />
+		</links>
+		<menu name="User guide">
+			<item href="README.html" name="README" />
+		</menu>
+		<menu ref="reports" />
+		<menu ref="parent" inherit="top" />
+		<menu ref="modules" inherit="top" />
+	</body>
+</project>

--- a/oshi-dist/pom.xml
+++ b/oshi-dist/pom.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/dblock/oshi)
+
+    Copyright (c) 2010 - 2016 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/dblock/oshi/graphs/contributors
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/oshi-dist/src/assembly/assembly.xml
+++ b/oshi-dist/src/assembly/assembly.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/dblock/oshi)
+
+    Copyright (c) 2010 - 2016 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/dblock/oshi/graphs/contributors
+
+-->
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/oshi-dist/src/main/resources/eclipse/format.xml
+++ b/oshi-dist/src/main/resources/eclipse/format.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/dblock/oshi)
+
+    Copyright (c) 2010 - 2016 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/dblock/oshi/graphs/contributors
+
+-->
 <profiles version="12">
 	<profile kind="CodeFormatterProfile" name="Sun Java Conventions"
 		version="12">

--- a/oshi-dist/src/site/site.xml
+++ b/oshi-dist/src/site/site.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/dblock/oshi)
+
+    Copyright (c) 2010 - 2016 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/dblock/oshi/graphs/contributors
+
+-->
+<project xmlns="http://maven.apache.org/DECORATION/1.7.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="${project.name}"
+	xsi:schemaLocation="http://maven.apache.org/DECORATION/1.7.0 http://maven.apache.org/xsd/decoration-1.7.0.xsd">
+	<skin>
+		<groupId>org.apache.maven.skins</groupId>
+		<artifactId>maven-fluido-skin</artifactId>
+		<version>1.5</version>
+	</skin>
+	<custom>
+		<fluidoSkin>
+			<topBarEnabled>true</topBarEnabled>
+			<sideBarEnabled>true</sideBarEnabled>
+		</fluidoSkin>
+	</custom>
+	<body>
+		<links>
+			<item name="oshi" href="http://github.com/dblock/oshi" />
+		</links>
+		<menu name="User guide">
+			<item href="README.html" name="README" />
+		</menu>
+		<menu ref="reports" />
+		<menu ref="parent" inherit="top" />
+		<menu ref="modules" inherit="top" />
+	</body>
+</project>

--- a/oshi-json/pom.xml
+++ b/oshi-json/pom.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/dblock/oshi)
+
+    Copyright (c) 2010 - 2016 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/dblock/oshi/graphs/contributors
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/oshi-json/src/site/site.xml
+++ b/oshi-json/src/site/site.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/dblock/oshi)
+
+    Copyright (c) 2010 - 2016 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/dblock/oshi/graphs/contributors
+
+-->
+<project xmlns="http://maven.apache.org/DECORATION/1.7.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="${project.name}"
+	xsi:schemaLocation="http://maven.apache.org/DECORATION/1.7.0 http://maven.apache.org/xsd/decoration-1.7.0.xsd">
+	<skin>
+		<groupId>org.apache.maven.skins</groupId>
+		<artifactId>maven-fluido-skin</artifactId>
+		<version>1.5</version>
+	</skin>
+	<custom>
+		<fluidoSkin>
+			<topBarEnabled>true</topBarEnabled>
+			<sideBarEnabled>true</sideBarEnabled>
+		</fluidoSkin>
+	</custom>
+	<body>
+		<links>
+			<item name="oshi" href="http://github.com/dblock/oshi" />
+		</links>
+		<menu name="User guide">
+			<item href="README.html" name="README" />
+		</menu>
+		<menu ref="reports" />
+		<menu ref="parent" inherit="top" />
+		<menu ref="modules" inherit="top" />
+	</body>
+</project>

--- a/oshi-json/src/test/resources/oshi.json.properties
+++ b/oshi-json/src/test/resources/oshi.json.properties
@@ -1,3 +1,22 @@
+#
+# Oshi (https://github.com/dblock/oshi)
+#
+# Copyright (c) 2010 - 2016 The Oshi Project Team
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Maintainers:
+# dblock[at]dblock[dot]org
+# widdis[at]gmail[dot]com
+# enrico.bianchi[at]gmail[dot]com
+#
+# Contributors:
+# https://github.com/dblock/oshi/graphs/contributors
+#
+
 ############################
 # OSHI JSON Properties File
 ############################

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/dblock/oshi)
+
+    Copyright (c) 2010 - 2016 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/dblock/oshi/graphs/contributors
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -374,19 +394,9 @@
 					<version>3.0</version>
 					<configuration>
 						<header>LICENSE_HEADER</header>
-						<excludes>
-							<exclude>**/*.txt</exclude>
-							<exclude>**/*.xml</exclude>
-							<exclude>**/*.properties</exclude>
-							<exclude>**/*.html</exclude>
-							<exclude>**/*.css</exclude>
-						</excludes>
-						<includes>
-							<include>**/*.java</include>
-						</includes>
-						<mapping>
-							<java>JAVADOC_STYLE</java>
-						</mapping>
+                        <excludes>
+							<exclude>**/*test.*.txt</exclude>
+                        </excludes>
 					</configuration>
 				</plugin>
 				<!-- Report Only -->

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/dblock/oshi)
+
+    Copyright (c) 2010 - 2016 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/dblock/oshi/graphs/contributors
+
+-->
 <project xmlns="http://maven.apache.org/DECORATION/1.7.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="${project.name}"
 	xsi:schemaLocation="http://maven.apache.org/DECORATION/1.7.0 http://maven.apache.org/xsd/decoration-1.7.0.xsd">


### PR DESCRIPTION
Site.xml should exist in every module folder otherwise it doesn't properly build individually for local usage.

License setup was originally just copied from the plugin website.  That was wrong as it was  sample and limited it to only the java files.  Fixed that and adjusted it so it doesn't affect what is considered simply test files that shouldn't have headers.