### PR TITLE
Fix NetworkIF.isConnectorPresent() on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 5.5.1 (in progress)
 
 * Your contribution here
+##### Bug fixes / Improvements
+* [#1535](https://github.com/oshi/oshi/pull/1535): Fix NetworkIF.isConnectorPresent() on Windows - [@dornand](https://github.com/dornand).
 
 # 5.5.0 (2021-02-08)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIF.java
@@ -49,7 +49,7 @@ public final class WindowsNetworkIF extends AbstractNetworkIF {
     private static final Logger LOG = LoggerFactory.getLogger(WindowsNetworkIF.class);
 
     private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
-    private static final byte CONNECTOR_PRESENT_BIT = 0b00100000;
+    private static final byte CONNECTOR_PRESENT_BIT = 0b00000100;
 
     private int ifType;
     private int ndisPhysicalMediumType;


### PR DESCRIPTION
Windows bit fields are in little-endian order.