### PR TITLE
Refactor duplicated queryTcpnetstat method

### DIFF
--- a/oshi-core/src/main/java/oshi/driver/unix/NetStatTcp.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/NetStatTcp.java
@@ -1,0 +1,61 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2010 - 2020 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package oshi.driver.unix;
+
+import java.util.List;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.ExecutingCommand;
+import oshi.util.tuples.Pair;
+
+/**
+ * Utility to query TCP connections
+ */
+@ThreadSafe
+public final class NetStatTcp {
+
+    private NetStatTcp() {
+    }
+
+    /**
+     * Query netstat to obtain number of established TCP connections
+     *
+     * @return A pair with number of established IPv4 and IPv6 connections
+     */
+    public static Pair<Long, Long> queryTcpnetstat() {
+        long tcp4 = 0L;
+        long tcp6 = 0L;
+        List<String> activeConns = ExecutingCommand.runNative("netstat -n -p tcp");
+        for (String s : activeConns) {
+            if (s.endsWith("ESTABLISHED")) {
+                if (s.startsWith("tcp4")) {
+                    tcp4++;
+                } else if (s.startsWith("tcp6")) {
+                    tcp6++;
+                }
+            }
+        }
+        return new Pair<>(tcp4, tcp6);
+    }
+}


### PR DESCRIPTION
Fix #1200
- Create`NetStatTcp` class with `queryTcpnetstat()` method
- Delete repeated methods in `MacInternetProtocolStats.java` and `FreeBsdInternetProtocolStats.java`