### PR TITLE
Include instructions to run SystemInfoTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ USB Devices:
              |-- Fitbit Base Station (Fitbit Inc.)
 ```
 
+You can run the [SystemInfoTest](https://github.com/oshi/oshi/blob/master/oshi-core/src/test/java/oshi/SystemInfoTest.java)
+and see the full output for your system by cloning the project and building it with [Maven](http://maven.apache.org/index.html).
+
+```
+git clone https://github.com/oshi/oshi.git && cd oshi
+
+mvn test-compile -pl oshi-core -q exec:java \
+  -Dexec.mainClass="oshi.SystemInfoTest" \
+  -Dexec.classpathScope="test"
+```
+
 
 Where are we?
 -------------


### PR DESCRIPTION
It is not very straight forward to run the advertised `SystemInfoTest` from the command line unless one is eager to download a few jars and add them to the classpath (SLF4J, JNI, JSON).

For people familiar with **Git** and **Maven**, running a mvn command to execute `SystemInfoTest` will require less effort ...and if included in the README it comes down to a simple copy and paste :smile:

```Bash
mvn test-compile -pl oshi-core -q exec:java \
  -Dexec.mainClass="oshi.SystemInfoTest" \
  -Dexec.classpathScope="test"
```