### PR TITLE
Adding in logical volume attribute to file system (only implemented i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ================
 * [#336](https://github.com/dblock/oshi/pull/336): Add Process Current Working Directory - [@dbwiddis](https://github.com/dbwiddis).
 * [#357](https://github.com/dblock/oshi/pull/357): Prioritize OpenHardwareMonitor for Windows Sensors - [@dbwiddis](https://github.com/dbwiddis).
+* [#362](https://github.com/oshi/oshi/pull/362): Add logical volume attribute to OSFileStore (Linux support only), providing a place for an alternate volume name. [@darinhoward](https://github.com/darinhoward)
 * Your contribution here.
 
 3.4.2 (3/2/2017)

--- a/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
@@ -115,6 +115,9 @@ public class OSFileStore implements Serializable {
     /**
      * Logical volume of the File System
      *
+     * Provides an optional alternative volume identifier for the file system.
+     * Only supported on Linux, provides symlink value via '/dev/mapper/' (used with LVM file systems).
+     *
      * @return The logical volume of the file system
      */
     public String getLogicalVolume() {

--- a/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
@@ -35,6 +35,8 @@ public class OSFileStore implements Serializable {
 
     private String volume;
 
+    private String logicalVolume;
+
     private String mount;
 
     private String description;
@@ -46,6 +48,8 @@ public class OSFileStore implements Serializable {
     private long usableSpace;
 
     private long totalSpace;
+
+    public OSFileStore() {}
 
     /**
      * Creates an OSFileStore with the specified parameters.
@@ -71,6 +75,7 @@ public class OSFileStore implements Serializable {
             String newUuid, long newUsableSpace, long newTotalSpace) {
         setName(newName);
         setVolume(newVolume);
+        setLogicalVolume("");
         setMount(newMount);
         setDescription(newDescription);
         setType(newType);
@@ -108,6 +113,15 @@ public class OSFileStore implements Serializable {
     }
 
     /**
+     * Logical volume of the File System
+     *
+     * @return The logical volume of the file system
+     */
+    public String getLogicalVolume() {
+        return this.logicalVolume;
+    }
+
+    /**
      * Sets the volume of the File System
      *
      * @param value
@@ -115,6 +129,16 @@ public class OSFileStore implements Serializable {
      */
     public void setVolume(String value) {
         this.volume = value;
+    }
+
+    /**
+     * Sets the logical volume of the File System
+     *
+     * @param value
+     *            The logical volume
+     */
+    public void setLogicalVolume(String value) {
+        this.logicalVolume = value;
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
@@ -20,6 +20,9 @@ package oshi.software.os.linux;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -168,7 +171,24 @@ public class LinuxFileSystem implements FileSystem {
                 description = "Mount Point";
             }
 
+            // Add in logical volume found at /dev/mapper, useful when linking file system with drive.
+            String logicalVolume = "";
+            String volumeMapperDirectory = "/dev/mapper/";
+            Path link = Paths.get(volume);
+            if (Files.exists(link) && Files.isSymbolicLink(link)) {
+                try {
+                    Path slink = Files.readSymbolicLink(link);
+                    Path full = Paths.get(volumeMapperDirectory + slink.toString());
+                    if (Files.exists(full)) {
+                        logicalVolume = full.normalize().toString();
+                    }
+                } catch (IOException e) {
+                    LOG.warn("Couldn't access symbolic path  {}. {}", link, e);
+                }
+            }
+
             OSFileStore osStore = new OSFileStore(name, volume, path, description, type, uuid, usableSpace, totalSpace);
+            osStore.setLogicalVolume(logicalVolume);
             fsList.add(osStore);
         }
 

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -267,7 +267,9 @@ public class SystemInfoTest {
         for (OSFileStore fs : fsArray) {
             long usable = fs.getUsableSpace();
             long total = fs.getTotalSpace();
-            System.out.format(" %s (%s) [%s] %s of %s free (%.1f%%) is %s [%s] and is mounted at %s%n", fs.getName(),
+            System.out.format(" %s (%s) [%s] %s of %s free (%.1f%%) is %s " +
+                            (fs.getLogicalVolume() != null && fs.getLogicalVolume().length() > 0 ? "[%s]" : "%s") +
+                            " and is mounted at %s%n", fs.getName(),
                     fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,
                     fs.getVolume(), fs.getLogicalVolume(), fs.getMount());

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -267,10 +267,10 @@ public class SystemInfoTest {
         for (OSFileStore fs : fsArray) {
             long usable = fs.getUsableSpace();
             long total = fs.getTotalSpace();
-            System.out.format(" %s (%s) [%s] %s of %s free (%.1f%%) is %s and is mounted at %s%n", fs.getName(),
+            System.out.format(" %s (%s) [%s] %s of %s free (%.1f%%) is %s [%s] and is mounted at %s%n", fs.getName(),
                     fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,
-                    fs.getVolume(), fs.getMount());
+                    fs.getVolume(), fs.getLogicalVolume(), fs.getMount());
         }
     }
 

--- a/oshi-core/src/test/java/oshi/software/os/FileSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/FileSystemTest.java
@@ -49,6 +49,7 @@ public class FileSystemTest {
         for (OSFileStore store : fs) {
             assertNotNull(store.getName());
             assertNotNull(store.getVolume());
+            assertNotNull(store.getLogicalVolume());
             assertNotNull(store.getDescription());
             assertNotNull(store.getType());
             assertNotNull(store.getMount());
@@ -58,6 +59,7 @@ public class FileSystemTest {
 
             store.setName("name");
             store.setVolume("volume");
+            store.setLogicalVolume("logical volume");
             store.setDescription("desc");
             store.setType("type");
             store.setMount("mount");
@@ -67,6 +69,7 @@ public class FileSystemTest {
 
             assertEquals("name", store.getName());
             assertEquals("volume", store.getVolume());
+            assertEquals("logical volume", store.getLogicalVolume());
             assertEquals("desc", store.getDescription());
             assertEquals("type", store.getType());
             assertEquals("mount", store.getMount());

--- a/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
@@ -109,6 +109,25 @@ public class OSFileStore extends AbstractOshiJsonObject {
     }
 
     /**
+     * Logical volume of the File System
+     *
+     * @return The logical volume of the file system
+     */
+    public String getLogicalvolume() {
+        return this.fileStore.getLogicalVolume();
+    }
+
+    /**
+     * Sets the logical volume of the File System
+     *
+     * @param value
+     *            The logical volume
+     */
+    public void setLogicalvolume(String value) {
+        this.fileStore.setLogicalVolume(value);
+    }
+
+    /**
      * Mountpoint of the File System
      *
      * @return The mountpoint of the file system

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
@@ -63,9 +63,10 @@ public class FileSystemImpl extends AbstractOshiJsonObject implements FileSystem
         oshi.software.os.OSFileStore[] fs = this.fileSystem.getFileStores();
         OSFileStore[] fileStores = new OSFileStore[fs.length];
         for (int i = 0; i < fs.length; i++) {
-            fileStores[i] = new OSFileStore(fs[i].getName(), fs[i].getVolume(), fs[i].getMount(),
+            fileStores[i] = new OSFileStore(fs[i].getName(), fs[i].getVolume(),fs[i].getMount(),
                     fs[i].getDescription(), fs[i].getType(), fs[i].getUUID(), fs[i].getUsableSpace(),
                     fs[i].getTotalSpace());
+            fileStores[i].setLogicalvolume(fs[i].getLogicalVolume());
         }
         return fileStores;
     }


### PR DESCRIPTION
Adding in logical volume attribute to file system (only implemented in linux). This fixes a gap where some filesystems via LVM cannot be linked to drives with the volume or mount values.