### PR TITLE
Outputs for IPv4 & subnetMask and IPv6 & prefix lengths combined

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -225,8 +225,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
         sb.append("Name: ").append(getName()).append(" ").append("(").append(getDisplayName()).append(")").append("\n");
         sb.append("  MAC Address: ").append(getMacaddr()).append("\n");
         sb.append("  MTU: ").append(getMTU()).append(", ").append("Speed: ").append(getSpeed()).append("\n");
-        sb.append("  IPv4: ").append(Arrays.toString(getIPv4addr())).append("\n");
-        sb.append("  Netmask:  ").append(Arrays.toString(getSubnetMasks())).append("\n");
+        sb.append("  IPv4: ").append(Arrays.toString(getIPv4addr())).append("/").append(Arrays.toString(getSubnetMasks())).append("\n");
         sb.append("  IPv6: ").append(Arrays.toString(getIPv6addr())).append("\n");
         sb.append("  Prefix Lengths:  ").append(Arrays.toString(getPrefixLengths())).append("\n");
         sb.append("  Traffic: received ").append(getPacketsRecv()).append(" packets/")

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -226,8 +226,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
         sb.append("  MAC Address: ").append(getMacaddr()).append("\n");
         sb.append("  MTU: ").append(getMTU()).append(", ").append("Speed: ").append(getSpeed()).append("\n");
         sb.append("  IPv4: ").append(Arrays.toString(getIPv4addr())).append("/").append(Arrays.toString(getSubnetMasks())).append("\n");
-        sb.append("  IPv6: ").append(Arrays.toString(getIPv6addr())).append("\n");
-        sb.append("  Prefix Lengths:  ").append(Arrays.toString(getPrefixLengths())).append("\n");
+        sb.append("  IPv6: ").append(Arrays.toString(getIPv6addr())).append("/").append(Arrays.toString(getPrefixLengths())).append("\n");
         sb.append("  Traffic: received ").append(getPacketsRecv()).append(" packets/")
                 .append(FormatUtil.formatBytes(getBytesRecv())).append(" (" + getInErrors() + " err, ")
                 .append(getInDrops() + " drop);");

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -232,8 +232,8 @@ public abstract class AbstractNetworkIF implements NetworkIF {
 
         String[] ipv6withprefixlength = getIPv6addr(); 
         if (this.ipv6.length == this.prefixLengths.length) {
-            for (int j = 0; j < this.prefixLengths.length; i++) {
-                ipv6withprefixlength[i] += "/" + this.prefixLengths[i];
+            for (int j = 0; j < this.prefixLengths.length; j++) {
+                ipv6withprefixlength[j] += "/" + this.prefixLengths[j];
             }
         }
         

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -110,6 +110,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
             this.subnetMasks = subnetMaskList.toArray(new Short[0]);
             this.ipv6 = ipv6list.toArray(new String[0]);
             this.prefixLengths = prefixLengthList.toArray(new Short[0]);
+
         } catch (SocketException e) {
             LOG.error("Socket exception: {}", e.getMessage());
         }
@@ -221,12 +222,27 @@ public abstract class AbstractNetworkIF implements NetworkIF {
 
     @Override
     public String toString() {
+
+        String[] ipv4withmask = getIPv4addr(); 
+        if (this.ipv4.length == this.subnetMasks.length) {
+            for (int i = 0; i < this.subnetMasks.length; i++) {
+                ipv4withmask[i] += "/" + this.subnetMasks[i];
+            }
+        }
+
+        String[] ipv6withprefixlength = getIPv6addr(); 
+        if (this.ipv6.length == this.prefixLengths.length) {
+            for (int j = 0; j < this.prefixLengths.length; i++) {
+                ipv6withprefixlength[i] += "/" + this.prefixLengths[i];
+            }
+        }
+        
         StringBuilder sb = new StringBuilder();
         sb.append("Name: ").append(getName()).append(" ").append("(").append(getDisplayName()).append(")").append("\n");
         sb.append("  MAC Address: ").append(getMacaddr()).append("\n");
         sb.append("  MTU: ").append(getMTU()).append(", ").append("Speed: ").append(getSpeed()).append("\n");
-        sb.append("  IPv4: ").append(Arrays.toString(getIPv4addr())).append("/").append(Arrays.toString(getSubnetMasks())).append("\n");
-        sb.append("  IPv6: ").append(Arrays.toString(getIPv6addr())).append("/").append(Arrays.toString(getPrefixLengths())).append("\n");
+        sb.append("  IPv4: ").append(Arrays.toString(ipv4withmask)).append("\n");
+        sb.append("  IPv6: ").append(Arrays.toString(ipv6withprefixlength)).append("\n");
         sb.append("  Traffic: received ").append(getPacketsRecv()).append(" packets/")
                 .append(FormatUtil.formatBytes(getBytesRecv())).append(" (" + getInErrors() + " err, ")
                 .append(getInDrops() + " drop);");

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -110,7 +110,6 @@ public abstract class AbstractNetworkIF implements NetworkIF {
             this.subnetMasks = subnetMaskList.toArray(new Short[0]);
             this.ipv6 = ipv6list.toArray(new String[0]);
             this.prefixLengths = prefixLengthList.toArray(new Short[0]);
-
         } catch (SocketException e) {
             LOG.error("Socket exception: {}", e.getMessage());
         }
@@ -222,26 +221,23 @@ public abstract class AbstractNetworkIF implements NetworkIF {
 
     @Override
     public String toString() {
-
-        String[] ipv4withmask = getIPv4addr(); 
+        StringBuilder sb = new StringBuilder();
+        sb.append("Name: ").append(getName()).append(" ").append("(").append(getDisplayName()).append(")").append("\n");
+        sb.append("  MAC Address: ").append(getMacaddr()).append("\n");
+        sb.append("  MTU: ").append(getMTU()).append(", ").append("Speed: ").append(getSpeed()).append("\n");
+        String[] ipv4withmask = getIPv4addr();
         if (this.ipv4.length == this.subnetMasks.length) {
             for (int i = 0; i < this.subnetMasks.length; i++) {
                 ipv4withmask[i] += "/" + this.subnetMasks[i];
             }
         }
-
-        String[] ipv6withprefixlength = getIPv6addr(); 
+        sb.append("  IPv4: ").append(Arrays.toString(ipv4withmask)).append("\n");
+        String[] ipv6withprefixlength = getIPv6addr();
         if (this.ipv6.length == this.prefixLengths.length) {
             for (int j = 0; j < this.prefixLengths.length; j++) {
                 ipv6withprefixlength[j] += "/" + this.prefixLengths[j];
             }
         }
-        
-        StringBuilder sb = new StringBuilder();
-        sb.append("Name: ").append(getName()).append(" ").append("(").append(getDisplayName()).append(")").append("\n");
-        sb.append("  MAC Address: ").append(getMacaddr()).append("\n");
-        sb.append("  MTU: ").append(getMTU()).append(", ").append("Speed: ").append(getSpeed()).append("\n");
-        sb.append("  IPv4: ").append(Arrays.toString(ipv4withmask)).append("\n");
         sb.append("  IPv6: ").append(Arrays.toString(ipv6withprefixlength)).append("\n");
         sb.append("  Traffic: received ").append(getPacketsRecv()).append(" packets/")
                 .append(FormatUtil.formatBytes(getBytesRecv())).append(" (" + getInErrors() + " err, ")


### PR DESCRIPTION
This fix will work for single element arrays, but not for multi-element arrays I think.
Am I supposed to only manipulate the String builder part? One solution I thought would be to combine the two arrays when they are being initially fed values, but that would mean only 2 arrays remain instead of current 4.