### PR TITLE
Initialization timing issue for static variable

### DIFF
--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -66,29 +66,25 @@ public class SystemInfo {
 
     // The platform isn't going to change, and making this static enables easy
     // access from outside this class
-    private static PlatformEnum currentPlatform;
+    private static final PlatformEnum currentPlatform = queryCurrentPlatform();
 
-    static {
-        initCurrentPlatform();
-    }
-
-    private static void initCurrentPlatform() {
+    private static PlatformEnum queryCurrentPlatform() {
         if (Platform.isWindows()) {
-            currentPlatform = WINDOWS;
+            return WINDOWS;
         } else if (Platform.isLinux()) {
-            currentPlatform = LINUX;
+            return LINUX;
         } else if (Platform.isMac()) {
-            currentPlatform = MACOS;
+            return MACOS;
         } else if (Platform.isSolaris()) {
-            currentPlatform = SOLARIS;
+            return SOLARIS;
         } else if (Platform.isFreeBSD()) {
-            currentPlatform = FREEBSD;
+            return FREEBSD;
         } else if (Platform.isAIX()) {
-            currentPlatform = AIX;
+            return AIX;
         } else if (Platform.isOpenBSD()) {
-            currentPlatform = OPENBSD;
+            return OPENBSD;
         } else {
-            currentPlatform = UNKNOWN;
+            return UNKNOWN;
         }
     }
 
@@ -109,9 +105,6 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
-        if (currentPlatform == null) {
-            initCurrentPlatform();
-        }
         if (getCurrentPlatform().equals(PlatformEnum.UNKNOWN)) {
             throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
         }

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -66,9 +66,13 @@ public class SystemInfo {
 
     // The platform isn't going to change, and making this static enables easy
     // access from outside this class
-    private static final PlatformEnum currentPlatform;
+    private static PlatformEnum currentPlatform;
 
     static {
+        initCurrentPlatform();
+    }
+
+    private static void initCurrentPlatform() {
         if (Platform.isWindows()) {
             currentPlatform = WINDOWS;
         } else if (Platform.isLinux()) {
@@ -105,6 +109,9 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
+        if (currentPlatform == null) {
+            initCurrentPlatform();
+        }
         if (getCurrentPlatform().equals(PlatformEnum.UNKNOWN)) {
             throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
         }


### PR DESCRIPTION
currentPlatform variable initialized in static block of this class.
But it's also accessed via constructor for validate unsupported environment.
This variable possible not initialized yet when access make a instance use constructor.
I'm already met this kind of issue when I run unit test use this library.
I think one more variable init checking required, at least If constructor want to check unsupported or not.