### PR TITLE
Handle SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX union as subclassing

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -355,8 +355,11 @@ public interface CentralProcessor extends Serializable {
 
         /**
          * @param processorNumber
+         *            the Processor number
          * @param physicalProcessorNumber
+         *            the core number
          * @param physicalPackageNumber
+         *            the package/socket number
          */
         public LogicalProcessor(int processorNumber, int physicalProcessorNumber, int physicalPackageNumber) {
             this(processorNumber, physicalProcessorNumber, physicalPackageNumber, 0, 0);
@@ -364,9 +367,13 @@ public interface CentralProcessor extends Serializable {
 
         /**
          * @param processorNumber
+         *            the Processor number
          * @param physicalProcessorNumber
+         *            the core number
          * @param physicalPackageNumber
+         *            the package/socket number
          * @param numaNode
+         *            the NUMA node number
          */
         public LogicalProcessor(int processorNumber, int physicalProcessorNumber, int physicalPackageNumber,
                 int numaNode) {
@@ -375,10 +382,15 @@ public interface CentralProcessor extends Serializable {
 
         /**
          * @param processorNumber
+         *            the Processor number
          * @param physicalProcessorNumber
+         *            the core number
          * @param physicalPackageNumber
+         *            the package/socket number
          * @param numaNode
+         *            the NUMA node number
          * @param processorGroup
+         *            the Processor Group number
          */
         public LogicalProcessor(int processorNumber, int physicalProcessorNumber, int physicalPackageNumber,
                 int numaNode, int processorGroup) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
@@ -53,7 +53,7 @@ import oshi.jna.platform.windows.PowrProf.ProcessorPowerInformation;
 import oshi.jna.platform.windows.VersionHelpers;
 import oshi.jna.platform.windows.WinNT;
 import oshi.jna.platform.windows.WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX;
-import oshi.jna.platform.windows.WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX.GROUP_AFFINITY;
+import oshi.jna.platform.windows.WinNT.GROUP_AFFINITY;
 import oshi.util.ParseUtil;
 import oshi.util.platform.windows.WmiQueryHandler;
 import oshi.util.platform.windows.WmiUtil;
@@ -271,10 +271,10 @@ public class WindowsCentralProcessor extends AbstractCentralProcessor {
         for (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX proc : processors) {
             if (proc.relationship == WinNT.LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorPackage) {
                 // Package may be on multiple processor groups
-                packageMaskList.add(proc.payload.Processor.getGroupMask());
+                packageMaskList.add(((WinNT.PROCESSOR_RELATIONSHIP)proc).groupMask);
             } else if (proc.relationship == WinNT.LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore) {
                 // Exactly one element for the ProcessorCore relationship
-                coreMaskList.add(proc.payload.Processor.getGroupMask()[0]);
+                coreMaskList.add(((WinNT.PROCESSOR_RELATIONSHIP)proc).groupMask[0]);
             }
         }
         this.physicalProcessorCount = coreMaskList.size();

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/Kernel32Util.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/Kernel32Util.java
@@ -57,15 +57,10 @@ public class Kernel32Util extends com.sun.jna.platform.win32.Kernel32Util {
      */
     public static final SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX[] getLogicalProcessorInformationEx(
             int relationshipType) {
-        // Because JNA will ensure memory is allocated for the largest member of
-        // a Union it is necessary to over-allocate the Java-side buffer. Union
-        // member structure sizes are 48 and 56 bytes, so we pad with 8 bytes so
-        // the ensureAllocated() call requiring 56 bytes doesn't fail when
-        // populating a 48-byte structure.
         WinDef.DWORDByReference bufferSize = new WinDef.DWORDByReference(new WinDef.DWORD(1));
         Memory memory;
         while (true) {
-            memory = new Memory(bufferSize.getValue().intValue() + SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX.AnonymousUnionPayload.UNION_ALLOCATION_PADDING);
+            memory = new Memory(bufferSize.getValue().intValue());
             if (!Kernel32.INSTANCE.GetLogicalProcessorInformationEx(relationshipType, memory, bufferSize)) {
                 int err = Kernel32.INSTANCE.GetLastError();
                 if (err != WinError.ERROR_INSUFFICIENT_BUFFER)
@@ -78,8 +73,7 @@ public class Kernel32Util extends com.sun.jna.platform.win32.Kernel32Util {
         List<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX> procInfoList = new ArrayList<>();
         int offset = 0;
         while (offset < bufferSize.getValue().intValue()) {
-            SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX information = new SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX(
-                    memory.share(offset));
+            SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX information = SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX.fromPointer(memory.share(offset));
             procInfoList.add(information);
             offset += information.size;
         }

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/WinNT.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/WinNT.java
@@ -23,11 +23,9 @@
  */
 package oshi.jna.platform.windows;
 
-import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
-import com.sun.jna.Union;
 
 /**
  * WinNT.
@@ -44,8 +42,9 @@ public interface WinNT extends com.sun.jna.platform.win32.WinNT {
      * related hardware. The {@link Kernel32#GetLogicalProcessorInformationEx}
      * function uses this structure.
      */
-    @FieldOrder({ "relationship", "size", "payload" })
-    class SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX extends Structure {
+    @FieldOrder({ "relationship", "size" })
+    public abstract class SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX extends Structure {
+
         /**
          * The type of relationship between the logical processors. This
          * parameter can be one of the following values:
@@ -62,361 +61,309 @@ public interface WinNT extends com.sun.jna.platform.win32.WinNT {
          */
         public int size;
 
-        /**
-         * A union of fields which differs depending on {@link #relationship}.
-         * The type is either {@link PROCESSOR_RELATIONSHIP},
-         * {@link NUMA_NODE_RELATIONSHIP}, {@link CACHE_RELATIONSHIP}, or
-         * {@link GROUP_RELATIONSHIP}.
-         */
-        public AnonymousUnionPayload payload;
-
         public SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX() {
             super();
         }
 
         public SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX(Pointer memory) {
             super(memory);
-            read();
+        }
+
+        public static SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX fromPointer(Pointer memory) {
+            int relationship = memory.getInt(0);
+            SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX result;
+            switch (relationship) {
+                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore:
+                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorPackage:
+                    result = new PROCESSOR_RELATIONSHIP(memory);
+                    break;
+                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationNumaNode:
+                    result = new NUMA_NODE_RELATIONSHIP(memory);
+                    break;
+                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationCache:
+                    result = new CACHE_RELATIONSHIP(memory);
+                    break;
+                case LOGICAL_PROCESSOR_RELATIONSHIP.RelationGroup:
+                    result = new GROUP_RELATIONSHIP(memory);
+                    break;
+                default:
+                    throw new IllegalStateException("Unmapped relationship: " + relationship);
+            }
+            result.read();
+            return result;
+        }
+    }
+
+    /**
+     * The PROCESSOR_RELATIONSHIP structure describes the logical processors
+     * associated with either a processor core or a processor package.
+     */
+    @FieldOrder({"flags", "efficiencyClass", "reserved", "groupCount", "groupMask"})
+    public static class PROCESSOR_RELATIONSHIP extends SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
+
+        /**
+         * If the Relationship member of the
+         * {@link SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX} structure is
+         * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationProcessorCore}, this
+         * member is {@link #LTP_PC_SMT} if the core has more than one logical
+         * processor, or 0 if the core has one logical processor.
+         * <p>
+         * If the Relationship member of the
+         * {@link SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX} structure is
+         * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationProcessorPackage}, this
+         * member is always 0.
+         */
+        public byte flags;
+
+        /**
+         * If the Relationship member of the
+         * {@link SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX} structure is
+         * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationProcessorCore},
+         * EfficiencyClass specifies the intrinsic tradeoff between performance
+         * and power for the applicable core. A core with a higher value for the
+         * efficiency class has intrinsically greater performance and less
+         * efficiency than a core with a lower value for the efficiency class.
+         * EfficiencyClass is only nonzero on systems with a heterogeneous set
+         * of cores.
+         * <p>
+         * If the Relationship member of the
+         * {@link SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX} structure is
+         * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationProcessorPackage},
+         * EfficiencyClass is always 0.
+         * <p>
+         * The minimum operating system version that supports this member is
+         * Windows 10.
+         */
+        public byte efficiencyClass;
+
+        /**
+         * This member is reserved.
+         */
+        public byte[] reserved = new byte[20];
+
+        /**
+         * This member specifies the number of entries in the GroupMask array.
+         * <p>
+         * If the PROCESSOR_RELATIONSHIP structure represents a processor core,
+         * the GroupCount member is always 1.
+         * <p>
+         * If the PROCESSOR_RELATIONSHIP structure represents a processor
+         * package, the GroupCount member is 1 only if all processors are in the
+         * same processor group. If the package contains more than one NUMA
+         * node, the system might assign different NUMA nodes to different
+         * processor groups. In this case, the GroupCount member is the number
+         * of groups to which NUMA nodes in the package are assigned.
+         */
+        public short groupCount;
+
+        /**
+         * An array of {@link GROUP_AFFINITY} structures. The
+         * {@link #groupCount} member specifies the number of structures in the
+         * array. Each structure in the array specifies a group number and
+         * processor affinity within the group.
+         * <p>
+         * This Pointer is a placeholder. Use {@link #getGroupMask()} to return
+         * the array.
+         */
+        public GROUP_AFFINITY[] groupMask = new GROUP_AFFINITY[1];
+
+        public PROCESSOR_RELATIONSHIP() {
+        }
+
+        public PROCESSOR_RELATIONSHIP(Pointer memory) {
+            super(memory);
         }
 
         @Override
         public void read() {
+            readField("groupCount");
+            groupMask = new GROUP_AFFINITY[groupCount];
             super.read();
-            switch (relationship) {
-            case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore:
-            case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorPackage:
-                payload.setType(PROCESSOR_RELATIONSHIP.class);
-                break;
-            case LOGICAL_PROCESSOR_RELATIONSHIP.RelationNumaNode:
-                payload.setType(NUMA_NODE_RELATIONSHIP.class);
-                break;
-            case LOGICAL_PROCESSOR_RELATIONSHIP.RelationCache:
-                payload.setType(CACHE_RELATIONSHIP.class);
-                break;
-            case LOGICAL_PROCESSOR_RELATIONSHIP.RelationGroup:
-                payload.setType(GROUP_RELATIONSHIP.class);
-                break;
-            default:
-                break;
-            }
-            payload.read();
-        }
-
-        public static class AnonymousUnionPayload extends Union {
-
-            /**
-             * JNA requires allocated memory for the largest structure in a
-             * Union. This padding value calculates the minimum extra Java-side
-             * allocation required beyond native memory requirements.
-             */
-            public static final int UNION_ALLOCATION_PADDING;
-            static {
-                int proc = new PROCESSOR_RELATIONSHIP().size();
-                int numa = new NUMA_NODE_RELATIONSHIP().size();
-                int cache = new CACHE_RELATIONSHIP().size();
-                int group = new GROUP_RELATIONSHIP().size();
-                UNION_ALLOCATION_PADDING = Math.max(Math.max(proc, numa), Math.max(cache, group))
-                        - Math.min(Math.min(proc, numa), Math.min(cache, group));
-            }
-            /**
-             * A PROCESSOR_RELATIONSHIP structure that describes processor
-             * affinity. This structure contains valid data only if the
-             * Relationship member is
-             * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationProcessorCore} or
-             * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationProcessorPackage}.
-             */
-            public PROCESSOR_RELATIONSHIP Processor;
-
-            /**
-             * A NUMA_NODE_RELATIONSHIP structure that describes a NUMA node.
-             * This structure contains valid data only if the Relationship
-             * member is
-             * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationNumaNode}.
-             */
-            public NUMA_NODE_RELATIONSHIP NumaNode;
-
-            /**
-             * A CACHE_RELATIONSHIP structure that describes cache attributes.
-             * This structure contains valid data only if the Relationship
-             * member is {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationCache}.
-             */
-            public CACHE_RELATIONSHIP Cache;
-
-            /**
-             * A GROUP_RELATIONSHIP structure that contains information about
-             * the processor groups. This structure contains valid data only if
-             * the Relationship member is RelationGroup.
-             */
-            public GROUP_RELATIONSHIP Group;
-        }
-
-        /**
-         * The PROCESSOR_RELATIONSHIP structure describes the logical processors
-         * associated with either a processor core or a processor package.
-         */
-        @FieldOrder({ "flags", "efficiencyClass", "reserved", "groupCount", "groupMask" })
-        public static class PROCESSOR_RELATIONSHIP extends Structure {
-            /**
-             * If the Relationship member of the
-             * {@link SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX} structure is
-             * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationProcessorCore},
-             * this member is {@link #LTP_PC_SMT} if the core has more than one
-             * logical processor, or 0 if the core has one logical processor.
-             * <p>
-             * If the Relationship member of the
-             * {@link SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX} structure is
-             * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationProcessorPackage},
-             * this member is always 0.
-             */
-            public byte flags;
-
-            /**
-             * If the Relationship member of the
-             * {@link SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX} structure is
-             * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationProcessorCore},
-             * EfficiencyClass specifies the intrinsic tradeoff between
-             * performance and power for the applicable core. A core with a
-             * higher value for the efficiency class has intrinsically greater
-             * performance and less efficiency than a core with a lower value
-             * for the efficiency class. EfficiencyClass is only nonzero on
-             * systems with a heterogeneous set of cores.
-             * <p>
-             * If the Relationship member of the
-             * {@link SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX} structure is
-             * {@link LOGICAL_PROCESSOR_RELATIONSHIP#RelationProcessorPackage},
-             * EfficiencyClass is always 0.
-             * <p>
-             * The minimum operating system version that supports this member is
-             * Windows 10.
-             */
-            public byte efficiencyClass;
-
-            /**
-             * This member is reserved.
-             */
-            public byte[] reserved = new byte[20];
-
-            /**
-             * This member specifies the number of entries in the GroupMask
-             * array.
-             * <p>
-             * If the PROCESSOR_RELATIONSHIP structure represents a processor
-             * core, the GroupCount member is always 1.
-             * <p>
-             * If the PROCESSOR_RELATIONSHIP structure represents a processor
-             * package, the GroupCount member is 1 only if all processors are in
-             * the same processor group. If the package contains more than one
-             * NUMA node, the system might assign different NUMA nodes to
-             * different processor groups. In this case, the GroupCount member
-             * is the number of groups to which NUMA nodes in the package are
-             * assigned.
-             */
-            public short groupCount;
-
-            /**
-             * An array of {@link GROUP_AFFINITY} structures. The
-             * {@link #groupCount} member specifies the number of structures in
-             * the array. Each structure in the array specifies a group number
-             * and processor affinity within the group.
-             * <p>
-             * This Pointer is a placeholder. Use {@link #getGroupMask()} to
-             * return the array.
-             */
-            public Pointer groupMask;
-
-            /**
-             * @return An array of {@link GROUP_AFFINITY} structures. The
-             *         {@link #groupCount} member specifies the number of
-             *         structures in the array. Each structure in the array
-             *         specifies a group number and processor affinity within
-             *         the group.
-             */
-            public GROUP_AFFINITY[] getGroupMask() {
-                // Get pointer to array in memory
-                int baseOffset = this.fieldOffset("groupMask");
-                // Instantiate new array
-                GROUP_AFFINITY[] mask = new GROUP_AFFINITY[this.groupCount];
-                for (int i = 0; i < mask.length; i++) {
-                    int offset = baseOffset + i * Native.getNativeSize(GROUP_AFFINITY.class);
-                    mask[i] = new GROUP_AFFINITY(this.getPointer().share(offset));
-                }
-                return mask;
-            }
-        }
-
-        /**
-         * Represents information about a NUMA node in a processor group.
-         */
-        @FieldOrder({ "nodeNumber", "reserved", "groupMask" })
-        public static class NUMA_NODE_RELATIONSHIP extends Structure {
-            /**
-             * Identifies the NUMA node. Valid values are {@code 0} to the
-             * highest NUMA node number inclusive. A non-NUMA multiprocessor
-             * system will report that all processors belong to one NUMA node.
-             */
-            public int nodeNumber;
-            /**
-             * This member is reserved.
-             */
-            public byte[] reserved = new byte[20];
-            /**
-             * A {@link GROUP_AFFINITY} structure that specifies a group number
-             * and processor affinity within the group.
-             */
-            public GROUP_AFFINITY groupMask;
-        }
-
-        /**
-         * Describes cache attributes.
-         */
-        @FieldOrder({ "level", "associativity", "lineSize", "cacheSize", "type", "reserved", "groupMask" })
-        public static class CACHE_RELATIONSHIP extends Structure {
-            /**
-             * The cache level. This member can be 1 (L1), 2 (L2), or 3 (L3).
-             */
-            public byte level;
-            /**
-             * The cache associativity. If this member is
-             * {@link #CACHE_FULLY_ASSOCIATIVE}, the cache is fully associative.
-             */
-            public byte associativity;
-            /**
-             * The cache line size, in bytes.
-             */
-            public short lineSize;
-            /**
-             * The cache size, in bytes.
-             */
-            public int cacheSize;
-            /**
-             * The cache type. This member is a {@link PROCESSOR_CACHE_TYPE}
-             * value.
-             */
-            public int /* PROCESSOR_CACHE_TYPE */ type;
-            /**
-             * This member is reserved.
-             */
-            public byte[] reserved = new byte[20];
-            /**
-             * A {@link GROUP_AFFINITY} structure that specifies a group number
-             * and processor affinity within the group.
-             */
-            public GROUP_AFFINITY groupMask;
-        }
-
-        /**
-         * Represents information about processor groups.
-         */
-        @FieldOrder({ "maximumGroupCount", "activeGroupCount", "reserved", "groupInfo" })
-        public static class GROUP_RELATIONSHIP extends Structure {
-            /**
-             * The maximum number of processor groups on the system.
-             */
-            public short maximumGroupCount;
-            /**
-             * The number of active groups on the system. This member indicates
-             * the number of {@link PROCESSOR_GROUP_INFO} structures in the
-             * GroupInfo array.
-             */
-            public short activeGroupCount;
-            /**
-             * This member is reserved.
-             */
-            public byte[] reserved = new byte[20];
-            /**
-             * An array of {@link PROCESSOR_GROUP_INFO} structures. The
-             * {@link #activeGroupCount} member specifies the number of
-             * structures in the array. Each structure in the array specifies
-             * the number and affinity of processors in an active group on the
-             * system.
-             * <p>
-             * This Pointer is a placeholder. Use {@link #getGroupInfo()} to
-             * return the array.
-             */
-            public Pointer groupInfo;
-
-            /**
-             * @return An array of {@link PROCESSOR_GROUP_INFO} structures. The
-             *         {@link #activeGroupCount} member specifies the number of
-             *         structures in the array. Each structure in the array
-             *         specifies the number and affinity of processors in an
-             *         active group on the system.
-             */
-            public PROCESSOR_GROUP_INFO[] getGroupInfo() {
-                // Get pointer to array in memory
-                int baseOffset = this.fieldOffset("groupInfo");
-                // Instantiate new array
-                PROCESSOR_GROUP_INFO[] info = new PROCESSOR_GROUP_INFO[this.activeGroupCount];
-                for (int i = 0; i < info.length; i++) {
-                    int offset = baseOffset + i * Native.getNativeSize(PROCESSOR_GROUP_INFO.class);
-                    info[i] = new PROCESSOR_GROUP_INFO(this.getPointer().share(offset));
-                }
-                return info;
-            }
-        }
-
-        /**
-         * Represents a processor group-specific affinity, such as the affinity
-         * of a thread.
-         */
-        @FieldOrder({ "mask", "group", "reserved" })
-        public static class GROUP_AFFINITY extends Structure {
-            /**
-             * A bitmap that specifies the affinity for zero or more processors
-             * within the specified group.
-             */
-            public ULONG_PTR /* KAFFINITY */ mask;
-            /**
-             * The processor group number.
-             */
-            public short group;
-            /**
-             * This member is reserved.
-             */
-            public short[] reserved = new short[3];
-
-            public GROUP_AFFINITY(Pointer memory) {
-                super(memory);
-                read();
-            }
-
-            public GROUP_AFFINITY() {
-                super();
-            }
-        }
-
-        /**
-         * Represents the number and affinity of processors in a processor
-         * group.
-         */
-        @FieldOrder({ "maximumProcessorCount", "activeProcessorCount", "reserved", "activeProcessorMask" })
-        public static class PROCESSOR_GROUP_INFO extends Structure {
-            /**
-             * The maximum number of processors in the group.
-             */
-            public byte maximumProcessorCount;
-            /**
-             * The number of active processors in the group.
-             */
-            public byte activeProcessorCount;
-            /**
-             * This member is reserved.
-             */
-            public byte[] reserved = new byte[38];
-            /**
-             * A bitmap that specifies the affinity for zero or more active
-             * processors within the group.
-             */
-            public ULONG_PTR /* KAFFINITY */ activeProcessorMask;
-
-            public PROCESSOR_GROUP_INFO(Pointer memory) {
-                super(memory);
-                read();
-            }
-
-            public PROCESSOR_GROUP_INFO() {
-                super();
-            }
         }
     }
+
+    /**
+     * Represents information about a NUMA node in a processor group.
+     */
+    @FieldOrder({"nodeNumber", "reserved", "groupMask"})
+    public static class NUMA_NODE_RELATIONSHIP extends SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
+
+        /**
+         * Identifies the NUMA node. Valid values are {@code 0} to the highest
+         * NUMA node number inclusive. A non-NUMA multiprocessor system will
+         * report that all processors belong to one NUMA node.
+         */
+        public int nodeNumber;
+        /**
+         * This member is reserved.
+         */
+        public byte[] reserved = new byte[20];
+        /**
+         * A {@link GROUP_AFFINITY} structure that specifies a group number and
+         * processor affinity within the group.
+         */
+        public GROUP_AFFINITY groupMask;
+
+        public NUMA_NODE_RELATIONSHIP() {
+        }
+
+        public NUMA_NODE_RELATIONSHIP(Pointer memory) {
+            super(memory);
+        }
+    }
+
+    /**
+     * Describes cache attributes.
+     */
+    @FieldOrder({"level", "associativity", "lineSize", "cacheSize", "type", "reserved", "groupMask"})
+    public static class CACHE_RELATIONSHIP extends SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
+
+        /**
+         * The cache level. This member can be 1 (L1), 2 (L2), or 3 (L3).
+         */
+        public byte level;
+        /**
+         * The cache associativity. If this member is
+         * {@link #CACHE_FULLY_ASSOCIATIVE}, the cache is fully associative.
+         */
+        public byte associativity;
+        /**
+         * The cache line size, in bytes.
+         */
+        public short lineSize;
+        /**
+         * The cache size, in bytes.
+         */
+        public int cacheSize;
+        /**
+         * The cache type. This member is a {@link PROCESSOR_CACHE_TYPE} value.
+         */
+        public int /* PROCESSOR_CACHE_TYPE */ type;
+        /**
+         * This member is reserved.
+         */
+        public byte[] reserved = new byte[20];
+        /**
+         * A {@link GROUP_AFFINITY} structure that specifies a group number and
+         * processor affinity within the group.
+         */
+        public GROUP_AFFINITY groupMask;
+
+        public CACHE_RELATIONSHIP() {
+        }
+
+        public CACHE_RELATIONSHIP(Pointer memory) {
+            super(memory);
+        }
+    }
+
+    /**
+     * Represents information about processor groups.
+     */
+    @FieldOrder({"maximumGroupCount", "activeGroupCount", "reserved", "groupInfo"})
+    public static class GROUP_RELATIONSHIP extends SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
+
+        /**
+         * The maximum number of processor groups on the system.
+         */
+        public short maximumGroupCount;
+        /**
+         * The number of active groups on the system. This member indicates the
+         * number of {@link PROCESSOR_GROUP_INFO} structures in the GroupInfo
+         * array.
+         */
+        public short activeGroupCount;
+        /**
+         * This member is reserved.
+         */
+        public byte[] reserved = new byte[20];
+        /**
+         * An array of {@link PROCESSOR_GROUP_INFO} structures. The
+         * {@link #activeGroupCount} member specifies the number of structures
+         * in the array. Each structure in the array specifies the number and
+         * affinity of processors in an active group on the system.
+         * <p>
+         * This Pointer is a placeholder. Use {@link #getGroupInfo()} to return
+         * the array.
+         */
+        public PROCESSOR_GROUP_INFO[] groupInfo = new PROCESSOR_GROUP_INFO[1];
+
+        public GROUP_RELATIONSHIP() {
+        }
+
+        public GROUP_RELATIONSHIP(Pointer memory) {
+            super(memory);
+        }
+
+        @Override
+        public void read() {
+            readField("activeGroupCount");
+            groupInfo = new PROCESSOR_GROUP_INFO[activeGroupCount];
+            super.read();
+        }
+    }
+
+    /**
+     * Represents a processor group-specific affinity, such as the affinity of a
+     * thread.
+     */
+    @FieldOrder({"mask", "group", "reserved"})
+    public static class GROUP_AFFINITY extends Structure {
+
+        /**
+         * A bitmap that specifies the affinity for zero or more processors
+         * within the specified group.
+         */
+        public ULONG_PTR /* KAFFINITY */ mask;
+        /**
+         * The processor group number.
+         */
+        public short group;
+        /**
+         * This member is reserved.
+         */
+        public short[] reserved = new short[3];
+
+        public GROUP_AFFINITY(Pointer memory) {
+            super(memory);
+        }
+
+        public GROUP_AFFINITY() {
+            super();
+        }
+    }
+
+    /**
+     * Represents the number and affinity of processors in a processor group.
+     */
+    @FieldOrder({"maximumProcessorCount", "activeProcessorCount", "reserved", "activeProcessorMask"})
+    public static class PROCESSOR_GROUP_INFO extends Structure {
+
+        /**
+         * The maximum number of processors in the group.
+         */
+        public byte maximumProcessorCount;
+        /**
+         * The number of active processors in the group.
+         */
+        public byte activeProcessorCount;
+        /**
+         * This member is reserved.
+         */
+        public byte[] reserved = new byte[38];
+        /**
+         * A bitmap that specifies the affinity for zero or more active
+         * processors within the group.
+         */
+        public ULONG_PTR /* KAFFINITY */ activeProcessorMask;
+
+        public PROCESSOR_GROUP_INFO(Pointer memory) {
+            super(memory);
+        }
+
+        public PROCESSOR_GROUP_INFO() {
+            super();
+        }
+    }
+
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/WinNT.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/WinNT.java
@@ -161,9 +161,6 @@ public interface WinNT extends com.sun.jna.platform.win32.WinNT {
          * {@link #groupCount} member specifies the number of structures in the
          * array. Each structure in the array specifies a group number and
          * processor affinity within the group.
-         * <p>
-         * This Pointer is a placeholder. Use {@link #getGroupMask()} to return
-         * the array.
          */
         public GROUP_AFFINITY[] groupMask = new GROUP_AFFINITY[1];
 
@@ -282,9 +279,6 @@ public interface WinNT extends com.sun.jna.platform.win32.WinNT {
          * {@link #activeGroupCount} member specifies the number of structures
          * in the array. Each structure in the array specifies the number and
          * affinity of processors in an active group on the system.
-         * <p>
-         * This Pointer is a placeholder. Use {@link #getGroupInfo()} to return
-         * the array.
          */
         public PROCESSOR_GROUP_INFO[] groupInfo = new PROCESSOR_GROUP_INFO[1];
 


### PR DESCRIPTION
The union embedded in SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX has a
dynamic size. So at decoding time the size depends on the Relationship
code embedded in the structure.

Instead of trying to press this through the default JNA union 
deserialization, model the four cases created by the four embedded
structures in the dummy union as separate subclasses of 
SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX.

Implementation provided by @matthiasblaesing 