### PR TITLE
Cache USB Devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#557](https://github.com/oshi/oshi/pull/557): Localize PDH Counter paths. - [@dbwiddis](https://github.com/dbwiddis).
 * [#561](https://github.com/oshi/oshi/pull/561): Optimize Process CPU sort. - [@dbwiddis](https://github.com/dbwiddis).
 * [#564](https://github.com/oshi/oshi/pull/564): Cache WMI connections. - [@dbwiddis](https://github.com/dbwiddis).
+* [#567](https://github.com/oshi/oshi/pull/567): Cache USB devices. - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here.
 
 3.6.2 (7/10/18)

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/Cfgmgr32.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/Cfgmgr32.java
@@ -20,29 +20,169 @@ package oshi.jna.platform.windows;
 
 import com.sun.jna.Library;
 import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
-import com.sun.jna.ptr.NativeLongByReference;
 import com.sun.jna.win32.W32APIOptions;
 
 /**
- * Windows Cfgmgr32. This class should be considered non-API as it may be
- * removed if/when its code is incorporated into the JNA project.
+ * Windows Cfgmgr32.
  *
  * @author widdis[at]gmail[dot]com
  */
 public interface Cfgmgr32 extends Library {
     Cfgmgr32 INSTANCE = Native.loadLibrary("Cfgmgr32", Cfgmgr32.class, W32APIOptions.DEFAULT_OPTIONS);
 
-    int CM_Get_Parent(IntByReference pdnDevInst, int dnDevInst, int ulFlags);
+    public final static int CR_SUCCESS = 0;
+    public final static int CR_BUFFER_SMALL = 0x0000001A;
 
-    int CM_Get_Child(IntByReference pdnDevInst, int dnDevInst, int ulFlags);
+    public final static int CM_LOCATE_DEVNODE_NORMAL = 0;
+    public final static int CM_LOCATE_DEVNODE_PHANTOM = 1;
+    public final static int CM_LOCATE_DEVNODE_CANCELREMOVE = 2;
+    public final static int CM_LOCATE_DEVNODE_NOVALIDATION = 4;
+    public final static int CM_LOCATE_DEVNODE_BITS = 7;
 
-    int CM_Get_Sibling(IntByReference pdnDevInst, int dnDevInst, int ulFlags);
-
-    int CM_Get_Device_ID(int devInst, char[] Buffer, int BufferLen, int ulFlags);
-
-    int CM_Get_Device_ID_Size(NativeLongByReference pulLen, int dnDevInst, int ulFlags);
-
+    /**
+     * The CM_Locate_DevNode function obtains a device instance handle to the
+     * device node that is associated with a specified device instance ID on the
+     * local machine.
+     * 
+     * @param pdnDevInst
+     *            A pointer to a device instance handle that CM_Locate_DevNode
+     *            retrieves. The retrieved handle is bound to the local machine.
+     * @param pDeviceID
+     *            A pointer to a NULL-terminated string representing a device
+     *            instance ID. If this value is NULL, or if it points to a
+     *            zero-length string, the function retrieves a device instance
+     *            handle to the device at the root of the device tree. *
+     * @param ulFlags
+     *            A variable of ULONG type that supplies one of the following
+     *            flag values that apply if the caller supplies a device
+     *            instance identifier: CM_LOCATE_DEVNODE_NORMAL,
+     *            CM_LOCATE_DEVNODE_PHANTOM, CM_LOCATE_DEVNODE_CANCELREMOVE, or
+     *            CM_LOCATE_DEVNODE_NOVALIDATION
+     * @return If the operation succeeds, CM_Locate_DevNode returns CR_SUCCESS.
+     *         Otherwise, the function returns one of the CR_Xxx error codes
+     *         that are defined in Cfgmgr32.h.
+     * @see <A HREF=
+     *      "https://docs.microsoft.com/en-us/windows/desktop/api/cfgmgr32/nf-cfgmgr32-cm_locate_devnodea">
+     *      CM_Locate_DevNode</A>
+     */
     int CM_Locate_DevNode(IntByReference pdnDevInst, String pDeviceID, int ulFlags);
 
+    /**
+     * The CM_Get_Parent function obtains a device instance handle to the parent
+     * node of a specified device node (devnode) in the local machine's device
+     * tree.
+     * 
+     * @param pdnDevInst
+     *            Caller-supplied pointer to the device instance handle to the
+     *            parent node that this function retrieves. The retrieved handle
+     *            is bound to the local machine.
+     * @param dnDevInst
+     *            Caller-supplied device instance handle that is bound to the
+     *            local machine.
+     * @param ulFlags
+     *            Not used, must be zero.
+     * @return If the operation succeeds, the function returns CR_SUCCESS.
+     *         Otherwise, it returns one of the CR_-prefixed error codes defined
+     *         in Cfgmgr32.h.
+     * @see <A HREF=
+     *      "https://docs.microsoft.com/en-us/windows/desktop/api/cfgmgr32/nf-cfgmgr32-cm_get_parent">
+     *      CM_Get_Parent</A>
+     */
+    int CM_Get_Parent(IntByReference pdnDevInst, int dnDevInst, int ulFlags);
+
+    /**
+     * The CM_Get_Child function is used to retrieve a device instance handle to
+     * the first child node of a specified device node (devnode) in the local
+     * machine's device tree.
+     * 
+     * @param pdnDevInst
+     *            Caller-supplied pointer to the device instance handle to the
+     *            child node that this function retrieves. The retrieved handle
+     *            is bound to the local machine.
+     * @param dnDevInst
+     *            Caller-supplied device instance handle that is bound to the
+     *            local machine.
+     * @param ulFlags
+     *            Not used, must be zero.
+     * @return If the operation succeeds, the function returns CR_SUCCESS.
+     *         Otherwise, it returns one of the CR_-prefixed error codes defined
+     *         in Cfgmgr32.h.
+     * @see <A HREF=
+     *      "https://docs.microsoft.com/en-us/windows/desktop/api/cfgmgr32/nf-cfgmgr32-cm_get_child">
+     *      CM_Get_Child</A>
+     */
+    int CM_Get_Child(IntByReference pdnDevInst, int dnDevInst, int ulFlags);
+
+    /**
+     * The CM_Get_Sibling function obtains a device instance handle to the next
+     * sibling node of a specified device node (devnode) in the local machine's
+     * device tree.
+     * 
+     * @param pdnDevInst
+     *            Caller-supplied pointer to the device instance handle to the
+     *            sibling node that this function retrieves. The retrieved
+     *            handle is bound to the local machine.
+     * @param dnDevInst
+     *            Caller-supplied device instance handle that is bound to the
+     *            local machine.
+     * @param ulFlags
+     *            Not used, must be zero.
+     * @return If the operation succeeds, the function returns CR_SUCCESS.
+     *         Otherwise, it returns one of the CR_-prefixed error codes defined
+     *         in Cfgmgr32.h.
+     * @see <A HREF=
+     *      "https://docs.microsoft.com/en-us/windows/desktop/api/cfgmgr32/nf-cfgmgr32-cm_get_sibling">
+     *      CM_Get_Sibling</A>
+     */
+    int CM_Get_Sibling(IntByReference pdnDevInst, int dnDevInst, int ulFlags);
+
+    /**
+     * The CM_Get_Device_ID function retrieves the device instance ID for a
+     * specified device instance on the local machine.
+     * 
+     * @param devInst
+     *            Caller-supplied device instance handle that is bound to the
+     *            local machine.
+     * @param Buffer
+     *            Address of a buffer to receive a device instance ID string.
+     *            The required buffer size can be obtained by calling
+     *            CM_Get_Device_ID_Size, then incrementing the received value to
+     *            allow room for the string's terminating NULL.
+     * @param BufferLen
+     *            Caller-supplied length, in characters, of the buffer specified
+     *            by Buffer.
+     * @param ulFlags
+     *            Not used, must be zero.
+     * @return If the operation succeeds, the function returns CR_SUCCESS.
+     *         Otherwise, it returns one of the CR_-prefixed error codes defined
+     *         in Cfgmgr32.h.
+     * @see <A HREF=
+     *      "https://docs.microsoft.com/en-us/windows/desktop/api/cfgmgr32/nf-cfgmgr32-cm_get_device_idw">
+     *      CM_Get_Device_ID</A>
+     */
+    int CM_Get_Device_ID(int devInst, Pointer Buffer, int BufferLen, int ulFlags);
+
+    /**
+     * The CM_Get_Device_ID_Size function retrieves the buffer size required to
+     * hold a device instance ID for a device instance on the local machine.
+     * 
+     * @param pulLen
+     *            Receives a value representing the required buffer size, in
+     *            characters.
+     * @param dnDevInst
+     *            Caller-supplied device instance handle that is bound to the
+     *            local machine.
+     * @param ulFlags
+     *            Not used, must be zero.
+     * @return If the operation succeeds, the function returns CR_SUCCESS.
+     *         Otherwise, it returns one of the CR_-prefixed error codes defined
+     *         in Cfgmgr32.h.
+     * @see <A HREF=
+     *      "https://docs.microsoft.com/en-us/windows/desktop/api/cfgmgr32/nf-cfgmgr32-cm_get_device_id_size">
+     *      CM_Get_Device_ID_Size</A>
+     */
+    int CM_Get_Device_ID_Size(IntByReference pulLen, int dnDevInst, int ulFlags);
 }
+

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/Cfgmgr32.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/Cfgmgr32.java
@@ -42,4 +42,7 @@ public interface Cfgmgr32 extends Library {
     int CM_Get_Device_ID(int devInst, char[] Buffer, int BufferLen, int ulFlags);
 
     int CM_Get_Device_ID_Size(NativeLongByReference pulLen, int dnDevInst, int ulFlags);
+
+    int CM_Locate_DevNode(IntByReference pdnDevInst, String pDeviceID, int ulFlags);
+
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/Cfgmgr32Util.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/Cfgmgr32Util.java
@@ -1,0 +1,95 @@
+/**
+ * Oshi (https://github.com/oshi/oshi)
+ *
+ * Copyright (c) 2010 - 2018 The Oshi Project Team
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Maintainers:
+ * dblock[at]dblock[dot]org
+ * widdis[at]gmail[dot]com
+ * enrico.bianchi[at]gmail[dot]com
+ *
+ * Contributors:
+ * https://github.com/oshi/oshi/graphs/contributors
+ */
+package oshi.jna.platform.windows;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.ptr.IntByReference;
+
+/**
+ * Windows Cfgmgr32Util. This class should be considered non-API as it may be
+ * removed if/when its code is incorporated into the JNA project.
+ *
+ * @author widdis[at]gmail[dot]com
+ */
+public abstract class Cfgmgr32Util {
+    @SuppressWarnings("serial")
+    public static class Cfgmgr32Exception extends RuntimeException {
+        private final int errorCode;
+
+        public Cfgmgr32Exception(int errorCode) {
+            this.errorCode = errorCode;
+        }
+
+        public int getErrorCode() {
+            return errorCode;
+        }
+    }
+
+    /**
+     * Utility method to call Cfgmgr32's CM_Get_Device_ID that allocates the
+     * required memory for the Buffer parameter based on the type mapping used,
+     * calls to CM_Get_Device_ID, and returns the received string.
+     * 
+     * @param devInst
+     *            Caller-supplied device instance handle that is bound to the
+     *            local machine.
+     * @return The device instance ID string.
+     * @throws Cfgmgr32Exception
+     */
+    public static String CM_Get_Device_ID(int devInst) throws Cfgmgr32Exception {
+        int charToBytes = Boolean.getBoolean("w32.ascii") ? 1 : Native.WCHAR_SIZE;
+
+        // Get Device ID character count
+        IntByReference pulLen = new IntByReference();
+        int ret = Cfgmgr32.INSTANCE.CM_Get_Device_ID_Size(pulLen, devInst, 0);
+        if (ret != Cfgmgr32.CR_SUCCESS) {
+            throw new Cfgmgr32Exception(ret);
+        }
+
+        // Add one to length to allow null terminator
+        Memory buffer = new Memory((pulLen.getValue() + 1) * charToBytes);
+        // Zero the buffer (including the extra character)
+        buffer.clear();
+        // Fetch the buffer specifying only the current length
+        ret = Cfgmgr32.INSTANCE.CM_Get_Device_ID(devInst, buffer, pulLen.getValue(), 0);
+        // In the unlikely event the device id changes this might not be big
+        // enough, try again. This happens rarely enough one retry should be
+        // sufficient.
+        if (ret == Cfgmgr32.CR_BUFFER_SMALL) {
+            ret = Cfgmgr32.INSTANCE.CM_Get_Device_ID_Size(pulLen, devInst, 0);
+            if (ret != Cfgmgr32.CR_SUCCESS) {
+                throw new Cfgmgr32Exception(ret);
+            }
+            buffer = new Memory((pulLen.getValue() + 1) * charToBytes);
+            buffer.clear();
+            ret = Cfgmgr32.INSTANCE.CM_Get_Device_ID(devInst, buffer, pulLen.getValue(), 0);
+        }
+        // If we still aren't successful throw an exception
+        if (ret != Cfgmgr32.CR_SUCCESS) {
+            throw new Cfgmgr32Exception(ret);
+        }
+        // Convert buffer to Java String
+        if (charToBytes == 1) {
+            return buffer.getString(0);
+        } else {
+            return buffer.getWideString(0);
+        }
+    }
+}

--- a/oshi-core/src/main/java/oshi/util/platform/windows/WmiUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/WmiUtil.java
@@ -631,7 +631,7 @@ public class WmiUtil {
         LOG.debug("Query: {}", sb);
         // Send the query. The flags allow us to return immediately and begin
         // enumerating in the forward direction as results come in.
-        HRESULT hres = svc.ExecQuery(new BSTR("WQL"), new BSTR(sb.toString()),
+        HRESULT hres = svc.ExecQuery(new BSTR("WQL"), new BSTR(sb.toString().replaceAll("\\\\", "\\\\\\\\")),
                 new NativeLong(
                         EnumWbemClassObject.WBEM_FLAG_FORWARD_ONLY | EnumWbemClassObject.WBEM_FLAG_RETURN_IMMEDIATELY),
                 null, pEnumerator);


### PR DESCRIPTION
Fixes #566 . Completely eliminates WMI queries when there's no change in USB devices, reducing average repeat USB device retrieval time from 1.9 seconds to 1.5 milliseconds.