### PR TITLE
TCP and UDP connection listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 5.3.8 (in progress)
+# 5.4.0 (in progress)
 
+##### New Features
+* [#1461](https://github.com/oshi/oshi/pull/1461): List TCP and UDP connections - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here
 
 # 5.3.0 (2020-10-11), 5.3.1 (2020-10-18), 5.3.2 (2020-10-25), 5.3.3 (2020-10-28), 5.3.4 (2020-11-01), 5.3.5 (2020-11-11), 5.3.6 (2020-11-15), 5.3.7 (2020-12-20)

--- a/oshi-core-shaded/pom.xml
+++ b/oshi-core-shaded/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>com.github.oshi</groupId>
 		<artifactId>oshi-parent</artifactId>
-		<version>5.3.8-SNAPSHOT</version>
+		<version>5.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>oshi-core-shaded</artifactId>

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>com.github.oshi</groupId>
 		<artifactId>oshi-parent</artifactId>
-		<version>5.3.8-SNAPSHOT</version>
+		<version>5.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>oshi-core</artifactId>

--- a/oshi-core/src/main/java/oshi/driver/unix/NetStat.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/NetStat.java
@@ -84,7 +84,7 @@ public final class NetStat {
                     Pair<byte[], Integer> foreign = parseIP(split[4]);
                     connections.add(new IPConnection(type, local.getA(), local.getB(), foreign.getA(), foreign.getB(),
                             state == null ? null : TcpState.valueOf(state), ParseUtil.parseIntOrDefault(split[2], 0),
-                            ParseUtil.parseIntOrDefault(split[1], 0)));
+                            ParseUtil.parseIntOrDefault(split[1], 0), -1));
                 }
             }
         }

--- a/oshi-core/src/main/java/oshi/driver/unix/NetStat.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/NetStat.java
@@ -1,0 +1,123 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2010 - 2020 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package oshi.driver.unix;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.os.InternetProtocolStats.IPConnection;
+import oshi.software.os.InternetProtocolStats.TcpState;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
+
+/**
+ * Utility to query TCP connections
+ */
+@ThreadSafe
+public final class NetStat {
+
+    private NetStat() {
+    }
+
+    /**
+     * Query netstat to obtain number of established TCP connections
+     *
+     * @return A pair with number of established IPv4 and IPv6 connections
+     */
+    public static Pair<Long, Long> queryTcpnetstat() {
+        long tcp4 = 0L;
+        long tcp6 = 0L;
+        List<String> activeConns = ExecutingCommand.runNative("netstat -n -p tcp");
+        for (String s : activeConns) {
+            if (s.endsWith("ESTABLISHED")) {
+                if (s.startsWith("tcp4")) {
+                    tcp4++;
+                } else if (s.startsWith("tcp6")) {
+                    tcp6++;
+                }
+            }
+        }
+        return new Pair<>(tcp4, tcp6);
+    }
+
+    /**
+     * Query netstat to all TCP and UDP connections
+     *
+     * @return A list of TCP and UDP connections
+     */
+    public static List<IPConnection> queryNetstat() {
+        List<IPConnection> connections = new ArrayList<>();
+        List<String> activeConns = ExecutingCommand.runNative("netstat -n");
+        for (String s : activeConns) {
+            String[] split = null;
+            if (s.startsWith("tcp") || s.startsWith("udp")) {
+                split = ParseUtil.whitespaces.split(s);
+                if (split.length >= 5) {
+                    String state = (split.length == 6) ? split[5] : null;
+                    String type = split[0];
+                    Pair<byte[], Integer> local = parseIP(split[3]);
+                    Pair<byte[], Integer> foreign = parseIP(split[4]);
+                    connections.add(new IPConnection(type, local.getA(), local.getB(), foreign.getA(), foreign.getB(),
+                            state == null ? null : TcpState.valueOf(state), ParseUtil.parseIntOrDefault(split[2], 0),
+                            ParseUtil.parseIntOrDefault(split[1], 0)));
+                }
+            }
+        }
+        return connections;
+    }
+
+    private static Pair<byte[], Integer> parseIP(String s) {
+        // 73.169.134.6.9599 to 73.169.134.6 port 9599
+        // or
+        // 2001:558:600a:a5.123 to 2001:558:600a:a5 port 123
+        int portPos = s.lastIndexOf('.');
+        if (portPos > 0 && s.length() > portPos) {
+            int port = ParseUtil.parseIntOrDefault(s.substring(portPos + 1), 0);
+            String ip = s.substring(0, portPos);
+            try {
+                // Try to parse existing IP
+                return new Pair<>(InetAddress.getByName(ip).getAddress(), port);
+            } catch (UnknownHostException e) {
+                try {
+                    // Try again with trailing ::
+                    if (ip.endsWith(":") && ip.contains("::")) {
+                        ip = ip + "0";
+                    } else if (ip.endsWith(":") || ip.contains("::")) {
+                        ip = ip + ":0";
+                    } else {
+                        ip = ip + "::0";
+                    }
+                    return new Pair<>(InetAddress.getByName(ip).getAddress(), port);
+                } catch (UnknownHostException e2) {
+                    return new Pair<>(new byte[0], port);
+                }
+            }
+        }
+        return new Pair<>(new byte[0], 0);
+    }
+}

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
@@ -26,6 +26,7 @@ package oshi.jna.platform.mac;
 import com.sun.jna.Native; // NOSONAR squid:S1191
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
+import com.sun.jna.Union;
 
 import oshi.jna.platform.unix.CLibrary;
 
