### PR TITLE
Moved windows version parsing logic to a properties file

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -158,7 +158,6 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         // http://msdn.microsoft.com/en-us/library/windows/desktop/ms724833%28v=vs.85%29.aspx
         boolean ntWorkstation = WmiUtil.getUint32(versionInfo, OSVersionProperty.PRODUCTTYPE,
                 0) == WinNT.VER_NT_WORKSTATION;
-        boolean fivePtTwo = major == 5 && minor == 2;
 
         StringBuilder verLookup = new StringBuilder(major).append(".").append(minor);
 
@@ -166,7 +165,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
             verLookup.append(".nt");
         } else if (major == 10 && ParseUtil.parseLongOrDefault(buildNumber, 0L) > 17762) {
             verLookup.append(".17763+");
-        } else if (fivePtTwo) {
+        } else if (major == 5 && minor == 2) {
             if (ntWorkstation && getBitness() == 64) {
                 verLookup.append(".nt.x64");
             } else if ((suiteMask & 0x00008000) != 0) { // VER_SUITE_WH_SERVER

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -159,14 +159,14 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         boolean ntWorkstation = WmiUtil.getUint32(versionInfo, OSVersionProperty.PRODUCTTYPE,
                 0) == WinNT.VER_NT_WORKSTATION;
 
-        StringBuilder verLookup = new StringBuilder(major + "." + minor);
+        StringBuilder verLookup = new StringBuilder(major).append(".").append(minor);
 
-        if ((suiteMask & 0x00008000) != 0) { // VER_SUITE_WH_SERVER
+        if (!IS_VISTA_OR_GREATER && (suiteMask & 0x00008000) != 0) { // VER_SUITE_WH_SERVER
             verLookup.append(".HS");
-        } else if (ntWorkstation && !"5.1".equals(verLookup.toString()) && !"5.0".equals(verLookup.toString())) {
+        } else if (ntWorkstation && VersionHelpers.IsWindowsVersionOrGreater(5,2,0)) {
             verLookup.append(".nt");
         } else if (ParseUtil.parseLongOrDefault(buildNumber, 0L) > 17762) {
-            verLookup.append(".17762");
+            verLookup.append(".17763+");
         } else if (User32.INSTANCE.GetSystemMetrics(WinUser.SM_SERVERR2) == 0) {
             verLookup.append(".R2");
         }

--- a/oshi-core/src/main/resources/oshi.windows.versions.properties
+++ b/oshi-core/src/main/resources/oshi.windows.versions.properties
@@ -35,9 +35,10 @@
 6.1.false=Server 2008 R2
 6.0.true=Vista
 6.0.false=Server 2008
-5.2.1=Home Server
-5.2.2=XP
-5.2.3.true=Server 2003
-5.2.3.false=Server 2003 R2
-5.1.=XP
+5.2.HS=Home Server
+5.2.true=XP
+5.2.false.true=Server 2003
+5.2.false.false=Server 2003 R2
+5.1=XP
+#32 bits
 5.0=2000

--- a/oshi-core/src/main/resources/oshi.windows.versions.properties
+++ b/oshi-core/src/main/resources/oshi.windows.versions.properties
@@ -24,21 +24,21 @@
 
 #Mapping Windows version names to major, minor and build values
 
-10.0.true=10
-10.0.false.true=Server 2019
-10.0.false.false=Server 2016
-6.3.true=8.1
-6.3.false=Server 2012 R2
-6.2.true=8
-6.2.false=Server 2012
-6.1.true=7
-6.1.false=Server 2008 R2
-6.0.true=Vista
-6.0.false=Server 2008
+10.0.nt=10
+10.0.17762=Server 2019
+10.0=Server 2016
+6.3.nt=8.1
+6.3=Server 2012 R2
+6.2.nt=8
+6.2=Server 2012
+6.1.nt=7
+6.1=Server 2008 R2
+6.0.nt=Vista
+6.0=Server 2008
 5.2.HS=Home Server
-5.2.true=XP
-5.2.false.true=Server 2003
-5.2.false.false=Server 2003 R2
+5.2.nt=XP
+5.2=Server 2003
+5.2.R2=Server 2003 R2
 5.1=XP
 #32 bits
 5.0=2000

--- a/oshi-core/src/main/resources/oshi.windows.versions.properties
+++ b/oshi-core/src/main/resources/oshi.windows.versions.properties
@@ -35,10 +35,11 @@
 6.1=Server 2008 R2
 6.0.nt=Vista
 6.0=Server 2008
+5.2.nt.x64=XP Professional x64 Edition
+5.2.nt=XP Professional
 5.2.HS=Home Server
-5.2.nt=XP
-5.2=Server 2003
 5.2.R2=Server 2003 R2
+5.2=Server 2003
 5.1=XP
 #32 bits
 5.0=2000

--- a/oshi-core/src/main/resources/oshi.windows.versions.properties
+++ b/oshi-core/src/main/resources/oshi.windows.versions.properties
@@ -1,0 +1,43 @@
+#
+# MIT License
+#
+# Copyright (c) 2010 - 2020 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#Mapping Windows version names to major, minor and build values
+
+10.0.true=10
+10.0.false.true=Server 2019
+10.0.false.false=Server 2016
+6.3.true=8.1
+6.3.false=Server 2012 R2
+6.2.true=8
+6.2.false=Server 2012
+6.1.true=7
+6.1.false=Server 2008 R2
+6.0.true=Vista
+6.0.false=Server 2008
+5.2.1=Home Server
+5.2.2=XP
+5.2.3.true=Server 2003
+5.2.3.false=Server 2003 R2
+5.1.=XP
+5.0=2000

--- a/oshi-core/src/main/resources/oshi.windows.versions.properties
+++ b/oshi-core/src/main/resources/oshi.windows.versions.properties
@@ -25,7 +25,7 @@
 #Mapping Windows version names to major, minor and build values
 
 10.0.nt=10
-10.0.17762=Server 2019
+10.0.17763+=Server 2019
 10.0=Server 2016
 6.3.nt=8.1
 6.3=Server 2012 R2


### PR DESCRIPTION
Hello Daniel(@dbwiddis),

I moved the windows version names from WindowsOperatingSystem.parseVersion to the properties file, oshi.windows.versions.properties. 

Please review my changes and let me know if anything needs to updated or even a changelog updation is required.

Thanks.
