### PR TITLE
Specialize getHostName()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The default configuration file has been renamed to `oshi.properties` to prevent 
 * [#977](https://github.com/oshi/oshi/pull/977): Rename default configuration - [@cilki](https://github.com/cilki).
 * [#989](https://github.com/oshi/oshi/pull/989): Improve Windows current frequency stats. - [@dbwiddis](https://github.com/dbwiddis).
 * [#995](https://github.com/oshi/oshi/pull/995): CoreFoundation, IOKit, DiskArbitration API overhaul. - [@dbwiddis](https://github.com/dbwiddis).
-* Your contribution here
+* [#1008](https://github.com/oshi/oshi/pull/1008): Specialize getHostName() - [@2kindsofcs](https://github.com/2kindsofcs).
 
 4.0.0 (8/10/2019)
 ================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The default configuration file has been renamed to `oshi.properties` to prevent 
 * [#989](https://github.com/oshi/oshi/pull/989): Improve Windows current frequency stats. - [@dbwiddis](https://github.com/dbwiddis).
 * [#995](https://github.com/oshi/oshi/pull/995): CoreFoundation, IOKit, DiskArbitration API overhaul. - [@dbwiddis](https://github.com/dbwiddis).
 * [#1008](https://github.com/oshi/oshi/pull/1008): Specialize getHostName() - [@2kindsofcs](https://github.com/2kindsofcs).
+* Your contribution here.
 
 4.0.0 (8/10/2019)
 ================

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -24,7 +24,9 @@
     SOFTWARE.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -61,5 +63,5 @@
 			<artifactId>jna-platform</artifactId>
 			<version>${jna.version}</version>
 		</dependency>
- 	</dependencies>
+	</dependencies>
 </project>

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -61,5 +61,5 @@
 			<artifactId>jna-platform</artifactId>
 			<version>${jna.version}</version>
 		</dependency>
-	</dependencies>
+ 	</dependencies>
 </project>

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
@@ -24,6 +24,7 @@
 package oshi.jna.platform.linux;
 
 import com.sun.jna.Native;
+import com.sun.jna.platform.linux.LibC;
 
 import oshi.jna.platform.unix.CLibrary;
 
@@ -31,7 +32,7 @@ import oshi.jna.platform.unix.CLibrary;
  * Linux C Library. This class should be considered non-API as it may be removed
  * if/when its code is incorporated into the JNA project.
  */
-public interface LinuxLibc extends CLibrary {
+public interface LinuxLibc extends LibC, CLibrary {
 
     /** Constant <code>INSTANCE</code> */
     LinuxLibc INSTANCE = Native.load("c", LinuxLibc.class);

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
@@ -23,8 +23,7 @@
  */
 package oshi.jna.platform.mac;
 
-import com.sun.jna.Native;
-import com.sun.jna.platform.unix.LibCAPI;
+import com.sun.jna.Native; // NOSONAR squid:S1191
 
 import oshi.jna.platform.unix.CLibrary;
 
@@ -32,7 +31,7 @@ import oshi.jna.platform.unix.CLibrary;
  * System class. This class should be considered non-API as it may be removed
  * if/when its code is incorporated into the JNA project.
  */
-public interface SystemB extends CLibrary, com.sun.jna.platform.mac.SystemB, LibCAPI {
+public interface SystemB extends CLibrary, com.sun.jna.platform.mac.SystemB {
 
     SystemB INSTANCE = Native.load("System", SystemB.class);
 

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
@@ -24,6 +24,7 @@
 package oshi.jna.platform.mac;
 
 import com.sun.jna.Native;
+import com.sun.jna.platform.unix.LibCAPI;
 
 import oshi.jna.platform.unix.CLibrary;
 
@@ -31,7 +32,7 @@ import oshi.jna.platform.unix.CLibrary;
  * System class. This class should be considered non-API as it may be removed
  * if/when its code is incorporated into the JNA project.
  */
-public interface SystemB extends CLibrary, com.sun.jna.platform.mac.SystemB {
+public interface SystemB extends CLibrary, com.sun.jna.platform.mac.SystemB, LibCAPI {
 
     SystemB INSTANCE = Native.load("System", SystemB.class);
 

--- a/oshi-core/src/main/java/oshi/jna/platform/unix/CLibrary.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/unix/CLibrary.java
@@ -27,6 +27,7 @@ import com.sun.jna.Library;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
+import com.sun.jna.platform.unix.LibCAPI;
 import com.sun.jna.ptr.PointerByReference;
 
 /**
@@ -34,7 +35,7 @@ import com.sun.jna.ptr.PointerByReference;
  * should be considered non-API as it may be removed if/when its code is
  * incorporated into the JNA project.
  */
-public interface CLibrary extends Library {
+public interface CLibrary extends LibCAPI, Library {
 
     /*
      * For getaddrinfo()
@@ -83,25 +84,6 @@ public interface CLibrary extends Library {
             read();
         }
     }
-
-    /**
-     * The getloadavg() function returns the number of processes in the system run
-     * queue averaged over various periods of time. Up to nelem samples are
-     * retrieved and assigned to successive elements of loadavg[]. The system
-     * imposes a maximum of 3 samples, representing averages over the last 1, 5, and
-     * 15 minutes, respectively.
-     *
-     * @param loadavg
-     *            An array of doubles which will be filled with the results
-     * @param nelem
-     *            Number of samples to return
-     * @return If the load average was unobtainable, -1 is returned; otherwise, the
-     *         number of samples actually retrieved is returned.
-     * @see <A HREF=
-     *      "https://www.freebsd.org/cgi/man.cgi?query=getloadavg&sektion=3">
-     *      getloadavg(3)</A>
-     */
-    int getloadavg(double[] loadavg, int nelem);
 
     /**
      * Returns the process ID of the calling process. The ID is guaranteed to be

--- a/oshi-core/src/main/java/oshi/jna/platform/unix/freebsd/FreeBsdLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/unix/freebsd/FreeBsdLibc.java
@@ -27,7 +27,9 @@ import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
+import com.sun.jna.platform.unix.LibCAPI;
 import com.sun.jna.ptr.IntByReference;
+
 
 import oshi.jna.platform.unix.CLibrary;
 
@@ -35,7 +37,7 @@ import oshi.jna.platform.unix.CLibrary;
  * C library. This class should be considered non-API as it may be removed
  * if/when its code is incorporated into the JNA project.
  */
-public interface FreeBsdLibc extends CLibrary {
+public interface FreeBsdLibc extends CLibrary, LibCAPI {
     /** Constant <code>INSTANCE</code> */
     FreeBsdLibc INSTANCE = Native.load("libc", FreeBsdLibc.class);
 

--- a/oshi-core/src/main/java/oshi/jna/platform/unix/freebsd/FreeBsdLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/unix/freebsd/FreeBsdLibc.java
@@ -23,13 +23,11 @@
  */
 package oshi.jna.platform.unix.freebsd;
 
-import com.sun.jna.Native;
+import com.sun.jna.Native; // NOSONAR squid:S1191
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
-import com.sun.jna.platform.unix.LibCAPI;
 import com.sun.jna.ptr.IntByReference;
-
 
 import oshi.jna.platform.unix.CLibrary;
 
@@ -37,7 +35,7 @@ import oshi.jna.platform.unix.CLibrary;
  * C library. This class should be considered non-API as it may be removed
  * if/when its code is incorporated into the JNA project.
  */
-public interface FreeBsdLibc extends CLibrary, LibCAPI {
+public interface FreeBsdLibc extends CLibrary {
     /** Constant <code>INSTANCE</code> */
     FreeBsdLibc INSTANCE = Native.load("libc", FreeBsdLibc.class);
 
@@ -71,32 +69,32 @@ public interface FreeBsdLibc extends CLibrary, LibCAPI {
     }
 
     /**
-     * The sysctl() function retrieves system information and allows processes
-     * with appropriate privileges to set system information. The information
-     * available from sysctl() consists of integers, strings, and tables.
+     * The sysctl() function retrieves system information and allows processes with
+     * appropriate privileges to set system information. The information available
+     * from sysctl() consists of integers, strings, and tables.
      *
      * The state is described using a "Management Information Base" (MIB) style
      * name, listed in name, which is a namelen length array of integers.
      *
-     * The information is copied into the buffer specified by oldp. The size of
-     * the buffer is given by the location specified by oldlenp before the call,
-     * and that location gives the amount of data copied after a successful call
-     * and after a call that returns with the error code ENOMEM. If the amount
-     * of data available is greater than the size of the buffer supplied, the
-     * call supplies as much data as fits in the buffer provided and returns
-     * with the error code ENOMEM. If the old value is not desired, oldp and
-     * oldlenp should be set to NULL.
+     * The information is copied into the buffer specified by oldp. The size of the
+     * buffer is given by the location specified by oldlenp before the call, and
+     * that location gives the amount of data copied after a successful call and
+     * after a call that returns with the error code ENOMEM. If the amount of data
+     * available is greater than the size of the buffer supplied, the call supplies
+     * as much data as fits in the buffer provided and returns with the error code
+     * ENOMEM. If the old value is not desired, oldp and oldlenp should be set to
+     * NULL.
      *
-     * The size of the available data can be determined by calling sysctl() with
-     * the NULL argument for oldp. The size of the available data will be
-     * returned in the location pointed to by oldlenp. For some operations, the
-     * amount of space may change often. For these operations, the system
-     * attempts to round up so that the returned size is large enough for a call
-     * to return the data shortly thereafter.
+     * The size of the available data can be determined by calling sysctl() with the
+     * NULL argument for oldp. The size of the available data will be returned in
+     * the location pointed to by oldlenp. For some operations, the amount of space
+     * may change often. For these operations, the system attempts to round up so
+     * that the returned size is large enough for a call to return the data shortly
+     * thereafter.
      *
-     * To set a new value, newp is set to point to a buffer of length newlen
-     * from which the requested value is to be taken. If a new value is not to
-     * be set, newp should be set to NULL and newlen set to 0.
+     * To set a new value, newp is set to point to a buffer of length newlen from
+     * which the requested value is to be taken. If a new value is not to be set,
+     * newp should be set to NULL and newlen set to 0.
      *
      * @param name
      *            MIB array of integers
@@ -115,9 +113,9 @@ public interface FreeBsdLibc extends CLibrary, LibCAPI {
     int sysctl(int[] name, int namelen, Pointer oldp, IntByReference oldlenp, Pointer newp, int newlen);
 
     /**
-     * The sysctlbyname() function accepts an ASCII representation of the name
-     * and internally looks up the integer name vector. Apart from that, it
-     * behaves the same as the standard sysctl() function.
+     * The sysctlbyname() function accepts an ASCII representation of the name and
+     * internally looks up the integer name vector. Apart from that, it behaves the
+     * same as the standard sysctl() function.
      *
      * @param name
      *            ASCII representation of the MIB name
@@ -134,33 +132,31 @@ public interface FreeBsdLibc extends CLibrary, LibCAPI {
     int sysctlbyname(String name, Pointer oldp, IntByReference oldlenp, Pointer newp, int newlen);
 
     /**
-     * The sysctlnametomib() function accepts an ASCII representation of the
-     * name, looks up the integer name vector, and returns the numeric
-     * representation in the mib array pointed to by mibp. The number of
-     * elements in the mib array is given by the location specified by sizep
-     * before the call, and that location gives the number of entries copied
-     * after a successful call. The resulting mib and size may be used in
-     * subsequent sysctl() calls to get the data associated with the requested
-     * ASCII name. This interface is intended for use by applications that want
-     * to repeatedly request the same variable (the sysctl() function runs in
-     * about a third the time as the same request made via the sysctlbyname()
-     * function).
+     * The sysctlnametomib() function accepts an ASCII representation of the name,
+     * looks up the integer name vector, and returns the numeric representation in
+     * the mib array pointed to by mibp. The number of elements in the mib array is
+     * given by the location specified by sizep before the call, and that location
+     * gives the number of entries copied after a successful call. The resulting mib
+     * and size may be used in subsequent sysctl() calls to get the data associated
+     * with the requested ASCII name. This interface is intended for use by
+     * applications that want to repeatedly request the same variable (the sysctl()
+     * function runs in about a third the time as the same request made via the
+     * sysctlbyname() function).
      *
      * The number of elements in the mib array can be determined by calling
      * sysctlnametomib() with the NULL argument for mibp.
      *
-     * The sysctlnametomib() function is also useful for fetching mib prefixes.
-     * If size on input is greater than the number of elements written, the
-     * array still contains the additional elements which may be written
-     * programmatically.
+     * The sysctlnametomib() function is also useful for fetching mib prefixes. If
+     * size on input is greater than the number of elements written, the array still
+     * contains the additional elements which may be written programmatically.
      *
      * @param name
      *            ASCII representation of the name
      * @param mibp
      *            Integer array containing the corresponding name vector.
      * @param size
-     *            On input, number of elements in the returned array; on output,
-     *            the number of entries copied.
+     *            On input, number of elements in the returned array; on output, the
+     *            number of entries copied.
      * @return 0 on success; sets errno on failure
      */
     int sysctlnametomib(String name, Pointer mibp, IntByReference size);

--- a/oshi-core/src/main/java/oshi/jna/platform/unix/solaris/SolarisLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/unix/solaris/SolarisLibc.java
@@ -24,6 +24,7 @@
 package oshi.jna.platform.unix.solaris;
 
 import com.sun.jna.Native;
+import com.sun.jna.platform.unix.LibCAPI;
 
 import oshi.jna.platform.unix.CLibrary;
 
@@ -31,7 +32,7 @@ import oshi.jna.platform.unix.CLibrary;
  * C library. This class should be considered non-API as it may be removed
  * if/when its code is incorporated into the JNA project.
  */
-public interface SolarisLibc extends CLibrary {
+public interface SolarisLibc extends CLibrary, LibCAPI {
     /** Constant <code>INSTANCE</code> */
     SolarisLibc INSTANCE = Native.load("libc", SolarisLibc.class);
 

--- a/oshi-core/src/main/java/oshi/jna/platform/unix/solaris/SolarisLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/unix/solaris/SolarisLibc.java
@@ -23,8 +23,7 @@
  */
 package oshi.jna.platform.unix.solaris;
 
-import com.sun.jna.Native;
-import com.sun.jna.platform.unix.LibCAPI;
+import com.sun.jna.Native; // NOSONAR squid:S1191
 
 import oshi.jna.platform.unix.CLibrary;
 
@@ -32,7 +31,7 @@ import oshi.jna.platform.unix.CLibrary;
  * C library. This class should be considered non-API as it may be removed
  * if/when its code is incorporated into the JNA project.
  */
-public interface SolarisLibc extends CLibrary, LibCAPI {
+public interface SolarisLibc extends CLibrary {
     /** Constant <code>INSTANCE</code> */
     SolarisLibc INSTANCE = Native.load("libc", SolarisLibc.class);
 

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
@@ -30,7 +30,9 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.ptr.PointerByReference; // NOSONAR
+import com.sun.jna.Native; // NOSONAR
+import com.sun.jna.platform.linux.LibC;
+import com.sun.jna.ptr.PointerByReference; 
 
 import oshi.jna.platform.linux.LinuxLibc;
 import oshi.software.common.AbstractNetworkParams;
@@ -72,6 +74,16 @@ public class LinuxNetworkParams extends AbstractNetworkParams {
         String canonname = info.ai_canonname.trim();
         LinuxLibc.INSTANCE.freeaddrinfo(ptr.getValue());
         return canonname;
+    }
+
+    @Override
+    public String getHostName() {
+        byte[] hostnameBuffer = new byte[LibC.HOST_NAME_MAX + 1];
+        int result = LibC.INSTANCE.gethostname(hostnameBuffer, hostnameBuffer.length);
+        if (result != 0) {
+            return super.getHostName();
+        }
+        return Native.toString(hostnameBuffer);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParams.java
@@ -23,6 +23,8 @@
  */
 package oshi.software.os.linux;
 
+import static com.sun.jna.platform.unix.LibCAPI.HOST_NAME_MAX; // NOSONAR squid:S1191
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
@@ -30,11 +32,13 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.Native; // NOSONAR
+import com.sun.jna.Native;
 import com.sun.jna.platform.linux.LibC;
-import com.sun.jna.ptr.PointerByReference; 
+import com.sun.jna.ptr.PointerByReference;
 
 import oshi.jna.platform.linux.LinuxLibc;
+import oshi.jna.platform.unix.CLibrary;
+import oshi.jna.platform.unix.CLibrary.Addrinfo;
 import oshi.software.common.AbstractNetworkParams;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -48,13 +52,15 @@ public class LinuxNetworkParams extends AbstractNetworkParams {
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxNetworkParams.class);
 
+    private static final LinuxLibc LIBC = LinuxLibc.INSTANCE;
+
     private static final String IPV4_DEFAULT_DEST = "0.0.0.0"; // NOSONAR
     private static final String IPV6_DEFAULT_DEST = "::/0";
 
     @Override
     public String getDomainName() {
-        LinuxLibc.Addrinfo hint = new LinuxLibc.Addrinfo();
-        hint.ai_flags = LinuxLibc.AI_CANONNAME;
+        Addrinfo hint = new Addrinfo();
+        hint.ai_flags = CLibrary.AI_CANONNAME;
         String hostname = "";
         try {
             hostname = InetAddress.getLocalHost().getHostName();
@@ -63,24 +69,23 @@ public class LinuxNetworkParams extends AbstractNetworkParams {
             return "";
         }
         PointerByReference ptr = new PointerByReference();
-        int res = LinuxLibc.INSTANCE.getaddrinfo(hostname, null, hint, ptr);
+        int res = LIBC.getaddrinfo(hostname, null, hint, ptr);
         if (res > 0) {
             if (LOG.isErrorEnabled()) {
-                LOG.error("Failed getaddrinfo(): {}", LinuxLibc.INSTANCE.gai_strerror(res));
+                LOG.error("Failed getaddrinfo(): {}", LIBC.gai_strerror(res));
             }
             return "";
         }
-        LinuxLibc.Addrinfo info = new LinuxLibc.Addrinfo(ptr.getValue());
+        Addrinfo info = new Addrinfo(ptr.getValue());
         String canonname = info.ai_canonname.trim();
-        LinuxLibc.INSTANCE.freeaddrinfo(ptr.getValue());
+        LIBC.freeaddrinfo(ptr.getValue());
         return canonname;
     }
 
     @Override
     public String getHostName() {
-        byte[] hostnameBuffer = new byte[LibC.HOST_NAME_MAX + 1];
-        int result = LibC.INSTANCE.gethostname(hostnameBuffer, hostnameBuffer.length);
-        if (result != 0) {
+        byte[] hostnameBuffer = new byte[HOST_NAME_MAX + 1];
+        if (0 != LibC.INSTANCE.gethostname(hostnameBuffer, hostnameBuffer.length)) {
             return super.getHostName();
         }
         return Native.toString(hostnameBuffer);

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParams.java
@@ -30,7 +30,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.ptr.PointerByReference; // NOSONAR
+import com.sun.jna.Native; // NOSONAR
+import com.sun.jna.ptr.PointerByReference;
 
 import oshi.jna.platform.mac.SystemB;
 import oshi.software.common.AbstractNetworkParams;
@@ -73,6 +74,16 @@ public class MacNetworkParams extends AbstractNetworkParams {
         String canonname = info.ai_canonname.trim();
         SystemB.INSTANCE.freeaddrinfo(ptr.getValue());
         return canonname;
+    }
+
+    @Override
+    public String getHostName() {
+        byte[] hostnameBuffer = new byte[SystemB.HOST_NAME_MAX + 1];
+        int result = SystemB.INSTANCE.gethostname(hostnameBuffer, hostnameBuffer.length);
+        if (result != 0) {
+            return super.getHostName();
+        }
+        return Native.toString(hostnameBuffer);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParams.java
@@ -23,6 +23,8 @@
  */
 package oshi.software.os.mac;
 
+import static com.sun.jna.platform.unix.LibCAPI.HOST_NAME_MAX; // NOSONAR squid:S1191
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
@@ -30,10 +32,12 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.Native; // NOSONAR
+import com.sun.jna.Native;
 import com.sun.jna.ptr.PointerByReference;
 
 import oshi.jna.platform.mac.SystemB;
+import oshi.jna.platform.unix.CLibrary;
+import oshi.jna.platform.unix.CLibrary.Addrinfo;
 import oshi.software.common.AbstractNetworkParams;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -47,14 +51,16 @@ public class MacNetworkParams extends AbstractNetworkParams {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacNetworkParams.class);
 
+    private static final SystemB SYS = SystemB.INSTANCE;
+
     private static final String IPV6_ROUTE_HEADER = "Internet6:";
 
     private static final String DEFAULT_GATEWAY = "default";
 
     @Override
     public String getDomainName() {
-        SystemB.Addrinfo hint = new SystemB.Addrinfo();
-        hint.ai_flags = SystemB.AI_CANONNAME;
+        Addrinfo hint = new Addrinfo();
+        hint.ai_flags = CLibrary.AI_CANONNAME;
         String hostname = "";
         try {
             hostname = InetAddress.getLocalHost().getHostName();
@@ -63,24 +69,23 @@ public class MacNetworkParams extends AbstractNetworkParams {
             return "";
         }
         PointerByReference ptr = new PointerByReference();
-        int res = SystemB.INSTANCE.getaddrinfo(hostname, null, hint, ptr);
+        int res = SYS.getaddrinfo(hostname, null, hint, ptr);
         if (res > 0) {
             if (LOG.isErrorEnabled()) {
-                LOG.error("Failed getaddrinfo(): {}", SystemB.INSTANCE.gai_strerror(res));
+                LOG.error("Failed getaddrinfo(): {}", SYS.gai_strerror(res));
             }
             return "";
         }
-        SystemB.Addrinfo info = new SystemB.Addrinfo(ptr.getValue());
+        Addrinfo info = new Addrinfo(ptr.getValue());
         String canonname = info.ai_canonname.trim();
-        SystemB.INSTANCE.freeaddrinfo(ptr.getValue());
+        SYS.freeaddrinfo(ptr.getValue());
         return canonname;
     }
 
     @Override
     public String getHostName() {
-        byte[] hostnameBuffer = new byte[SystemB.HOST_NAME_MAX + 1];
-        int result = SystemB.INSTANCE.gethostname(hostnameBuffer, hostnameBuffer.length);
-        if (result != 0) {
+        byte[] hostnameBuffer = new byte[HOST_NAME_MAX + 1];
+        if (0 != SYS.gethostname(hostnameBuffer, hostnameBuffer.length)) {
             return super.getHostName();
         }
         return Native.toString(hostnameBuffer);

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
@@ -29,7 +29,7 @@ import java.net.UnknownHostException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.Native; 
+import com.sun.jna.Native; // NOSONAR
 import com.sun.jna.ptr.PointerByReference; 
 
 import oshi.jna.platform.unix.freebsd.FreeBsdLibc;

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
@@ -23,15 +23,18 @@
  */
 package oshi.software.os.unix.freebsd;
 
+import static com.sun.jna.platform.unix.LibCAPI.HOST_NAME_MAX; // NOSONAR squid:S1191
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.Native; // NOSONAR
-import com.sun.jna.ptr.PointerByReference; 
+import com.sun.jna.Native;
+import com.sun.jna.ptr.PointerByReference;
 
+import oshi.jna.platform.unix.CLibrary;
 import oshi.jna.platform.unix.freebsd.FreeBsdLibc;
 import oshi.software.common.AbstractNetworkParams;
 import oshi.util.ExecutingCommand;
@@ -45,11 +48,12 @@ public class FreeBsdNetworkParams extends AbstractNetworkParams {
 
     private static final Logger LOG = LoggerFactory.getLogger(FreeBsdNetworkParams.class);
 
-    /** {@inheritDoc} */
+    private static final FreeBsdLibc LIBC = FreeBsdLibc.INSTANCE;
+
     @Override
     public String getDomainName() {
         FreeBsdLibc.Addrinfo hint = new FreeBsdLibc.Addrinfo();
-        hint.ai_flags = FreeBsdLibc.AI_CANONNAME;
+        hint.ai_flags = CLibrary.AI_CANONNAME;
         String hostname = "";
         try {
             hostname = InetAddress.getLocalHost().getHostName();
@@ -58,37 +62,33 @@ public class FreeBsdNetworkParams extends AbstractNetworkParams {
             return "";
         }
         PointerByReference ptr = new PointerByReference();
-        int res = FreeBsdLibc.INSTANCE.getaddrinfo(hostname, null, hint, ptr);
+        int res = LIBC.getaddrinfo(hostname, null, hint, ptr);
         if (res > 0) {
             if (LOG.isErrorEnabled()) {
-                LOG.error("Failed getaddrinfo(): {}", FreeBsdLibc.INSTANCE.gai_strerror(res));
+                LOG.error("Failed getaddrinfo(): {}", LIBC.gai_strerror(res));
             }
             return "";
         }
         FreeBsdLibc.Addrinfo info = new FreeBsdLibc.Addrinfo(ptr.getValue());
         String canonname = info.ai_canonname.trim();
-        FreeBsdLibc.INSTANCE.freeaddrinfo(ptr.getValue());
+        LIBC.freeaddrinfo(ptr.getValue());
         return canonname;
     }
 
     @Override
     public String getHostName() {
-        byte[] hostnameBuffer = new byte[FreeBsdLibc.HOST_NAME_MAX + 1];
-        int result = FreeBsdLibc.INSTANCE.gethostname(hostnameBuffer, hostnameBuffer.length);
-        if (result != 0) {
+        byte[] hostnameBuffer = new byte[HOST_NAME_MAX + 1];
+        if (0 != LIBC.gethostname(hostnameBuffer, hostnameBuffer.length)) {
             return super.getHostName();
         }
         return Native.toString(hostnameBuffer);
     }
 
-
-    /** {@inheritDoc} */
     @Override
     public String getIpv4DefaultGateway() {
         return searchGateway(ExecutingCommand.runNative("route -4 get default"));
     }
 
-    /** {@inheritDoc} */
     @Override
     public String getIpv6DefaultGateway() {
         return searchGateway(ExecutingCommand.runNative("route -6 get default"));

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParams.java
@@ -29,7 +29,8 @@ import java.net.UnknownHostException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.ptr.PointerByReference; // NOSONAR
+import com.sun.jna.Native; 
+import com.sun.jna.ptr.PointerByReference; 
 
 import oshi.jna.platform.unix.freebsd.FreeBsdLibc;
 import oshi.software.common.AbstractNetworkParams;
@@ -69,6 +70,17 @@ public class FreeBsdNetworkParams extends AbstractNetworkParams {
         FreeBsdLibc.INSTANCE.freeaddrinfo(ptr.getValue());
         return canonname;
     }
+
+    @Override
+    public String getHostName() {
+        byte[] hostnameBuffer = new byte[FreeBsdLibc.HOST_NAME_MAX + 1];
+        int result = FreeBsdLibc.INSTANCE.gethostname(hostnameBuffer, hostnameBuffer.length);
+        if (result != 0) {
+            return super.getHostName();
+        }
+        return Native.toString(hostnameBuffer);
+    }
+
 
     /** {@inheritDoc} */
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
@@ -23,10 +23,23 @@
  */
 package oshi.software.os.unix.solaris;
 
+import com.sun.jna.Native;
+
+import oshi.jna.platform.unix.solaris.SolarisLibc;
 import oshi.software.common.AbstractNetworkParams;
 import oshi.util.ExecutingCommand;
 
 public class SolarisNetworkParams extends AbstractNetworkParams {
+
+    @Override
+    public String getHostName() {
+        byte[] hostnameBuffer = new byte[SolarisLibc.HOST_NAME_MAX + 1];
+        int result = SolarisLibc.INSTANCE.gethostname(hostnameBuffer, hostnameBuffer.length);
+        if (result != 0) {
+            return super.getHostName();
+        }
+        return Native.toString(hostnameBuffer);
+    }
 
     @Override
     public String getIpv4DefaultGateway() {

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
@@ -23,7 +23,9 @@
  */
 package oshi.software.os.unix.solaris;
 
-import com.sun.jna.Native; // NOSONAR
+import static com.sun.jna.platform.unix.LibCAPI.HOST_NAME_MAX; // NOSONAR squid:S1191
+
+import com.sun.jna.Native;
 
 import oshi.jna.platform.unix.solaris.SolarisLibc;
 import oshi.software.common.AbstractNetworkParams;
@@ -31,11 +33,12 @@ import oshi.util.ExecutingCommand;
 
 public class SolarisNetworkParams extends AbstractNetworkParams {
 
+    private static final SolarisLibc LIBC = SolarisLibc.INSTANCE;
+
     @Override
     public String getHostName() {
-        byte[] hostnameBuffer = new byte[SolarisLibc.HOST_NAME_MAX + 1];
-        int result = SolarisLibc.INSTANCE.gethostname(hostnameBuffer, hostnameBuffer.length);
-        if (result != 0) {
+        byte[] hostnameBuffer = new byte[HOST_NAME_MAX + 1];
+        if (0 != LIBC.gethostname(hostnameBuffer, hostnameBuffer.length)) {
             return super.getHostName();
         }
         return Native.toString(hostnameBuffer);

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParams.java
@@ -23,7 +23,7 @@
  */
 package oshi.software.os.unix.solaris;
 
-import com.sun.jna.Native;
+import com.sun.jna.Native; // NOSONAR
 
 import oshi.jna.platform.unix.solaris.SolarisLibc;
 import oshi.software.common.AbstractNetworkParams;

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
@@ -34,6 +34,7 @@ import com.sun.jna.platform.win32.IPHlpAPI;
 import com.sun.jna.platform.win32.IPHlpAPI.FIXED_INFO;
 import com.sun.jna.platform.win32.IPHlpAPI.IP_ADDR_STRING;
 import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.Kernel32Util;
 import com.sun.jna.platform.win32.WinError;
 import com.sun.jna.ptr.IntByReference;
 
@@ -92,6 +93,11 @@ public class WindowsNetworkParams extends AbstractNetworkParams {
             dns = dns.Next;
         }
         return list.toArray(new String[0]);
+    }
+
+    @Override
+    public String getHostName() {
+        return Kernel32Util.getComputerName();
     }
 
     @Override


### PR DESCRIPTION
Fixes #1006
on windows, getHostName() uses Kernel32Util.getComputerName().
and on Mac, Linux, Solaris, and BSD it returns the value from JNA's LibC class method getHostName().

I have a question. [contributing guide](https://github.com/oshi/oshi/blob/master/CONTRIBUTING.md#update-changelog-again) says "Update CHANGELOG Again" and I'm somewhat confused. Do I have to update changelog at the moment I made a pull request or when my pull request got merged? 
