### PR TITLE
Improve performance AbstractNetworkIF::isLocalInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [#1603](https://github.com/oshi/oshi/pull/1603): Improve performance of Windows USB device tree parsing - [@dbwiddis](https://github.com/dbwiddis).
 * [#1605](https://github.com/oshi/oshi/pull/1605): Cache localized perf counter object strings - [@dbwiddis](https://github.com/dbwiddis).
 * [#1608](https://github.com/oshi/oshi/pull/1608): LinuxOSProcess#getOpenFiles returns one more than expected - [@slaha](https://github.com/slaha).
-* [#1609](https://github.com/oshi/oshi/pull/1610): Remove redundant check for isLocalInterface - [@barddoo](https://github.com/barddoo).
+* [#1610](https://github.com/oshi/oshi/pull/1610): Remove redundant check for isLocalInterface - [@barddoo](https://github.com/barddoo).
 
 # 5.7.0 (2021-04-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#1603](https://github.com/oshi/oshi/pull/1603): Improve performance of Windows USB device tree parsing - [@dbwiddis](https://github.com/dbwiddis).
 * [#1605](https://github.com/oshi/oshi/pull/1605): Cache localized perf counter object strings - [@dbwiddis](https://github.com/dbwiddis).
 * [#1608](https://github.com/oshi/oshi/pull/1608): LinuxOSProcess#getOpenFiles returns one more than expected - [@slaha](https://github.com/slaha).
+* [#1609](https://github.com/oshi/oshi/pull/1610): Remove redundant check for isLocalInterface - [@barddoo](https://github.com/barddoo).
 
 # 5.7.0 (2021-04-01)
 

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -173,7 +173,8 @@ public abstract class AbstractNetworkIF implements NetworkIF {
 
     private static boolean isLocalInterface(NetworkInterface networkInterface) {
         try {
-            return networkInterface.isLoopback() || networkInterface.getHardwareAddress() == null;
+            // getHardwareAddress also checks for loopback
+            return networkInterface.getHardwareAddress() == null;
         } catch (SocketException e) {
             LOG.error("Socket exception when retrieving interface information for {}: {}", networkInterface,
                     e.getMessage());


### PR DESCRIPTION
Remove redundant check for isLocalInterface. JDK already [does that](https://github.com/openjdk/jdk/blob/3423f3e1f5a2120e8f761a238c2929c44957760d/src/java.base/share/classes/java/net/NetworkInterface.java#L526) so it improves performance.
This PR solves https://github.com/oshi/oshi/issues/1606