### PR TITLE
Use udev for Linux cpu enumeration and frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#1836](https://github.com/oshi/oshi/pull/1836): Remove all lsof calls and replace with procfs equivalent - [@dbwiddis](https://github.com/dbwiddis).
 * [#1837](https://github.com/oshi/oshi/pull/1837): Implement Kstat2 for Solaris 11.4+ - [@dbwiddis](https://github.com/dbwiddis).
 * [#1844](https://github.com/oshi/oshi/pull/1844): Update Microarchitecture table - [@dbwiddis](https://github.com/dbwiddis).
+* [#1849](https://github.com/oshi/oshi/pull/1849): Use udev for Linux cpu enumeration and frequency - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.0.0 (2021-12-31)
 

--- a/oshi-core/src/main/resources/oshi.properties
+++ b/oshi-core/src/main/resources/oshi.properties
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2010 - 2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+# Copyright (c) 2020-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,9 +26,6 @@
 # to provide container-level output in preference to system-level output.
 # The /proc filesystem location
 oshi.util.proc.path=/proc
-
-# See https://www.kernel.org/doc/Documentation/cpu-freq/user-guide.txt
-oshi.cpu.freq.path=/sys/devices/system/cpu
 
 # The WMI query timeout in milliseconds
 # Default is -1, no timeout


### PR DESCRIPTION
Enumeration of sysfs via udev saves a command line call for numa node info, and will enable easier hybrid topology detection in #1571.