### PR TITLE
support systemctl list-unit-files return 3 columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 5.3.4 (in progress)
 ================
 * [#1387](https://github.com/oshi/oshi/pull/1387): Switch tests to JUnit5 and Hamcrest matchers - [@dbwiddis](https://github.com/dbwiddis).
+* [#1388](https://github.com/oshi/oshi/pull/1388): Support systemctl list-unit-files return 3 and more columns - [@Szwendacz99](https://github.com/Szwendacz99).
 * Your contribution here
 
 5.3.0 (2020-10-11), 5.3.1 (2020-10-18), 5.3.2 (2020-10-25), 5.3.3 (2020-10-28)

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -562,7 +562,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         List<String> systemctl = ExecutingCommand.runNative("systemctl list-unit-files");
         for (String str : systemctl) {
             String[] split = ParseUtil.whitespaces.split(str);
-            if (split.length == 2 && split[0].endsWith(".service") && "enabled".equals(split[1])) {
+            if ((split.length == 2 || split.length == 3) && split[0].endsWith(".service") && "enabled".equals(split[1])) {
                 // remove .service extension
                 String name = split[0].substring(0, split[0].length() - 8);
                 int index = name.lastIndexOf('.');

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -562,7 +562,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         List<String> systemctl = ExecutingCommand.runNative("systemctl list-unit-files");
         for (String str : systemctl) {
             String[] split = ParseUtil.whitespaces.split(str);
-            if ((split.length == 2 || split.length == 3) && split[0].endsWith(".service") && "enabled".equals(split[1])) {
+            if (split.length >= 2 && split[0].endsWith(".service") && "enabled".equals(split[1])) {
                 // remove .service extension
                 String name = split[0].substring(0, split[0].length() - 8);
                 int index = name.lastIndexOf('.');


### PR DESCRIPTION
I was getting error on maven test:

[ERROR] oshi.software.os.OperatingSystemTest.testGetServices  Time elapsed: 0.443 s  <<< FAILURE!
java.lang.AssertionError: 
There should be at least 1 stopped service
Expected: is a value greater than <0>
     but: <0> was equal to <0>
        at oshi.software.os.OperatingSystemTest.testGetServices(OperatingSystemTest.java:339)

and found out that getServices() in LinuxOperatingSystem class was trying to get current list of services from systemd assuming that systemctl list-unit-files returns just two columns of data while on my version (systemd 246 (246.6-1-arch)) it returns 3 columns: " 'UNIT FILE'          'STATE'           'VENDOR PRESET' ", so I updated that function so it will handle 3 columns, and after my small change it seems to work good now, maven test passes.

Tested on latest Arch Linux with systemd 246 (246.6-1-arch)