### PR TITLE
Introduce AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,10 @@ version: '{build}'
 
 image: Visual Studio 2017
 
+branches:
+  except:
+    - coverity_scan
+
 skip_tags: true
 
 environment:
@@ -21,6 +25,4 @@ build_script:
   - mvn clean package -Dmaven.test.skip=true
 
 test_script:
-  # Skip tests on coverity_scan branch
-  - if [[ "${APPVEYOR_REPO_BRANCH}" == "coverity_scan" ]]; then exit 0; fi
   - mvn test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+version: '{build}'
+
+image: Visual Studio 2017
+
+skip_tags: true
+
+environment:
+  TERM: dumb
+  matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    - JAVA_HOME: C:\Program Files\Java\jdk11
+
+init:
+  - git config --global --unset core.autocrlf
+
+install:
+  - mvn --version
+  - java -version
+
+build_script:
+  - mvn clean package -Dmaven.test.skip=true
+
+test_script:
+  # Skip tests on coverity_scan branch
+  - if [[ "${APPVEYOR_REPO_BRANCH}" == "coverity_scan" ]]; then exit 0; fi
+  - mvn test


### PR DESCRIPTION
Closes #881. This configuration doesn't calculate code coverage or anything fancy since Travis is already doing that.

Getting AppVeyor to build the repo is basically the same process as Travis.