### PR TITLE
Adding in mapped volume attribute to file system (only implemented in…

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
@@ -35,6 +35,8 @@ public class OSFileStore implements Serializable {
 
     private String volume;
 
+    private String mappedVolume;
+
     private String mount;
 
     private String description;
@@ -54,6 +56,8 @@ public class OSFileStore implements Serializable {
      *            Name of the filestore
      * @param newVolume
      *            Volume of the filestore
+     * @param newMappedVolume
+     *            Mapped Volume of the filestore
      * @param newMount
      *            Mountpoint of the filestore
      * @param newDescription
@@ -67,10 +71,11 @@ public class OSFileStore implements Serializable {
      * @param newTotalSpace
      *            Total bytes
      */
-    public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
+    public OSFileStore(String newName, String newVolume, String newMappedVolume, String newMount, String newDescription, String newType,
             String newUuid, long newUsableSpace, long newTotalSpace) {
         setName(newName);
         setVolume(newVolume);
+        setMappedVolume(newMappedVolume);
         setMount(newMount);
         setDescription(newDescription);
         setType(newType);
@@ -108,6 +113,15 @@ public class OSFileStore implements Serializable {
     }
 
     /**
+     * Mapped Volume of the File System
+     *
+     * @return The mapped volume of the file system
+     */
+    public String getMappedVolume() {
+        return this.mappedVolume;
+    }
+
+    /**
      * Sets the volume of the File System
      *
      * @param value
@@ -115,6 +129,16 @@ public class OSFileStore implements Serializable {
      */
     public void setVolume(String value) {
         this.volume = value;
+    }
+
+    /**
+     * Sets the mapped volume of the File System
+     *
+     * @param value
+     *            The mapped volume
+     */
+    public void setMappedVolume(String value) {
+        this.mappedVolume = value;
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystem.java
@@ -166,7 +166,7 @@ public class MacFileSystem implements FileSystem {
                 }
 
                 // Add to the list
-                fsList.add(new OSFileStore(name, volume, path, description, type, uuid, file.getUsableSpace(),
+                fsList.add(new OSFileStore(name, volume, "", path, description, type, uuid, file.getUsableSpace(),
                         file.getTotalSpace()));
             }
         }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
@@ -151,7 +151,7 @@ public class FreeBsdFileSystem implements FileSystem {
             }
             // Match UUID
             String uuid = MapUtil.getOrDefault(uuidMap, name, "");
-            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, uuid, usableSpace, totalSpace);
+            OSFileStore osStore = new OSFileStore(name, volume, "", path, description, type, uuid, usableSpace, totalSpace);
             fsList.add(osStore);
         }
         return fsList.toArray(new OSFileStore[fsList.size()]);

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
@@ -128,7 +128,7 @@ public class SolarisFileSystem implements FileSystem {
                 description = "Mount Point";
             }
             // No UUID info on Solaris
-            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, "", usableSpace, totalSpace);
+            OSFileStore osStore = new OSFileStore(name, volume, "", path, description, type, "", usableSpace, totalSpace);
             fsList.add(osStore);
         }
         return fsList.toArray(new OSFileStore[fsList.size()]);

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
@@ -140,7 +140,7 @@ public class WindowsFileSystem implements FileSystem {
 
             if (!strMount.isEmpty()) {
                 // Volume is mounted
-                fs.add(new OSFileStore(String.format("%s (%s)", strName, strMount), volume, strMount,
+                fs.add(new OSFileStore(String.format("%s (%s)", strName, strMount), volume, "", strMount,
                         getDriveType(strMount), strFsType, uuid, systemFreeBytes.getValue(), totalBytes.getValue()));
             }
             retVal = Kernel32.INSTANCE.FindNextVolume(hVol, aVolume, BUFSIZE);
@@ -192,7 +192,7 @@ public class WindowsFileSystem implements FileSystem {
             }
 
             fs.add(new OSFileStore(String.format("%s (%s)", description, drives.get("Name").get(i)), volume,
-                    drives.get("Name").get(i) + "\\", getDriveType(drives.get("Name").get(i)),
+                    null, drives.get("Name").get(i) + "\\", getDriveType(drives.get("Name").get(i)),
                     drives.get("FileSystem").get(i), "", free, total));
         }
         return fs;

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -267,10 +267,10 @@ public class SystemInfoTest {
         for (OSFileStore fs : fsArray) {
             long usable = fs.getUsableSpace();
             long total = fs.getTotalSpace();
-            System.out.format(" %s (%s) [%s] %s of %s free (%.1f%%) is %s and is mounted at %s%n", fs.getName(),
+            System.out.format(" %s (%s) [%s] %s of %s free (%.1f%%) is %s [%s] and is mounted at %s%n", fs.getName(),
                     fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,
-                    fs.getVolume(), fs.getMount());
+                    fs.getVolume(), fs.getMappedVolume(), fs.getMount());
         }
     }
 

--- a/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
@@ -51,6 +51,8 @@ public class OSFileStore extends AbstractOshiJsonObject {
      *            Name of the filestore
      * @param newVolume
      *            Volume of the filestore
+     * @param newMappedVolume
+     *            Mapped Volume of the filestore
      * @param newMount
      *            Mountpoint of the filestore
      * @param newDescription
@@ -64,9 +66,9 @@ public class OSFileStore extends AbstractOshiJsonObject {
      * @param newTotalSpace
      *            Total bytes
      */
-    public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
+    public OSFileStore(String newName, String newVolume, String newMappedVolume, String newMount, String newDescription, String newType,
             String newUuid, long newUsableSpace, long newTotalSpace) {
-        this.fileStore = new oshi.software.os.OSFileStore(newName, newVolume, newMount, newDescription, newType,
+        this.fileStore = new oshi.software.os.OSFileStore(newName, newVolume, newMappedVolume, newMount, newDescription, newType,
                 newUuid, newUsableSpace, newTotalSpace);
     }
 
@@ -106,6 +108,25 @@ public class OSFileStore extends AbstractOshiJsonObject {
      */
     public void setVolume(String value) {
         this.fileStore.setVolume(value);
+    }
+
+    /**
+     * Mapped Volume of the File System
+     *
+     * @return The mapped volume of the file system
+     */
+    public String getMappedVolume() {
+        return this.fileStore.getMappedVolume();
+    }
+
+    /**
+     * Sets the mapped volume of the File System
+     *
+     * @param value
+     *            The mapped volume
+     */
+    public void setMappedVolume(String value) {
+        this.fileStore.setMappedVolume(value);
     }
 
     /**

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
@@ -63,8 +63,8 @@ public class FileSystemImpl extends AbstractOshiJsonObject implements FileSystem
         oshi.software.os.OSFileStore[] fs = this.fileSystem.getFileStores();
         OSFileStore[] fileStores = new OSFileStore[fs.length];
         for (int i = 0; i < fs.length; i++) {
-            fileStores[i] = new OSFileStore(fs[i].getName(), fs[i].getVolume(), fs[i].getMount(),
-                    fs[i].getDescription(), fs[i].getType(), fs[i].getUUID(), fs[i].getUsableSpace(),
+            fileStores[i] = new OSFileStore(fs[i].getName(), fs[i].getVolume(), fs[i].getMappedVolume(),
+                    fs[i].getMount(), fs[i].getDescription(), fs[i].getType(), fs[i].getUUID(), fs[i].getUsableSpace(),
                     fs[i].getTotalSpace());
         }
         return fileStores;


### PR DESCRIPTION
Adding in mapped volume attribute to file system (only implemented in linux). This fixes a gap where some filesystems via LVM cannot be linked to drives with the volume or mount values.