### PR TITLE
Updated links in the docs to https

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,6 @@
 What is the intended use of the API?
 ========
-Users should create a new instance of [SystemInfo](http://oshi.github.io/oshi/apidocs/oshi/SystemInfo.html) and use the getters from this class to access the platform-specific hardware and software interfaces using the respective `get*()` methods. The interfaces in `oshi.hardware` and `oshi.software.os` provide cross-platform functionality. See the `main()` method of [SystemInfoTest](https://github.com/oshi/oshi/blob/master/oshi-core/src/test/java/oshi/SystemInfoTest.java) for sample code.
+Users should create a new instance of [SystemInfo](https://oshi.github.io/oshi/apidocs/oshi/SystemInfo.html) and use the getters from this class to access the platform-specific hardware and software interfaces using the respective `get*()` methods. The interfaces in `oshi.hardware` and `oshi.software.os` provide cross-platform functionality. See the `main()` method of [SystemInfoTest](https://github.com/oshi/oshi/blob/master/oshi-core/src/test/java/oshi/SystemInfoTest.java) for sample code.
 
 Methods return a "snapshot" of current levels. To display values which change over time, it is intended that users poll for information no more frequently than approximately every second. Disk and file system calls may incur some latency and should be polled less frequently.
 CPU usage calculation precision depends on the relation of the polling interval to both system clock tick granularity and the number of logical processors.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ Projects using OSHI
 * [Dolphin Scheduler](https://dolphinscheduler.apache.org/)
 * [Guns](https://github.com/stylefeng/Guns)
 * [GeoServer](https://docs.geoserver.org/stable/en/user/community/status-monitoring/index.html)
-* [ND4J](http://nd4j.org/) <!-- Note: Url is dead -->
 * [Apache Doris](https://doris.incubator.apache.org/)
 * [UniversalMediaServer](https://github.com/UniversalMediaServer/UniversalMediaServer)
 * [PSI Probe](https://github.com/psi-probe/psi-probe)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![OSHI](https://dl.dropboxusercontent.com/s/c82qboyvvudpvdp/oshilogo.png)
 
-[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Maven central](https://maven-badges.herokuapp.com/maven-central/com.github.oshi/oshi-core/badge.svg?)](https://search.maven.org/search?q=com.github.oshi)
 [![Tidelift](https://tidelift.com/badges/package/maven/com.github.oshi:oshi-core)](https://tidelift.com/subscription/pkg/maven-com-github-oshi-oshi-core?utm_source=maven-com-github-oshi-oshi-core&utm_medium=referral&utm_campaign=readme)
 [![Travis Build Status](https://travis-ci.org/oshi/oshi.svg)](https://travis-ci.org/oshi/oshi)
@@ -29,7 +29,7 @@ Windows • Linux • macOS • Unix (Solaris, FreeBSD, AIX)
 
 Essentials
 ----------
-* [API](http://oshi.github.io/oshi/apidocs/) (javadocs) - [Operating System](http://oshi.github.io/oshi/apidocs/oshi/software/os/package-summary.html) / [Hardware](http://oshi.github.io/oshi/apidocs/oshi/hardware/package-summary.html)
+* [API](https://oshi.github.io/oshi/apidocs/) (javadocs) - [Operating System](https://oshi.github.io/oshi/apidocs/oshi/software/os/package-summary.html) / [Hardware](https://oshi.github.io/oshi/apidocs/oshi/hardware/package-summary.html)
 * [FAQ](https://github.com/oshi/oshi/blob/master/FAQ.md)
 * [Find OSHI on Maven Central](https://search.maven.org/search?q=com.github.oshi)
 * [Upgrading from an earlier version?](https://github.com/oshi/oshi/blob/master/UPGRADING.md) 
@@ -71,7 +71,7 @@ CentralProcessor cpu = hal.getProcessor();
 ```
 
 You can see more examples and run the [SystemInfoTest](https://github.com/oshi/oshi/blob/master/oshi-core/src/test/java/oshi/SystemInfoTest.java)
-and see the full output for your system by cloning the project and building it with [Maven](http://maven.apache.org/index.html):
+and see the full output for your system by cloning the project and building it with [Maven](https://maven.apache.org/index.html):
 
 ```
 git clone https://github.com/oshi/oshi.git && cd oshi
@@ -163,7 +163,7 @@ Disks:
 
 ```
 
-Sensor readings are available for some hardware (see notes in the [API](http://oshi.github.io/oshi/apidocs/oshi/hardware/Sensors.html)).
+Sensor readings are available for some hardware (see notes in the [API](https://oshi.github.io/oshi/apidocs/oshi/hardware/Sensors.html)).
 ```
 Sensors:
  CPU Temperature: 69.8°C
@@ -199,7 +199,7 @@ USB Devices:
 
 Where are we? How can I help?
 -----------------------------
-[OSHI originated](http://code.dblock.org/2010/06/23/introducing-oshi-operating-system-and-hardware-information-java.html) 
+[OSHI originated](https://code.dblock.org/2010/06/23/introducing-oshi-operating-system-and-hardware-information-java.html) 
 as a platform-independent library that did not require additional software and had a license compatible with 
 both open source and commercial products. We have developed a strong core of features on major Operating Systems, 
 but we would love for *you* to help by:
@@ -226,8 +226,8 @@ Projects using OSHI
 * [Dolphin Scheduler](https://dolphinscheduler.apache.org/)
 * [Guns](https://github.com/stylefeng/Guns)
 * [GeoServer](https://docs.geoserver.org/stable/en/user/community/status-monitoring/index.html)
-* [ND4J](http://nd4j.org/)
-* [Apache Doris](http://doris.incubator.apache.org/)
+* [ND4J](http://nd4j.org/) <!-- Note: Url is dead -->
+* [Apache Doris](https://doris.incubator.apache.org/)
 * [UniversalMediaServer](https://github.com/UniversalMediaServer/UniversalMediaServer)
 * [PSI Probe](https://github.com/psi-probe/psi-probe)
 * [JPPF](https://jppf.org/)
@@ -240,13 +240,13 @@ Projects using OSHI
 * [Hawkular Agent](https://github.com/hawkular/hawkular-agent)
 * [Dagr](https://github.com/fulcrumgenomics/dagr)
 * [sys-API](https://github.com/Krillsson/sys-API)
-* [NexCapMAT](http://www.nexess-solutions.com/fr/produits/application-nexcap-mat/)
+* [NexCapMAT](https://www.nexess-solutions.com/fr/produits/application-nexcap-mat/)
 * [360Suite](https://360suite.io/)
 * [GoMint](https://gomint.io/)
 * [Stefan's OS](https://BotCompany.de/)
 * [Eclipse Passage](https://projects.eclipse.org/projects/technology.passage)
 * [Eclipse Orbit](https://projects.eclipse.org/projects/tools.orbit)
-* [Ruoyi](http://www.ruoyi.vip/)
+* [Ruoyi](https://www.ruoyi.vip/)
 * [DataX](https://github.com/WeiYe-Jing/datax-web)
 
 License

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,8 +2,8 @@ Releasing OSHI
 =====================
 ### Credentials
 
-* Put your [repository credentials in your Maven settings.xml file](http://central.sonatype.org/pages/apache-maven.html#distribution-management-and-authentication) for both snapshot and staging repositories in [pom.xml](pom.xml). 
-* Put your [gpg certificate credentials in the settings.xml file](http://central.sonatype.org/pages/apache-maven.html#gpg-signed-components)
+* Put your [repository credentials in your Maven settings.xml file](https://central.sonatype.org/pages/apache-maven.html#distribution-management-and-authentication) for both snapshot and staging repositories in [pom.xml](pom.xml). 
+* Put your [gpg certificate credentials in the settings.xml file](https://central.sonatype.org/pages/apache-maven.html#gpg-signed-components)
 
 ### Snapshots
 
@@ -15,7 +15,7 @@ Releasing OSHI
 * Make sure tests are green on [Travis CI](https://travis-ci.org/oshi/oshi).
 * Review [SonarQube](https://sonarcloud.io/dashboard?id=com.github.oshi%3Aoshi-parent) for any bugs.
 * Run `mvn clean test` on every OS you have access to
-* Choose an appropriate [version number](http://semver.org/) for the release
+* Choose an appropriate [version number](https://semver.org/) for the release
  	* Proactively change version numbers in the download links on [README.md](README.md).
 	* Copy [README.md](README.md) to [src/site/markdown/README.md](src/site/markdown/README.md)
 		* HTML-escape `&`, `<`, and `>` in any links in the site version
@@ -25,7 +25,7 @@ Releasing OSHI
 
 ### Release
 
-* See [this page](http://central.sonatype.org/pages/apache-maven.html#performing-a-release-deployment-with-the-maven-release-plugin) for a summary of the below steps
+* See [this page](https://central.sonatype.org/pages/apache-maven.html#performing-a-release-deployment-with-the-maven-release-plugin) for a summary of the below steps
 * `mvn clean deploy`
 	* Do a final snapshot release and fix any errors in the javadocs
 	* If license headers are rewritten as part of this deployment, commit the changes
@@ -39,11 +39,11 @@ Releasing OSHI
 	* Takes a few minutes. 
 	* This pushes the release to the [Nexus](https://oss.sonatype.org/) staging repository
 	* This also pushes to [gh_pages](https://oshi.github.io/oshi)
-* Log on to [Nexus](https://oss.sonatype.org/) and [release the deployment from OSSRH to the Central Repository](http://central.sonatype.org/pages/releasing-the-deployment.html).
+* Log on to [Nexus](https://oss.sonatype.org/) and [release the deployment from OSSRH to the Central Repository](https://central.sonatype.org/pages/releasing-the-deployment.html).
 	
 * Add a title and release notes [to the tag](https://github.com/oshi/oshi/tags) on GitHub and publish the release to make it current.
 
-* As development progresses, update version in [pom.xml](pom.xml) using -SNAPSHOT appended to the new version using [Semantic Versioning](http://semver.org/) standards:
+* As development progresses, update version in [pom.xml](pom.xml) using -SNAPSHOT appended to the new version using [Semantic Versioning](https://semver.org/) standards:
 	* Increment major version (x.0) for API-breaking changes or additions
 	* Increment minor version (x.1) for substantive additions, bugfixes and changes that are backwards compatible
 	* Increment patch version (x.x.1) for minor bugfixes or changes that are backwards compatible

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -58,7 +58,7 @@ The deprecated `OSProcess` method `calculateCpuPercent()` was removed, replaced 
 OSHI 4.0 requires minimum Java 8 compatibility.
 
 The `oshi-json` artifact has been completely removed. It is trivial to obtain JSON output using the
-[Jackson ObjectMapper](http://www.mkyong.com/java/jackson-2-convert-java-object-to-from-json/).
+[Jackson ObjectMapper](https://www.mkyong.com/java/jackson-2-convert-java-object-to-from-json/).
 
 There is a new `oshi-demo` artifact which will contain many "how to" classes
 to demonstrate OSHI's capabilities and integration with other libraries. These classes are intended

--- a/oshi-core/src/main/java/oshi/driver/mac/net/NetStat.java
+++ b/oshi-core/src/main/java/oshi/driver/mac/net/NetStat.java
@@ -67,7 +67,7 @@ public final class NetStat {
      */
     public static Map<Integer, IFdata> queryIFdata(int index) {
         // Ported from source code of "netstat -ir". See
-        // http://opensource.apple.com/source/network_cmds/network_cmds-457/netstat.tproj/if.c
+        // https://opensource.apple.com/source/network_cmds/network_cmds-457/netstat.tproj/if.c
         Map<Integer, IFdata> data = new HashMap<>();
         // Get buffer of all interface information
         int[] mib = { CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0 };

--- a/oshi-core/src/main/java/oshi/hardware/Sensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/Sensors.java
@@ -38,7 +38,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  * Windows information is retrieved via Windows Management Instrumentation
  * (WMI). Unfortunately, most hardware providers do not publish values to WMI.
  * Oshi attempts to retrieve values from
- * <a href="http://openhardwaremonitor.org/">Open Hardware Monitor</a> if it is
+ * <a href="https://openhardwaremonitor.org/">Open Hardware Monitor</a> if it is
  * running, in preference to the Microsoft API, which may require elevated
  * permissions and still may provide no results or unchanging results depending
  * on the motherboard manufacturer.

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -265,7 +265,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         // Some systems are still using the lsb standard which parses a
         // variety of /etc/*-release files and is most easily accessed via
         // the commandline lsb_release -a, see here:
-        // http://linux.die.net/man/1/lsb_release
+        // https://linux.die.net/man/1/lsb_release
         // In this case, the /etc/lsb-release file (if it exists) has
         // optional overrides to the information in the /etc/distrib-release
         // files, which show: "Distributor release x.x (Codename)"

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -155,7 +155,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         int minor = verSplit.length > 1 ? ParseUtil.parseIntOrDefault(verSplit[1], 0) : 0;
 
         // see
-        // http://msdn.microsoft.com/en-us/library/windows/desktop/ms724833%28v=vs.85%29.aspx
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724833%28v=vs.85%29.aspx
         boolean ntWorkstation = WmiUtil.getUint32(versionInfo, OSVersionProperty.PRODUCTTYPE,
                 0) == WinNT.VER_NT_WORKSTATION;
 

--- a/oshi-core/src/main/java/oshi/util/FormatUtil.java
+++ b/oshi-core/src/main/java/oshi/util/FormatUtil.java
@@ -37,7 +37,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 public final class FormatUtil {
     /**
      * Binary prefixes, used in IEC Standard for naming bytes.
-     * (http://en.wikipedia.org/wiki/International_Electrotechnical_Commission)
+     * (https://en.wikipedia.org/wiki/International_Electrotechnical_Commission)
      *
      * Should be used for most representations of bytes
      */


### PR DESCRIPTION
Updated some links to https for more secure connections :sunglasses:
* Note: The link to ``nd4j.org`` is dead; you may want to remove it