### PR TITLE
Add validation for uninitialized fields in LinuxOperatingSystem

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -247,9 +247,13 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         proc.setPriority(ParseUtil.parseIntOrDefault(split[17], 0));
         proc.setVirtualSize(ParseUtil.parseLongOrDefault(split[22], 0L));
         proc.setResidentSetSize(ParseUtil.parseLongOrDefault(split[23], 0L) * this.memoryPageSize);
-        proc.setKernelTime(ParseUtil.parseLongOrDefault(split[14], 0L) * 1000L / hz);
-        proc.setUserTime(ParseUtil.parseLongOrDefault(split[13], 0L) * 1000L / hz);
-        proc.setStartTime(bootTime + ParseUtil.parseLongOrDefault(split[21], 0L) * 1000L / hz);
+        if(hz != 0) {
+            proc.setKernelTime(ParseUtil.parseLongOrDefault(split[14], 0L) * 1000L / hz);
+            proc.setUserTime(ParseUtil.parseLongOrDefault(split[13], 0L) * 1000L / hz);
+            proc.setStartTime(bootTime + ParseUtil.parseLongOrDefault(split[21], 0L) * 1000L / hz);
+        } else {
+            LOG.warn("Process info recovery called on improperly initialized Linux OS handler.");
+        }
         proc.setUpTime(now - proc.getStartTime());
         // See man proc for how to parse /proc/[pid]/io
         proc.setBytesRead(ParseUtil.parseLongOrDefault(MapUtil.getOrDefault(io, "read_bytes", ""), 0L));

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -162,6 +162,8 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
 
         // divide jiffies (since boot) by seconds (since boot)
         hz = (long) (youngestJiffies / startTimeSecsSinceBoot + 0.5f);
+        // reset to default if value is invalid
+        if(hz == 0) hz = 1000L;
     }
 
     private static int getMemoryPageSize() {
@@ -247,13 +249,9 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         proc.setPriority(ParseUtil.parseIntOrDefault(split[17], 0));
         proc.setVirtualSize(ParseUtil.parseLongOrDefault(split[22], 0L));
         proc.setResidentSetSize(ParseUtil.parseLongOrDefault(split[23], 0L) * this.memoryPageSize);
-        if(hz != 0) {
-            proc.setKernelTime(ParseUtil.parseLongOrDefault(split[14], 0L) * 1000L / hz);
-            proc.setUserTime(ParseUtil.parseLongOrDefault(split[13], 0L) * 1000L / hz);
-            proc.setStartTime(bootTime + ParseUtil.parseLongOrDefault(split[21], 0L) * 1000L / hz);
-        } else {
-            LOG.warn("Process info recovery called on improperly initialized Linux OS handler.");
-        }
+        proc.setKernelTime(ParseUtil.parseLongOrDefault(split[14], 0L) * 1000L / hz);
+        proc.setUserTime(ParseUtil.parseLongOrDefault(split[13], 0L) * 1000L / hz);
+        proc.setStartTime(bootTime + ParseUtil.parseLongOrDefault(split[21], 0L) * 1000L / hz);
         proc.setUpTime(now - proc.getStartTime());
         // See man proc for how to parse /proc/[pid]/io
         proc.setBytesRead(ParseUtil.parseLongOrDefault(MapUtil.getOrDefault(io, "read_bytes", ""), 0L));


### PR DESCRIPTION
Added validation on use of fields that might be zero after initialization error for the LinuxOperatingSystem class