@@ -37,10 +38,20 @@ public interface SystemB extends com.sun.jna.platform.mac.SystemB, CLibrary {
 
     SystemB INSTANCE = Native.load("System", SystemB.class);
 
+    int PROC_PIDLISTFDS = 1;
+    int PROX_FDTYPE_SOCKET = 2;
+    int PROC_PIDFDSOCKETINFO = 3;
+    int TSI_T_NTIMERS = 4;
+    int SOCKINFO_IN = 1;
+    int SOCKINFO_TCP = 2;
+
     int UTX_USERSIZE = 256;
     int UTX_LINESIZE = 32;
     int UTX_IDSIZE = 4;
     int UTX_HOSTSIZE = 256;
+
+    int AF_INET = 2; // The Internet Protocol version 4 (IPv4) address family.
+    int AF_INET6 = 30; // The Internet Protocol version 6 (IPv6) address family.
 
     @FieldOrder({ "ut_user", "ut_id", "ut_line", "ut_pid", "ut_type", "ut_tv", "ut_host", "ut_pad" })
     class MacUtmpx extends Structure {
@@ -54,6 +65,91 @@ public interface SystemB extends com.sun.jna.platform.mac.SystemB, CLibrary {
         public byte[] ut_pad = new byte[16]; // reserved for future use
     }
 
+    @FieldOrder({ "proc_fd", "proc_fdtype" })
+    class ProcFdInfo extends Structure {
+        public int proc_fd;
+        public int proc_fdtype;
+    }
+
+    @FieldOrder({ "insi_fport", "insi_lport", "insi_gencnt", "insi_flags", "insi_flow", "insi_vflag", "insi_ip_ttl",
+            "rfu_1", "insi_faddr", "insi_laddr", "insi_v4", "insi_v6" })
+    class InSockInfo extends Structure {
+        public int insi_fport; /* foreign port */
+        public int insi_lport; /* local port */
+        public long insi_gencnt; /* generation count of this instance */
+        public int insi_flags; /* generic IP/datagram flags */
+        public int insi_flow;
+
+        public byte insi_vflag; /* ini_IPV4 or ini_IPV6 */
+        public byte insi_ip_ttl; /* time to live proto */
+        public int rfu_1; /* reserved */
+        /* protocol dependent part, v4 only in last element */
+        public int[] insi_faddr = new int[4]; /* foreign host table entry */
+        public int[] insi_laddr = new int[4]; /* local host table entry */
+        public byte insi_v4; /* type of service */
+        public byte[] insi_v6 = new byte[9];
+    }
+
+    @FieldOrder({ "tcpsi_ini", "tcpsi_state", "tcpsi_timer", "tcpsi_mss", "tcpsi_flags", "rfu_1", "tcpsi_tp" })
+    class TcpSockInfo extends Structure {
+        public InSockInfo tcpsi_ini;
+        public int tcpsi_state;
+        public int[] tcpsi_timer = new int[TSI_T_NTIMERS];
+        public int tcpsi_mss;
+        public int tcpsi_flags;
+        public int rfu_1; /* reserved */
+        public long tcpsi_tp; /* opaque handle of TCP protocol control block */
+    }
+
+    @FieldOrder({ "soi_stat", "soi_so", "soi_pcb", "soi_type", "soi_protocol", "soi_family", "soi_options",
+            "soi_linger", "soi_state", "soi_qlen", "soi_incqlen", "soi_qlimit", "soi_timeo", "soi_error", "soi_oobmark",
+            "soi_rcv", "soi_snd", "soi_kind", "rfu_1", "soi_proto" })
+    class SocketInfo extends Structure {
+        public long[] soi_stat = new long[17]; // vinfo_stat
+        public long soi_so; /* opaque handle of socket */
+        public long soi_pcb; /* opaque handle of protocol control block */
+        public int soi_type;
+        public int soi_protocol;
+        public int soi_family;
+        public short soi_options;
+        public short soi_linger;
+        public short soi_state;
+        public short soi_qlen;
+        public short soi_incqlen;
+        public short soi_qlimit;
+        public short soi_timeo;
+        public short soi_error;
+        public int soi_oobmark;
+        public int[] soi_rcv = new int[6]; // sockbuf_info
+        public int[] soi_snd = new int[6]; // sockbuf_info
+        public int soi_kind;
+        public int rfu_1; /* reserved */
+        public Pri soi_proto;
+    }
+
+    @FieldOrder({ "fi_openflags", "fi_status", "fi_offset", "fi_type", "fi_guardflags" })
+    class ProcFileInfo extends Structure {
+        public int fi_openflags;
+        public int fi_status;
+        public long fi_offset;
+        public int fi_type;
+        public int fi_guardflags;
+    }
+
+    @FieldOrder({ "pfi", "psi" })
+    class SocketFdInfo extends Structure {
+        public ProcFileInfo pfi;
+        public SocketInfo psi;
+    }
+
+    @FieldOrder({ "pri_in", "pri_tcp", "max_size" })
+    class Pri extends Union {
+        public InSockInfo pri_in;
+        public TcpSockInfo pri_tcp;
+        // max element is 524 bytes
+        public byte[] max_size = new byte[524];
+    }
+
     /**
      * Reads a line from the current file position in the utmp file. It returns a
      * pointer to a structure containing the fields of the line.
@@ -64,4 +160,6 @@ public interface SystemB extends com.sun.jna.platform.mac.SystemB, CLibrary {
      *         the "record not found" case)
      */
     MacUtmpx getutxent();
+
+    int proc_pidfdinfo(int pid, int fd, int flavor, Structure buffer, int buffersize);
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/IPHlpAPI.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/IPHlpAPI.java
@@ -1,0 +1,209 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2010 - 2020 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package oshi.jna.platform.windows;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native; // NOSONAR squid:S1191
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.Structure.FieldOrder;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.W32APIOptions;
+
+public interface IPHlpAPI extends com.sun.jna.platform.win32.IPHlpAPI {
+    IPHlpAPI INSTANCE = Native.load("IPHlpAPI", IPHlpAPI.class, W32APIOptions.DEFAULT_OPTIONS);
+
+    int UDP_TABLE_OWNER_PID = 1;
+    int TCP_TABLE_OWNER_PID_ALL = 5;
+
+    /**
+     * Contains information that describes an IPv4 TCP connection.
+     */
+    @FieldOrder({ "dwState", "dwLocalAddr", "dwLocalPort", "dwRemoteAddr", "dwRemotePort", "dwOwningPid" })
+    class MIB_TCPROW_OWNER_PID extends Structure {
+        public int dwState;
+        public int dwLocalAddr;
+        public int dwLocalPort;
+        public int dwRemoteAddr;
+        public int dwRemotePort;
+        public int dwOwningPid;
+    }
+
+    /**
+     * Contains a table of IPv4 TCP connections on the local computer.
+     */
+    @FieldOrder({ "dwNumEntries", "table" })
+    class MIB_TCPTABLE_OWNER_PID extends Structure {
+        public int dwNumEntries;
+        public MIB_TCPROW_OWNER_PID[] table = new MIB_TCPROW_OWNER_PID[1];
+
+        public MIB_TCPTABLE_OWNER_PID(Memory buf) {
+            super(buf);
+            // First element contains array size
+            table = (MIB_TCPROW_OWNER_PID[]) new MIB_TCPROW_OWNER_PID().toArray(buf.getInt(0));
+            read();
+        }
+
+    }
+
+    /**
+     * Contains information that describes an IPv6 TCP connection.
+     */
+    @FieldOrder({ "LocalAddr", "dwLocalScopeId", "dwLocalPort", "RemoteAddr", "dwRemoteScopeId", "dwRemotePort",
+            "State", "dwOwningPid" })
+    class MIB_TCP6ROW_OWNER_PID extends Structure {
+        public byte[] LocalAddr = new byte[16];
+        public int dwLocalScopeId;
+        public int dwLocalPort;
+        public byte[] RemoteAddr = new byte[16];
+        public int dwRemoteScopeId;
+        public int dwRemotePort;
+        public int State;
+        public int dwOwningPid;
+    }
+
+    /**
+     * Contains a table of IPv6 TCP connections on the local computer.
+     */
+    @FieldOrder({ "dwNumEntries", "table" })
+    class MIB_TCP6TABLE_OWNER_PID extends Structure {
+        public int dwNumEntries;
+        public MIB_TCP6ROW_OWNER_PID[] table = new MIB_TCP6ROW_OWNER_PID[1];
+
+        public MIB_TCP6TABLE_OWNER_PID(Memory buf) {
+            super(buf);
+            // First element contains array size
+            table = (MIB_TCP6ROW_OWNER_PID[]) new MIB_TCP6ROW_OWNER_PID().toArray(buf.getInt(0));
+            read();
+        }
+    }
+
+    /**
+     * Contains information that describes an IPv6 UDP connection.
+     */
+    @FieldOrder({ "dwLocalAddr", "dwLocalPort", "dwOwningPid" })
+    class MIB_UDPROW_OWNER_PID extends Structure {
+        public int dwLocalAddr;
+        public int dwLocalPort;
+        public int dwOwningPid;
+    }
+
+    /**
+     * Contains a table of IPv6 UDP connections on the local computer.
+     */
+    @FieldOrder({ "dwNumEntries", "table" })
+    class MIB_UDPTABLE_OWNER_PID extends Structure {
+        public int dwNumEntries;
+        public MIB_UDPROW_OWNER_PID[] table = new MIB_UDPROW_OWNER_PID[1];
+
+        public MIB_UDPTABLE_OWNER_PID(Memory buf) {
+            super(buf);
+            // First element contains array size
+            table = (MIB_UDPROW_OWNER_PID[]) new MIB_UDPROW_OWNER_PID().toArray(buf.getInt(0));
+            read();
+        }
+    }
+
+    /**
+     * Contains information that describes an IPv6 UDP connection.
+     */
+    @FieldOrder({ "ucLocalAddr", "dwLocalScopeId", "dwLocalPort", "dwOwningPid" })
+    class MIB_UDP6ROW_OWNER_PID extends Structure {
+        public byte[] ucLocalAddr = new byte[16];
+        public int dwLocalScopeId;
+        public int dwLocalPort;
+        public int dwOwningPid;
+    }
+
+    /**
+     * Contains a table of IPv6 UDP connections on the local computer.
+     */
+    @FieldOrder({ "dwNumEntries", "table" })
+    class MIB_UDP6TABLE_OWNER_PID extends Structure {
+        public int dwNumEntries;
+        public MIB_UDP6ROW_OWNER_PID[] table = new MIB_UDP6ROW_OWNER_PID[1];
+
+        public MIB_UDP6TABLE_OWNER_PID(Memory buf) {
+            super(buf);
+            // First element contains array size
+            table = (MIB_UDP6ROW_OWNER_PID[]) new MIB_UDP6ROW_OWNER_PID().toArray(buf.getInt(0));
+            read();
+        }
+    }
+
+    /**
+     * Retrieves a table that contains a list of TCP endpoints available to the
+     * application.
+     *
+     * @param pTcpTable
+     *            A pointer to the table structure that contains the filtered TCP
+     *            endpoints available to the application.
+     * @param pdwSize
+     * @param bOrder
+     * @param ulAf
+     * @param TableClass
+     * @param Reserved
+     * @return
+     */
+    int GetExtendedTcpTable(Pointer pTcpTable, IntByReference pdwSize, boolean bOrder, int ulAf, int TableClass,
+            int Reserved);
+
+    /**
+     * Retrieves a table that contains a list of UDP endpoints available to the
+     * application.
+     *
+     * @param pUdpTable
+     *            A pointer to the table structure that contains the filtered UDP
+     *            endpoints available to the application.
+     * @param pdwSize
+     *            The estimated size of the structure returned in pTcpTable, in
+     *            bytes. If this value is set too small,
+     *            {@code ERROR_INSUFFICIENT_BUFFER} is returned by this function,
+     *            and this field will contain the correct size of the structure.
+     * @param bOrder
+     *            A value that specifies whether the TCP connection table should be
+     *            sorted. If this parameter is set to TRUE, the TCP endpoints in the
+     *            table are sorted in ascending order, starting with the lowest
+     *            local IP address. If this parameter is set to FALSE, the TCP
+     *            endpoints in the table appear in the order in which they were
+     *            retrieved. The following values are compared (as listed) when
+     *            ordering the TCP endpoints: Local IP address, Local scope ID
+     *            (applicable when the ulAf parameter is set to {@code AF_INET6}),
+     *            Local TCP port, Remote IP address, Remote scope ID (applicable
+     *            when the ulAf parameter is set to {@code AF_INET6}), Remote TCP
+     *            port.
+     * @param ulAf
+     *            The version of IP used by the UDP endpoints.
+     * @param TableClass
+     *            The type of the TCP table structure to retrieve. This parameter
+     *            can be one of the values from the {@code TCP_TABLE_CLASS}
+     *            enumeration.
+     * @param Reserved
+     *            Reserved. This value must be zero.
+     * @return If the function succeeds, the return value is {@code NO_ERROR}. If
+     *         the function fails, the return value is an error code.
+     */
+    int GetExtendedUdpTable(Pointer pUdpTable, IntByReference pdwSize, boolean bOrder, int ulAf, int TableClass,
+            int Reserved);
+}

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/IPHlpAPI.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/IPHlpAPI.java
@@ -160,11 +160,31 @@ public interface IPHlpAPI extends com.sun.jna.platform.win32.IPHlpAPI {
      *            A pointer to the table structure that contains the filtered TCP
      *            endpoints available to the application.
      * @param pdwSize
+     *            The estimated size of the structure returned in pTcpTable, in
+     *            bytes. If this value is set too small,
+     *            {@code ERROR_INSUFFICIENT_BUFFER} is returned by this function,
+     *            and this field will contain the correct size of the structure.
      * @param bOrder
+     *            A value that specifies whether the TCP connection table should be
+     *            sorted. If this parameter is set to TRUE, the TCP endpoints in the
+     *            table are sorted in ascending order, starting with the lowest
+     *            local IP address. If this parameter is set to FALSE, the TCP
+     *            endpoints in the table appear in the order in which they were
+     *            retrieved. The following values are compared (as listed) when
+     *            ordering the TCP endpoints: Local IP address, Local scope ID
+     *            (applicable when the ulAf parameter is set to AF_INET6), Local TCP
+     *            port, Remote IP address, Remote scope ID (applicable when the ulAf
+     *            parameter is set to AF_INET6), Remote TCP port.
      * @param ulAf
+     *            The version of IP used by the TCP endpoints.
      * @param TableClass
+     *            The type of the TCP table structure to retrieve. This parameter
+     *            can be one of the values from the {@code TCP_TABLE_CLASS}
+     *            enumeration.
      * @param Reserved
-     * @return
+     *            Reserved. This value must be zero.
+     * @return If the function succeeds, the return value is {@code NO_ERROR}. If
+     *         the function fails, the return value is an error code.
      */
     int GetExtendedTcpTable(Pointer pTcpTable, IntByReference pdwSize, boolean bOrder, int ulAf, int TableClass,
             int Reserved);

--- a/oshi-core/src/main/java/oshi/software/common/AbstractInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/common/AbstractInternetProtocolStats.java
@@ -21,41 +21,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package oshi.driver.unix;
+package oshi.software.common;
 
+import java.util.Collections;
 import java.util.List;
 
-import oshi.annotation.concurrent.ThreadSafe;
-import oshi.util.ExecutingCommand;
-import oshi.util.tuples.Pair;
+import oshi.driver.unix.NetStat;
+import oshi.software.os.InternetProtocolStats;
 
-/**
- * Utility to query TCP connections
- */
-@ThreadSafe
-public final class NetStatTcp {
+public abstract class AbstractInternetProtocolStats implements InternetProtocolStats {
 
-    private NetStatTcp() {
+    public AbstractInternetProtocolStats() {
+        super();
     }
 
-    /**
-     * Query netstat to obtain number of established TCP connections
-     *
-     * @return A pair with number of established IPv4 and IPv6 connections
-     */
-    public static Pair<Long, Long> queryTcpnetstat() {
-        long tcp4 = 0L;
-        long tcp6 = 0L;
-        List<String> activeConns = ExecutingCommand.runNative("netstat -n -p tcp");
-        for (String s : activeConns) {
-            if (s.endsWith("ESTABLISHED")) {
-                if (s.startsWith("tcp4")) {
-                    tcp4++;
-                } else if (s.startsWith("tcp6")) {
-                    tcp6++;
-                }
-            }
-        }
-        return new Pair<>(tcp4, tcp6);
+    @Override
+    public List<IPConnection> getConnections() {
+        return Collections.unmodifiableList(NetStat.queryNetstat());
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/InternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/InternetProtocolStats.java
@@ -408,17 +408,15 @@ public interface InternetProtocolStats {
 
         @Override
         public String toString() {
-            String localIp;
+            String localIp = "*";
             try {
                 localIp = InetAddress.getByAddress(localAddress).toString();
-            } catch (UnknownHostException e) {
-                localIp = "*";
+            } catch (UnknownHostException e) { // NOSONAR squid:S108
             }
-            String foreignIp;
+            String foreignIp = "*";
             try {
                 foreignIp = InetAddress.getByAddress(foreignAddress).toString();
-            } catch (UnknownHostException e) {
-                foreignIp = "*";
+            } catch (UnknownHostException e) { // NOSONAR squid:S108
             }
             return "IPConnection [type=" + type + ", localAddress=" + localIp + ", localPort=" + localPort
                     + ", foreignAddress=" + foreignIp + ", foreignPort=" + foreignPort + ", state=" + state

--- a/oshi-core/src/main/java/oshi/software/os/InternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/InternetProtocolStats.java
@@ -68,6 +68,12 @@ public interface InternetProtocolStats {
      */
     UdpStats getUDPv6Stats();
 
+    /**
+     * Gets a list of TCP and UDP connections.
+     *
+     * @return An {@code UnmodifiableList} of {@link IPConnection} objects for TCP
+     *         and UDP connections.
+     */
     List<IPConnection> getConnections();
 
     final class TcpStats {
@@ -319,8 +325,9 @@ public interface InternetProtocolStats {
          * Gets the local address. For IPv4 addresses this is a 4-byte array. For IPv6
          * addresses this is a 16-byte array.
          * <p>
-         * On Unix operating systems, this value may be truncated. IPv6 addresses ending
-         * in zeroes should be considered suspect.
+         * On Unix operating systems, the 16-bit value may be truncated, giving only the
+         * high order bytes. IPv6 addresses ending in zeroes should be considered
+         * suspect.
          *
          * @return The local address, or an empty array if the listener can accept a
          *         connection on any interface.

--- a/oshi-core/src/main/java/oshi/software/os/InternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/InternetProtocolStats.java
@@ -25,6 +25,7 @@ package oshi.software.os;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -302,9 +303,9 @@ public interface InternetProtocolStats {
         public IPConnection(String type, byte[] localAddress, int localPort, byte[] foreignAddress, int foreignPort,
                 TcpState state, int transmitQueue, int receiveQueue, int owningProcessId) {
             this.type = type;
-            this.localAddress = localAddress;
+            this.localAddress = Arrays.copyOf(localAddress, localAddress.length);
             this.localPort = localPort;
-            this.foreignAddress = foreignAddress;
+            this.foreignAddress = Arrays.copyOf(foreignAddress, foreignAddress.length);
             this.foreignPort = foreignPort;
             this.state = state;
             this.transmitQueue = transmitQueue;
@@ -333,7 +334,7 @@ public interface InternetProtocolStats {
          *         connection on any interface.
          */
         public byte[] getLocalAddress() {
-            return localAddress;
+            return Arrays.copyOf(localAddress, localAddress.length);
         }
 
         /**
@@ -356,7 +357,7 @@ public interface InternetProtocolStats {
          *         array will also result if
          */
         public byte[] getForeignAddress() {
-            return foreignAddress;
+            return Arrays.copyOf(foreignAddress, foreignAddress.length);
         }
 
         /**
@@ -407,15 +408,17 @@ public interface InternetProtocolStats {
 
         @Override
         public String toString() {
-            String localIp = "*";
+            String localIp;
             try {
                 localIp = InetAddress.getByAddress(localAddress).toString();
-            } catch (UnknownHostException e) { // NOSONAR squid:S108
+            } catch (UnknownHostException e) {
+                localIp = "*";
             }
-            String foreignIp = "*";
+            String foreignIp;
             try {
                 foreignIp = InetAddress.getByAddress(foreignAddress).toString();
-            } catch (UnknownHostException e) { // NOSONAR squid:S108
+            } catch (UnknownHostException e) {
+                foreignIp = "*";
             }
             return "IPConnection [type=" + type + ", localAddress=" + localIp + ", localPort=" + localPort
                     + ", foreignAddress=" + foreignIp + ", foreignPort=" + foreignPort + ", state=" + state

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
@@ -26,12 +26,12 @@ package oshi.software.os.linux;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.os.InternetProtocolStats;
+import oshi.software.common.AbstractInternetProtocolStats;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 @ThreadSafe
-public class LinuxInternetProtocolStats implements InternetProtocolStats {
+public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
 
     @Override
     public TcpStats getTCPv4Stats() {

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
@@ -171,7 +171,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         return Collections.unmodifiableList(conns);
     }
 
-    private List<IPConnection> queryConnections(String protocol, int ipver, Map<Integer, Integer> pidMap) {
+    private static List<IPConnection> queryConnections(String protocol, int ipver, Map<Integer, Integer> pidMap) {
         List<IPConnection> conns = new ArrayList<>();
         for (String s : FileUtil.readFile(ProcPath.NET + "/" + protocol + (ipver == 6 ? "6" : ""))) {
             if (s.indexOf(':') >= 0) {
@@ -190,7 +190,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         return conns;
     }
 
-    private Pair<byte[], Integer> parseIpAddr(String s) {
+    private static Pair<byte[], Integer> parseIpAddr(String s) {
         int colon = s.indexOf(':');
         if (colon > 0 && colon < s.length()) {
             byte[] first = ParseUtil.hexStringToByteArray(s.substring(0, colon));
@@ -209,7 +209,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         return new Pair<>(new byte[0], 0);
     }
 
-    private Pair<Integer, Integer> parseHexColonHex(String s) {
+    private static Pair<Integer, Integer> parseHexColonHex(String s) {
         int colon = s.indexOf(':');
         if (colon > 0 && colon < s.length()) {
             int first = ParseUtil.hexStringToInt(s.substring(0, colon), 0);

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
@@ -23,12 +23,32 @@
  */
 package oshi.software.os.linux;
 
+import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
+import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
+import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
+import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT1;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT2;
+import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
+import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
+import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
+import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
+import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
+import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.linux.proc.ProcessStat;
 import oshi.software.common.AbstractInternetProtocolStats;
 import oshi.util.ExecutingCommand;
+import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.platform.linux.ProcPath;
+import oshi.util.tuples.Pair;
 
 @ThreadSafe
 public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
@@ -138,5 +158,101 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
             }
         }
         return new UdpStats(datagramsSent, datagramsReceived, datagramsNoPort, datagramsReceivedErrors);
+    }
+
+    @Override
+    public List<IPConnection> getConnections() {
+        List<IPConnection> conns = new ArrayList<>();
+        Map<Integer, Integer> pidMap = ProcessStat.querySocketToPidMap();
+        conns.addAll(queryConnections("tcp", 4, pidMap));
+        conns.addAll(queryConnections("tcp", 6, pidMap));
+        conns.addAll(queryConnections("udp", 4, pidMap));
+        conns.addAll(queryConnections("udp", 6, pidMap));
+        return Collections.unmodifiableList(conns);
+    }
+
+    private List<IPConnection> queryConnections(String protocol, int ipver, Map<Integer, Integer> pidMap) {
+        List<IPConnection> conns = new ArrayList<>();
+        for (String s : FileUtil.readFile(ProcPath.NET + "/" + protocol + (ipver == 6 ? "6" : ""))) {
+            if (s.indexOf(':') >= 0) {
+                String[] split = ParseUtil.whitespaces.split(s.trim());
+                if (split.length > 9) {
+                    Pair<byte[], Integer> lAddr = parseIpAddr(split[1]);
+                    Pair<byte[], Integer> fAddr = parseIpAddr(split[2]);
+                    TcpState state = stateLookup(ParseUtil.hexStringToInt(split[3], 0));
+                    Pair<Integer, Integer> txQrxQ = parseHexColonHex(split[4]);
+                    int inode = ParseUtil.parseIntOrDefault(split[9], 0);
+                    conns.add(new IPConnection(protocol + ipver, lAddr.getA(), lAddr.getB(), fAddr.getA(), fAddr.getB(),
+                            state, txQrxQ.getA(), txQrxQ.getB(), pidMap.getOrDefault(inode, 0)));
+                }
+            }
+        }
+        return conns;
+    }
+
+    private Pair<byte[], Integer> parseIpAddr(String s) {
+        int colon = s.indexOf(':');
+        if (colon > 0 && colon < s.length()) {
+            byte[] first = ParseUtil.hexStringToByteArray(s.substring(0, colon));
+            // Bytes are in __be32 endianness. we must invert each set of 4 bytes
+            for (int i = 0; i + 3 < first.length; i += 4) {
+                byte tmp = first[i];
+                first[i] = first[i + 3];
+                first[i + 3] = tmp;
+                tmp = first[i + 1];
+                first[i + 1] = first[i + 2];
+                first[i + 2] = tmp;
+            }
+            int second = ParseUtil.hexStringToInt(s.substring(colon + 1), 0);
+            return new Pair<>(first, second);
+        }
+        return new Pair<>(new byte[0], 0);
+    }
+
+    private Pair<Integer, Integer> parseHexColonHex(String s) {
+        int colon = s.indexOf(':');
+        if (colon > 0 && colon < s.length()) {
+            int first = ParseUtil.hexStringToInt(s.substring(0, colon), 0);
+            int second = ParseUtil.hexStringToInt(s.substring(colon + 1), 0);
+            return new Pair<>(first, second);
+        }
+        return new Pair<>(0, 0);
+    }
+
+    private static TcpState stateLookup(int state) {
+        switch (state) {
+        case 0x01:
+            return ESTABLISHED;
+        case 0x02:
+            return SYN_SENT;
+        case 0x03:
+            return SYN_RECV;
+        case 0x04:
+            return FIN_WAIT1;
+        case 0x05:
+            return FIN_WAIT2;
+        case 0x06:
+            return TIME_WAIT;
+        case 0x07:
+            return CLOSED;
+        case 0x08:
+            return CLOSE_WAIT;
+        case 0x09:
+            return LAST_ACK;
+        case 0x0A:
+            return LISTEN;
+        case 0x0B:
+            return CLOSING;
+        case 0x00:
+        default:
+            return UNKNOWN;
+        }
+    }
+
+    public static void main(String[] args) {
+        LinuxInternetProtocolStats lips = new LinuxInternetProtocolStats();
+        for (IPConnection conn : lips.getConnections()) {
+            System.out.println(conn.toString());
+        }
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
@@ -183,7 +183,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
                     Pair<Integer, Integer> txQrxQ = parseHexColonHex(split[4]);
                     int inode = ParseUtil.parseIntOrDefault(split[9], 0);
                     conns.add(new IPConnection(protocol + ipver, lAddr.getA(), lAddr.getB(), fAddr.getA(), fAddr.getB(),
-                            state, txQrxQ.getA(), txQrxQ.getB(), pidMap.getOrDefault(inode, 0)));
+                            state, txQrxQ.getA(), txQrxQ.getB(), pidMap.getOrDefault(inode, -1)));
                 }
             }
         }
@@ -246,13 +246,6 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         case 0x00:
         default:
             return UNKNOWN;
-        }
-    }
-
-    public static void main(String[] args) {
-        LinuxInternetProtocolStats lips = new LinuxInternetProtocolStats();
-        for (IPConnection conn : lips.getConnections()) {
-            System.out.println(conn.toString());
         }
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStats.java
@@ -31,18 +31,18 @@ import java.util.function.Supplier;
 import com.sun.jna.Memory; // NOSONAR squid:S1191
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.NetStatTcp;
+import oshi.driver.unix.NetStat;
 import oshi.jna.platform.unix.CLibrary.BsdIp6stat;
 import oshi.jna.platform.unix.CLibrary.BsdIpstat;
 import oshi.jna.platform.unix.CLibrary.BsdTcpstat;
 import oshi.jna.platform.unix.CLibrary.BsdUdpstat;
-import oshi.software.os.InternetProtocolStats;
+import oshi.software.common.AbstractInternetProtocolStats;
 import oshi.util.ParseUtil;
 import oshi.util.platform.mac.SysctlUtil;
 import oshi.util.tuples.Pair;
 
 @ThreadSafe
-public class MacInternetProtocolStats implements InternetProtocolStats {
+public class MacInternetProtocolStats extends AbstractInternetProtocolStats {
 
     private boolean isElevated;
 
@@ -50,7 +50,7 @@ public class MacInternetProtocolStats implements InternetProtocolStats {
         this.isElevated = elevated;
     }
 
-    private Supplier<Pair<Long, Long>> establishedv4v6 = memoize(NetStatTcp::queryTcpnetstat, defaultExpiration());
+    private Supplier<Pair<Long, Long>> establishedv4v6 = memoize(NetStat::queryTcpnetstat, defaultExpiration());
     private Supplier<BsdTcpstat> tcpstat = memoize(MacInternetProtocolStats::queryTcpstat, defaultExpiration());
     private Supplier<BsdUdpstat> udpstat = memoize(MacInternetProtocolStats::queryUdpstat, defaultExpiration());
     // With elevated permissions use tcpstat only

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStats.java
@@ -23,15 +23,46 @@
  */
 package oshi.software.os.mac;
 
+import static com.sun.jna.platform.mac.SystemB.INT_SIZE; // NOSONAR squid:S1191
+import static com.sun.jna.platform.mac.SystemB.PROC_ALL_PIDS;
+import static oshi.jna.platform.mac.SystemB.AF_INET;
+import static oshi.jna.platform.mac.SystemB.AF_INET6;
+import static oshi.jna.platform.mac.SystemB.PROC_PIDFDSOCKETINFO;
+import static oshi.jna.platform.mac.SystemB.PROC_PIDLISTFDS;
+import static oshi.jna.platform.mac.SystemB.PROX_FDTYPE_SOCKET;
+import static oshi.jna.platform.mac.SystemB.SOCKINFO_IN;
+import static oshi.jna.platform.mac.SystemB.SOCKINFO_TCP;
+import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
+import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
+import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
+import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT1;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT2;
+import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
+import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
+import static oshi.software.os.InternetProtocolStats.TcpState.NONE;
+import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
+import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
+import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
+import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Supplier;
 
 import com.sun.jna.Memory; // NOSONAR squid:S1191
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.NetStat;
+import oshi.jna.platform.mac.SystemB;
+import oshi.jna.platform.mac.SystemB.InSockInfo;
+import oshi.jna.platform.mac.SystemB.ProcFdInfo;
+import oshi.jna.platform.mac.SystemB.SocketFdInfo;
 import oshi.jna.platform.unix.CLibrary.BsdIp6stat;
 import oshi.jna.platform.unix.CLibrary.BsdIpstat;
 import oshi.jna.platform.unix.CLibrary.BsdTcpstat;
@@ -105,6 +136,138 @@ public class MacInternetProtocolStats extends AbstractInternetProtocolStats {
         BsdUdpstat stat = udpstat.get();
         return new UdpStats(ParseUtil.unsignedIntToLong(stat.udps_snd6_swcsum),
                 ParseUtil.unsignedIntToLong(stat.udps_rcv6_swcsum), 0L, 0L);
+    }
+
+    @Override
+    public List<IPConnection> getConnections() {
+        List<IPConnection> conns = new ArrayList<>();
+        int[] pids = new int[1024];
+        int numberOfProcesses = SystemB.INSTANCE.proc_listpids(PROC_ALL_PIDS, 0, pids, pids.length * INT_SIZE)
+                / INT_SIZE;
+        for (int i = 0; i < numberOfProcesses; i++) {
+            // Handle off-by-one bug in proc_listpids where the size returned
+            // is: SystemB.INT_SIZE * (pids + 1)
+            if (pids[i] > 0) {
+                for (Integer fd : queryFdList(pids[i])) {
+                    IPConnection ipc = queryIPConnection(pids[i], fd);
+                    if (ipc != null) {
+                        conns.add(ipc);
+                    }
+                }
+            }
+        }
+        return Collections.unmodifiableList(conns);
+    }
+
+    private List<Integer> queryFdList(int pid) {
+        List<Integer> fdList = new ArrayList<>();
+        int bufferSize = SystemB.INSTANCE.proc_pidinfo(pid, PROC_PIDLISTFDS, 0, null, 0);
+        if (bufferSize > 0) {
+            ProcFdInfo fdInfo = new ProcFdInfo();
+            int numStructs = bufferSize / fdInfo.size();
+            ProcFdInfo[] fdArray = (ProcFdInfo[]) fdInfo.toArray(numStructs);
+            bufferSize = SystemB.INSTANCE.proc_pidinfo(pid, PROC_PIDLISTFDS, 0, fdArray[0], bufferSize);
+            numStructs = bufferSize / fdInfo.size();
+            for (int i = 0; i < numStructs; i++) {
+                if (fdArray[i].proc_fdtype == PROX_FDTYPE_SOCKET) {
+                    fdList.add(fdArray[i].proc_fd);
+                }
+            }
+        }
+        return fdList;
+    }
+
+    private IPConnection queryIPConnection(int pid, int fd) {
+        SocketFdInfo si = new SocketFdInfo();
+        int ret = SystemB.INSTANCE.proc_pidfdinfo(pid, fd, PROC_PIDFDSOCKETINFO, si, si.size());
+        if (si.size() == ret && si.psi.soi_family == AF_INET || si.psi.soi_family == AF_INET6) {
+            InSockInfo ini;
+            String type;
+            TcpState state;
+            if (si.psi.soi_kind == SOCKINFO_TCP) {
+                si.psi.soi_proto.setType("pri_tcp");
+                si.psi.soi_proto.read();
+                ini = si.psi.soi_proto.pri_tcp.tcpsi_ini;
+                state = stateLookup(si.psi.soi_proto.pri_tcp.tcpsi_state);
+                type = "tcp";
+            } else if (si.psi.soi_kind == SOCKINFO_IN) {
+                si.psi.soi_proto.setType("pri_in");
+                si.psi.soi_proto.read();
+                ini = si.psi.soi_proto.pri_in;
+                state = NONE;
+                type = "udp";
+            } else {
+                return null;
+            }
+
+            byte[] laddr;
+            byte[] faddr;
+            if (ini.insi_vflag == 1) {
+                laddr = parseIntToIP(ini.insi_laddr[3]);
+                faddr = parseIntToIP(ini.insi_faddr[3]);
+                type += "4";
+            } else if (ini.insi_vflag == 2) {
+                laddr = parseIntArrayToIP(ini.insi_laddr);
+                faddr = parseIntArrayToIP(ini.insi_faddr);
+                type += "6";
+            } else {
+                return null;
+            }
+            // Ports are in big-endian 16-bit, need little-endian
+            int lport = bigEndian16ToLittleEndian(ini.insi_lport);
+            int fport = bigEndian16ToLittleEndian(ini.insi_fport);
+            return new IPConnection(type, laddr, lport, faddr, fport, state, si.psi.soi_qlen, si.psi.soi_incqlen, pid);
+        }
+        return null;
+    }
+
+    private int bigEndian16ToLittleEndian(int port) {
+        // 20480 = 0x5000 should be 0x0050 = 80
+        // 47873 = 0xBB01 should be 0x01BB = 443
+        return port >> 8 & 0xff | port << 8 & 0xff00;
+    }
+
+    private byte[] parseIntToIP(int ip) {
+        // convert int to its 4 bytes
+        return ByteBuffer.allocate(4).order(ByteOrder.nativeOrder()).putInt(ip).array();
+    }
+
+    private byte[] parseIntArrayToIP(int[] ip6) {
+        // convert int[] to its 16 bytes
+        ByteBuffer bb = ByteBuffer.allocate(16).order(ByteOrder.nativeOrder());
+        for (int i : ip6) {
+            bb.putInt(i);
+        }
+        return bb.array();
+    }
+
+    private TcpState stateLookup(int state) {
+        switch (state) {
+        case 0:
+            return CLOSED;
+        case 1:
+            return LISTEN;
+        case 2:
+            return SYN_SENT;
+        case 3:
+            return SYN_RECV;
+        case 4:
+            return ESTABLISHED;
+        case 5:
+            return CLOSE_WAIT;
+        case 6:
+            return FIN_WAIT1;
+        case 7:
+            return CLOSING;
+        case 8:
+            return LAST_ACK;
+        case 9:
+            return FIN_WAIT2;
+        case 10:
+            return TIME_WAIT;
+        default:
+            return UNKNOWN;
+        }
     }
 
     /*

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStats.java
@@ -157,7 +157,7 @@ public class MacInternetProtocolStats extends AbstractInternetProtocolStats {
         return Collections.unmodifiableList(conns);
     }
 
-    private List<Integer> queryFdList(int pid) {
+    private static List<Integer> queryFdList(int pid) {
         List<Integer> fdList = new ArrayList<>();
         int bufferSize = SystemB.INSTANCE.proc_pidinfo(pid, PROC_PIDLISTFDS, 0, null, 0);
         if (bufferSize > 0) {
@@ -175,7 +175,7 @@ public class MacInternetProtocolStats extends AbstractInternetProtocolStats {
         return fdList;
     }
 
-    private IPConnection queryIPConnection(int pid, int fd) {
+    private static IPConnection queryIPConnection(int pid, int fd) {
         SocketFdInfo si = new SocketFdInfo();
         int ret = SystemB.INSTANCE.proc_pidfdinfo(pid, fd, PROC_PIDFDSOCKETINFO, si, si.size());
         if (si.size() == ret && si.psi.soi_family == AF_INET || si.psi.soi_family == AF_INET6) {

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixInternetProtocolStats.java
@@ -33,10 +33,10 @@ import com.sun.jna.Native; // NOSONAR squid:S1191
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.aix.perfstat.PerfstatProtocol;
 import oshi.jna.platform.unix.aix.Perfstat.perfstat_protocol_t;
-import oshi.software.os.InternetProtocolStats;
+import oshi.software.common.AbstractInternetProtocolStats;
 
 @ThreadSafe
-public class AixInternetProtocolStats implements InternetProtocolStats {
+public class AixInternetProtocolStats extends AbstractInternetProtocolStats {
 
     private Supplier<perfstat_protocol_t[]> ipstats = memoize(PerfstatProtocol::queryProtocols, defaultExpiration());
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdInternetProtocolStats.java
@@ -31,18 +31,18 @@ import java.util.function.Supplier;
 import com.sun.jna.Memory; // NOSONAR squid:S1191
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.NetStatTcp;
+import oshi.driver.unix.NetStat;
 import oshi.jna.platform.unix.CLibrary.BsdTcpstat;
 import oshi.jna.platform.unix.CLibrary.BsdUdpstat;
-import oshi.software.os.InternetProtocolStats;
+import oshi.software.common.AbstractInternetProtocolStats;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
 import oshi.util.tuples.Pair;
 
 @ThreadSafe
-public class FreeBsdInternetProtocolStats implements InternetProtocolStats {
+public class FreeBsdInternetProtocolStats extends AbstractInternetProtocolStats {
 
-    private Supplier<Pair<Long, Long>> establishedv4v6 = memoize(NetStatTcp::queryTcpnetstat, defaultExpiration());
+    private Supplier<Pair<Long, Long>> establishedv4v6 = memoize(NetStat::queryTcpnetstat, defaultExpiration());
     private Supplier<BsdTcpstat> tcpstat = memoize(FreeBsdInternetProtocolStats::queryTcpstat, defaultExpiration());
     private Supplier<BsdUdpstat> udpstat = memoize(FreeBsdInternetProtocolStats::queryUdpstat, defaultExpiration());
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisInternetProtocolStats.java
@@ -26,12 +26,12 @@ package oshi.software.os.unix.solaris;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.os.InternetProtocolStats;
+import oshi.software.common.AbstractInternetProtocolStats;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 @ThreadSafe
-public class SolarisInternetProtocolStats implements InternetProtocolStats {
+public class SolarisInternetProtocolStats extends AbstractInternetProtocolStats {
 
     @Override
     public TcpStats getTCPv4Stats() {

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStats.java
@@ -115,7 +115,7 @@ public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats 
         return Collections.emptyList();
     }
 
-    private List<IPConnection> queryTCPv4Connections() {
+    private static List<IPConnection> queryTCPv4Connections() {
         List<IPConnection> conns = new ArrayList<>();
         // Get size needed
         IntByReference sizePtr = new IntByReference();
@@ -140,7 +140,7 @@ public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats 
         return conns;
     }
 
-    private List<IPConnection> queryTCPv6Connections() {
+    private static List<IPConnection> queryTCPv6Connections() {
         List<IPConnection> conns = new ArrayList<>();
         // Get size needed
         IntByReference sizePtr = new IntByReference();
@@ -164,7 +164,7 @@ public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats 
         return conns;
     }
 
-    private List<IPConnection> queryUDPv4Connections() {
+    private static List<IPConnection> queryUDPv4Connections() {
         List<IPConnection> conns = new ArrayList<>();
         // Get size needed
         IntByReference sizePtr = new IntByReference();
@@ -188,7 +188,7 @@ public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats 
         return conns;
     }
 
-    private List<IPConnection> queryUDPv6Connections() {
+    private static List<IPConnection> queryUDPv6Connections() {
         List<IPConnection> conns = new ArrayList<>();
         // Get size needed
         IntByReference sizePtr = new IntByReference();

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStats.java
@@ -240,11 +240,4 @@ public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats 
             return UNKNOWN;
         }
     }
-
-    public static void main(String[] args) {
-        WindowsInternetProtocolStats wips = new WindowsInternetProtocolStats();
-        for (IPConnection conn : wips.getConnections()) {
-            System.out.println(conn.toString());
-        }
-    }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStats.java
@@ -23,22 +23,57 @@
  */
 package oshi.software.os.windows;
 
-import com.sun.jna.platform.win32.IPHlpAPI; // NOSONAR squid:S1191
+import static com.sun.jna.platform.win32.IPHlpAPI.AF_INET; // NOSONAR squid:S1191
+import static com.sun.jna.platform.win32.IPHlpAPI.AF_INET6;
+import static oshi.jna.platform.windows.IPHlpAPI.TCP_TABLE_OWNER_PID_ALL;
+import static oshi.jna.platform.windows.IPHlpAPI.UDP_TABLE_OWNER_PID;
+import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
+import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
+import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
+import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT1;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT2;
+import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
+import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
+import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
+import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
+import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
+import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.sun.jna.Memory; // NOSONAR squid:S1191
 import com.sun.jna.platform.win32.IPHlpAPI.MIB_TCPSTATS;
 import com.sun.jna.platform.win32.IPHlpAPI.MIB_UDPSTATS;
+import com.sun.jna.platform.win32.VersionHelpers;
+import com.sun.jna.ptr.IntByReference;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.jna.platform.windows.IPHlpAPI;
+import oshi.jna.platform.windows.IPHlpAPI.MIB_TCP6ROW_OWNER_PID;
+import oshi.jna.platform.windows.IPHlpAPI.MIB_TCP6TABLE_OWNER_PID;
+import oshi.jna.platform.windows.IPHlpAPI.MIB_TCPROW_OWNER_PID;
+import oshi.jna.platform.windows.IPHlpAPI.MIB_TCPTABLE_OWNER_PID;
+import oshi.jna.platform.windows.IPHlpAPI.MIB_UDP6ROW_OWNER_PID;
+import oshi.jna.platform.windows.IPHlpAPI.MIB_UDP6TABLE_OWNER_PID;
+import oshi.jna.platform.windows.IPHlpAPI.MIB_UDPROW_OWNER_PID;
+import oshi.jna.platform.windows.IPHlpAPI.MIB_UDPTABLE_OWNER_PID;
 import oshi.software.common.AbstractInternetProtocolStats;
+import oshi.util.ParseUtil;
 
 @ThreadSafe
 public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats {
 
     private static final IPHlpAPI IPHLP = IPHlpAPI.INSTANCE;
 
+    private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
+
     @Override
     public TcpStats getTCPv4Stats() {
         MIB_TCPSTATS stats = new MIB_TCPSTATS();
-        IPHLP.GetTcpStatisticsEx(stats, IPHlpAPI.AF_INET);
+        IPHLP.GetTcpStatisticsEx(stats, AF_INET);
         return new TcpStats(stats.dwCurrEstab, stats.dwActiveOpens, stats.dwPassiveOpens, stats.dwAttemptFails,
                 stats.dwEstabResets, stats.dwOutSegs, stats.dwInSegs, stats.dwRetransSegs, stats.dwInErrs,
                 stats.dwOutRsts);
@@ -47,7 +82,7 @@ public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats 
     @Override
     public TcpStats getTCPv6Stats() {
         MIB_TCPSTATS stats = new MIB_TCPSTATS();
-        IPHLP.GetTcpStatisticsEx(stats, IPHlpAPI.AF_INET6);
+        IPHLP.GetTcpStatisticsEx(stats, AF_INET6);
         return new TcpStats(stats.dwCurrEstab, stats.dwActiveOpens, stats.dwPassiveOpens, stats.dwAttemptFails,
                 stats.dwEstabResets, stats.dwOutSegs, stats.dwInSegs, stats.dwRetransSegs, stats.dwInErrs,
                 stats.dwOutRsts);
@@ -56,14 +91,160 @@ public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats 
     @Override
     public UdpStats getUDPv4Stats() {
         MIB_UDPSTATS stats = new MIB_UDPSTATS();
-        IPHLP.GetUdpStatisticsEx(stats, IPHlpAPI.AF_INET);
+        IPHLP.GetUdpStatisticsEx(stats, AF_INET);
         return new UdpStats(stats.dwOutDatagrams, stats.dwInDatagrams, stats.dwNoPorts, stats.dwInErrors);
     }
 
     @Override
     public UdpStats getUDPv6Stats() {
         MIB_UDPSTATS stats = new MIB_UDPSTATS();
-        IPHLP.GetUdpStatisticsEx(stats, IPHlpAPI.AF_INET6);
+        IPHLP.GetUdpStatisticsEx(stats, AF_INET6);
         return new UdpStats(stats.dwOutDatagrams, stats.dwInDatagrams, stats.dwNoPorts, stats.dwInErrors);
+    }
+
+    @Override
+    public List<IPConnection> getConnections() {
+        if (IS_VISTA_OR_GREATER) {
+            List<IPConnection> conns = new ArrayList<>();
+            conns.addAll(queryTCPv4Connections());
+            conns.addAll(queryTCPv6Connections());
+            conns.addAll(queryUDPv4Connections());
+            conns.addAll(queryUDPv6Connections());
+            return Collections.unmodifiableList(conns);
+        }
+        return Collections.emptyList();
+    }
+
+    private List<IPConnection> queryTCPv4Connections() {
+        List<IPConnection> conns = new ArrayList<>();
+        // Get size needed
+        IntByReference sizePtr = new IntByReference();
+        IPHLP.GetExtendedTcpTable(null, sizePtr, false, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
+        // Get buffer and populate table
+        int size;
+        Memory buf;
+        do {
+            size = sizePtr.getValue();
+            buf = new Memory(size);
+            IPHLP.GetExtendedTcpTable(buf, sizePtr, false, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
+            // In case size changes and buffer was too small, repeat
+        } while (size < sizePtr.getValue());
+        MIB_TCPTABLE_OWNER_PID tcpTable = new MIB_TCPTABLE_OWNER_PID(buf);
+        for (int i = 0; i < tcpTable.dwNumEntries; i++) {
+            MIB_TCPROW_OWNER_PID row = tcpTable.table[i];
+            conns.add(new IPConnection("tcp4", ParseUtil.parseIntToIP(row.dwLocalAddr),
+                    ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort), ParseUtil.parseIntToIP(row.dwRemoteAddr),
+                    ParseUtil.bigEndian16ToLittleEndian(row.dwRemotePort), stateLookup(row.dwState), 0, 0,
+                    row.dwOwningPid));
+        }
+        return conns;
+    }
+
+    private List<IPConnection> queryTCPv6Connections() {
+        List<IPConnection> conns = new ArrayList<>();
+        // Get size needed
+        IntByReference sizePtr = new IntByReference();
+        IPHLP.GetExtendedTcpTable(null, sizePtr, false, AF_INET6, TCP_TABLE_OWNER_PID_ALL, 0);
+        // Get buffer and populate table
+        int size;
+        Memory buf;
+        do {
+            size = sizePtr.getValue();
+            buf = new Memory(size);
+            IPHLP.GetExtendedTcpTable(buf, sizePtr, false, AF_INET6, TCP_TABLE_OWNER_PID_ALL, 0);
+            // In case size changes and buffer was too small, repeat
+        } while (size < sizePtr.getValue());
+        MIB_TCP6TABLE_OWNER_PID tcpTable = new MIB_TCP6TABLE_OWNER_PID(buf);
+        for (int i = 0; i < tcpTable.dwNumEntries; i++) {
+            MIB_TCP6ROW_OWNER_PID row = tcpTable.table[i];
+            conns.add(new IPConnection("tcp6", row.LocalAddr, ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort),
+                    row.RemoteAddr, ParseUtil.bigEndian16ToLittleEndian(row.dwRemotePort), stateLookup(row.State), 0, 0,
+                    row.dwOwningPid));
+        }
+        return conns;
+    }
+
+    private List<IPConnection> queryUDPv4Connections() {
+        List<IPConnection> conns = new ArrayList<>();
+        // Get size needed
+        IntByReference sizePtr = new IntByReference();
+        IPHLP.GetExtendedUdpTable(null, sizePtr, false, AF_INET, UDP_TABLE_OWNER_PID, 0);
+        // Get buffer and populate table
+        int size;
+        Memory buf;
+        do {
+            size = sizePtr.getValue();
+            buf = new Memory(size);
+            IPHLP.GetExtendedUdpTable(buf, sizePtr, false, AF_INET, UDP_TABLE_OWNER_PID, 0);
+            // In case size changes and buffer was too small, repeat
+        } while (size < sizePtr.getValue());
+        MIB_UDPTABLE_OWNER_PID udpTable = new MIB_UDPTABLE_OWNER_PID(buf);
+        for (int i = 0; i < udpTable.dwNumEntries; i++) {
+            MIB_UDPROW_OWNER_PID row = udpTable.table[i];
+            conns.add(new IPConnection("udp4", ParseUtil.parseIntToIP(row.dwLocalAddr),
+                    ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort), new byte[0], 0, TcpState.NONE, 0, 0,
+                    row.dwOwningPid));
+        }
+        return conns;
+    }
+
+    private List<IPConnection> queryUDPv6Connections() {
+        List<IPConnection> conns = new ArrayList<>();
+        // Get size needed
+        IntByReference sizePtr = new IntByReference();
+        IPHLP.GetExtendedUdpTable(null, sizePtr, false, AF_INET6, UDP_TABLE_OWNER_PID, 0);
+        // Get buffer and populate table
+        int size;
+        Memory buf;
+        do {
+            size = sizePtr.getValue();
+            buf = new Memory(size);
+            IPHLP.GetExtendedUdpTable(buf, sizePtr, false, AF_INET6, UDP_TABLE_OWNER_PID, 0);
+            // In case size changes and buffer was too small, repeat
+        } while (size < sizePtr.getValue());
+        MIB_UDP6TABLE_OWNER_PID udpTable = new MIB_UDP6TABLE_OWNER_PID(buf);
+        for (int i = 0; i < udpTable.dwNumEntries; i++) {
+            MIB_UDP6ROW_OWNER_PID row = udpTable.table[i];
+            conns.add(new IPConnection("udp6", row.ucLocalAddr, ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort),
+                    new byte[0], 0, TcpState.NONE, 0, 0, row.dwOwningPid));
+        }
+        return conns;
+    }
+
+    private static TcpState stateLookup(int state) {
+        switch (state) {
+        case 1:
+        case 12:
+            return CLOSED;
+        case 2:
+            return LISTEN;
+        case 3:
+            return SYN_SENT;
+        case 4:
+            return SYN_RECV;
+        case 5:
+            return ESTABLISHED;
+        case 6:
+            return FIN_WAIT1;
+        case 7:
+            return FIN_WAIT2;
+        case 8:
+            return CLOSE_WAIT;
+        case 9:
+            return CLOSING;
+        case 10:
+            return LAST_ACK;
+        case 11:
+            return TIME_WAIT;
+        default:
+            return UNKNOWN;
+        }
+    }
+
+    public static void main(String[] args) {
+        WindowsInternetProtocolStats wips = new WindowsInternetProtocolStats();
+        for (IPConnection conn : wips.getConnections()) {
+            System.out.println(conn.toString());
+        }
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStats.java
@@ -28,10 +28,10 @@ import com.sun.jna.platform.win32.IPHlpAPI.MIB_TCPSTATS;
 import com.sun.jna.platform.win32.IPHlpAPI.MIB_UDPSTATS;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.os.InternetProtocolStats;
+import oshi.software.common.AbstractInternetProtocolStats;
 
 @ThreadSafe
-public class WindowsInternetProtocolStats implements InternetProtocolStats {
+public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats {
 
     private static final IPHlpAPI IPHLP = IPHlpAPI.INSTANCE;
 

--- a/oshi-core/src/main/java/oshi/util/FileUtil.java
+++ b/oshi-core/src/main/java/oshi/util/FileUtil.java
@@ -264,4 +264,19 @@ public final class FileUtil {
         }
         return true;
     }
+
+    /**
+     * Reads the target of a symbolic link
+     *
+     * @param file
+     *            The file to read
+     * @return The symlink name, or null if the read failed
+     */
+    public static String readSymlinkTarget(File file) {
+        try {
+            return Files.readSymbolicLink(Paths.get(file.getAbsolutePath())).toString();
+        } catch (IOException e) {
+            return null;
+        }
+    }
 }

--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -1119,7 +1119,7 @@ public final class ParseUtil {
      * Parse an integer array in big endian IP format to its component bytes
      * representing an IPv6 address
      *
-     * @param ip
+     * @param ip6
      *            The address as an integer array
      * @return The address as an array of sizteen bytes
      */

--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -27,6 +27,7 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
@@ -1100,6 +1101,51 @@ public final class ParseUtil {
             }
         }
         return result;
+    }
+
+    /**
+     * Parse an integer in big endian IP format to its component bytes representing
+     * an IPv4 address
+     *
+     * @param ip
+     *            The address as an integer
+     * @return The address as an array of four bytes
+     */
+    public static byte[] parseIntToIP(int ip) {
+        return ByteBuffer.allocate(4).order(ByteOrder.nativeOrder()).putInt(ip).array();
+    }
+
+    /**
+     * Parse an integer array in big endian IP format to its component bytes
+     * representing an IPv6 address
+     *
+     * @param ip
+     *            The address as an integer array
+     * @return The address as an array of sizteen bytes
+     */
+    public static byte[] parseIntArrayToIP(int[] ip6) {
+        ByteBuffer bb = ByteBuffer.allocate(16).order(ByteOrder.nativeOrder());
+        for (int i : ip6) {
+            bb.putInt(i);
+        }
+        return bb.array();
+    }
+
+    /**
+     * TCP network addresses and ports are in big endian format by definition. The
+     * order of the two bytes in the 16-bit unsigned short port value must be
+     * reversed
+     *
+     * @param port
+     *            The port number in big endian order
+     * @return The port number
+     * @see <a href=
+     *      "https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-ntohs">ntohs</a>
+     */
+    public static int bigEndian16ToLittleEndian(int port) {
+        // 20480 = 0x5000 should be 0x0050 = 80
+        // 47873 = 0xBB01 should be 0x01BB = 443
+        return port >> 8 & 0xff | port << 8 & 0xff00;
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -1190,7 +1190,26 @@ public final class ParseUtil {
     }
 
     /**
-     * Parses a string of hex digits to long value.
+     * Parses a string of hex digits to an int value.
+     *
+     * @param hexString
+     *            A sequence of hex digits
+     * @param defaultValue
+     *            default value to return if parsefails
+     * @return The corresponding int value
+     */
+    public static int hexStringToInt(String hexString, int defaultValue) {
+        try {
+            return new BigInteger(hexString, 16).intValue();
+        } catch (NumberFormatException e) {
+            LOG.trace(DEFAULT_LOG_MSG, hexString, e);
+            // Hex failed to parse, just return the default long
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Parses a string of hex digits to a long value.
      *
      * @param hexString
      *            A sequence of hex digits

--- a/oshi-core/src/main/java/oshi/util/platform/linux/ProcPath.java
+++ b/oshi-core/src/main/java/oshi/util/platform/linux/ProcPath.java
@@ -48,6 +48,7 @@ public final class ProcPath {
     public static final String DISKSTATS = PROC + "/diskstats";
     public static final String MEMINFO = PROC + "/meminfo";
     public static final String MOUNTS = PROC + "/mounts";
+    public static final String NET = PROC + "/net";
     public static final String PID_CMDLINE = PROC + "/%d/cmdline";
     public static final String PID_CWD = PROC + "/%d/cwd";
     public static final String PID_EXE = PROC + "/%d/exe";

--- a/oshi-core/src/test/java/oshi/software/os/InternetProtocolStatsTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/InternetProtocolStatsTest.java
@@ -24,8 +24,13 @@
 package oshi.software.os;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -131,6 +136,27 @@ class InternetProtocolStatsTest {
     @Test
     void testGetConnections() {
         for (IPConnection conn : ipStats.getConnections()) {
+            assertThat("Protocol name is not null or empty", conn.getType(),
+                    allOf(is(not(emptyString())), is(notNullValue())));
+            if (conn.getType().contains("6")) {
+                assertThat("Local address array size should be 0, or 16", conn.getLocalAddress().length,
+                        anyOf(is(0), is(16)));
+                assertThat("Foreign address rray size should be 0, or 16", conn.getForeignAddress().length,
+                        anyOf(is(0), is(16)));
+            } else {
+                assertThat("Local address array size should be 0, or 4", conn.getLocalAddress().length,
+                        anyOf(is(0), is(4)));
+                assertThat("Foreign address rray size should be 0, or 4", conn.getForeignAddress().length,
+                        anyOf(is(0), is(4)));
+            }
+            assertThat("Local port must be a 16 bit value", conn.getLocalPort(),
+                    allOf(greaterThanOrEqualTo(0), lessThanOrEqualTo(0xffff)));
+            assertThat("Foreign port must be a 16 bit value", conn.getLocalPort(),
+                    allOf(greaterThanOrEqualTo(0), lessThanOrEqualTo(0xffff)));
+            assertThat("Transmit queue msut be nonnegative", conn.getTransmitQueue(), greaterThanOrEqualTo(0));
+            assertThat("Receive queue msut be nonnegative", conn.getReceiveQueue(), greaterThanOrEqualTo(0));
+            assertThat("Connection state must not be null", conn.getState(), is(notNullValue()));
+            assertThat("Owning Process ID must be -1 or higher", conn.getowningProcessId(), greaterThanOrEqualTo(-1));
             assertThat("Connection toString must not be null", conn.toString(), is(notNullValue()));
         }
     }

--- a/oshi-core/src/test/java/oshi/software/os/InternetProtocolStatsTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/InternetProtocolStatsTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import oshi.SystemInfo;
+import oshi.software.os.InternetProtocolStats.IPConnection;
 import oshi.software.os.InternetProtocolStats.TcpStats;
 import oshi.software.os.InternetProtocolStats.UdpStats;
 
@@ -125,5 +126,12 @@ class InternetProtocolStatsTest {
 
         assertThat("IPV4 UDP stats shouldn't be null", udp4.toString(), is(notNullValue()));
         assertThat("IPV6 UDP stats shouldn't be null", udp6.toString(), is(notNullValue()));
+    }
+
+    @Test
+    void testGetConnections() {
+        for (IPConnection conn : ipStats.getConnections()) {
+            assertThat("Connection toString must not be null", conn.toString(), is(notNullValue()));
+        }
     }
 }

--- a/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
@@ -575,6 +575,13 @@ class ParseUtilTest {
     }
 
     @Test
+    void testHexStringToInt() {
+        assertThat(ParseUtil.hexStringToInt("ff", 0), is(255));
+        assertThat(ParseUtil.hexStringToInt("830f53a0", 0), is(-2096147552));
+        assertThat(ParseUtil.hexStringToInt("pqwe", 0), is(0));
+    }
+
+    @Test
     void testHexStringToLong() {
         assertThat(ParseUtil.hexStringToLong("ff", 0L), is(255L));
         assertThat(ParseUtil.hexStringToLong("ffffffff830f53a0", 0L), is(-2096147552L));

--- a/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
@@ -524,6 +524,33 @@ class ParseUtilTest {
     }
 
     @Test
+    void testParseIntToIP() {
+        // IP addresses are big endian
+        int ip = 1 | 2 << 8 | 3 << 16 | 4 << 24;
+        byte[] ipb = { (byte) 1, (byte) 2, (byte) 3, (byte) 4 };
+        assertThat("IP did not parse properly", ParseUtil.parseIntToIP(ip), is(ipb));
+    }
+
+    @Test
+    void testParseIntArrayToIP() {
+        // IP addresses are big endian
+        int[] ip = new int[4];
+        ip[0] = 1 | 2 << 8 | 3 << 16 | 4 << 24;
+        ip[1] = 5 | 6 << 8 | 7 << 16 | 8 << 24;
+        ip[2] = 9 | 10 << 8 | 11 << 16 | 12 << 24;
+        ip[3] = 13 | 14 << 8 | 15 << 16 | 16 << 24;
+        byte[] ipb = { (byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5, (byte) 6, (byte) 7, (byte) 8, (byte) 9,
+                (byte) 10, (byte) 11, (byte) 12, (byte) 13, (byte) 14, (byte) 15, (byte) 16 };
+        assertThat("IP array did not parse properly", ParseUtil.parseIntArrayToIP(ip), is(ipb));
+    }
+
+    @Test
+    void testBigEndian16ToLittleEndian() {
+        assertThat("Port 80 did not convert properly", ParseUtil.bigEndian16ToLittleEndian(0x5000), is(80));
+        assertThat("Port 443 did not convert properly", ParseUtil.bigEndian16ToLittleEndian(0xBB01), is(443));
+    }
+
+    @Test
     void testParseUtAddrV6toIP() {
         int[] zero = { 0, 0, 0, 0 };
         int[] loopback = { 0, 0, 0, 1 };

--- a/oshi-demo/pom.xml
+++ b/oshi-demo/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>com.github.oshi</groupId>
 		<artifactId>oshi-parent</artifactId>
-		<version>5.3.8-SNAPSHOT</version>
+		<version>5.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>oshi-demo</artifactId>

--- a/oshi-dist/pom.xml
+++ b/oshi-dist/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>com.github.oshi</groupId>
 		<artifactId>oshi-parent</artifactId>
-		<version>5.3.8-SNAPSHOT</version>
+		<version>5.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>oshi-dist</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
 	<groupId>com.github.oshi</groupId>
 	<artifactId>oshi-parent</artifactId>
-	<version>5.3.8-SNAPSHOT</version>
+	<version>5.4.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Operating System and Hardware Information</name>


### PR DESCRIPTION
Fixes #1422.  I've implemented native code for Windows, macOS, and Linux.  

The linux code relies on `/proc/net` which is allegedly deprecated but is the easiest route. There's a much more complicated way of doing it using tcp_diag, noted on #1422, which someone else can put in if they want it.

I've got a default implementation using `netstat` for the unix ports.  They each have more direct native options (FreeBSD via a systctl call) but are complex enough that I'm not interested in doing them now.