### PR TITLE
Reinstate the interruption status in Util.sleep and remove the unused Util.sleepAfter

### DIFF
--- a/oshi-core/src/main/java/oshi/util/Util.java
+++ b/oshi-core/src/main/java/oshi/util/Util.java
@@ -49,25 +49,7 @@ public class Util {
             Thread.sleep(ms);
         } catch (InterruptedException e) { // NOSONAR squid:S2142
             LOG.warn("Interrupted while sleeping for {} ms: {}", ms, e);
-        }
-    }
-
-    /**
-     * Sleeps for the specified number of milliseconds after the given system
-     * time in milliseconds. If that number of milliseconds has already elapsed,
-     * does nothing.
-     *
-     * @param startTime
-     *            System time in milliseconds to sleep after
-     * @param ms
-     *            How long after startTime to sleep
-     */
-    public static void sleepAfter(long startTime, long ms) {
-        long now = System.currentTimeMillis();
-        long until = startTime + ms;
-        LOG.trace("Sleeping until {}", until);
-        if (now < until) {
-            sleep(until - now);
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/oshi-core/src/test/java/oshi/util/UtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/UtilTest.java
@@ -39,16 +39,6 @@ public class UtilTest {
         long now = System.nanoTime();
         Util.sleep(100);
         assertTrue(System.nanoTime() - now >= 90_000_000);
-
-        now = System.nanoTime();
-        long then = System.currentTimeMillis() + 100;
-        Util.sleepAfter(then, 100);
-        assertTrue(System.nanoTime() - now >= 190_000_000);
-
-        now = System.nanoTime();
-        then = System.currentTimeMillis() - 550;
-        Util.sleepAfter(then, 500);
-        assertTrue(System.nanoTime() - now < 500_000_000);
     }
 
     @Test


### PR DESCRIPTION
This pull request does not fully fix https://github.com/oshi/oshi/issues/796, there are many places where System.currentTimeMillis is used to measure time intervals, e.g. the MacNetworks.mapIFs method.