### PR TITLE
OSGi imports missing

### DIFF
--- a/oshi-core-shaded/pom.xml
+++ b/oshi-core-shaded/pom.xml
@@ -101,6 +101,19 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>3.5.0</version>
+				<configuration>
+				<bnd><![CDATA[
+					Export-Package: oshi.*;-noimport:=true
+					Import-Package: com.sun.management.*;optional:=true, !org.slf4j.*, *
+					Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
+					-snapshot: SNAPSHOT
+				]]></bnd>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -275,8 +275,8 @@
 					<version>3.5.0</version>
 					<configuration>
 					<bnd><![CDATA[
-						Export-Package: oshi.*
-                                                Import-Package: com.sun.jna.*
+						Export-Package: oshi.*;-noimport:=true
+						Import-Package: com.sun.management.*;optional:=true, *
 						Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
 						-snapshot: SNAPSHOT
 					]]></bnd>


### PR DESCRIPTION
Due to the change in https://github.com/oshi/oshi/pull/464 by @lprimak some OSGi imports where missing. I have readded them and deliberately made com.sun.management optional because in some OSGi environments this API is not exposed on default. oshi can be used without this package being imported as we can see in https://github.com/oshi/oshi/blob/master/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java there is a graceful fallback when "com.sun.management.OperatingSystemMXBean" can't be used.