### PR TITLE
Added OSFamily enum

### DIFF
--- a/oshi-core/src/main/java/oshi/software/common/AbstractOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/common/AbstractOperatingSystem.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
+import oshi.software.os.OSFamily;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OperatingSystem;
 import oshi.software.os.OperatingSystemVersion;
@@ -36,6 +37,7 @@ public abstract class AbstractOperatingSystem implements OperatingSystem {
     protected String manufacturer;
     protected String family;
     protected OperatingSystemVersion version;
+    protected OSFamily osFamily;
 
     /*
      * Comparators for use in processSort()
@@ -98,6 +100,14 @@ public abstract class AbstractOperatingSystem implements OperatingSystem {
     @Override
     public String getFamily() {
         return this.family;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OSFamily getOSFamily() {
+        return this.osFamily;
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/OSFamily.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSFamily.java
@@ -1,0 +1,6 @@
+package oshi.software.os;
+
+public enum OSFamily {
+    WINDOWS,
+    UNIX
+}

--- a/oshi-core/src/main/java/oshi/software/os/OperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/OperatingSystem.java
@@ -46,6 +46,13 @@ public interface OperatingSystem extends Serializable {
     String getFamily();
 
     /**
+     * Operating system family (enum).
+     *
+     * @return OSFamily.
+     */
+    OSFamily getOSFamily();
+
+    /**
      * Manufacturer.
      *
      * @return String.

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -37,10 +37,7 @@ import com.sun.jna.Pointer;
 import oshi.jna.platform.linux.Libc;
 import oshi.jna.platform.linux.Libc.Sysinfo;
 import oshi.software.common.AbstractOperatingSystem;
-import oshi.software.os.FileSystem;
-import oshi.software.os.NetworkParams;
-import oshi.software.os.OSProcess;
-import oshi.software.os.OSUser;
+import oshi.software.os.*;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.MapUtil;
@@ -86,6 +83,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         // The above call may also populate versionId and codeName
         // to pass to version constructor
         this.version = new LinuxOSVersionInfoEx(this.versionId, this.codeName);
+        this.osFamily = OSFamily.UNIX;
         this.memoryPageSize = getMemoryPageSize();
         init();
     }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystem.java
@@ -40,6 +40,7 @@ import oshi.jna.platform.mac.SystemB.VnodePathInfo;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.NetworkParams;
+import oshi.software.os.OSFamily;
 import oshi.software.os.OSProcess;
 import oshi.util.FormatUtil;
 import oshi.util.ParseUtil;
@@ -69,6 +70,8 @@ public class MacOperatingSystem extends AbstractOperatingSystem {
         this.family = ParseUtil.getFirstIntValue(this.version.getVersion()) == 10
                 && ParseUtil.getNthIntValue(this.version.getVersion(), 2) >= 12 ? "macOS"
                         : System.getProperty("os.name");
+
+        this.osFamily = OSFamily.UNIX;
         // Set max processes
         this.maxProc = SysctlUtil.sysctl("kern.maxproc", 0x1000);
     }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -26,6 +26,7 @@ import oshi.jna.platform.linux.Libc;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.NetworkParams;
+import oshi.software.os.OSFamily;
 import oshi.software.os.OSProcess;
 import oshi.util.ExecutingCommand;
 import oshi.util.LsofUtil;
@@ -45,6 +46,7 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
     public FreeBsdOperatingSystem() {
         this.manufacturer = "Unix/BSD";
         this.family = BsdSysctlUtil.sysctl("kern.ostype", "FreeBSD");
+        this.osFamily = OSFamily.UNIX;
         this.version = new FreeBsdOSVersionInfoEx();
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystem.java
@@ -26,6 +26,7 @@ import oshi.jna.platform.linux.Libc;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.NetworkParams;
+import oshi.software.os.OSFamily;
 import oshi.software.os.OSProcess;
 import oshi.util.ExecutingCommand;
 import oshi.util.LsofUtil;
@@ -45,6 +46,7 @@ public class SolarisOperatingSystem extends AbstractOperatingSystem {
     public SolarisOperatingSystem() {
         this.manufacturer = "Oracle";
         this.family = "SunOS";
+        this.osFamily = OSFamily.UNIX;
         this.version = new SolarisOSVersionInfoEx();
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -54,6 +54,7 @@ import oshi.jna.platform.windows.Wtsapi32.WTS_PROCESS_INFO_EX;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.NetworkParams;
+import oshi.software.os.OSFamily;
 import oshi.software.os.OSProcess;
 import oshi.util.FormatUtil;
 import oshi.util.ParseUtil;
@@ -95,6 +96,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
     public WindowsOperatingSystem() {
         this.manufacturer = "Microsoft";
         this.family = "Windows";
+        this.osFamily = OSFamily.WINDOWS;
         this.version = new WindowsOSVersionInfoEx();
     }
 


### PR DESCRIPTION
Sometimes it's useful to be able to distinguish between Windows and Unix operating systems.  This adds that capability to OSHI.

Feedback welcome, this is an early draft of the interface that includes everything I need for my specific use-case, but I'm happy to add or change anything :)