### PR TITLE
Tweak tests and logs for persnickety Solaris VM

### DIFF
--- a/oshi-core/src/main/java/oshi/util/platform/unix/solaris/KstatUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/solaris/KstatUtil.java
@@ -253,8 +253,8 @@ public final class KstatUtil {
         }
         Pointer p = KS.kstat_data_lookup(ksp, name);
         if (p == null) {
-            if (LOG.isErrorEnabled()) {
-                LOG.error("Failed lo lookup kstat value on {}:{}:{} for key {}",
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Failed lo lookup kstat value on {}:{}:{} for key {}",
                         Native.toString(ksp.ks_module, StandardCharsets.US_ASCII), ksp.ks_instance,
                         Native.toString(ksp.ks_name, StandardCharsets.US_ASCII), name);
             }

--- a/oshi-core/src/test/java/oshi/hardware/DisksTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/DisksTest.java
@@ -81,12 +81,14 @@ class DisksTest {
 
             long oldReads = disk.getReads();
             long oldReadBytes = disk.getReadBytes();
-            assertThat("Updating the disk statistics should work", disk.updateAttributes(), is(true));
-            assertThat("Number of reads from the disk has not been updated", disk.getReads(),
-                    is(greaterThanOrEqualTo(oldReads)));
-            assertThat("Number of read bytes from the disk has not been updated", disk.getReadBytes(),
-                    is(greaterThanOrEqualTo(oldReadBytes)));
-
+            if (oldReads > 0) {
+                assertThat("Updating the disk statistics should work for " + disk.getName(), disk.updateAttributes(),
+                        is(true));
+                assertThat("Number of reads from the disk has not been updated", disk.getReads(),
+                        is(greaterThanOrEqualTo(oldReads)));
+                assertThat("Number of read bytes from the disk has not been updated", disk.getReadBytes(),
+                        is(greaterThanOrEqualTo(oldReadBytes)));
+            }
             for (HWPartition partition : disk.getPartitions()) {
                 assertThat("Identification of partition is null", partition.getIdentification(), is(notNullValue()));
                 assertThat("Name of partition is null", partition.getName(), is(notNullValue()));


### PR DESCRIPTION
A disk on a VM that failed the first stats read with 0's shouldn't fail an update of the same 0's.

Also reducing the log level for failed kstats.