### PR TITLE
Nanoseconds to Milliseconds

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisks.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisks.java
@@ -263,7 +263,7 @@ public class MacDisks implements Disks {
                                 stat = CoreFoundation.INSTANCE.CFDictionaryGetValue(statistics,
                                         CfUtil.getCFString("Total Time (Write)"));
                                 xferTime += CfUtil.cfPointerToLong(stat);
-                                diskStore.setTransferTime(xferTime / 10000L);
+                                diskStore.setTransferTime(xferTime / 1000000L);
 
                                 CfUtil.release(properties);
                             } else {


### PR DESCRIPTION
The conversion from nanoseconds 10 ^ -9 to milliseconds 10 ^ -3 should
be division by 1,000,000 not 10,000.