### PR TITLE
Thread safety examples

### DIFF
--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -52,6 +52,8 @@ public class SystemInfo implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    public static final String UNKNOWN = "unknown";
+
     private OperatingSystem os = null;
 
     private HardwareAbstractionLayer hardware = null;

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -101,27 +101,11 @@ public interface CentralProcessor extends Serializable {
     String getVendor();
 
     /**
-     * Set processor vendor.
-     *
-     * @param vendor
-     *            Vendor.
-     */
-    void setVendor(String vendor);
-
-    /**
      * Name, eg. Intel(R) Core(TM)2 Duo CPU T7300 @ 2.00GHz
      *
      * @return Processor name.
      */
     String getName();
-
-    /**
-     * Set processor name.
-     *
-     * @param name
-     *            Name.
-     */
-    void setName(String name);
 
     /**
      * Vendor frequency (in Hz), eg. for processor named Intel(R) Core(TM)2 Duo
@@ -130,14 +114,6 @@ public interface CentralProcessor extends Serializable {
      * @return Processor frequency or -1 if unknown.
      */
     long getVendorFreq();
-
-    /**
-     * Set processor vendor frequency (in Hz).
-     *
-     * @param freq
-     *            Frequency.
-     */
-    void setVendorFreq(long freq);
 
     /**
      * Gets the Processor ID. This is a hexidecimal string representing an
@@ -155,27 +131,11 @@ public interface CentralProcessor extends Serializable {
     String getProcessorID();
 
     /**
-     * Set processor ID
-     *
-     * @param processorID
-     *            The processor ID
-     */
-    void setProcessorID(String processorID);
-
-    /**
      * Identifier, eg. x86 Family 6 Model 15 Stepping 10.
      *
      * @return Processor identifier.
      */
     String getIdentifier();
-
-    /**
-     * Set processor identifier.
-     *
-     * @param identifier
-     *            Identifier.
-     */
-    void setIdentifier(String identifier);
 
     /**
      * Is CPU 64bit?
@@ -185,23 +145,9 @@ public interface CentralProcessor extends Serializable {
     boolean isCpu64bit();
 
     /**
-     * Set flag is cpu is 64bit.
-     *
-     * @param cpu64
-     *            True if cpu is 64.
-     */
-    void setCpu64(boolean cpu64);
-
-    /**
      * @return the stepping
      */
     String getStepping();
-
-    /**
-     * @param stepping
-     *            the stepping to set
-     */
-    void setStepping(String stepping);
 
     /**
      * @return the model
@@ -209,21 +155,9 @@ public interface CentralProcessor extends Serializable {
     String getModel();
 
     /**
-     * @param model
-     *            the model to set
-     */
-    void setModel(String model);
-
-    /**
      * @return the family
      */
     String getFamily();
-
-    /**
-     * @param family
-     *            the family to set
-     */
-    void setFamily(String family);
 
     /**
      * Returns the "recent cpu usage" for the whole system by counting ticks

--- a/oshi-core/src/main/java/oshi/hardware/ComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/ComputerSystem.java
@@ -24,6 +24,7 @@
 package oshi.hardware;
 
 import java.io.Serializable;
+import oshi.SystemInfo;
 
 /**
  * The ComputerSystem represents the physical hardware, of a computer
@@ -65,7 +66,7 @@ public interface ComputerSystem extends Serializable {
      * but may have permissions altered by the user.
      *
      * @return the System Serial Number, if available, otherwise returns
-     *         "unknown"
+     *         {@link SystemInfo#UNKNOWN}
      */
     String getSerialNumber();
 

--- a/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
@@ -97,7 +97,7 @@ public class NetworkIF implements Serializable {
                 }
                 this.mac = StringUtil.join(":", octets);
             } else {
-                this.mac = "Unknown";
+                this.mac = SystemInfo.UNKNOWN;
             }
             // Set IP arrays
             ArrayList<String> ipv4list = new ArrayList<>();

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractBaseboard.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractBaseboard.java
@@ -23,11 +23,12 @@
  */
 package oshi.hardware.common;
 
-import oshi.SystemInfo;
+import static oshi.SystemInfo.UNKNOWN;
+import static oshi.util.StringUtil.isBlank;
 import oshi.hardware.Baseboard;
 
 /**
- * Baseboard data
+ * Baseboard data. This implementation is immutable.
  *
  * @author widdis [at] gmail [dot] com
  */
