### PR TITLE
Retool the travis ci jdk selection process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
   include:  
     - os: osx
       env: 
-      - JDK = "OpenJDK 8 - Mac"
+      - JDK = "OracleJDK 8 - Mac"
       - MATRIX_ID="first"
       jdk: openjdk8
       osx_image: xcode9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ matrix:
     - os: linux
       env: JDK = "OpenJDK 12 - Linux" 
     - os: linux
+      env: JDK = "OpenJDK 13 - Linux" 
+    - os: linux
       env: JDK = "OpenJDK 14-ea - Linux" 
   allow_failures:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,24 +37,32 @@ matrix:
       env: 
       - JDK = "OpenJDK 8 - Mac" 
       - MATRIX_ID="first"
+      jdk: openjdk8
       osx_image: xcode9.3
     - os: osx
       env: JDK = "OpenJDK 11 - Mac" 
+      jdk: openjdk11
       osx_image: xcode10.1
     - os: osx
       env: JDK = "OpenJDK 12 - Mac" 
+      jdk: openjdk12
       osx_image: xcode11
     - os: linux
       env: JDK = "OpenJDK 11 - Linux" 
+      jdk: openjdk11
     - os: linux
       env: JDK = "OpenJDK 12 - Linux" 
+      jdk: openjdk12
     - os: linux
       env: JDK = "OpenJDK 13 - Linux" 
+      jdk: openjdk13
     - os: linux
       env: JDK = "OpenJDK 14 - Linux" 
+      jdk: openjdk14
   allow_failures:
     - os: linux
-      env: JDK = "OpenJDK 14 - Linux" 
+      env: JDK = "OpenJDK 14 - Linux"
+      jdk: openjdk14
 
 script: 
   # Skip tests on coverity_scan branch

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,10 @@ matrix:
     - os: linux
       env: JDK = "OpenJDK 13 - Linux" 
     - os: linux
-      env: JDK = "OpenJDK 14-ea - Linux" 
+      env: JDK = "OpenJDK 14 - Linux" 
   allow_failures:
     - os: linux
-      env: JDK = "OpenJDK 14-ea - Linux" 
+      env: JDK = "OpenJDK 14 - Linux" 
 
 script: 
   # Skip tests on coverity_scan branch

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ matrix:
       env: 
       - JDK = "OracleJDK 8 - Mac"
       - MATRIX_ID="first"
-      jdk: openjdk8
       osx_image: xcode9.3
     - os: osx
       env: JDK = "OpenJDK 11 - Mac"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
   include:  
     - os: osx
       env: 
-      - JDK = "Oracle JDK 8 - Mac" 
+      - JDK = "OpenJDK 8 - Mac" 
       - MATRIX_ID="first"
       osx_image: xcode9.3
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: java
 before_install:
   # When building the coverity_scan branch, allow only the first job to continue.
   - if [[ "${TRAVIS_BRANCH}" == "coverity_scan" && "$MATRIX_ID" != "first" ]]; then exit 0; fi
-  # Get most recent JDK versions on-the-fly
-  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
   
 after_success:
   - bash <(curl -s https://codecov.io/bash)
@@ -47,13 +45,10 @@ matrix:
       env: JDK = "OpenJDK 12 - Mac" 
       osx_image: xcode11
     - os: linux
-      install: . ./install-jdk.sh -F 11 -L GPL
       env: JDK = "OpenJDK 11 - Linux" 
     - os: linux
-      install: . ./install-jdk.sh -F 12 -L GPL
       env: JDK = "OpenJDK 12 - Linux" 
     - os: linux
-      install: . ./install-jdk.sh -F ea -L GPL
       env: JDK = "OpenJDK 14-ea - Linux" 
   allow_failures:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,29 +35,29 @@ matrix:
   include:  
     - os: osx
       env: 
-      - JDK = "OpenJDK 8 - Mac" 
+      - JDK = "OpenJDK 8 - Mac"
       - MATRIX_ID="first"
       jdk: openjdk8
       osx_image: xcode9.3
     - os: osx
-      env: JDK = "OpenJDK 11 - Mac" 
+      env: JDK = "OpenJDK 11 - Mac"
       jdk: openjdk11
       osx_image: xcode10.1
     - os: osx
-      env: JDK = "OpenJDK 12 - Mac" 
+      env: JDK = "OpenJDK 12 - Mac"
       jdk: openjdk12
       osx_image: xcode11
     - os: linux
-      env: JDK = "OpenJDK 11 - Linux" 
+      env: JDK = "OpenJDK 11 - Linux"
       jdk: openjdk11
     - os: linux
-      env: JDK = "OpenJDK 12 - Linux" 
+      env: JDK = "OpenJDK 12 - Linux"
       jdk: openjdk12
     - os: linux
-      env: JDK = "OpenJDK 13 - Linux" 
+      env: JDK = "OpenJDK 13 - Linux"
       jdk: openjdk13
     - os: linux
-      env: JDK = "OpenJDK 14 - Linux" 
+      env: JDK = "OpenJDK 14 - Linux"
       jdk: openjdk14
   allow_failures:
     - os: linux


### PR DESCRIPTION
All jdks will be auto pulled via normal procedure now.  The install-jdk is part of travis by default.  For the xcode 9.3, that one will remain with jdk not set and thus will use what is on the vm (oracle jdk 8).