### PR TITLE
Deprecate CentralProcessor's getSystemSerialNumber method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ================
 * [#294](https://github.com/oshi/oshi/pull/294), [#305](https://github.com/oshi/oshi/pull/305): Add NetworkParams for network parameter of OS - [@chikei](https://github.com/chikei), [@dbwiddis](https://github.com/dbwiddis).
 * [#295](https://github.com/oshi/oshi/pull/295): Make OSProcess (AbstractProcess.java) more easily extendable - [@michaeldesigaud](https://github.com/michaeldesigaud).
+* [#307](https://github.com/dblock/oshi/pull/307): Deprecate CentralProcessor's getSystemSerialNumber method that duplicated ComputerSystem's getSerialNumber method. - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here.
 
 3.3 (12/31/2016)

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -342,7 +342,10 @@ public interface CentralProcessor extends Serializable {
      *
      * @return the System/CPU Serial Number, if available, otherwise returns
      *         "unknown"
+     * 
+     * @deprecated use {@link ComputerSystem#getSerialNumber()} instead.
      */
+    @Deprecated
     String getSystemSerialNumber();
 
     /**

--- a/oshi-core/src/main/java/oshi/hardware/ComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/ComputerSystem.java
@@ -44,9 +44,23 @@ public interface ComputerSystem extends Serializable {
     String getModel();
 
     /**
-     * Get the computer system serial number
+     * Get the computer system serial number, if available.
      * 
-     * @return The serial number.
+     * Performs a best-effort attempt to retrieve a unique serial number from
+     * the computer system. This may originate from the baseboard, BIOS,
+     * processor, hardware UUID, etc.
+     * 
+     * This value is provided for information only. Caution should be exercised
+     * if using this result to "fingerprint" a system for licensing or other
+     * purposes, as the result may change based on program permissions or
+     * installation of software packages. Specifically, on Linux and FreeBSD,
+     * this requires either root permissions, or installation of the
+     * (deprecated) HAL library (lshal command). Linux also attempts to read the
+     * dmi/id serial number files in sysfs, which are read-only root by default
+     * but may have permissions altered by the user.
+     *
+     * @return the System Serial Number, if available, otherwise returns
+     *         "unknown"
      */
     String getSerialNumber();
 

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -90,8 +90,6 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
 
     private String cpuName;
 
-    protected String cpuSerialNumber = null;
-
     private String cpuIdentifier;
 
     private String cpuStepping;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -27,13 +27,11 @@ import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 
 import oshi.hardware.common.AbstractCentralProcessor;
-import oshi.jna.platform.mac.IOKit;
 import oshi.jna.platform.mac.SystemB;
 import oshi.jna.platform.mac.SystemB.Timeval;
 import oshi.util.ExecutingCommand;
 import oshi.util.FormatUtil;
 import oshi.util.ParseUtil;
-import oshi.util.platform.mac.IOKitUtil;
 import oshi.util.platform.mac.SysctlUtil;
 
 /**
@@ -182,18 +180,8 @@ public class MacCentralProcessor extends AbstractCentralProcessor {
      * {@inheritDoc}
      */
     @Override
+    @Deprecated
     public String getSystemSerialNumber() {
-        if (this.cpuSerialNumber == null) {
-            int service = IOKitUtil.getMatchingService("IOPlatformExpertDevice");
-            if (service != 0) {
-                // Fetch the serial number
-                this.cpuSerialNumber = IOKitUtil.getIORegistryStringProperty(service, "IOPlatformSerialNumber");
-                IOKit.INSTANCE.IOObjectRelease(service);
-            }
-            if (this.cpuSerialNumber == null) {
-                this.cpuSerialNumber = "unknown";
-            }
-        }
-        return this.cpuSerialNumber;
+        return new MacComputerSystem().getSerialNumber();
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -223,32 +223,8 @@ public class FreeBsdCentralProcessor extends AbstractCentralProcessor {
      * {@inheritDoc}
      */
     @Override
+    @Deprecated
     public String getSystemSerialNumber() {
-        if (this.cpuSerialNumber == null) {
-            // If root privileges this will work
-            String marker = "Serial Number:";
-            for (String checkLine : ExecutingCommand.runNative("dmidecode -t system")) {
-                if (checkLine.contains(marker)) {
-                    this.cpuSerialNumber = checkLine.split(marker)[1].trim();
-                    break;
-                }
-            }
-            // if lshal command available (hald must be manually installed)
-            if (this.cpuSerialNumber == null) {
-                marker = "system.hardware.serial =";
-                for (String checkLine : ExecutingCommand.runNative("lshal")) {
-                    if (checkLine.contains(marker)) {
-                        String[] temp = checkLine.split(marker)[1].split("'");
-                        // Format: '12345' (string)
-                        this.cpuSerialNumber = temp.length > 0 ? temp[1] : null;
-                        break;
-                    }
-                }
-            }
-            if (this.cpuSerialNumber == null) {
-                this.cpuSerialNumber = "unknown";
-            }
-        }
-        return this.cpuSerialNumber;
+        return new FreeBsdComputerSystem().getSerialNumber();
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdComputerSystem.java
@@ -20,6 +20,7 @@ package oshi.hardware.platform.unix.freebsd;
 
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
 
 /**
  * Hardware data obtained from dmidecode
@@ -82,12 +83,23 @@ final class FreeBsdComputerSystem extends AbstractComputerSystem {
         if (!productName.isEmpty()) {
             setModel(productName);
         }
-        if (!serialNumber.isEmpty()) {
-            setSerialNumber(serialNumber);
+        if (serialNumber.isEmpty()) {
+            serialNumber = getSystemSerialNumber();
         }
+        setSerialNumber(serialNumber);
 
         setFirmware(new FreeBsdFirmware());
 
         setBaseboard(new FreeBsdBaseboard());
+    }
+
+    private String getSystemSerialNumber() {
+        String marker = "system.hardware.serial =";
+        for (String checkLine : ExecutingCommand.runNative("lshal")) {
+            if (checkLine.contains(marker)) {
+                return ParseUtil.getSingleQuoteStringValue(checkLine);
+            }
+        }
+        return "unknown";
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
@@ -170,36 +170,8 @@ public class SolarisCentralProcessor extends AbstractCentralProcessor {
      * {@inheritDoc}
      */
     @Override
+    @Deprecated
     public String getSystemSerialNumber() {
-        if (this.cpuSerialNumber == null) {
-            String marker = "Serial Number:";
-            for (String checkLine : ExecutingCommand.runNative("smbios -t SMB_TYPE_SYSTEM")) {
-                if (checkLine.contains(marker)) {
-                    this.cpuSerialNumber = checkLine.split(marker)[1].trim();
-                    break;
-                }
-            }
-            // if that didn't work, try...
-            if (this.cpuSerialNumber == null) {
-                // If they've installed STB (Sun Explorer) this should work
-                this.cpuSerialNumber = ExecutingCommand.getFirstAnswer("sneep");
-            }
-            // if that didn't work, try...
-            if (this.cpuSerialNumber.isEmpty()) {
-                marker = "chassis-sn:";
-                for (String checkLine : ExecutingCommand.runNative("prtconf -pv")) {
-                    if (checkLine.contains(marker)) {
-                        String[] temp = checkLine.split(marker)[1].split("'");
-                        // Format: '12345' (string)
-                        this.cpuSerialNumber = temp.length > 0 ? temp[1] : "";
-                        break;
-                    }
-                }
-            }
-            if (this.cpuSerialNumber.isEmpty()) {
-                this.cpuSerialNumber = "unknown";
-            }
-        }
-        return this.cpuSerialNumber;
+        return new SolarisComputerSystem().getSerialNumber();
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
@@ -219,18 +219,8 @@ public class WindowsCentralProcessor extends AbstractCentralProcessor {
      * {@inheritDoc}
      */
     @Override
+    @Deprecated
     public String getSystemSerialNumber() {
-        if (this.cpuSerialNumber == null) {
-            // This should always work
-            this.cpuSerialNumber = WmiUtil.selectStringFrom(null, "Win32_BIOS", "SerialNumber", null);
-            // If the above doesn't work, this might
-            if ("".equals(this.cpuSerialNumber)) {
-                this.cpuSerialNumber = WmiUtil.selectStringFrom(null, "Win32_Csproduct", "IdentifyingNumber", null);
-            }
-            if ("".equals(this.cpuSerialNumber)) {
-                this.cpuSerialNumber = "unknown";
-            }
-        }
-        return this.cpuSerialNumber;
+        return new WindowsComputerSystem().getSerialNumber();
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsComputerSystem.java
@@ -53,16 +53,23 @@ final class WindowsComputerSystem extends AbstractComputerSystem {
             setModel(models.get(0));
         }
 
-        final Map<String, List<String>> win32BIOS = WmiUtil.selectStringsFrom(null, "Win32_BIOS", "SerialNumber",
-                "where PrimaryBIOS=true");
-
-        final List<String> serialNumbers = win32BIOS.get("SerialNumber");
-        if (serialNumbers != null && !serialNumbers.isEmpty()) {
-            setSerialNumber(serialNumbers.get(0));
-        }
+        setSerialNumber(getSystemSerialNumber());
 
         setFirmware(new WindowsFirmware());
 
         setBaseboard(new WindowsBaseboard());
+    }
+
+    private String getSystemSerialNumber() {
+        // This should always work
+        String serialNumber = WmiUtil.selectStringFrom(null, "Win32_BIOS", "SerialNumber", "where PrimaryBIOS=true");
+        // If the above doesn't work, this might
+        if ("".equals(serialNumber)) {
+            serialNumber = WmiUtil.selectStringFrom(null, "Win32_Csproduct", "IdentifyingNumber", null);
+        }
+        if ("".equals(serialNumber)) {
+            serialNumber = "unknown";
+        }
+        return serialNumber;
     }
 }

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -142,7 +142,6 @@ public class SystemInfoTest {
         System.out.println(" " + processor.getLogicalProcessorCount() + " logical CPU(s)");
 
         System.out.println("Identifier: " + processor.getIdentifier());
-        System.out.println("Serial Num: " + processor.getSystemSerialNumber());
     }
 
     private static void printMemory(GlobalMemory memory) {

--- a/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
@@ -39,6 +39,7 @@ public class CentralProcessorTest {
     /**
      * Test central processor.
      */
+    @SuppressWarnings("deprecation") // Test serialNumber until removed
     @Test
     public void testCentralProcessor() {
         SystemInfo si = new SystemInfo();

--- a/oshi-json/src/main/java/oshi/json/hardware/CentralProcessor.java
+++ b/oshi-json/src/main/java/oshi/json/hardware/CentralProcessor.java
@@ -18,6 +18,7 @@
  */
 package oshi.json.hardware;
 
+import oshi.hardware.ComputerSystem;
 import oshi.json.json.OshiJsonObject;
 
 /**
@@ -282,13 +283,19 @@ public interface CentralProcessor extends OshiJsonObject {
     long getSystemUptime();
 
     /**
-     * Get the System/CPU Serial Number, if available. On Linux, this requires
-     * either root permissions, or installation of the (deprecated) HAL library
-     * (lshal command).
+     * Get the System/CPU Serial Number, if available.
+     *
+     * On Linux and FreeBSD, this requires either root permissions, installation
+     * of the (deprecated) HAL library (lshal command). Linux also attempts to
+     * read the dmi/id serial number files in sysfs, which are read-only root by
+     * default but may have permissions altered by the user.
      *
      * @return the System/CPU Serial Number, if available, otherwise returns
      *         "unknown"
+     * 
+     * @deprecated use {@link ComputerSystem#getSerialNumber()} instead.
      */
+    @Deprecated
     String getSystemSerialNumber();
 
     /**

--- a/oshi-json/src/main/java/oshi/json/hardware/impl/CentralProcessorImpl.java
+++ b/oshi-json/src/main/java/oshi/json/hardware/impl/CentralProcessorImpl.java
@@ -250,6 +250,7 @@ public class CentralProcessorImpl extends AbstractOshiJsonObject implements Cent
      * {@inheritDoc}
      */
     @Override
+    @Deprecated
     public String getSystemSerialNumber() {
         return this.processor.getSystemSerialNumber();
     }
@@ -284,9 +285,6 @@ public class CentralProcessorImpl extends AbstractOshiJsonObject implements Cent
         }
         if (PropertiesUtil.getBoolean(properties, "hardware.processor.logicalProcessorCount")) {
             json.add("logicalProcessorCount", getLogicalProcessorCount());
-        }
-        if (PropertiesUtil.getBoolean(properties, "hardware.processor.systemSerialNumber")) {
-            json.add("systemSerialNumber", getSystemSerialNumber());
         }
         if (PropertiesUtil.getBoolean(properties, "hardware.processor.vendor")) {
             json.add("vendor", getVendor());

--- a/oshi-json/src/test/java/oshi/json/SystemInfoTest.java
+++ b/oshi-json/src/test/java/oshi/json/SystemInfoTest.java
@@ -156,7 +156,6 @@ public class SystemInfoTest {
         System.out.println(" " + processor.getLogicalProcessorCount() + " logical CPU(s)");
 
         System.out.println("Identifier: " + processor.getIdentifier());
-        System.out.println("Serial Num: " + processor.getSystemSerialNumber());
     }
 
     private static void printMemory(GlobalMemory memory) {

--- a/oshi-json/src/test/java/oshi/json/hardware/CentralProcessorTest.java
+++ b/oshi-json/src/test/java/oshi/json/hardware/CentralProcessorTest.java
@@ -39,6 +39,7 @@ public class CentralProcessorTest {
     /**
      * Test central processor.
      */
+    @SuppressWarnings("deprecation") // serialNumber until removed
     @Test
     public void testCentralProcessor() {
         SystemInfo si = new SystemInfo();


### PR DESCRIPTION
It duplicated ComputerSystem's getSerialNumber method.  See #296 