### PR TITLE
[pom] Bump javadoc plugin to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
 		<!-- reporting plugins -->
 		<maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
-		<maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+		<maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
 		<!-- tools -->
 		<maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
 		<maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>


### PR DESCRIPTION
@dbwiddis Not sure if there was a reason this one was skipped or why dependabot v2 is not suggesting it.  I did fix a javadoc issue tonight with jdk 11 so possibly that was one reason it was missed or some odd mix up in dependabot.  Anyway, this should work fine.  I haven't run into any issues with latest.  