### PR TITLE
Fixes for issue 450

### DIFF
--- a/oshi-core/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-core/src/main/java/oshi/util/EdidUtil.java
@@ -211,8 +211,8 @@ public class EdidUtil {
      */
     public static String getTimingDescriptor(byte[] desc) {
         int clock = ByteBuffer.wrap(Arrays.copyOfRange(desc, 0, 2)).order(ByteOrder.LITTLE_ENDIAN).getShort() / 100;
-        int hActive = (desc[2] & 0xff) + (desc[4] & 0xf0) << 4;
-        int vActive = (desc[5] & 0xff) + (desc[7] & 0xf0) << 4;
+        int hActive = (desc[2] & 0xff) + ((desc[4] & 0xf0) << 4);
+        int vActive = (desc[5] & 0xff) + ((desc[7] & 0xf0) << 4);
         return String.format("Clock %dMHz, Active Pixels %dx%d ", clock, hActive, vActive);
     }
 

--- a/oshi-core/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-core/src/main/java/oshi/util/EdidUtil.java
@@ -147,7 +147,7 @@ public class EdidUtil {
      */
     public static boolean isDigital(byte[] edid) {
         // Byte 20 is Video input params
-        return 1 == edid[20] >> 7;
+        return 1 == (edid[20] & 0xff) >> 7;
     }
 
     /**

--- a/oshi-core/src/test/java/oshi/util/EdidUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/EdidUtilTest.java
@@ -19,7 +19,7 @@
 package oshi.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -71,7 +71,7 @@ public class EdidUtilTest {
         assertEquals((byte) 44, EdidUtil.getWeek(EDID));
         assertEquals(2012, EdidUtil.getYear(EDID));
         assertEquals("1.4", EdidUtil.getVersion(EDID));
-        assertFalse(EdidUtil.isDigital(EDID));
+        assertTrue(EdidUtil.isDigital(EDID));
         assertEquals(60, EdidUtil.getHcm(EDID));
         assertEquals(34, EdidUtil.getVcm(EDID));
     }
@@ -86,12 +86,12 @@ public class EdidUtilTest {
             switch (i) {
             case 0:
                 assertEquals(0x565E00A0, type);
-                assertEquals("Clock 241MHz, Active Pixels 2560x3840 ", timing);
+                assertEquals("Clock 241MHz, Active Pixels 2560x1440 ", timing);
                 assertEquals("Field Rate -96-41 Hz vertical, 80-48 Hz horizontal, Max clock: 320 MHz", range);
                 break;
             case 1:
                 assertEquals(0x1A1D0080, type);
-                assertEquals("Clock 74MHz, Active Pixels 1280x3840 ", timing);
+                assertEquals("Clock 74MHz, Active Pixels 1280x720 ", timing);
                 assertEquals("Field Rate -48-28 Hz vertical, 32-64 Hz horizontal, Max clock: -1280 MHz", range);
                 break;
             case 2:


### PR DESCRIPTION
This Pull Request addresses issue #450 
Fixes wrong reading of Digital/Analog detection method EdidUtil#isDigital 
Fixes wrong reading of active resolution detection method EdidUtil#getTimingDescriptor


Before:
```
Checking Displays...
Displays:
 Display 0:
  Manuf. ID=ACB, Product ID=216, Analog, Serial=110ￓ0E, ManufDate=4/2011, EDID v1.3
  53 x 30 cm (20,9 x 11,8 in)
  Preferred Timing: Clock 148MHz, Active Pixels 3840x1920 
  Range Limits: Field Rate 56-76 Hz vertical, 31-83 Hz horizontal, Max clock: 170 MHz
  Monitor Name: S242HL
  Serial Number: LR90D0048570
 Display 1:
  Manuf. ID=DEL, Product ID=a097, Analog, Serial=3MWS, ManufDate=12/2014, EDID v1.4
  48 x 27 cm (18,9 x 10,6 in)
  Preferred Timing: Clock 148MHz, Active Pixels 3840x1920 
  Serial Number: 29C294BO3MWS
  Monitor Name: DELL P2214H
  Range Limits: Field Rate 56-76 Hz vertical, 30-83 Hz horizontal, Max clock: 170 MHz
```

After:
```
Displays:
 Display 0:
  Manuf. ID=ACB, Product ID=216, Digital, Serial=110ￓ0E, ManufDate=4/2011, EDID v1.3
  53 x 30 cm (20,9 x 11,8 in)
  Preferred Timing: Clock 148MHz, Active Pixels 1920x1080 
  Range Limits: Field Rate 56-76 Hz vertical, 31-83 Hz horizontal, Max clock: 170 MHz
  Monitor Name: S242HL
  Serial Number: LR90D0048570
 Display 1:
  Manuf. ID=DEL, Product ID=a097, Digital, Serial=3MWS, ManufDate=12/2014, EDID v1.4
  48 x 27 cm (18,9 x 10,6 in)
  Preferred Timing: Clock 148MHz, Active Pixels 1920x1080 
  Serial Number: 29C294BO3MWS
  Monitor Name: DELL P2214H
  Range Limits: Field Rate 56-76 Hz vertical, 30-83 Hz horizontal, Max clock: 170 MHz
```