### PR TITLE
Fixed physical processor count fallback

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -154,6 +154,10 @@ public class LinuxCentralProcessor extends AbstractCentralProcessor {
         if (this.physicalProcessorCount == 0) {
             this.physicalProcessorCount = ids.size();
         }
+        // if at least one logical processor is present, we can safely assume there is at least one physical cpu
+        if (this.physicalProcessorCount == 0 && this.logicalProcessorCount > 0) {
+            this.physicalProcessorCount = 1;
+        }
         // Force at least one processor
         if (this.logicalProcessorCount < 1) {
             LOG.error("Couldn't find logical processor count. Assuming 1.");
@@ -283,7 +287,7 @@ public class LinuxCentralProcessor extends AbstractCentralProcessor {
      * Fetches the ProcessorID from dmidecode (if possible with root
      * permissions), the cpuid command (if installed) or by encoding the
      * stepping, model, family, and feature flags.
-     * 
+     *
      * @param stepping
      * @param model
      * @param family


### PR DESCRIPTION
when logical processors are detected but no physical one, you can
safely assume there is at least one physical cpu.

This case happens on virtual machines where there is in cpuinfo only
"processor" lines.

Example:
processor       : 0
vendor_id       : GenuineIntel
cpu family      : 6
model           : 62
model name      : Intel(R) Xeon(R) CPU E5-2640 v2 @ 2.00GHz
stepping        : 4
microcode       : 0x427
cpu MHz         : 2000.000
cache size      : 20480 KB
fpu             : yes
fpu_exception   : yes
cpuid level     : 13
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge
mca cmov pat pse36 clflush dts mmx fxsr sse sse2 ss syscall nx rdtscp
lm constant_tsc arch_perfmon pebs bts nopl xtopology tsc_reliable
nonstop_tsc aperfmperf pni pclmulqdq ssse3 cx16 sse4_1 sse4_2 popcnt
aes hypervisor lahf_lm ida arat pln pts dtherm
bogomips        : 4000.00
clflush size    : 64
cache_alignment : 64
address sizes   : 40 bits physical, 48 bits virtual
power management: