### PR TITLE
Add free/total inode counts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ after_success:
       ./mvnw clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=df16219a00545aae71f880423a6f23191330744f;
     fi
 
+after_failure:
+  - cat /home/travis/build/oshi/oshi/oshi-core/target/surefire-reports/*.dumpstream
+
 env:
   global:
    # COVERITY_SCAN_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ after_success:
       ./mvnw clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=df16219a00545aae71f880423a6f23191330744f;
     fi
 
-after_failure:
-  - cat /home/travis/build/oshi/oshi/oshi-core/target/surefire-reports/*.dumpstream
-
 env:
   global:
    # COVERITY_SCAN_TOKEN
@@ -32,12 +29,8 @@ addons:
 matrix:
   include:  
     - os: linux
-      jdk: oraclejdk11
-    - os: linux
-      jdk: openjdk10
-      env: AFTER_SUCCESS="jacoco"
-    - os: linux
       jdk: oraclejdk8
+      env: AFTER_SUCCESS="jacoco"
     - os: osx
       osx_image: xcode10  #jdk10
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ addons:
 matrix:
   include:  
     - os: linux
-      jdk: oraclejdk10
-      env: AFTER_SUCCESS="jacoco"
+      jdk: oraclejdk11
     - os: linux
       jdk: openjdk10
+      env: AFTER_SUCCESS="jacoco"
     - os: linux
       jdk: oraclejdk8
     - os: osx
-      osx_image: xcode6.4
+      osx_image: xcode10  #jdk10
     - os: osx
-      osx_image: xcode9.4.1
+      osx_image: xcode9.3 #jdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ addons:
 matrix:
   include:  
     - os: linux
+      jdk: oraclejdk10
+      env: AFTER_SUCCESS="jacoco"
+    - os: linux
       jdk: openjdk10
     - os: linux
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ addons:
 matrix:
   include:  
     - os: linux
-      jdk: oraclejdk10
-      env: AFTER_SUCCESS="jacoco"
-    - os: linux
       jdk: openjdk10
     - os: linux
       jdk: oraclejdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.10.0 (in progress)
 ================
 * [#656](https://github.com/oshi/oshi/pull/656): JNA 5.0.0. - [@dbwiddis](https://github.com/dbwiddis).
+* [#659](https://github.com/oshi/oshi/pull/659): Add free/total inode counts. - [@Space2Man](https://github.com/Space2Man).
 * Your contribution here.
 
 3.9.1 (10/14/18)

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/Libc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/Libc.java
@@ -20,13 +20,13 @@ package oshi.jna.platform.linux;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
 import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Structure;
+import com.sun.jna.Structure.FieldOrder;
 
 import oshi.jna.platform.unix.CLibrary;
 
@@ -40,9 +40,13 @@ public interface Libc extends CLibrary {
 
     Libc INSTANCE = Native.load("c", Libc.class);
 
+    @FieldOrder({ "uptime", "loads", "totalram", "freeram", "sharedram", "bufferram", "totalswap", "freeswap", "procs",
+            "totalhigh", "freehigh", "mem_unit", "_f" })
     class Sysinfo extends Structure {
+        private static final int PADDING_SIZE = 20 - 2 * NativeLong.SIZE - 4;
+
         public NativeLong uptime; // Seconds since boot
-        // 1, 5, and 15 minute load averages
+        // 1, 5, and 15 minute load averages, divide by 2^16
         public NativeLong[] loads = new NativeLong[3];
         public NativeLong totalram; // Total usable main memory size
         public NativeLong freeram; // Available memory size
@@ -54,15 +58,45 @@ public interface Libc extends CLibrary {
         public NativeLong totalhigh; // Total high memory size
         public NativeLong freehigh; // Available high memory size
         public int mem_unit; // Memory unit size in bytes
-        public byte[] _f = new byte[8]; // Won't be written for 64-bit systems
+        // Padding to 64 bytes
+        public byte[] _f = new byte[PADDING_SIZE];
+
+        /*
+         * getFieldList and getFieldOrder are overridden because PADDING_SIZE
+         * might be 0 - that is a GCC only extension and not supported by JNA
+         * 
+         * The dummy field at the end of the structure is just padding and so if
+         * the field is the zero length array, it is stripped from the fields
+         * and field order.
+         */
+        @Override
+        protected List<Field> getFieldList() {
+            List<Field> fields = new ArrayList<>(super.getFieldList());
+            if (PADDING_SIZE == 0) {
+                Iterator<Field> fieldIterator = fields.iterator();
+                while (fieldIterator.hasNext()) {
+                    Field field = fieldIterator.next();
+                    if ("_f".equals(field.getName())) {
+                        fieldIterator.remove();
+                    }
+                }
+            }
+            return fields;
+        }
 
         @Override
         protected List<String> getFieldOrder() {
-            return Arrays.asList(new String[] { "uptime", "loads", "totalram", "freeram", "sharedram", "bufferram",
-                    "totalswap", "freeswap", "procs", "totalhigh", "freehigh", "mem_unit", "_f" });
+            List<String> fieldOrder = new ArrayList<>(super.getFieldOrder());
+            if (PADDING_SIZE == 0) {
+                fieldOrder.remove("_f");
+            }
+            return fieldOrder;
         }
     }
 
+    @FieldOrder({ "fsBlockSize", "fsFragmentSize", "fsSizeInBlocks", "fsBlocksFree", "fsBlocksFreeUnpriv",
+            "fsTotalInodeCount", "fsFreeInodeCount", "fsFreeInodeCountUnpriv", "fsId", "_fPad32bit", "fsMountFlags",
+            "fsMaxFilenameLength", "_fSpare" })
     class Statvfs extends Structure {
         private static final int PADDING_SIZE = 8 / NativeLong.SIZE - 1;
 
@@ -75,7 +109,7 @@ public interface Libc extends CLibrary {
         public NativeLong fsFreeInodeCount;
         public NativeLong fsFreeInodeCountUnpriv;
         public NativeLong fsId;
-        public int[] _fPad32bit = new int[PADDING_SIZE];  // Won't be written for 64-bit systems
+        public int[] _fPad32bit = new int[PADDING_SIZE]; // 0 on 64-bit systems
         public NativeLong fsMountFlags;
         public NativeLong fsMaxFilenameLength;
         public int[] _fSpare = new int[6];
@@ -95,22 +129,36 @@ public interface Libc extends CLibrary {
             return fields;
         }
 
+        @Override
         protected List<String> getFieldOrder() {
+            List<String> fieldOrder = new ArrayList<>(super.getFieldOrder());
             if (PADDING_SIZE == 0) {
-                return Arrays.asList(new String[]{"fsBlockSize", "fsFragmentSize", "fsSizeInBlocks", "fsBlocksFree",
-                        "fsBlocksFreeUnpriv", "fsTotalInodeCount", "fsFreeInodeCount", "fsFreeInodeCountUnpriv",
-                        "fsId", "fsMountFlags", "fsMaxFilenameLength", "_fSpare"});
-            } else {
-                return Arrays.asList(new String[]{"fsBlockSize", "fsFragmentSize", "fsSizeInBlocks", "fsBlocksFree",
-                        "fsBlocksFreeUnpriv", "fsTotalInodeCount", "fsFreeInodeCount", "fsFreeInodeCountUnpriv",
-                        "fsId", "_fPad32bit", "fsMountFlags", "fsMaxFilenameLength", "_fSpare"});
+                fieldOrder.remove("_fPad32bit");
             }
+            return fieldOrder;
         }
-
     }
 
+    /**
+     * sysinfo() provides a simple way of getting overall system statistics.
+     * This is more portable than reading /dev/kmem.
+     * 
+     * @param info
+     *            A Sysinfo structure which will be populated
+     * @return On success, zero is returned. On error, -1 is returned, and errno
+     *         is set appropriately.
+     */
     int sysinfo(Sysinfo info);
 
+    /**
+     * The function statvfs() returns information about a mounted filesystem.
+     * 
+     * @param path
+     *            the pathname of any file within the mounted filesystem.
+     * @param buf
+     *            a pointer to a statvfs structure
+     * @return On success, zero is returned. On error, -1 is returned, and errno
+     *         is set appropriately.
+     */
     int statvfs(String path, Statvfs buf);
-
 }

