### PR TITLE
Update ParseUtil.java

### DIFF
--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -574,8 +574,12 @@ public final class ParseUtil {
             if (m.group(3) != null) {
                 milliseconds += parseLongOrDefault(m.group(3), 0L) * 60_000L;
             }
-            milliseconds += parseLongOrDefault(m.group(4), 0L) * 1000L;
-            milliseconds += (long) (1000 * parseDoubleOrDefault("0." + m.group(5), 0d));
+            if (m.group(4) != null) {
+                milliseconds += parseLongOrDefault(m.group(4), 0L) * 1000L;
+            }
+            if (m.group(5) != null){
+                milliseconds += (long) (1000 * parseDoubleOrDefault("0." + m.group(5), 0d));
+            }
             return milliseconds;
         }
         return defaultLong;


### PR DESCRIPTION
When running on AIX and Soalris produces NUMBER format exception error while parsing ETIME.
AIX 7.2> ps -o st,pid,ppid,user,uid,group,gid,thcount,pri,vsize,rssize,etime,time,comm,pagein,args
ST      PID     PPID     USER UID    GROUP   GID THCNT PRI   VSZ   RSS     ELAPSED        TIME COMMAND  PAGEIN COMMAND
A  64881208 37421480 controlm 210      dba   202     1  60   704  1052       00:16    00:00:00 tcsh          0 -tcsh
A  28968140 64881208 controlm 210   system     0     1  61  2092  2212       00:00    00:00:00 ps            0 ps -o st,pid,ppid,user,uid,group,gid,thcount,pri,vsize,rssize,etime,time,com
>

AIX 5.3ps -o st,pid,ppid,user,uid,group,gid,thcount,pri,vsize,rssize,etime,time,comm,pagein,args
ST    PID   PPID     USER    UID    GROUP   GID THCNT PRI   VSZ   RSS     ELAPSED        TIME COMMAND  PAGEIN COMMAND
A  397454 794624 dherschl 123860      mpm   313     1  60   876  1220       02:09    00:00:00 tcsh          1 -tcsh
A  790554 397454 dherschl 123860   system     0     1  60   768   860       00:00    00:00:00 ps            0 ps -o st,pid,ppid,user,uid,group,gid,thcount,pri,vsize,rssize,etime,time,comm
>

Solarisps -o s,pid,ppid,user,uid,group,gid,nlwp,pri,vsz,rss,etime,time,comm,args
S   PID  PPID     USER   UID    GROUP   GID NLWP PRI  VSZ      RSS     ELAPSED        TIME COMMAND                                                                          COMMAND
O  3873 50626    dshvo   100    staff    10    1  59 10160     6640       00:00       00:00 ps                                                                               ps -o s,pid,ppid,user,uid,group,gid,nlwp,pri,vsz,rss,etime,time,comm,args
S 50626 50622    dshvo   100    staff    10    1  49 12360     8648    20:19:40       00:00 -bash                                                                            -bash
S 55932 55930    dshvo   100    staff    10    1  59 22392    11264    13:45:45       00:02 /export/home/dshvo/ctm/exe/p_ctmatw                                              /export/home/dshvo/ctm/exe/p_ctmatw -ATW_NAME ATW000
S 55869     1    dshvo   100    staff    10    1  59 22392    11520    13:45:46       00:04 /export/home/dshvo/ctm/exe/p_ctmag                                               /export/home/dshvo/ctm/exe/p_ctmag
S 55829     1    dshvo   100    staff    10  276  59 1077200   559904    13:45:55       15:05 /export/home/dshvo/bmcjava/bmcjava-V4//bin/java                                  /export/home/dshvo/bmcjava/bmcjava-V4//bin/java -Xmx256m -XX:+UseG1GC -XX:+CrashOnOutOfMemoryError -Djava.io.tmpdir=/tmp -Djava.net.preferIPv4Stack=true -Doverride.default.services= -Dspring.profiles.active=tcp -DCTMAG.CONFIG.DBGLVL=5 -Dctm.logs.dir=/export/home/dshvo/ctm/proclog -Dlogging.config=/export/home/dshvo/ctm/data/logback.xml -Dctm.data.dir=/export/home/dshvo/ctm/data -XX:+PrintFlagsFinal -Dstdout=/export/home/dshvo/ctm/proclog/agjstd_55520-2021-11-23.0.tmp -DLIMIT_LOG_VERSIONS=8 -DLIMIT_LOG_FILE_SIZE=10 -jar /export/home/dshvo/ctm/exe/ag-app.jar
S 55930     1    dshvo   100    staff    10    1  59 22392    11264    13:45:45       00:06 /export/home/dshvo/ctm/exe/p_ctmat                                               /export/home/dshvo/ctm/exe/p_ctmat

error report Solaris:
[Housekeeping@sch-measureAgentProcesses] 0.null didn't parse. Returning default. {}
java.lang.NumberFormatException: For input string: "0.null"
	at java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2054)
	at java.base/jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
	at java.base/java.lang.Double.parseDouble(Double.java:543)
	at oshi.util.ParseUtil.parseDoubleOrDefault(ParseUtil.java:547)
	at oshi.util.ParseUtil.parseDHMSOrDefault(ParseUtil.java:578)

error report AIX:
1123 04:35:01.091 TRACE MeasureAllComponents1  oshi.util.ParseUtil                      - [@sch-measureAgentProcesses] 0.null didn't parse. Returning default. {}
java.lang.NumberFormatException: For input string: "0.null"
	at java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(Unknown Source)
	at java.base/jdk.internal.math.FloatingDecimal.parseDouble(Unknown Source)
	at java.base/java.lang.Double.parseDouble(Unknown Source)
	at oshi.util.ParseUtil.parseDoubleOrDefault(ParseUtil.java:547)
	at oshi.util.ParseUtil.parseDHMSOrDefault(ParseUtil.java:578)