### PR TITLE
#632 removeAllCounters() - Null query check

### DIFF
--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
@@ -224,7 +224,9 @@ public class PerfDataUtil {
         }
         // Remove query
         HANDLEByReference query = queryMap.get(queryKey);
-        PDH.PdhCloseQuery(query.getValue());
+        if (query != null) {
+            PDH.PdhCloseQuery(query.getValue());
+        }
         queryMap.remove(queryKey);
         disabledQueries.remove(queryKey);
     }


### PR DESCRIPTION
Make sure that the **PdhQuery** is not null before closing it in the _removeAllCounters()_ method.
This behavior can happen when the **PdhCounter** retrieval fails on the first counter: the **PdhQuery** was never opened/added to the _queryMap_ in the first place.