--- a/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
@@ -49,9 +49,9 @@ public class OSFileStore implements Serializable {
 
     private long totalSpace;
 
-    private long usableFiles;
+    private long usableInodes;
 
-    private long totalFiles;
+    private long totalInodes;
 
     public OSFileStore() {
     }
@@ -75,13 +75,13 @@ public class OSFileStore implements Serializable {
      *            Available/usable bytes
      * @param newTotalSpace
      *            Total bytes
-     * @param newUsableFiles
-     *            Available files / free inodes
-     * @param newTotalFiles
-     *            Total files allowed / maximum number of inodes in filesystem
+     * @param newUsableInodes
+     *            Available / free inodes
+     * @param newTotalInodes
+     *            Total / maximum number of inodes in filesystem
      */
     public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
-            String newUuid, long newUsableSpace, long newTotalSpace, long newUsableFiles, long newTotalFiles) {
+            String newUuid, long newUsableSpace, long newTotalSpace, long newUsableInodes, long newTotalInodes) {
         setName(newName);
         setVolume(newVolume);
         setLogicalVolume("");
@@ -91,8 +91,8 @@ public class OSFileStore implements Serializable {
         setUUID(newUuid);
         setUsableSpace(newUsableSpace);
         setTotalSpace(newTotalSpace);
-        setUsableFiles(newUsableFiles);
-        setTotalFiles(newTotalFiles);
+        setUsableInodes(newUsableInodes);
+        setTotalInodes(newTotalInodes);
     }
 
     /**
@@ -271,40 +271,40 @@ public class OSFileStore implements Serializable {
     }
 
     /**
-     * Usable files / free inodes on the drive.
+     * Usable / free inodes on the drive.
      *
-     * @return Usable files / free inodes on the drive (count)
+     * @return Usable / free inodes on the drive (count)
      */
-    public long getUsableFiles() {
-        return this.usableFiles;
+    public long getUsableInodes() {
+        return this.usableInodes;
     }
 
     /**
-     * Sets usable files on the drive.
+     * Sets usable inodes on the drive.
      *
      * @param value
-     *            Number of free files / free inodes.
+     *            Number of free inodes.
      */
-    public void setUsableFiles(long value) {
-        this.usableFiles = value;
+    public void setUsableInodes(long value) {
+        this.usableInodes = value;
     }
 
     /**
-     * Maximum number of files / inodes of the filesystem.
+     * Total / maximum number of inodes of the filesystem.
      *
-     * @return Maximum number of files / inodes of the filesystem (count)
+     * @return Total / maximum number of inodes of the filesystem (count)
      */
-    public long getTotalFiles() {
-        return this.totalFiles;
+    public long getTotalInodes() {
+        return this.totalInodes;
     }
 
     /**
-     * Sets the maximum number of files / inodes on the filesystem.
+     * Sets the total / maximum number of inodes on the filesystem.
      *
      * @param value
-     *            Count of maximum files / number of inodes
+     *            Total / maximum count of inodes
      */
-    public void setTotalFiles(long value) {
-        this.totalFiles = value;
+    public void setTotalInodes(long value) {
+        this.totalInodes = value;
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
@@ -57,42 +57,23 @@ public class OSFileStore implements Serializable {
     }
 
     /**
-     * Creates an OSFileStore with the specified parameters.
+     * Creates a copy of an OSFileStore.
      *
-     * @param newName
-     *            Name of the filestore
-     * @param newVolume
-     *            Volume of the filestore
-     * @param newMount
-     *            Mountpoint of the filestore
-     * @param newDescription
-     *            Description of the file store
-     * @param newType
-     *            Type of the filestore, e.g. FAT, NTFS, etx2, ext4, etc.
-     * @param newUuid
-     *            UUID/GUID of the filestore
-     * @param newUsableSpace
-     *            Available/usable bytes
-     * @param newTotalSpace
-     *            Total bytes
-     * @param newFreeInodes
-     *            Available / free inodes
-     * @param newTotalInodes
-     *            Total / maximum number of inodes in filesystem
+     * @param fileStore
+     *            OSFileStore which is copied
      */
-    public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
-            String newUuid, long newUsableSpace, long newTotalSpace, long newFreeInodes, long newTotalInodes) {
-        setName(newName);
-        setVolume(newVolume);
-        setLogicalVolume("");
-        setMount(newMount);
-        setDescription(newDescription);
-        setType(newType);
-        setUUID(newUuid);
-        setUsableSpace(newUsableSpace);
-        setTotalSpace(newTotalSpace);
-        setFreeInodes(newFreeInodes);
-        setTotalInodes(newTotalInodes);
+    public OSFileStore(OSFileStore fileStore) {
+        setName(fileStore.getName());
+        setVolume(fileStore.getVolume());
+        setLogicalVolume(fileStore.getLogicalVolume());
+        setMount(fileStore.getMount());
+        setDescription(fileStore.getDescription());
+        setType(fileStore.getType());
+        setUUID(fileStore.getUUID());
+        setUsableSpace(fileStore.getUsableSpace());
+        setTotalSpace(fileStore.getTotalSpace());
+        setFreeInodes(fileStore.getFreeInodes());
+        setTotalInodes(fileStore.getTotalInodes());
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
@@ -49,6 +49,10 @@ public class OSFileStore implements Serializable {
 
     private long totalSpace;
 
+    private long usableFiles;
+
+    private long totalFiles;
+
     public OSFileStore() {
     }
 
@@ -71,9 +75,13 @@ public class OSFileStore implements Serializable {
      *            Available/usable bytes
      * @param newTotalSpace
      *            Total bytes
+     * @param newUsableFiles
+     *            Available files / free inodes
+     * @param newTotalFiles
+     *            Total files allowed / maximum number of inodes in filesystem
      */
     public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
-            String newUuid, long newUsableSpace, long newTotalSpace) {
+            String newUuid, long newUsableSpace, long newTotalSpace, long newUsableFiles, long newTotalFiles) {
         setName(newName);
         setVolume(newVolume);
         setLogicalVolume("");
@@ -83,6 +91,8 @@ public class OSFileStore implements Serializable {
         setUUID(newUuid);
         setUsableSpace(newUsableSpace);
         setTotalSpace(newTotalSpace);
+        setUsableFiles(newUsableFiles);
+        setTotalFiles(newTotalFiles);
     }
 
     /**
@@ -258,5 +268,43 @@ public class OSFileStore implements Serializable {
      */
     public void setTotalSpace(long value) {
         this.totalSpace = value;
+    }
+
+    /**
+     * Usable files / free inodes on the drive.
+     *
+     * @return Usable files / free inodes on the drive (count)
+     */
+    public long getUsableFiles() {
+        return this.usableFiles;
+    }
+
+    /**
+     * Sets usable files on the drive.
+     *
+     * @param value
+     *            Number of free files / free inodes.
+     */
+    public void setUsableFiles(long value) {
+        this.usableFiles = value;
+    }
+
+    /**
+     * Maximum number of files / inodes of the filesystem.
+     *
+     * @return Maximum number of files / inodes of the filesystem (count)
+     */
+    public long getTotalFiles() {
+        return this.totalFiles;
+    }
+
+    /**
+     * Sets the maximum number of files / inodes on the filesystem.
+     *
+     * @param value
+     *            Count of maximum files / number of inodes
+     */
+    public void setTotalFiles(long value) {
+        this.totalFiles = value;
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
@@ -49,9 +49,9 @@ public class OSFileStore implements Serializable {
 
     private long totalSpace;
 
-    private long freeInodes;
+    private long freeInodes = -1;
 
-    private long totalInodes;
+    private long totalInodes = -1;
 
     public OSFileStore() {
     }
@@ -93,6 +93,39 @@ public class OSFileStore implements Serializable {
         setTotalSpace(newTotalSpace);
         setFreeInodes(newFreeInodes);
         setTotalInodes(newTotalInodes);
+    }
+
+    /**
+     * Creates an OSFileStore with the specified parameters.
+     *
+     * @param newName
+     *            Name of the filestore
+     * @param newVolume
+     *            Volume of the filestore
+     * @param newMount
+     *            Mountpoint of the filestore
+     * @param newDescription
+     *            Description of the file store
+     * @param newType
+     *            Type of the filestore, e.g. FAT, NTFS, etx2, ext4, etc.
+     * @param newUuid
+     *            UUID/GUID of the filestore
+     * @param newUsableSpace
+     *            Available/usable bytes
+     * @param newTotalSpace
+     *            Total bytes
+     */
+    public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
+                       String newUuid, long newUsableSpace, long newTotalSpace) {
+        setName(newName);
+        setVolume(newVolume);
+        setLogicalVolume("");
+        setMount(newMount);
+        setDescription(newDescription);
+        setType(newType);
+        setUUID(newUuid);
+        setUsableSpace(newUsableSpace);
+        setTotalSpace(newTotalSpace);
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
@@ -49,7 +49,7 @@ public class OSFileStore implements Serializable {
 
     private long totalSpace;
 
-    private long usableInodes;
+    private long freeInodes;
 
     private long totalInodes;
 
@@ -75,13 +75,13 @@ public class OSFileStore implements Serializable {
      *            Available/usable bytes
      * @param newTotalSpace
      *            Total bytes
-     * @param newUsableInodes
+     * @param newFreeInodes
      *            Available / free inodes
      * @param newTotalInodes
      *            Total / maximum number of inodes in filesystem
      */
     public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
-            String newUuid, long newUsableSpace, long newTotalSpace, long newUsableInodes, long newTotalInodes) {
+            String newUuid, long newUsableSpace, long newTotalSpace, long newFreeInodes, long newTotalInodes) {
         setName(newName);
         setVolume(newVolume);
         setLogicalVolume("");
@@ -91,7 +91,7 @@ public class OSFileStore implements Serializable {
         setUUID(newUuid);
         setUsableSpace(newUsableSpace);
         setTotalSpace(newTotalSpace);
-        setUsableInodes(newUsableInodes);
+        setFreeInodes(newFreeInodes);
         setTotalInodes(newTotalInodes);
     }
 
@@ -275,8 +275,8 @@ public class OSFileStore implements Serializable {
      *
      * @return Usable / free inodes on the drive (count)
      */
-    public long getUsableInodes() {
-        return this.usableInodes;
+    public long getFreeInodes() {
+        return this.freeInodes;
     }
 
     /**
@@ -285,8 +285,8 @@ public class OSFileStore implements Serializable {
      * @param value
      *            Number of free inodes.
      */
-    public void setUsableInodes(long value) {
-        this.usableInodes = value;
+    public void setFreeInodes(long value) {
+        this.freeInodes = value;
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSFileStore.java
@@ -32,25 +32,15 @@ public class OSFileStore implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String name;
-
     private String volume;
-
-    private String logicalVolume;
-
+    private String logicalVolume = "";
     private String mount;
-
     private String description;
-
     private String fsType;
-
     private String uuid;
-
     private long usableSpace;
-
     private long totalSpace;
-
     private long freeInodes = -1;
-
     private long totalInodes = -1;
 
     public OSFileStore() {
@@ -74,39 +64,6 @@ public class OSFileStore implements Serializable {
         setTotalSpace(fileStore.getTotalSpace());
         setFreeInodes(fileStore.getFreeInodes());
         setTotalInodes(fileStore.getTotalInodes());
-    }
-
-    /**
-     * Creates an OSFileStore with the specified parameters.
-     *
-     * @param newName
-     *            Name of the filestore
-     * @param newVolume
-     *            Volume of the filestore
-     * @param newMount
-     *            Mountpoint of the filestore
-     * @param newDescription
-     *            Description of the file store
-     * @param newType
-     *            Type of the filestore, e.g. FAT, NTFS, etx2, ext4, etc.
-     * @param newUuid
-     *            UUID/GUID of the filestore
-     * @param newUsableSpace
-     *            Available/usable bytes
-     * @param newTotalSpace
-     *            Total bytes
-     */
-    public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
-                       String newUuid, long newUsableSpace, long newTotalSpace) {
-        setName(newName);
-        setVolume(newVolume);
-        setLogicalVolume("");
-        setMount(newMount);
-        setDescription(newDescription);
-        setType(newType);
-        setUUID(newUuid);
-        setUsableSpace(newUsableSpace);
-        setTotalSpace(newTotalSpace);
     }
 
     /**
@@ -285,9 +242,9 @@ public class OSFileStore implements Serializable {
     }
 
     /**
-     * Usable / free inodes on the drive.
+     * Usable / free inodes on the drive. Not applicable on Windows.
      *
-     * @return Usable / free inodes on the drive (count)
+     * @return Usable / free inodes on the drive (count), or -1 if unimplemented
      */
     public long getFreeInodes() {
         return this.freeInodes;
@@ -304,9 +261,11 @@ public class OSFileStore implements Serializable {
     }
 
     /**
-     * Total / maximum number of inodes of the filesystem.
+     * Total / maximum number of inodes of the filesystem. Not applicable on
+     * Windows.
      *
-     * @return Total / maximum number of inodes of the filesystem (count)
+     * @return Total / maximum number of inodes of the filesystem (count), or -1
+     *         if unimplemented
      */
     public long getTotalInodes() {
         return this.totalInodes;

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
@@ -188,29 +188,41 @@ public class LinuxFileSystem implements FileSystem {
                 }
             }
 
-            long totalFiles = 0L;
-            long usableFiles = 0L;
+            long totalInodes = 0L;
+            long usableInodes = 0L;
             long totalSpace = 0L;
             long usableSpace = 0L;
 
             try {
                 Libc.Statvfs vfsStat = new Libc.Statvfs();
                 if (0 == Libc.INSTANCE.statvfs(path, vfsStat)) {
-                    totalFiles = vfsStat.fsTotalInodeCount.longValue();
-                    usableFiles = vfsStat.fsFreeInodeCount.longValue();
+                    totalInodes = vfsStat.fsTotalInodeCount.longValue();
+                    usableInodes = vfsStat.fsFreeInodeCount.longValue();
                     totalSpace = vfsStat.fsSizeInBlocks.longValue() * vfsStat.fsBlockSize.longValue();
                     usableSpace = vfsStat.fsBlocksFree.longValue() * vfsStat.fsBlockSize.longValue();
                 } else {
-                    totalSpace = new File(path).getTotalSpace();
-                    usableSpace = new File(path).getUsableSpace();
+                    File tmpFile = new File(path);
+                    totalSpace = tmpFile.getTotalSpace();
+                    usableSpace = tmpFile.getUsableSpace();
                     LOG.error("Failed to get statvfs. Error code: {}", Native.getLastError());
                 }
             } catch (UnsatisfiedLinkError | NoClassDefFoundError e) {
                 LOG.error("Failed to get file counts from statvfs. {}", e);
             }
 
-            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, uuid, usableSpace, totalSpace, usableFiles, totalFiles);
+            OSFileStore osStore = new OSFileStore();
+            osStore.setName(name);
+            osStore.setVolume(volume);
+            osStore.setMount(path);
+            osStore.setDescription(description);
+            osStore.setType(type);
+            osStore.setUUID(uuid);
+            osStore.setUsableSpace(usableSpace);
+            osStore.setTotalSpace(totalSpace);
+            osStore.setUsableInodes(usableInodes);
+            osStore.setTotalInodes(totalInodes);
             osStore.setLogicalVolume(logicalVolume);
+
             fsList.add(osStore);
         }
 

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
@@ -189,7 +189,7 @@ public class LinuxFileSystem implements FileSystem {
             }
 
             long totalInodes = 0L;
-            long usableInodes = 0L;
+            long freeInodes = 0L;
             long totalSpace = 0L;
             long usableSpace = 0L;
 
@@ -197,7 +197,7 @@ public class LinuxFileSystem implements FileSystem {
                 Libc.Statvfs vfsStat = new Libc.Statvfs();
                 if (0 == Libc.INSTANCE.statvfs(path, vfsStat)) {
                     totalInodes = vfsStat.fsTotalInodeCount.longValue();
-                    usableInodes = vfsStat.fsFreeInodeCount.longValue();
+                    freeInodes = vfsStat.fsFreeInodeCount.longValue();
                     totalSpace = vfsStat.fsSizeInBlocks.longValue() * vfsStat.fsBlockSize.longValue();
                     usableSpace = vfsStat.fsBlocksFree.longValue() * vfsStat.fsBlockSize.longValue();
                 } else {
@@ -219,7 +219,7 @@ public class LinuxFileSystem implements FileSystem {
             osStore.setUUID(uuid);
             osStore.setUsableSpace(usableSpace);
             osStore.setTotalSpace(totalSpace);
-            osStore.setUsableInodes(usableInodes);
+            osStore.setFreeInodes(freeInodes);
             osStore.setTotalInodes(totalInodes);
             osStore.setLogicalVolume(logicalVolume);
 

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystem.java
@@ -166,8 +166,16 @@ public class MacFileSystem implements FileSystem {
                 }
 
                 // Add to the list
-                fsList.add(new OSFileStore(name, volume, path, description, type, uuid,
-                        file.getUsableSpace(), file.getTotalSpace()));
+                OSFileStore osStore = new OSFileStore();
+                osStore.setName(name);
+                osStore.setVolume(volume);
+                osStore.setLogicalVolume(path);
+                osStore.setDescription(description);
+                osStore.setType(type);
+                osStore.setUUID(uuid);
+                osStore.setUsableSpace(file.getUsableSpace());
+                osStore.setTotalSpace(file.getTotalSpace());
+                fsList.add(osStore);
             }
         }
         // Close DA session

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystem.java
@@ -169,12 +169,14 @@ public class MacFileSystem implements FileSystem {
                 OSFileStore osStore = new OSFileStore();
                 osStore.setName(name);
                 osStore.setVolume(volume);
-                osStore.setLogicalVolume(path);
+                osStore.setMount(path);
                 osStore.setDescription(description);
                 osStore.setType(type);
                 osStore.setUUID(uuid);
                 osStore.setUsableSpace(file.getUsableSpace());
                 osStore.setTotalSpace(file.getTotalSpace());
+                osStore.setFreeInodes(fs[f].f_ffree);
+                osStore.setTotalInodes(fs[f].f_files);
                 fsList.add(osStore);
             }
         }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystem.java
@@ -166,8 +166,8 @@ public class MacFileSystem implements FileSystem {
                 }
 
                 // Add to the list
-                fsList.add(new OSFileStore(name, volume, path, description, type, uuid, file.getUsableSpace(),
-                        file.getTotalSpace(), -1, -1));
+                fsList.add(new OSFileStore(name, volume, path, description, type, uuid,
+                        file.getUsableSpace(), file.getTotalSpace()));
             }
         }
         // Close DA session

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystem.java
@@ -167,7 +167,7 @@ public class MacFileSystem implements FileSystem {
 
                 // Add to the list
                 fsList.add(new OSFileStore(name, volume, path, description, type, uuid, file.getUsableSpace(),
-                        file.getTotalSpace()));
+                        file.getTotalSpace(), -1, -1));
             }
         }
         // Close DA session

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
@@ -152,7 +152,17 @@ public class FreeBsdFileSystem implements FileSystem {
             }
             // Match UUID
             String uuid = MapUtil.getOrDefault(uuidMap, name, "");
-            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, uuid, usableSpace, totalSpace);
+
+            // Add to the list
+            OSFileStore osStore = new OSFileStore();
+            osStore.setName(name);
+            osStore.setVolume(volume);
+            osStore.setLogicalVolume(path);
+            osStore.setDescription(description);
+            osStore.setType(type);
+            osStore.setUUID(uuid);
+            osStore.setUsableSpace(usableSpace);
+            osStore.setTotalSpace(totalSpace);
             fsList.add(osStore);
         }
         return fsList.toArray(new OSFileStore[fsList.size()]);

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
@@ -112,6 +112,27 @@ public class FreeBsdFileSystem implements FileSystem {
 
         List<OSFileStore> fsList = new ArrayList<>();
 
+        // Get inode usage data
+        Map<String, Long> inodeFreeMap = new HashMap<>();
+        Map<String, Long> inodeTotalMap = new HashMap<>();
+        for (String line : ExecutingCommand.runNative("df -i")) {
+            /*- Sample Output:
+            Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on
+            /dev/twed0s1a   2026030 584112 1279836    31%    2751 279871    1%   /
+            */
+            if (line.startsWith("/")) {
+                String[] split = ParseUtil.whitespaces.split(line);
+                if (split.length > 7) {
+                    inodeFreeMap.put(split[0], ParseUtil.parseLongOrDefault(split[6], 0L));
+                    // total is actually used + free
+                    if (inodeFreeMap.get(split[0]) >= 0) {
+                        inodeTotalMap.put(split[0],
+                                inodeFreeMap.get(split[0]) + ParseUtil.parseLongOrDefault(split[5], 0L));
+                    }
+                }
+            }
+        }
+
         // Get mount table
         for (String fs : ExecutingCommand.runNative("mount -p")) {
             String[] split = ParseUtil.whitespaces.split(fs);
@@ -157,12 +178,14 @@ public class FreeBsdFileSystem implements FileSystem {
             OSFileStore osStore = new OSFileStore();
             osStore.setName(name);
             osStore.setVolume(volume);
-            osStore.setLogicalVolume(path);
+            osStore.setMount(path);
             osStore.setDescription(description);
             osStore.setType(type);
             osStore.setUUID(uuid);
             osStore.setUsableSpace(usableSpace);
             osStore.setTotalSpace(totalSpace);
+            osStore.setFreeInodes(inodeFreeMap.containsKey(path) ? inodeFreeMap.get(path) : 0L);
+            osStore.setTotalInodes(inodeTotalMap.containsKey(path) ? inodeTotalMap.get(path) : 0L);
             fsList.add(osStore);
         }
         return fsList.toArray(new OSFileStore[fsList.size()]);

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
@@ -152,7 +152,7 @@ public class FreeBsdFileSystem implements FileSystem {
             }
             // Match UUID
             String uuid = MapUtil.getOrDefault(uuidMap, name, "");
-            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, uuid, usableSpace, totalSpace, -1, -1);
+            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, uuid, usableSpace, totalSpace);
             fsList.add(osStore);
         }
         return fsList.toArray(new OSFileStore[fsList.size()]);

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
@@ -152,7 +152,7 @@ public class FreeBsdFileSystem implements FileSystem {
             }
             // Match UUID
             String uuid = MapUtil.getOrDefault(uuidMap, name, "");
-            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, uuid, usableSpace, totalSpace);
+            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, uuid, usableSpace, totalSpace, -1, -1);
             fsList.add(osStore);
         }
         return fsList.toArray(new OSFileStore[fsList.size()]);

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdFileSystem.java
@@ -124,11 +124,9 @@ public class FreeBsdFileSystem implements FileSystem {
                 String[] split = ParseUtil.whitespaces.split(line);
                 if (split.length > 7) {
                     inodeFreeMap.put(split[0], ParseUtil.parseLongOrDefault(split[6], 0L));
-                    // total is actually used + free
-                    if (inodeFreeMap.get(split[0]) >= 0) {
-                        inodeTotalMap.put(split[0],
-                                inodeFreeMap.get(split[0]) + ParseUtil.parseLongOrDefault(split[5], 0L));
-                    }
+                    // total is used + free
+                    inodeTotalMap.put(split[0],
+                            inodeFreeMap.get(split[0]) + ParseUtil.parseLongOrDefault(split[5], 0L));
                 }
             }
         }

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
@@ -129,8 +129,17 @@ public class SolarisFileSystem implements FileSystem {
             } else {
                 description = "Mount Point";
             }
-            // No UUID info on Solaris
-            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, "", usableSpace, totalSpace);
+
+            // Add to the list
+            OSFileStore osStore = new OSFileStore();
+            osStore.setName(name);
+            osStore.setVolume(volume);
+            osStore.setLogicalVolume(path);
+            osStore.setDescription(description);
+            osStore.setType(type);
+            osStore.setUUID(""); // No UUID info on Solaris
+            osStore.setUsableSpace(usableSpace);
+            osStore.setTotalSpace(totalSpace);
             fsList.add(osStore);
         }
         return fsList.toArray(new OSFileStore[fsList.size()]);

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
@@ -130,7 +130,7 @@ public class SolarisFileSystem implements FileSystem {
                 description = "Mount Point";
             }
             // No UUID info on Solaris
-            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, "", usableSpace, totalSpace);
+            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, "", usableSpace, totalSpace, -1, -1);
             fsList.add(osStore);
         }
         return fsList.toArray(new OSFileStore[fsList.size()]);

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
@@ -113,8 +113,8 @@ public class SolarisFileSystem implements FileSystem {
             } else if (line.contains("free files")) {
                 free = ParseUtil.getTextBetweenStrings(line, "", "free files").trim();
                 if (key != null) {
-                    inodeFreeMap.put(key, ParseUtil.parseLongOrDefault(free, -1L));
-                    inodeTotalMap.put(key, ParseUtil.parseLongOrDefault(total, -1L));
+                    inodeFreeMap.put(key, ParseUtil.parseLongOrDefault(free, 0L));
+                    inodeTotalMap.put(key, ParseUtil.parseLongOrDefault(total, 0L));
                     key = null;
                 }
             }

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
@@ -130,7 +130,7 @@ public class SolarisFileSystem implements FileSystem {
                 description = "Mount Point";
             }
             // No UUID info on Solaris
