### PR TITLE
Use correct type for Linux processor dmidecode

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -263,7 +263,7 @@ public class LinuxCentralProcessor extends AbstractCentralProcessor {
     private String getProcessorID(String stepping, String model, String family, String[] flags) {
         boolean procInfo = false;
         String marker = "Processor Information";
-        for (String checkLine : ExecutingCommand.runNative("dmidecode -t system")) {
+        for (String checkLine : ExecutingCommand.runNative("dmidecode -t 4")) {
             if (!procInfo && checkLine.contains(marker)) {
                 marker = "ID:";
                 procInfo = true;


### PR DESCRIPTION
Fixes bug noted in #430 