### PR TITLE
Moved cases from function to properties

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -167,7 +167,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
 
         // now for each file (with digit name) get process info
         for (File pidFile : pids) {
-                int pid = ParseUtil.parseIntOrDefault(pidFile.getName(), 0);
+            int pid = ParseUtil.parseIntOrDefault(pidFile.getName(), 0);
             OSProcess proc = new LinuxOSProcess(pid);
             if (!proc.getState().equals(State.INVALID)) {
                 procs.add(proc);

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -538,7 +538,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
 
         if (name.isEmpty()) {
             return "Solaris";
-        } else if ("issue".equals(name.toLowerCase())) {
+        } else if ("issue".equalsIgnoreCase(name)) {
             // /etc/issue will end up here
             return "Unknown";
         } else {

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +77,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
     private static final String LSB_RELEASE_LOG = "lsb-release: {}";
     private static final String RELEASE_DELIM = " release ";
     private static final String DOUBLE_QUOTES = "^\"|\"$";
+    private static final String FILENAME_PROPERTIES = "oshi.linux.filename.properties";
 
     /**
      * Jiffies per second, used for process time counters.
@@ -165,7 +167,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
 
         // now for each file (with digit name) get process info
         for (File pidFile : pids) {
-            int pid = ParseUtil.parseIntOrDefault(pidFile.getName(), 0);
+                int pid = ParseUtil.parseIntOrDefault(pidFile.getName(), 0);
             OSProcess proc = new LinuxOSProcess(pid);
             if (!proc.getState().equals(State.INVALID)) {
                 procs.add(proc);
@@ -533,64 +535,12 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @return Mixed case family
      */
     private static String filenameToFamily(String name) {
-        switch (name.toLowerCase()) {
-        // Handle known special cases
-        case "":
+        Properties filenameProps = FileUtil.readPropertiesFromFilename(FILENAME_PROPERTIES);
+        if (name.equals("")) {
             return "Solaris";
-        case "blackcat":
-            return "Black Cat";
-        case "bluewhite64":
-            return "BlueWhite64";
-        case "e-smith":
-            return "SME Server";
-        case "eos":
-            return "FreeEOS";
-        case "hlfs":
-            return "HLFS";
-        case "lfs":
-            return "Linux-From-Scratch";
-        case "linuxppc":
-            return "Linux-PPC";
-        case "meego":
-            return "MeeGo";
-        case "mandakelinux":
-            return "Mandrake";
-        case "mklinux":
-            return "MkLinux";
-        case "nld":
-            return "Novell Linux Desktop";
-        case "novell":
-        case "SuSE":
-            return "SUSE Linux";
-        case "pld":
-            return "PLD";
-        case "redhat":
-            return "Red Hat Linux";
-        case "sles":
-            return "SUSE Linux ES9";
-        case "sun":
-            return "Sun JDS";
-        case "synoinfo":
-            return "Synology";
-        case "tinysofa":
-            return "Tiny Sofa";
-        case "turbolinux":
-            return "TurboLinux";
-        case "ultrapenguin":
-            return "UltraPenguin";
-        case "va":
-            return "VA-Linux";
-        case "vmware":
-            return "VMWareESX";
-        case "yellowdog":
-            return "Yellow Dog";
-
-        // /etc/issue will end up here:
-        case "issue":
-            return "Unknown";
-        // If not a special case just capitalize first letter
-        default:
-            return name.substring(0, 1).toUpperCase() + name.substring(1);
+        } else {
+            String family = filenameProps.getProperty(name.toLowerCase());
+            return family != null ? family : name.substring(0, 1).toUpperCase() + name.substring(1);
         }
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -535,10 +535,14 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @return Mixed case family
      */
     private static String filenameToFamily(String name) {
-        Properties filenameProps = FileUtil.readPropertiesFromFilename(FILENAME_PROPERTIES);
-        if (name.equals("")) {
+
+        if (name.isEmpty()) {
             return "Solaris";
+        } else if ("issue".equals(name.toLowerCase())) {
+            // /etc/issue will end up here
+            return "Unknown";
         } else {
+            Properties filenameProps = FileUtil.readPropertiesFromFilename(FILENAME_PROPERTIES);
             String family = filenameProps.getProperty(name.toLowerCase());
             return family != null ? family : name.substring(0, 1).toUpperCase() + name.substring(1);
         }

--- a/oshi-core/src/main/resources/oshi.linux.filename.properties
+++ b/oshi-core/src/main/resources/oshi.linux.filename.properties
@@ -35,7 +35,7 @@ meego=MeeGo
 mandakelinux=Mandrake
 mklinux=MkLinux
 nld=Novell Linux Desktop
-#case "novell":
+novell=SUSE Linux
 SuSE=SUSE Linux
 pld=PLD
 redhat=Red Hat Linux
@@ -48,5 +48,4 @@ ultrapenguin=UltraPenguin
 va=VA-Linux
 vmware=VMWareESX
 yellowdog=Yellow Dog
-issue=Unknown
-#/etc/issue will end up here:
+

--- a/oshi-core/src/main/resources/oshi.linux.filename.properties
+++ b/oshi-core/src/main/resources/oshi.linux.filename.properties
@@ -1,0 +1,52 @@
+#
+# MIT License
+#
+# Copyright (c) 2010 - 2020 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#Mapping filename to a family representing
+
+blackcat=Black Cat
+bluewhite64=BlueWhite64
+e-smith=SME Server
+eos=FreeEOS
+hlfs=HLFS
+lfs=Linux-From-Scratch
+linuxppc=Linux-PPC
+meego=MeeGo
+mandakelinux=Mandrake
+mklinux=MkLinux
+nld=Novell Linux Desktop
+#case "novell":
+SuSE=SUSE Linux
+pld=PLD
+redhat=Red Hat Linux
+sles=SUSE Linux ES9
+sun=Sun JDS
+synoinfo=Synology
+tinysofa=Tiny Sofa
+turbolinux=TurboLinux
+ultrapenguin=UltraPenguin
+va=VA-Linux
+vmware=VMWareESX
+yellowdog=Yellow Dog
+issue=Unknown
+#/etc/issue will end up here:

--- a/oshi-core/src/main/resources/oshi.linux.filename.properties
+++ b/oshi-core/src/main/resources/oshi.linux.filename.properties
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-#Mapping filename to a family representing
+#Mapping filename to a family representation
 
 blackcat=Black Cat
 bluewhite64=BlueWhite64


### PR DESCRIPTION
Hello @dbwiddis 

I am trying to address the issue you pointed here ([#1264](https://github.com/oshi/oshi/issues/1264#issuecomment-646229626))

moved cases from  LinuxOperatingSystem.filenameToFamily() to oshi.linux.filename.properties

I will update the changelog file if there is nothing more to change here.
