### PR TITLE
[pom] Reconfigure spotbugs-maven-plugin and update to 3.1.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
 		<maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
 		<maven-release-plugin.version>2.5.3</maven-release-plugin.version>
 		<maven-source-plugin.version>3.1.0</maven-source-plugin.version>
-		<spotbugs-maven-plugin.version>3.1.12</spotbugs-maven-plugin.version>
+		<spotbugs-maven-plugin.version>3.1.12.2</spotbugs-maven-plugin.version>
 		<jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
 		<coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
 		<jaxb-api.version>2.3.1</jaxb-api.version>
@@ -461,15 +461,11 @@
 					<groupId>com.github.spotbugs</groupId>
 					<artifactId>spotbugs-maven-plugin</artifactId>
 					<version>${spotbugs-maven-plugin.version}</version>
-					<dependencies>
-						<!-- overwrite dependency on spotbugs if you want to specify the version 
-							of spotbugs -->
-						<dependency>
-							<groupId>com.github.spotbugs</groupId>
-							<artifactId>spotbugs</artifactId>
-							<version>${spotbugs-maven-plugin.version}</version>
-						</dependency>
-					</dependencies>
+					<configuration>
+						<effort>Max</effort>
+						<includeTests>true</includeTests>
+						<failOnError>false</failOnError>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.jacoco</groupId>
@@ -888,6 +884,18 @@
 						</configuration>
 					</plugin>
 					<!-- External Tools -->
+					<plugin>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<phase>verify</phase>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
 					<plugin>
 						<groupId>org.jacoco</groupId>
 						<artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
- Override is no longer necessary as spotbugs maven plugin is released often now.
- Adjusted settings to get slightly more items marked (3 in this case).
- Add spotbugs to check profile so that it executes there.