### PR TITLE
Restrict imports with maven enforcer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <url>github:ssh://oshi.github.io/oshi/</url>
         </site>
         <snapshotRepository>
-            <id>ossrh</id>
+            <id>ossrh-snapshot</id>
             <name>Sonatype Nexus Snapshots</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
@@ -107,6 +107,7 @@
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
         <nexus-staging-plugin.version>1.6.8</nexus-staging-plugin.version>
         <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
+        <restrict-imports-enforcer-rule.version>2.0.0-SNAPSHOT</restrict-imports-enforcer-rule.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
@@ -198,6 +199,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>${maven-enforcer-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>de.skuzzle.enforcer</groupId>
+                            <artifactId>restrict-imports-enforcer-rule</artifactId>
+                            <version>${restrict-imports-enforcer-rule.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -628,6 +636,39 @@
                         <goals>
                             <goal>enforce</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>ban-transitive-imports</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <RestrictImports>
+                                    <includeTestCode>true</includeTestCode>
+                                    <!-- Disallow all imports except explicitly 
+                                        allowed -->
+                                    <reason>Disallow transitive dependencies</reason>
+                                    <bannedImports>
+                                        <bannedImport>**</bannedImport>
+                                    </bannedImports>
+                                    <allowedImports>
+                                        <!-- Allow oshi itself :-) -->
+                                        <allowedImport>oshi.**</allowedImport>
+                                        <!-- Allow core Java usages -->
+                                        <allowedImport>java.**</allowedImport>
+                                        <!-- Allow known dependencies -->
+                                        <allowedImport>com.sun.jna.**</allowedImport>
+                                        <allowedImport>org.slf4j.**</allowedImport>
+                                        <allowedImport>org.junit.jupiter.api.**</allowedImport>
+                                        <allowedImport>org.hamcrest.**</allowedImport>
+                                    </allowedImports>
+                                    <!-- No restrictions on oshi-demo -->
+                                    <exclusion>oshi.demo.**</exclusion>
+                                </RestrictImports>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
         <nexus-staging-plugin.version>1.6.8</nexus-staging-plugin.version>
         <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
-        <restrict-imports-enforcer-rule.version>2.0.0-SNAPSHOT</restrict-imports-enforcer-rule.version>
+        <restrict-imports-enforcer-rule.version>2.0.0</restrict-imports-enforcer-rule.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
@@ -646,23 +646,22 @@
                         <configuration>
                             <rules>
                                 <RestrictImports>
+                                    <reason>Disallow dependencies not on module path</reason>
                                     <includeTestCode>true</includeTestCode>
-                                    <!-- Disallow all imports except explicitly 
-                                        allowed -->
-                                    <reason>Disallow transitive dependencies</reason>
                                     <bannedImports>
+                                        <!-- Disallow all imports except explicitly allowed -->
                                         <bannedImport>**</bannedImport>
                                     </bannedImports>
                                     <allowedImports>
                                         <!-- Allow oshi itself :-) -->
                                         <allowedImport>oshi.**</allowedImport>
-                                        <!-- Allow core Java usages -->
+                                        <!-- Allow core Java usage  -->
                                         <allowedImport>java.**</allowedImport>
                                         <!-- Allow known dependencies -->
                                         <allowedImport>com.sun.jna.**</allowedImport>
                                         <allowedImport>org.slf4j.**</allowedImport>
                                         <allowedImport>org.junit.jupiter.api.**</allowedImport>
-                                        <allowedImport>org.hamcrest.**</allowedImport>
+                                        <allowedImport>static org.hamcrest.**</allowedImport>
                                     </allowedImports>
                                     <!-- No restrictions on oshi-demo -->
                                     <exclusion>oshi.demo.**</exclusion>


### PR DESCRIPTION
Redo of #1802.

WIth the new version I don't have to specify static separately, so the configuration is pretty streamlined.  I like that the checkstyle plugin can be very strict on the modular part, allowing this to be a little more lenient.  But using enforcer has the advantage of working with mvn test (or most other maven commands), and not requiring a separate "checkstyle:check" call.  

Set as draft because it's using a snapshot dependency, but wanted to stick this up here for @mprins  and @hazendaz  review.  Will wait to merge until it's a released version.