### PR TITLE
Changed return type of getMTU() from int to long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#1725](https://github.com/oshi/oshi/pull/1725): Removed deprecated process sorting methods from the OperatingSystem class - [@varnaa](https://github.com/varnaa).
 * [#1729](https://github.com/oshi/oshi/pull/1729): Changed the return value of linuxOSPRocess and macOSProcess method getCommandLine() from null-delimited string to space-delimited string - [@prathamgandhi](https://github.com/prathamgandhi).
 * [#1730](https://github.com/oshi/oshi/pull/1730): Changed the return value of getServices() from `OSService[]` to `List<OSService>` in OperatingSystem - [@adrian-kong](https://github.com/adrian-kong).
+* [#1736](https://github.com/oshi/oshi/pull/1736): Changed the return type of the NetworkInterface method getMTU() from int to long in all its OS implementations.  - [@Simba-97](https://github.com/Simba-97).
 
 # 5.8.0 (2021-07-18), 5.8.1 (2021-08-22), 5.8.2 (2021-09-05)
 

--- a/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
@@ -402,7 +402,8 @@ public interface NetworkIF {
         /**
          * Find IfOperStatus by the integer value.
          *
-         * @param value Integer value specified in RFC 2863
+         * @param value 
+         *            Integer value specified in RFC 2863
          * @return the matching IfOperStatu or UNKNOWN if no matching IfOperStatus can
          *         be found
          */

--- a/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
@@ -402,7 +402,7 @@ public interface NetworkIF {
         /**
          * Find IfOperStatus by the integer value.
          *
-         * @param value 
+         * @param value
          *            Integer value specified in RFC 2863
          * @return the matching IfOperStatu or UNKNOWN if no matching IfOperStatus can
          *         be found

--- a/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/NetworkIF.java
@@ -111,7 +111,7 @@ public interface NetworkIF {
      *         This value is set when the {@link oshi.hardware.NetworkIF} is
      *         instantiated and may not be up to date.
      */
-    int getMTU();
+    long getMTU();
 
     /**
      * The Media Access Control (MAC) address.
@@ -402,8 +402,7 @@ public interface NetworkIF {
         /**
          * Find IfOperStatus by the integer value.
          *
-         * @param value
-         *            Integer value specified in RFC 2863
+         * @param value Integer value specified in RFC 2863
          * @return the matching IfOperStatu or UNKNOWN if no matching IfOperStatus can
          *         be found
          */

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -75,9 +75,9 @@ public abstract class AbstractNetworkIF implements NetworkIF {
      * Construct a {@link NetworkIF} object backed by the specified
      * {@link NetworkInterface}.
      *
-     * @param netint 
+     * @param netint
      *            The core java {@link NetworkInterface} backing this object.
-     * @throws InstantiationException 
+     * @throws InstantiationException
      *             If a socket exception prevents access to the backing interface.
      */
     protected AbstractNetworkIF(NetworkInterface netint) throws InstantiationException {
@@ -88,12 +88,12 @@ public abstract class AbstractNetworkIF implements NetworkIF {
      * Construct a {@link NetworkIF} object backed by the specified
      * {@link NetworkInterface}.
      *
-     * @param netint      
+     * @param netint
      *            The core java {@link NetworkInterface} backing this object.
-     * @param displayName 
+     * @param displayName
      *            A string to use for the display name in preference to the
      *            {@link NetworkInterface} value.
-     * @throws InstantiationException 
+     * @throws InstantiationException
      *             If a socket exception prevents access to the backing interface.
      */
     protected AbstractNetworkIF(NetworkInterface netint, String displayName) throws InstantiationException {
@@ -146,7 +146,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
     /**
      * Returns network interfaces on this machine.
      *
-     * @param includeLocalInterfaces 
+     * @param includeLocalInterfaces
      *            include local interfaces in the result
      * @return A list of network interfaces
      */
@@ -256,8 +256,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
         }
         sb.append("\n");
         sb.append("  MAC Address: ").append(getMacaddr()).append("\n");
-        sb.append("  MTU: ").append(getMTU()).append(", ").append("Speed: ")
-                .append(getSpeed()).append("\n");
+        sb.append("  MTU: ").append(getMTU()).append(", ").append("Speed: ").append(getSpeed()).append("\n");
         String[] ipv4withmask = getIPv4addr();
         if (this.ipv4.length == this.subnetMasks.length) {
             for (int i = 0; i < this.subnetMasks.length; i++) {

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -75,9 +75,10 @@ public abstract class AbstractNetworkIF implements NetworkIF {
      * Construct a {@link NetworkIF} object backed by the specified
      * {@link NetworkInterface}.
      *
-     * @param netint The core java {@link NetworkInterface} backing this object.
-     * @throws InstantiationException If a socket exception prevents access to the
-     *                                backing interface.
+     * @param netint 
+     *            The core java {@link NetworkInterface} backing this object.
+     * @throws InstantiationException 
+     *             If a socket exception prevents access to the backing interface.
      */
     protected AbstractNetworkIF(NetworkInterface netint) throws InstantiationException {
         this(netint, netint.getDisplayName());
@@ -87,11 +88,14 @@ public abstract class AbstractNetworkIF implements NetworkIF {
      * Construct a {@link NetworkIF} object backed by the specified
      * {@link NetworkInterface}.
      *
-     * @param netint      The core java {@link NetworkInterface} backing this
+     * @param netint      
+     *            The core java {@link NetworkInterface} backing this
      *                    object.
-     * @param displayName A string to use for the display name in preference to the
+     * @param displayName 
+     *            A string to use for the display name in preference to the
      *                    {@link NetworkInterface} value.
-     * @throws InstantiationException If a socket exception prevents access to the
+     * @throws InstantiationException 
+     *             If a socket exception prevents access to the
      *                                backing interface.
      */
     protected AbstractNetworkIF(NetworkInterface netint, String displayName) throws InstantiationException {
@@ -144,7 +148,8 @@ public abstract class AbstractNetworkIF implements NetworkIF {
     /**
      * Returns network interfaces on this machine.
      *
-     * @param includeLocalInterfaces include local interfaces in the result
+     * @param includeLocalInterfaces 
+     *            include local interfaces in the result
      * @return A list of network interfaces
      */
     protected static List<NetworkInterface> getNetworkInterfaces(boolean includeLocalInterfaces) {

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -94,8 +94,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
      *            A string to use for the display name in preference to the
      *            {@link NetworkInterface} value.
      * @throws InstantiationException 
-     *             If a socket exception prevents access to the
-     *                                backing interface.
+     *             If a socket exception prevents access to the backing interface.
      */
     protected AbstractNetworkIF(NetworkInterface netint, String displayName) throws InstantiationException {
         this.networkInterface = netint;

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -89,11 +89,10 @@ public abstract class AbstractNetworkIF implements NetworkIF {
      * {@link NetworkInterface}.
      *
      * @param netint      
-     *            The core java {@link NetworkInterface} backing this
-     *                    object.
+     *            The core java {@link NetworkInterface} backing this object.
      * @param displayName 
      *            A string to use for the display name in preference to the
-     *                    {@link NetworkInterface} value.
+     *            {@link NetworkInterface} value.
      * @throws InstantiationException 
      *             If a socket exception prevents access to the
      *                                backing interface.

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -62,7 +62,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
     private String name;
     private String displayName;
     private int index;
-    private int mtu;
+    private long mtu;
     private String mac;
     private String[] ipv4;
     private Short[] subnetMasks;
@@ -75,10 +75,9 @@ public abstract class AbstractNetworkIF implements NetworkIF {
      * Construct a {@link NetworkIF} object backed by the specified
      * {@link NetworkInterface}.
      *
-     * @param netint
-     *            The core java {@link NetworkInterface} backing this object.
-     * @throws InstantiationException
-     *             If a socket exception prevents access to the backing interface.
+     * @param netint The core java {@link NetworkInterface} backing this object.
+     * @throws InstantiationException If a socket exception prevents access to the
+     *                                backing interface.
      */
     protected AbstractNetworkIF(NetworkInterface netint) throws InstantiationException {
         this(netint, netint.getDisplayName());
@@ -88,13 +87,12 @@ public abstract class AbstractNetworkIF implements NetworkIF {
      * Construct a {@link NetworkIF} object backed by the specified
      * {@link NetworkInterface}.
      *
-     * @param netint
-     *            The core java {@link NetworkInterface} backing this object.
-     * @param displayName
-     *            A string to use for the display name in preference to the
-     *            {@link NetworkInterface} value.
-     * @throws InstantiationException
-     *             If a socket exception prevents access to the backing interface.
+     * @param netint      The core java {@link NetworkInterface} backing this
+     *                    object.
+     * @param displayName A string to use for the display name in preference to the
+     *                    {@link NetworkInterface} value.
+     * @throws InstantiationException If a socket exception prevents access to the
+     *                                backing interface.
      */
     protected AbstractNetworkIF(NetworkInterface netint, String displayName) throws InstantiationException {
         this.networkInterface = netint;
@@ -103,7 +101,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
             this.displayName = displayName;
             this.index = networkInterface.getIndex();
             // Set MTU
-            this.mtu = networkInterface.getMTU();
+            this.mtu = ParseUtil.unsignedIntToLong(networkInterface.getMTU());
             // Set MAC
             byte[] hwmac = networkInterface.getHardwareAddress();
             if (hwmac != null) {
@@ -146,8 +144,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
     /**
      * Returns network interfaces on this machine.
      *
-     * @param includeLocalInterfaces
-     *            include local interfaces in the result
+     * @param includeLocalInterfaces include local interfaces in the result
      * @return A list of network interfaces
      */
     protected static List<NetworkInterface> getNetworkInterfaces(boolean includeLocalInterfaces) {
@@ -205,7 +202,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
     }
 
     @Override
-    public int getMTU() {
+    public long getMTU() {
         return this.mtu;
     }
 
@@ -256,7 +253,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
         }
         sb.append("\n");
         sb.append("  MAC Address: ").append(getMacaddr()).append("\n");
-        sb.append("  MTU: ").append(ParseUtil.unsignedIntToLong(getMTU())).append(", ").append("Speed: ")
+        sb.append("  MTU: ").append(getMTU()).append(", ").append("Speed: ")
                 .append(getSpeed()).append("\n");
         String[] ipv4withmask = getIPv4addr();
         if (this.ipv4.length == this.subnetMasks.length) {

--- a/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
@@ -132,7 +132,7 @@ class NetworksTest {
                     is(notNullValue()));
 
             // On Windows, virtual interfaces may return max unsigned int value, -1.
-            assertThat("NetworkIF MTU should not be negative", net.getMTU(), is(greaterThanOrEqualTo(0)));
+            assertThat("NetworkIF MTU should not be negative", net.getMTU(), is(greaterThanOrEqualTo(0L)));
 
             assertThat("NetworkIF MacAddress should not be null", net.getMacaddr(), is(notNullValue()));
         }

--- a/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/NetworksTest.java
@@ -107,6 +107,7 @@ class NetworksTest {
                 is(greaterThanOrEqualTo(0L)));
         assertThat("NetworkIF collisions after update attr should not be negative", net.getCollisions(),
                 is(greaterThanOrEqualTo(0L)));
+        assertThat("NetworkIF MTU should not be negative", net.getMTU(), is(greaterThanOrEqualTo(0L)));
         assertThat("NetworkIF speed after update attr should not be negative", net.getSpeed(),
                 is(greaterThanOrEqualTo(0L)));
         assertThat("NetworkIF time stamp after update attr should not be negative", net.getTimeStamp(),
@@ -130,9 +131,6 @@ class NetworksTest {
                     net.queryNetworkInterface().isLoopback(), is(false));
             assertThat("Network interface has a hardware address", net.queryNetworkInterface().getHardwareAddress(),
                     is(notNullValue()));
-
-            // On Windows, virtual interfaces may return max unsigned int value, -1.
-            assertThat("NetworkIF MTU should not be negative", net.getMTU(), is(greaterThanOrEqualTo(0L)));
 
             assertThat("NetworkIF MacAddress should not be null", net.getMacaddr(), is(notNullValue()));
         }


### PR DESCRIPTION
Changed return type of the NetworkInterface method getMTU() from int to long in all its OS implementations.