### PR TITLE
Change linux swapin/swapout counters

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxVirtualMemory.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxVirtualMemory.java
@@ -126,10 +126,10 @@ final class LinuxVirtualMemory extends AbstractVirtualMemory {
             String[] memorySplit = ParseUtil.whitespaces.split(checkLine);
             if (memorySplit.length > 1) {
                 switch (memorySplit[0]) {
-                case "pgpgin":
+                case "pswpin":
                     swapPagesIn = ParseUtil.parseLongOrDefault(memorySplit[1], 0L);
                     break;
-                case "pgpgout":
+                case "pswpout":
                     swapPagesOut = ParseUtil.parseLongOrDefault(memorySplit[1], 0L);
                     break;
                 default:

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisVirtualMemory.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisVirtualMemory.java
@@ -101,7 +101,7 @@ final class SolarisVirtualMemory extends AbstractVirtualMemory {
 
     private static long queryPagesIn() {
         long swapPagesIn = 0L;
-        for (String s : ExecutingCommand.runNative("kstat -p cpu_stat:::pgpgin")) {
+        for (String s : ExecutingCommand.runNative("kstat -p cpu_stat:::pgswapin")) {
             swapPagesIn += ParseUtil.parseLastLong(s, 0L);
         }
         return swapPagesIn;
@@ -109,7 +109,7 @@ final class SolarisVirtualMemory extends AbstractVirtualMemory {
 
     private static long queryPagesOut() {
         long swapPagesOut = 0L;
-        for (String s : ExecutingCommand.runNative("kstat -p cpu_stat:::pgpgout")) {
+        for (String s : ExecutingCommand.runNative("kstat -p cpu_stat:::pgswapout")) {
             swapPagesOut += ParseUtil.parseLastLong(s, 0L);
         }
         return swapPagesOut;


### PR DESCRIPTION
-Change Linux virtual memory to use pswpin and pswap out instead of pgpgin and pgpgout.
-Change Solaris virtual memory to use pgswpin and pgswap out instead of pgpgin and pgpgout.

Cherry-picked from roeezz-linux-swp