### PR TITLE
Fix leaking udev reference in LinuxUsbDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##### Bug fixes / Improvements
 * [#1673](https://github.com/oshi/oshi/pull/1673): Fix FreeBSD ps command arguments for context switches. [@basil](https://github.com/basil)
+* [#1678](https://github.com/oshi/oshi/pull/1678): Refactor to fix leaking udev reference in LinuxUsbDevice - [@mattmacleod](https://github.com/mattmacleod)
 
 # 5.7.0 (2021-04-01), 5.7.1 (2021-04-15), 5.7.2 (2021-05-01), 5.7.3 (2021-05-16), 5.7.4 (2021-05-30), 5.7.5 (2021-06-12)
 


### PR DESCRIPTION
This change fixes a leaking device reference in the Linux USB device implementation. When an interface device is encountered (i.e. devtype is "usb_device") the rest of the loop was skipped and the allocated device would never be unreferenced. This change adds an additional explicit unreference in this case.

This was the underlying leak causing the issue reported by @botto in #1670