### PR TITLE
Read HKEY_PERFORMANCE_DATA for process counters if possible

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sun.jna.Memory;
 import com.sun.jna.Native; // NOSONAR squid:S1191
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Advapi32;
@@ -49,6 +50,7 @@ import com.sun.jna.platform.win32.Advapi32Util.EventLogIterator;
 import com.sun.jna.platform.win32.Advapi32Util.EventLogRecord;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.Kernel32Util;
+import com.sun.jna.platform.win32.PdhUtil;
 import com.sun.jna.platform.win32.Psapi;
 import com.sun.jna.platform.win32.Psapi.PERFORMANCE_INFORMATION;
 import com.sun.jna.platform.win32.Tlhelp32;
@@ -62,6 +64,12 @@ import com.sun.jna.platform.win32.WinError;
 import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
+import com.sun.jna.platform.win32.WinPerf.PERF_COUNTER_BLOCK;
+import com.sun.jna.platform.win32.WinPerf.PERF_COUNTER_DEFINITION;
+import com.sun.jna.platform.win32.WinPerf.PERF_DATA_BLOCK;
+import com.sun.jna.platform.win32.WinPerf.PERF_INSTANCE_DEFINITION;
+import com.sun.jna.platform.win32.WinPerf.PERF_OBJECT_TYPE;
+import com.sun.jna.platform.win32.WinReg;
 import com.sun.jna.platform.win32.WinUser;
 import com.sun.jna.platform.win32.Winsvc;
 import com.sun.jna.platform.win32.Wtsapi32;
@@ -89,6 +97,24 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(WindowsOperatingSystem.class);
 
     private static final long BOOTTIME = querySystemBootTime();
