### PR TITLE
Subnet Mask & Prefix Length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 4.3.0 (in progress)
 ================
-* Your contribution here.
+* [#1057](https://github.com/oshi/oshi/pull/1057): Added Subnet Mask & Prefix Length to NetworkIF. - [@vesyrak](https://github.com/Vesyrak).
 
 4.2.0 (11/9/2019), 4.2.1 (11/14/2019)
 ================

--- a/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
@@ -54,7 +54,9 @@ public class NetworksTest {
             assertNotNull(net.getDisplayName());
             assertNotNull(net.getMacaddr());
             assertNotNull(net.getIPv4addr());
+            assertNotNull(net.getSubnetMasks());
             assertNotNull(net.getIPv6addr());
+            assertNotNull(net.getPrefixLengths());
             assertTrue(net.getBytesRecv() >= 0);
             assertTrue(net.getBytesSent() >= 0);
             assertTrue(net.getPacketsRecv() >= 0);


### PR DESCRIPTION
First time PR.

Adds Subnet Mask and Prefix Length to the NetworkIF.
This was one of the problems addressed in #696 

If there is interest, I also have something which can read most of the other problems defined in the issue. This code is, however, Linux specific, as it uses the corresponding interface files. 
