### PR TITLE
Mention Eclipse Passage and Eclipse Orbit

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Projects using OSHI
 * [360Suite](https://360suite.io/)
 * [GoMint](https://gomint.io/)
 * [Stefan's OS](https://BotCompany.de/)
+* [Eclipse Passage](https://projects.eclipse.org/projects/technology.passage)
+* [Eclipse Orbit](https://projects.eclipse.org/projects/tools.orbit)
 
 License
 -------


### PR DESCRIPTION
Thanks a lot for the very good library!

The [Eclipse Passage](https://projects.eclipse.org/projects/technology.passage) project (open source license management solution) started to use OSHI last year to support node-locked licensing story.
[Recently](https://download.eclipse.org/tools/orbit/downloads/drops/I20190221153854/) oshi-core 3.8.0 has been added to [Eclipse Orbit](https://projects.eclipse.org/projects/tools.orbit) to be available for other Eclipse projects. This version has been selected to simplify the process, as required libraries for this version were already there.

I'm planning to upgrade it to more recent version but may need your advice.

Thanks again,
AF