### PR TITLE
Skip license header rewrites on CI

### DIFF
--- a/.github/workflows/aix.yaml
+++ b/.github/workflows/aix.yaml
@@ -35,4 +35,4 @@ jobs:
           git checkout master
           git reset --hard HEAD~2
           git pull upstream master
-          ./mvnw clean test -B -Djacoco.skip=true
+          ./mvnw clean test -B -Djacoco.skip=true -Dlicense.skip=true

--- a/.github/workflows/freebsd.yaml
+++ b/.github/workflows/freebsd.yaml
@@ -30,5 +30,5 @@ jobs:
             pkg install -y curl
             pkg install -y openjdk8
           run: |
-            ./mvnw test -B -Djacoco.skip=true
+            ./mvnw test -B -Djacoco.skip=true -Dlicense.skip=true
           

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -37,12 +37,12 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2          
       - name: Checkstyle
-        if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '8')
+        if: contains(matrix.java, '8')
         run: ./mvnw checkstyle:check
       - name: Test with Maven
-        run: ./mvnw test -B
+        run: ./mvnw test -B -Dlicense.skip=true
       - name: Report Coverage to Coveralls
-        if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '8')
+        if: contains(matrix.java, '8')
         run: ./mvnw test jacoco:report coveralls:report -q -Dlicense.skip=true -DrepoToken=$GITHUB_TOKEN -DserviceName=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -37,9 +37,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2          
       - name: Test with Maven
-        run: ./mvnw test -B
-      - name: Report Coverage to Coveralls
-        if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '8')
-        run: ./mvnw test jacoco:report coveralls:report -q -Dlicense.skip=true -DrepoToken=$GITHUB_TOKEN -DserviceName=github
+        run: ./mvnw test -B  -Dlicense.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/openbsd.yaml
+++ b/.github/workflows/openbsd.yaml
@@ -36,5 +36,5 @@ jobs:
           doas git pull
           doas mvn clean
           doas chown -R oshi:oshi .
-          mvn test -B -Djacoco.skip=true
-          doas mvn test -B -Djacoco.skip=true          
+          mvn test -B -Djacoco.skip=true -Dlicense.skip=true
+          doas mvn test -B -Djacoco.skip=true -Dlicense.skip=true     

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,10 +35,13 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: ./mvnw checkstyle:check
       - name: Test with Maven
-        run: ./mvnw test -B
+        run: ./mvnw test -B -Dlicense.skip=true
       - name: Report Coverage to Coveralls for Pull Requests
         if: contains(matrix.os, 'ubuntu')
         run: ./mvnw test jacoco:report coveralls:report -q -Dlicense.skip=true -DrepoToken=$GITHUB_TOKEN -DserviceName=github -DpullRequest=$PR_NUMBER
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
+      - name: License
+        if: contains(matrix.os, 'ubuntu')
+        run: git fetch --unshallow && ./mvnw license:check

--- a/.github/workflows/solaris.yaml
+++ b/.github/workflows/solaris.yaml
@@ -32,7 +32,7 @@ jobs:
           git checkout master
           git reset --hard HEAD~2
           git pull
-          mvn clean test -B -Djacoco.skip=true
+          mvn clean test -B -Djacoco.skip=true -Dlicense.skip=true
   # Runs current branch on Solaris 11.3 on SPARC
   testsolaris_sparc:
     runs-on: ubuntu-latest
@@ -53,5 +53,5 @@ jobs:
           git checkout master
           git reset --hard HEAD~2
           git pull
-          ./mvnw clean test -B -Djacoco.skip=true
+          ./mvnw clean test -B -Djacoco.skip=true -Dlicense.skip=true
                     

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -30,7 +30,7 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Analyze with SonarCloud
-        run: ./mvnw verify sonar:sonar -B -D"sonar.projectKey=oshi_oshi" -D"sonar.organization=oshi-oshi" -D"sonar.host.url=https://sonarcloud.io" -D"sonar.login=$SONAR_TOKEN"
+        run: ./mvnw verify sonar:sonar -B -D"sonar.projectKey=oshi_oshi" -D"sonar.organization=oshi-oshi" -D"sonar.host.url=https://sonarcloud.io" -D"sonar.login=$SONAR_TOKEN" -Dlicense.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonatype.yaml
+++ b/.github/workflows/sonatype.yaml
@@ -21,7 +21,7 @@ jobs:
           java-version: 11
           distribution: 'zulu'
       - name: Deploy to Sonatype
-        run: ./mvnw deploy -Djacoco.skip=true -DskipTests -B --settings ./.mvn/settings.xml
+        run: ./mvnw deploy -Djacoco.skip=true -Dlicense.skip=true -DskipTests -B --settings ./.mvn/settings.xml
         env:
           CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
           CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,9 +39,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2          
       - name: Test with Maven
-        run: ./mvnw test -B
-      - name: Report Coverage to Coveralls
-        if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '8')
-        run: ./mvnw test jacoco:report coveralls:report -q -Dlicense.skip=true -DrepoToken=$GITHUB_TOKEN -DserviceName=github
+        run: ./mvnw test -B -Dlicense.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `license-maven-plugin` version 4.2 enabled a new feature to use the file's creation date and last edit date as a copyright range, which we have now configured.  However, this new feature:
 - is resource intensive, navigating the git history for each file
 - breaks on shallow clones, since git history doesn't identify the oldest commit per file properly

Our CI workflows using the `actions/checkout` GitHub Action are shallow clones (to improve performance), using a default `fetch-depth` of 1.  This results in all license headers being incorrectly rewritten (and then thrown away) during CI runs.

Even without rewriting, the multiple checks are unneded.  This PR skips the `license:format` goal for CI, and only executes `license:check` once on PRs (after fetching full history).