### PR TITLE
[CI] Update Java versions for Windows and MacOS workflows

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # Baseline support, Current LTS, Current GA, Current EA
-        java: [8, 11, 16, 17-ea]
+        java: [8, 11, 17, 18-ea]
         os: [macos-latest, macos-11]
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # Baseline support, Current LTS, Current GA, Current EA
-        java: [8, 11, 16, 17-ea]
+        java: [8, 11, 17, 18-ea]
         os: [windows-2016, windows-latest]
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -19,7 +19,9 @@ jobs:
       matrix:
         # Baseline support, Current LTS, Current GA, Current EA
         java: [8, 11, 17, 18-ea]
-        os: [windows-2016, windows-latest]
+        # note that windows-2016 will be removed on 15-march-2022
+        # see https://github.com/actions/virtual-environments/issues/4312
+        os: [windows-2016, windows-2019, windows-2022]
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
 


### PR DESCRIPTION
- "adopt" is now deprecated, use "temurin"
- java 17 was released
- jav 16 is EOL
- java 18 is now early access
- add Windows 2022 (beta)