### PR TITLE
Implement QueueLength metric in HWDiskStore (macOS does not provide t…

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/HWDiskStore.java
+++ b/oshi-core/src/main/java/oshi/hardware/HWDiskStore.java
@@ -54,6 +54,7 @@ public class HWDiskStore implements Serializable, Comparable<HWDiskStore> {
     private long readBytes;
     private long writes;
     private long writeBytes;
+    private long queueLength;
     private long transferTime;
     private HWPartition[] partitions;
     private long timeStamp;
@@ -62,7 +63,7 @@ public class HWDiskStore implements Serializable, Comparable<HWDiskStore> {
      * Create an object with empty/default values
      */
     public HWDiskStore() {
-        this("", "", "", 0L, 0L, 0L, 0L, 0L, 0L, new HWPartition[0], 0L);
+        this("", "", "", 0L, 0L, 0L, 0L, 0L, 0L, 0L, new HWPartition[0], 0L);
     }
 
     /**
@@ -84,6 +85,8 @@ public class HWDiskStore implements Serializable, Comparable<HWDiskStore> {
      *            Number of writes to the disk
      * @param writeBytes
      *            Number of bytes written to the disk
+     * @param queueLength
+     *            Number of I/O operations currently in progress
      * @param transferTime
      *            milliseconds spent reading or writing to the disk
      * @param partitions
@@ -92,7 +95,7 @@ public class HWDiskStore implements Serializable, Comparable<HWDiskStore> {
      *            milliseconds since the epoch
      */
     public HWDiskStore(String name, String model, String serial, long size, long reads, long readBytes, long writes,
-            long writeBytes, long transferTime, HWPartition[] partitions, long timeStamp) {
+            long writeBytes, long queueLength, long transferTime, HWPartition[] partitions, long timeStamp) {
         setName(name);
         setModel(model);
         setSerial(serial);
@@ -101,6 +104,7 @@ public class HWDiskStore implements Serializable, Comparable<HWDiskStore> {
         setReadBytes(readBytes);
         setWrites(writes);
         setWriteBytes(writeBytes);
+        setQueueLength(queueLength);
         setTransferTime(transferTime);
         setPartitions(partitions);
         setTimeStamp(timeStamp);
@@ -198,6 +202,13 @@ public class HWDiskStore implements Serializable, Comparable<HWDiskStore> {
     }
 
     /**
+     * @return the length of the disk queue (#I/O's in progress)
+     */
+    public long getQueueLength() {
+        return this.queueLength;
+    }
+
+    /**
      * @return the milliseconds spent reading or writing
      */
     public long getTransferTime() {
@@ -281,6 +292,12 @@ public class HWDiskStore implements Serializable, Comparable<HWDiskStore> {
     public void setWriteBytes(long writeBytes) {
         this.writeBytes = writeBytes;
     }
+
+    /**
+     * @param queueLength
+     *            the length of the disk queue (#I/O's in progress) to set
+     */
+    public void setQueueLength(long queueLength) { this.queueLength = queueLength; }
 
     /**
      * @param transferTime

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxDisks.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxDisks.java
@@ -55,7 +55,7 @@ public class LinuxDisks implements Disks {
     enum UdevStat {
         // The parsing implementation in ParseUtil requires these to be declared
         // in increasing order. Use 0-ordered index here
-        READS(0), READ_BYTES(2), WRITES(4), WRITE_BYTES(6), ACTIVE_MS(9);
+        READS(0), READ_BYTES(2), WRITES(4), WRITE_BYTES(6), QUEUE_LENGTH(8), ACTIVE_MS(9);
 
         private int order;
 
@@ -210,6 +210,7 @@ public class LinuxDisks implements Disks {
         store.setReadBytes(devstatArray[UdevStat.READ_BYTES.ordinal()] * SECTORSIZE);
         store.setWrites(devstatArray[UdevStat.WRITES.ordinal()]);
         store.setWriteBytes(devstatArray[UdevStat.WRITE_BYTES.ordinal()] * SECTORSIZE);
+        store.setQueueLength(devstatArray[UdevStat.QUEUE_LENGTH.ordinal()]);
         store.setTransferTime(devstatArray[UdevStat.ACTIVE_MS.ordinal()]);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisks.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisks.java
@@ -378,7 +378,7 @@ public class MacDisks implements Disks {
                 if (size <= 0) {
                     continue;
                 }
-                HWDiskStore diskStore = new HWDiskStore(bsdName, model.trim(), serial.trim(), size, 0L, 0L, 0L, 0L, 0L,
+                HWDiskStore diskStore = new HWDiskStore(bsdName, model.trim(), serial.trim(), size, 0L, 0L, 0L, 0L, 0L, 0L,
                         new HWPartition[0], 0L);
 
                 updateDiskStats(diskStore, session);

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdDisks.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdDisks.java
@@ -66,6 +66,7 @@ public class FreeBsdDisks implements Disks {
             // In KB
             diskStore.setReadBytes((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024));
             diskStore.setWriteBytes((long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024));
+            diskStore.setQueueLength((long) (ParseUtil.parseDoubleOrDefault(split[5], 0d)));
             // In seconds, multiply for ms
             diskStore.setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
             diskStore.setTimeStamp(timeStamp);
@@ -106,6 +107,7 @@ public class FreeBsdDisks implements Disks {
             // In KB
             store.setReadBytes((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024));
             store.setWriteBytes((long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024));
+            store.setQueueLength((long) (ParseUtil.parseDoubleOrDefault(split[5], 0d)));
             // In seconds, multiply for ms
             store.setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
             store.setTimeStamp(timeStamp);

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisDisks.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisDisks.java
@@ -52,6 +52,7 @@ public class SolarisDisks implements Disks {
             diskStore.setWrites(data.writes);
             diskStore.setReadBytes(data.nread);
             diskStore.setWriteBytes(data.nwritten);
+            diskStore.setQueueLength(data.wcnt+data.rcnt);
             // rtime and snaptime are nanoseconds, convert to millis
             diskStore.setTransferTime(data.rtime / 1000000L);
             diskStore.setTimeStamp(ksp.ks_snaptime / 1000000L);

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsDisks.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsDisks.java
@@ -64,6 +64,7 @@ public class WindowsDisks implements Disks {
     private static Map<String, Long> readByteMap = new HashMap<>();
     private static Map<String, Long> writeMap = new HashMap<>();
     private static Map<String, Long> writeByteMap = new HashMap<>();
+    private static Map<String, Long> queueLengthMap = new HashMap<>();
     private static Map<String, Long> xferTimeMap = new HashMap<>();
     private static Map<String, Long> timeStampMap = new HashMap<>();
     private static Map<String, List<String>> driveToPartitionMap = new HashMap<>();
@@ -107,7 +108,7 @@ public class WindowsDisks implements Disks {
      * For disk query
      */
     enum PhysicalDiskProperty {
-        NAME, DISKREADSPERSEC, DISKREADBYTESPERSEC, DISKWRITESPERSEC, DISKWRITEBYTESPERSEC, PERCENTDISKTIME, TIMESTAMP_SYS100NS;
+        NAME, DISKREADSPERSEC, DISKREADBYTESPERSEC, DISKWRITESPERSEC, DISKWRITEBYTESPERSEC, CURRENTDISKQUEUELENGTH, PERCENTDISKTIME, TIMESTAMP_SYS100NS;
     }
 
     // Only one of counter or query will be used
@@ -115,6 +116,7 @@ public class WindowsDisks implements Disks {
     private static Map<String, PerfCounter> diskReadBytesCounterMap = new HashMap<>();
     private static Map<String, PerfCounter> diskWritesCounterMap = new HashMap<>();
     private static Map<String, PerfCounter> diskWriteBytesCounterMap = new HashMap<>();
+    private static Map<String, PerfCounter> diskQueueLengthCounterMap = new HashMap<>();
     private static Map<String, PerfCounter> diskXferTimeCounterMap = new HashMap<>();
 
     private static WmiQuery<PhysicalDiskProperty> physicalDiskQuery = null;
@@ -154,6 +156,12 @@ public class WindowsDisks implements Disks {
                         throw new PdhException(0);
                     }
 
+                    counter = PerfDataUtil.createCounter(PHYSICAL_DISK, instance, "Current Disk Queue Length");
+                    diskQueueLengthCounterMap.put(instance, counter);
+                    if (!PerfDataUtil.addCounterToQuery(counter)) {
+                        throw new PdhException(0);
+                    }
+
                     counter = PerfDataUtil.createCounter(PHYSICAL_DISK, instance, "% Disk Time");
                     diskXferTimeCounterMap.put(instance, counter);
                     if (!PerfDataUtil.addCounterToQuery(counter)) {
@@ -171,6 +179,7 @@ public class WindowsDisks implements Disks {
             diskReadBytesCounterMap = null;
             diskWritesCounterMap = null;
             diskWriteBytesCounterMap = null;
+            diskQueueLengthCounterMap = null;
             diskXferTimeCounterMap = null;
 
             physicalDiskQuery = new WmiQuery<>("Win32_PerfRawData_PerfDisk_PhysicalDisk", PhysicalDiskProperty.class);
@@ -205,6 +214,7 @@ public class WindowsDisks implements Disks {
             diskStore.setReadBytes(MapUtil.getOrDefault(readByteMap, index, 0L));
             diskStore.setWrites(MapUtil.getOrDefault(writeMap, index, 0L));
             diskStore.setWriteBytes(MapUtil.getOrDefault(writeByteMap, index, 0L));
+            diskStore.setTransferTime(MapUtil.getOrDefault(queueLengthMap, index, 0L));
             diskStore.setTransferTime(MapUtil.getOrDefault(xferTimeMap, index, 0L));
             diskStore.setTimeStamp(MapUtil.getOrDefault(timeStampMap, index, 0L));
             return true;
@@ -235,6 +245,7 @@ public class WindowsDisks implements Disks {
             ds.setReadBytes(MapUtil.getOrDefault(readByteMap, index, 0L));
             ds.setWrites(MapUtil.getOrDefault(writeMap, index, 0L));
             ds.setWriteBytes(MapUtil.getOrDefault(writeByteMap, index, 0L));
+            ds.setQueueLength(MapUtil.getOrDefault(queueLengthMap, index, 0L));
             ds.setTransferTime(MapUtil.getOrDefault(xferTimeMap, index, 0L));
             ds.setTimeStamp(MapUtil.getOrDefault(timeStampMap, index, 0L));
             ds.setSize(WmiUtil.getUint64(vals, DiskDriveProperty.SIZE, i));
@@ -269,6 +280,7 @@ public class WindowsDisks implements Disks {
             readByteMap.clear();
             writeMap.clear();
             writeByteMap.clear();
+            queueLengthMap.clear();
             xferTimeMap.clear();
             timeStampMap.clear();
         }
@@ -284,6 +296,7 @@ public class WindowsDisks implements Disks {
                 readByteMap.put(name, WmiUtil.getUint64(result, PhysicalDiskProperty.DISKREADBYTESPERSEC, i));
                 writeMap.put(name, WmiUtil.getUint32asLong(result, PhysicalDiskProperty.DISKWRITESPERSEC, i));
                 writeByteMap.put(name, WmiUtil.getUint64(result, PhysicalDiskProperty.DISKWRITEBYTESPERSEC, i));
+                queueLengthMap.put(name, WmiUtil.getUint64(result, PhysicalDiskProperty.CURRENTDISKQUEUELENGTH, i));
                 xferTimeMap.put(name, WmiUtil.getUint64(result, PhysicalDiskProperty.PERCENTDISKTIME, i) / 10000L);
                 long timestamp = WmiUtil.getUint64(result, PhysicalDiskProperty.TIMESTAMP_SYS100NS, i);
                 timeStampMap.put(name,
@@ -340,6 +353,14 @@ public class WindowsDisks implements Disks {
                 }
             }
 
+            if (!diskQueueLengthCounterMap.containsKey(instance)) {
+                PerfCounter counter = PerfDataUtil.createCounter(PHYSICAL_DISK, instance, "Current Disk Queue Length");
+                diskQueueLengthCounterMap.put(instance, counter);
+                if (!PerfDataUtil.addCounterToQuery(counter)) {
+                    diskQueueLengthCounterMap.remove(instance);
+                }
+            }
+
             if (!diskXferTimeCounterMap.containsKey(instance)) {
                 PerfCounter counter = PerfDataUtil.createCounter(PHYSICAL_DISK, instance, "% Disk Time");
                 diskXferTimeCounterMap.put(instance, counter);
@@ -360,6 +381,7 @@ public class WindowsDisks implements Disks {
             readByteMap.put(name, PerfDataUtil.queryCounter(diskReadBytesCounterMap.get(instance)));
             writeMap.put(name, PerfDataUtil.queryCounter(diskWritesCounterMap.get(instance)));
             writeByteMap.put(name, PerfDataUtil.queryCounter(diskWriteBytesCounterMap.get(instance)));
+            queueLengthMap.put(name, PerfDataUtil.queryCounter(diskQueueLengthCounterMap.get(instance)));
             xferTimeMap.put(name, PerfDataUtil.queryCounter(diskXferTimeCounterMap.get(instance)) / 10000L);
             timeStampMap.put(name, timestamp);
         }
@@ -375,6 +397,9 @@ public class WindowsDisks implements Disks {
             PerfDataUtil.removeCounterFromQuery(counter);
 
             counter = diskWriteBytesCounterMap.get(instance);
+            PerfDataUtil.removeCounterFromQuery(counter);
+
+            counter = diskQueueLengthCounterMap.get(instance);
             PerfDataUtil.removeCounterFromQuery(counter);
 
             counter = diskXferTimeCounterMap.get(instance);

--- a/oshi-json/src/main/java/oshi/json/hardware/HWDiskStore.java
+++ b/oshi-json/src/main/java/oshi/json/hardware/HWDiskStore.java
@@ -73,6 +73,8 @@ public class HWDiskStore extends AbstractOshiJsonObject implements Comparable<HW
      *            Number of writes to the disk
      * @param writeBytes
      *            Number of bytes written to the disk
+     * @param queueLength
+     *            Number of I/O outstanding operations (waiting + running)
      * @param transferTime
      *            milliseconds spent reading or writing to the disk
      * @param partitions
@@ -81,7 +83,7 @@ public class HWDiskStore extends AbstractOshiJsonObject implements Comparable<HW
      *            milliseconds since the epoch
      */
     public HWDiskStore(String name, String model, String serial, long size, long reads, long readBytes, long writes,
-            long writeBytes, long transferTime, HWPartition[] partitions, long timeStamp) {
+            long writeBytes, long queueLength, long transferTime, HWPartition[] partitions, long timeStamp) {
         oshi.hardware.HWPartition[] parts = new oshi.hardware.HWPartition[partitions.length];
         for (int i = 0; i < partitions.length; i++) {
             parts[i] = new oshi.hardware.HWPartition(partitions[i].getIdentification(), partitions[i].getName(),
@@ -89,14 +91,14 @@ public class HWDiskStore extends AbstractOshiJsonObject implements Comparable<HW
                     partitions[i].getMinor(), partitions[i].getMountPoint());
         }
         this.hwDiskStore = new oshi.hardware.HWDiskStore(name, model, serial, size, reads, readBytes, writes,
-                writeBytes, transferTime, parts, timeStamp);
+                writeBytes, queueLength, transferTime, parts, timeStamp);
     }
 
     /**
      * Create a new HWDiskStore with default/empty values
      */
     public HWDiskStore() {
-        this("", "", "", 0L, 0L, 0L, 0L, 0L, 0L, new HWPartition[0], 0L);
+        this("", "", "", 0L, 0L, 0L, 0L, 0L, 0L, 0L, new HWPartition[0], 0L);
     }
 
     /**
@@ -185,6 +187,13 @@ public class HWDiskStore extends AbstractOshiJsonObject implements Comparable<HW
      */
     public long getWriteBytes() {
         return this.hwDiskStore.getWriteBytes();
+    }
+
+    /**
+     * @return the length of the disk queue (#I/O's in progress)
+     */
+    public long getQueueLength() {
+        return this.hwDiskStore.getQueueLength();
     }
 
     /**
@@ -281,6 +290,12 @@ public class HWDiskStore extends AbstractOshiJsonObject implements Comparable<HW
     }
 
     /**
+     * @param queueLength
+     *            the length of the disk queue (#I/O's in progress) to set
+     */
+    public void setQueueLength(long queueLength) { this.hwDiskStore.setQueueLength(queueLength); }
+
+    /**
      * @param transferTime
      *            milliseconds spent reading or writing to set
      */
@@ -340,7 +355,10 @@ public class HWDiskStore extends AbstractOshiJsonObject implements Comparable<HW
         if (PropertiesUtil.getBoolean(properties, "hardware.disks.writeBytes")) {
             json.add("writeBytes", this.hwDiskStore.getWriteBytes());
         }
-        if (PropertiesUtil.getBoolean(properties, "hardware.disks.writeBytes")) {
+        if (PropertiesUtil.getBoolean(properties, "hardware.disks.queueLength")) {
+            json.add("queueLength", this.hwDiskStore.getQueueLength());
+        }
+        if (PropertiesUtil.getBoolean(properties, "hardware.disks.transferTime")) {
             json.add("transferTime", this.hwDiskStore.getTransferTime());
         }
         if (PropertiesUtil.getBoolean(properties, "hardware.disks.partitions")) {

--- a/oshi-json/src/main/java/oshi/json/hardware/impl/HardwareAbstractionLayerImpl.java
+++ b/oshi-json/src/main/java/oshi/json/hardware/impl/HardwareAbstractionLayerImpl.java
@@ -133,7 +133,7 @@ public class HardwareAbstractionLayerImpl extends AbstractOshiJsonObject impleme
             }
             diskStores[i] = new HWDiskStore(ds[i].getName(), ds[i].getModel(), ds[i].getSerial(), ds[i].getSize(),
                     ds[i].getReads(), ds[i].getReadBytes(), ds[i].getWrites(), ds[i].getWriteBytes(),
-                    ds[i].getTransferTime(), partitions, ds[i].getTimeStamp());
+                    ds[i].getQueueLength(), ds[i].getTransferTime(), partitions, ds[i].getTimeStamp());
         }
         return diskStores;
     }

--- a/oshi-json/src/test/java/oshi/json/hardware/DisksTest.java
+++ b/oshi-json/src/test/java/oshi/json/hardware/DisksTest.java
@@ -75,6 +75,7 @@ public class DisksTest {
             assertTrue(disk.getReadBytes() >= 0);
             assertTrue(disk.getWrites() >= 0);
             assertTrue(disk.getWriteBytes() >= 0);
+            assertTrue(disk.getQueueLength() >= 0);
             assertTrue(disk.getTransferTime() >= 0);
             assertTrue(disk.getTimeStamp() >= 0);
 
@@ -132,7 +133,8 @@ public class DisksTest {
             disk.setReadBytes(789L);
             disk.setWrites(101112L);
             disk.setWriteBytes(131415L);
-            disk.setTransferTime(161718L);
+            disk.setQueueLength(161718L);
+            disk.setTransferTime(192021L);
             disk.setTimeStamp(timeStamp);
 
             assertEquals("name", disk.getName());
@@ -143,7 +145,8 @@ public class DisksTest {
             assertEquals(789L, disk.getReadBytes());
             assertEquals(101112L, disk.getWrites());
             assertEquals(131415L, disk.getWriteBytes());
-            assertEquals(161718L, disk.getTransferTime());
+            assertEquals(161718L, disk.getQueueLength());
+            assertEquals(192021L, disk.getTransferTime());
             assertEquals(timeStamp, disk.getTimeStamp());
 
             for (HWPartition partition : disk.getPartitions()) {


### PR DESCRIPTION
…hat value -> always 0)

The following values are returned. They only show the current/instantaneous queue length:

- Linux (see linux/Documentation/iostat.txt):

> Field  9 -- # of I/Os currently in progress
>     The only field that should go to zero. Incremented as requests are
>     given to appropriate struct request_queue and decremented as they finish.

- Solaris (see kstat in JNA or man(3) kstat) - sum of wcnt + rcnt

> uint_t	  wcnt;		    /* count of	elements in wait state */
> uint_t	  rcnt;		    /* count of	elements in run	state */
 
- FreeBSD (see man iostat -Ix):

> qlen	   transactions	queue length

- Windows (see [https://blogs.technet.microsoft.com/askcore/2012/03/16/windows-performance-monitor-disk-counters-explained/](https://blogs.technet.microsoft.com/askcore/2012/03/16/windows-performance-monitor-disk-counters-explained/):

> Current Disk Queue Length
> Current Disk Queue Length is a direct measurement of the disk queue present at the time of the sampling. 

- on MacOS this metric is not defined or at least I could not find it