### PR TITLE
Fix Linux OS issues: #440 and #442

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworks.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworks.java
@@ -52,6 +52,7 @@ public class LinuxNetworks extends AbstractNetworks {
         netIF.setPacketsRecv(FileUtil.getUnsignedLongFromFile(rxPacketsPath));
         netIF.setOutErrors(FileUtil.getUnsignedLongFromFile(txErrorsPath));
         netIF.setInErrors(FileUtil.getUnsignedLongFromFile(rxErrorsPath));
-        netIF.setSpeed(FileUtil.getUnsignedLongFromFile(speed));
+        long netSpeed = FileUtil.getUnsignedLongFromFile(speed) * 1024 * 1024;
+        netIF.setSpeed(netSpeed < 0 ?0 :netSpeed);
     }
 }


### PR DESCRIPTION
#440:
Multiplied the network speed by 2^20 to normalize it from MiBs to Bytes.
Also added an overflow check (It shouldn't ever happen though, as that would mean network speeds above 7 Exabytes per second)

#442:
Instead of building a whole new method inside a util class to allow for the correct **/proc/[PID]/stat** file parsing (where the first two delimiters are " (" and ") ", instead of whitespaces), I just used the current file splitting, then concatenated any resulting token that belonged to the **name** field.