-            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, "", usableSpace, totalSpace, -1, -1);
+            OSFileStore osStore = new OSFileStore(name, volume, path, description, type, "", usableSpace, totalSpace);
             fsList.add(osStore);
         }
         return fsList.toArray(new OSFileStore[fsList.size()]);

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystem.java
@@ -21,7 +21,9 @@ package oshi.software.os.unix.solaris;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.sun.jna.platform.unix.solaris.LibKstat.Kstat; // NOSONAR
 
@@ -91,6 +93,33 @@ public class SolarisFileSystem implements FileSystem {
     public OSFileStore[] getFileStores() {
         List<OSFileStore> fsList = new ArrayList<>();
 
+        // Get inode usage data
+        Map<String, Long> inodeFreeMap = new HashMap<>();
+        Map<String, Long> inodeTotalMap = new HashMap<>();
+        String key = null;
+        String total = null;
+        String free = null;
+        for (String line : ExecutingCommand.runNative("df -g")) {
+            /*- Sample Output:
+            /                  (/dev/md/dsk/d0    ):         8192 block size          1024 frag size
+            41310292 total blocks   18193814 free blocks 17780712 available        2486848 total files
+             2293351 free files     22282240 filesys id
+                 ufs fstype       0x00000004 flag             255 filename length
+            */
+            if (line.startsWith("/")) {
+                key = ParseUtil.whitespaces.split(line)[0];
+            } else if (line.contains("available") && line.contains("total files")) {
+                total = ParseUtil.getTextBetweenStrings(line, "available", "total files").trim();
+            } else if (line.contains("free files")) {
+                free = ParseUtil.getTextBetweenStrings(line, "", "free files").trim();
+                if (key != null) {
+                    inodeFreeMap.put(key, ParseUtil.parseLongOrDefault(free, -1L));
+                    inodeTotalMap.put(key, ParseUtil.parseLongOrDefault(total, -1L));
+                    key = null;
+                }
+            }
+        }
+
         // Get mount table
         for (String fs : ExecutingCommand.runNative("cat /etc/mnttab")) {
             String[] split = ParseUtil.whitespaces.split(fs);
@@ -134,12 +163,14 @@ public class SolarisFileSystem implements FileSystem {
             OSFileStore osStore = new OSFileStore();
             osStore.setName(name);
             osStore.setVolume(volume);
-            osStore.setLogicalVolume(path);
+            osStore.setMount(path);
             osStore.setDescription(description);
             osStore.setType(type);
             osStore.setUUID(""); // No UUID info on Solaris
             osStore.setUsableSpace(usableSpace);
             osStore.setTotalSpace(totalSpace);
+            osStore.setFreeInodes(inodeFreeMap.containsKey(path) ? inodeFreeMap.get(path) : 0L);
+            osStore.setTotalInodes(inodeTotalMap.containsKey(path) ? inodeTotalMap.get(path) : 0L);
             fsList.add(osStore);
         }
         return fsList.toArray(new OSFileStore[fsList.size()]);

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
@@ -183,8 +183,16 @@ public class WindowsFileSystem implements FileSystem {
 
             if (!strMount.isEmpty()) {
                 // Volume is mounted
-                fs.add(new OSFileStore(String.format("%s (%s)", strName, strMount), volume, strMount,
-                        getDriveType(strMount), strFsType, uuid, systemFreeBytes.getValue(), totalBytes.getValue()));
+                OSFileStore osStore = new OSFileStore();
+                osStore.setName(String.format("%s (%s)", strName, strMount));
+                osStore.setVolume(volume);
+                osStore.setLogicalVolume(strMount);
+                osStore.setDescription(getDriveType(strMount));
+                osStore.setType(strFsType);
+                osStore.setUUID(uuid);
+                osStore.setUsableSpace(systemFreeBytes.getValue());
+                osStore.setTotalSpace(totalBytes.getValue());
+                fs.add(osStore);
             }
             retVal = Kernel32.INSTANCE.FindNextVolume(hVol, aVolume, BUFSIZE);
             if (!retVal) {
@@ -228,8 +236,16 @@ public class WindowsFileSystem implements FileSystem {
                 }
             }
 
-            fs.add(new OSFileStore(String.format("%s (%s)", description, name), volume, name + "\\", getDriveType(name),
-                    WmiUtil.getString(drives, LogicalDiskProperty.FILESYSTEM, i), "", free, total));
+            OSFileStore osStore = new OSFileStore();
+            osStore.setName(String.format("%s (%s)", description, name));
+            osStore.setVolume(volume);
+            osStore.setLogicalVolume(name + "\\");
+            osStore.setDescription(getDriveType(name));
+            osStore.setType(WmiUtil.getString(drives, LogicalDiskProperty.FILESYSTEM, i));
+            osStore.setUUID("");
+            osStore.setUsableSpace(free);
+            osStore.setTotalSpace(total);
+            fs.add(osStore);
         }
 
         return fs;

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
@@ -184,7 +184,7 @@ public class WindowsFileSystem implements FileSystem {
             if (!strMount.isEmpty()) {
                 // Volume is mounted
                 fs.add(new OSFileStore(String.format("%s (%s)", strName, strMount), volume, strMount,
-                        getDriveType(strMount), strFsType, uuid, systemFreeBytes.getValue(), totalBytes.getValue(), -1, -1));
+                        getDriveType(strMount), strFsType, uuid, systemFreeBytes.getValue(), totalBytes.getValue()));
             }
             retVal = Kernel32.INSTANCE.FindNextVolume(hVol, aVolume, BUFSIZE);
             if (!retVal) {
@@ -229,7 +229,7 @@ public class WindowsFileSystem implements FileSystem {
             }
 
             fs.add(new OSFileStore(String.format("%s (%s)", description, name), volume, name + "\\", getDriveType(name),
-                    WmiUtil.getString(drives, LogicalDiskProperty.FILESYSTEM, i), "", free, total, -1, -1));
+                    WmiUtil.getString(drives, LogicalDiskProperty.FILESYSTEM, i), "", free, total));
         }
 
         return fs;

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
@@ -184,7 +184,7 @@ public class WindowsFileSystem implements FileSystem {
             if (!strMount.isEmpty()) {
                 // Volume is mounted
                 fs.add(new OSFileStore(String.format("%s (%s)", strName, strMount), volume, strMount,
-                        getDriveType(strMount), strFsType, uuid, systemFreeBytes.getValue(), totalBytes.getValue()));
+                        getDriveType(strMount), strFsType, uuid, systemFreeBytes.getValue(), totalBytes.getValue(), -1, -1));
             }
             retVal = Kernel32.INSTANCE.FindNextVolume(hVol, aVolume, BUFSIZE);
             if (!retVal) {
@@ -229,7 +229,7 @@ public class WindowsFileSystem implements FileSystem {
             }
 
             fs.add(new OSFileStore(String.format("%s (%s)", description, name), volume, name + "\\", getDriveType(name),
-                    WmiUtil.getString(drives, LogicalDiskProperty.FILESYSTEM, i), "", free, total));
+                    WmiUtil.getString(drives, LogicalDiskProperty.FILESYSTEM, i), "", free, total, -1, -1));
         }
 
         return fs;

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -286,11 +286,12 @@ public class SystemInfoTest {
             long usable = fs.getUsableSpace();
             long total = fs.getTotalSpace();
             System.out.format(
-                    " %s (%s) [%s] %s of %s free (%.1f%%) is %s "
+                    " %s (%s) [%s] %s of %s free (%.1f%%), %s of %s files free (%.1f%%) is %s "
                             + (fs.getLogicalVolume() != null && fs.getLogicalVolume().length() > 0 ? "[%s]" : "%s")
                             + " and is mounted at %s%n",
                     fs.getName(), fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,
+                    fs.getUsableFiles(), fs.getTotalFiles(), 100d * fs.getUsableFiles() / fs.getTotalFiles(),
                     fs.getVolume(), fs.getLogicalVolume(), fs.getMount());
         }
     }

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -291,7 +291,7 @@ public class SystemInfoTest {
                             + " and is mounted at %s%n",
                     fs.getName(), fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,
-                    fs.getUsableInodes(), fs.getTotalInodes(), 100d * fs.getUsableInodes() / fs.getTotalInodes(),
+                    fs.getFreeInodes(), fs.getTotalInodes(), 100d * fs.getFreeInodes() / fs.getTotalInodes(),
                     fs.getVolume(), fs.getLogicalVolume(), fs.getMount());
         }
     }

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -291,7 +291,7 @@ public class SystemInfoTest {
                             + " and is mounted at %s%n",
                     fs.getName(), fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,
-                    fs.getUsableFiles(), fs.getTotalFiles(), 100d * fs.getUsableFiles() / fs.getTotalFiles(),
+                    fs.getUsableInodes(), fs.getTotalInodes(), 100d * fs.getUsableInodes() / fs.getTotalInodes(),
                     fs.getVolume(), fs.getLogicalVolume(), fs.getMount());
         }
     }

