### PR TITLE
Fix exception sorting child process list on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 5.3.3 (in progress)
 ================
 * [#1379](https://github.com/oshi/oshi/pull/1379): Add `squashfs` as a pseudo file system so it will be skipped by default - [@mprins](https://github.com/mprins).
+* [#1380](https://github.com/oshi/oshi/pull/1389): Fix exception sorting child process list on Windows - [@agaponik](https://github.com/agaponik).
 * Your contribution here
+
 
 5.3.0 (2020-10-11), 5.3.1 (2020-10-18), 5.3.2 (2020-10-25)
 ================

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -292,6 +292,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         } finally {
             Kernel32.INSTANCE.CloseHandle(snapshot);
         }
+        // Get modifiable version
         List<OSProcess> procList = processMapToList(childPids);
         List<OSProcess> sorted = processSort(procList, limit, sort);
         return Collections.unmodifiableList(sorted);

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -292,7 +292,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         } finally {
             Kernel32.INSTANCE.CloseHandle(snapshot);
         }
-        List<OSProcess> procList = getProcesses(childPids);
+        List<OSProcess> procList = processMapToList(childPids);
         List<OSProcess> sorted = processSort(procList, limit, sort);
         return Collections.unmodifiableList(sorted);
     }

--- a/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/OperatingSystemTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import oshi.SystemInfo;
 import oshi.software.os.OSProcess.State;
 import oshi.software.os.OperatingSystem.OSVersionInfo;
+import oshi.software.os.OperatingSystem.ProcessSort;
 
 /**
  * Test OS
@@ -231,7 +232,8 @@ public class OperatingSystemTest {
         matched = 0;
         total = 0;
         for (Integer i : manyChildSet) {
-            if (os.getChildProcesses(i, 0, null).size() > 1) {
+            // Use a non-null sorting for test purposes
+            if (os.getChildProcesses(i, Integer.MAX_VALUE, ProcessSort.PID).size() > 1) {
                 matched++;
             }
             // Quit if enough to test


### PR DESCRIPTION
Fix for WindowsOperatingSystem.getChildProcesses throwing exception, trying to sort unmodifiableList:

java.lang.UnsupportedOperationException
	at java.util.Collections$UnmodifiableList.sort(Collections.java:1331)
	at oshi.software.common.AbstractOperatingSystem.processSort(AbstractOperatingSystem.java:155)
	at oshi.software.os.windows.WindowsOperatingSystem.getChildProcesses(WindowsOperatingSystem.java:296)