### PR TITLE
Move supported operating system check out of SystemInfo constructor

### DIFF
--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -66,29 +66,25 @@ public class SystemInfo {
 
     // The platform isn't going to change, and making this static enables easy
     // access from outside this class
-    private static PlatformEnum currentPlatform;
+    private static final PlatformEnum currentPlatform = queryCurrentPlatform();
 
-    static {
-        initCurrentPlatform();
-    }
-
-    private static void initCurrentPlatform() {
+    private static PlatformEnum queryCurrentPlatform() {
         if (Platform.isWindows()) {
-            currentPlatform = WINDOWS;
+            return WINDOWS;
         } else if (Platform.isLinux()) {
-            currentPlatform = LINUX;
+            return LINUX;
         } else if (Platform.isMac()) {
-            currentPlatform = MACOS;
+            return MACOS;
         } else if (Platform.isSolaris()) {
-            currentPlatform = SOLARIS;
+            return SOLARIS;
         } else if (Platform.isFreeBSD()) {
-            currentPlatform = FREEBSD;
+            return FREEBSD;
         } else if (Platform.isAIX()) {
-            currentPlatform = AIX;
+            return AIX;
         } else if (Platform.isOpenBSD()) {
-            currentPlatform = OPENBSD;
+            return OPENBSD;
         } else {
-            currentPlatform = UNKNOWN;
+            return UNKNOWN;
         }
     }
 
@@ -109,9 +105,6 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
-        if (currentPlatform == null) {
-            initCurrentPlatform();
-        }
         if (getCurrentPlatform().equals(PlatformEnum.UNKNOWN)) {
             throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
         }

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -105,6 +105,9 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
+        // Intentionally empty, here to enable the constructor javadoc.
+        // Trying to access the static currentPlatform variable for OS check caused
+        // unexplained problems with initialization.
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -66,25 +66,25 @@ public class SystemInfo {
 
     // The platform isn't going to change, and making this static enables easy
     // access from outside this class
-    private static final PlatformEnum currentPlatform = queryCurrentPlatform();
+    private static final PlatformEnum currentPlatform;
 
-    private static PlatformEnum queryCurrentPlatform() {
+    static {
         if (Platform.isWindows()) {
-            return WINDOWS;
+            currentPlatform = WINDOWS;
         } else if (Platform.isLinux()) {
-            return LINUX;
+            currentPlatform = LINUX;
         } else if (Platform.isMac()) {
-            return MACOS;
+            currentPlatform = MACOS;
         } else if (Platform.isSolaris()) {
-            return SOLARIS;
+            currentPlatform = SOLARIS;
         } else if (Platform.isFreeBSD()) {
-            return FREEBSD;
+            currentPlatform = FREEBSD;
         } else if (Platform.isAIX()) {
-            return AIX;
+            currentPlatform = AIX;
         } else if (Platform.isOpenBSD()) {
-            return OPENBSD;
+            currentPlatform = OPENBSD;
         } else {
-            return UNKNOWN;
+            currentPlatform = UNKNOWN;
         }
     }
 
@@ -105,8 +105,26 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
-        if (getCurrentPlatform().equals(PlatformEnum.UNKNOWN)) {
+        if (!isKnownPlatform()) {
             throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
+        }
+    }
+
+    private boolean isKnownPlatform() {
+        if (Platform.isWindows()) {
+            return true;
+        } else if (Platform.isLinux()) {
+            return true;
+        } else if (Platform.isMac()) {
+            return true;
+        } else if (Platform.isSolaris()) {
+            return true;
+        } else if (Platform.isFreeBSD()) {
+            return true;
+        } else if (Platform.isAIX()) {
+            return true;
+        } else {
+            return Platform.isOpenBSD();
         }
     }
 

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -66,9 +66,13 @@ public class SystemInfo {
 
     // The platform isn't going to change, and making this static enables easy
     // access from outside this class
-    private static final PlatformEnum currentPlatform;
+    private static PlatformEnum currentPlatform;
 
     static {
+        initCurrentPlatform();
+    }
+
+    private static void initCurrentPlatform() {
         if (Platform.isWindows()) {
             currentPlatform = WINDOWS;
         } else if (Platform.isLinux()) {
@@ -105,6 +109,9 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
+        if (currentPlatform == null) {
+            initCurrentPlatform();
+        }
         if (getCurrentPlatform().equals(PlatformEnum.UNKNOWN)) {
             throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
         }

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -105,27 +105,6 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
-        if (!isKnownPlatform()) {
-            throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
-        }
-    }
-
-    private boolean isKnownPlatform() {
-        if (Platform.isWindows()) {
-            return true;
-        } else if (Platform.isLinux()) {
-            return true;
-        } else if (Platform.isMac()) {
-            return true;
-        } else if (Platform.isSolaris()) {
-            return true;
-        } else if (Platform.isFreeBSD()) {
-            return true;
-        } else if (Platform.isAIX()) {
-            return true;
-        } else {
-            return Platform.isOpenBSD();
-        }
     }
 
     /**
@@ -176,7 +155,7 @@ public class SystemInfo {
         case OPENBSD:
             return new OpenBsdOperatingSystem();
         default:
-            return null;
+            throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
         }
     }
 
@@ -207,7 +186,7 @@ public class SystemInfo {
         case OPENBSD:
             return new OpenBsdHardwareAbstractionLayer();
         default:
-            return null;
+            throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
         }
     }
 }


### PR DESCRIPTION
#1671 not worked for me.
Run CI with snapshot version but I saw same error message below.
```
[ERROR] display as string  Time elapsed: 0.016 s  <<< ERROR!
java.lang.UnsupportedOperationException: Operating system not supported: JNA Platform type 2
Caused by: java.lang.UnsupportedOperationException: Operating system not supported: JNA Platform type 2
```
JNA could recognize current os in static block when failed on a constructor of SystemInfo class.
So I tried check unknown environment by JNA method instead of OSHI. At the result my CI passed successfully.
I'm not sure what is exact reason. But I just think that JNA and OSHI depends on many static initialization and it's make not easy to assume proper working.

In my opinion, static blocks and variables should be minimized.
But if OSHI have important reason to check unsupported environment in constructor this MR need to approved.

There is remained riddle why OSHI's static variable and JNA static method result don't have consistency.
Anyway, This change working for me.
Please consider enough.