### PR TITLE
Fix wrong constructor call in FreeBsdDisplay and LinuxDisplay.

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxDisplay.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxDisplay.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import oshi.hardware.Display;
 import oshi.hardware.common.AbstractDisplay;
-import oshi.hardware.platform.unix.solaris.SolarisDisplay;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
@@ -72,7 +71,7 @@ public class LinuxDisplay extends AbstractDisplay {
                 LOG.debug("Parsed EDID: {}", edidStr);
                 byte[] edid = ParseUtil.hexStringToByteArray(edidStr);
                 if (edid.length >= 128) {
-                    displays.add(new SolarisDisplay(edid));
+                    displays.add(new LinuxDisplay(edid));
                 }
                 sb = null;
             }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdDisplay.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdDisplay.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import oshi.hardware.Display;
 import oshi.hardware.common.AbstractDisplay;
-import oshi.hardware.platform.unix.solaris.SolarisDisplay;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
@@ -72,7 +71,7 @@ public class FreeBsdDisplay extends AbstractDisplay {
                 LOG.debug("Parsed EDID: {}", edidStr);
                 byte[] edid = ParseUtil.hexStringToByteArray(edidStr);
                 if (edid.length >= 128) {
-                    displays.add(new SolarisDisplay(edid));
+                    displays.add(new FreeBsdDisplay(edid));
                 }
                 sb = null;
             }


### PR DESCRIPTION
It seems that the constructor was not updated when copying
SolarisDisplay to FreeBsdDisplay and LinuxDisplay.