### PR TITLE
removed deprecated process sorting methods from OperatingSystem class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 5.8.3 (in progress)
+# 6.0.0 (in progress)
 
-* Your contribution here
+##### Breaking Changes
+* [#1725](https://github.com/oshi/oshi/pull/1725): Removed deprecated process sorting methods from the OperatingSystem class - [@varnaa](https://github.com/varnaa).
 
 # 5.8.0 (2021-07-18), 5.8.1 (2021-08-22), 5.8.2 (2021-09-05)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,11 @@
+# Guide to upgrading from OSHI 5.x to 6.x
+
+## API Changes
+
+### Deprecated method removal
+
+The deprecated methods `getProcesses(int limit, ProcessSort sort)`, `getChildProcesses(int parentPid, int limit, ProcessSort sort)`, and the enum `ProcessSort` were removed, replaced by methods leveraging constants in the `ProcessSorting` class.
+
 # Guide to upgrading from OSHI 4.x to 5.x
 
 OSHI 5.0.0-5.1.2 releases are functionally equivalent to 4.7.0-4.8.2 releases,
@@ -67,7 +75,7 @@ as proof-of-concept only, and are not intended for production use.
 `NetworkIF#getNetworkInterface()` is now `queryNetworkInterface()` to prevent
 Jackson's ObjectMapper from attempting to serialize the returned object.
 
-There is a new `VirtualMemory `class which is accessible with a getter from 
+There is a new `VirtualMemory `class which is accessible with a getter from
 `GlobalMemory`.  Methods associated with swap file usage were moved to this
 new class.
 
@@ -76,9 +84,9 @@ The `CentralProcessor` setters were removed from the API. The methods
 an argument with the previous set of ticks, rather than internally saving the
 previous call. This enables users to measure over a longer period or multiple
 different periods.  The `getSystemCpuLoad()` method has been removed; users
-running the Oracle JVM should use the  `OperatingSystemMXBean` method if 
-they desire this value.  The no-argument `getSystemLoadAverage()` has been 
-removed; users can call with an argument of 1 to obtain the same value. 
+running the Oracle JVM should use the  `OperatingSystemMXBean` method if
+they desire this value.  The no-argument `getSystemLoadAverage()` has been
+removed; users can call with an argument of 1 to obtain the same value.
 
 The `getSystemUptime()` method was moved from the `CentralProcessor` class to
 the `OperatingSystem` class.
@@ -92,12 +100,12 @@ to permit update of individual elements of arrays.
 The most significant change in OSHI 3.0 is the separation of JSON output to a
 separate artifact, filtering output using configurable properties. Users of
 `oshi-core` who do not require JSON will find most of the API the same except
-as noted below.  Those who use JSON will find improved functionality in the 
+as noted below.  Those who use JSON will find improved functionality in the
 `oshi-json` module.
 
 ## API Changes - oshi-core
 
-The `CentralProcessor`'s `getSystemIOWaitTicks()` and `getSystemIrqTicks()` 
+The `CentralProcessor`'s `getSystemIOWaitTicks()` and `getSystemIrqTicks()`
 methods were removed. The `getSystemCpuLoadTicks()` now include the IOWait and
 IRQ tick information previously reported by those methods, although Idle time
 no longer includes IOWait, and System Time no longer includes IRQ ticks. The
@@ -134,9 +142,9 @@ JSON objects associated with the above method changes were updated:
  been removed from the `processor` object.
  - `fileSystem` is now an element of `operatingSystem` rather than `processor`.
  - `fileStores` is now an element of `fileSystem` rather than `processor`.
- - `processID`, `processCount`, `threadCount`, and `processes` are now 
+ - `processID`, `processCount`, `threadCount`, and `processes` are now
  elements of `operatingSystem` rather than `processor`.
- 
+
 While the existing `toJSON()` method remains and is backwards compatible, the
 new API permits using a `java.util.Properties` object as an optional parameter
 which will be persistent to future (no argument) calls to that method until
@@ -156,7 +164,7 @@ New packages `oshi.jna.platform.*` were created and code which extends
 classes should be considered non-API as they may be removed if/when their
 code is incorporated into the JNA project.
 
-New packages `oshi.hardware.platform.*` were created and contain the 
+New packages `oshi.hardware.platform.*` were created and contain the
 platform-specific implementations of interfaces in `oshi.hardware`, with
 implementing classes renamed to prepend the platform name to the interface
 name.  Similar renaming was done for implementations of `oshi.software.os`
@@ -170,15 +178,15 @@ JNA's `Memory` class.
 The `Processor` interface, which represented one of an array of logical
 processor objects, was renamed `CentralProcessor` and represents the entire
 System CPU which may contain multiple logical processors.  Methods applicable
-to an individual logical processor were modified to return arrays.  
+to an individual logical processor were modified to return arrays.
 
 The `HardwareAbstractionLayer`'s `getProcessors()` method was renamed to
 `getProcessor()` and now returns a singular `CentralProcessor` object.
 
 Specific changes to `CentralProcessor` methods:
-* The constructor no longer takes a processor number argument and the 
+* The constructor no longer takes a processor number argument and the
 `getProcessorNumber()` method was removed
-* The deprecated `getLoad()` method was removed. Use 
+* The deprecated `getLoad()` method was removed. Use
 `getSystemCpuLoadBetweenTicks()`.
 * The `getProcessorCpuLoadBetweenTicks()` method now returns an array of
 load values, one value for each logical processor.

--- a/oshi-core/src/main/java/oshi/software/os/OperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/OperatingSystem.java
@@ -52,16 +52,6 @@ import oshi.util.Util;
 public interface OperatingSystem {
 
     /**
-     * Controls sorting of Process lists.
-     *
-     * @deprecated Use comparators from {@link ProcessSorting}.
-     */
-    @Deprecated
-    enum ProcessSort {
-        CPU, MEMORY, OLDEST, NEWEST, PID, PARENTPID, NAME
-    }
-
-    /**
      * Constants which may be used to filter Process lists in
      * {@link #getProcesses(Predicate, Comparator, int)},
      * {@link #getChildProcesses(int, Predicate, Comparator, int)}, and
@@ -139,41 +129,6 @@ public interface OperatingSystem {
          */
         public static final Comparator<OSProcess> NAME_ASC = Comparator.comparing(OSProcess::getName,
                 String.CASE_INSENSITIVE_ORDER);
-
-        /**
-         * Temporary method to convert deprecated ProcessSort to its corresponding
-         * comparator. Remove when the deprecated enum is removed.
-         *
-         * @param sort
-         *            The process sort
-         * @return The corresponding comparator
-         */
-        private static Comparator<OSProcess> convertSortToComparator(ProcessSort sort) {
-            if (sort != null) {
-                switch (sort) {
-                case CPU:
-                    return CPU_DESC;
-                case MEMORY:
-                    return RSS_DESC;
-                case OLDEST:
-                    return UPTIME_DESC;
-                case NEWEST:
-                    return UPTIME_ASC;
-                case PID:
-                    return PID_ASC;
-                case PARENTPID:
-                    return PARENTPID_ASC;
-                case NAME:
-                    return NAME_ASC;
-                default:
-                    // Should never get here! If you get this exception you've
-                    // added something to the enum without adding it here. Tsk.
-                    // But that enum is now deprecated so double-tsk if you add!
-                    throw new IllegalArgumentException("Unimplemented enum type: " + sort.toString());
-                }
-            }
-            return NO_SORTING;
-        }
     }
 
     /**
@@ -248,30 +203,6 @@ public interface OperatingSystem {
     List<OSProcess> getProcesses(Predicate<OSProcess> filter, Comparator<OSProcess> sort, int limit);
 
     /**
-     * Gets currently running processes, optionally limited to the top "N" for a
-     * particular sorting order. If a positive limit is specified, returns only that
-     * number of processes; zero will return all processes. The order may be
-     * specified by the sort parameter, for example, to return the top cpu or memory
-     * consuming processes; if the sort is {@code null}, no order is guaranteed.
-     *
-     * @param limit
-     *            Max number of results to return, or 0 to return all results
-     * @param sort
-     *            If not null, determines sorting of results
-     * @return A list of {@link oshi.software.os.OSProcess} objects for the
-     *         specified number (or all) of currently running processes, sorted as
-     *         specified. The list may contain null elements or processes with a
-     *         state of {@link OSProcess.State#INVALID} if a process terminates
-     *         during iteration.
-     * @deprecated Use {@link #getProcesses(Predicate, Comparator, int)} with
-     *             sorting constants from {@link ProcessSorting}.
-     */
-    @Deprecated
-    default List<OSProcess> getProcesses(int limit, ProcessSort sort) {
-        return getProcesses(null, ProcessSorting.convertSortToComparator(sort), limit);
-    }
-
-    /**
      * Gets information on a {@link Collection} of currently running processes. This
      * has potentially improved performance vs. iterating individual processes.
      *
@@ -294,33 +225,6 @@ public interface OperatingSystem {
      *         process id if it is running; null otherwise
      */
     OSProcess getProcess(int pid);
-
-    /**
-     * Gets currently running child processes of provided parent PID, optionally
-     * limited to the top "N" for a particular sorting order. If a positive limit is
-     * specified, returns only that number of processes; zero will return all
-     * processes. The order may be specified by the sort parameter, for example, to
-     * return the top cpu or memory consuming processes; if the sort is
-     * {@code null}, no order is guaranteed.
-     *
-     * @param parentPid
-     *            A process ID
-     * @param limit
-     *            Max number of results to return, or 0 to return all results
-     * @param sort
-     *            If not null, determines sorting of results
-     * @return A list of {@link oshi.software.os.OSProcess} objects representing the
-     *         specified number (or all) of currently running child processes of the
-     *         provided PID, sorted as specified. The list may contain null elements
-     *         or processes with a state of {@link OSProcess.State#INVALID} if a
-     *         process terminates during iteration.
-     * @deprecated Use {@link #getChildProcesses(int, Predicate, Comparator, int)}
-     *             with sorting constants from {@link ProcessSorting}.
-     */
-    @Deprecated
-    default List<OSProcess> getChildProcesses(int parentPid, int limit, ProcessSort sort) {
-        return getChildProcesses(parentPid, null, ProcessSorting.convertSortToComparator(sort), limit);
-    }
 
     /**
      * Gets currently running child processes of provided parent PID, optionally


### PR DESCRIPTION
Removed deprecated process sorting methods from the OperatingSystem class. Task 5 in issue #1723. 
