### PR TITLE
Retry mvn-clean-package if failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - java -version
 
 build_script:
-  - mvn clean package -Dmaven.test.skip=true
+  - appveyor-retry mvn clean package -Dmaven.test.skip=true
 
 test_script:
   - mvn test


### PR DESCRIPTION
I wasn't able to get the connection to fail on my fork, but this should retry three times if any artifacts fail to download during the build.