### PR TITLE
Return Windows Handle Count instead of 0 for File Descriptor counts.

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/FileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/FileSystem.java
@@ -47,10 +47,9 @@ public interface FileSystem extends Serializable {
      * connections. On UNIX-based systems there is a system-wide limit on the
      * number of open file descriptors.
      *
-     * On Windows systems, this method returns 0. While Windows handles are
-     * conceptually similar to file descriptors, they may also refer to a number
-     * of non-I/O related objects, and there does not appear to be a system-wide
-     * limit for open handles.
+     * On Windows systems, this method returns the total number of handles held
+     * by Processes. While Windows handles are conceptually similar to file
+     * descriptors, they may also refer to a number of non-I/O related objects.
      *
      * @return The number of open file descriptors if available, 0 otherwise.
      */
@@ -62,10 +61,10 @@ public interface FileSystem extends Serializable {
      * connections. On UNIX-based systems there is a system-wide limit on the
      * number of open file descriptors.
      *
-     * On Windows systems, this method returns 0. While Windows handles are
+     * On Windows systems, this method returns the theoretical system limit of
+     * 65536. There may be a lower per-process limit. While Windows handles are
      * conceptually similar to file descriptors, they may also refer to a number
-     * of non-I/O related objects, and there does not appear to be a system-wide
-     * limit for open handles.
+     * of non-I/O related objects.
      *
      * @return The maximum number of file descriptors if available, 0 otherwise.
      */

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
@@ -29,6 +29,7 @@ import com.sun.jna.platform.win32.WinNT;
 import oshi.software.os.FileSystem;
 import oshi.software.os.OSFileStore;
 import oshi.util.ParseUtil;
+import oshi.util.platform.windows.PdhUtil;
 import oshi.util.platform.windows.WmiUtil;
 
 /**
@@ -46,6 +47,8 @@ public class WindowsFileSystem implements FileSystem {
     private static final int BUFSIZE = 255;
 
     private static final int SEM_FAILCRITICALERRORS = 0x0001;
+
+    private static final String HANDLE_COUNT_COUNTER = "\\Process(_Total)\\Handle Count";
 
     public WindowsFileSystem() {
         // Set error mode to fail rather than prompt for FLoppy/CD-Rom
@@ -224,11 +227,15 @@ public class WindowsFileSystem implements FileSystem {
 
     @Override
     public long getOpenFileDescriptors() {
-        return 0L;
+        if (!PdhUtil.isCounter(HANDLE_COUNT_COUNTER)) {
+            PdhUtil.addCounter(HANDLE_COUNT_COUNTER);
+        }
+        return PdhUtil.queryCounter(HANDLE_COUNT_COUNTER);
     }
 
     @Override
     public long getMaxFileDescriptors() {
-        return 0L;
+        // There is a theoretical limit of 65,536 user handles per session.
+        return 65536L;
     }
 }


### PR DESCRIPTION
Fixes #461 