### PR TITLE
Cache localized perf counter object strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug fixes / Improvements
 * [#1596](https://github.com/oshi/oshi/pull/1596): Single COM initialization for groups of queries - [@dbwiddis](https://github.com/dbwiddis).
 * [#1603](https://github.com/oshi/oshi/pull/1603): Improve performance of Windows USB device tree parsing - [@dbwiddis](https://github.com/dbwiddis).
+* [#1605](https://github.com/oshi/oshi/pull/1605): Cache localized perf counter object strings - [@dbwiddis](https://github.com/dbwiddis).
 
 # 5.7.0 (2021-04-01)
 

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
@@ -27,6 +27,7 @@ import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
@@ -55,6 +56,8 @@ public final class PerfCounterQuery {
     @GuardedBy("failedQueryCacheLock")
     private static final Set<String> failedQueryCache = new HashSet<>();
     private static final ReentrantLock failedQueryCacheLock = new ReentrantLock();
+    // Use a map to cache localization strings
+    private static final ConcurrentHashMap<String, String> localizeCache = new ConcurrentHashMap<>();
 
     /*
      * Multiple classes use these constants
@@ -208,6 +211,10 @@ public final class PerfCounterQuery {
      *         string otherwise.
      */
     public static String localize(String perfObject) {
+        return localizeCache.computeIfAbsent(perfObject, k -> localizeUsingPerfIndex(k));
+    }
+
+    private static String localizeUsingPerfIndex(String perfObject) {
         String localized = perfObject;
         try {
             localized = PdhUtil.PdhLookupPerfNameByIndex(null, PdhUtil.PdhLookupPerfIndexByEnglishName(perfObject));


### PR DESCRIPTION
Profiling identifies the largest significant non-native CPU time is associated with the localization of PDH counter strings.  The localization code is inefficient, an O(n<sup>2</sup>) process where every counter string is individually localized by querying the entire list of strings to fetch an index, which is then passed to native code to query the localized value.

These localized strings don't change so it makes sense to cache them.  It's still slightly inefficient for the first insertion but will be non-blocking O(1) lookup once the string has been initially localized.