### PR TITLE
Parse processor name on Orange Pi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 5.3.6 (in progress)
 
+* [#1409](https://github.com/oshi/oshi/pull/1409): Parse processor name on Orange Pi - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here
 
 # 5.3.0 (2020-10-11), 5.3.1 (2020-10-18), 5.3.2 (2020-10-25), 5.3.3 (2020-10-28), 5.3.4 (2020-11-01), 5.3.5 (2020-11-11)

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -82,6 +82,7 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
                 cpuVendor = splitLine[1];
                 break;
             case "model name":
+            case "Processor": // for Orange Pi
                 cpuName = splitLine[1];
                 break;
             case "flags":


### PR DESCRIPTION
Fixes #1406 