### PR TITLE
Add checking if cpu has boost enabled (only for linux currently)

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -81,12 +81,14 @@ public interface CentralProcessor {
     long[] getCurrentFreq();
 
     /**
+     * checks if cpu have boost mode enabled
+     * if cpu don't support or it is not enabled then returns false,
+     * otherwise returns true
      *
-     *
-     *
-     *
+     *@return state of boost mode
      */
-    Boolean boostEnabled();
+    boolean boostEnabled();
+
     /**
      * Returns an {@code UnmodifiableList} of the CPU's logical processors. The list
      * will be sorted in order of increasing NUMA node number, and then processor

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -81,6 +81,13 @@ public interface CentralProcessor {
     long[] getCurrentFreq();
 
     /**
+     *
+     *
+     *
+     *
+     */
+    Boolean boostEnabled();
+    /**
      * Returns an {@code UnmodifiableList} of the CPU's logical processors. The list
      * will be sorted in order of increasing NUMA node number, and then processor
      * number. This order is consistent with other methods providing per-processor

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -49,6 +49,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
 
     private final Supplier<ProcessorIdentifier> cpuid = memoize(this::queryProcessorId);
     private final Supplier<Long> maxFreq = memoize(this::queryMaxFreq);
+    private final Supplier<Boolean> boost = memoize(this::queryBoostEnabled);
     private final Supplier<long[]> currentFreq = memoize(this::queryCurrentFreq, defaultExpiration());
     private final Supplier<Long> contextSwitches = memoize(this::queryContextSwitches, defaultExpiration());
     private final Supplier<Long> interrupts = memoize(this::queryInterrupts, defaultExpiration());
@@ -114,6 +115,17 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * @return The max frequency.
      */
     protected abstract long queryMaxFreq();
+
+    public Boolean boostEnabled() {
+        return boost.get();
+    }
+
+    /**
+     * Check if processor have boost mode enabled.
+     *
+     * @return cpu boost state.
+     */
+    protected abstract Boolean queryBoostEnabled();
 
     @Override
     public long[] getCurrentFreq() {

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -49,7 +49,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
 
     private final Supplier<ProcessorIdentifier> cpuid = memoize(this::queryProcessorId);
     private final Supplier<Long> maxFreq = memoize(this::queryMaxFreq);
-    private final Supplier<Boolean> boost = memoize(this::queryBoostEnabled);
+    private final boolean boost = queryBoostEnabled();
     private final Supplier<long[]> currentFreq = memoize(this::queryCurrentFreq, defaultExpiration());
     private final Supplier<Long> contextSwitches = memoize(this::queryContextSwitches, defaultExpiration());
     private final Supplier<Long> interrupts = memoize(this::queryInterrupts, defaultExpiration());
@@ -116,8 +116,8 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      */
     protected abstract long queryMaxFreq();
 
-    public Boolean boostEnabled() {
-        return boost.get();
+    public boolean boostEnabled() {
+        return boost;
     }
 
     /**
@@ -125,7 +125,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      *
      * @return cpu boost state.
      */
-    protected abstract Boolean queryBoostEnabled();
+    protected abstract boolean queryBoostEnabled();
 
     @Override
     public long[] getCurrentFreq() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -243,6 +243,17 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
+    protected Boolean queryBoostEnabled() {
+        // file should be there if cpu supports boost and if boost enabled then value should be 1
+        List<String> boost = FileUtil.readFile("/sys/devices/system/cpu/cpufreq/boost");
+        if(boost.isEmpty())
+            return Boolean.FALSE;
+        if(boost.get(0).equals("1"))
+            return Boolean.TRUE;
+        return Boolean.FALSE;
+    }
+
+    @Override
     public double[] getSystemLoadAverage(int nelem) {
         if (nelem < 1 || nelem > 3) {
             throw new IllegalArgumentException("Must include from one to three elements.");

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -243,14 +243,16 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Boolean queryBoostEnabled() {
+    protected boolean queryBoostEnabled() {
         // file should be there if cpu supports boost and if boost enabled then value should be 1
         List<String> boost = FileUtil.readFile("/sys/devices/system/cpu/cpufreq/boost");
-        if(boost.isEmpty())
-            return Boolean.FALSE;
-        if(boost.get(0).equals("1"))
-            return Boolean.TRUE;
-        return Boolean.FALSE;
+        if (boost.isEmpty()) {
+            return false;
+        }
+        if (boost.get(0).equals("1")) {
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -115,9 +115,9 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Boolean queryBoostEnabled() {
+    protected boolean queryBoostEnabled() {
         // TODO
-        return null;
+        return false;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -115,6 +115,12 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
+    protected Boolean queryBoostEnabled() {
+        // TODO
+        return null;
+    }
+
+    @Override
     public double[] getSystemLoadAverage(int nelem) {
         if (nelem < 1 || nelem > 3) {
             throw new IllegalArgumentException("Must include from one to three elements.");

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
@@ -178,9 +178,9 @@ final class AixCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Boolean queryBoostEnabled() {
+    protected boolean queryBoostEnabled() {
         // TODO
-        return null;
+        return false;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
@@ -178,6 +178,12 @@ final class AixCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
+    protected Boolean queryBoostEnabled() {
+        // TODO
+        return null;
+    }
+
+    @Override
     public double[] getSystemLoadAverage(int nelem) {
         if (nelem < 1 || nelem > 3) {
             throw new IllegalArgumentException("Must include from one to three elements.");

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -245,6 +245,12 @@ final class FreeBsdCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
+    protected Boolean queryBoostEnabled() {
+        // TODO
+        return null;
+    }
+
+    @Override
     public double[] getSystemLoadAverage(int nelem) {
         if (nelem < 1 || nelem > 3) {
             throw new IllegalArgumentException("Must include from one to three elements.");

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -245,9 +245,9 @@ final class FreeBsdCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Boolean queryBoostEnabled() {
+    protected boolean queryBoostEnabled() {
         // TODO
-        return null;
+        return false;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
@@ -172,6 +172,12 @@ final class SolarisCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
+    protected Boolean queryBoostEnabled() {
+        // TODO
+        return null;
+    }
+
+    @Override
     public double[] getSystemLoadAverage(int nelem) {
         if (nelem < 1 || nelem > 3) {
             throw new IllegalArgumentException("Must include from one to three elements.");

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
@@ -172,9 +172,9 @@ final class SolarisCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Boolean queryBoostEnabled() {
+    protected boolean queryBoostEnabled() {
         // TODO
-        return null;
+        return false;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
@@ -226,9 +226,9 @@ final class WindowsCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Boolean queryBoostEnabled() {
+    protected boolean queryBoostEnabled() {
         // TODO
-        return null;
+        return false;
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
@@ -225,6 +225,12 @@ final class WindowsCentralProcessor extends AbstractCentralProcessor {
         return Arrays.stream(freqs).max().getAsLong();
     }
 
+    @Override
+    protected Boolean queryBoostEnabled() {
+        // TODO
+        return null;
+    }
+
     /**
      * Call CallNTPowerInformation for Processor information and return an array of
      * the specified index

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -574,6 +574,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
                 }
             }
         }
+
         if (!systemctlFound) {
             // Get Directories for stopped services
             File dir = new File("/etc/init");

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -236,6 +236,10 @@ public class SystemInfoTest {
         if (freq > 0) {
             oshi.add("Max Frequency: " + FormatUtil.formatHertz(freq));
         }
+
+        boolean isBoostEnabled = processor.boostEnabled().booleanValue();
+        oshi.add("Is boost enabled:"+isBoostEnabled);
+
         long[] freqs = processor.getCurrentFreq();
         if (freqs[0] > 0) {
             StringBuilder sb = new StringBuilder("Current Frequencies: ");

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -237,7 +237,7 @@ public class SystemInfoTest {
             oshi.add("Max Frequency: " + FormatUtil.formatHertz(freq));
         }
 
-        boolean isBoostEnabled = processor.boostEnabled().booleanValue();
+        boolean isBoostEnabled = processor.boostEnabled();
         oshi.add("Is boost enabled:"+isBoostEnabled);
 
         long[] freqs = processor.getCurrentFreq();

--- a/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import org.jetbrains.kotlin.js.config.JsConfig;
 import org.junit.Test;
 
 import oshi.SystemInfo;
@@ -36,8 +35,7 @@ import oshi.hardware.CentralProcessor.ProcessorIdentifier;
 import oshi.hardware.CentralProcessor.TickType;
 import oshi.util.Util;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 /**
  * Test CPU

--- a/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
@@ -107,7 +107,8 @@ public class CentralProcessorTest {
         assertEquals(
                 "Central Processor's logical processor frequency array length should be the same as its logical processor count",
                 curr.length, p.getLogicalProcessorCount());
-        if (max >= 0) {
+        boolean boost = p.boostEnabled();
+        if (max >= 0 && !boost) {
             for (int i = 0; i < curr.length; i++) {
                 assertTrue("Central Processor's logical processor frequency should be at most it's max frequency, max frequency:"+
                                 max+", logical core frequency:"+curr[i],

--- a/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
@@ -28,12 +28,16 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.jetbrains.kotlin.js.config.JsConfig;
 import org.junit.Test;
 
 import oshi.SystemInfo;
 import oshi.hardware.CentralProcessor.ProcessorIdentifier;
 import oshi.hardware.CentralProcessor.TickType;
 import oshi.util.Util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Test CPU
@@ -107,7 +111,8 @@ public class CentralProcessorTest {
                 curr.length, p.getLogicalProcessorCount());
         if (max >= 0) {
             for (int i = 0; i < curr.length; i++) {
-                assertTrue("Central Processor's logical processor frequency should be at most it's max frequency",
+                assertTrue("Central Processor's logical processor frequency should be at most it's max frequency, max frequency:"+
+                                max+", logical core frequency:"+curr[i],
                         curr[i] <= max);
             }
         }


### PR DESCRIPTION
Sorry i am new in contributing, but i saw in maven test that it shows failure if detect cpu frequency higher than maxFrequency and it happens cause cpu can have boost enabled which allow cpu to have bigger Frequency than detected max, so i tried to make boost detecting feature (partially implemented, dont have other systems to make it work on them)