### PR TITLE
Ban the use of `junit:junit` (4.x) and `org.hamcrest:hamcrest-core` (1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#1712](https://github.com/oshi/oshi/pull/1712): Align PlatformEnum to JNA Platform type - [@dbwiddis](https://github.com/dbwiddis).
 * [#1768](https://github.com/oshi/oshi/pull/1768): Fixed incorrect use of reference equality - [@mythili-rajaraman](https://github.com/mythili-rajaraman).
 * [#1792](https://github.com/oshi/oshi/pull/1792): Fix fd leaks in Solaris after Runtime.exec calls - [@shvo123](https://github.com/shvo123).
+* [#1796](https://github.com/oshi/oshi/pull/1796): Ban the use of Junit 4 and associated Hamcrest Core - [@mprins](https://github.com/mprins)
 
 # 5.7.0 (2021-04-01), 5.7.1 (2021-04-15), 5.7.2 (2021-05-01), 5.7.3 (2021-05-16), 5.7.4 (2021-05-30), 5.7.5 (2021-06-12)
 

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -24,7 +24,7 @@
     </scm>
 
     <properties>
-        <!-- Users of the Spring Boot Starter Parent should include this property 
+        <!-- Users of the Spring Boot Starter Parent should include this property
             in their POM -->
         <jna.version>5.10.0</jna.version>
         <main.basedir>${project.parent.basedir}</main.basedir>
@@ -33,7 +33,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Due to critical nature of OSHI jna usage, set to dependency management 
+            <!-- Due to critical nature of OSHI jna usage, set to dependency management
                 to help influence usage -->
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
@@ -84,6 +84,16 @@
             <artifactId>code-assert</artifactId>
             <version>${code-assert.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/oshi-core/src/test/java/oshi/driver/linux/DevicetreeTest.java
+++ b/oshi-core/src/test/java/oshi/driver/linux/DevicetreeTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.jna.Platform;
 

--- a/oshi-core/src/test/java/oshi/driver/linux/DmidecodeTest.java
+++ b/oshi-core/src/test/java/oshi/driver/linux/DmidecodeTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.jna.Platform;
 

--- a/oshi-core/src/test/java/oshi/driver/linux/LshalTest.java
+++ b/oshi-core/src/test/java/oshi/driver/linux/LshalTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.not;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.jna.Platform;
 

--- a/oshi-core/src/test/java/oshi/driver/linux/LshwTest.java
+++ b/oshi-core/src/test/java/oshi/driver/linux/LshwTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.jna.Platform;
 

--- a/oshi-core/src/test/java/oshi/driver/linux/SysfsTest.java
+++ b/oshi-core/src/test/java/oshi/driver/linux/SysfsTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.not;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.jna.Platform;
 

--- a/oshi-core/src/test/java/oshi/driver/linux/WhoTest.java
+++ b/oshi-core/src/test/java/oshi/driver/linux/WhoTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.jna.Platform;
 

--- a/oshi-core/src/test/java/oshi/driver/linux/proc/CpuInfoTest.java
+++ b/oshi-core/src/test/java/oshi/driver/linux/proc/CpuInfoTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.jna.Platform;
 

--- a/oshi-core/src/test/java/oshi/driver/linux/proc/CpuStatTest.java
+++ b/oshi-core/src/test/java/oshi/driver/linux/proc/CpuStatTest.java
@@ -26,7 +26,7 @@ package oshi.driver.linux.proc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.jna.Platform;
 

--- a/oshi-core/src/test/java/oshi/driver/mac/WhoTest.java
+++ b/oshi-core/src/test/java/oshi/driver/mac/WhoTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sun.jna.Platform;
 

--- a/pom.xml
+++ b/pom.xml
@@ -406,13 +406,13 @@
                         </archive>
                     </configuration>
                     <executions>
-                        <!-- ! here we override the super-pom attach-sources execution 
-                            id which ! calls sources:jar goal. That goals forks the lifecycle, ! causing the 
-                            generate-sources phase to be called twice for the install goal. ! Starting with 
-                            Maven 3.4.0 (https://issues.apache.org/jira/browse/MNG-5940) ! this is not needed 
+                        <!-- ! here we override the super-pom attach-sources execution
+                            id which ! calls sources:jar goal. That goals forks the lifecycle, ! causing the
+                            generate-sources phase to be called twice for the install goal. ! Starting with
+                            Maven 3.4.0 (https://issues.apache.org/jira/browse/MNG-5940) ! this is not needed
                             anymore. -->
-                        <!-- except that OSSRH fails with no sources with this 
-                            excluded <execution> <id>attach-sources</id> <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase> 
+                        <!-- except that OSSRH fails with no sources with this
+                            excluded <execution> <id>attach-sources</id> <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase>
                             </execution> -->
                     </executions>
                 </plugin>
@@ -590,6 +590,12 @@
                         <requireMavenVersion>
                             <version>${maven.min-version}</version>
                         </requireMavenVersion>
+                        <bannedDependencies>
+                            <excludes>
+                                <exclude>junit:junit</exclude>
+                                <exclude>org.hamcrest:hamcrest-core</exclude>
+                            </excludes>
+                        </bannedDependencies>
                     </rules>
                 </configuration>
                 <executions>
@@ -707,7 +713,7 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            <!-- Checkstyle dependencies required here or they won't be used (per 
+            <!-- Checkstyle dependencies required here or they won't be used (per
                 maven) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -885,7 +891,7 @@
             <build>
                 <pluginManagement>
                     <plugins>
-                        <!--This plugin's configuration is used to store Eclipse 
+                        <!--This plugin's configuration is used to store Eclipse
                             m2e settings only. It has no influence on the Maven build itself. -->
                         <plugin>
                             <groupId>org.eclipse.m2e</groupId>
@@ -1007,7 +1013,7 @@
                                 <configuration>
                                     <keyname>${gpg.keyname}</keyname>
                                     <passphraseServerId>${gpg.keyname}</passphraseServerId>
-                                    <!-- GPG 2.1 requires pinentry-mode to be set 
+                                    <!-- GPG 2.1 requires pinentry-mode to be set
                                         to loopback in order to pick up the gpg.passphrase value defined in Maven settings.xml. -->
                                     <gpgArguments>
                                         <arg>--pinentry-mode</arg>


### PR DESCRIPTION
update al leftover testcases to use `org.junit.jupiter.api.Test`, either this was leftover from #1387 or these imports snuck back in when adding/updating these test cases


see: https://github.com/oshi/oshi/issues/1794#issuecomment-978938037