### PR TITLE
Fix a NPE in NetworkIF.toString() on Windows.

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIF.java
@@ -208,6 +208,7 @@ public final class WindowsNetworkIF extends AbstractNetworkIF {
             this.collisions = ParseUtil.unsignedIntToLong(ifRow.dwOutDiscards); // closest proxy
             this.inDrops = ParseUtil.unsignedIntToLong(ifRow.dwInDiscards); // closest proxy
             this.speed = ParseUtil.unsignedIntToLong(ifRow.dwSpeed);
+            this.ifAlias = ""; // not supported by MIB_IFROW
         }
         this.timeStamp = System.currentTimeMillis();
         return true;

--- a/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
@@ -83,6 +83,8 @@ class NetworksTest {
                 assertThat("Invalid MAC adress corresponds to a known virtual machine", net.isKnownVmMacAddr(),
                         is(false));
             }
+
+            assertThat("NetworkIF.toString() should not be null", net.toString(), is(notNullValue()));
         }
     }
 


### PR DESCRIPTION
ifAlias was not initialized properly on Windows before Vista.