### PR TITLE
Expose network interface operational status

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
@@ -24,6 +24,7 @@
 package oshi.hardware;
 
 import java.net.NetworkInterface;
+import java.util.Arrays;
 
 import oshi.annotation.concurrent.ThreadSafe;
 
@@ -70,13 +71,24 @@ public interface NetworkIF {
      * its assigned ifAlias value across reboots, even if an agent chooses a new
      * ifIndex value for the interface.
      * <p>
-     * Only implemented for Windows and Linux.
+     * Only implemented for Windows (Vista and newer) and Linux.
      *
      * @return The {@code ifAlias} of the interface if available, otherwise the
      *         empty string.
      */
     default String getIfAlias() {
         return "";
+    }
+
+    /**
+     * The {@code ifOperStatus} as described in RFC 2863.
+     * <p>
+     * Only implemented for Windows (Vista and newer) and Linux.
+     *
+     * @return The current operational state of the interface.
+     */
+    default IfOperStatus getIfOperStatus() {
+        return IfOperStatus.UNKNOWN;
     }
 
     /**
@@ -330,4 +342,68 @@ public interface NetworkIF {
      * @return {@code true} if the update was successful, {@code false} otherwise.
      */
     boolean updateAttributes();
+
+    /**
+     * The current operational state of a network interface.
+     * <p>
+     * As described in RFC 2863.
+     */
+    enum IfOperStatus {
+        /**
+         * Up and operational. Ready to pass packets.
+         */
+        UP(1),
+        /**
+         * Down and not operational. Not ready to pass packets.
+         */
+        DOWN(2),
+        /**
+         * In some test mode.
+         */
+        TESTING(3),
+        /**
+         * The interface status is unknown.
+         */
+        UNKNOWN(4),
+        /**
+         * The interface is not up, but is in a pending state, waiting for some external
+         * event.
+         */
+        DORMANT(5),
+        /**
+         * Some component is missing
+         */
+        NOT_PRESENT(6),
+        /**
+         * Down due to state of lower-layer interface(s).
+         */
+        LOWER_LAYER_DOWN(7);
+
+        private final int value;
+
+        IfOperStatus(int value) {
+            this.value = value;
+        }
+
+        /**
+         * @return the integer value specified in RFC 2863 for this operational status.
+         */
+        public int getValue() {
+            return this.value;
+        }
+
+        /**
+         * Find IfOperStatus by the integer value.
+         *
+         * @param value
+         *            Integer value specified in RFC 2863
+         * @return the matching IfOperStatu or UNKNOWN if no matching IfOperStatus can
+         *         be found
+         */
+        public static IfOperStatus byValue(int value) {
+            return Arrays.stream(IfOperStatus.values()).filter(st -> st.getValue() == value).findFirst()
+                    .orElse(UNKNOWN);
+        }
+
+    }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIF.java
@@ -62,6 +62,7 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
     private long speed;
     private long timeStamp;
     private String ifAlias;
+    private IfOperStatus ifOperStatus;
 
     public LinuxNetworkIF(NetworkInterface netint) throws InstantiationException {
         super(netint, queryIfModel(netint));
@@ -174,6 +175,11 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
+    public IfOperStatus getIfOperStatus() {
+        return ifOperStatus;
+    }
+
+    @Override
     public boolean updateAttributes() {
         try {
             File ifDir = new File(String.format("/sys/class/net/%s/statistics", getName()));
@@ -195,6 +201,7 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
         String rxDropsPath = String.format("/sys/class/net/%s/statistics/rx_dropped", getName());
         String ifSpeed = String.format("/sys/class/net/%s/speed", getName());
         String ifAliasPath = String.format("/sys/class/net/%s/ifalias", getName());
+        String ifOperStatusPath = String.format("/sys/class/net/%s/operstate", getName());
 
         this.timeStamp = System.currentTimeMillis();
         this.ifType = FileUtil.getIntFromFile(ifTypePath);
@@ -211,7 +218,28 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
         // speed may be -1 from file.
         this.speed = speedMiB < 0 ? 0 : speedMiB << 20;
         this.ifAlias = FileUtil.getStringFromFile(ifAliasPath);
+        this.ifOperStatus = parseIfOperStatus(FileUtil.getStringFromFile(ifOperStatusPath));
 
         return true;
+    }
+
+    private static IfOperStatus parseIfOperStatus(String operState) {
+        switch (operState) {
+        case "up":
+            return IfOperStatus.UP;
+        case "down":
+            return IfOperStatus.DOWN;
+        case "testing":
+            return IfOperStatus.TESTING;
+        case "dormant":
+            return IfOperStatus.DORMANT;
+        case "notpresent":
+            return IfOperStatus.NOT_PRESENT;
+        case "lowerlayerdown":
+            return IfOperStatus.LOWER_LAYER_DOWN;
+        case "unknown":
+        default:
+            return IfOperStatus.UNKNOWN;
+        }
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIF.java
@@ -66,6 +66,7 @@ public final class WindowsNetworkIF extends AbstractNetworkIF {
     private long speed;
     private long timeStamp;
     private String ifAlias;
+    private IfOperStatus ifOperStatus;
 
     public WindowsNetworkIF(NetworkInterface netint) throws InstantiationException {
         super(netint);
@@ -162,6 +163,11 @@ public final class WindowsNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
+    public IfOperStatus getIfOperStatus() {
+        return ifOperStatus;
+    }
+
+    @Override
     public boolean updateAttributes() {
         // MIB_IFROW2 requires Vista (6.0) or later.
         if (IS_VISTA_OR_GREATER) {
@@ -187,6 +193,7 @@ public final class WindowsNetworkIF extends AbstractNetworkIF {
             this.inDrops = ifRow.InDiscards; // closest proxy
             this.speed = ifRow.ReceiveLinkSpeed;
             this.ifAlias = Native.toString(ifRow.Alias);
+            this.ifOperStatus = IfOperStatus.byValue(ifRow.OperStatus);
         } else {
             // Create new MIB_IFROW and set index to this interface index
             MIB_IFROW ifRow = new MIB_IFROW();
@@ -209,6 +216,7 @@ public final class WindowsNetworkIF extends AbstractNetworkIF {
             this.inDrops = ParseUtil.unsignedIntToLong(ifRow.dwInDiscards); // closest proxy
             this.speed = ParseUtil.unsignedIntToLong(ifRow.dwSpeed);
             this.ifAlias = ""; // not supported by MIB_IFROW
+            this.ifOperStatus = IfOperStatus.UNKNOWN; // not supported
         }
         this.timeStamp = System.currentTimeMillis();
         return true;

--- a/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
@@ -55,6 +55,7 @@ class NetworksTest {
             assertThat("NetworkIF name should not be null", net.getName(), is(notNullValue()));
             assertThat("NetworkIF display name should not be null", net.getDisplayName(), is(notNullValue()));
             assertThat("NetworkIF ifAlias should not be null", net.getIfAlias(), is(notNullValue()));
+            assertThat("NetworkIF ifOperStatus should not be null", net.getIfOperStatus(), is(notNullValue()));
             assertThat("NetworkIF IPv4 address should not be null", net.getIPv4addr(), is(notNullValue()));
             assertThat("NetworkIF SubnetMasks should not be null", net.getSubnetMasks(), is(notNullValue()));
             assertThat("NetworkIF IPv6 should not be null", net.getIPv6addr(), is(notNullValue()));
@@ -80,7 +81,7 @@ class NetworksTest {
             testUpdateAttributes(net);
 
             if (net.getMacaddr().startsWith("00:00:00") || net.getMacaddr().length() < 8) {
-                assertThat("Invalid MAC adress corresponds to a known virtual machine", net.isKnownVmMacAddr(),
+                assertThat("Invalid MAC address corresponds to a known virtual machine", net.isKnownVmMacAddr(),
                         is(false));
             }
 


### PR DESCRIPTION
Expose the `ifOperStatus` as described in [RFC 2863](https://tools.ietf.org/html/rfc2863) as `NetworkIF.getIfOperStatus()`.