### PR TITLE
Fix fd leaks in Solaris after Runtime.exec calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##### Bug fixes / Improvements
 * [#1768](https://github.com/oshi/oshi/pull/1768): Fixed incorrect use of reference equality - [@mythili-rajaraman](https://github.com/mythili-rajaraman).
+* [#1792](https://github.com/oshi/oshi/pull/1792): Fix fd leaks in Solaris after Runtime.exec calls - [@shvo123](https://github.com/shvo123).
 
 ##### Breaking Changes
 * [#1724](https://github.com/oshi/oshi/pull/1724): Removed deprecated MACOSX value from PlatformEnum and SystemInfo and removed the getCurrentPlatformEnum() method - [@Novaenn](https://github.com/Novaenn).

--- a/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
@@ -32,12 +32,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import com.sun.jna.Platform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import oshi.PlatformEnum;
-import oshi.SystemInfo;
+import com.sun.jna.Platform;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -55,13 +54,10 @@ public final class ExecutingCommand {
     }
 
     private static String[] getDefaultEnv() {
-        PlatformEnum platform = SystemInfo.getCurrentPlatform();
-        if (platform == PlatformEnum.WINDOWS) {
+        if (Platform.isWindows()) {
             return new String[] { "LANGUAGE=C" };
-        } else if (platform != PlatformEnum.UNKNOWN) {
-            return new String[] { "LC_ALL=C" };
         } else {
-            return null; // NOSONAR squid:S1168
+            return new String[] { "LC_ALL=C" };
         }
     }
 
@@ -124,22 +120,24 @@ public final class ExecutingCommand {
         } catch (SecurityException | IOException e) {
             LOG.trace("Couldn't run command {}: {}", Arrays.toString(cmdToRunWithArgs), e.getMessage());
         } finally {
+            // Ensure all resources are released
             if (p != null) {
+                // Solaris doesn't close descriptors on destroy so we must handle separately
                 if (Platform.isSolaris()) {
                     try {
                         p.getOutputStream().close();
                     } catch (IOException e) {
-                        LOG.warn("close OutputStream failed {}", e.getMessage());
+                        // do nothing on failure
                     }
                     try {
                         p.getInputStream().close();
                     } catch (IOException e) {
-                        LOG.warn("close InputStream failed {}", e.getMessage());
+                        // do nothing on failure
                     }
                     try {
                         p.getErrorStream().close();
                     } catch (IOException e) {
-                        LOG.warn("close ErrorStream failed {}", e.getMessage());
+                        // do nothing on failure
                     }
                 }
                 p.destroy();

--- a/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.sun.jna.Platform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,25 +125,24 @@ public final class ExecutingCommand {
             LOG.trace("Couldn't run command {}: {}", Arrays.toString(cmdToRunWithArgs), e.getMessage());
         } finally {
             if (p != null) {
-                p.destroy();
-                if (p.getOutputStream() != null) {
+                if (Platform.isSolaris()) {
                     try {
                         p.getOutputStream().close();
                     } catch (IOException e) {
+                        LOG.warn("close OutputStream failed {}", e.getMessage());
                     }
-                }
-                if (p.getInputStream() != null) {
                     try {
                         p.getInputStream().close();
                     } catch (IOException e) {
+                        LOG.warn("close InputStream failed {}", e.getMessage());
                     }
-                }
-                if (p.getErrorStream() != null) {
                     try {
                         p.getErrorStream().close();
                     } catch (IOException e) {
+                        LOG.warn("close ErrorStream failed {}", e.getMessage());
                     }
                 }
+                p.destroy();
             }
         }
         return Collections.emptyList();

--- a/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
@@ -162,6 +162,27 @@ public final class ExecutingCommand {
             LOG.trace("Interrupted while reading output from {}: {}", Arrays.toString(cmd), ie.getMessage());
             Thread.currentThread().interrupt();
         } finally {
+            if (p != null) {
+                if (p.getOutputStream() != null) {
+                    try {
+                        p.getOutputStream().close();
+                    } catch (IOException e) {
+                    }
+                }
+                if (p.getInputStream() != null) {
+                    try {
+                        p.getInputStream().close();
+                    } catch (IOException e) {
+                    }
+                }
+                if (p.getErrorStream() != null) {
+                    try {
+                        p.getErrorStream().close();
+                    } catch (IOException e) {
+                    }
+                }
+
+            }
             p.destroy();
         }
         return sa;

--- a/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
@@ -119,11 +119,12 @@ public final class ExecutingCommand {
         Process p = null;
         try {
             p = Runtime.getRuntime().exec(cmdToRunWithArgs, envp);
-            return getProcessOutputAndDestroy(p, cmdToRunWithArgs);
+            return getProcessOutput(p, cmdToRunWithArgs);
         } catch (SecurityException | IOException e) {
             LOG.trace("Couldn't run command {}: {}", Arrays.toString(cmdToRunWithArgs), e.getMessage());
         } finally {
             if (p != null) {
+                p.destroy();
                 if (p.getOutputStream() != null) {
                     try {
                         p.getOutputStream().close();
@@ -147,7 +148,7 @@ public final class ExecutingCommand {
         return Collections.emptyList();
     }
 
-    private static List<String> getProcessOutputAndDestroy(Process p, String[] cmd) {
+    private static List<String> getProcessOutput(Process p, String[] cmd) {
         ArrayList<String> sa = new ArrayList<>();
         try (BufferedReader reader = new BufferedReader(
                 new InputStreamReader(p.getInputStream(), Charset.defaultCharset()))) {
@@ -161,29 +162,6 @@ public final class ExecutingCommand {
         } catch (InterruptedException ie) {
             LOG.trace("Interrupted while reading output from {}: {}", Arrays.toString(cmd), ie.getMessage());
             Thread.currentThread().interrupt();
-        } finally {
-            if (p != null) {
-                if (p.getOutputStream() != null) {
-                    try {
-                        p.getOutputStream().close();
-                    } catch (IOException e) {
-                    }
-                }
-                if (p.getInputStream() != null) {
-                    try {
-                        p.getInputStream().close();
-                    } catch (IOException e) {
-                    }
-                }
-                if (p.getErrorStream() != null) {
-                    try {
-                        p.getErrorStream().close();
-                    } catch (IOException e) {
-                    }
-                }
-
-            }
-            p.destroy();
         }
         return sa;
     }

--- a/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-core/src/main/java/oshi/util/ExecutingCommand.java
@@ -116,11 +116,33 @@ public final class ExecutingCommand {
      *         string if the command failed
      */
     public static List<String> runNative(String[] cmdToRunWithArgs, String[] envp) {
+        Process p = null;
         try {
-            Process p = Runtime.getRuntime().exec(cmdToRunWithArgs, envp);
+            p = Runtime.getRuntime().exec(cmdToRunWithArgs, envp);
             return getProcessOutputAndDestroy(p, cmdToRunWithArgs);
         } catch (SecurityException | IOException e) {
             LOG.trace("Couldn't run command {}: {}", Arrays.toString(cmdToRunWithArgs), e.getMessage());
+        } finally {
+            if (p != null) {
+                if (p.getOutputStream() != null) {
+                    try {
+                        p.getOutputStream().close();
+                    } catch (IOException e) {
+                    }
+                }
+                if (p.getInputStream() != null) {
+                    try {
+                        p.getInputStream().close();
+                    } catch (IOException e) {
+                    }
+                }
+                if (p.getErrorStream() != null) {
+                    try {
+                        p.getErrorStream().close();
+                    } catch (IOException e) {
+                    }
+                }
+            }
         }
         return Collections.emptyList();
     }


### PR DESCRIPTION
adding close streams clause in getProcessOutputAndDestroy prior to destroy
in Solaris, p.destory failed to close the streams, so we need to close the streams explictly