### PR TITLE
Switch from formatted to raw WMI data for Temperature.

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensors.java
@@ -87,7 +87,7 @@ public class WindowsSensors implements Sensors {
                         this.wmiTempFilter);
             }
             if (tempK == 0) {
-                this.wmiTempClass = "Win32_PerfFormattedData_Counters_ThermalZoneInformation";
+                this.wmiTempClass = "Win32_PerfRawData_Counters_ThermalZoneInformation";
                 this.wmiTempProperty = "Temperature";
                 this.wmiTempFilter = "WHERE Name LIKE \"%CPU%\"";
                 tempK = WmiUtil.selectUint32From(this.wmiTempNamespace, this.wmiTempClass, this.wmiTempProperty,


### PR DESCRIPTION
Fixes #472.   Formatted data apparently requires multiple background WMI calls which are not needed for a single data point!  Between this change and moving many other WMI calls to Perf counters, Windows responses are pretty snappy.  