+
+    /*
+     * Associated with registry process counter buffer reading
+     */
+    private boolean readHkeyPerformanceData;
+    private int perfDataBufferSize = 8192;
+    private int processIndex;
+    private String processIndexStr;
+    /*
+     * Registry counter offsets
+     */
+    private int priorityBaseOffset; // 92
+    private int elapsedTimeOffset; // 96
+    private int idProcessOffset; // 104
+    private int creatingProcessIdOffset; // 108
+    private int ioReadOffset; // 160
+    private int ioWriteOffset; // 168
+    private int workingSetPrivateOffset; // 192
 
     enum OSVersionProperty {
         Version, ProductType, BuildNumber, CSDVersion, SuiteMask;
@@ -154,6 +180,106 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
     @SuppressWarnings("deprecation")
     public WindowsOperatingSystem() {
         this.version = new WindowsOSVersionInfoEx();
+        // Check whether perf counters can be read from HKEY_PERFORMANCE_DATA
+        this.readHkeyPerformanceData = initRegistry();
+    }
+
+    private boolean initRegistry() {
+        // Get the title indices
+        int priorityBaseIndex;
+        int elapsedTimeIndex;
+        int idProcessIndex;
+        int creatingProcessIdIndex;
+        int ioReadIndex;
+        int ioWriteIndex;
+        int workingSetPrivateIndex;
+        try {
+            this.processIndex = PdhUtil.PdhLookupPerfIndexByEnglishName("Process");
+            priorityBaseIndex = PdhUtil.PdhLookupPerfIndexByEnglishName("Priority Base");
+            elapsedTimeIndex = PdhUtil.PdhLookupPerfIndexByEnglishName("Elapsed Time");
+            idProcessIndex = PdhUtil.PdhLookupPerfIndexByEnglishName("ID Process");
+            creatingProcessIdIndex = PdhUtil.PdhLookupPerfIndexByEnglishName("Creating Process ID");
+            ioReadIndex = PdhUtil.PdhLookupPerfIndexByEnglishName("IO Read Bytes/sec");
+            ioWriteIndex = PdhUtil.PdhLookupPerfIndexByEnglishName("IO Write Bytes/sec");
+            workingSetPrivateIndex = PdhUtil.PdhLookupPerfIndexByEnglishName("Working Set - Private");
+        } catch (Win32Exception e) {
+            LOG.warn(
+                    "Unable to locate English counter names in registry Perflib 009. Process statistics will be read from PDH or WMI.");
+            return false;
+        }
+        this.processIndexStr = Integer.toString(this.processIndex);
+
+        // now load the Process registry to match up the offsets
+        // Sequentially increase the buffer until everything fits.
+        // Save this buffer size for later use
+        IntByReference lpcbData = new IntByReference(this.perfDataBufferSize);
+        Pointer pPerfData = new Memory(this.perfDataBufferSize);
+        int ret = Advapi32.INSTANCE.RegQueryValueEx(WinReg.HKEY_PERFORMANCE_DATA, this.processIndexStr, 0, null,
+                pPerfData, lpcbData);
+        if (ret != WinError.ERROR_SUCCESS && ret != WinError.ERROR_MORE_DATA) {
+            LOG.warn(
+                    "Error {} reading HKEY_PERFORMANCE_DATA from the registry. Process statistics will be read from PDH or WMI.",
+                    ret);
+            return false;
+        }
+        while (ret == WinError.ERROR_MORE_DATA) {
+            this.perfDataBufferSize += 4096;
+            lpcbData.setValue(this.perfDataBufferSize);
+            pPerfData = new Memory(this.perfDataBufferSize);
+            ret = Advapi32.INSTANCE.RegQueryValueEx(WinReg.HKEY_PERFORMANCE_DATA, this.processIndexStr, 0, null,
+                    pPerfData, lpcbData);
+        }
+
+        PERF_DATA_BLOCK perfData = new PERF_DATA_BLOCK(pPerfData.share(0));
+
+        // See format at
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa373105(v=vs.85).aspx
+        // [ ] Object Type
+        // [ ][ ][ ] Multiple counter definitions
+        // Then multiple:
+        // [ ] Instance Definition
+        // [ ] Instance name
+        // [ ] Counter Block
+        // [ ][ ][ ] Counter data for each definition above
+
+        long perfObjectOffset = perfData.HeaderLength;
+
+        // Iterate object types. For Process should only be one here
+        for (int obj = 0; obj < perfData.NumObjectTypes; obj++) {
+            PERF_OBJECT_TYPE perfObject = new PERF_OBJECT_TYPE(pPerfData.share(perfObjectOffset));
+            // Identify where counter definitions start
+            long perfCounterOffset = perfObjectOffset + perfObject.HeaderLength;
+            // If this isn't the Process object, ignore
+            if (perfObject.ObjectNameTitleIndex == this.processIndex) {
+                for (int counter = 0; counter < perfObject.NumCounters; counter++) {
+                    PERF_COUNTER_DEFINITION perfCounter = new PERF_COUNTER_DEFINITION(
+                            pPerfData.share(perfCounterOffset));
+                    if (perfCounter.CounterNameTitleIndex == priorityBaseIndex) {
+                        this.priorityBaseOffset = perfCounter.CounterOffset;
+                    } else if (perfCounter.CounterNameTitleIndex == elapsedTimeIndex) {
+                        this.elapsedTimeOffset = perfCounter.CounterOffset;
+                    } else if (perfCounter.CounterNameTitleIndex == creatingProcessIdIndex) {
+                        this.creatingProcessIdOffset = perfCounter.CounterOffset;
+                    } else if (perfCounter.CounterNameTitleIndex == idProcessIndex) {
+                        this.idProcessOffset = perfCounter.CounterOffset;
+                    } else if (perfCounter.CounterNameTitleIndex == ioReadIndex) {
+                        this.ioReadOffset = perfCounter.CounterOffset;
+                    } else if (perfCounter.CounterNameTitleIndex == ioWriteIndex) {
+                        this.ioWriteOffset = perfCounter.CounterOffset;
+                    } else if (perfCounter.CounterNameTitleIndex == workingSetPrivateIndex) {
+                        this.workingSetPrivateOffset = perfCounter.CounterOffset;
+                    }
+                    // Increment for next Counter
+                    perfCounterOffset += perfCounter.ByteLength;
+                }
+                // We're done, break the loop
+                break;
+            }
+            // Increment for next object (should never need this)
+            perfObjectOffset += perfObject.TotalByteLength;
+        }
+        // Success
+        return true;
     }
 
     @Override
@@ -356,8 +482,10 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @return A corresponding list of processes
      */
     private List<OSProcess> processMapToList(Collection<Integer> pids, boolean slowFields) {
-        // Get data from the registry
-        Map<Integer, OSProcess> processMap = buildProcessMapFromPerfCounters(pids);
+        // Get data from the registry if possible, otherwise performance counters with
+        // WMI backup
+        Map<Integer, OSProcess> processMap = this.readHkeyPerformanceData ? buildProcessMapFromRegistry(pids)
+                : buildProcessMapFromPerfCounters(pids);
 
         // define here to avoid object repeated creation overhead later
         List<String> groupList = new ArrayList<>();
@@ -572,6 +700,94 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
     protected void handleWin32ExceptionOnGetProcessInfo(OSProcess proc, Win32Exception ex) {
         LOG.warn("Failed to set path or get user/group on PID {}. It may have terminated. {}", proc.getProcessID(),
                 ex.getMessage());
+    }
+
+    private Map<Integer, OSProcess> buildProcessMapFromRegistry(Collection<Integer> pids) {
+        Map<Integer, OSProcess> processMap = new HashMap<>();
+        // Grab the PERF_DATA_BLOCK from the registry.
+        // Sequentially increase the buffer until everything fits.
+        IntByReference lpcbData = new IntByReference(this.perfDataBufferSize);
+        Pointer pPerfData = new Memory(this.perfDataBufferSize);
+        int ret = Advapi32.INSTANCE.RegQueryValueEx(WinReg.HKEY_PERFORMANCE_DATA, this.processIndexStr, 0, null,
+                pPerfData, lpcbData);
+        if (ret != WinError.ERROR_SUCCESS && ret != WinError.ERROR_MORE_DATA) {
+            LOG.error("Error {} reading HKEY_PERFORMANCE_DATA from the registry.", ret);
+            return processMap;
+        }
+        while (ret == WinError.ERROR_MORE_DATA) {
+            this.perfDataBufferSize += 4096;
+            lpcbData.setValue(this.perfDataBufferSize);
+            pPerfData = new Memory(this.perfDataBufferSize);
+            ret = Advapi32.INSTANCE.RegQueryValueEx(WinReg.HKEY_PERFORMANCE_DATA, this.processIndexStr, 0, null,
+                    pPerfData, lpcbData);
+        }
+
+        PERF_DATA_BLOCK perfData = new PERF_DATA_BLOCK(pPerfData.share(0));
+        long perfTime100nSec = perfData.PerfTime100nSec.getValue(); // 1601
+        long now = System.currentTimeMillis(); // 1970 epoch
+
+        // See format at
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa373105(v=vs.85).aspx
+        // [ ] Object Type
+        // [ ][ ][ ] Multiple counter definitions
+        // Then multiple:
+        // [ ] Instance Definition
+        // [ ] Instance name
+        // [ ] Counter Block
+        // [ ][ ][ ] Counter data for each definition above
+        long perfObjectOffset = perfData.HeaderLength;
+
+        // Iterate object types. For Process should only be one here
+        for (int obj = 0; obj < perfData.NumObjectTypes; obj++) {
+            PERF_OBJECT_TYPE perfObject = new PERF_OBJECT_TYPE(pPerfData.share(perfObjectOffset));
+            // If this isn't the Process object, ignore
+            if (perfObject.ObjectNameTitleIndex == this.processIndex) {
+                // Skip over counter definitions
+                // There will be many of these, this points to the first one
+                long perfInstanceOffset = perfObjectOffset + perfObject.DefinitionLength;
+
+                // We need this for every process, initialize outside loop to
+                // save overhead
+                PERF_COUNTER_BLOCK perfCounterBlock = null;
+                // Iterate instances.
+                // The last instance is _Total so subtract 1 from max
+                for (int inst = 0; inst < perfObject.NumInstances - 1; inst++) {
+                    PERF_INSTANCE_DEFINITION perfInstance = new PERF_INSTANCE_DEFINITION(
+                            pPerfData.share(perfInstanceOffset));
+                    long perfCounterBlockOffset = perfInstanceOffset + perfInstance.ByteLength;
+
+                    int pid = pPerfData.getInt(perfCounterBlockOffset + this.idProcessOffset);
+                    if (pids == null || pids.contains(pid)) {
+                        OSProcess proc = new OSProcess(this);
+                        processMap.put(pid, proc);
+
+                        proc.setProcessID(pid);
+                        proc.setName(pPerfData.getWideString(perfInstanceOffset + perfInstance.NameOffset));
+                        long upTime = (perfTime100nSec
+                                - pPerfData.getLong(perfCounterBlockOffset + this.elapsedTimeOffset)) / 10_000L;
+                        proc.setUpTime(upTime < 1L ? 1L : upTime);
+                        proc.setStartTime(now - upTime);
+                        proc.setBytesRead(pPerfData.getLong(perfCounterBlockOffset + this.ioReadOffset));
+                        proc.setBytesWritten(pPerfData.getLong(perfCounterBlockOffset + this.ioWriteOffset));
+                        proc.setResidentSetSize(
+                                pPerfData.getLong(perfCounterBlockOffset + this.workingSetPrivateOffset));
+                        proc.setParentProcessID(
+                                pPerfData.getInt(perfCounterBlockOffset + this.creatingProcessIdOffset));
+                        proc.setPriority(pPerfData.getInt(perfCounterBlockOffset + this.priorityBaseOffset));
+                    }
+
+                    // Increment to next instance
+                    perfCounterBlock = new PERF_COUNTER_BLOCK(pPerfData.share(perfCounterBlockOffset));
+                    perfInstanceOffset = perfCounterBlockOffset + perfCounterBlock.ByteLength;
+                }
+                // We've found the process object and are done, no need to look at any other
+                // objects (shouldn't be any). Break the loop
+                break;
+            }
+            // Increment for next object (should never need this)
+            perfObjectOffset += perfObject.TotalByteLength;
+        }
+        return processMap;
     }
 
     private Map<Integer, OSProcess> buildProcessMapFromPerfCounters(Collection<Integer> pids) {


### PR DESCRIPTION
Puts back in faster code removed in #1001, preferred to WMI for the case when PDH counters are disabled.  See #1029 for discussion.