### PR TITLE
[pom] Use suggested sonatype id as 'ossrh' for both

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,12 @@
 			<url>github:ssh://oshi.github.io/oshi/</url>
 		</site>
 		<snapshotRepository>
-			<id>sonatype-nexus-snapshots</id>
+			<id>ossrh</id>
 			<name>Sonatype Nexus Snapshots</name>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
 		<repository>
-			<id>sonatype-nexus-staging</id>
+			<id>ossrh</id>
 			<name>Nexus Release Repository</name>
 			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>


### PR DESCRIPTION
This ties to the maven settings file.  Using a different name on both would require duplicate entries for the account data.  The suggested entry at least check (few years) was to call it ossrh.  Either way, its duplicate settings or consistent name.  Please do make sure to adjust your local as well.  In fact, there makes sense to have duplicate entries for all 3 (2 original plus this) as many teams use various older setups.