### PR TITLE
Fix #299: Suppress expected WARN and ERROR messages during Maven test build

### DIFF
--- a/oshi-core/src/test/resources/simplelogger.properties
+++ b/oshi-core/src/test/resources/simplelogger.properties
@@ -1,0 +1,30 @@
+#
+# Oshi (https://github.com/dblock/oshi)
+#
+# Copyright (c) 2010 - 2017 The Oshi Project Team
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Maintainers:
+# dblock[at]dblock[dot]org
+# widdis[at]gmail[dot]com
+# enrico.bianchi[at]gmail[dot]com
+#
+# Contributors:
+# https://github.com/dblock/oshi/graphs/contributors
+#
+
+# see http://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html
+org.slf4j.simpleLogger.logFile=target/unit-tests.log
+org.slf4j.simpleLogger.defaultLogLevel=INFO
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS
+org.slf4j.simpleLogger.showThreadName=false
+org.slf4j.simpleLogger.showShortLogName=true
+org.slf4j.simpleLogger.levelInBrackets=true
+
+# don't show expected errors during test execution
+org.slf4j.simpleLogger.log.oshi.util=ERROR

--- a/oshi-json/src/test/resources/simplelogger.properties
+++ b/oshi-json/src/test/resources/simplelogger.properties
@@ -1,0 +1,30 @@
+#
+# Oshi (https://github.com/dblock/oshi)
+#
+# Copyright (c) 2010 - 2017 The Oshi Project Team
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Maintainers:
+# dblock[at]dblock[dot]org
+# widdis[at]gmail[dot]com
+# enrico.bianchi[at]gmail[dot]com
+#
+# Contributors:
+# https://github.com/dblock/oshi/graphs/contributors
+#
+
+# see http://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html
+org.slf4j.simpleLogger.logFile=target/unit-tests.log
+org.slf4j.simpleLogger.defaultLogLevel=INFO
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS
+org.slf4j.simpleLogger.showThreadName=false
+org.slf4j.simpleLogger.showShortLogName=true
+org.slf4j.simpleLogger.levelInBrackets=true
+
+# don't show expected errors during test execution
+org.slf4j.simpleLogger.log.oshi.json.util=OFF


### PR DESCRIPTION
Fix for issue #299

**Proposed change**

- capture log messages in log file `**/target/unit-tests.log` instead of mixing them in with surefire console output
- don't log _expected_ errors and warning from `oshi.util.*` and `oshi.json.util.*` during test execution

**How was this change tested**

- ran full maven build and test build, verified log files get created and are empty
- captured STDOUT and STDERR separately make sure undesired log messages are no longer in the build output
- temporarily added log statements into test source code to verify output was captured in the modules respective log file `**/target/unit-tests.log`