### PR TITLE
minor correction for catching future fault

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/OSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSProcess.java
@@ -58,7 +58,7 @@ public class OSProcess {
     private String userID = "";
     private String group = "";
     private String groupID = "";
-    private State state = null;
+    private State state = State.OTHER;
     private int processID;
     private int parentProcessID;
     private int threadCount;

--- a/oshi-core/src/main/java/oshi/software/os/OSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSProcess.java
@@ -58,7 +58,7 @@ public class OSProcess {
     private String userID = "";
     private String group = "";
     private String groupID = "";
-    private State state = State.OTHER;
+    private State state = null;
     private int processID;
     private int parentProcessID;
     private int threadCount;

--- a/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
@@ -103,7 +103,7 @@ public class OperatingSystemTest {
         if (os.getBitness() == 32) {
             assertEquals("Process on 32-bit OS must have bitness 0 or 32", 0, proc.getBitness() & ~32);
         } else {
-            assertEquals("Process on 64-bit OS must have bitness 0, 32, or 64", 0, proc.getBitness() & ~(32 + 64));
+            assertTrue("Process on 64-bit OS must have bitness 0, 32, or 64", (0==(proc.getBitness() & ~(32 + 64)))&&(poc.getBitness!=(32+64)));
         }
         assertTrue(proc.getOpenFiles() >= -1);
     }

--- a/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
@@ -80,7 +80,7 @@ public class OperatingSystemTest {
         assertNotNull(proc.getGroupID());
         assertNotNull(proc.getState());
         assertEquals(proc.getProcessID(), os.getProcessId());
-        assertTrue(proc.getParentProcessID() >= 0);
+        os.getProcess(proc.getParentProcessID());
         assertTrue(proc.getThreadCount() > 0);
         assertTrue(proc.getPriority() >= -20 && proc.getPriority() <= 128);
         assertTrue(proc.getVirtualSize() >= 0);
@@ -100,8 +100,7 @@ public class OperatingSystemTest {
         assertTrue(proc.getStartTime() >= 0);
         assertTrue(proc.getBytesRead() >= 0);
         assertTrue(proc.getBytesWritten() >= 0);
-        assertTrue(proc.getBitness() >= 0);
-        assertTrue(proc.getBitness() <= 64);
+        assertTrue(proc.getBitness() == 64||proc.getBitness() == 32||proc.getBitness() == 0);
         assertTrue(proc.getOpenFiles() >= -1);
     }
 

--- a/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
@@ -103,7 +103,7 @@ public class OperatingSystemTest {
         if (os.getBitness() == 32) {
             assertEquals("Process on 32-bit OS must have bitness 0 or 32", 0, proc.getBitness() & ~32);
         } else {
-            assertTrue("Process on 64-bit OS must have bitness 0, 32, or 64", (0==(proc.getBitness() & ~(32 + 64)))&&(poc.getBitness!=(32+64)));
+            assertEquals("Process on 64-bit OS must have bitness 0, 32, or 64", 0, proc.getBitness() & ~(32 + 64));
         }
         assertTrue(proc.getOpenFiles() >= -1);
     }

--- a/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
@@ -80,7 +80,7 @@ public class OperatingSystemTest {
         assertNotNull(proc.getGroupID());
         assertNotNull(proc.getState());
         assertEquals(proc.getProcessID(), os.getProcessId());
-        os.getProcess(proc.getParentProcessID());
+        assertTrue(proc.getParentProcessID() >= 0);
         assertTrue(proc.getThreadCount() > 0);
         assertTrue(proc.getPriority() >= -20 && proc.getPriority() <= 128);
         assertTrue(proc.getVirtualSize() >= 0);
@@ -100,7 +100,11 @@ public class OperatingSystemTest {
         assertTrue(proc.getStartTime() >= 0);
         assertTrue(proc.getBytesRead() >= 0);
         assertTrue(proc.getBytesWritten() >= 0);
-        assertTrue(proc.getBitness() == 64||proc.getBitness() == 32||proc.getBitness() == 0);
+        if (os.getBitness() == 32) {
+            assertEquals("Process on 32-bit OS must have bitness 0 or 32", 0, proc.getBitness() & ~32);
+        } else {
+            assertEquals("Process on 64-bit OS must have bitness 0, 32, or 64", 0, proc.getBitness() & ~(32 + 64));
+        }
         assertTrue(proc.getOpenFiles() >= -1);
     }
 


### PR DESCRIPTION
- set initial 'state' of OSProcess instance as 'null' to detect OSProcess instance that does not reflect real process information
- Change testing of 'os.getParentProcessID()' to see whether it points real process id
- Change testing of 'proc.getBitness()' to rigorously check its condition (32 or 64 bit)