### PR TITLE
Remove redundant process list calls for descendants

### DIFF
--- a/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
@@ -149,7 +149,7 @@ public final class LogicalProcessorInformation {
         // package.
         List<Long> packageMaskList = new ArrayList<>();
         List<Long> coreMaskList = new ArrayList<>();
-        WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION[] processors = Kernel32Util.getLogicalProcessorInformation();
+        WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION[] processors = com.sun.jna.platform.win32.Kernel32Util.getLogicalProcessorInformation();
         for (SYSTEM_LOGICAL_PROCESSOR_INFORMATION proc : processors) {
             if (proc.relationship == WinNT.LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorPackage) {
                 packageMaskList.add(proc.processorMask.longValue());

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -192,8 +192,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
     @Override
     public List<OSProcess> queryDescendantProcesses(int parentPid) {
         File[] pidFiles = ProcessStat.getPidFiles();
-        Set<Integer> descendantPids = getChildrenOrDescendants(getParentPidsFromProcFiles(pidFiles), parentPid, false);
-        return queryProcessList(descendantPids);
+        return queryProcessList(getChildrenOrDescendants(getParentPidsFromProcFiles(pidFiles), parentPid, true));
     }
 
     private static List<OSProcess> queryProcessList(Set<Integer> descendantPids) {

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
@@ -46,7 +46,6 @@ import com.sun.jna.platform.win32.BaseTSD.ULONG_PTRByReference;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.Kernel32Util;
 import com.sun.jna.platform.win32.VersionHelpers;
-import com.sun.jna.platform.win32.W32Errors;
 import com.sun.jna.platform.win32.Win32Exception;
 import com.sun.jna.platform.win32.WinError;
 import com.sun.jna.platform.win32.WinNT;
@@ -399,7 +398,7 @@ public class WindowsOSProcess extends AbstractOSProcess {
             throw new RuntimeException("Expected GetTokenInformation to fail with ERROR_INSUFFICIENT_BUFFER");
         }
         int rc = Kernel32.INSTANCE.GetLastError();
-        if (rc != W32Errors.ERROR_INSUFFICIENT_BUFFER) {
+        if (rc != WinError.ERROR_INSUFFICIENT_BUFFER) {
             throw new Win32Exception(rc);
         }
         // get token user information


### PR DESCRIPTION
Including the parent pid in the process list prevents an inefficient call to create it just for the process start time. Fixed other bugs and inefficiencies.