### PR TITLE
Add `squashfs` as a pseudo file system so it will be skipped by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 5.3.3 (in progress)
 ================
+* [#1379](https://github.com/oshi/oshi/pull/1379): Add `squashfs` as a pseudo file system so it will be skipped by default - [@mprins](https://github.com/mprins).
 * Your contribution here
 
 5.3.0 (2020-10-11), 5.3.1 (2020-10-18), 5.3.2 (2020-10-25)

--- a/oshi-core/src/main/resources/oshi.properties
+++ b/oshi-core/src/main/resources/oshi.properties
@@ -146,4 +146,5 @@ oshi.network.filesystem.types=afs,cifs,smbfs,sshfs,ncpfs,ncp,nfs,nfs4,gfs,gds2,g
 #  "mntfs", Mount file system
 #  "sharefs", Share file system
 #  "lofs" Library file system
-oshi.pseudo.filesystem.types=anon_inodefs,autofs,bdev,binfmt_misc,bpf,cgroup,cgroup2,configfs,cpuset,dax,debugfs,devpts,devtmpfs,drm,ecryptfs,efivarfs,fuse,fusectl,hugetlbfs,inotifyfs,mqueue,nfsd,overlay,proc,pstore,rootfs,rpc_pipefs,securityfs,selinuxfs,sunrpc,sysfs,systemd-1,tracefs,usbfs,procfs,devfs,ctfs,fdescfs,objfs,mntfs,sharefs,lofs
+#  "SquashFS" read-only filesystem used by snap on eg. Ubuntu
+oshi.pseudo.filesystem.types=anon_inodefs,autofs,bdev,binfmt_misc,bpf,cgroup,cgroup2,configfs,cpuset,dax,debugfs,devpts,devtmpfs,drm,ecryptfs,efivarfs,fuse,fusectl,hugetlbfs,inotifyfs,mqueue,nfsd,overlay,proc,pstore,rootfs,rpc_pipefs,securityfs,selinuxfs,sunrpc,sysfs,systemd-1,tracefs,usbfs,procfs,devfs,ctfs,fdescfs,objfs,mntfs,sharefs,lofs,squashfs


### PR DESCRIPTION
This will result in [SquashFS](https://nl.wikipedia.org/wiki/SquashFS) filesystems - which are read-only by design - being hidden by default from `os.getFileSystem().getFileStores()`

Ubuntu snaps generate a lot of these when you have some snaps installed


close #1378 