### PR TITLE
Changed the return value of getCommandLine() method of linuxOSProcess and macOSProcess from null-delimited string to space-delimited string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ##### Breaking Changes
 * [#1724](https://github.com/oshi/oshi/pull/1724): Removed deprecated MACOSX value from PlatformEnum and SystemInfo and removed the getCurrentPlatformEnum() method - [@Novaenn](https://github.com/Novaenn).
 * [#1725](https://github.com/oshi/oshi/pull/1725): Removed deprecated process sorting methods from the OperatingSystem class - [@varnaa](https://github.com/varnaa).
-* [#1730](https://github.com/oshi/oshi/pull/1730): Changed the return value of linuxOSPRocess and macOSProcess method getCommandLine() from null-delimited string to space-delimited string - [@prathamgandhi](https://github.com/prathamgandhi).
+* [#1729](https://github.com/oshi/oshi/pull/1729): Changed the return value of linuxOSPRocess and macOSProcess method getCommandLine() from null-delimited string to space-delimited string - [@prathamgandhi](https://github.com/prathamgandhi).
 
 # 5.8.0 (2021-07-18), 5.8.1 (2021-08-22), 5.8.2 (2021-09-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Breaking Changes
 * [#1724](https://github.com/oshi/oshi/pull/1724): Removed deprecated MACOSX value from PlatformEnum and SystemInfo and removed the getCurrentPlatformEnum() method - [@Novaenn](https://github.com/Novaenn).
 * [#1725](https://github.com/oshi/oshi/pull/1725): Removed deprecated process sorting methods from the OperatingSystem class - [@varnaa](https://github.com/varnaa).
+* [#1730](https://github.com/oshi/oshi/pull/1730): Changed the return value of linuxOSPRocess and macOSProcess method getCommandLine() from null-delimited string to space-delimited string - [@prathamgandhi](https://github.com/prathamgandhi).
 
 # 5.8.0 (2021-07-18), 5.8.1 (2021-08-22), 5.8.2 (2021-09-05)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,11 @@
 
 The deprecated methods `getProcesses(int limit, ProcessSort sort)`, `getChildProcesses(int parentPid, int limit, ProcessSort sort)`, and the enum `ProcessSort` were removed, replaced by methods leveraging constants in the `ProcessSorting` class.
 
+### Changed the type of string value returned by `getCommandLine()`
+
+The value returned from `macOSProcess` and `LinuxOSProcess` method `getCommandLine()` has been changed from null-delimited string to space-delimited string.
+Note : To parse the executables and arguments, the `getArguments()` method is the preferred alternative.
+
 # Guide to upgrading from OSHI 4.x to 5.x
 
 OSHI 5.0.0-5.1.2 releases are functionally equivalent to 4.7.0-4.8.2 releases,

--- a/oshi-core/src/main/java/oshi/software/os/OSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSProcess.java
@@ -63,8 +63,6 @@ public interface OSProcess {
      * {@link #getArguments()} which already parses the results, and use this method
      * as a backup.
      * <p>
-     * On Linux and macOS systems, the string is space-character-delimited.
-     * <p>
      * On AIX and Solaris, the string may be truncated to 80 characters if there was
      * insufficient permission to read the process memory.
      * <p>

--- a/oshi-core/src/main/java/oshi/software/os/OSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSProcess.java
@@ -63,10 +63,7 @@ public interface OSProcess {
      * {@link #getArguments()} which already parses the results, and use this method
      * as a backup.
      * <p>
-     * On Linux and macOS systems, the string is null-character-delimited, to permit
-     * the end user to parse the executable and arguments if desired. This
-     * null-delimited behavior may change in future versions and should not be
-     * relied upon; use {@link #getArguments()} instead.
+     * On Linux and macOS systems, the string is space-character-delimited.
      * <p>
      * On AIX and Solaris, the string may be truncated to 80 characters if there was
      * insufficient permission to read the process memory.

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
@@ -39,7 +39,6 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 import java.util.stream.Collectors;
 import java.util.Arrays;
 import java.util.function.Supplier;

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
@@ -39,8 +39,10 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.stream.Stream;
 import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,7 +120,7 @@ public class LinuxOSProcess extends AbstractOSProcess {
 
     @Override
     public String getCommandLine() {
-        return commandLine.get();
+       return Arrays.stream(commandLine.get().split("\0")).collect(Collectors.joining(" "));
     }
 
     private String queryCommandLine() {

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
@@ -119,11 +119,11 @@ public class LinuxOSProcess extends AbstractOSProcess {
 
     @Override
     public String getCommandLine() {
-       return Arrays.stream(commandLine.get().split("\0")).collect(Collectors.joining(" "));
+        return commandLine.get();
     }
 
     private String queryCommandLine() {
-        return FileUtil.getStringFromFile(String.format(ProcPath.PID_CMDLINE, getProcessID()));
+        return Arrays.stream(FileUtil.getStringFromFile(String.format(ProcPath.PID_CMDLINE, getProcessID())).split("\0")).collect(Collectors.joining(" "));
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcess.java
@@ -40,6 +40,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,7 +136,7 @@ public class MacOSProcess extends AbstractOSProcess {
 
     @Override
     public String getCommandLine() {
-        return this.commandLine.get();
+        return Arrays.stream(commandLine.get().split("\0")).collect(Collectors.joining(" "));
     }
 
     private String queryCommandLine() {

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcess.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.Arrays;
-import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcess.java
@@ -40,8 +40,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcess.java
@@ -135,11 +135,11 @@ public class MacOSProcess extends AbstractOSProcess {
 
     @Override
     public String getCommandLine() {
-        return Arrays.stream(commandLine.get().split("\0")).collect(Collectors.joining(" "));
+        return this.commandLine.get();
     }
 
     private String queryCommandLine() {
-        return String.join("\0", getArguments());
+        return String.join(" ", getArguments());
     }
 
     @Override


### PR DESCRIPTION
This is a fix to the third issue mentioned in https://github.com/oshi/oshi/issues/1723. The OSProcess javadoc and UPGRADING.md have been fixed as required.