--- a/oshi-core/src/test/java/oshi/software/os/FileSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/FileSystemTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 
 import org.junit.Test;
 
+import oshi.PlatformEnum;
 import oshi.SystemInfo;
 
 /**
@@ -56,6 +57,10 @@ public class FileSystemTest {
             assertNotNull(store.getUUID());
             assertTrue(store.getTotalSpace() >= 0);
             assertTrue(store.getUsableSpace() >= 0);
+            if (SystemInfo.getCurrentPlatformEnum() != PlatformEnum.WINDOWS) {
+                assertTrue(store.getFreeInodes() >= 0);
+                assertTrue(store.getTotalInodes() >= store.getFreeInodes());
+            }
             if (!store.getDescription().equals("Network drive")) {
                 assertTrue(store.getUsableSpace() <= store.getTotalSpace());
             }

--- a/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
@@ -324,11 +324,15 @@ public class ParseUtilTest {
         String after = "baz";
         assertEquals(" bar ", ParseUtil.getTextBetweenStrings(text, before, after));
 
+        before = "";
+        assertEquals("foo bar ", ParseUtil.getTextBetweenStrings(text, before, after));
+
         before = "food";
         assertEquals("", ParseUtil.getTextBetweenStrings(text, before, after));
 
         before = "foo";
         after = "qux";
         assertEquals("", ParseUtil.getTextBetweenStrings(text, before, after));
+
     }
 }

--- a/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
@@ -226,9 +226,9 @@ public class OSFileStore extends AbstractOshiJsonObject {
     }
 
     /**
-     * Usable / free inodes on the drive.
+     * Usable / free inodes on the drive. Not applicable on Windows.
      *
-     * @return Usable / free inodes on the drive (count)
+     * @return Usable / free inodes on the drive (count), or -1 if unimplemented
      */
     public long getFreeInodes() {
         return this.fileStore.getFreeInodes();
@@ -245,9 +245,11 @@ public class OSFileStore extends AbstractOshiJsonObject {
     }
 
     /**
-     * Maximum number of inodes of the filesystem.
+     * Total / maximum number of inodes of the filesystem. Not applicable on
+     * Windows.
      *
-     * @return Maximum number of inodes of the filesystem (count)
+     * @return Total / maximum number of inodes of the filesystem (count), or -1
+     *         if unimplemented
      */
     public long getTotalInodes() {
         return this.fileStore.getTotalInodes();

--- a/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
@@ -63,15 +63,15 @@ public class OSFileStore extends AbstractOshiJsonObject {
      *            Available/usable bytes
      * @param newTotalSpace
      *            Total bytes
-     * @param newUsableFiles
-     *            Available files / free inodes
-     * @param newTotalFiles
-     *            Total files allowed / maximum number of inodes in filesystem
+     * @param newFreeInodes
+     *            Available / free inodes
+     * @param newTotalInodes
+     *            Total / maximum number of inodes in filesystem
      */
     public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
-            String newUuid, long newUsableSpace, long newTotalSpace, long newUsableFiles, long newTotalFiles) {
+            String newUuid, long newUsableSpace, long newTotalSpace, long newFreeInodes, long newTotalInodes) {
         this.fileStore = new oshi.software.os.OSFileStore(newName, newVolume, newMount, newDescription, newType,
-                newUuid, newUsableSpace, newTotalSpace, newUsableFiles, newTotalFiles);
+                newUuid, newUsableSpace, newTotalSpace, newFreeInodes, newTotalInodes);
     }
 
     /**
@@ -246,40 +246,40 @@ public class OSFileStore extends AbstractOshiJsonObject {
     }
 
     /**
-     * Usable files / free inodes on the drive.
+     * Usable / free inodes on the drive.
      *
-     * @return Usable files / free inodes on the drive (count)
+     * @return Usable / free inodes on the drive (count)
      */
     public long getUsableFiles() {
-        return this.fileStore.getUsableInodes();
+        return this.fileStore.getFreeInodes();
     }
 
     /**
-     * Sets usable files on the drive.
+     * Sets usable inodes on the drive.
      *
      * @param value
-     *            Number of free files / free inodes.
+     *            Number of free inodes.
      */
-    public void setUsableFiles(long value) {
-        this.fileStore.setUsableInodes(value);
+    public void setFreeInodes(long value) {
+        this.fileStore.setFreeInodes(value);
     }
 
     /**
-     * Maximum number of files / inodes of the filesystem.
+     * Maximum number of inodes of the filesystem.
      *
-     * @return Maximum number of files / inodes of the filesystem (count)
+     * @return Maximum number of inodes of the filesystem (count)
      */
-    public long getTotalFiles() {
+    public long getTotalInodes() {
         return this.fileStore.getTotalInodes();
     }
 
     /**
-     * Sets the maximum number of files / inodes on the filesystem.
+     * Sets the maximum number of inodes on the filesystem.
      *
      * @param value
-     *            Count of maximum files / number of inodes
+     *            Count of maximum number of inodes
      */
-    public void setTotalFiles(long value) {
+    public void setTotalInodes(long value) {
         this.fileStore.setTotalInodes(value);
     }
 
@@ -313,11 +313,11 @@ public class OSFileStore extends AbstractOshiJsonObject {
         if (PropertiesUtil.getBoolean(properties, "operatingSystem.fileSystem.fileStores.totalSpace")) {
             json.add("totalSpace", getTotalSpace());
         }
-        if (PropertiesUtil.getBoolean(properties, "operatingSystem.fileSystem.fileStores.usableFiles")) {
-            json.add("usableFiles", getUsableFiles());
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.fileSystem.fileStores.freeInodes")) {
+            json.add("freeInodes", getUsableFiles());
         }
-        if (PropertiesUtil.getBoolean(properties, "operatingSystem.fileSystem.fileStores.totalFiles")) {
-            json.add("totalFiles", getTotalFiles());
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.fileSystem.fileStores.totalInodes")) {
+            json.add("totalInodes", getTotalInodes());
         }
         return json.build();
     }

--- a/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
@@ -250,7 +250,7 @@ public class OSFileStore extends AbstractOshiJsonObject {
      *
      * @return Usable / free inodes on the drive (count)
      */
-    public long getUsableFiles() {
+    public long getFreeInodes() {
         return this.fileStore.getFreeInodes();
     }
 
@@ -314,7 +314,7 @@ public class OSFileStore extends AbstractOshiJsonObject {
             json.add("totalSpace", getTotalSpace());
         }
         if (PropertiesUtil.getBoolean(properties, "operatingSystem.fileSystem.fileStores.freeInodes")) {
-            json.add("freeInodes", getUsableFiles());
+            json.add("freeInodes", getFreeInodes());
         }
         if (PropertiesUtil.getBoolean(properties, "operatingSystem.fileSystem.fileStores.totalInodes")) {
             json.add("totalInodes", getTotalInodes());

--- a/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
@@ -251,7 +251,7 @@ public class OSFileStore extends AbstractOshiJsonObject {
      * @return Usable files / free inodes on the drive (count)
      */
     public long getUsableFiles() {
-        return this.fileStore.getUsableFiles();
+        return this.fileStore.getUsableInodes();
     }
 
     /**
@@ -261,7 +261,7 @@ public class OSFileStore extends AbstractOshiJsonObject {
      *            Number of free files / free inodes.
      */
     public void setUsableFiles(long value) {
-        this.fileStore.setUsableFiles(value);
+        this.fileStore.setUsableInodes(value);
     }
 
     /**
@@ -270,7 +270,7 @@ public class OSFileStore extends AbstractOshiJsonObject {
      * @return Maximum number of files / inodes of the filesystem (count)
      */
     public long getTotalFiles() {
-        return this.fileStore.getTotalFiles();
+        return this.fileStore.getTotalInodes();
     }
 
     /**
@@ -280,7 +280,7 @@ public class OSFileStore extends AbstractOshiJsonObject {
      *            Count of maximum files / number of inodes
      */
     public void setTotalFiles(long value) {
-        this.fileStore.setTotalFiles(value);
+        this.fileStore.setTotalInodes(value);
     }
 
     /**

--- a/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
@@ -63,11 +63,15 @@ public class OSFileStore extends AbstractOshiJsonObject {
      *            Available/usable bytes
      * @param newTotalSpace
      *            Total bytes
+     * @param newUsableFiles
+     *            Available files / free inodes
+     * @param newTotalFiles
+     *            Total files allowed / maximum number of inodes in filesystem
      */
     public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
-            String newUuid, long newUsableSpace, long newTotalSpace) {
+            String newUuid, long newUsableSpace, long newTotalSpace, long newUsableFiles, long newTotalFiles) {
         this.fileStore = new oshi.software.os.OSFileStore(newName, newVolume, newMount, newDescription, newType,
-                newUuid, newUsableSpace, newTotalSpace);
+                newUuid, newUsableSpace, newTotalSpace, newUsableFiles, newTotalFiles);
     }
 
     /**
@@ -242,6 +246,44 @@ public class OSFileStore extends AbstractOshiJsonObject {
     }
 
     /**
+     * Usable files / free inodes on the drive.
+     *
+     * @return Usable files / free inodes on the drive (count)
+     */
+    public long getUsableFiles() {
+        return this.fileStore.getUsableFiles();
+    }
+
+    /**
+     * Sets usable files on the drive.
+     *
+     * @param value
+     *            Number of free files / free inodes.
+     */
+    public void setUsableFiles(long value) {
+        this.fileStore.setUsableFiles(value);
+    }
+
+    /**
+     * Maximum number of files / inodes of the filesystem.
+     *
+     * @return Maximum number of files / inodes of the filesystem (count)
+     */
+    public long getTotalFiles() {
+        return this.fileStore.getTotalFiles();
+    }
+
+    /**
+     * Sets the maximum number of files / inodes on the filesystem.
+     *
+     * @param value
+     *            Count of maximum files / number of inodes
+     */
+    public void setTotalFiles(long value) {
+        this.fileStore.setTotalFiles(value);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -270,6 +312,12 @@ public class OSFileStore extends AbstractOshiJsonObject {
         }
         if (PropertiesUtil.getBoolean(properties, "operatingSystem.fileSystem.fileStores.totalSpace")) {
             json.add("totalSpace", getTotalSpace());
+        }
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.fileSystem.fileStores.usableFiles")) {
+            json.add("usableFiles", getUsableFiles());
+        }
+        if (PropertiesUtil.getBoolean(properties, "operatingSystem.fileSystem.fileStores.totalFiles")) {
+            json.add("totalFiles", getTotalFiles());
         }
         return json.build();
     }

--- a/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/OSFileStore.java
@@ -45,33 +45,13 @@ public class OSFileStore extends AbstractOshiJsonObject {
     private oshi.software.os.OSFileStore fileStore;
 
     /**
-     * Creates an OSFileStore with the specified parameters.
+     * Create an json OSFileStore from OSFileStore.
      *
-     * @param newName
-     *            Name of the filestore
-     * @param newVolume
-     *            Volume of the filestore
-     * @param newMount
-     *            Mountpoint of the filestore
-     * @param newDescription
-     *            Description of the file store
-     * @param newType
-     *            Type of the filestore, e.g. FAT, NTFS, etx2, ext4, etc.
-     * @param newUuid
-     *            UUID/GUID of the filestore
-     * @param newUsableSpace
-     *            Available/usable bytes
-     * @param newTotalSpace
-     *            Total bytes
-     * @param newFreeInodes
-     *            Available / free inodes
-     * @param newTotalInodes
-     *            Total / maximum number of inodes in filesystem
+     * @param origFileStore
+     *            Original filestore
      */
-    public OSFileStore(String newName, String newVolume, String newMount, String newDescription, String newType,
-            String newUuid, long newUsableSpace, long newTotalSpace, long newFreeInodes, long newTotalInodes) {
-        this.fileStore = new oshi.software.os.OSFileStore(newName, newVolume, newMount, newDescription, newType,
-                newUuid, newUsableSpace, newTotalSpace, newFreeInodes, newTotalInodes);
+    public OSFileStore(oshi.software.os.OSFileStore origFileStore) {
+        this.fileStore = new oshi.software.os.OSFileStore(origFileStore);
     }
 
     /**

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
@@ -63,10 +63,7 @@ public class FileSystemImpl extends AbstractOshiJsonObject implements FileSystem
         oshi.software.os.OSFileStore[] fs = this.fileSystem.getFileStores();
         OSFileStore[] fileStores = new OSFileStore[fs.length];
         for (int i = 0; i < fs.length; i++) {
-            fileStores[i] = new OSFileStore(fs[i].getName(), fs[i].getVolume(), fs[i].getMount(),
-                    fs[i].getDescription(), fs[i].getType(), fs[i].getUUID(), fs[i].getUsableSpace(),
-                    fs[i].getTotalSpace(), fs[i].getFreeInodes(), fs[i].getTotalInodes());
-            fileStores[i].setLogicalvolume(fs[i].getLogicalVolume());
+            fileStores[i] = new OSFileStore(fs[i]);
         }
         return fileStores;
     }

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
@@ -65,7 +65,7 @@ public class FileSystemImpl extends AbstractOshiJsonObject implements FileSystem
         for (int i = 0; i < fs.length; i++) {
             fileStores[i] = new OSFileStore(fs[i].getName(), fs[i].getVolume(), fs[i].getMount(),
                     fs[i].getDescription(), fs[i].getType(), fs[i].getUUID(), fs[i].getUsableSpace(),
-                    fs[i].getTotalSpace());
+                    fs[i].getTotalSpace(), fs[i].getUsableFiles(), fs[i].getTotalFiles());
             fileStores[i].setLogicalvolume(fs[i].getLogicalVolume());
         }
         return fileStores;

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
@@ -65,7 +65,7 @@ public class FileSystemImpl extends AbstractOshiJsonObject implements FileSystem
         for (int i = 0; i < fs.length; i++) {
             fileStores[i] = new OSFileStore(fs[i].getName(), fs[i].getVolume(), fs[i].getMount(),
                     fs[i].getDescription(), fs[i].getType(), fs[i].getUUID(), fs[i].getUsableSpace(),
-                    fs[i].getTotalSpace(), fs[i].getUsableFiles(), fs[i].getTotalFiles());
+                    fs[i].getTotalSpace(), fs[i].getUsableInodes(), fs[i].getTotalInodes());
             fileStores[i].setLogicalvolume(fs[i].getLogicalVolume());
         }
         return fileStores;

--- a/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
+++ b/oshi-json/src/main/java/oshi/json/software/os/impl/FileSystemImpl.java
@@ -65,7 +65,7 @@ public class FileSystemImpl extends AbstractOshiJsonObject implements FileSystem
         for (int i = 0; i < fs.length; i++) {
             fileStores[i] = new OSFileStore(fs[i].getName(), fs[i].getVolume(), fs[i].getMount(),
                     fs[i].getDescription(), fs[i].getType(), fs[i].getUUID(), fs[i].getUsableSpace(),
-                    fs[i].getTotalSpace(), fs[i].getUsableInodes(), fs[i].getTotalInodes());
+                    fs[i].getTotalSpace(), fs[i].getFreeInodes(), fs[i].getTotalInodes());
             fileStores[i].setLogicalvolume(fs[i].getLogicalVolume());
         }
         return fileStores;

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.21.0</version>
+					<version>2.22.1</version>
+					<configuration>
+						<forkCount>3</forkCount>
+						<reuseForks>true</reuseForks>
+						<argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+					</configuration>
 				</plugin>
 				<!-- Build Plugins -->
 				<plugin>


### PR DESCRIPTION
Hi,

initial pull request ... not sure about the variable names ... in LibC I have called them (free|total)InodeCounts because that's what it  is (at least on Linux) ... not sure if it's called like that for all the other OS as well. In FreeBSD it's called

> file serial numbers (i.e., inodes)

But in LinuxFileSystem I have called them file counts ... let me know what you prefer. Furthermore I had issues using the "new" JNA stuff ... if you convert the existing Sysinfo I can adapt Statvfs as well.

Furthermore I have set it to -1 for all other OS except of Linux ... not sure how to implement it for FreeBSD, Solaris, MacOS, ...