### PR TITLE
Switch to Unix standard netstat state

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/InternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/InternetProtocolStats.java
@@ -285,7 +285,7 @@ public interface InternetProtocolStats {
      * The TCP connection state as described in RFC 793.
      */
     enum TcpState {
-        UNKNOWN, CLOSED, LISTEN, SYN_SENT, SYN_RECV, ESTABLISHED, FIN_WAIT1, FIN_WAIT2, CLOSE_WAIT, CLOSING, LAST_ACK,
+        UNKNOWN, CLOSED, LISTEN, SYN_SENT, SYN_RECV, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, CLOSE_WAIT, CLOSING, LAST_ACK,
         TIME_WAIT, NONE;
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
@@ -27,8 +27,8 @@ import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
 import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
 import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
 import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT1;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT2;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_1;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_2;
 import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
 import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
 import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
@@ -228,9 +228,9 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         case 0x03:
             return SYN_RECV;
         case 0x04:
-            return FIN_WAIT1;
+            return FIN_WAIT_1;
         case 0x05:
-            return FIN_WAIT2;
+            return FIN_WAIT_2;
         case 0x06:
             return TIME_WAIT;
         case 0x07:

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStats.java
@@ -36,8 +36,8 @@ import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
 import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
 import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
 import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT1;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT2;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_1;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_2;
 import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
 import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
 import static oshi.software.os.InternetProtocolStats.TcpState.NONE;
@@ -233,13 +233,13 @@ public class MacInternetProtocolStats extends AbstractInternetProtocolStats {
         case 5:
             return CLOSE_WAIT;
         case 6:
-            return FIN_WAIT1;
+            return FIN_WAIT_1;
         case 7:
             return CLOSING;
         case 8:
             return LAST_ACK;
         case 9:
-            return FIN_WAIT2;
+            return FIN_WAIT_2;
         case 10:
             return TIME_WAIT;
         default:

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStats.java
@@ -31,8 +31,8 @@ import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
 import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
 import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
 import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT1;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT2;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_1;
+import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_2;
 import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
 import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
 import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
@@ -225,9 +225,9 @@ public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats 
         case 5:
             return ESTABLISHED;
         case 6:
-            return FIN_WAIT1;
+            return FIN_WAIT_1;
         case 7:
-            return FIN_WAIT2;
+            return FIN_WAIT_2;
         case 8:
             return CLOSE_WAIT;
         case 9:


### PR DESCRIPTION
Linux uses `FIN_WAIT1` and `FIN_WAIT2` but has its own implementation. Unix implementations use `FIN_WAIT_1` and `FIN_WAIT_2` and the code relies on this spelling