### PR TITLE
Initialize static variable from static method instead of static block - rollback

### DIFF
--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -143,22 +143,22 @@ public class SystemInfo {
 
     private static OperatingSystem createOperatingSystem() {
         switch (currentPlatform) {
-            case WINDOWS:
-                return new WindowsOperatingSystem();
-            case LINUX:
-                return new LinuxOperatingSystem();
-            case MACOS:
-                return new MacOperatingSystem();
-            case SOLARIS:
-                return new SolarisOperatingSystem();
-            case FREEBSD:
-                return new FreeBsdOperatingSystem();
-            case AIX:
-                return new AixOperatingSystem();
-            case OPENBSD:
-                return new OpenBsdOperatingSystem();
-            default:
-                return null;
+        case WINDOWS:
+            return new WindowsOperatingSystem();
+        case LINUX:
+            return new LinuxOperatingSystem();
+        case MACOS:
+            return new MacOperatingSystem();
+        case SOLARIS:
+            return new SolarisOperatingSystem();
+        case FREEBSD:
+            return new FreeBsdOperatingSystem();
+        case AIX:
+            return new AixOperatingSystem();
+        case OPENBSD:
+            return new OpenBsdOperatingSystem();
+        default:
+            return null;
         }
     }
 
@@ -174,22 +174,22 @@ public class SystemInfo {
 
     private static HardwareAbstractionLayer createHardware() {
         switch (currentPlatform) {
-            case WINDOWS:
-                return new WindowsHardwareAbstractionLayer();
-            case LINUX:
-                return new LinuxHardwareAbstractionLayer();
-            case MACOS:
-                return new MacHardwareAbstractionLayer();
-            case SOLARIS:
-                return new SolarisHardwareAbstractionLayer();
-            case FREEBSD:
-                return new FreeBsdHardwareAbstractionLayer();
-            case AIX:
-                return new AixHardwareAbstractionLayer();
-            case OPENBSD:
-                return new OpenBsdHardwareAbstractionLayer();
-            default:
-                return null;
+        case WINDOWS:
+            return new WindowsHardwareAbstractionLayer();
+        case LINUX:
+            return new LinuxHardwareAbstractionLayer();
+        case MACOS:
+            return new MacHardwareAbstractionLayer();
+        case SOLARIS:
+            return new SolarisHardwareAbstractionLayer();
+        case FREEBSD:
+            return new FreeBsdHardwareAbstractionLayer();
+        case AIX:
+            return new AixHardwareAbstractionLayer();
+        case OPENBSD:
+            return new OpenBsdHardwareAbstractionLayer();
+        default:
+            return null;
         }
     }
 }

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -66,29 +66,25 @@ public class SystemInfo {
 
     // The platform isn't going to change, and making this static enables easy
     // access from outside this class
-    private static PlatformEnum currentPlatform;
+    private static final PlatformEnum currentPlatform = queryCurrentPlatform();
 
-    static {
-        initCurrentPlatform();
-    }
-
-    private static void initCurrentPlatform() {
+    private static PlatformEnum queryCurrentPlatform() {
         if (Platform.isWindows()) {
-            currentPlatform = WINDOWS;
+            return WINDOWS;
         } else if (Platform.isLinux()) {
-            currentPlatform = LINUX;
+            return LINUX;
         } else if (Platform.isMac()) {
-            currentPlatform = MACOS;
+            return MACOS;
         } else if (Platform.isSolaris()) {
-            currentPlatform = SOLARIS;
+            return SOLARIS;
         } else if (Platform.isFreeBSD()) {
-            currentPlatform = FREEBSD;
+            return FREEBSD;
         } else if (Platform.isAIX()) {
-            currentPlatform = AIX;
+            return AIX;
         } else if (Platform.isOpenBSD()) {
-            currentPlatform = OPENBSD;
+            return OPENBSD;
         } else {
-            currentPlatform = UNKNOWN;
+            return UNKNOWN;
         }
     }
 
@@ -109,9 +105,6 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
-        if (currentPlatform == null) {
-            initCurrentPlatform();
-        }
         if (getCurrentPlatform().equals(PlatformEnum.UNKNOWN)) {
             throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
         }

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -105,9 +105,9 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
-        // Intentionally empty, here to enable the constructor javadoc.
-        // Trying to access the static currentPlatform variable for OS check caused
-        // unexplained problems with initialization.
+        if (getCurrentPlatform() == PlatformEnum.UNKNOWN) {
+            throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
+        }
     }
 
     /**
@@ -128,7 +128,7 @@ public class SystemInfo {
     @Deprecated
     public static PlatformEnum getCurrentPlatformEnum() {
         PlatformEnum platform = getCurrentPlatform();
-        return platform.equals(MACOS) ? MACOSX : platform;
+        return platform == MACOS ? MACOSX : platform;
     }
 
     /**
@@ -143,22 +143,22 @@ public class SystemInfo {
 
     private static OperatingSystem createOperatingSystem() {
         switch (currentPlatform) {
-        case WINDOWS:
-            return new WindowsOperatingSystem();
-        case LINUX:
-            return new LinuxOperatingSystem();
-        case MACOS:
-            return new MacOperatingSystem();
-        case SOLARIS:
-            return new SolarisOperatingSystem();
-        case FREEBSD:
-            return new FreeBsdOperatingSystem();
-        case AIX:
-            return new AixOperatingSystem();
-        case OPENBSD:
-            return new OpenBsdOperatingSystem();
-        default:
-            throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
+            case WINDOWS:
+                return new WindowsOperatingSystem();
+            case LINUX:
+                return new LinuxOperatingSystem();
+            case MACOS:
+                return new MacOperatingSystem();
+            case SOLARIS:
+                return new SolarisOperatingSystem();
+            case FREEBSD:
+                return new FreeBsdOperatingSystem();
+            case AIX:
+                return new AixOperatingSystem();
+            case OPENBSD:
+                return new OpenBsdOperatingSystem();
+            default:
+                return null;
         }
     }
 
@@ -174,22 +174,22 @@ public class SystemInfo {
 
     private static HardwareAbstractionLayer createHardware() {
         switch (currentPlatform) {
-        case WINDOWS:
-            return new WindowsHardwareAbstractionLayer();
-        case LINUX:
-            return new LinuxHardwareAbstractionLayer();
-        case MACOS:
-            return new MacHardwareAbstractionLayer();
-        case SOLARIS:
-            return new SolarisHardwareAbstractionLayer();
-        case FREEBSD:
-            return new FreeBsdHardwareAbstractionLayer();
-        case AIX:
-            return new AixHardwareAbstractionLayer();
-        case OPENBSD:
-            return new OpenBsdHardwareAbstractionLayer();
-        default:
-            throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
+            case WINDOWS:
+                return new WindowsHardwareAbstractionLayer();
+            case LINUX:
+                return new LinuxHardwareAbstractionLayer();
+            case MACOS:
+                return new MacHardwareAbstractionLayer();
+            case SOLARIS:
+                return new SolarisHardwareAbstractionLayer();
+            case FREEBSD:
+                return new FreeBsdHardwareAbstractionLayer();
+            case AIX:
+                return new AixHardwareAbstractionLayer();
+            case OPENBSD:
+                return new OpenBsdHardwareAbstractionLayer();
+            default:
+                return null;
         }
     }
 }

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -105,6 +105,9 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
+        // Intentionally empty, here to enable the constructor javadoc.
+        // Trying to access the static currentPlatform variable for OS check caused
+        // unexplained problems with initialization.
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -66,25 +66,25 @@ public class SystemInfo {
 
     // The platform isn't going to change, and making this static enables easy
     // access from outside this class
-    private static final PlatformEnum currentPlatform = queryCurrentPlatform();
+    private static final PlatformEnum currentPlatform;
 
-    private static PlatformEnum queryCurrentPlatform() {
+    static {
         if (Platform.isWindows()) {
-            return WINDOWS;
+            currentPlatform = WINDOWS;
         } else if (Platform.isLinux()) {
-            return LINUX;
+            currentPlatform = LINUX;
         } else if (Platform.isMac()) {
-            return MACOS;
+            currentPlatform = MACOS;
         } else if (Platform.isSolaris()) {
-            return SOLARIS;
+            currentPlatform = SOLARIS;
         } else if (Platform.isFreeBSD()) {
-            return FREEBSD;
+            currentPlatform = FREEBSD;
         } else if (Platform.isAIX()) {
-            return AIX;
+            currentPlatform = AIX;
         } else if (Platform.isOpenBSD()) {
-            return OPENBSD;
+            currentPlatform = OPENBSD;
         } else {
-            return UNKNOWN;
+            currentPlatform = UNKNOWN;
         }
     }
 
@@ -105,8 +105,26 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
-        if (getCurrentPlatform().equals(PlatformEnum.UNKNOWN)) {
+        if (!isKnownPlatform()) {
             throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
+        }
+    }
+
+    private boolean isKnownPlatform() {
+        if (Platform.isWindows()) {
+            return true;
+        } else if (Platform.isLinux()) {
+            return true;
+        } else if (Platform.isMac()) {
+            return true;
+        } else if (Platform.isSolaris()) {
+            return true;
+        } else if (Platform.isFreeBSD()) {
+            return true;
+        } else if (Platform.isAIX()) {
+            return true;
+        } else {
+            return Platform.isOpenBSD();
         }
     }
 

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -66,9 +66,13 @@ public class SystemInfo {
 
     // The platform isn't going to change, and making this static enables easy
     // access from outside this class
-    private static final PlatformEnum currentPlatform;
+    private static PlatformEnum currentPlatform;
 
     static {
+        initCurrentPlatform();
+    }
+
+    private static void initCurrentPlatform() {
         if (Platform.isWindows()) {
             currentPlatform = WINDOWS;
         } else if (Platform.isLinux()) {
@@ -105,6 +109,9 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
+        if (currentPlatform == null) {
+            initCurrentPlatform();
+        }
         if (getCurrentPlatform().equals(PlatformEnum.UNKNOWN)) {
             throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
         }

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -105,27 +105,6 @@ public class SystemInfo {
      * {@link SystemInfo} object for future queries.
      */
     public SystemInfo() {
-        if (!isKnownPlatform()) {
-            throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
-        }
-    }
-
-    private boolean isKnownPlatform() {
-        if (Platform.isWindows()) {
-            return true;
-        } else if (Platform.isLinux()) {
-            return true;
-        } else if (Platform.isMac()) {
-            return true;
-        } else if (Platform.isSolaris()) {
-            return true;
-        } else if (Platform.isFreeBSD()) {
-            return true;
-        } else if (Platform.isAIX()) {
-            return true;
-        } else {
-            return Platform.isOpenBSD();
-        }
     }
 
     /**
@@ -176,7 +155,7 @@ public class SystemInfo {
         case OPENBSD:
             return new OpenBsdOperatingSystem();
         default:
-            return null;
+            throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
         }
     }
 
@@ -207,7 +186,7 @@ public class SystemInfo {
         case OPENBSD:
             return new OpenBsdHardwareAbstractionLayer();
         default:
-            return null;
+            throw new UnsupportedOperationException(NOT_SUPPORTED + Platform.getOSType());
         }
     }
 }


### PR DESCRIPTION
@dbwiddis I'm so sorry. It's my fault.
Before some day, I wrote some unit test for unsupported environment as blow for ensure unsupported platform.
At that time this class didn't have check logic.
```java
ReflectionUtil.setFinalFieldValue(
  SystemInfo::class.java,
  SystemInfo::class.java.getDeclaredField("currentPlatform"),
  PlatformEnum.UNKNOWN
)
OSCompatibleCentralProcessor.getProcessorIfPossible() shouldBe null
```
I should have been recovered currentPlatform forcibly before.
After remove above code, everything worked expectedly.
This MR just include rollback to before.

I appreciate you hear my opinion although my mistake.
And I want say again sorry for my mistake.