### PR TITLE
Refactor Linus version parsing to use getStringBetween() [issue #702]

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSVersionInfoEx.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSVersionInfoEx.java
@@ -146,7 +146,7 @@ public class LinuxOSVersionInfoEx extends AbstractOSVersionInfoEx {
                     // remove beginning and ending '"' characters, etc from
                     // VERSION="14.04.4 LTS, Trusty Tahr" (Ubuntu style)
                     // or VERSION="17 (Beefy Miracle)" (os-release doc style)
-                    line = line.replace("VERSION=", "").replaceAll("^\"|\"$", "").trim();
+                    line = ParseUtil.getDoubleQuoteStringValue(line.replace("VERSION_ID=", ""));
                     String[] split = line.split("[()]");
                     if (split.length <= 1) {
                         // If no parentheses, check for Ubuntu's comma format
@@ -162,7 +162,7 @@ public class LinuxOSVersionInfoEx extends AbstractOSVersionInfoEx {
                     LOG.debug("os-release: {}", line);
                     // remove beginning and ending '"' characters, etc from
                     // VERSION_ID="14.04"
-                    this.version = line.replace("VERSION_ID=", "").replaceAll("^\"|\"$", "").trim();
+                    this.version = ParseUtil.getDoubleQuoteStringValue(line.replace("VERSION_ID=", ""));
                 }
             }
         }
@@ -210,16 +210,16 @@ public class LinuxOSVersionInfoEx extends AbstractOSVersionInfoEx {
             for (String line : osRelease) {
                 if (line.startsWith("DISTRIB_DESCRIPTION=")) {
                     LOG.debug("lsb-release: {}", line);
-                    line = line.replace("DISTRIB_DESCRIPTION=", "").replaceAll("^\"|\"$", "").trim();
+                    line = ParseUtil.getDoubleQuoteStringValue(line.replace("DISTRIB_DESCRIPTION=", ""));
                     if (line.contains(" release ")) {
                         this.version = parseRelease(line, " release ");
                     }
                 } else if (line.startsWith("DISTRIB_RELEASE=") && this.version == null) {
                     LOG.debug("lsb-release: {}", line);
-                    this.version = line.replace("DISTRIB_RELEASE=", "").replaceAll("^\"|\"$", "").trim();
+                    this.version = ParseUtil.getDoubleQuoteStringValue(line.replace("DISTRIB_RELEASE=", ""));
                 } else if (line.startsWith("DISTRIB_CODENAME=") && this.codeName == null) {
                     LOG.debug("lsb-release: {}", line);
-                    this.codeName = line.replace("DISTRIB_CODENAME=", "").replaceAll("^\"|\"$", "").trim();
+                    this.codeName = ParseUtil.getDoubleQuoteStringValue(line.replace("DISTRIB_CODENAME=", ""));
                 }
             }
         }

--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -491,11 +491,18 @@ public class ParseUtil {
      * @return the value contained between single tick marks
      */
     public static String getSingleQuoteStringValue(String line) {
-        String[] split = line.split("'");
-        if (split.length < 2) {
-            return "";
-        }
-        return split[1];
+        return getStringBetween(line, '\'');
+    }
+
+    /**
+     * Parses a string key = "value" (string)
+     *
+     * @param line
+     *            The entire string
+     * @return the value contained between double tick marks
+     */
+    public static String getDoubleQuoteStringValue(String line) {
+        return getStringBetween(line, '\"');
     }
 
     /**

--- a/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
@@ -239,6 +239,15 @@ public class ParseUtilTest {
     }
 
     /**
+     * Test parse DoubleQuoteString
+     */
+    @Test
+    public void testGetDoubleQuoteStringValue() {
+        assertEquals("bar", ParseUtil.getDoubleQuoteStringValue("foo = \"bar\" (string)"));
+        assertEquals("", ParseUtil.getDoubleQuoteStringValue("foo = bar (string)"));
+    }
+
+    /**
      * Test parse SingleQuoteBetweenMultipleQuotes
      */
     @Test


### PR DESCRIPTION
Modify code in LinuxOSVersionInfoEx.java to use new method getDoubleQuoteStringValue() to parse the version string, as is discribed in issue #702 . Feel free to feedback if there is any problems to fix.