### PR TITLE
macOS doesn't provide system level context switches or interrupts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 5.6.2 (in progress)
 
-* Your contribution here!
+##### Bug fixes / Improvements
+* [#1585](https://github.com/oshi/oshi/pull/1585): macOS doesn't provide system level context switches or interrupts - [@dbwiddis](https://github.com/dbwiddis).
 
 # 5.6.0 (2021-03-01), 5.6.1 (2021-03-22)
 

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.os.OSThread;
 import oshi.util.Constants;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
@@ -222,16 +223,23 @@ public interface CentralProcessor {
     int getPhysicalPackageCount();
 
     /**
-     * Get the number of context switches which have occurred
+     * Get the number of system-wide context switches which have occurred.
+     * <p>
+     * Not available system-wide on macOS. Thread-level context switches are
+     * available from {@link OSThread#getContextSwitches()}.
      *
-     * @return The number of context switches
+     * @return The number of context switches, if this information is available; -1
+     *         otherwise.
      */
     long getContextSwitches();
 
     /**
-     * Get the number of interrupts which have occurred
+     * Get the number of system-wide interrupts which have occurred.
+     * <p>
+     * Not available system-wide on macOS.
      *
-     * @return The number of interrupts
+     * @return The number of interrupts, if this information is available; -1
+     *         otherwise.
      */
     long getInterrupts();
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -42,7 +42,6 @@ import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
 import com.sun.jna.platform.mac.IOKitUtil;
 import com.sun.jna.platform.mac.SystemB;
 import com.sun.jna.platform.mac.SystemB.HostCpuLoadInfo;
-import com.sun.jna.platform.mac.SystemB.VMMeter;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 
@@ -209,26 +208,18 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
 
     @Override
     public long queryContextSwitches() {
-        int machPort = SystemB.INSTANCE.mach_host_self();
-        VMMeter vmstats = new VMMeter();
-        if (0 != SystemB.INSTANCE.host_statistics(machPort, SystemB.HOST_VM_INFO, vmstats,
-                new IntByReference(vmstats.size()))) {
-            LOG.error("Failed to update vmstats. Error code: {}", Native.getLastError());
-            return -1;
-        }
-        return ParseUtil.unsignedIntToLong(vmstats.v_swtch);
+        // Not available on macOS since at least 10.3.9. Early versions may have
+        // provided access to the vmmeter structure using sysctl [CTL_VM, VM_METER] but
+        // it now fails (ENOENT) and there is no other reference to it in source code
+        return -1L;
     }
 
     @Override
     public long queryInterrupts() {
-        int machPort = SystemB.INSTANCE.mach_host_self();
-        VMMeter vmstats = new VMMeter();
-        if (0 != SystemB.INSTANCE.host_statistics(machPort, SystemB.HOST_VM_INFO, vmstats,
-                new IntByReference(vmstats.size()))) {
-            LOG.error("Failed to update vmstats. Error code: {}", Native.getLastError());
-            return -1;
-        }
-        return ParseUtil.unsignedIntToLong(vmstats.v_intr);
+        // Not available on macOS since at least 10.3.9. Early versions may have
+        // provided access to the vmmeter structure using sysctl [CTL_VM, VM_METER] but
+        // it now fails (ENOENT) and there is no other reference to it in source code
+        return -1L;
     }
 
     private static String platformExpert() {

--- a/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+import com.sun.jna.Platform;
+
 import oshi.SystemInfo;
 import oshi.hardware.CentralProcessor.ProcessorIdentifier;
 import oshi.hardware.CentralProcessor.TickType;
@@ -131,11 +133,17 @@ class CentralProcessorTest {
                 p.getPhysicalProcessorCount(), is(greaterThanOrEqualTo(p.getPhysicalPackageCount())));
         assertThat("Central Processor's physical package count should be higher than 0", p.getPhysicalPackageCount(),
                 is(greaterThan(0)));
-        assertThat("Central Processor's context switch count should be 0 or higher", p.getContextSwitches(),
-                is(greaterThanOrEqualTo(0L)));
-        assertThat("Central Processor's interrupt count should be 0 or higher", p.getInterrupts(),
-                is(greaterThanOrEqualTo(0L)));
-
+        if (Platform.isMac()) {
+            // these are unavailable on macOS
+            assertThat("Central Processor's context switch count should be -1 on macOS", p.getContextSwitches(),
+                    is(-1L));
+            assertThat("Central Processor's interrupt count should be -1 on macOS", p.getInterrupts(), is(-1L));
+        } else {
+            assertThat("Central Processor's context switch count should be 0 or higher", p.getContextSwitches(),
+                    is(greaterThanOrEqualTo(0L)));
+            assertThat("Central Processor's interrupt count should be 0 or higher", p.getInterrupts(),
+                    is(greaterThanOrEqualTo(0L)));
+        }
         for (int lp = 0; lp < p.getLogicalProcessorCount(); lp++) {
             assertThat("Logical processor number is negative", p.getLogicalProcessors().get(lp).getProcessorNumber(),
                     is(greaterThanOrEqualTo(0)));


### PR DESCRIPTION
Fixes #1583 (or at least doesn't return incorrect values)