@@ -35,16 +36,31 @@ public abstract class AbstractBaseboard implements Baseboard {
 
     private static final long serialVersionUID = 1L;
 
-    private String manufacturer;
-    private String model;
-    private String version;
-    private String serialNumber;
+    private final String manufacturer;
+    private final String model;
+    private final String version;
+    private final String serialNumber;
 
     public AbstractBaseboard() {
-        this.manufacturer = SystemInfo.UNKNOWN;
-        this.model = SystemInfo.UNKNOWN;
-        this.version = SystemInfo.UNKNOWN;
-        this.serialNumber = "";
+        this(null);
+    }
+
+    public AbstractBaseboard(BaseboardInitializer initializer ) {
+        if (initializer == null) {
+            initializer = getInitializer();
+        }
+
+        if (initializer != null) {
+            manufacturer = isBlank(initializer.manufacturer) ? UNKNOWN : initializer.manufacturer;
+            model = isBlank(initializer.model) ? UNKNOWN : initializer.model;
+            version = isBlank(initializer.version) ? UNKNOWN : initializer.version;
+            serialNumber = isBlank(initializer.serialNumber) ? "" : initializer.serialNumber;
+        } else {
+            manufacturer = UNKNOWN;
+            model = UNKNOWN;
+            version = UNKNOWN;
+            serialNumber = "";
+        }
     }
 
     /**
@@ -79,36 +95,12 @@ public abstract class AbstractBaseboard implements Baseboard {
         return this.serialNumber;
     }
 
-    /**
-     * @param manufacturer
-     *            The manufacturer to set.
-     */
-    public void setManufacturer(String manufacturer) {
-        this.manufacturer = manufacturer;
-    }
+    protected abstract BaseboardInitializer getInitializer();
 
-    /**
-     * @param model
-     *            The model to set.
-     */
-    public void setModel(String model) {
-        this.model = model;
+    public static class BaseboardInitializer {
+        public String manufacturer;
+        public String model;
+        public String version;
+        public String serialNumber;
     }
-
-    /**
-     * @param version
-     *            The version to set.
-     */
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    /**
-     * @param serialNumber
-     *            The serialNumber to set.
-     */
-    public void setSerialNumber(String serialNumber) {
-        this.serialNumber = serialNumber;
-    }
-
 }

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractBaseboard.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractBaseboard.java
@@ -23,6 +23,7 @@
  */
 package oshi.hardware.common;
 
+import oshi.SystemInfo;
 import oshi.hardware.Baseboard;
 
 /**
@@ -40,9 +41,9 @@ public abstract class AbstractBaseboard implements Baseboard {
     private String serialNumber;
 
     public AbstractBaseboard() {
-        this.manufacturer = "unknown";
-        this.model = "unknown";
-        this.version = "unknown";
+        this.manufacturer = SystemInfo.UNKNOWN;
+        this.model = SystemInfo.UNKNOWN;
+        this.version = SystemInfo.UNKNOWN;
         this.serialNumber = "";
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -23,6 +23,7 @@
  */
 package oshi.hardware.common;
 
+import static oshi.util.StringUtil.isBlank;
 import java.lang.management.ManagementFactory;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -34,7 +35,7 @@ import oshi.hardware.CentralProcessor;
 import oshi.util.ParseUtil;
 
 /**
- * A CPU as defined in Linux /proc.
+ * A CPU as defined in Linux /proc. This implementation is thread-safe.
  *
  * @author alessandro[at]perucchi[dot]org
  * @author alessio.fachechi[at]gmail[dot]com
@@ -54,6 +55,16 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
             .getOperatingSystemMXBean();
 
     /**
+     * Keep track whether MXBean supports Oracle JVM methods
+     */
+    private final boolean sunMXBean;
+
+    /**
+     * The lock for all mutable (non-final) fields
+     */
+    protected final Object instanceLock = new Object();
+
+    /**
      * Calling OperatingSystemMxBean too rapidly results in NaN. Store the
      * latest value to return if polling is too rapid
      */
@@ -64,18 +75,6 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * enough time has elapsed
      */
     private long lastCpuLoadTime = 0;
-
-    /**
-     * Keep track whether MXBean supports Oracle JVM methods
-     */
-    private boolean sunMXBean = false;
-
-    // Logical and Physical Processor Counts
-    protected int logicalProcessorCount = 0;
-
-    protected int physicalProcessorCount = 0;
-
-    protected int physicalPackageCount = 0;
 
     // Maintain previous ticks to be used for calculating usage between them.
     // System ticks
@@ -92,74 +91,140 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
 
     private long[][] curProcTicks;
 
+    // Logical and Physical Processor Counts
+    protected final int logicalProcessorCount;
+
+    protected final int physicalProcessorCount;
+
+    protected final int physicalPackageCount;
+
     // Processor info
-    private String cpuVendor;
+    protected final String cpuVendor;
 
-    private String cpuName;
+    protected final String cpuName;
 
-    private String processorID;
+    protected final String processorID;
 
-    private String cpuIdentifier;
+    protected final String cpuIdentifier;
 
-    private String cpuStepping;
+    protected final String cpuStepping;
 
-    private String cpuModel;
+    protected final String cpuModel;
 
-    private String cpuFamily;
+    protected final String cpuFamily;
 
-    private Long cpuVendorFreq;
+    protected final long cpuVendorFreq;
 
-    private Boolean cpu64;
+    protected final boolean cpu64;
 
     /**
      * Create a Processor
      */
     public AbstractCentralProcessor() {
-        initMXBean();
-        // Initialize processor counts
-        calculateProcessorCounts();
+        sunMXBean = initMXBean();
+
+        CentralProcessorInitializer initializer = getInitializer();
+
+        if (initializer != null) {
+            logicalProcessorCount = initializer.logicalProcessorCount;
+            physicalProcessorCount = initializer.physicalProcessorCount;
+            physicalPackageCount = initializer.physicalPackageCount;
+            cpuVendor = isBlank(initializer.cpuVendor) ? "" : initializer.cpuVendor;
+            cpuName = isBlank(initializer.cpuName) ? "" : initializer.cpuName;
+            processorID = isBlank(initializer.processorID) ? "" : initializer.processorID;
+            cpu64 = initializer.cpu64;
+            if (initializer.cpuFamily == null) {
+                cpuFamily = initializer.cpuIdentifier == null ? "?" : parseIdentifier("Family", initializer.cpuIdentifier);
+            } else {
+                cpuFamily = initializer.cpuFamily;
+            }
+            if (initializer.cpuModel == null) {
+                cpuModel = initializer.cpuIdentifier == null ? "?" : parseIdentifier("Model", initializer.cpuIdentifier);
+            } else {
+                cpuModel = initializer.cpuModel;
+            }
+            if (initializer.cpuStepping == null) {
+                cpuStepping = initializer.cpuIdentifier == null ? "?" : parseIdentifier("Stepping", initializer.cpuIdentifier);
+            } else {
+                cpuStepping = initializer.cpuStepping;
+            }
+            if (initializer.cpuIdentifier == null) {
+                StringBuilder sb = new StringBuilder();
+                if (cpuVendor.contentEquals("GenuineIntel")) {
+                    sb.append(cpu64 ? "Intel64" : "x86");
+                } else {
+                    sb.append(cpuVendor);
+                }
+                sb.append(" Family ").append(cpuFamily);
+                sb.append(" Model ").append(cpuModel);
+                sb.append(" Stepping ").append(cpuStepping);
+                cpuIdentifier = sb.toString();
+            } else {
+                cpuIdentifier = initializer.cpuIdentifier;
+            }
+
+            Pattern pattern = Pattern.compile("@ (.*)$");
+            Matcher matcher = pattern.matcher(cpuName);
+
+            if (matcher.find()) {
+                String unit = matcher.group(1);
+                this.cpuVendorFreq = ParseUtil.parseHertz(unit);
+            } else {
+                this.cpuVendorFreq = -1L;
+            }
+        } else {
+            logicalProcessorCount = 0;
+            physicalProcessorCount = 0;
+            physicalPackageCount = 0;
+            cpuVendor = "";
+            cpuName = "";
+            processorID = "";
+            cpuIdentifier = "?";
+            cpuStepping = "?";
+            cpuModel = "?";
+            cpuFamily = "?";
+            cpuVendorFreq = -1L;
+            cpu64 = false;
+        }
     }
 
     /**
      * Initializes mxBean boolean
      */
-    private void initMXBean() {
+    private boolean initMXBean() {
         try {
             Class.forName("com.sun.management.OperatingSystemMXBean");
             // Initialize CPU usage
-            this.lastCpuLoad = ((com.sun.management.OperatingSystemMXBean) OS_MXBEAN).getSystemCpuLoad();
-            this.lastCpuLoadTime = System.currentTimeMillis();
-            this.sunMXBean = true;
+            synchronized (instanceLock) {
+                this.lastCpuLoad = ((com.sun.management.OperatingSystemMXBean) OS_MXBEAN).getSystemCpuLoad();
+                this.lastCpuLoadTime = System.currentTimeMillis();
+            }
             LOG.debug("Oracle MXBean detected.");
+            return true;
         } catch (ClassNotFoundException | ClassCastException e) {
             LOG.debug("Oracle MXBean not detected.");
             LOG.trace("{}", e);
+            return false;
         }
     }
 
     /**
      * Initializes tick arrays
      */
-    protected synchronized void initTicks() {
-        this.prevProcTicks = new long[this.logicalProcessorCount][TickType.values().length];
-        this.curProcTicks = new long[this.logicalProcessorCount][TickType.values().length];
-        this.prevTicks = new long[TickType.values().length];
-        this.curTicks = new long[TickType.values().length];
+    protected void initTicks() {
+        synchronized (instanceLock) {
+            this.prevProcTicks = new long[this.logicalProcessorCount][TickType.values().length];
+            this.curProcTicks = new long[this.logicalProcessorCount][TickType.values().length];
+            this.prevTicks = new long[TickType.values().length];
+            this.curTicks = new long[TickType.values().length];
+        }
     }
-
-    /**
-     * Updates logical and physical processor counts
-     */
-    protected abstract void calculateProcessorCounts();
 
     /**
      * {@inheritDoc}
      */
     @Override
     public String getVendor() {
-        if (this.cpuVendor == null) {
-            setVendor("");
-        }
         return this.cpuVendor;
     }
 
@@ -167,18 +232,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * {@inheritDoc}
      */
     @Override
-    public void setVendor(String vendor) {
-        this.cpuVendor = vendor;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String getName() {
-        if (this.cpuName == null) {
-            setName("");
-        }
         return this.cpuName;
     }
 
@@ -186,18 +240,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * {@inheritDoc}
      */
     @Override
-    public void setName(String name) {
-        this.cpuName = name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String getProcessorID() {
-        if (this.processorID == null) {
-            setProcessorID("");
-        }
         return this.processorID;
     }
 
@@ -205,35 +248,8 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * {@inheritDoc}
      */
     @Override
-    public void setProcessorID(String processorID) {
-        this.processorID = processorID;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public long getVendorFreq() {
-        if (this.cpuVendorFreq == null) {
-            Pattern pattern = Pattern.compile("@ (.*)$");
-            Matcher matcher = pattern.matcher(getName());
-
-            if (matcher.find()) {
-                String unit = matcher.group(1);
-                this.cpuVendorFreq = Long.valueOf(ParseUtil.parseHertz(unit));
-            } else {
-                this.cpuVendorFreq = Long.valueOf(-1L);
-            }
-        }
-        return this.cpuVendorFreq.longValue();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setVendorFreq(long freq) {
-        this.cpuVendorFreq = Long.valueOf(freq);
+        return this.cpuVendorFreq;
     }
 
     /**
@@ -241,18 +257,6 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      */
     @Override
     public String getIdentifier() {
-        if (this.cpuIdentifier == null) {
-            StringBuilder sb = new StringBuilder();
-            if (getVendor().contentEquals("GenuineIntel")) {
-                sb.append(isCpu64bit() ? "Intel64" : "x86");
-            } else {
-                sb.append(getVendor());
-            }
-            sb.append(" Family ").append(getFamily());
-            sb.append(" Model ").append(getModel());
-            sb.append(" Stepping ").append(getStepping());
-            setIdentifier(sb.toString());
-        }
         return this.cpuIdentifier;
     }
 
@@ -260,18 +264,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * {@inheritDoc}
      */
     @Override
-    public void setIdentifier(String identifier) {
-        this.cpuIdentifier = identifier;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public boolean isCpu64bit() {
-        if (this.cpu64 == null) {
-            setCpu64(false);
-        }
         return this.cpu64;
     }
 
@@ -279,21 +272,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * {@inheritDoc}
      */
     @Override
-    public void setCpu64(boolean value) {
-        this.cpu64 = Boolean.valueOf(value);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String getStepping() {
-        if (this.cpuStepping == null) {
-            if (this.cpuIdentifier == null) {
-                return "?";
-            }
-            setStepping(parseIdentifier("Stepping"));
-        }
         return this.cpuStepping;
     }
 
@@ -301,21 +280,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * {@inheritDoc}
      */
     @Override
-    public void setStepping(String stepping) {
-        this.cpuStepping = stepping;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String getModel() {
-        if (this.cpuModel == null) {
-            if (this.cpuIdentifier == null) {
-                return "?";
-            }
-            setModel(parseIdentifier("Model"));
-        }
         return this.cpuModel;
     }
 
@@ -323,30 +288,8 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * {@inheritDoc}
      */
     @Override
-    public void setModel(String model) {
-        this.cpuModel = model;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String getFamily() {
-        if (this.cpuFamily == null) {
-            if (this.cpuIdentifier == null) {
-                return "?";
-            }
-            setFamily(parseIdentifier("Family"));
-        }
         return this.cpuFamily;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setFamily(String family) {
-        this.cpuFamily = family;
     }
 
     /**
@@ -356,8 +299,8 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      *            the id to retrieve
      * @return the string following id
      */
-    private String parseIdentifier(String id) {
-        String[] idSplit = ParseUtil.whitespaces.split(getIdentifier());
+    private static String parseIdentifier(String id, String identifier) {
+        String[] idSplit = ParseUtil.whitespaces.split(identifier);
         boolean found = false;
         for (String s : idSplit) {
             // If id string found, return next value
@@ -374,22 +317,25 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * {@inheritDoc}
      */
     @Override
-    public synchronized double getSystemCpuLoadBetweenTicks() {
+    public double getSystemCpuLoadBetweenTicks() {
         // Check if > ~ 0.95 seconds since last tick count.
         long now = System.currentTimeMillis();
-        LOG.trace("Current time: {}  Last tick time: {}", now, this.tickTime);
-        if (now - this.tickTime > 950) {
-            // Enough time has elapsed.
-            updateSystemTicks();
+        long total, idle;
+        synchronized (instanceLock) {
+            LOG.trace("Current time: {}  Last tick time: {}", now, this.tickTime);
+            if (now - this.tickTime > 950) {
+                // Enough time has elapsed.
+                updateSystemTicks();
+            }
+            // Calculate total
+            total = 0;
+            for (int i = 0; i < this.curTicks.length; i++) {
+                total += this.curTicks[i] - this.prevTicks[i];
+            }
+            // Calculate idle from difference in idle and IOwait
+            idle = this.curTicks[TickType.IDLE.getIndex()] + this.curTicks[TickType.IOWAIT.getIndex()]
+                    - this.prevTicks[TickType.IDLE.getIndex()] - this.prevTicks[TickType.IOWAIT.getIndex()];
         }
-        // Calculate total
-        long total = 0;
-        for (int i = 0; i < this.curTicks.length; i++) {
-            total += this.curTicks[i] - this.prevTicks[i];
-        }
-        // Calculate idle from difference in idle and IOwait
-        long idle = this.curTicks[TickType.IDLE.getIndex()] + this.curTicks[TickType.IOWAIT.getIndex()]
-                - this.prevTicks[TickType.IDLE.getIndex()] - this.prevTicks[TickType.IOWAIT.getIndex()];
         LOG.trace("Total ticks: {}  Idle ticks: {}", total, idle);
 
         return total > 0 && idle >= 0 ? (double) (total - idle) / total : 0d;
@@ -409,14 +355,16 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
         // Iterate to find a nonzero tick value and return; this should quickly
         // find a nonzero value if one exists and be fast in checking 0's
         // through branch prediction if it doesn't
-        for (long tick : ticks) {
-            if (tick != 0) {
-                // We have a nonzero tick array, update and return!
-                this.tickTime = System.currentTimeMillis();
-                // Copy to previous
-                System.arraycopy(this.curTicks, 0, this.prevTicks, 0, this.curTicks.length);
-                System.arraycopy(ticks, 0, this.curTicks, 0, ticks.length);
-                return;
+        synchronized (instanceLock) {
+            for (long tick : ticks) {
+                if (tick != 0) {
+                    // We have a nonzero tick array, update and return!
+                    this.tickTime = System.currentTimeMillis();
+                    // Copy to previous
+                    System.arraycopy(this.curTicks, 0, this.prevTicks, 0, this.curTicks.length);
+                    System.arraycopy(ticks, 0, this.curTicks, 0, ticks.length);
+                    return;
+                }
             }
         }
     }
@@ -427,14 +375,16 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
     @Override
     public double getSystemCpuLoad() {
         if (this.sunMXBean) {
-            long now = System.currentTimeMillis();
-            // If called too recently, return latest value
-            if (now - this.lastCpuLoadTime < 200) {
+            synchronized (instanceLock) {
+                long now = System.currentTimeMillis();
+                // If called too recently, return latest value
+                if (now - this.lastCpuLoadTime < 200) {
+                    return this.lastCpuLoad;
+                }
+                this.lastCpuLoad = ((com.sun.management.OperatingSystemMXBean) OS_MXBEAN).getSystemCpuLoad();
+                this.lastCpuLoadTime = now;
                 return this.lastCpuLoad;
             }
-            this.lastCpuLoad = ((com.sun.management.OperatingSystemMXBean) OS_MXBEAN).getSystemCpuLoad();
-            this.lastCpuLoadTime = now;
-            return this.lastCpuLoad;
         }
         return getSystemCpuLoadBetweenTicks();
     }
@@ -454,28 +404,30 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
     public double[] getProcessorCpuLoadBetweenTicks() {
         // Check if > ~ 0.95 seconds since last tick count.
         long now = System.currentTimeMillis();
-        LOG.trace("Current time: {}  Last tick time: {}", now, this.procTickTime);
-        if (now - this.procTickTime > 950) {
-            // Enough time has elapsed.
-            // Update latest
-            updateProcessorTicks();
-        }
-        double[] load = new double[this.logicalProcessorCount];
-        for (int cpu = 0; cpu < this.logicalProcessorCount; cpu++) {
-            long total = 0;
-            for (int i = 0; i < this.curProcTicks[cpu].length; i++) {
-                total += this.curProcTicks[cpu][i] - this.prevProcTicks[cpu][i];
+        synchronized (instanceLock) {
+            LOG.trace("Current time: {}  Last tick time: {}", now, this.procTickTime);
+            if (now - this.procTickTime > 950) {
+                // Enough time has elapsed.
+                // Update latest
+                updateProcessorTicks();
             }
-            // Calculate idle from difference in idle and IOwait
-            long idle = this.curProcTicks[cpu][TickType.IDLE.getIndex()]
-                    + this.curProcTicks[cpu][TickType.IOWAIT.getIndex()]
-                    - this.prevProcTicks[cpu][TickType.IDLE.getIndex()]
-                    - this.prevProcTicks[cpu][TickType.IOWAIT.getIndex()];
-            LOG.trace("CPU: {}  Total ticks: {}  Idle ticks: {}", cpu, total, idle);
-            // update
-            load[cpu] = total > 0 && idle >= 0 ? (double) (total - idle) / total : 0d;
+            double[] load = new double[this.logicalProcessorCount];
+            for (int cpu = 0; cpu < this.logicalProcessorCount; cpu++) {
+                long total = 0;
+                for (int i = 0; i < this.curProcTicks[cpu].length; i++) {
+                    total += this.curProcTicks[cpu][i] - this.prevProcTicks[cpu][i];
+                }
+                // Calculate idle from difference in idle and IOwait
+                long idle = this.curProcTicks[cpu][TickType.IDLE.getIndex()]
+                        + this.curProcTicks[cpu][TickType.IOWAIT.getIndex()]
+                        - this.prevProcTicks[cpu][TickType.IDLE.getIndex()]
+                        - this.prevProcTicks[cpu][TickType.IOWAIT.getIndex()];
+                LOG.trace("CPU: {}  Total ticks: {}  Idle ticks: {}", cpu, total, idle);
+                // update
+                load[cpu] = total > 0 && idle >= 0 ? (double) (total - idle) / total : 0d;
+            }
+            return load;
         }
-        return load;
     }
 
     /**
@@ -493,20 +445,22 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
         // Iterate to find a nonzero tick value and return; this should quickly
         // find a nonzero value if one exists and be fast in checking 0's
         // through branch prediction if it doesn't
-        for (long[] tick : ticks) {
-            for (long element : tick) {
-                if (element != 0L) {
-                    // We have a nonzero tick array, update and return!
-                    this.procTickTime = System.currentTimeMillis();
-                    // Copy to previous
-                    for (int cpu = 0; cpu < this.logicalProcessorCount; cpu++) {
-                        System.arraycopy(this.curProcTicks[cpu], 0, this.prevProcTicks[cpu], 0,
-                                this.curProcTicks[cpu].length);
+        synchronized (instanceLock) {
+            for (long[] tick : ticks) {
+                for (long element : tick) {
+                    if (element != 0L) {
+                        // We have a nonzero tick array, update and return!
+                        this.procTickTime = System.currentTimeMillis();
+                        // Copy to previous
+                        for (int cpu = 0; cpu < this.logicalProcessorCount; cpu++) {
+                            System.arraycopy(this.curProcTicks[cpu], 0, this.prevProcTicks[cpu], 0,
+                                    this.curProcTicks[cpu].length);
+                        }
+                        for (int cpu = 0; cpu < this.logicalProcessorCount; cpu++) {
+                            System.arraycopy(ticks[cpu], 0, this.curProcTicks[cpu], 0, ticks[cpu].length);
+                        }
+                        return;
                     }
-                    for (int cpu = 0; cpu < this.logicalProcessorCount; cpu++) {
-                        System.arraycopy(ticks[cpu], 0, this.curProcTicks[cpu], 0, ticks[cpu].length);
-                    }
-                    return;
                 }
             }
         }
@@ -666,5 +620,22 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
             }
         }
         return String.format("%016X", processorIdBytes);
+    }
+
+    protected abstract CentralProcessorInitializer getInitializer();
+
+    public static class CentralProcessorInitializer {
+        public int logicalProcessorCount;
+        public int physicalProcessorCount;
+        public int physicalPackageCount;
+        public String cpuVendor;
+        public String cpuName;
+        public String processorID;
+        public String cpuIdentifier;
+        public String cpuStepping;
+        public String cpuModel;
+        public String cpuFamily;
+        public long cpuVendorFreq;
+        public boolean cpu64;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractComputerSystem.java
@@ -23,6 +23,7 @@
  */
 package oshi.hardware.common;
 
+import oshi.SystemInfo;
 import oshi.hardware.Baseboard;
 import oshi.hardware.ComputerSystem;
 import oshi.hardware.Firmware;
@@ -44,9 +45,9 @@ public abstract class AbstractComputerSystem implements ComputerSystem {
     private Baseboard baseboard;
 
     protected AbstractComputerSystem() {
-        this.manufacturer = "unknown";
-        this.model = "unknown";
-        this.serialNumber = "unknown";
+        this.manufacturer = SystemInfo.UNKNOWN;
+        this.model = SystemInfo.UNKNOWN;
+        this.serialNumber = SystemInfo.UNKNOWN;
         this.firmware = null;
         this.baseboard = null;
     }

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractFirmware.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractFirmware.java
@@ -23,6 +23,7 @@
  */
 package oshi.hardware.common;
 
+import oshi.SystemInfo;
 import oshi.hardware.Firmware;
 
 /**
@@ -41,14 +42,12 @@ public abstract class AbstractFirmware implements Firmware {
     private String version;
     private String releaseDate;
 
-    private static final String UNKNOWN = "unknown";
-
     public AbstractFirmware() {
-        this.manufacturer = UNKNOWN;
-        this.name = UNKNOWN;
-        this.description = UNKNOWN;
-        this.version = UNKNOWN;
-        this.releaseDate = UNKNOWN;
+        this.manufacturer = SystemInfo.UNKNOWN;
+        this.name = SystemInfo.UNKNOWN;
+        this.description = SystemInfo.UNKNOWN;
+        this.version = SystemInfo.UNKNOWN;
+        this.releaseDate = SystemInfo.UNKNOWN;
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxBaseboard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxBaseboard.java
@@ -39,11 +39,9 @@ final class LinuxBaseboard extends AbstractBaseboard {
     // official/approved path for sysfs information
     private static final String SYSFS_SERIAL_PATH = "/sys/devices/virtual/dmi/id/";
 
-    LinuxBaseboard() {
-        init();
-    }
-
-    private void init() {
+    @Override
+    protected BaseboardInitializer getInitializer() {
+        BaseboardInitializer result = new BaseboardInitializer();
 
         // $ ls /sys/devices/virtual/dmi/id/
         // bios_date board_vendor chassis_version product_version
@@ -53,24 +51,17 @@ final class LinuxBaseboard extends AbstractBaseboard {
         // board_name chassis_type product_serial
         // board_serial chassis_vendor product_uuid
 
-        final String boardVendor = FileUtil.getStringFromFile(SYSFS_SERIAL_PATH + "board_vendor");
-        if (boardVendor != null && !boardVendor.trim().isEmpty()) {
-            setManufacturer(boardVendor.trim());
-        }
+        String boardVendor = FileUtil.getStringFromFile(SYSFS_SERIAL_PATH + "board_vendor");
+        result.manufacturer = boardVendor == null ? null : boardVendor.trim();
 
-        final String boardName = FileUtil.getStringFromFile(SYSFS_SERIAL_PATH + "board_name");
-        if (boardName != null && !boardName.trim().isEmpty()) {
-            setModel(boardName.trim());
-        }
+        String boardName = FileUtil.getStringFromFile(SYSFS_SERIAL_PATH + "board_name");
+        result.model = boardName == null ? null : boardName.trim();
 
-        final String boardVersion = FileUtil.getStringFromFile(SYSFS_SERIAL_PATH + "board_version");
-        if (boardVersion != null && !boardVersion.trim().isEmpty()) {
-            setVersion(boardVersion.trim());
-        }
+        String boardVersion = FileUtil.getStringFromFile(SYSFS_SERIAL_PATH + "board_version");
+        result.version = boardVersion == null ? null : boardVersion.trim();
 
-        final String boardSerialNumber = FileUtil.getStringFromFile(SYSFS_SERIAL_PATH + "board_serial");
-        if (boardSerialNumber != null && !boardSerialNumber.trim().isEmpty()) {
-            setSerialNumber(boardSerialNumber.trim());
-        }
+        String boardSerialNumber = FileUtil.getStringFromFile(SYSFS_SERIAL_PATH + "board_serial");
+        result.serialNumber = boardSerialNumber == null ? null : boardSerialNumber.trim();
+        return result;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxComputerSystem.java
@@ -23,6 +23,7 @@
  */
 package oshi.hardware.platform.linux;
 
+import oshi.SystemInfo;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
@@ -41,7 +42,6 @@ final class LinuxComputerSystem extends AbstractComputerSystem {
     // Note: /sys/class/dmi/id symlinks here, but /sys/devices/* is the
     // official/approved path for sysfs information
     private static final String SYSFS_SERIAL_PATH = "/sys/devices/virtual/dmi/id/";
-    private static final String UNKNOWN = "unknown";
 
     LinuxComputerSystem() {
         init();
@@ -94,12 +94,12 @@ final class LinuxComputerSystem extends AbstractComputerSystem {
         if (serialNumber.isEmpty() || "None".equals(serialNumber)) {
             serialNumber = FileUtil.getStringFromFile(SYSFS_SERIAL_PATH + "board_serial");
             if (serialNumber.isEmpty() || "None".equals(serialNumber)) {
-                serialNumber = UNKNOWN;
+                serialNumber = SystemInfo.UNKNOWN;
             }
         }
         // If root privileges this will work
         String marker = "Serial Number:";
-        if (UNKNOWN.equals(serialNumber)) {
+        if (SystemInfo.UNKNOWN.equals(serialNumber)) {
             for (String checkLine : ExecutingCommand.runNative("dmidecode -t system")) {
                 if (checkLine.contains(marker)) {
                     serialNumber = checkLine.split(marker)[1].trim();
@@ -108,7 +108,7 @@ final class LinuxComputerSystem extends AbstractComputerSystem {
             }
         }
         // if lshal command available (HAL deprecated in newer linuxes)
-        if (UNKNOWN.equals(serialNumber)) {
+        if (SystemInfo.UNKNOWN.equals(serialNumber)) {
             marker = "system.hardware.serial =";
             for (String checkLine : ExecutingCommand.runNative("lshal")) {
                 if (checkLine.contains(marker)) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxDisks.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxDisks.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import oshi.SystemInfo;
 import oshi.hardware.Disks;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
@@ -124,10 +124,10 @@ public class LinuxDisks implements Disks {
 
                         // Avoid model and serial in virtual environments
                         store.setModel(
-                                Udev.INSTANCE.udev_device_get_property_value(device, "ID_MODEL") == null ? "Unknown"
+                                Udev.INSTANCE.udev_device_get_property_value(device, "ID_MODEL") == null ? SystemInfo.UNKNOWN
                                         : Udev.INSTANCE.udev_device_get_property_value(device, "ID_MODEL"));
                         store.setSerial(Udev.INSTANCE.udev_device_get_property_value(device, "ID_SERIAL_SHORT") == null
-                                ? "Unknown"
+                                ? SystemInfo.UNKNOWN
                                 : Udev.INSTANCE.udev_device_get_property_value(device, "ID_SERIAL_SHORT"));
 
                         store.setSize(ParseUtil.parseLongOrDefault(

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxPowerSource.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxPowerSource.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import oshi.SystemInfo;
 import oshi.hardware.PowerSource;
 import oshi.hardware.common.AbstractPowerSource;
 import oshi.util.FileUtil;
@@ -81,7 +81,7 @@ public class LinuxPowerSource extends AbstractPowerSource {
             // Initialize defaults
             boolean isPresent = false;
             boolean isCharging = false;
-            String name = "Unknown";
+            String name = SystemInfo.UNKNOWN;
             int energyNow = 0;
             int energyFull = 1;
             int powerNow = 1;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacBaseboard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacBaseboard.java
@@ -29,4 +29,12 @@ final class MacBaseboard extends AbstractBaseboard {
 
     private static final long serialVersionUID = 1L;
 
+    public MacBaseboard(BaseboardInitializer initializer) {
+        super(initializer);
+    }
+
+    @Override
+    protected BaseboardInitializer getInitializer() {
+        return null;
+    }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -74,39 +74,35 @@ public class MacCentralProcessor extends AbstractCentralProcessor {
      * Create a Processor
      */
     public MacCentralProcessor() {
-        super();
-        // Initialize class variables
-        initVars();
         // Initialize tick arrays
         initTicks();
 
         LOG.debug("Initialized Processor");
     }
 
-    private void initVars() {
-        setVendor(SysctlUtil.sysctl("machdep.cpu.vendor", ""));
-        setName(SysctlUtil.sysctl("machdep.cpu.brand_string", ""));
-        setCpu64(SysctlUtil.sysctl("hw.cpu64bit_capable", 0) != 0);
+    @Override
+    protected CentralProcessorInitializer getInitializer() {
+        CentralProcessorInitializer result = new CentralProcessorInitializer();
+        result.cpuVendor = SysctlUtil.sysctl("machdep.cpu.vendor", "");
+        result.cpuName = SysctlUtil.sysctl("machdep.cpu.brand_string", "");
+        result.cpu64 = SysctlUtil.sysctl("hw.cpu64bit_capable", 0) != 0;
         int i = SysctlUtil.sysctl("machdep.cpu.stepping", -1);
-        setStepping(i < 0 ? "" : Integer.toString(i));
+        result.cpuStepping = i < 0 ? "" : Integer.toString(i);
         i = SysctlUtil.sysctl("machdep.cpu.model", -1);
-        setModel(i < 0 ? "" : Integer.toString(i));
+        result.cpuModel = i < 0 ? "" : Integer.toString(i);
         i = SysctlUtil.sysctl("machdep.cpu.family", -1);
-        setFamily(i < 0 ? "" : Integer.toString(i));
+        result.cpuFamily = i < 0 ? "" : Integer.toString(i);
         long processorID = 0L;
         processorID |= SysctlUtil.sysctl("machdep.cpu.signature", 0);
         processorID |= (SysctlUtil.sysctl("machdep.cpu.feature_bits", 0L) & 0xffffffff) << 32;
-        setProcessorID(String.format("%016X", processorID));
-    }
+        result.processorID = String.format("%016X", processorID);
 
-    /**
-     * Updates logical and physical processor counts from sysctl calls
-     */
-    @Override
-    protected void calculateProcessorCounts() {
-        this.logicalProcessorCount = SysctlUtil.sysctl("hw.logicalcpu", 1);
-        this.physicalProcessorCount = SysctlUtil.sysctl("hw.physicalcpu", 1);
-        this.physicalPackageCount = SysctlUtil.sysctl("hw.packages", 1);
+        // Calculate processor counts
+        result.logicalProcessorCount = SysctlUtil.sysctl("hw.logicalcpu", 1);
+        result.physicalProcessorCount = SysctlUtil.sysctl("hw.physicalcpu", 1);
+        result.physicalPackageCount = SysctlUtil.sysctl("hw.packages", 1);
+
+        return result;
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacComputerSystem.java
@@ -25,6 +25,7 @@ package oshi.hardware.platform.mac;
 
 import java.util.regex.Pattern;
 import oshi.SystemInfo;
+import oshi.hardware.common.AbstractBaseboard.BaseboardInitializer;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.jna.platform.mac.IOKit;
 import oshi.util.ExecutingCommand;
@@ -86,9 +87,9 @@ final class MacComputerSystem extends AbstractComputerSystem {
         firmware.setManufacturer(APPLE);
         firmware.setName("EFI");
 
-        final MacBaseboard baseboard = new MacBaseboard();
-        baseboard.setManufacturer(APPLE);
-        baseboard.setModel("SMC");
+        BaseboardInitializer baseboardInitializer = new BaseboardInitializer();
+        baseboardInitializer.manufacturer = APPLE;
+        baseboardInitializer.model = "SMC";
 
         // Populate name and ID
         for (final String checkLine : ExecutingCommand.runNative("system_profiler SPHardwareDataType")) {
@@ -124,16 +125,16 @@ final class MacComputerSystem extends AbstractComputerSystem {
             serialNumberSystem = getSystemSerialNumber();
         }
         setSerialNumber(serialNumberSystem);
-        baseboard.setSerialNumber(serialNumberSystem);
+        baseboardInitializer.serialNumber = serialNumberSystem;
         if (!smcVersion.isEmpty()) {
-            baseboard.setVersion(smcVersion);
+            baseboardInitializer.version = smcVersion;
         }
         if (bootRomVersion != null && !bootRomVersion.isEmpty()) {
             firmware.setVersion(bootRomVersion);
         }
 
         setFirmware(firmware);
-        setBaseboard(baseboard);
+        setBaseboard(new MacBaseboard(baseboardInitializer));
     }
 
     private String getSystemSerialNumber() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacComputerSystem.java
@@ -24,7 +24,7 @@
 package oshi.hardware.platform.mac;
 
 import java.util.regex.Pattern;
-
+import oshi.SystemInfo;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.jna.platform.mac.IOKit;
 import oshi.util.ExecutingCommand;
@@ -145,7 +145,7 @@ final class MacComputerSystem extends AbstractComputerSystem {
             IOKit.INSTANCE.IOObjectRelease(service);
         }
         if (serialNumber == null) {
-            serialNumber = "unknown";
+            serialNumber = SystemInfo.UNKNOWN;
         }
         return serialNumber;
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdBaseboard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdBaseboard.java
@@ -30,11 +30,9 @@ final class FreeBsdBaseboard extends AbstractBaseboard {
 
     private static final long serialVersionUID = 1L;
 
-    FreeBsdBaseboard() {
-        init();
-    }
-
-    private void init() {
+    @Override
+    protected BaseboardInitializer getInitializer() {
+        BaseboardInitializer result = new BaseboardInitializer();
 
         // $ sudo dmidecode -t system
         // # dmidecode 3.0
@@ -57,41 +55,26 @@ final class FreeBsdBaseboard extends AbstractBaseboard {
         // System Boot Information
         // Status: No errors detected
 
-        String manufacturer = "";
         final String manufacturerMarker = "Manufacturer:";
-        String model = "";
         final String productNameMarker = "Product Name:";
-        String version = "";
         final String versionMarker = "Version:";
-        String serialNumber = "";
         final String serialNumMarker = "Serial Number:";
 
         // Only works with root permissions but it's all we've got
         for (final String checkLine : ExecutingCommand.runNative("dmidecode -t baseboard")) {
             if (checkLine.contains(manufacturerMarker)) {
-                manufacturer = checkLine.split(manufacturerMarker)[1].trim();
+                result.manufacturer = checkLine.split(manufacturerMarker)[1].trim();
             }
             if (checkLine.contains(productNameMarker)) {
-                model = checkLine.split(productNameMarker)[1].trim();
+                result.model = checkLine.split(productNameMarker)[1].trim();
             }
             if (checkLine.contains(versionMarker)) {
-                version = checkLine.split(versionMarker)[1].trim();
+                result.version = checkLine.split(versionMarker)[1].trim();
             }
             if (checkLine.contains(serialNumMarker)) {
-                serialNumber = checkLine.split(serialNumMarker)[1].trim();
+                result.serialNumber = checkLine.split(serialNumMarker)[1].trim();
             }
         }
-        if (!manufacturer.isEmpty()) {
-            setManufacturer(manufacturer);
-        }
-        if (!model.isEmpty()) {
-            setModel(model);
-        }
-        if (!version.isEmpty()) {
-            setVersion(version);
-        }
-        if (!serialNumber.isEmpty()) {
-            setSerialNumber(serialNumber);
-        }
+        return result;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdComputerSystem.java
@@ -23,6 +23,7 @@
  */
 package oshi.hardware.platform.unix.freebsd;
 
+import oshi.SystemInfo;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -105,6 +106,6 @@ final class FreeBsdComputerSystem extends AbstractComputerSystem {
                 return ParseUtil.getSingleQuoteStringValue(checkLine);
             }
         }
-        return "unknown";
+        return SystemInfo.UNKNOWN;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisBaseboard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisBaseboard.java
@@ -29,4 +29,12 @@ final class SolarisBaseboard extends AbstractBaseboard {
 
     private static final long serialVersionUID = 1L;
 
+    public SolarisBaseboard(BaseboardInitializer initializer) {
+        super(initializer);
+    }
+
+    @Override
+    protected BaseboardInitializer getInitializer() {
+        return null;
+    }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisComputerSystem.java
@@ -23,6 +23,7 @@
  */
 package oshi.hardware.platform.unix.solaris;
 
+import oshi.SystemInfo;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -35,8 +36,6 @@ import oshi.util.ParseUtil;
 final class SolarisComputerSystem extends AbstractComputerSystem {
 
     private static final long serialVersionUID = 1L;
-
-    private static final String UNKNOWN = "unknown";
 
     SolarisComputerSystem() {
         init();
@@ -213,7 +212,7 @@ final class SolarisComputerSystem extends AbstractComputerSystem {
             }
         }
         if (serialNumber.isEmpty()) {
-            serialNumber = UNKNOWN;
+            serialNumber = SystemInfo.UNKNOWN;
         }
         return serialNumber;
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisComputerSystem.java
@@ -24,6 +24,7 @@
 package oshi.hardware.platform.unix.solaris;
 
 import oshi.SystemInfo;
+import oshi.hardware.common.AbstractBaseboard.BaseboardInitializer;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -99,7 +100,7 @@ final class SolarisComputerSystem extends AbstractComputerSystem {
         final String serialNumMarker = "Serial Number:";
 
         SolarisFirmware firmware = new SolarisFirmware();
-        SolarisBaseboard baseboard = new SolarisBaseboard();
+        BaseboardInitializer baseboardInitializer = new BaseboardInitializer();
 
         boolean smbTypeBIOS = false;
         boolean smbTypeSystem = false;
@@ -181,21 +182,13 @@ final class SolarisComputerSystem extends AbstractComputerSystem {
         }
         setSerialNumber(serialNumber);
 
-        if (!boardManufacturer.isEmpty()) {
-            baseboard.setManufacturer(boardManufacturer);
-        }
-        if (!model.isEmpty()) {
-            baseboard.setModel(model);
-        }
-        if (!version.isEmpty()) {
-            baseboard.setVersion(version);
-        }
-        if (!boardSerialNumber.isEmpty()) {
-            baseboard.setSerialNumber(boardSerialNumber);
-        }
+        baseboardInitializer.manufacturer = boardManufacturer;
+        baseboardInitializer.model = model;
+        baseboardInitializer.version = version;
+        baseboardInitializer.serialNumber = boardSerialNumber;
 
         setFirmware(firmware);
-        setBaseboard(baseboard);
+        setBaseboard(new SolarisBaseboard(baseboardInitializer));
     }
 
     private String getSystemSerialNumber() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisDisks.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisDisks.java
@@ -31,7 +31,7 @@ import java.util.Map.Entry;
 
 import com.sun.jna.platform.unix.solaris.LibKstat.Kstat; //NOSONAR
 import com.sun.jna.platform.unix.solaris.LibKstat.KstatIO;
-
+import oshi.SystemInfo;
 import oshi.hardware.Disks;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
@@ -313,7 +313,7 @@ public class SolarisDisks implements Disks {
                     partition.setName("private region");
                     break;
                 default:
-                    partition.setName("unknown");
+                    partition.setName(SystemInfo.UNKNOWN);
                     break;
                 }
                 // Third field is flags.

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsBaseboard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsBaseboard.java
@@ -43,18 +43,17 @@ public class WindowsBaseboard extends AbstractBaseboard {
         MANUFACTURER, MODEL, VERSION, SERIALNUMBER;
     }
 
-    WindowsBaseboard() {
-        init();
-    }
-
-    private void init() {
+    @Override
+    protected BaseboardInitializer getInitializer() {
+        BaseboardInitializer result = new BaseboardInitializer();
         WmiQuery<BaseboardProperty> baseboardQuery = new WmiQuery<>("Win32_BaseBoard", BaseboardProperty.class);
         WmiResult<BaseboardProperty> win32BaseBoard = WmiQueryHandler.createInstance().queryWMI(baseboardQuery);
         if (win32BaseBoard.getResultCount() > 0) {
-            setManufacturer(WmiUtil.getString(win32BaseBoard, BaseboardProperty.MANUFACTURER, 0));
-            setModel(WmiUtil.getString(win32BaseBoard, BaseboardProperty.MODEL, 0));
-            setVersion(WmiUtil.getString(win32BaseBoard, BaseboardProperty.VERSION, 0));
-            setSerialNumber(WmiUtil.getString(win32BaseBoard, BaseboardProperty.SERIALNUMBER, 0));
+            result.manufacturer = WmiUtil.getString(win32BaseBoard, BaseboardProperty.MANUFACTURER, 0);
+            result.model = WmiUtil.getString(win32BaseBoard, BaseboardProperty.MODEL, 0);
+            result.version = WmiUtil.getString(win32BaseBoard, BaseboardProperty.VERSION, 0);
+            result.serialNumber = WmiUtil.getString(win32BaseBoard, BaseboardProperty.SERIALNUMBER, 0);
         }
+        return result;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsComputerSystem.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsComputerSystem.java
@@ -25,7 +25,7 @@ package oshi.hardware.platform.windows;
 
 import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiQuery; // NOSONAR squid:S1191
 import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
-
+import oshi.SystemInfo;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.util.platform.windows.WmiQueryHandler;
 import oshi.util.platform.windows.WmiUtil;
@@ -99,7 +99,7 @@ final class WindowsComputerSystem extends AbstractComputerSystem {
         }
         // Nothing worked. Default.
         if ("".equals(this.systemSerialNumber)) {
-            this.systemSerialNumber = "unknown";
+            this.systemSerialNumber = SystemInfo.UNKNOWN;
         }
         return this.systemSerialNumber;
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSource.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSource.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sun.jna.NativeLong; // NOSONAR squid:S1191
-
+import oshi.SystemInfo;
 import oshi.hardware.PowerSource;
 import oshi.hardware.common.AbstractPowerSource;
 import oshi.jna.platform.windows.PowrProf;
@@ -63,7 +63,7 @@ public class WindowsPowerSource extends AbstractPowerSource {
         SystemBatteryState batteryState = new SystemBatteryState();
         if (0 != PowrProf.INSTANCE.CallNtPowerInformation(PowrProf.SYSTEM_BATTERY_STATE, null, new NativeLong(0),
                 batteryState, new NativeLong(batteryState.size())) || batteryState.batteryPresent == 0) {
-            psArray[0] = new WindowsPowerSource("Unknown", 0d, -1d);
+            psArray[0] = new WindowsPowerSource(SystemInfo.UNKNOWN, 0d, -1d);
         } else {
             int estimatedTime = -2; // -1 = unknown, -2 = unlimited
             if (batteryState.acOnLine == 0 && batteryState.charging == 0 && batteryState.discharging > 0) {

--- a/oshi-core/src/main/java/oshi/software/common/AbstractOSVersionInfoEx.java
+++ b/oshi-core/src/main/java/oshi/software/common/AbstractOSVersionInfoEx.java
@@ -23,6 +23,7 @@
  */
 package oshi.software.common;
 
+import oshi.SystemInfo;
 import oshi.software.os.OperatingSystemVersion;
 
 /**
@@ -93,7 +94,7 @@ public class AbstractOSVersionInfoEx implements OperatingSystemVersion {
     @Override
     public String toString() {
         if (this.versionStr == null) {
-            StringBuilder sb = new StringBuilder(getVersion() != null ? getVersion() : "Unknown");
+            StringBuilder sb = new StringBuilder(getVersion() != null ? getVersion() : SystemInfo.UNKNOWN);
             if (getCodeName().length() > 0) {
                 sb.append(" (").append(getCodeName()).append(')');
             }

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -40,7 +40,7 @@ import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.linux.LibC;
 import com.sun.jna.platform.linux.LibC.Sysinfo;
-
+import oshi.SystemInfo;
 import oshi.jna.platform.linux.Libc;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
@@ -688,7 +688,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
 
         // /etc/issue will end up here:
         case "issue":
-            return "Unknown";
+            return SystemInfo.UNKNOWN;
         // If not a special case just capitalize first letter
         default:
             return name.substring(0, 1).toUpperCase() + name.substring(1);

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSVersionInfoEx.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSVersionInfoEx.java
@@ -34,7 +34,7 @@ import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.WinUser;
 import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiQuery;
 import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
-
+import oshi.SystemInfo;
 import oshi.software.common.AbstractOSVersionInfoEx;
 import oshi.util.ParseUtil;
 import oshi.util.StringUtil;
@@ -146,7 +146,7 @@ public class WindowsOSVersionInfoEx extends AbstractOSVersionInfoEx {
         }
 
         String sp = WmiUtil.getString(versionInfo, OSVersionProperty.CSDVERSION, 0);
-        if (!sp.isEmpty() && !"unknown".equals(sp)) {
+        if (!sp.isEmpty() && !SystemInfo.UNKNOWN.equals(sp)) {
             version = version + " " + sp.replace("Service Pack ", "SP");
         }
 

--- a/oshi-core/src/main/java/oshi/util/StringUtil.java
+++ b/oshi-core/src/main/java/oshi/util/StringUtil.java
@@ -70,4 +70,27 @@ public class StringUtil {
         return join(delimiter, stringList.toArray(new String[stringList.size()]));
     }
 
+    /**
+     * Evaluates if the specified character sequence is {@code null}, empty or
+     * only consists of whitespace.
+     *
+     * @param cs the {@link CharSequence} to evaluate.
+     * @return true if {@code cs} is {@code null}, empty or only consists of
+     *         whitespace, {@code false} otherwise.
+     */
+    public static boolean isBlank(CharSequence cs) {
+        if (cs == null) {
+            return true;
+        }
+        int strLen = cs.length();
+        if (strLen == 0) {
+            return true;
+        }
+        for (int i = 0; i < strLen; i++) {
+            if (!Character.isWhitespace(cs.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -147,8 +147,8 @@ public class SystemInfoTest {
         System.out.println("  name: " + firmware.getName());
         System.out.println("  description: " + firmware.getDescription());
         System.out.println("  version: " + firmware.getVersion());
-        System.out.println("  release date: " + (firmware.getReleaseDate() == null ? "unknown"
-                : firmware.getReleaseDate() == null ? "unknown" : firmware.getReleaseDate()));
+        System.out.println("  release date: " + (firmware.getReleaseDate() == null ? SystemInfo.UNKNOWN
+                : firmware.getReleaseDate() == null ? SystemInfo.UNKNOWN : firmware.getReleaseDate()));
         final Baseboard baseboard = computerSystem.getBaseboard();
         System.out.println("baseboard:");
         System.out.println("  manufacturer: " + baseboard.getManufacturer());
@@ -242,7 +242,7 @@ public class SystemInfoTest {
     private static void printPowerSources(PowerSource[] powerSources) {
         StringBuilder sb = new StringBuilder("Power: ");
         if (powerSources.length == 0) {
-            sb.append("Unknown");
+            sb.append(SystemInfo.UNKNOWN);
         } else {
             double timeRemaining = powerSources[0].getTimeRemaining();
             if (timeRemaining < -1d) {


### PR DESCRIPTION
I wrote in #869 that I would consider making a PR implementing thread-safety. When looking at it closer, it seems that this is too much work for me. The reason for my "miscalculation" as to how much work it would be, is that I always create classes "defensively" when it comes to concurrency, regardless of if they are intended to be thread-safe or not. I forgot that not everybody does this :wink: 

The problem is the way the classes are initialized. Since there are performance penalties with synchronization (even though they are over-emphasized in many situations), I prefer immutability when possible. Immutable classes and/or fields means that you don't have to think about concurrency when using them, and there's no performance penalty. There might be a small penalty when constructing them, but often there's not or it's negligible. The essential challenge is that every final field must be set in the constructor. Java has some unfortunate limitations when it comes to how constructors work, which is why "factories" are often used instead to create immutable instances.

Thread-safety can be solved in many different ways. I've made implementations for `Baseboard` and `CentralProcessor` as examples of how I would solve this without making it too complicated.
I think the system of "initializers" I made up here would work fine for most of the classes in this project. They are basically very simplified builders that sub-classes can initialize, which is then used to set the final fields in the constructor. 

For `Baseboard` the implementation is completely immutable and all is handled using a such "initializer". `CentralProcessor` can't be immutable because some real-time data can be updated. I've implemented every field that can be immutable using an "initializer" like in `Baseboards`. The rest I've simply protected with a simple synchronization object. There were some `synchronized` statements in some of the methods, which I removed. The reason for this is two-fold: First, I prefer not to expose the synchronization object publicly unless there's a good reason to do so. This way we know that "we" (including sub-classes) control the synchronization object. Second, fields protected by a synchronization object *must* be protected everywhere it's used, or the synchronization is pointless.

For `Baseboard` I think this implementation is uncontroversial. The only change (seen from the outside), is that the setters are gone from `AbstractBaseboard`. I find it very unlikely that client code would call these setters, unless somebody has made their own sub-class implementation. While the same can be argued for `CentralProcessor`, the setters were in the interface here, which means I had to remove them from the interface itself. I consider that a "more serious" breach of the API, although I don't know if it really matters in practical use of the library.

In any case, I think doing this for all the classes will be too time-consuming for me, so I chose to simply create this PR to show how I would go about doing it. I don't intend for this to be merged, as it would add little value making these two classes alone thread-safe.

When it comes to our use-case and the need for a thread-safe instance that could be used for evaluations, I think the only practical solution is for me to make a thread-safe class that only contains the information we actually need, and then use OSHI to populate it from a separate thread during startup. 