### PR TITLE
Rework SystemInfoTest for Better Usability (Fixes #829)

### DIFF
--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -26,6 +26,7 @@ package oshi;
 import static org.junit.Assert.assertFalse;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -63,6 +64,11 @@ import oshi.util.Util;
  */
 public class SystemInfoTest {
 
+    /** The Constant logger. */
+    private static final Logger logger = LoggerFactory.getLogger(SystemInfoTest.class);
+
+    static List<String> oshi = new ArrayList<>();
+
     /**
      * Test system info.
      */
@@ -78,12 +84,7 @@ public class SystemInfoTest {
      *            the arguments
      */
     public static void main(String[] args) {
-        // Options: ERROR > WARN > INFO > DEBUG > TRACE
-        System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "INFO");
-        System.setProperty(org.slf4j.impl.SimpleLogger.LOG_FILE_KEY, "System.err");
-        Logger LOG = LoggerFactory.getLogger(SystemInfoTest.class);
-
-        LOG.info("Initializing System...");
+        logger.info("Initializing System...");
         SystemInfo si = new SystemInfo();
 
         HardwareAbstractionLayer hal = si.getHardware();
@@ -91,107 +92,117 @@ public class SystemInfoTest {
 
         printOperatingSystem(os);
 
-        LOG.info("Checking computer system...");
+        logger.info("Checking computer system...");
         printComputerSystem(hal.getComputerSystem());
 
-        LOG.info("Checking Processor...");
+        logger.info("Checking Processor...");
         printProcessor(hal.getProcessor());
 
-        LOG.info("Checking Memory...");
+        logger.info("Checking Memory...");
         printMemory(hal.getMemory());
 
-        LOG.info("Checking CPU...");
+        logger.info("Checking CPU...");
         printCpu(hal.getProcessor());
 
-        LOG.info("Checking Processes...");
+        logger.info("Checking Processes...");
         printProcesses(os, hal.getMemory());
 
-        LOG.info("Checking Sensors...");
+        logger.info("Checking Sensors...");
         printSensors(hal.getSensors());
 
-        LOG.info("Checking Power sources...");
+        logger.info("Checking Power sources...");
         printPowerSources(hal.getPowerSources());
 
-        LOG.info("Checking Disks...");
+        logger.info("Checking Disks...");
         printDisks(hal.getDiskStores());
 
-        LOG.info("Checking File System...");
+        logger.info("Checking File System...");
         printFileSystem(os.getFileSystem());
 
-        LOG.info("Checking Network interfaces...");
+        logger.info("Checking Network interfaces...");
         printNetworkInterfaces(hal.getNetworkIFs());
 
-        LOG.info("Checking Network parameterss...");
+        logger.info("Checking Network parameters...");
         printNetworkParameters(os.getNetworkParams());
 
         // hardware: displays
-        LOG.info("Checking Displays...");
+        logger.info("Checking Displays...");
         printDisplays(hal.getDisplays());
 
         // hardware: USB devices
-        LOG.info("Checking USB Devices...");
+        logger.info("Checking USB Devices...");
         printUsbDevices(hal.getUsbDevices(true));
 
-        LOG.info("Checking Sound Cards...");
+        logger.info("Checking Sound Cards...");
         printSoundCards(hal.getSoundCards());
+
+        StringBuilder output = new StringBuilder();
+        for (int i = 0; i < oshi.size(); i++) {
+            output.append(oshi.get(i));
+            if (!"\n".equals(oshi.get(i))) {
+                output.append('\n');
+            }
+        }
+        logger.info("Printing List: {}", output);
     }
 
     private static void printOperatingSystem(final OperatingSystem os) {
-        System.out.println(os);
-        System.out.println("Booted: " + Instant.ofEpochSecond(os.getSystemBootTime()));
-        System.out.println("Uptime: " + FormatUtil.formatElapsedSecs(os.getSystemUptime()));
-        System.out.println("Running with" + (os.isElevated() ? "" : "out") + " elevated permissions.");
+        oshi.add(String.valueOf(os));
+        oshi.add("Booted: " + Instant.ofEpochSecond(os.getSystemBootTime()));
+        oshi.add("Uptime: " + FormatUtil.formatElapsedSecs(os.getSystemUptime()));
+        oshi.add("Running with" + (os.isElevated() ? "" : "out") + " elevated permissions.");
     }
 
     private static void printComputerSystem(final ComputerSystem computerSystem) {
 
-        System.out.println("manufacturer: " + computerSystem.getManufacturer());
-        System.out.println("model: " + computerSystem.getModel());
-        System.out.println("serialnumber: " + computerSystem.getSerialNumber());
+        oshi.add("manufacturer: " + computerSystem.getManufacturer());
+        oshi.add("model: " + computerSystem.getModel());
+        oshi.add("serialnumber: " + computerSystem.getSerialNumber());
         final Firmware firmware = computerSystem.getFirmware();
-        System.out.println("firmware:");
-        System.out.println("  manufacturer: " + firmware.getManufacturer());
-        System.out.println("  name: " + firmware.getName());
-        System.out.println("  description: " + firmware.getDescription());
-        System.out.println("  version: " + firmware.getVersion());
-        System.out.println("  release date: " + (firmware.getReleaseDate() == null ? "unknown"
+        oshi.add("firmware:");
+        oshi.add("  manufacturer: " + firmware.getManufacturer());
+        oshi.add("  name: " + firmware.getName());
+        oshi.add("  description: " + firmware.getDescription());
+        oshi.add("  version: " + firmware.getVersion());
+        oshi.add("  release date: " + (firmware.getReleaseDate() == null ? "unknown"
                 : firmware.getReleaseDate() == null ? "unknown" : firmware.getReleaseDate()));
         final Baseboard baseboard = computerSystem.getBaseboard();
-        System.out.println("baseboard:");
-        System.out.println("  manufacturer: " + baseboard.getManufacturer());
-        System.out.println("  model: " + baseboard.getModel());
-        System.out.println("  version: " + baseboard.getVersion());
-        System.out.println("  serialnumber: " + baseboard.getSerialNumber());
+        oshi.add("baseboard:");
+        oshi.add("  manufacturer: " + baseboard.getManufacturer());
+        oshi.add("  model: " + baseboard.getModel());
+        oshi.add("  version: " + baseboard.getVersion());
+        oshi.add("  serialnumber: " + baseboard.getSerialNumber());
     }
 
     private static void printProcessor(CentralProcessor processor) {
-        System.out.println(processor);
-        System.out.println(" " + processor.getPhysicalPackageCount() + " physical CPU package(s)");
-        System.out.println(" " + processor.getPhysicalProcessorCount() + " physical CPU core(s)");
-        System.out.println(" " + processor.getLogicalProcessorCount() + " logical CPU(s)");
+        oshi.add(String.valueOf(processor));
+        oshi.add(" " + processor.getPhysicalPackageCount() + " physical CPU package(s)");
+        oshi.add(" " + processor.getPhysicalProcessorCount() + " physical CPU core(s)");
+        oshi.add(" " + processor.getLogicalProcessorCount() + " logical CPU(s)");
 
-        System.out.println("Identifier: " + processor.getIdentifier());
-        System.out.println("ProcessorID: " + processor.getProcessorID());
+        oshi.add("Identifier: " + processor.getIdentifier());
+        oshi.add("ProcessorID: " + processor.getProcessorID());
     }
 
     private static void printMemory(GlobalMemory memory) {
-        System.out.println("Memory: " + FormatUtil.formatBytes(memory.getAvailable()) + "/"
+        oshi.add("Memory: " + FormatUtil.formatBytes(memory.getAvailable()) + "/"
                 + FormatUtil.formatBytes(memory.getTotal()));
         VirtualMemory vm = memory.getVirtualMemory();
-        System.out.println("Swap used: " + FormatUtil.formatBytes(vm.getSwapUsed()) + "/"
+        oshi.add("Swap used: " + FormatUtil.formatBytes(vm.getSwapUsed()) + "/"
                 + FormatUtil.formatBytes(vm.getSwapTotal()));
     }
 
     private static void printCpu(CentralProcessor processor) {
-        System.out.println(
+        oshi.add(
                 "Context Switches/Interrupts: " + processor.getContextSwitches() + " / " + processor.getInterrupts());
+
         long[] prevTicks = processor.getSystemCpuLoadTicks();
         long[][] prevProcTicks = processor.getProcessorCpuLoadTicks();
-        System.out.println("CPU, IOWait, and IRQ ticks @ 0 sec:" + Arrays.toString(prevTicks));
+        oshi.add("CPU, IOWait, and IRQ ticks @ 0 sec:" + Arrays.toString(prevTicks));
         // Wait a second...
         Util.sleep(1000);
         long[] ticks = processor.getSystemCpuLoadTicks();
-        System.out.println("CPU, IOWait, and IRQ ticks @ 1 sec:" + Arrays.toString(ticks));
+        oshi.add("CPU, IOWait, and IRQ ticks @ 1 sec:" + Arrays.toString(ticks));
         long user = ticks[TickType.USER.getIndex()] - prevTicks[TickType.USER.getIndex()];
         long nice = ticks[TickType.NICE.getIndex()] - prevTicks[TickType.NICE.getIndex()];
         long sys = ticks[TickType.SYSTEM.getIndex()] - prevTicks[TickType.SYSTEM.getIndex()];
@@ -202,14 +213,14 @@ public class SystemInfoTest {
         long steal = ticks[TickType.STEAL.getIndex()] - prevTicks[TickType.STEAL.getIndex()];
         long totalCpu = user + nice + sys + idle + iowait + irq + softirq + steal;
 
-        System.out.format(
+        oshi.add(String.format(
                 "User: %.1f%% Nice: %.1f%% System: %.1f%% Idle: %.1f%% IOwait: %.1f%% IRQ: %.1f%% SoftIRQ: %.1f%% Steal: %.1f%%%n",
                 100d * user / totalCpu, 100d * nice / totalCpu, 100d * sys / totalCpu, 100d * idle / totalCpu,
-                100d * iowait / totalCpu, 100d * irq / totalCpu, 100d * softirq / totalCpu, 100d * steal / totalCpu);
-        System.out.format("CPU load: %.1f%%%n",
-                processor.getSystemCpuLoadBetweenTicks(prevTicks) * 100);
+                100d * iowait / totalCpu, 100d * irq / totalCpu, 100d * softirq / totalCpu, 100d * steal / totalCpu));
+        oshi.add(String.format("CPU load: %.1f%%%n",
+                processor.getSystemCpuLoadBetweenTicks(prevTicks) * 100));
         double[] loadAverage = processor.getSystemLoadAverage(3);
-        System.out.println("CPU load averages:" + (loadAverage[0] < 0 ? " N/A" : String.format(" %.2f", loadAverage[0]))
+        oshi.add("CPU load averages:" + (loadAverage[0] < 0 ? " N/A" : String.format(" %.2f", loadAverage[0]))
                 + (loadAverage[1] < 0 ? " N/A" : String.format(" %.2f", loadAverage[1]))
                 + (loadAverage[2] < 0 ? " N/A" : String.format(" %.2f", loadAverage[2])));
         // per core CPU
@@ -218,14 +229,14 @@ public class SystemInfoTest {
         for (double avg : load) {
             procCpu.append(String.format(" %.1f%%", avg * 100));
         }
-        System.out.println(procCpu.toString());
+        oshi.add(procCpu.toString());
         long freq = processor.getVendorFreq();
         if (freq > 0) {
-            System.out.println("Vendor Frequency: " + FormatUtil.formatHertz(freq));
+            oshi.add("Vendor Frequency: " + FormatUtil.formatHertz(freq));
         }
         freq = processor.getMaxFreq();
         if (freq > 0) {
-            System.out.println("Max Frequency: " + FormatUtil.formatHertz(freq));
+            oshi.add("Max Frequency: " + FormatUtil.formatHertz(freq));
         }
         long[] freqs = processor.getCurrentFreq();
         if (freqs[0] > 0) {
@@ -236,30 +247,30 @@ public class SystemInfoTest {
                 }
                 sb.append(FormatUtil.formatHertz(freqs[i]));
             }
-            System.out.println(sb.toString());
+            oshi.add(sb.toString());
         }
     }
 
     private static void printProcesses(OperatingSystem os, GlobalMemory memory) {
-        System.out.println("Processes: " + os.getProcessCount() + ", Threads: " + os.getThreadCount());
+        oshi.add("Processes: " + os.getProcessCount() + ", Threads: " + os.getThreadCount());
         // Sort by highest CPU
         List<OSProcess> procs = Arrays.asList(os.getProcesses(5, ProcessSort.CPU));
 
-        System.out.println("   PID  %CPU %MEM       VSZ       RSS Name");
+        oshi.add("   PID  %CPU %MEM       VSZ       RSS Name");
         for (int i = 0; i < procs.size() && i < 5; i++) {
             OSProcess p = procs.get(i);
-            System.out.format(" %5d %5.1f %4.1f %9s %9s %s%n", p.getProcessID(),
+            oshi.add(String.format(" %5d %5.1f %4.1f %9s %9s %s%n", p.getProcessID(),
                     100d * (p.getKernelTime() + p.getUserTime()) / p.getUpTime(),
                     100d * p.getResidentSetSize() / memory.getTotal(), FormatUtil.formatBytes(p.getVirtualSize()),
-                    FormatUtil.formatBytes(p.getResidentSetSize()), p.getName());
+                    FormatUtil.formatBytes(p.getResidentSetSize()), p.getName()));
         }
     }
 
     private static void printSensors(Sensors sensors) {
-        System.out.println("Sensors:");
-        System.out.format(" CPU Temperature: %.1f°C%n", sensors.getCpuTemperature());
-        System.out.println(" Fan Speeds: " + Arrays.toString(sensors.getFanSpeeds()));
-        System.out.format(" CPU Voltage: %.1fV%n", sensors.getCpuVoltage());
+        oshi.add("Sensors:");
+        oshi.add(String.format(" CPU Temperature: %.1f°C%n", sensors.getCpuTemperature()));
+        oshi.add(" Fan Speeds: " + Arrays.toString(sensors.getFanSpeeds()));
+        oshi.add(String.format(" CPU Voltage: %.1fV%n", sensors.getCpuVoltage()));
     }
 
     private static void printPowerSources(PowerSource[] powerSources) {
@@ -280,105 +291,104 @@ public class SystemInfoTest {
         for (PowerSource pSource : powerSources) {
             sb.append(String.format("%n %s @ %.1f%%", pSource.getName(), pSource.getRemainingCapacity() * 100d));
         }
-        System.out.println(sb.toString());
+        oshi.add(sb.toString());
     }
 
     private static void printDisks(HWDiskStore[] diskStores) {
-        System.out.println("Disks:");
+        oshi.add("Disks:");
         for (HWDiskStore disk : diskStores) {
             boolean readwrite = disk.getReads() > 0 || disk.getWrites() > 0;
-            System.out.format(" %s: (model: %s - S/N: %s) size: %s, reads: %s (%s), writes: %s (%s), xfer: %s ms%n",
+            oshi.add(String.format(" %s: (model: %s - S/N: %s) size: %s, reads: %s (%s), writes: %s (%s), xfer: %s ms%n",
                     disk.getName(), disk.getModel(), disk.getSerial(),
                     disk.getSize() > 0 ? FormatUtil.formatBytesDecimal(disk.getSize()) : "?",
                     readwrite ? disk.getReads() : "?", readwrite ? FormatUtil.formatBytes(disk.getReadBytes()) : "?",
                     readwrite ? disk.getWrites() : "?", readwrite ? FormatUtil.formatBytes(disk.getWriteBytes()) : "?",
-                    readwrite ? disk.getTransferTime() : "?");
+                    readwrite ? disk.getTransferTime() : "?"));
             HWPartition[] partitions = disk.getPartitions();
             if (partitions == null) {
                 // TODO Remove when all OS's implemented
                 continue;
             }
             for (HWPartition part : partitions) {
-                System.out.format(" |-- %s: %s (%s) Maj:Min=%d:%d, size: %s%s%n", part.getIdentification(),
+                oshi.add(String.format(" |-- %s: %s (%s) Maj:Min=%d:%d, size: %s%s%n", part.getIdentification(),
                         part.getName(), part.getType(), part.getMajor(), part.getMinor(),
                         FormatUtil.formatBytesDecimal(part.getSize()),
-                        part.getMountPoint().isEmpty() ? "" : " @ " + part.getMountPoint());
+                        part.getMountPoint().isEmpty() ? "" : " @ " + part.getMountPoint()));
             }
         }
     }
 
     private static void printFileSystem(FileSystem fileSystem) {
-        System.out.println("File System:");
+        oshi.add("File System:");
 
-        System.out.format(" File Descriptors: %d/%d%n", fileSystem.getOpenFileDescriptors(),
-                fileSystem.getMaxFileDescriptors());
+        oshi.add(String.format(" File Descriptors: %d/%d%n", fileSystem.getOpenFileDescriptors(),
+                fileSystem.getMaxFileDescriptors()));
 
         OSFileStore[] fsArray = fileSystem.getFileStores();
         for (OSFileStore fs : fsArray) {
             long usable = fs.getUsableSpace();
             long total = fs.getTotalSpace();
-            System.out.format(
-                    " %s (%s) [%s] %s of %s free (%.1f%%), %s of %s files free (%.1f%%) is %s "
-                            + (fs.getLogicalVolume() != null && fs.getLogicalVolume().length() > 0 ? "[%s]" : "%s")
-                            + " and is mounted at %s%n",
+            oshi.add(String.format(" %s (%s) [%s] %s of %s free (%.1f%%), %s of %s files free (%.1f%%) is %s " +
+                            (fs.getLogicalVolume() != null && fs.getLogicalVolume().length() > 0 ? "[%s]" : "%s") +
+                            " and is mounted at %s%n",
                     fs.getName(), fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,
                     FormatUtil.formatValue(fs.getFreeInodes(), ""), FormatUtil.formatValue(fs.getTotalInodes(), ""),
                     100d * fs.getFreeInodes() / fs.getTotalInodes(), fs.getVolume(), fs.getLogicalVolume(),
-                    fs.getMount());
+                    fs.getMount()));
         }
     }
 
     private static void printNetworkInterfaces(NetworkIF[] networkIFs) {
-        System.out.println("Network interfaces:");
+        oshi.add("Network interfaces:");
         for (NetworkIF net : networkIFs) {
-            System.out.format(" Name: %s (%s)%n", net.getName(), net.getDisplayName());
-            System.out.format("   MAC Address: %s %n", net.getMacaddr());
-            System.out.format("   MTU: %s, Speed: %s %n", net.getMTU(), FormatUtil.formatValue(net.getSpeed(), "bps"));
-            System.out.format("   IPv4: %s %n", Arrays.toString(net.getIPv4addr()));
-            System.out.format("   IPv6: %s %n", Arrays.toString(net.getIPv6addr()));
+            oshi.add(String.format(" Name: %s (%s)%n", net.getName(), net.getDisplayName()));
+            oshi.add(String.format("   MAC Address: %s %n", net.getMacaddr()));
+            oshi.add(String.format("   MTU: %s, Speed: %s %n", net.getMTU(), FormatUtil.formatValue(net.getSpeed(), "bps")));
+            oshi.add(String.format("   IPv4: %s %n", Arrays.toString(net.getIPv4addr())));
+            oshi.add(String.format("   IPv6: %s %n", Arrays.toString(net.getIPv6addr())));
             boolean hasData = net.getBytesRecv() > 0 || net.getBytesSent() > 0 || net.getPacketsRecv() > 0
                     || net.getPacketsSent() > 0;
-            System.out.format("   Traffic: received %s/%s%s; transmitted %s/%s%s %n",
+            oshi.add(String.format("   Traffic: received %s/%s%s; transmitted %s/%s%s %n",
                     hasData ? net.getPacketsRecv() + " packets" : "?",
                     hasData ? FormatUtil.formatBytes(net.getBytesRecv()) : "?",
                     hasData ? " (" + net.getInErrors() + " err)" : "",
                     hasData ? net.getPacketsSent() + " packets" : "?",
                     hasData ? FormatUtil.formatBytes(net.getBytesSent()) : "?",
-                    hasData ? " (" + net.getOutErrors() + " err)" : "");
+                    hasData ? " (" + net.getOutErrors() + " err)" : ""));
         }
     }
 
     private static void printNetworkParameters(NetworkParams networkParams) {
-        System.out.println("Network parameters:");
-        System.out.format(" Host name: %s%n", networkParams.getHostName());
-        System.out.format(" Domain name: %s%n", networkParams.getDomainName());
-        System.out.format(" DNS servers: %s%n", Arrays.toString(networkParams.getDnsServers()));
-        System.out.format(" IPv4 Gateway: %s%n", networkParams.getIpv4DefaultGateway());
-        System.out.format(" IPv6 Gateway: %s%n", networkParams.getIpv6DefaultGateway());
+        oshi.add("Network parameters:");
+        oshi.add(String.format(" Host name: %s%n", networkParams.getHostName()));
+        oshi.add(String.format(" Domain name: %s%n", networkParams.getDomainName()));
+        oshi.add(String.format(" DNS servers: %s%n", Arrays.toString(networkParams.getDnsServers())));
+        oshi.add(String.format(" IPv4 Gateway: %s%n", networkParams.getIpv4DefaultGateway()));
+        oshi.add(String.format(" IPv6 Gateway: %s%n", networkParams.getIpv6DefaultGateway()));
     }
 
     private static void printDisplays(Display[] displays) {
-        System.out.println("Displays:");
+        oshi.add("Displays:");
         int i = 0;
         for (Display display : displays) {
-            System.out.println(" Display " + i + ":");
-            System.out.println(display.toString());
+            oshi.add(" Display " + i + ":");
+            oshi.add(String.valueOf(display));
             i++;
         }
     }
 
     private static void printUsbDevices(UsbDevice[] usbDevices) {
-        System.out.println("USB Devices:");
+        oshi.add("USB Devices:");
         for (UsbDevice usbDevice : usbDevices) {
-            System.out.println(usbDevice.toString());
+            oshi.add(String.valueOf(usbDevice));
         }
     }
 
     private static void printSoundCards(SoundCard[] cards) {
-        System.out.println("Sound Cards:");
+        oshi.add("Sound Cards:");
         for (SoundCard card : cards) {
-            System.out.println(card.toString());
+            oshi.add(String.valueOf(card));
         }
     }
 }

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -288,8 +288,8 @@ public class SystemInfoTest {
                         (int) (timeRemaining / 60) % 60));
             }
         }
-        for (PowerSource pSource : powerSources) {
-            sb.append(String.format("%n %s @ %.1f%%", pSource.getName(), pSource.getRemainingCapacity() * 100d));
+        for (PowerSource powerSource : powerSources) {
+            sb.append(String.format("%n %s @ %.1f%%", powerSource.getName(), powerSource.getRemainingCapacity() * 100d));
         }
         oshi.add(sb.toString());
     }

--- a/oshi-core/src/test/resources/simplelogger.properties
+++ b/oshi-core/src/test/resources/simplelogger.properties
@@ -23,7 +23,7 @@
 #
 
 # see http://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html
-org.slf4j.simpleLogger.logFile=target/unit-tests.log
+#org.slf4j.simpleLogger.logFile=target/unit-tests.log
 org.slf4j.simpleLogger.defaultLogLevel=INFO
 org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
 						<forkCount>3</forkCount>
 						<reuseForks>true</reuseForks>
 						<argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+						<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					</configuration>
 				</plugin>
 				<!-- Build Plugins -->


### PR DESCRIPTION
Fixes #829 

The overall class is great for testing with oshi.  This class has become a baseline for [psi-probe](https://github.com/psi-probe/psi-probe/blob/master/core/src/main/java/psiprobe/controllers/oshi/OshiController.java).  In order to allow for easier porting of changes over to psi-probe, the structure needs to better adhere to accepted java standards such as not using system out printing.  Further, in this case, psi probe wants to show the results on a webpage rather than logging.  While Oshi did a little bit of both using a logger and system out printing, some slight adjustments and use of an array list result in similar outcome.  Essentially, outside of psi probe usage of setting up a controller, the port will mostly be intack same code without the current merge conflict concerns.

No performance hit was noticed during the test run.

Configuration now redirects logs via surefire rather than via slf4j simple.  While logs are spit per test which is a variance, the output to screen remains the same.  The slf4j configuration has simple been commented out here.  It could use a note as to why if the config line stays otherwise it can be removed.  If memory serves me, I believe this adjustment item was the original concern with the design change due to output that would have otherwise went to the console during a build.

For readibility, the powerSource has been remaned from pSource which also followed generally accepted coding practice.  This was not entirely necessary but helpful and simlar change was being made in psi probe port.