### PR TITLE
DisksTest minor update

### DIFF
--- a/oshi-core/src/test/java/oshi/hardware/DisksTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/DisksTest.java
@@ -112,7 +112,7 @@ public class DisksTest {
             assertEquals(disk, lastDisk);
             assertEquals(lastDisk, disk);
 
-            lastDisk.setSize(0);
+            lastDisk.setSize(-1);
             assertNotEquals(lastDisk, disk);
             assertNotEquals(disk, lastDisk);
             lastDisk.setSize(disk.getSize());

--- a/oshi-json/src/test/java/oshi/json/hardware/DisksTest.java
+++ b/oshi-json/src/test/java/oshi/json/hardware/DisksTest.java
@@ -112,7 +112,7 @@ public class DisksTest {
             assertEquals(disk, lastDisk);
             assertEquals(lastDisk, disk);
 
-            lastDisk.setSize(0);
+            lastDisk.setSize(-1);
             assertNotEquals(lastDisk, disk);
             assertNotEquals(disk, lastDisk);
             lastDisk.setSize(disk.getSize());


### PR DESCRIPTION
Changed the disk size check to -1 to handle SD card readers that are detected, but not mounted, and therefore have a size of 0.