### PR TITLE
Also get disk statistics from AppleAPFSContainerScheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # 5.4.0 (in progress)
+* Your contribution here
 
 ##### New Features
 * [#1461](https://github.com/oshi/oshi/pull/1461): List TCP and UDP connections - [@dbwiddis](https://github.com/dbwiddis).
-* Your contribution here
+
+##### Bug fixes / Improvements
+* [#1464](https://github.com/oshi/oshi/pull/1464): Also get disk statistics from AppleAPFSContainerScheme - [@mpfz0r](https://github.com/mpfz0r).
 
 # 5.3.0 (2020-10-11), 5.3.1 (2020-10-18), 5.3.2 (2020-10-25), 5.3.3 (2020-10-28), 5.3.4 (2020-11-01), 5.3.5 (2020-11-11), 5.3.6 (2020-11-15), 5.3.7 (2020-12-20)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStore.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStore.java
@@ -165,8 +165,8 @@ public final class MacHWDiskStore extends AbstractHWDiskStore {
                     // Get the properties from the parent
                     if (drive.conformsTo("IOMedia")) {
                         IORegistryEntry parent = drive.getParentEntry("IOService");
-                        if (parent != null && parent.conformsTo("IOBlockStorageDriver")
-                                           || parent.conformsTo("AppleAPFSContainerScheme")) {
+                        if (parent != null && (parent.conformsTo("IOBlockStorageDriver")
+                                || parent.conformsTo("AppleAPFSContainerScheme"))) {
                             CFMutableDictionaryRef properties = parent.createCFProperties();
                             // We now have a properties object with the
                             // statistics we need on it. Fetch them

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStore.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStore.java
@@ -165,8 +165,8 @@ public final class MacHWDiskStore extends AbstractHWDiskStore {
                     // Get the properties from the parent
                     if (drive.conformsTo("IOMedia")) {
                         IORegistryEntry parent = drive.getParentEntry("IOService");
-                        if (parent != null && parent.conformsTo("IOBlockStorageDriver") ||
-                                              parent.conformsTo("AppleAPFSContainerScheme")) {
+                        if (parent != null && parent.conformsTo("IOBlockStorageDriver")
+                                           || parent.conformsTo("AppleAPFSContainerScheme")) {
                             CFMutableDictionaryRef properties = parent.createCFProperties();
                             // We now have a properties object with the
                             // statistics we need on it. Fetch them


### PR DESCRIPTION
Looking up a disk from a filesystem does not lead to the physical,
but to a "synthesized" disk, which cannot be traversed to an entry
with a IOBlockStorageDriver parent.
However, the APFSConainerScheme contains the statistics as well,
(except for the timers, which this change omits)

```
$ df -h /
Filesystem     Size   Used  Avail Capacity iused      ifree %iused  Mounted on
/dev/disk1s5  466Gi   10Gi   68Gi    14%  488564 4882988356    0%   /

$ diskutil list
/dev/disk0 (internal, physical):
   #:                       TYPE NAME                    SIZE       IDENTIFIER
   0:      GUID_partition_scheme                        *500.3 GB   disk0
   1:                        EFI EFI                     209.7 MB   disk0s1
   2:                 Apple_APFS Container disk1         500.1 GB   disk0s2

/dev/disk1 (synthesized):
   #:                       TYPE NAME                    SIZE       IDENTIFIER
   0:      APFS Container Scheme -                      +500.1 GB   disk1
                                 Physical Store disk0s2
   1:                APFS Volume Macintosh HD - Data     409.4 GB   disk1s1
   2:                APFS Volume Preboot                 81.3 MB    disk1s2
   3:                APFS Volume Recovery                529.0 MB   disk1s3
   4:                APFS Volume VM                      6.4 GB     disk1s4
   5:                APFS Volume Macintosh HD            11.3 GB    disk1s5

$ ioreg -c AppleAPFSContainerScheme
[...]
    | |   |               +-o IOBlockStorageDriver  <class IOBlockStorageDriver, id 0x1000002c8, registered, matched, active, busy 0 (528 ms), retain 8>
    | |   |                 +-o APPLE SSD SM0512F Media  <class IOMedia, id 0x1000002c9, registered, matched, active, busy 0 (528 ms), retain 12>
    | |   |                   +-o IOMediaBSDClient  <class IOMediaBSDClient, id 0x1000002ca, registered, matched, active, busy 0 (0 ms), retain 6>
    | |   |                   +-o IOGUIDPartitionScheme  <class IOGUIDPartitionScheme, id 0x1000002cc, !registered, !matched, active, busy 0 (25 ms), retain 7>
    | |   |                     +-o EFI System Partition@1  <class IOMedia, id 0x1000002de, registered, matched, active, busy 0 (0 ms), retain 10>
    | |   |                     | +-o IOMediaBSDClient  <class IOMediaBSDClient, id 0x1000002e4, registered, matched, active, busy 0 (0 ms), retain 6>
    | |   |                     +-o Macintosh HD@2  <class IOMedia, id 0x1000002df, registered, matched, active, busy 0 (25 ms), retain 15>
    | |   |                       +-o IOMediaBSDClient  <class IOMediaBSDClient, id 0x1000002e3, registered, matched, active, busy 0 (0 ms), retain 6>
    | |   |                       +-o AppleAPFSContainerScheme  <class AppleAPFSContainerScheme, id 0x1000002e5, !registered, !matched, active, busy 0 (20 ms), retain 7>
    | |   |                         | {
    | |   |                         |   "IOProbeScore" = 2000
    | |   |                         |   "IOPropertyMatch" = ({"Content Hint"="7C3457EF-0000-11AA-AA11-00306543ECAC"})
    | |   |                         |   "IOMatchCategory" = "IOStorage"
    | |   |                         |   "IOClass" = "AppleAPFSContainerScheme"
    | |   |                         |   "CFBundleIdentifier" = "com.apple.filesystems.apfs"
    | |   |                         |   "IOProviderClass" = "IOMedia"
    | |   |                         |   "CFBundleIdentifierKernel" = "com.apple.filesystems.apfs"
    | |   |                         |   "Statistics" = {"Operations (Read)"=24917591,"Bytes (Write)"=424527667200,"Operations (Write)"=22814116,"Bytes (Read)"=596721795072}
    | |   |                         |   "IOGeneralInterest" = "IOCommand is not serializable"
    | |   |                         |   "APFSComposited" = No
    | |   |                         | }
    | |   |                         |
    | |   |                         +-o AppleAPFSMedia  <class AppleAPFSMedia, id 0x1000002f4, registered, matched, active, busy 0 (20 ms), retain 20>
    | |   |                           +-o AppleAPFSMediaBSDClient  <class AppleAPFSMediaBSDClient, id 0x1000002f5, registered, matched, active, busy 0 (0 ms), retain 7>
    | |   |                           +-o AppleAPFSContainer  <class AppleAPFSContainer, id 0x1000002fc, registered, matched, active, busy 0 (4 ms), retain 12>
    | |   |                             +-o Macintosh HD - Data@1  <class AppleAPFSVolume, id 0x1000002fd, registered, matched, active, busy 0 (0 ms), retain 12>
    | |   |                             | +-o AppleAPFSVolumeBSDClient  <class AppleAPFSVolumeBSDClient, id 0x100000302, registered, matched, active, busy 0 (0 ms), retain 7>
    | |   |                             +-o Preboot@2  <class AppleAPFSVolume, id 0x1000002fe, registered, matched, active, busy 0 (0 ms), retain 10>
    | |   |                             | +-o AppleAPFSVolumeBSDClient  <class AppleAPFSVolumeBSDClient, id 0x100000304, registered, matched, active, busy 0 (0 ms), retain 6>
    | |   |                             +-o Recovery@3  <class AppleAPFSVolume, id 0x1000002ff, registered, matched, active, busy 0 (3 ms), retain 10>
    | |   |                             | +-o AppleAPFSVolumeBSDClient  <class AppleAPFSVolumeBSDClient, id 0x100000306, registered, matched, active, busy 0 (0 ms), retain 7>
    | |   |                             +-o VM@4  <class AppleAPFSVolume, id 0x100000300, registered, matched, active, busy 0 (0 ms), retain 10>
    | |   |                             | +-o AppleAPFSVolumeBSDClient  <class AppleAPFSVolumeBSDClient, id 0x100000308, registered, matched, active, busy 0 (0 ms), retain 7>
    | |   |                             +-o Macintosh HD@5  <class AppleAPFSVolume, id 0x100000301, registered, matched, active, busy 0 (0 ms), retain 11>
    | |   |                               +-o AppleAPFSVolumeBSDClient  <class AppleAPFSVolumeBSDClient, id 0x10000030a, registered, matched, active, busy 0 (0 ms), retain 7>
```

SystemInfoTest output with this change:
```
Disks:
 disk0: (model: APPLE SSD SM0512F - S/N: S1K5NYBDC84553) size: 500.3 GB, reads: 24889575 (554.8 GiB), writes: 22727474 (394.2 GiB), xfer: 16908112
 |-- disk0s1: EFI (EFI System Partition) Maj:Min=1:1, size: 209.7 MB
 |-- disk0s2: Macintosh HD (Macintosh HD) Maj:Min=1:2, size: 500.1 GB
 disk1: (model: APPLE SSD SM0512F - S/N: S1K5NYBDC84553) size: 500.1 GB, reads: 24889415 (554.8 GiB), writes: 22727474 (394.2 GiB), xfer: 0
 |-- disk1s5: Macintosh HD (Macintosh HD) Maj:Min=1:7, size: 500.1 GB @ /
 |-- disk1s1: Macintosh HD - Data (Macintosh HD - Data) Maj:Min=1:4, size: 500.1 GB @ /System/Volumes/Data
 |-- disk1s2: Preboot (Preboot) Maj:Min=1:5, size: 500.1 GB
 |-- disk1s3: Recovery (Recovery) Maj:Min=1:8, size: 500.1 GB @ /Volumes/Recovery
 |-- disk1s4: VM (VM) Maj:Min=1:6, size: 500.1 GB @ /private/var/vm
```
SystemInfoTest output without this change:
```
[...]
 disk1: (model: APPLE SSD SM0512F - S/N: S1K5NYBDC84553) size: 500.1 GB, reads: ? (?), writes: ? (?), xfer: ?
[...]
```