### PR TITLE
Expose the alias of a network interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 5.5.2 (in progress)
 
 * Your contribution here
+##### New Features
+* [#1541](https://github.com/oshi/oshi/pull/1541): Expose the alias of a network interface (Windows and Linux) - [@dornand](https://github.com/dornand).
 
 # 5.5.0 (2021-02-08), 5.5.1 (2021-02-21)
 

--- a/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
@@ -62,11 +62,22 @@ public interface NetworkIF {
     String getDisplayName();
 
     /**
-     * Interface alias.
+     * The {@code ifAlias} as described in RFC 2863.
+     * <p>
+     * The ifAlias object allows a network manager to give one or more interfaces
+     * their own unique names, irrespective of any interface-stack relationship.
+     * Further, the ifAlias name is non-volatile, and thus an interface must retain
+     * its assigned ifAlias value across reboots, even if an agent chooses a new
+     * ifIndex value for the interface.
+     * <p>
+     * Only implemented for Windows and Linux.
      *
-     * @return The 'ifAlias' as described in RFC 2863.
+     * @return The {@code ifAlias} of the interface if available, otherwise the
+     *         empty string.
      */
-    String getIfAlias();
+    default String getIfAlias() {
+        return "";
+    }
 
     /**
      * The interface Maximum Transmission Unit (MTU).

--- a/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
@@ -62,6 +62,13 @@ public interface NetworkIF {
     String getDisplayName();
 
     /**
+     * Interface alias.
+     *
+     * @return The 'ifAlias' as described in RFC 2863.
+     */
+    String getIfAlias();
+
+    /**
      * The interface Maximum Transmission Unit (MTU).
      *
      * @return The MTU of the network interface.

--- a/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
@@ -159,7 +159,9 @@ public interface NetworkIF {
      *
      * @return the ifType
      */
-    int getIfType();
+    default int getIfType() {
+        return 0;
+    }
 
     /**
      * (Windows Vista and higher only) The NDIS physical medium type. This member
@@ -168,7 +170,9 @@ public interface NetworkIF {
      *
      * @return the ndisPhysicalMediumType
      */
-    int getNdisPhysicalMediumType();
+    default int getNdisPhysicalMediumType() {
+        return 0;
+    }
 
     /**
      * (Windows Vista and higher) Set if a connector is present on the network
@@ -179,7 +183,9 @@ public interface NetworkIF {
      * @return {@code true} if there is a physical network adapter (Windows) or a
      *         connected cable (Linux), false otherwise
      */
-    boolean isConnectorPresent();
+    default boolean isConnectorPresent() {
+        return false;
+    }
 
     /**
      * <p>

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -229,6 +229,12 @@ public abstract class AbstractNetworkIF implements NetworkIF {
         return false;
     }
 
+    @Override
+    public String getIfAlias() {
+        // default
+        return "";
+    }
+
     private static Properties queryVmMacAddrProps() {
         return FileUtil.readPropertiesFromFilename(OSHI_VM_MAC_ADDR_PROPERTIES);
     }

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -232,24 +232,6 @@ public abstract class AbstractNetworkIF implements NetworkIF {
         return this.vmMacAddrProps.get().containsKey(oui.toUpperCase());
     }
 
-    @Override
-    public int getIfType() {
-        // default
-        return 0;
-    }
-
-    @Override
-    public int getNdisPhysicalMediumType() {
-        // default
-        return 0;
-    }
-
-    @Override
-    public boolean isConnectorPresent() {
-        // default
-        return false;
-    }
-
     private static Properties queryVmMacAddrProps() {
         return FileUtil.readPropertiesFromFilename(OSHI_VM_MAC_ADDR_PROPERTIES);
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIF.java
@@ -56,6 +56,7 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
     private long collisions;
     private long speed;
     private long timeStamp;
+    private String ifAlias;
 
     public LinuxNetworkIF(NetworkInterface netint) throws InstantiationException {
         super(netint);
@@ -142,6 +143,11 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
+    public String getIfAlias() {
+        return ifAlias;
+    }
+
+    @Override
     public boolean updateAttributes() {
         try {
             File ifDir = new File(String.format("/sys/class/net/%s/statistics", getName()));
@@ -162,6 +168,7 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
         String collisionsPath = String.format("/sys/class/net/%s/statistics/collisions", getName());
         String rxDropsPath = String.format("/sys/class/net/%s/statistics/rx_dropped", getName());
         String ifSpeed = String.format("/sys/class/net/%s/speed", getName());
+        String ifAlias = String.format("/sys/class/net/%s/ifalias", getName());
 
         this.timeStamp = System.currentTimeMillis();
         this.ifType = FileUtil.getIntFromFile(ifTypePath);
@@ -177,6 +184,7 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
         long speedMiB = FileUtil.getUnsignedLongFromFile(ifSpeed);
         // speed may be -1 from file.
         this.speed = speedMiB < 0 ? 0 : speedMiB << 20;
+        this.ifAlias = FileUtil.getStringFromFile(ifAlias);
 
         return true;
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIF.java
@@ -194,7 +194,7 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
         String collisionsPath = String.format("/sys/class/net/%s/statistics/collisions", getName());
         String rxDropsPath = String.format("/sys/class/net/%s/statistics/rx_dropped", getName());
         String ifSpeed = String.format("/sys/class/net/%s/speed", getName());
-        String ifAlias = String.format("/sys/class/net/%s/ifalias", getName());
+        String ifAliasPath = String.format("/sys/class/net/%s/ifalias", getName());
 
         this.timeStamp = System.currentTimeMillis();
         this.ifType = FileUtil.getIntFromFile(ifTypePath);
@@ -210,7 +210,7 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
         long speedMiB = FileUtil.getUnsignedLongFromFile(ifSpeed);
         // speed may be -1 from file.
         this.speed = speedMiB < 0 ? 0 : speedMiB << 20;
-        this.ifAlias = FileUtil.getStringFromFile(ifAlias);
+        this.ifAlias = FileUtil.getStringFromFile(ifAliasPath);
 
         return true;
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIF.java
@@ -27,6 +27,7 @@ import java.net.NetworkInterface;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.sun.jna.Native;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +65,7 @@ public final class WindowsNetworkIF extends AbstractNetworkIF {
     private long collisions;
     private long speed;
     private long timeStamp;
+    private String ifAlias;
 
     public WindowsNetworkIF(NetworkInterface netint) throws InstantiationException {
         super(netint);
@@ -155,6 +157,11 @@ public final class WindowsNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
+    public String getIfAlias() {
+        return ifAlias;
+    }
+
+    @Override
     public boolean updateAttributes() {
         // MIB_IFROW2 requires Vista (6.0) or later.
         if (IS_VISTA_OR_GREATER) {
@@ -179,6 +186,7 @@ public final class WindowsNetworkIF extends AbstractNetworkIF {
             this.collisions = ifRow.OutDiscards; // closest proxy
             this.inDrops = ifRow.InDiscards; // closest proxy
             this.speed = ifRow.ReceiveLinkSpeed;
+            this.ifAlias = Native.toString(ifRow.Alias);
         } else {
             // Create new MIB_IFROW and set index to this interface index
             MIB_IFROW ifRow = new MIB_IFROW();

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/SystemConfiguration.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/SystemConfiguration.java
@@ -1,0 +1,57 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2010 - 2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package oshi.jna.platform.mac;
+
+import com.sun.jna.Library; // NOSONAR squid:S1191
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.mac.CoreFoundation.CFArrayRef;
+import com.sun.jna.platform.mac.CoreFoundation.CFStringRef;
+import com.sun.jna.platform.mac.CoreFoundation.CFTypeRef;
+
+/**
+ * Allow applications to access a device’s network configuration settings.
+ * Determine the reachability of the device, such as whether Wi-Fi or cell
+ * connectivity are active.
+ */
+public interface SystemConfiguration extends Library {
+
+    SystemConfiguration INSTANCE = Native.load("SystemConfiguration", SystemConfiguration.class);
+
+    class SCNetworkInterfaceRef extends CFTypeRef {
+        public SCNetworkInterfaceRef() {
+            super();
+        }
+
+        public SCNetworkInterfaceRef(Pointer p) {
+            super(p);
+        }
+    }
+
+    CFArrayRef SCNetworkInterfaceCopyAll();
+
+    CFStringRef SCNetworkInterfaceGetBSDName(SCNetworkInterfaceRef netint);
+
+    CFStringRef SCNetworkInterfaceGetLocalizedDisplayName(SCNetworkInterfaceRef netint);
+}

--- a/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
@@ -54,6 +54,7 @@ class NetworksTest {
             assertThat("NetworkIF should not be null", net.queryNetworkInterface(), is(notNullValue()));
             assertThat("NetworkIF name should not be null", net.getName(), is(notNullValue()));
             assertThat("NetworkIF display name should not be null", net.getDisplayName(), is(notNullValue()));
+            assertThat("NetworkIF ifAlias should not be null", net.getIfAlias(), is(notNullValue()));
             assertThat("NetworkIF IPv4 address should not be null", net.getIPv4addr(), is(notNullValue()));
             assertThat("NetworkIF SubnetMasks should not be null", net.getSubnetMasks(), is(notNullValue()));
             assertThat("NetworkIF IPv6 should not be null", net.getIPv6addr(), is(notNullValue()));


### PR DESCRIPTION
`NetworkIF.getIfAlias()` for Windows and Linux.  Relates to #1541 