### PR TITLE
Fix for wrong unsigned int to long widening in WindowsNetworks

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworks.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworks.java
@@ -29,6 +29,7 @@ import oshi.hardware.common.AbstractNetworks;
 import oshi.jna.platform.windows.IPHlpAPI;
 import oshi.jna.platform.windows.IPHlpAPI.MIB_IFROW;
 import oshi.jna.platform.windows.IPHlpAPI.MIB_IFROW2;
+import oshi.util.ParseUtil;
 
 /**
  * @author widdis[at]gmail[dot]com
@@ -80,13 +81,13 @@ public class WindowsNetworks extends AbstractNetworks {
                 return;
             }
             // These are unsigned ints. Widen them to longs.
-            netIF.setBytesSent(ifRow.dwOutOctets & 0xfffffffL);
-            netIF.setBytesRecv(ifRow.dwInOctets & 0xfffffffL);
-            netIF.setPacketsSent(ifRow.dwOutUcastPkts & 0xfffffffL);
-            netIF.setPacketsRecv(ifRow.dwInUcastPkts & 0xfffffffL);
-            netIF.setOutErrors(ifRow.dwOutErrors & 0xfffffffL);
-            netIF.setInErrors(ifRow.dwInErrors & 0xfffffffL);
-            netIF.setSpeed(ifRow.dwSpeed & 0xfffffffL);
+            netIF.setBytesSent(ParseUtil.unsignedIntToLong(ifRow.dwOutOctets));
+            netIF.setBytesRecv(ParseUtil.unsignedIntToLong(ifRow.dwInOctets));
+            netIF.setPacketsSent(ParseUtil.unsignedIntToLong(ifRow.dwOutUcastPkts));
+            netIF.setPacketsRecv(ParseUtil.unsignedIntToLong(ifRow.dwInUcastPkts));
+            netIF.setOutErrors(ParseUtil.unsignedIntToLong(ifRow.dwOutErrors));
+            netIF.setInErrors(ParseUtil.unsignedIntToLong(ifRow.dwInErrors));
+            netIF.setSpeed(ParseUtil.unsignedIntToLong(ifRow.dwSpeed));
         }
         netIF.setTimeStamp(System.currentTimeMillis());
     }

--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -275,6 +275,23 @@ public class ParseUtil {
     }
 
     /**
+     * Convert an unsigned integer to a long value.
+     * The method assumes that all bits in the specified integer value are 'data' bits, including the most-significant bit which
+     * Java normally considers a sign bit. The method must be used only when it is certain that the integer value
+     * represents an unsigned integer, for example when the integer is returned by JNA library in a structure
+     * which holds unsigned integers.
+     *
+     * @param unsignedValue The unsigned integer value to convert.
+     * @return The unsigned integer value widened to a long.
+     */
+    public static long unsignedIntToLong(int unsignedValue) {
+        //use standard Java widening conversion to long which does sign-extension,
+        //then drop any copies of the sign bit, to prevent the value being considered a negative one by Java if it is set
+        long longValue = (long) unsignedValue;
+        return longValue & 0xffffffffL;
+    }
+
+    /**
      * Parses a CIM_DateTime format (from WMI) to milliseconds since the epoch.
      * See https://msdn.microsoft.com/en-us/library/aa387237(v=vs.85).aspx
      *

--- a/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
@@ -135,6 +135,16 @@ public class ParseUtilTest {
     }
 
     /**
+     * Test unsigned int to long
+     */
+    @Test
+    public void testUnsignedIntToLong() {
+        assertEquals(0L, ParseUtil.unsignedIntToLong(0));
+        assertEquals(123L, ParseUtil.unsignedIntToLong(123));
+        assertEquals(4294967295L, ParseUtil.unsignedIntToLong(0xffffffff));
+    }
+
+    /**
      * Test CIM date to long.
      */
     @Test


### PR DESCRIPTION
This fixes a widening conversion issue in `WindowsNetworks` where improper mask of 7 `f` digits instead of 8 is used. This was discussed in #333 and @dbwiddis suggested moving the unsigned int to long conversion to an utility method in `ParseUtil`.