### PR TITLE
Passes default locale setting when executing commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 5.3.0 (in progress)
 ================
 * [#1350](https://github.com/oshi/oshi/pull/1350): Optionally list loopback and virtual network interfaces - [@zalintyre](https://github.com/zalintyre).
+* [#1347](https://github.com/oshi/oshi/pull/1353): runNative locale issues on linux - [@dmitraver](https://github.com/dmitraver)
 * Your contribution here
 
 4.9.1 / 5.2.1 (2020-07-14), 4.9.2 / 5.2.2 (2020-07-20), 4.9.3 / 5.2.3 (2020-08-09), 4.9.4 / 5.2.4 (2020-08-16), 4.9.5 / 5.2.5 (2020-08-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 5.3.0 (in progress)
 ================
 * [#1350](https://github.com/oshi/oshi/pull/1350): Optionally list loopback and virtual network interfaces - [@zalintyre](https://github.com/zalintyre).
-* [#1347](https://github.com/oshi/oshi/pull/1353): runNative locale issues on linux - [@dmitraver](https://github.com/dmitraver)
+* [#1353](https://github.com/oshi/oshi/pull/1353): runNative locale issues on linux - [@dmitraver](https://github.com/dmitraver)
 * Your contribution here
 
 4.9.1 / 5.2.1 (2020-07-14), 4.9.2 / 5.2.2 (2020-07-20), 4.9.3 / 5.2.3 (2020-08-09), 4.9.4 / 5.2.4 (2020-08-16), 4.9.5 / 5.2.5 (2020-08-30)

--- a/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
@@ -34,6 +34,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import oshi.PlatformEnum;
+import oshi.SystemInfo;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -81,7 +83,16 @@ public final class ExecutingCommand {
     public static List<String> runNative(String[] cmdToRunWithArgs) {
         Process p = null;
         try {
-            p = Runtime.getRuntime().exec(cmdToRunWithArgs);
+            PlatformEnum platform = SystemInfo.getCurrentPlatformEnum();
+            if (platform == PlatformEnum.WINDOWS) {
+                p = Runtime.getRuntime().exec(cmdToRunWithArgs, new String[]{"LANGUAGE=C"});
+            } else if (platform == PlatformEnum.LINUX || platform == PlatformEnum.FREEBSD
+                    || platform == PlatformEnum.SOLARIS || platform == PlatformEnum.AIX
+                    || platform == PlatformEnum.MACOSX) {
+                p = Runtime.getRuntime().exec(cmdToRunWithArgs, new String[]{"LC_ALL=C"});
+            } else {
+                p = Runtime.getRuntime().exec(cmdToRunWithArgs);
+            }
         } catch (SecurityException | IOException e) {
             LOG.trace("Couldn't run command {}: {}", Arrays.toString(cmdToRunWithArgs), e.getMessage());
             return new ArrayList<>(0);

--- a/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
@@ -47,7 +47,20 @@ public final class ExecutingCommand {
 
     private static final Logger LOG = LoggerFactory.getLogger(ExecutingCommand.class);
 
+    private static final String[] DEFAULT_ENV = getDefaultEnv();
+
     private ExecutingCommand() {
+    }
+
+    private static String[] getDefaultEnv() {
+        PlatformEnum platform = SystemInfo.getCurrentPlatformEnum();
+        if (platform == PlatformEnum.WINDOWS) {
+            return new String[]{"LANGUAGE=C"};
+        } else if (platform != PlatformEnum.UNKNOWN) {
+            return new String[]{"LC_ALL=C"};
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -83,16 +96,7 @@ public final class ExecutingCommand {
     public static List<String> runNative(String[] cmdToRunWithArgs) {
         Process p = null;
         try {
-            PlatformEnum platform = SystemInfo.getCurrentPlatformEnum();
-            if (platform == PlatformEnum.WINDOWS) {
-                p = Runtime.getRuntime().exec(cmdToRunWithArgs, new String[]{"LANGUAGE=C"});
-            } else if (platform == PlatformEnum.LINUX || platform == PlatformEnum.FREEBSD
-                    || platform == PlatformEnum.SOLARIS || platform == PlatformEnum.AIX
-                    || platform == PlatformEnum.MACOSX) {
-                p = Runtime.getRuntime().exec(cmdToRunWithArgs, new String[]{"LC_ALL=C"});
-            } else {
-                p = Runtime.getRuntime().exec(cmdToRunWithArgs);
-            }
+            p = Runtime.getRuntime().exec(cmdToRunWithArgs, DEFAULT_ENV);
         } catch (SecurityException | IOException e) {
             LOG.trace("Couldn't run command {}: {}", Arrays.toString(cmdToRunWithArgs), e.getMessage());
             return new ArrayList<>(0);

--- a/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
@@ -55,11 +55,11 @@ public final class ExecutingCommand {
     private static String[] getDefaultEnv() {
         PlatformEnum platform = SystemInfo.getCurrentPlatformEnum();
         if (platform == PlatformEnum.WINDOWS) {
-            return new String[]{"LANGUAGE=C"};
+            return new String[] { "LANGUAGE=C" };
         } else if (platform != PlatformEnum.UNKNOWN) {
-            return new String[]{"LC_ALL=C"};
+            return new String[] { "LC_ALL=C" };
         } else {
-            return null;
+            return null; // NOSONAR squid:S1168
         }
     }
 


### PR DESCRIPTION
Closes #1347 

Passes locale when executing commands on different platforms. 
