### PR TITLE
Correct process information caching and command line retrieval under Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.7.0 (in progress)
 ================
 * Your contribution here.
+* [#527](https://github.com/oshi/oshi/pull/527): Correct process information caching and command line retrieval under Windows - [@dustin-johnson](https://github.com/dustin-johnson).
 
 3.6.0 (6/20/2018)
 ================

--- a/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
@@ -20,9 +20,11 @@ package oshi.software.os;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -36,6 +38,19 @@ import oshi.SystemInfo;
  * Test OS
  */
 public class OperatingSystemTest {
+
+    @Test
+    public void testGetCommandLine() {
+        int processesWithNonEmptyCmdLine = 0;
+
+        for (OSProcess process : new SystemInfo().getOperatingSystem().getProcesses(0, null)) {
+            if (!process.getCommandLine().trim().isEmpty()) {
+                processesWithNonEmptyCmdLine++;
+            }
+        }
+
+        assertTrue(processesWithNonEmptyCmdLine >= 1);
+    }
 
     /**
      * Test operating system


### PR DESCRIPTION
For the most part command line retrieval appears to be broken under Windows. When investigating the issue, I found that process caching also appears a bit suspect, so I tweaked that logic a bit as well. Since the changes are concise, I'll let the diff speak for the details.