### PR TITLE
Revert "Bump doxia-module-markdown from 1.9.1 to 1.10"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <!-- maven-site-plugin dependencies -->
-        <doxia-module-markdown.version>1.10</doxia-module-markdown.version>
+        <doxia-module-markdown.version>1.9.1</doxia-module-markdown.version>
         <wagon-git.version>2.0.3</wagon-git.version><!-- https://github.com/trajano/wagon-git/issues/18 -->
         <wagon-ssh.version>3.4.3</wagon-ssh.version>
         <maven-fluido-skin.version>1.9</maven-fluido-skin.version>


### PR DESCRIPTION
Reverts oshi/oshi#1672

Getting this error trying to release:

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.9.1:site (default-site) on project oshi-parent: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.9.1:site failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-site-plugin:3.9.1:site: java.lang.AbstractMethodError: Receiver class org.apache.maven.doxia.module.markdown.MarkdownParser does not define or inherit an implementation of the resolved method 'abstract void parse(java.io.Reader, org.apache.maven.doxia.sink.Sink)' of interface org.apache.maven.doxia.parser.Parser.
>     [ERROR] -----------------------------------------------------
>     [ERROR] realm =    plugin>org.apache.maven.plugins:maven-site-plugin:3.9.1
>     [ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
>     [ERROR] urls[0] = file:/Users/danielwiddis/.m2/repository/org/apache/maven/plugins/maven-site-plugin/3.9.1/maven-site-plugin-3.9.1.jar
>     [ERROR] urls[1] = file:/Users/danielwiddis/.m2/repository/org/apache/maven/doxia/doxia-module-markdown/1.10/doxia-module-markdown-1.10.jar
>     [ERROR] urls[2] = file:/Users/danielwiddis/.m2/repository/com/vladsch/flexmark/flexmark-all/0.42.14/flexmark-all-0.42.14.jar
>     [ERROR] urls[3] = file:/Users/danielwiddis/.m2/repository/com/vladsch/flexmark/flexmark/0.42.14/flexmark-0.42.14.jar