### PR TITLE
Shaded jar that includes it's dependencies for Oshi core

### DIFF
--- a/oshi-core-shaded/pom.xml
+++ b/oshi-core-shaded/pom.xml
@@ -72,6 +72,7 @@
                                     <includes>
                                         <include>org.slf4j:slf4j-api:</include>
                                         <include>org.slf4j:slf4j-jdk14:</include>
+                                        <include>org.threeten:threetenbp:</include>
                                     </includes>
                                 </artifactSet>
                             </configuration>

--- a/oshi-core-shaded/pom.xml
+++ b/oshi-core-shaded/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Oshi (https://github.com/oshi/oshi)
+
+    Copyright (c) 2010 - 2017 The Oshi Project Team
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Maintainers:
+    dblock[at]dblock[dot]org
+    widdis[at]gmail[dot]com
+    enrico.bianchi[at]gmail[dot]com
+
+    Contributors:
+    https://github.com/oshi/oshi/graphs/contributors
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.github.oshi</groupId>
+		<artifactId>oshi-parent</artifactId>
+		<version>3.5.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>oshi-core-shaded</artifactId>
+	<packaging>jar</packaging>
+
+	<name>oshi-core-shaded</name>
+
+	<scm>
+		<connection>scm:git:git@github.com:dblock/oshi.git</connection>
+		<developerConnection>scm:git:git@github.com:dblock/oshi.git</developerConnection>
+		<url>https://github.com/dblock/oshi.git</url>
+		<tag>HEAD</tag>
+	</scm>
+
+        <dependencies>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+                <version>1.7.25</version>
+                <scope>runtime</scope>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>oshi-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.1.0</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                            <configuration>
+                                <artifactSet>
+                                    <includes>
+                                        <include>org.slf4j:slf4j-api:</include>
+                                        <include>org.slf4j:slf4j-jdk14:</include>
+                                    </includes>
+                                </artifactSet>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-jdk14</artifactId>
+			<version>1.7.25</version>
+                        <scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.25</version>
 			<scope>test</scope>
@@ -703,6 +709,27 @@
                         <version>8.2</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.slf4j:slf4j-api:</include>
+                                    <include>org.slf4j:slf4j-jdk14:</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
 		<extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
 
 	<modules>
 		<module>oshi-core</module>
+		<module>oshi-core-shaded</module>
 		<module>oshi-json</module>
 		<module>oshi-dist</module>
 	</modules>
@@ -120,12 +121,6 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.25</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<version>1.7.25</version>
-                        <scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -709,27 +704,6 @@
                         <version>8.2</version>
                     </dependency>
                 </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>org.slf4j:slf4j-api:</include>
-                                    <include>org.slf4j:slf4j-jdk14:</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
 		<extensions>


### PR DESCRIPTION
This is also needed for Payara because SLF4J isn't OSGi compliant,
This deploys an additional -shaded JAR that includes the transitive dependencies