### PR TITLE
Don't attempt to parse optional regex match if it is null, fixes #1788

### DIFF
--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -575,7 +575,9 @@ public final class ParseUtil {
                 milliseconds += parseLongOrDefault(m.group(3), 0L) * 60_000L;
             }
             milliseconds += parseLongOrDefault(m.group(4), 0L) * 1000L;
-            milliseconds += (long) (1000 * parseDoubleOrDefault("0." + m.group(5), 0d));
+            if (m.group(5) != null) {
+                milliseconds += (long) (1000 * parseDoubleOrDefault("0." + m.group(5), 0d));
+            }
             return milliseconds;
         }
         return defaultLong;


### PR DESCRIPTION
I don't know how to link this pull request to issue #1788 