### PR TITLE
Fixes #395 the forth parameter to proc_listpids() is the size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.5.0 (in progress)
 ================
 * [#392](https://github.com/dblock/oshi/pull/392): Fix NPE for processes terminating before iteration - [@dbwiddis](https://github.com/dbwiddis).
+* [#396](https://github.com/oshi/oshi/pull/396): Fix issue on Mac OS X whereby the buffer size for the call to proc_listpids() was improperly calculated - [@brettwooldridge](https://github.com/brettwooldridge)
 * Your contribution here.
 
 3.4.3 (6/2/17)

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystem.java
@@ -88,9 +88,14 @@ public class MacOperatingSystem extends AbstractOperatingSystem {
     public OSProcess[] getProcesses(int limit, ProcessSort sort) {
         List<OSProcess> procs = new ArrayList<>();
         int[] pids = new int[this.maxProc];
-        int numberOfProcesses = SystemB.INSTANCE.proc_listpids(SystemB.PROC_ALL_PIDS, 0, pids, pids.length)
+        int numberOfProcesses = SystemB.INSTANCE.proc_listpids(SystemB.PROC_ALL_PIDS, 0, pids, pids.length * SystemB.INT_SIZE)
                 / SystemB.INT_SIZE;
         for (int i = 0; i < numberOfProcesses; i++) {
+            // Handle off-by-one bug in proc_listpids where the size returned is: SystemB.INT_SIZE * (pids + 1)
+            if (pids[i] == 0) {
+                continue;
+            }
+
             OSProcess proc = getProcess(pids[i]);
             if (proc != null) {
                 procs.add(proc);


### PR DESCRIPTION
of the buffer into which it can copy, not the number of elements.