### PR TITLE
FreeBSD process listing results in "keyword not found" errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 5.7.6 (in progress)
 
-* Your contribution here.
+##### Bug fixes / Improvements
+* [#1673](https://github.com/oshi/oshi/pull/1673): Fix FreeBSD ps command arguments for context switches. [@basil](https://github.com/basil)
 
 # 5.7.0 (2021-04-01), 5.7.1 (2021-04-15), 5.7.2 (2021-05-01), 5.7.3 (2021-05-16), 5.7.4 (2021-05-30), 5.7.5 (2021-06-12)
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
@@ -281,10 +281,7 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
     @Override
     public boolean updateAttributes() {
         String psCommand =
-                "ps -awwxo "
-                        + String.join(",", FreeBsdOperatingSystem.PS_KEYWORDS)
-                        + " -p "
-                        + getProcessID();
+                "ps -awwxo " + FreeBsdOperatingSystem.PS_KEYWORD_ARGS + " -p " + getProcessID();
         List<String> procList = ExecutingCommand.runNative(psCommand);
         if (procList.size() > 1) {
             // skip header row
@@ -344,7 +341,10 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
         this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
         this.minorFaults = ParseUtil.parseLongOrDefault(split[15], 0L);
         this.majorFaults = ParseUtil.parseLongOrDefault(split[16], 0L);
-        this.commandLine = split[17];
+        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(split[17], 0L);
+        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(split[18], 0L);
+        this.contextSwitches = voluntaryContextSwitches + nonVoluntaryContextSwitches;
+        this.commandLine = split[19];
         return true;
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
@@ -280,13 +280,18 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
 
     @Override
     public boolean updateAttributes() {
-        String psCommand = "ps -awwxo state,pid,ppid,user,uid,group,gid,nlwp,pri,vsz,rss,etimes,systime,time,comm,majflt,minflt,args -p "
-                + getProcessID();
+        String psCommand =
+                "ps -awwxo "
+                        + String.join(",", FreeBsdOperatingSystem.PS_KEYWORDS)
+                        + " -p "
+                        + getProcessID();
         List<String> procList = ExecutingCommand.runNative(psCommand);
         if (procList.size() > 1) {
             // skip header row
-            String[] split = ParseUtil.whitespaces.split(procList.get(1).trim(), 18);
-            if (split.length == 18) {
+            String[] split =
+                    ParseUtil.whitespaces.split(
+                            procList.get(1).trim(), FreeBsdOperatingSystem.PS_KEYWORDS.size());
+            if (split.length == FreeBsdOperatingSystem.PS_KEYWORDS.size()) {
                 return updateAttributes(split);
             }
         }
@@ -339,10 +344,7 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
         this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
         this.minorFaults = ParseUtil.parseLongOrDefault(split[15], 0L);
         this.majorFaults = ParseUtil.parseLongOrDefault(split[16], 0L);
-        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(split[17], 0L);
-        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(split[18], 0L);
-        this.contextSwitches = voluntaryContextSwitches + nonVoluntaryContextSwitches;
-        this.commandLine = split[19];
+        this.commandLine = split[17];
         return true;
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -76,7 +76,9 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
                     Arrays.asList(
                             "state", "pid", "ppid", "user", "uid", "group", "gid", "nlwp", "pri",
                             "vsz", "rss", "etimes", "systime", "time", "comm", "majflt", "minflt",
-                            "args"));
+                            "nvcsw", "nivcsw", "args"));
+
+    static final String PS_KEYWORD_ARGS = String.join(",", PS_KEYWORDS);
 
     @Override
     public String queryManufacturer() {
@@ -147,7 +149,7 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
 
     private static List<OSProcess> getProcessListFromPS(int pid) {
         List<OSProcess> procs = new ArrayList<>();
-        String psCommand = "ps -awwxo " + String.join(",", PS_KEYWORDS);
+        String psCommand = "ps -awwxo " + PS_KEYWORD_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
         }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -28,6 +28,8 @@ import static oshi.software.os.OSService.State.STOPPED;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -65,6 +67,16 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(FreeBsdOperatingSystem.class);
 
     private static final long BOOTTIME = querySystemBootTime();
+
+    /*
+     * Package-private for use by FreeBsdOSProcess
+     */
+    static final List<String> PS_KEYWORDS =
+            Collections.unmodifiableList(
+                    Arrays.asList(
+                            "state", "pid", "ppid", "user", "uid", "group", "gid", "nlwp", "pri",
+                            "vsz", "rss", "etimes", "systime", "time", "comm", "majflt", "minflt",
+                            "args"));
 
     @Override
     public String queryManufacturer() {
@@ -135,7 +147,7 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
 
     private static List<OSProcess> getProcessListFromPS(int pid) {
         List<OSProcess> procs = new ArrayList<>();
-        String psCommand = "ps -awwxo state,pid,ppid,user,uid,group,gid,nlwp,pri,vsz,rss,etimes,systime,time,comm,majflt,minflt,nvscw,nivscw,args";
+        String psCommand = "ps -awwxo " + String.join(",", PS_KEYWORDS);
         if (pid >= 0) {
             psCommand += " -p " + pid;
         }
@@ -147,9 +159,9 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
         procList.remove(0);
         // Fill list
         for (String proc : procList) {
-            String[] split = ParseUtil.whitespaces.split(proc.trim(), 20);
+            String[] split = ParseUtil.whitespaces.split(proc.trim(), PS_KEYWORDS.size());
             // Elements should match ps command order
-            if (split.length == 20) {
+            if (split.length == PS_KEYWORDS.size()) {
                 procs.add(new FreeBsdOSProcess(pid < 0 ? ParseUtil.parseIntOrDefault(split[1], 0) : pid, split));
             }
         }


### PR DESCRIPTION
While testing FreeBSD support in a separate PR, I noticed that some processes weren't getting listed. Debugging it further, I found that `ps(1)` was printing the following:

```bash
$ uname -a
FreeBSD freebsd 13.0-RELEASE FreeBSD 13.0-RELEASE #0 releng/13.0-n244733-ea31abc261f: Fri Apr  9 04:24:09 UTC 2021     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC  amd64
$ ps -awwxo state,pid,ppid,user,uid,group,gid,nlwp,pri,vsz,rss,etimes,systime,time,comm,majflt,minflt,nvscw,nivscw,args
ps: nvscw: keyword not found
ps: nivscw: keyword not found
STAT  PID PPID USER        UID GROUP       GID NLWP PRI     VSZ   RSS ELAPSED   SYSTIME      TIME COMMAND            MAJFLT MINFLT COMMAND
DLs     0    0 root          0 wheel         0  368 -16       0  5888    2667   0:10.32   0:10.32 kernel                  0      0 [kernel]
[…]
$
```

Despite the fact that those keywords are listed in the man page, they don't appear to work (at least not on FreeBSD 13.0).

Another problem I noticed was that the list of `ps(1)` keywords was duplicated in OSHI: once in `FreeBsdOperatingSystem` and again in `FreeBsdOSProcess`. The former used 20 arguments, including the broken `nvscw` and `nivscw`. The latter used 18 arguments, excluding `nvscw` and `nivscw`. Yet both passed the result of the `ps(1)` invocation to `reeBsdOSProcess#updateAttributes(java.lang.String[])`, which seemed broken.

I made the two classes consistent with each other by consolidating the list of `ps(1)` keywords into a single 18-element list that is shared by both classes. The list doesn't contain the problematic keywords. Yes, this means that `getContextSwitches()` will always return 0, but this seems to have been broken even before this PR, and FreeBSD's `getBytesRead()` and `getBytesWritten()` are also broken in this manner today, so I doubt this will be a big problem. And at least this fixes my original problem: now I can get a listing of all processes on the system. I tested this on FreeBSD 13.0 and it resolved my original issue.