### PR TITLE
Prevent fd leaks in ExecutingCommand

### DIFF
--- a/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
@@ -116,11 +116,33 @@ public final class ExecutingCommand {
      *         string if the command failed
      */
     public static List<String> runNative(String[] cmdToRunWithArgs, String[] envp) {
+        Process p = null;
         try {
-            Process p = Runtime.getRuntime().exec(cmdToRunWithArgs, envp);
+            p = Runtime.getRuntime().exec(cmdToRunWithArgs, envp);
             return getProcessOutputAndDestroy(p, cmdToRunWithArgs);
         } catch (SecurityException | IOException e) {
             LOG.trace("Couldn't run command {}: {}", Arrays.toString(cmdToRunWithArgs), e.getMessage());
+        } finally {
+            if (p != null) {
+                if (p.getOutputStream() != null) {
+                    try {
+                        p.getOutputStream().close();
+                    } catch (IOException e) {
+                    }
+                }
+                if (p.getInputStream() != null) {
+                    try {
+                        p.getInputStream().close();
+                    } catch (IOException e) {
+                    }
+                }
+                if (p.getErrorStream() != null) {
+                    try {
+                        p.getErrorStream().close();
+                    } catch (IOException e) {
+                    }
+                }
+            }
         }
         return Collections.emptyList();
     }


### PR DESCRIPTION
in Solaris11 OS, pipes left open in case their corresponding OutputStream - stdout, InputStream - stdin, ErrorStream - stderr are not explicitly closed.