### PR TITLE
No warning when PID file is no longer avail

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -119,7 +119,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         long youngestJiffies = 0L;
         String youngestPid = "";
         for (File pid : pids) {
-            List<String> stat = FileUtil.readFile(String.format("/proc/%s/stat", pid.getName()));
+            List<String> stat = FileUtil.readFile(String.format("/proc/%s/stat", pid.getName()), false);
             if (!stat.isEmpty()) {
                 String[] split = ParseUtil.whitespaces.split(stat.get(0));
                 if (split.length >= 22) {


### PR DESCRIPTION
When initializing LinuxOperatingSystem class, a lookup
is done through PID files to find the more recent one
However some processes may have been already killed
between the PID list is obtained and the time the PID
files are accessed
So explicitly say that no error should be printed when
this happens