### PR TITLE
Fix macOS codename with new versioning scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#1440](https://github.com/oshi/oshi/pull/1440): Add ps backup for command line for macOS Big Sur compatibility - [@dbwiddis](https://github.com/dbwiddis).
 * [#1442](https://github.com/oshi/oshi/pull/1442), [#1443](https://github.com/oshi/oshi/pull/1443): FreeBSD CI; fix FreeBSD Test Failures - [@dbwiddis](https://github.com/dbwiddis).
 * [#1455](https://github.com/oshi/oshi/pull/1455): Fix hanging prstat call on Solaris thread details - [@dbwiddis](https://github.com/dbwiddis).
+* [#1457](https://github.com/oshi/oshi/pull/1457): Fix macOS codename with new versioning scheme - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here
 
 # 5.3.0 (2020-10-11), 5.3.1 (2020-10-18), 5.3.2 (2020-10-25), 5.3.3 (2020-10-28), 5.3.4 (2020-11-01), 5.3.5 (2020-11-11), 5.3.6 (2020-11-15)

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystem.java
@@ -56,6 +56,7 @@ import oshi.software.os.OSSession;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.Util;
 import oshi.util.platform.mac.SysctlUtil;
 
 /**
@@ -131,12 +132,17 @@ public class MacOperatingSystem extends AbstractOperatingSystem {
     }
 
     private String parseCodeName() {
-        if (this.major >= 10) {
-            Properties verProps = FileUtil.readPropertiesFromFilename(MACOS_VERSIONS_PROPERTIES);
-            return verProps.getProperty(this.major + "." + this.minor);
+        Properties verProps = FileUtil.readPropertiesFromFilename(MACOS_VERSIONS_PROPERTIES);
+        String codeName = null;
+        if (this.major > 10) {
+            codeName = verProps.getProperty(Integer.toString(this.major));
+        } else if (this.major == 10) {
+            codeName = verProps.getProperty(this.major + "." + this.minor);
         }
-        LOG.warn("Unable to parse version {}.{} to a codename.", this.major, this.minor);
-        return "";
+        if (Util.isBlank(codeName)) {
+            LOG.warn("Unable to parse version {}.{} to a codename.", this.major, this.minor);
+        }
+        return codeName;
     }
 
     @Override

--- a/oshi-core/src/main/resources/oshi.macos.versions.properties
+++ b/oshi-core/src/main/resources/oshi.macos.versions.properties
@@ -23,7 +23,9 @@
 #
 
 # Mapping of Mac OS Version names with thier numbers
-11.0=Big Sur
+# All 11.x are Big Sur
+11=Big Sur
+# OS X iterated on minor versions
 10.15=Catalina
 10.14=Mojave
 10.13=High Sierra


### PR DESCRIPTION
Fixes #1456 