### PR TITLE
Host/domain name, dns servers and default gateways information for Win/Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 3.4 (in progress)
 ================
-* Your contribution here.
+* [#294](https://github.com/oshi/oshi/pull/294): Add NetworkParams for network parameter of OS - [@chikei](https://github.com/chikei).
 
 3.3 (12/31/2016)
 ================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 3.4 (in progress)
 ================
 * [#294](https://github.com/oshi/oshi/pull/294): Add NetworkParams for network parameter of OS - [@chikei](https://github.com/chikei).
+* [#295](https://github.com/oshi/oshi/pull/295): Make OSProcess (AbstractProcess.java) more easily extendable - [@michaeldesigaud](https://github.com/michaeldesigaud).
+* Your contribution here.
 
 3.3 (12/31/2016)
 ================

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/Libc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/Libc.java
@@ -26,6 +26,9 @@ import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import com.sun.jna.ptr.PointerByReference;
+
+import oshi.jna.platform.unix.LibC;
 
 /**
  * Linux C Library. This class should be considered non-API as it may be removed
@@ -118,10 +121,32 @@ public interface Libc extends Library {
 
     /**
      * Returns the number of bytes in a memory page, where "page" is a
-     * fixed-length block, the unit for memory allocation and file
-     * mapping performed by mmap(2).
+     * fixed-length block, the unit for memory allocation and file mapping
+     * performed by mmap(2).
      *
      * @return the memory page size
      */
     int getpagesize();
+
+    /**
+     * Given node and service, which identify an Internet host and a service,
+     * getaddrinfo() returns one or more addrinfo structures, each of which
+     * contains an Internet address that can be specified in a call to bind(2)
+     * or connect(2).
+     *
+     * @param node
+     *            a numerical network address or a network hostname, whose
+     *            network addresses are looked up and resolved.
+     * @param service
+     *            sets the port in each returned address structure.
+     * @param hints
+     *            specifies criteria for selecting the socket address structures
+     *            returned in the list pointed to by res.
+     * @param res
+     *            returned address structure
+     * @return 0 on success; sets errno on failure
+     */
+    int getaddrinfo(String node, String service, LibC.Addrinfo hints, PointerByReference res);
+
+    void freeaddrinfo(Pointer res);
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/IPHlpAPI.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/IPHlpAPI.java
@@ -151,21 +151,22 @@ public interface IPHlpAPI extends Library {
 
         @Override
         protected List<String> getFieldOrder() {
-            return Arrays.asList(new String[]{"String"});
+            return Arrays.asList(new String[] { "String" });
         }
     }
 
     class IP_ADDR_STRING extends Structure {
-        public static class ByReference extends IP_ADDR_STRING implements Structure.ByReference{}
-
         public ByReference Next;
         public IP_ADDRESS_STRING IpAddress;
         public IP_ADDRESS_STRING IpMask;
         public int Context;
 
+        public static class ByReference extends IP_ADDR_STRING implements Structure.ByReference {
+        }
+
         @Override
         protected List<String> getFieldOrder() {
-            return Arrays.asList(new String[]{"Next", "IpAddress", "IpMask", "Context"});
+            return Arrays.asList(new String[] { "Next", "IpAddress", "IpMask", "Context" });
         }
     }
 
@@ -182,8 +183,8 @@ public interface IPHlpAPI extends Library {
 
         @Override
         protected List<String> getFieldOrder() {
-            return Arrays.asList(new String[]{"HostName", "DomainName", "CurrentDnsServer", "DnsServerList",
-                "NodeType", "ScopeId", "EnableRouting", "EnableProxy", "EnableDns"});
+            return Arrays.asList(new String[] { "HostName", "DomainName", "CurrentDnsServer", "DnsServerList",
+                    "NodeType", "ScopeId", "EnableRouting", "EnableProxy", "EnableDns" });
         }
 
         public FIXED_INFO(Pointer p) {
@@ -239,15 +240,16 @@ public interface IPHlpAPI extends Library {
      * computer.
      *
      * @param pFixedInfo
-     *            A pointer to a buffer that contains a FIXED_INFO structure that
-     *            receives the network parameters for the local computer, if the
-     *            function was successful. This buffer must be allocated by the caller
-     *            prior to calling the GetNetworkParams function.
+     *            A pointer to a buffer that contains a FIXED_INFO structure
+     *            that receives the network parameters for the local computer,
+     *            if the function was successful. This buffer must be allocated
+     *            by the caller prior to calling the GetNetworkParams function.
      * @param pOutBufLen
-     *            A pointer to a ULONG variable that specifies the size of the FIXED_INFO
-     *            structure. If this size is insufficient to hold the information,
-     *            GetNetworkParams fills in this variable with the required size, and
-     *            returns an error code of ERROR_BUFFER_OVERFLOW.
+     *            A pointer to a ULONG variable that specifies the size of the
+     *            FIXED_INFO structure. If this size is insufficient to hold the
+     *            information, GetNetworkParams fills in this variable with the
+     *            required size, and returns an error code of
+     *            ERROR_BUFFER_OVERFLOW.
      * @return If the function succeeds, the return value is ERROR_SUCCESS.
      */
     int GetNetworkParams(FIXED_INFO pFixedInfo, ULONGByReference pOutBufLen);

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/Kernel32.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/Kernel32.java
@@ -33,6 +33,9 @@ public interface Kernel32 extends com.sun.jna.platform.win32.Kernel32 {
 
     int SEM_FAILCRITICALERRORS = 0x0001;
 
+    int ComputerNameDnsHostname = 1;
+    int ComputerNameDnsDomain = 2;
+
     // TODO: Submit this change to JNA Kernel32 class
     /**
      * Retrieves system timing information. On a multiprocessor system, the

--- a/oshi-core/src/main/java/oshi/software/common/AbstractNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/common/AbstractNetworkParams.java
@@ -1,5 +1,24 @@
+/**
+ * Oshi (https://github.com/dblock/oshi)
+ *
+ * Copyright (c) 2010 - 2017 The Oshi Project Team
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Maintainers:
+ * dblock[at]dblock[dot]org
+ * widdis[at]gmail[dot]com
+ * enrico.bianchi[at]gmail[dot]com
+ *
+ * Contributors:
+ * https://github.com/dblock/oshi/graphs/contributors
+ */
 package oshi.software.common;
 
+import com.sun.jna.ptr.PointerByReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -8,6 +27,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
+import oshi.jna.platform.unix.LibC;
 import oshi.software.os.NetworkParams;
 import oshi.util.FileUtil;
 
@@ -20,6 +40,41 @@ public abstract class AbstractNetworkParams implements NetworkParams {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractNetworkParams.class);
     private static final String NAMESERVER = "nameserver";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDomainName() {
+        LibC.Addrinfo hint = new LibC.Addrinfo();
+        hint.ai_flags = LibC.AI_CANONNAME;
+        String hostname = null;
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            LOG.error("Unknown host exception when getting address of local host: " + e);
+            return "";
+        }
+        PointerByReference ptr = new PointerByReference();
+        doGetaddrinfo(hint, hostname, ptr);
+        LibC.Addrinfo info = new LibC.Addrinfo(ptr.getValue());
+        String canonname = info.ai_canonname;
+        doFreeaddrinfo(ptr);
+        int dot = canonname.indexOf('.');
+        if (dot == -1) {
+            return "";
+        } else {
+            return canonname.substring(dot + 1);
+        }
+    }
+
+    protected void doFreeaddrinfo(PointerByReference ptr) {
+        LibC.INSTANCE.freeaddrinfo(ptr.getValue());
+    }
+
+    protected void doGetaddrinfo(LibC.Addrinfo hint, String hostname, PointerByReference ptr) {
+        LibC.INSTANCE.getaddrinfo(hostname, null, hint, ptr);
+    }
 
     /**
      * {@inheritDoc}
@@ -62,10 +117,10 @@ public abstract class AbstractNetworkParams implements NetworkParams {
         return servers.toArray(new String[servers.size()]);
     }
 
-    static protected String searchGateway(List<String> lines){
-        for(String line: lines){
+    static protected String searchGateway(List<String> lines) {
+        for (String line : lines) {
             String leftTrimmed = line.replaceFirst("^[ \t]+", "");
-            if(leftTrimmed.startsWith("gateway:")){
+            if (leftTrimmed.startsWith("gateway:")) {
                 return leftTrimmed.split("[ \t]", 2)[1];
             }
         }

--- a/oshi-core/src/main/java/oshi/software/common/AbstractNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/common/AbstractNetworkParams.java
@@ -61,4 +61,14 @@ public abstract class AbstractNetworkParams implements NetworkParams {
         }
         return servers.toArray(new String[servers.size()]);
     }
+
+    static protected String searchGateway(List<String> lines){
+        for(String line: lines){
+            String leftTrimmed = line.replaceFirst("^[ \t]+", "");
+            if(leftTrimmed.startsWith("gateway:")){
+                return leftTrimmed.split("[ \t]", 2)[1];
+            }
+        }
+        return "";
+    }
 }

--- a/oshi-core/src/main/java/oshi/software/common/AbstractNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/common/AbstractNetworkParams.java
@@ -1,0 +1,64 @@
+package oshi.software.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+
+import oshi.software.os.NetworkParams;
+import oshi.util.FileUtil;
+
+/**
+ * Common NetworkParams implementation.
+ */
+public abstract class AbstractNetworkParams implements NetworkParams {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractNetworkParams.class);
+    private static final String NAMESERVER = "nameserver";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getHostName() {
+        try {
+            String hn = InetAddress.getLocalHost().getHostName();
+            int dot = hn.indexOf('.');
+            if (dot == -1) {
+                return hn;
+            } else {
+                return hn.substring(0, dot);
+            }
+        } catch (UnknownHostException e) {
+            LOG.error("Unknown host exception when getting address of local host: " + e);
+            return "";
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getDnsServers() {
+        List<String> resolv = FileUtil.readFile("/etc/resolv.conf");
+        String key = NAMESERVER;
+        int maxNameServer = 3;
+        List<String> servers = new ArrayList<>();
+        for (int i = 0; i < resolv.size() && servers.size() < maxNameServer; i++) {
+            String line = resolv.get(i);
+            if (line.startsWith(key)) {
+                String value = line.substring(key.length()).replaceFirst("^[ \t]+", "");
+                if (value.length() != 0 && value.charAt(0) != '#' && value.charAt(0) != ';') {
+                    String val = value.split("[ \t#;]", 2)[0];
+                    servers.add(val);
+                }
+            }
+        }
+        return servers.toArray(new String[servers.size()]);
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/NetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/NetworkParams.java
@@ -21,7 +21,8 @@ package oshi.software.os;
 import java.io.Serializable;
 
 /**
- * NetworkParams presents network parameters of running OS, such as DNS, host name etc.
+ * NetworkParams presents network parameters of running OS, such as DNS, host
+ * name etc.
  */
 public interface NetworkParams extends Serializable {
 
@@ -41,14 +42,14 @@ public interface NetworkParams extends Serializable {
     String[] getDnsServers();
 
     /**
-     * @return Gets default gateway(routing destination for 0.0.0.0/0) for IPv4, empty string if not
-     * defined.
+     * @return Gets default gateway(routing destination for 0.0.0.0/0) for IPv4,
+     *         empty string if not defined.
      */
     String getIpv4DefaultGateway();
 
     /**
-     * @return Gets default gateway(routing destination for ::/0) for IPv6, empty string if not
-     * defined.
+     * @return Gets default gateway(routing destination for ::/0) for IPv6,
+     *         empty string if not defined.
      */
     String getIpv6DefaultGateway();
 }

--- a/oshi-core/src/main/java/oshi/software/os/NetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/NetworkParams.java
@@ -1,0 +1,36 @@
+package oshi.software.os;
+
+import java.io.Serializable;
+
+/**
+ * NetworkParams presents network parameters of running OS, such as DNS, host name etc.
+ */
+public interface NetworkParams extends Serializable {
+
+    /**
+     * @return Gets host name
+     */
+    String getHostName();
+
+    /**
+     * @return Gets domain name
+     */
+    String getDomainName();
+
+    /**
+     * @return Gets DNS servers
+     */
+    String[] getDnsServers();
+
+    /**
+     * @return Gets default gateway(routing destination for 0.0.0.0/0) for IPv4, empty string if not
+     * defined.
+     */
+    String getV4DefaultGateway();
+
+    /**
+     * @return Gets default gateway(routing destination for ::/0) for IPv6, empty string if not
+     * defined.
+     */
+    String getV6DefaultGateway();
+}

--- a/oshi-core/src/main/java/oshi/software/os/NetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/NetworkParams.java
@@ -26,11 +26,11 @@ public interface NetworkParams extends Serializable {
      * @return Gets default gateway(routing destination for 0.0.0.0/0) for IPv4, empty string if not
      * defined.
      */
-    String getV4DefaultGateway();
+    String getIpv4DefaultGateway();
 
     /**
      * @return Gets default gateway(routing destination for ::/0) for IPv6, empty string if not
      * defined.
      */
-    String getV6DefaultGateway();
+    String getIpv6DefaultGateway();
 }

--- a/oshi-core/src/main/java/oshi/software/os/OperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/OperatingSystem.java
@@ -112,4 +112,11 @@ public interface OperatingSystem extends Serializable {
      * @return The number of threads running
      */
     int getThreadCount();
+
+    /**
+     * Instantiates a {@link NetworkParams} object.
+     *
+     * @return A {@link NetworkParams} object.
+     */
+    NetworkParams getNetworkParams();
 }

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
@@ -18,15 +18,13 @@
  */
 package oshi.software.os.linux;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import oshi.software.os.NetworkParams;
+import oshi.software.common.AbstractNetworkParams;
 import oshi.util.ExecutingCommand;
-import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 
-public class LinuxNetworkParams implements NetworkParams {
+public class LinuxNetworkParams extends AbstractNetworkParams {
 
     private static final long serialVersionUID = 1L;
 
@@ -37,44 +35,8 @@ public class LinuxNetworkParams implements NetworkParams {
      * {@inheritDoc}
      */
     @Override
-    public String getHostName() {
-        String hn = FileUtil.getStringFromFile("/proc/sys/kernel/hostname");
-        int dot = hn.indexOf('.');
-        if (dot == -1) {
-            return hn;
-        } else {
-            return hn.substring(0, dot);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String getDomainName() {
         return ExecutingCommand.getFirstAnswer("dnsdomainname");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String[] getDnsServers() {
-        List<String> resolv = FileUtil.readFile("/etc/resolv.conf");
-        String key = "nameserver";
-        int maxNameServer = 3;
-        List<String> servers = new ArrayList<>();
-        for (int i = 0; i < resolv.size() && servers.size() < maxNameServer; i++) {
-            String line = resolv.get(i);
-            if (line.startsWith(key)) {
-                String value = line.substring(key.length()).replaceFirst("^[ \t]+", "");
-                if (value.length() != 0 && value.charAt(0) != '#' && value.charAt(0) != ';') {
-                    String val = value.split("[ \t#;]", 2)[0];
-                    servers.add(val);
-                }
-            }
-        }
-        return servers.toArray(new String[servers.size()]);
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
@@ -1,0 +1,115 @@
+package oshi.software.os.linux;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import oshi.software.os.NetworkParams;
+import oshi.util.ExecutingCommand;
+import oshi.util.FileUtil;
+
+public class LinuxNetworkParams implements NetworkParams{
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxNetworkParams.class);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getHostName() {
+        return FileUtil.getStringFromFile("/proc/sys/kernel/hostname");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDomainName() {
+        return ExecutingCommand.getFirstAnswer("dnsdomainname");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getDnsServers() {
+        List<String> resolv = FileUtil.readFile("/etc/resolv.conf");
+        String key = "nameserver";
+        int maxNameServer = 3;
+        List<String> servers = new ArrayList<>();
+        for(String line: resolv){
+            if(!line.startsWith(key)) continue;
+
+            String value = line.substring(key.length())
+                .replaceFirst("^[ \t]+", "");
+            if(value.length() == 0 ||
+                value.charAt(0) == '#' || value.charAt(0) == ';') continue;
+            String val = value.split("[ \t]", 2)[0];
+            servers.add(val);
+            if(servers.size() >= maxNameServer) break;
+        }
+        return servers.toArray(new String[0]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getV4DefaultGateway() {
+        List<String> routes = ExecutingCommand.runNative("route -A inet -n");
+        if(routes.size() <= 2){
+            return "";
+        }
+
+        String gateway = "";
+        int minMetric = Integer.MAX_VALUE;
+
+        for(int i = 2; i < routes.size(); i++){
+            String[] fields = routes.get(i).split("\\s");
+            if(fields.length > 4 && fields[0].equals("0.0.0.0")) {
+                try{
+                    boolean isGateway = fields[3].indexOf('G') != -1;
+                    int metric = Integer.parseInt(fields[4]);
+                    if(isGateway && (metric < minMetric)){
+                        minMetric = metric;
+                        gateway = fields[1];
+                    }
+                } catch (NumberFormatException ignored){}
+            }
+        }
+        return gateway;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getV6DefaultGateway() {
+        List<String> routes = ExecutingCommand.runNative("route -A inet6 -n");
+        if(routes.size() <= 2){
+            return "";
+        }
+
+        String gateway = "";
+        int minMetric = Integer.MAX_VALUE;
+
+        for(int i = 2; i < routes.size(); i++){
+            String[] fields = routes.get(i).split("\\s");
+            if(fields.length > 3 && fields[0].equals("::/0")) {
+                try{
+                    boolean isGateway = fields[2].indexOf('G') != -1;
+                    int metric = Integer.parseInt(fields[3]);
+                    if(isGateway && (metric < minMetric)){
+                        minMetric = metric;
+                        gateway = fields[1];
+                    }
+                } catch (NumberFormatException ignored){}
+            }
+        }
+        return gateway;
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
@@ -20,6 +20,11 @@ package oshi.software.os.linux;
 
 import java.util.List;
 
+import com.sun.jna.ptr.PointerByReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import oshi.jna.platform.linux.Libc;
+import oshi.jna.platform.unix.LibC.Addrinfo;
 import oshi.software.common.AbstractNetworkParams;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -28,15 +33,19 @@ public class LinuxNetworkParams extends AbstractNetworkParams {
 
     private static final long serialVersionUID = 1L;
 
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxNetworkParams.class);
+
     private static final String IPV4_DEFAULT_DEST = "0.0.0.0";
     private static final String IPV6_DEFAULT_DEST = "::/0";
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public String getDomainName() {
-        return ExecutingCommand.getFirstAnswer("dnsdomainname");
+    protected void doFreeaddrinfo(PointerByReference ptr) {
+        Libc.INSTANCE.freeaddrinfo(ptr.getValue());
+    }
+
+    @Override
+    protected void doGetaddrinfo(Addrinfo hint, String hostname, PointerByReference ptr) {
+        Libc.INSTANCE.getaddrinfo(hostname, null, hint, ptr);
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
@@ -21,7 +21,13 @@ public class LinuxNetworkParams implements NetworkParams{
      */
     @Override
     public String getHostName() {
-        return FileUtil.getStringFromFile("/proc/sys/kernel/hostname");
+        String hn = FileUtil.getStringFromFile("/proc/sys/kernel/hostname");
+        int dot = hn.indexOf('.');
+        if(dot == -1) {
+            return hn;
+        } else {
+            return hn.substring(0, dot);
+        }
     }
 
     /**
@@ -59,7 +65,7 @@ public class LinuxNetworkParams implements NetworkParams{
      * {@inheritDoc}
      */
     @Override
-    public String getV4DefaultGateway() {
+    public String getIpv4DefaultGateway() {
         List<String> routes = ExecutingCommand.runNative("route -A inet -n");
         if(routes.size() <= 2){
             return "";
@@ -88,7 +94,7 @@ public class LinuxNetworkParams implements NetworkParams{
      * {@inheritDoc}
      */
     @Override
-    public String getV6DefaultGateway() {
+    public String getIpv6DefaultGateway() {
         List<String> routes = ExecutingCommand.runNative("route -A inet6 -n");
         if(routes.size() <= 2){
             return "";

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
@@ -18,21 +18,20 @@
  */
 package oshi.software.os.linux;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import oshi.software.os.NetworkParams;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
+import oshi.util.ParseUtil;
 
-public class LinuxNetworkParams implements NetworkParams{
+public class LinuxNetworkParams implements NetworkParams {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger LOG = LoggerFactory.getLogger(LinuxNetworkParams.class);
+    private static final String IPV4_DEFAULT_DEST = "0.0.0.0";
+    private static final String IPV6_DEFAULT_DEST = "::/0";
 
     /**
      * {@inheritDoc}
@@ -41,7 +40,7 @@ public class LinuxNetworkParams implements NetworkParams{
     public String getHostName() {
         String hn = FileUtil.getStringFromFile("/proc/sys/kernel/hostname");
         int dot = hn.indexOf('.');
-        if(dot == -1) {
+        if (dot == -1) {
             return hn;
         } else {
             return hn.substring(0, dot);
@@ -65,18 +64,17 @@ public class LinuxNetworkParams implements NetworkParams{
         String key = "nameserver";
         int maxNameServer = 3;
         List<String> servers = new ArrayList<>();
-        for(String line: resolv){
-            if(!line.startsWith(key)) continue;
-
-            String value = line.substring(key.length())
-                .replaceFirst("^[ \t]+", "");
-            if(value.length() == 0 ||
-                value.charAt(0) == '#' || value.charAt(0) == ';') continue;
-            String val = value.split("[ \t#;]", 2)[0];
-            servers.add(val);
-            if(servers.size() >= maxNameServer) break;
+        for (int i = 0; i < resolv.size() && servers.size() < maxNameServer; i++) {
+            String line = resolv.get(i);
+            if (line.startsWith(key)) {
+                String value = line.substring(key.length()).replaceFirst("^[ \t]+", "");
+                if (value.length() != 0 && value.charAt(0) != '#' && value.charAt(0) != ';') {
+                    String val = value.split("[ \t#;]", 2)[0];
+                    servers.add(val);
+                }
+            }
         }
-        return servers.toArray(new String[0]);
+        return servers.toArray(new String[servers.size()]);
     }
 
     /**
@@ -85,24 +83,22 @@ public class LinuxNetworkParams implements NetworkParams{
     @Override
     public String getIpv4DefaultGateway() {
         List<String> routes = ExecutingCommand.runNative("route -A inet -n");
-        if(routes.size() <= 2){
+        if (routes.size() <= 2) {
             return "";
         }
 
         String gateway = "";
         int minMetric = Integer.MAX_VALUE;
 
-        for(int i = 2; i < routes.size(); i++){
+        for (int i = 2; i < routes.size(); i++) {
             String[] fields = routes.get(i).split("\\s+");
-            if(fields.length > 4 && fields[0].equals("0.0.0.0")) {
-                try{
-                    boolean isGateway = fields[3].indexOf('G') != -1;
-                    int metric = Integer.parseInt(fields[4]);
-                    if(isGateway && (metric < minMetric)){
-                        minMetric = metric;
-                        gateway = fields[1];
-                    }
-                } catch (NumberFormatException ignored){}
+            if (fields.length > 4 && fields[0].equals(IPV4_DEFAULT_DEST)) {
+                boolean isGateway = fields[3].indexOf('G') != -1;
+                int metric = ParseUtil.parseIntOrDefault(fields[4], Integer.MAX_VALUE);
+                if (isGateway && (metric < minMetric)) {
+                    minMetric = metric;
+                    gateway = fields[1];
+                }
             }
         }
         return gateway;
@@ -114,24 +110,22 @@ public class LinuxNetworkParams implements NetworkParams{
     @Override
     public String getIpv6DefaultGateway() {
         List<String> routes = ExecutingCommand.runNative("route -A inet6 -n");
-        if(routes.size() <= 2){
+        if (routes.size() <= 2) {
             return "";
         }
 
         String gateway = "";
         int minMetric = Integer.MAX_VALUE;
 
-        for(int i = 2; i < routes.size(); i++){
+        for (int i = 2; i < routes.size(); i++) {
             String[] fields = routes.get(i).split("\\s+");
-            if(fields.length > 3 && fields[0].equals("::/0")) {
-                try{
-                    boolean isGateway = fields[2].indexOf('G') != -1;
-                    int metric = Integer.parseInt(fields[3]);
-                    if(isGateway && (metric < minMetric)){
-                        minMetric = metric;
-                        gateway = fields[1];
-                    }
-                } catch (NumberFormatException ignored){}
+            if (fields.length > 3 && fields[0].equals(IPV6_DEFAULT_DEST)) {
+                boolean isGateway = fields[2].indexOf('G') != -1;
+                int metric = ParseUtil.parseIntOrDefault(fields[3], Integer.MAX_VALUE);
+                if (isGateway && (metric < minMetric)) {
+                    minMetric = metric;
+                    gateway = fields[1];
+                }
             }
         }
         return gateway;

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
@@ -48,7 +48,7 @@ public class LinuxNetworkParams implements NetworkParams{
                 .replaceFirst("^[ \t]+", "");
             if(value.length() == 0 ||
                 value.charAt(0) == '#' || value.charAt(0) == ';') continue;
-            String val = value.split("[ \t]", 2)[0];
+            String val = value.split("[ \t#;]", 2)[0];
             servers.add(val);
             if(servers.size() >= maxNameServer) break;
         }
@@ -69,7 +69,7 @@ public class LinuxNetworkParams implements NetworkParams{
         int minMetric = Integer.MAX_VALUE;
 
         for(int i = 2; i < routes.size(); i++){
-            String[] fields = routes.get(i).split("\\s");
+            String[] fields = routes.get(i).split("\\s+");
             if(fields.length > 4 && fields[0].equals("0.0.0.0")) {
                 try{
                     boolean isGateway = fields[3].indexOf('G') != -1;
@@ -98,7 +98,7 @@ public class LinuxNetworkParams implements NetworkParams{
         int minMetric = Integer.MAX_VALUE;
 
         for(int i = 2; i < routes.size(); i++){
-            String[] fields = routes.get(i).split("\\s");
+            String[] fields = routes.get(i).split("\\s+");
             if(fields.length > 3 && fields[0].equals("::/0")) {
                 try{
                     boolean isGateway = fields[2].indexOf('G') != -1;

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
@@ -1,3 +1,21 @@
+/**
+ * Oshi (https://github.com/dblock/oshi)
+ *
+ * Copyright (c) 2010 - 2017 The Oshi Project Team
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Maintainers:
+ * dblock[at]dblock[dot]org
+ * widdis[at]gmail[dot]com
+ * enrico.bianchi[at]gmail[dot]com
+ *
+ * Contributors:
+ * https://github.com/dblock/oshi/graphs/contributors
+ */
 package oshi.software.os.linux;
 
 import org.slf4j.Logger;

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -34,6 +34,7 @@ import oshi.jna.platform.linux.Libc;
 import oshi.jna.platform.linux.Libc.Sysinfo;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
@@ -177,6 +178,14 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
             LOG.error("Failed to get procs from sysinfo. {}", e);
         }
         return 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public NetworkParams getNetworkParams() {
+        return new LinuxNetworkParams();
     }
 
     private void setFamilyFromReleaseFiles() {

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParams.java
@@ -1,0 +1,45 @@
+package oshi.software.os.mac;
+
+import oshi.software.os.NetworkParams;
+
+public class MacNetworkParams implements NetworkParams{
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getHostName() {
+        return "";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDomainName() {
+        return "";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getDnsServers() {
+        return new String[0];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIpv4DefaultGateway() {
+        return "";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIpv6DefaultGateway() {
+        return "";
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParams.java
@@ -1,3 +1,21 @@
+/**
+ * Oshi (https://github.com/dblock/oshi)
+ *
+ * Copyright (c) 2010 - 2017 The Oshi Project Team
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Maintainers:
+ * dblock[at]dblock[dot]org
+ * widdis[at]gmail[dot]com
+ * enrico.bianchi[at]gmail[dot]com
+ *
+ * Contributors:
+ * https://github.com/dblock/oshi/graphs/contributors
+ */
 package oshi.software.os.mac;
 
 import oshi.software.os.NetworkParams;

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParams.java
@@ -18,17 +18,9 @@
  */
 package oshi.software.os.mac;
 
-import oshi.software.os.NetworkParams;
+import oshi.software.common.AbstractNetworkParams;
 
-public class MacNetworkParams implements NetworkParams{
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getHostName() {
-        return "";
-    }
-
+public class MacNetworkParams extends AbstractNetworkParams{
     /**
      * {@inheritDoc}
      */

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystem.java
@@ -30,6 +30,7 @@ import oshi.jna.platform.mac.SystemB.ProcTaskInfo;
 import oshi.jna.platform.mac.SystemB.RUsageInfoV2;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.util.ParseUtil;
 import oshi.util.platform.mac.SysctlUtil;
@@ -168,5 +169,13 @@ public class MacOperatingSystem extends AbstractOperatingSystem {
             numberOfThreads += taskInfo.pti_threadnum;
         }
         return numberOfThreads;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public NetworkParams getNetworkParams() {
+        return new MacNetworkParams();
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
@@ -18,16 +18,9 @@
  */
 package oshi.software.os.unix.freebsd;
 
-import oshi.software.os.NetworkParams;
+import oshi.software.common.AbstractNetworkParams;
 
-public class FreeBsdNetworkParams implements NetworkParams{
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getHostName() {
-        return "";
-    }
+public class FreeBsdNetworkParams extends AbstractNetworkParams {
 
     /**
      * {@inheritDoc}
@@ -35,14 +28,6 @@ public class FreeBsdNetworkParams implements NetworkParams{
     @Override
     public String getDomainName() {
         return "";
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String[] getDnsServers() {
-        return new String[0];
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
@@ -19,6 +19,7 @@
 package oshi.software.os.unix.freebsd;
 
 import oshi.software.common.AbstractNetworkParams;
+import oshi.util.ExecutingCommand;
 
 public class FreeBsdNetworkParams extends AbstractNetworkParams {
 
@@ -35,7 +36,7 @@ public class FreeBsdNetworkParams extends AbstractNetworkParams {
      */
     @Override
     public String getIpv4DefaultGateway() {
-        return "";
+        return searchGateway(ExecutingCommand.runNative("route -4 get default"));
     }
 
     /**
@@ -43,6 +44,6 @@ public class FreeBsdNetworkParams extends AbstractNetworkParams {
      */
     @Override
     public String getIpv6DefaultGateway() {
-        return "";
+        return searchGateway(ExecutingCommand.runNative("route -6 get default"));
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
@@ -1,3 +1,21 @@
+/**
+ * Oshi (https://github.com/dblock/oshi)
+ *
+ * Copyright (c) 2010 - 2017 The Oshi Project Team
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Maintainers:
+ * dblock[at]dblock[dot]org
+ * widdis[at]gmail[dot]com
+ * enrico.bianchi[at]gmail[dot]com
+ *
+ * Contributors:
+ * https://github.com/dblock/oshi/graphs/contributors
+ */
 package oshi.software.os.unix.freebsd;
 
 import oshi.software.os.NetworkParams;

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
@@ -1,0 +1,45 @@
+package oshi.software.os.unix.freebsd;
+
+import oshi.software.os.NetworkParams;
+
+public class FreeBsdNetworkParams implements NetworkParams{
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getHostName() {
+        return "";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDomainName() {
+        return "";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getDnsServers() {
+        return new String[0];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIpv4DefaultGateway() {
+        return "";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIpv6DefaultGateway() {
+        return "";
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -24,6 +24,7 @@ import java.util.List;
 import oshi.jna.platform.linux.Libc;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -161,5 +162,13 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
             threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
         }
         return threads;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public NetworkParams getNetworkParams() {
+        return new FreeBsdNetworkParams();
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
@@ -18,16 +18,9 @@
  */
 package oshi.software.os.unix.solaris;
 
-import oshi.software.os.NetworkParams;
+import oshi.software.common.AbstractNetworkParams;
 
-public class SolarisNetworkParams implements NetworkParams{
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getHostName() {
-        return "";
-    }
+public class SolarisNetworkParams extends AbstractNetworkParams {
 
     /**
      * {@inheritDoc}
@@ -35,14 +28,6 @@ public class SolarisNetworkParams implements NetworkParams{
     @Override
     public String getDomainName() {
         return "";
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String[] getDnsServers() {
-        return new String[0];
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
@@ -19,6 +19,7 @@
 package oshi.software.os.unix.solaris;
 
 import oshi.software.common.AbstractNetworkParams;
+import oshi.util.ExecutingCommand;
 
 public class SolarisNetworkParams extends AbstractNetworkParams {
 
@@ -35,7 +36,7 @@ public class SolarisNetworkParams extends AbstractNetworkParams {
      */
     @Override
     public String getIpv4DefaultGateway() {
-        return "";
+        return searchGateway(ExecutingCommand.runNative("route get -inet default"));
     }
 
     /**
@@ -43,6 +44,6 @@ public class SolarisNetworkParams extends AbstractNetworkParams {
      */
     @Override
     public String getIpv6DefaultGateway() {
-        return "";
+        return searchGateway(ExecutingCommand.runNative("route get -inet6 default"));
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
@@ -1,3 +1,21 @@
+/**
+ * Oshi (https://github.com/dblock/oshi)
+ *
+ * Copyright (c) 2010 - 2017 The Oshi Project Team
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Maintainers:
+ * dblock[at]dblock[dot]org
+ * widdis[at]gmail[dot]com
+ * enrico.bianchi[at]gmail[dot]com
+ *
+ * Contributors:
+ * https://github.com/dblock/oshi/graphs/contributors
+ */
 package oshi.software.os.unix.solaris;
 
 import oshi.software.os.NetworkParams;

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
@@ -1,0 +1,45 @@
+package oshi.software.os.unix.solaris;
+
+import oshi.software.os.NetworkParams;
+
+public class SolarisNetworkParams implements NetworkParams{
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getHostName() {
+        return "";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDomainName() {
+        return "";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getDnsServers() {
+        return new String[0];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIpv4DefaultGateway() {
+        return "";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIpv6DefaultGateway() {
+        return "";
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystem.java
@@ -24,6 +24,7 @@ import java.util.List;
 import oshi.jna.platform.linux.Libc;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -153,5 +154,13 @@ public class SolarisOperatingSystem extends AbstractOperatingSystem {
             return threadList.size() - 1;
         }
         return getProcessCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public NetworkParams getNetworkParams() {
+        return new SolarisNetworkParams();
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
@@ -32,32 +32,18 @@ import java.util.Map;
 import oshi.jna.platform.windows.IPHlpAPI;
 import oshi.jna.platform.windows.IPHlpAPI.FIXED_INFO;
 import oshi.jna.platform.windows.Kernel32;
-import oshi.software.os.NetworkParams;
+import oshi.software.common.AbstractNetworkParams;
 import oshi.util.platform.windows.WmiUtil;
 
-public class WindowsNetworkParams implements NetworkParams {
+public class WindowsNetworkParams extends AbstractNetworkParams {
 
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsNetworkParams.class);
 
-    private static final WmiUtil.ValueType[] GATEWAY_TYPES = { WmiUtil.ValueType.STRING, WmiUtil.ValueType.UINT16 };
+    private static final WmiUtil.ValueType[] GATEWAY_TYPES = {WmiUtil.ValueType.STRING, WmiUtil.ValueType.UINT16};
     private static final String IPV4_DEFAULT_DEST = "0.0.0.0/0";
     private static final String IPV6_DEFAULT_DEST = "::/0";
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getHostName() {
-        char[] buffer = new char[256];
-        IntByReference bufferSize = new IntByReference(buffer.length);
-        if (!Kernel32.INSTANCE.GetComputerNameEx(Kernel32.ComputerNameDnsHostname, buffer, bufferSize)) {
-            LOG.error("Failed to get host name. Error code: {}", Kernel32.INSTANCE.GetLastError());
-            return "";
-        }
-        return new String(buffer);
-    }
 
     /**
      * {@inheritDoc}
@@ -117,13 +103,12 @@ public class WindowsNetworkParams implements NetworkParams {
      */
     @Override
     public String getIpv4DefaultGateway() {
-        String dest = IPV4_DEFAULT_DEST;
-        return getNextHop(dest);
+        return getNextHop(IPV4_DEFAULT_DEST);
     }
 
     private String getNextHop(String dest) {
         Map<String, List<Object>> vals = WmiUtil.selectObjectsFrom("ROOT\\StandardCimv2", "MSFT_NetRoute",
-                "NextHop,RouteMetric", "WHERE DestinationPrefix=\"" + dest + "\"", GATEWAY_TYPES);
+            "NextHop,RouteMetric", "WHERE DestinationPrefix=\"" + dest + "\"", GATEWAY_TYPES);
         List<Object> metrics = vals.get("RouteMetric");
         if (vals.get("RouteMetric").size() == 0) {
             return "";
@@ -146,7 +131,6 @@ public class WindowsNetworkParams implements NetworkParams {
      */
     @Override
     public String getIpv6DefaultGateway() {
-        String dest = IPV6_DEFAULT_DEST;
-        return getNextHop(dest);
+        return getNextHop(IPV6_DEFAULT_DEST);
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
@@ -94,7 +94,7 @@ public class WindowsNetworkParams implements NetworkParams {
      * {@inheritDoc}
      */
     @Override
-    public String getV4DefaultGateway() {
+    public String getIpv4DefaultGateway() {
         String dest = "0.0.0.0/0";
         return getNextHop(dest);
     }
@@ -123,7 +123,7 @@ public class WindowsNetworkParams implements NetworkParams {
      * {@inheritDoc}
      */
     @Override
-    public String getV6DefaultGateway() {
+    public String getIpv6DefaultGateway() {
         String dest = "::/0";
         return getNextHop(dest);
     }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
@@ -1,0 +1,130 @@
+package oshi.software.os.windows;
+
+import com.sun.jna.Memory;
+import com.sun.jna.platform.win32.WinDef;
+import com.sun.jna.ptr.IntByReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import oshi.jna.platform.windows.IPHlpAPI;
+import oshi.jna.platform.windows.IPHlpAPI.FIXED_INFO;
+import oshi.jna.platform.windows.Kernel32;
+import oshi.software.os.NetworkParams;
+import oshi.util.platform.windows.WmiUtil;
+
+public class WindowsNetworkParams implements NetworkParams {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsNetworkParams.class);
+
+    private static final WmiUtil.ValueType[] GATEWAY_TYPES = {WmiUtil.ValueType.STRING, WmiUtil.ValueType.UINT16};
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getHostName() {
+        char[] buffer = new char[256];
+        IntByReference bufferSize = new IntByReference(buffer.length);
+        if (!Kernel32.INSTANCE.GetComputerNameEx(Kernel32.ComputerNameDnsHostname, buffer, bufferSize)) {
+            LOG.error("Failed to get host name. Error code: {}", Kernel32.INSTANCE.GetLastError());
+            return "";
+        }
+        return new String(buffer);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDomainName() {
+        char[] buffer = new char[256];
+        IntByReference bufferSize = new IntByReference(buffer.length);
+        if (!Kernel32.INSTANCE.GetComputerNameEx(Kernel32.ComputerNameDnsDomain, buffer, bufferSize)) {
+            LOG.error("Failed to get dns domain name. Error code: {}", Kernel32.INSTANCE.GetLastError());
+            return "";
+        }
+        return new String(buffer);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getDnsServers() {
+        // this may be done by iterating WMI instances ROOT\CIMV2\Win32_NetworkAdapterConfiguration
+        // then sort by IPConnectionMetric, but current JNA release does not have string array support
+        // for Variant (it's merged but not release yet).
+        WinDef.ULONGByReference bufferSize = new WinDef.ULONGByReference();
+        int ret = IPHlpAPI.INSTANCE.GetNetworkParams(null, bufferSize);
+        if (ret != IPHlpAPI.ERROR_BUFFER_OVERFLOW) {
+            LOG.error("Failed to get network parameters buffer size. Error code: {}", ret);
+            return new String[0];
+        }
+
+        FIXED_INFO buffer = new FIXED_INFO(new Memory(bufferSize.getValue().longValue()));
+        ret = IPHlpAPI.INSTANCE.GetNetworkParams(buffer, bufferSize);
+        if (ret != 0) {
+            LOG.error("Failed to get network parameters. Error code: {}", ret);
+            return new String[0];
+        }
+
+        List<String> list = new ArrayList<>();
+        IPHlpAPI.IP_ADDR_STRING dns = buffer.DnsServerList;
+        while(dns != null) {
+            String addr = new String(dns.IpAddress.String);
+            int nullPos = addr.indexOf(0);
+            if(nullPos != -1) {
+                addr = addr.substring(0, nullPos);
+            }
+            list.add(addr);
+            dns = dns.Next;
+        }
+
+        return list.toArray(new String[0]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getV4DefaultGateway() {
+        String dest = "0.0.0.0/0";
+        return getNextHop(dest);
+    }
+
+    private String getNextHop(String dest) {
+        Map<String, List<Object>> vals = WmiUtil.selectObjectsFrom("ROOT\\StandardCimv2", "MSFT_NetRoute",
+            "NextHop,RouteMetric", "WHERE DestinationPrefix=\"" + dest + "\"", GATEWAY_TYPES);
+        List<Object> metrics = vals.get("RouteMetric");
+        if (vals.get("RouteMetric").size() == 0) {
+            return "";
+        } else {
+            int index = 0;
+            Long min = Long.MAX_VALUE;
+            for (int i = 0; i < metrics.size(); i++) {
+                Long metric = (Long) metrics.get(i);
+                if (metric < min) {
+                    min = metric;
+                    index = i;
+                }
+            }
+            return (String) vals.get("NextHop").get(index);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getV6DefaultGateway() {
+        String dest = "::/0";
+        return getNextHop(dest);
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
@@ -1,3 +1,21 @@
+/**
+ * Oshi (https://github.com/dblock/oshi)
+ *
+ * Copyright (c) 2010 - 2017 The Oshi Project Team
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Maintainers:
+ * dblock[at]dblock[dot]org
+ * widdis[at]gmail[dot]com
+ * enrico.bianchi[at]gmail[dot]com
+ *
+ * Contributors:
+ * https://github.com/dblock/oshi/graphs/contributors
+ */
 package oshi.software.os.windows;
 
 import com.sun.jna.Memory;

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -30,6 +30,7 @@ import oshi.jna.platform.windows.Psapi;
 import oshi.jna.platform.windows.Psapi.PERFORMANCE_INFORMATION;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.util.ParseUtil;
 import oshi.util.platform.windows.WmiUtil;
@@ -141,5 +142,13 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
             return 0;
         }
         return perfInfo.ThreadCount.intValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public NetworkParams getNetworkParams() {
+        return new WindowsNetworkParams();
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/WmiUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/WmiUtil.java
@@ -60,7 +60,7 @@ public class WmiUtil {
      * Enum for WMI queries for proper parsing from the returned VARIANT
      */
     public enum ValueType {
-        STRING, UINT32, FLOAT, DATETIME, BOOLEAN, UINT64
+        STRING, UINT32, FLOAT, DATETIME, BOOLEAN, UINT64, UINT16
     }
 
     /**
@@ -478,6 +478,7 @@ public class WmiUtil {
                 case STRING:
                     values.get(property).add(vtProp.getValue() == null ? "unknown" : vtProp.stringValue());
                     break;
+                case UINT16: // uint16 == VT_I4
                 // WMI Uint32s will return as longs
                 case UINT32: // WinDef.LONG TODO improve in JNA 4.3
                 case UINT64:

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -39,6 +39,7 @@ import oshi.hardware.PowerSource;
 import oshi.hardware.Sensors;
 import oshi.hardware.UsbDevice;
 import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
 import oshi.software.os.OSFileStore;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OperatingSystem;
@@ -100,6 +101,9 @@ public class SystemInfoTest {
 
         LOG.info("Checking Network interfaces...");
         printNetworkInterfaces(hal.getNetworkIFs());
+
+        LOG.info("Checking Network parameterss...");
+        printNetworkParameters(os.getNetworkParams());
 
         // hardware: displays
         LOG.info("Checking Displays...");
@@ -286,6 +290,15 @@ public class SystemInfoTest {
                     hasData ? FormatUtil.formatBytes(net.getBytesSent()) : "?",
                     hasData ? " (" + net.getOutErrors() + " err)" : "");
         }
+    }
+
+    private static void printNetworkParameters(NetworkParams networkParams) {
+        System.out.println("Network parameters:");
+        System.out.format(" Host name: %s%n", networkParams.getHostName());
+        System.out.format(" Domain name: %s%n", networkParams.getDomainName());
+        System.out.format(" DNS servers: %s%n", Arrays.toString(networkParams.getDnsServers()));
+        System.out.format(" IPv4 Gateway: %s%n", networkParams.getIpv4DefaultGateway());
+        System.out.format(" IPv6 Gateway: %s%n", networkParams.getIpv6DefaultGateway());
     }
 
     private static void printDisplays(Display[] displays) {

--- a/oshi-core/src/test/java/oshi/software/os/NetworkParamsTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/NetworkParamsTest.java
@@ -1,0 +1,47 @@
+/**
+ * Oshi (https://github.com/dblock/oshi)
+ *
+ * Copyright (c) 2010 - 2017 The Oshi Project Team
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Maintainers:
+ * dblock[at]dblock[dot]org
+ * widdis[at]gmail[dot]com
+ * enrico.bianchi[at]gmail[dot]com
+ *
+ * Contributors:
+ * https://github.com/dblock/oshi/graphs/contributors
+ */
+package oshi.software.os;
+
+import org.junit.Test;
+
+import oshi.SystemInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test network parameters
+ */
+public class NetworkParamsTest {
+
+    /**
+     * Test network parameters
+     */
+    @Test
+    public void testOperatingSystem() {
+        SystemInfo si = new SystemInfo();
+        NetworkParams params = si.getOperatingSystem().getNetworkParams();
+        assertNotNull(params.getHostName());
+        assertNotNull(params.getDomainName());
+        assertNotNull(params.getDnsServers());
+        assertNotNull(params.getIpv4DefaultGateway());
+        assertNotNull(params.getIpv6DefaultGateway());
+    }
+}

--- a/oshi-core/src/test/java/oshi/software/os/NetworkParamsTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/NetworkParamsTest.java
@@ -22,9 +22,7 @@ import org.junit.Test;
 
 import oshi.SystemInfo;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test network parameters

--- a/oshi-json/src/main/java/oshi/json/software/os/NetworkParams.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/NetworkParams.java
@@ -16,14 +16,14 @@
  * Contributors:
  * https://github.com/dblock/oshi/graphs/contributors
  */
-package oshi.software.os;
+package oshi.json.software.os;
 
-import java.io.Serializable;
+import oshi.json.json.OshiJsonObject;
 
 /**
  * NetworkParams presents network parameters of running OS, such as DNS, host name etc.
  */
-public interface NetworkParams extends Serializable {
+public interface NetworkParams extends OshiJsonObject {
 
     /**
      * @return Gets host name

--- a/oshi-json/src/main/java/oshi/json/software/os/NetworkParams.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/NetworkParams.java
@@ -21,7 +21,8 @@ package oshi.json.software.os;
 import oshi.json.json.OshiJsonObject;
 
 /**
- * NetworkParams presents network parameters of running OS, such as DNS, host name etc.
+ * NetworkParams presents network parameters of running OS, such as DNS, host
+ * name etc.
  */
 public interface NetworkParams extends OshiJsonObject {
 
@@ -41,14 +42,14 @@ public interface NetworkParams extends OshiJsonObject {
     String[] getDnsServers();
 
     /**
-     * @return Gets default gateway(routing destination for 0.0.0.0/0) for IPv4, empty string if not
-     * defined.
+     * @return Gets default gateway(routing destination for 0.0.0.0/0) for IPv4,
+     *         empty string if not defined.
      */
     String getIpv4DefaultGateway();
 
     /**
-     * @return Gets default gateway(routing destination for ::/0) for IPv6, empty string if not
-     * defined.
+     * @return Gets default gateway(routing destination for ::/0) for IPv6,
+     *         empty string if not defined.
      */
     String getIpv6DefaultGateway();
 }

--- a/oshi-json/src/main/java/oshi/json/software/os/OperatingSystem.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/OperatingSystem.java
@@ -110,4 +110,11 @@ public interface OperatingSystem extends OshiJsonObject {
      * @return The number of threads running
      */
     int getThreadCount();
+
+    /**
+     * Instantiates a {@link NetworkParams} object.
+     *
+     * @return A {@link NetworkParams} object.
+     */
+    NetworkParams getNetworkParams();
 }

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/NetworkParamsImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/NetworkParamsImpl.java
@@ -29,10 +29,9 @@ import javax.json.JsonObjectBuilder;
 import oshi.json.json.AbstractOshiJsonObject;
 import oshi.json.json.NullAwareJsonObjectBuilder;
 import oshi.json.software.os.NetworkParams;
-import oshi.json.software.os.OSFileStore;
 import oshi.json.util.PropertiesUtil;
 
-public class NetworkPramsImpl extends AbstractOshiJsonObject implements NetworkParams{
+public class NetworkParamsImpl extends AbstractOshiJsonObject implements NetworkParams{
 
     private static final long serialVersionUID = 1L;
 
@@ -47,7 +46,7 @@ public class NetworkPramsImpl extends AbstractOshiJsonObject implements NetworkP
      * @param networkParams
      *            a platform-specific NetworkParams object
      */
-    public NetworkPramsImpl(oshi.software.os.NetworkParams networkParams){
+    public NetworkParamsImpl(oshi.software.os.NetworkParams networkParams){
         this.networkParams = networkParams;
     }
 

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/NetworkPramsImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/NetworkPramsImpl.java
@@ -1,0 +1,111 @@
+/**
+ * Oshi (https://github.com/dblock/oshi)
+ *
+ * Copyright (c) 2010 - 2017 The Oshi Project Team
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Maintainers:
+ * dblock[at]dblock[dot]org
+ * widdis[at]gmail[dot]com
+ * enrico.bianchi[at]gmail[dot]com
+ *
+ * Contributors:
+ * https://github.com/dblock/oshi/graphs/contributors
+ */
+package oshi.json.software.os.impl;
+
+import java.util.Properties;
+
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+
+import oshi.json.json.AbstractOshiJsonObject;
+import oshi.json.json.NullAwareJsonObjectBuilder;
+import oshi.json.software.os.NetworkParams;
+import oshi.json.software.os.OSFileStore;
+import oshi.json.util.PropertiesUtil;
+
+public class NetworkPramsImpl extends AbstractOshiJsonObject implements NetworkParams{
+
+    private static final long serialVersionUID = 1L;
+
+    private transient JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+
+    private oshi.software.os.NetworkParams networkParams;
+
+    /**
+     * Creates a new platform-specific NetworkParams object wrapping the
+     * provided argument
+     *
+     * @param networkParams
+     *            a platform-specific NetworkParams object
+     */
+    public NetworkPramsImpl(oshi.software.os.NetworkParams networkParams){
+        this.networkParams = networkParams;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getHostName() { return this.networkParams.getHostName(); }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDomainName() { return this.networkParams.getDomainName(); }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getDnsServers() { return this.networkParams.getDnsServers(); }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIpv4DefaultGateway() { return this.networkParams.getIpv4DefaultGateway(); }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIpv6DefaultGateway() { return this.networkParams.getIpv6DefaultGateway(); }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JsonObject toJSON(Properties properties) {
+        JsonObjectBuilder json = NullAwareJsonObjectBuilder.wrap(this.jsonFactory.createObjectBuilder());
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.networkParams.hostName")) {
+            json.add("hostName", getHostName());
+        }
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.networkParams.domainName")) {
+            json.add("domainName", getDomainName());
+        }
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.networkParams.dnsServers")) {
+            JsonArrayBuilder nameServerArrayBuilder = this.jsonFactory.createArrayBuilder();
+            for (String server : getDnsServers()) {
+                nameServerArrayBuilder.add(server);
+            }
+            json.add("dnsServers", nameServerArrayBuilder.build());
+        }
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.networkParams.ipv4DefaultGateway")) {
+            json.add("ipv4DefaultGateway", getIpv4DefaultGateway());
+        }
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.networkParams.ipv6DefaultGateway")) {
+            json.add("ipv6DefaultGateway", getIpv6DefaultGateway());
+        }
+        return json.build();
+    }
+}

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/OperatingSystemImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/OperatingSystemImpl.java
@@ -143,7 +143,7 @@ public class OperatingSystemImpl extends AbstractOshiJsonObject implements Opera
      * {@inheritDoc}
      */
     @Override
-    public NetworkParams getNetworkParams() { return new NetworkPramsImpl(this.os.getNetworkParams()); }
+    public NetworkParams getNetworkParams() { return new NetworkParamsImpl(this.os.getNetworkParams()); }
 
     /**
      * {@inheritDoc}

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/OperatingSystemImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/OperatingSystemImpl.java
@@ -29,6 +29,7 @@ import javax.json.JsonObjectBuilder;
 import oshi.json.json.AbstractOshiJsonObject;
 import oshi.json.json.NullAwareJsonObjectBuilder;
 import oshi.json.software.os.FileSystem;
+import oshi.json.software.os.NetworkParams;
 import oshi.json.software.os.OSProcess;
 import oshi.json.software.os.OperatingSystem;
 import oshi.json.software.os.OperatingSystemVersion;
@@ -142,6 +143,12 @@ public class OperatingSystemImpl extends AbstractOshiJsonObject implements Opera
      * {@inheritDoc}
      */
     @Override
+    public NetworkParams getNetworkParams() { return new NetworkPramsImpl(this.os.getNetworkParams()); }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JsonObject toJSON(Properties properties) {
         JsonObjectBuilder json = NullAwareJsonObjectBuilder.wrap(this.jsonFactory.createObjectBuilder());
         if (PropertiesUtil.getBoolean(properties, "operatingSystem.manufacturer")) {
@@ -173,6 +180,9 @@ public class OperatingSystemImpl extends AbstractOshiJsonObject implements Opera
                 processArrayBuilder.add(proc.toJSON(properties));
             }
             json.add("processes", processArrayBuilder.build());
+        }
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.networkParams")) {
+            json.add("networkParams", getNetworkParams().toJSON(properties));
         }
         return json.build();
     }

--- a/oshi-json/src/test/java/oshi/json/SystemInfoTest.java
+++ b/oshi-json/src/test/java/oshi/json/SystemInfoTest.java
@@ -44,6 +44,7 @@ import oshi.json.hardware.PowerSource;
 import oshi.json.hardware.Sensors;
 import oshi.json.hardware.UsbDevice;
 import oshi.json.software.os.FileSystem;
+import oshi.json.software.os.NetworkParams;
 import oshi.json.software.os.OSFileStore;
 import oshi.json.software.os.OSProcess;
 import oshi.json.software.os.OperatingSystem;
@@ -106,6 +107,9 @@ public class SystemInfoTest {
 
         LOG.info("Checking Network interfaces...");
         printNetworkInterfaces(hal.getNetworkIFs());
+
+        LOG.info("Checking Network parameterss...");
+        printNetworkParameters(os.getNetworkParams());
 
         // hardware: displays
         LOG.info("Checking Displays...");
@@ -300,6 +304,15 @@ public class SystemInfoTest {
                     hasData ? FormatUtil.formatBytes(net.getBytesSent()) : "?",
                     hasData ? " (" + net.getOutErrors() + " err)" : "");
         }
+    }
+
+    private static void printNetworkParameters(NetworkParams networkParams) {
+        System.out.println("Network parameters:");
+        System.out.format(" Host name: %s%n", networkParams.getHostName());
+        System.out.format(" Domain name: %s%n", networkParams.getDomainName());
+        System.out.format(" DNS servers: %s%n", Arrays.toString(networkParams.getDnsServers()));
+        System.out.format(" IPv4 Gateway: %s%n", networkParams.getIpv4DefaultGateway());
+        System.out.format(" IPv6 Gateway: %s%n", networkParams.getIpv6DefaultGateway());
     }
 
     private static void printDisplays(Display[] displays) {

--- a/oshi-json/src/test/java/oshi/json/software/os/NetworkParamsTest.java
+++ b/oshi-json/src/test/java/oshi/json/software/os/NetworkParamsTest.java
@@ -1,0 +1,45 @@
+/**
+ * Oshi (https://github.com/dblock/oshi)
+ *
+ * Copyright (c) 2010 - 2017 The Oshi Project Team
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Maintainers:
+ * dblock[at]dblock[dot]org
+ * widdis[at]gmail[dot]com
+ * enrico.bianchi[at]gmail[dot]com
+ *
+ * Contributors:
+ * https://github.com/dblock/oshi/graphs/contributors
+ */
+package oshi.json.software.os;
+
+import org.junit.Test;
+
+import oshi.json.SystemInfo;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test network parameters
+ */
+public class NetworkParamsTest {
+
+    /**
+     * Test network parameters
+     */
+    @Test
+    public void testOperatingSystem() {
+        SystemInfo si = new SystemInfo();
+        NetworkParams params = si.getOperatingSystem().getNetworkParams();
+        assertNotNull(params.getHostName());
+        assertNotNull(params.getDomainName());
+        assertNotNull(params.getDnsServers());
+        assertNotNull(params.getIpv4DefaultGateway());
+        assertNotNull(params.getIpv6DefaultGateway());
+    }
+}

--- a/oshi-json/src/test/resources/oshi.json.properties
+++ b/oshi-json/src/test/resources/oshi.json.properties
@@ -89,6 +89,12 @@
 #    operatingSystem.processes.startTime                 = false
 #    operatingSystem.processes.bytesRead                 = false
 #    operatingSystem.processes.bytesWritten              = false
+#  operatingSystem.networkParams                         = false
+#    operatingSystem.networkParams.hostName              = false
+#    operatingSystem.networkParams.domainName            = false
+#    operatingSystem.networkParams.dnsServers            = false
+#    operatingSystem.networkParams.ipv4DefaultGateway    = false
+#    operatingSystem.networkParams.ipv6DefaultGateway    = false
 
 ############################
 # HARDWARE


### PR DESCRIPTION
Hi,

here is interface for OS networking parameters and implementation for Linux/Win (sorry I don't have machine for other OS :().
Now it contains host name/dns domain name/dns servers/default gateway of IPv4/6.

Domain suffix search list is also considered but I think I'll wait JNA release `VT_ARRAY` support for this.