### PR TITLE
Add support for modular/hybrid processor topology

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: ./mvnw checkstyle:check
       - name: Test with Maven
-        run: ./mvnw test -B -Dlicense.skip=true
+        run: ./mvnw test -B -D"license.skip=true"
       - name: Report Coverage to Coveralls for Pull Requests
         if: contains(matrix.os, 'ubuntu')
         run: ./mvnw test jacoco:report coveralls:report -q -Dlicense.skip=true -DrepoToken=$GITHUB_TOKEN -DserviceName=github -DpullRequest=$PR_NUMBER

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,6 +39,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2          
       - name: Test with Maven
-        run: ./mvnw test -B -Dlicense.skip=true
+        run: ./mvnw test -B -D"license.skip=true"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 6.0.1 (in progress)
+# 6.1.0 (in progress)
+
+##### New Features
+* [#1851](https://github.com/oshi/oshi/pull/1851): Add PhysicalProcessor class to expose hybrid processor topology - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug fixes / Improvements
 * [#1831](https://github.com/oshi/oshi/pull/1831): Improve Solaris and AIX process listing using procfs - [@dbwiddis](https://github.com/dbwiddis).

--- a/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
@@ -38,6 +38,8 @@ import com.sun.jna.platform.win32.WinNT.SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor.LogicalProcessor;
+import oshi.hardware.CentralProcessor.PhysicalProcessor;
+import oshi.util.tuples.Pair;
 
 /**
  * Utility to query Logical Processor Information
@@ -54,7 +56,7 @@ public final class LogicalProcessorInformation {
      *
      * @return A list of logical processors
      */
-    public static List<LogicalProcessor> getLogicalProcessorInformationEx() {
+    public static Pair<List<LogicalProcessor>, List<PhysicalProcessor>> getLogicalProcessorInformationEx() {
         // Collect a list of logical processors on each physical core and
         // package. These will be 64-bit bitmasks.
         SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX[] procInfo = Kernel32Util
@@ -112,7 +114,7 @@ public final class LogicalProcessorInformation {
                 }
             }
         }
-        return logProcs;
+        return new Pair<>(logProcs, null);
     }
 
     private static int getMatchingPackage(List<GROUP_AFFINITY[]> packages, int g, int lp) {
@@ -144,7 +146,7 @@ public final class LogicalProcessorInformation {
      *
      * @return A list of logical processors
      */
-    public static List<LogicalProcessor> getLogicalProcessorInformation() {
+    public static Pair<List<LogicalProcessor>, List<PhysicalProcessor>> getLogicalProcessorInformation() {
         // Collect a list of logical processors on each physical core and
         // package.
         List<Long> packageMaskList = new ArrayList<>();
@@ -178,7 +180,7 @@ public final class LogicalProcessorInformation {
                 }
             }
         }
-        return logProcs;
+        return new Pair<>(logProcs, null);
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2021-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -442,14 +442,16 @@ public interface CentralProcessor {
     class PhysicalProcessor {
         private final int physicalProcessorNumber;
         private final int efficiency;
+        private final String idString;
 
         public PhysicalProcessor(int physicalProcessorNumber) {
-            this(physicalProcessorNumber, 0);
+            this(physicalProcessorNumber, 0, "");
         }
 
-        public PhysicalProcessor(int physicalProcessorNumber, int efficiency) {
+        public PhysicalProcessor(int physicalProcessorNumber, int efficiency, String idString) {
             this.physicalProcessorNumber = physicalProcessorNumber;
             this.efficiency = efficiency;
+            this.idString = idString;
         }
 
         /**
@@ -481,6 +483,19 @@ public interface CentralProcessor {
          */
         public int getEfficiency() {
             return efficiency;
+        }
+
+        /**
+         * Gets a patform specific identification string representing this core.
+         * <p>
+         * For unimplemented operating systems, returns an empty string.
+         * <p>
+         * On Windows, returns the per-core Processor ID (CPUID).
+         *
+         * @return the idString
+         */
+        public String getIdString() {
+            return idString;
         }
 
         @Override

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -96,6 +96,14 @@ public interface CentralProcessor {
     List<LogicalProcessor> getLogicalProcessors();
 
     /**
+     * Returns an {@code UnmodifiableList} of the CPU's physical processors. The
+     * list will be sorted in order of increasing core ID.
+     *
+     * @return An {@code UnmodifiabeList} of physical processors.
+     */
+    List<PhysicalProcessor> getPhysicalProcessors();
+
+    /**
      * Returns the "recent cpu usage" for the whole system by counting ticks from
      * {@link #getSystemCpuLoadTicks()} between the user-provided value from a
      * previous call.
@@ -423,6 +431,32 @@ public interface CentralProcessor {
             return "LogicalProcessor [processorNumber=" + processorNumber + ", coreNumber=" + physicalProcessorNumber
                     + ", packageNumber=" + physicalPackageNumber + ", numaNode=" + numaNode + ", processorGroup="
                     + processorGroup + "]";
+        }
+    }
+
+    /**
+     * A class representing a Physical Processor (a core) providing per-core
+     * statistics that may vary, particularly in hybrid/modular processors.
+     */
+    @Immutable
+    class PhysicalProcessor {
+        private final int physicalProcessorNumber;
+
+        @Override
+        public String toString() {
+            return "LogicalProcessor [coreNumber=" + physicalProcessorNumber + "]";
+        }
+
+        public PhysicalProcessor(int physicalProcessorNumber) {
+            super();
+            this.physicalProcessorNumber = physicalProcessorNumber;
+        }
+
+        /**
+         * @return the physicalProcessorNumber
+         */
+        public int getPhysicalProcessorNumber() {
+            return physicalProcessorNumber;
         }
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -476,10 +476,18 @@ public interface CentralProcessor {
          * {@code PROCESSOR_RELATIONSHIP} structure. A core with a higher value for the
          * efficiency class has intrinsically greater performance and less efficiency
          * than a core with a lower value for the efficiency class.
+         * <p>
+         * On Linux, returns the {@code cpu_capacity} value from sysfs. This is an
+         * optional cpu node property representing CPU capacity expressed in normalized
+         * DMIPS/MHz.
          *
-         * @return the processor efficiency, efficiency class, or similar metric
+         * @return the processor efficiency, efficiency class, or similar metric if
+         *         available, otherwise 0
+         *
          * @see <a href=
          *      "https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-processor_relationship">PROCESSOR_RELATIONSHIP</a>
+         * @see <a href=
+         *      "https://www.kernel.org/doc/Documentation/devicetree/bindings/arm/cpu-capacity.txt">cpu-capacity</a>
          */
         public int getEfficiency() {
             return efficiency;
@@ -491,8 +499,10 @@ public interface CentralProcessor {
          * For unimplemented operating systems, returns an empty string.
          * <p>
          * On Windows, returns the per-core Processor ID (CPUID).
+         * <p>
+         * On Linux, returns the {@code MODALIAS} value for the core's driver.
          *
-         * @return the idString
+         * @return the identification string
          */
         public String getIdString() {
             return idString;

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -477,6 +477,9 @@ public interface CentralProcessor {
          * efficiency class has intrinsically greater performance and less efficiency
          * than a core with a lower value for the efficiency class.
          * <p>
+         * On macOS, attempts to emulate the same relative efficiency class values as
+         * Windows.
+         * <p>
          * On Linux, returns the {@code cpu_capacity} value from sysfs. This is an
          * optional cpu node property representing CPU capacity expressed in normalized
          * DMIPS/MHz.
@@ -494,11 +497,16 @@ public interface CentralProcessor {
         }
 
         /**
-         * Gets a patform specific identification string representing this core.
+         * Gets a platform specific identification string representing this core. This
+         * string requires user parsing to obtain meaningful information. As this is an
+         * experimental feature, users should not rely on the format.
          * <p>
          * For unimplemented operating systems, returns an empty string.
          * <p>
          * On Windows, returns the per-core Processor ID (CPUID).
+         * <p>
+         * On macOS, returns a compatibility string from the IO Registry identifying
+         * hybrid cores.
          * <p>
          * On Linux, returns the {@code MODALIAS} value for the core's driver.
          *
@@ -510,7 +518,8 @@ public interface CentralProcessor {
 
         @Override
         public String toString() {
-            return "LogicalProcessor [coreNumber=" + physicalProcessorNumber + ", efficiency=" + efficiency + "]";
+            return "LogicalProcessor [coreNumber=" + physicalProcessorNumber + ", efficiency=" + efficiency
+                    + ", idString=" + idString + "]";
         }
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2021-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -441,22 +441,51 @@ public interface CentralProcessor {
     @Immutable
     class PhysicalProcessor {
         private final int physicalProcessorNumber;
-
-        @Override
-        public String toString() {
-            return "LogicalProcessor [coreNumber=" + physicalProcessorNumber + "]";
-        }
+        private final int efficiency;
 
         public PhysicalProcessor(int physicalProcessorNumber) {
-            super();
+            this(physicalProcessorNumber, 0);
+        }
+
+        public PhysicalProcessor(int physicalProcessorNumber, int efficiency) {
             this.physicalProcessorNumber = physicalProcessorNumber;
+            this.efficiency = efficiency;
         }
 
         /**
+         * Gets the core id. This is also the physical processor number which
+         * corresponds to {@link LogicalProcessor#getPhysicalProcessorNumber()}.
+         *
          * @return the physicalProcessorNumber
          */
         public int getPhysicalProcessorNumber() {
             return physicalProcessorNumber;
+        }
+
+        /**
+         * Gets a platform specific measure of processor efficiency, useful for
+         * identifying performance and efficiency cores in hybrid/System on Chip (SoC)
+         * processors such as ARM's big.LITTLE architecture, Apple's M1, and Intel's
+         * P-core and E-core hybrid technology.
+         * <p>
+         * For unimplemented operating systems, returns 0.
+         * <p>
+         * On Windows 10 and higher, returns the {@code EfficiencyClass} value from the
+         * {@code PROCESSOR_RELATIONSHIP} structure. A core with a higher value for the
+         * efficiency class has intrinsically greater performance and less efficiency
+         * than a core with a lower value for the efficiency class.
+         *
+         * @return the processor efficiency, efficiency class, or similar metric
+         * @see <a href=
+         *      "https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-processor_relationship">PROCESSOR_RELATIONSHIP</a>
+         */
+        public int getEfficiency() {
+            return efficiency;
+        }
+
+        @Override
+        public String toString() {
+            return "LogicalProcessor [coreNumber=" + physicalProcessorNumber + ", efficiency=" + efficiency + "]";
         }
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -465,24 +465,23 @@ public interface CentralProcessor {
         }
 
         /**
-         * Gets a platform specific measure of processor efficiency, useful for
-         * identifying performance and efficiency cores in hybrid/System on Chip (SoC)
-         * processors such as ARM's big.LITTLE architecture, Apple's M1, and Intel's
-         * P-core and E-core hybrid technology.
-         * <p>
-         * For unimplemented operating systems, returns 0.
+         * Gets a platform specific measure of processor performance vs. efficiency,
+         * useful for identifying cores in hybrid/System on Chip (SoC) processors such
+         * as ARM's big.LITTLE architecture, Apple's M1, and Intel's P-core and E-core
+         * hybrid technology. A core with a higher value for the efficiency class has
+         * intrinsically greater performance and less efficiency than a core with a
+         * lower value for the efficiency class.
          * <p>
          * On Windows 10 and higher, returns the {@code EfficiencyClass} value from the
-         * {@code PROCESSOR_RELATIONSHIP} structure. A core with a higher value for the
-         * efficiency class has intrinsically greater performance and less efficiency
-         * than a core with a lower value for the efficiency class.
+         * {@code PROCESSOR_RELATIONSHIP} structure.
          * <p>
-         * On macOS, attempts to emulate the same relative efficiency class values as
-         * Windows.
+         * On macOS, emulates the same relative efficiency class values as Windows.
          * <p>
          * On Linux, returns the {@code cpu_capacity} value from sysfs. This is an
          * optional cpu node property representing CPU capacity expressed in normalized
          * DMIPS/MHz.
+         * <p>
+         * For unimplemented operating systems, returns 0.
          *
          * @return the processor efficiency, efficiency class, or similar metric if
          *         available, otherwise 0
@@ -501,14 +500,14 @@ public interface CentralProcessor {
          * string requires user parsing to obtain meaningful information. As this is an
          * experimental feature, users should not rely on the format.
          * <p>
-         * For unimplemented operating systems, returns an empty string.
-         * <p>
          * On Windows, returns the per-core Processor ID (CPUID).
          * <p>
          * On macOS, returns a compatibility string from the IO Registry identifying
          * hybrid cores.
          * <p>
          * On Linux, returns the {@code MODALIAS} value for the core's driver.
+         * <p>
+         * For unimplemented operating systems, returns an empty string.
          *
          * @return the identification string
          */
@@ -518,7 +517,7 @@ public interface CentralProcessor {
 
         @Override
         public String toString() {
-            return "LogicalProcessor [coreNumber=" + physicalProcessorNumber + ", efficiency=" + efficiency
+            return "PhysicalProcessor [coreNumber=" + physicalProcessorNumber + ", efficiency=" + efficiency
                     + ", idString=" + idString + "]";
         }
     }

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -471,21 +471,21 @@ public interface CentralProcessor {
          * hybrid technology. A core with a higher value for the efficiency class has
          * intrinsically greater performance and less efficiency than a core with a
          * lower value for the efficiency class.
-         * <p>
-         * On Windows 10 and higher, returns the {@code EfficiencyClass} value from the
-         * {@code PROCESSOR_RELATIONSHIP} structure.
-         * <p>
-         * On macOS, emulates the same relative efficiency class values as Windows.
-         * <p>
-         * On Linux, returns the {@code cpu_capacity} value from sysfs. This is an
-         * optional cpu node property representing CPU capacity expressed in normalized
-         * DMIPS/MHz.
-         * <p>
-         * For unimplemented operating systems, returns 0.
          *
-         * @return the processor efficiency, efficiency class, or similar metric if
-         *         available, otherwise 0
-         *
+         * @return On Windows 10 and higher, returns the {@code EfficiencyClass} value
+         *         from the {@code PROCESSOR_RELATIONSHIP} structure.
+         *         <p>
+         *         On macOS with Apple Silicon, emulates the same relative efficiency
+         *         class values as Windows.
+         *         <p>
+         *         On Linux, returns the {@code cpu_capacity} value from sysfs. This is
+         *         an optional cpu node property representing CPU capacity expressed in
+         *         normalized DMIPS/MHz.
+         *         <p>
+         *         On OpenBSD, FreeBSD, and Solaris with ARM big.LITTLE processors,
+         *         emulates the same relative efficiency class values as Windows.
+         *         <p>
+         *         For unimplemented operating systems or architectures, returns 0.
          * @see <a href=
          *      "https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-processor_relationship">PROCESSOR_RELATIONSHIP</a>
          * @see <a href=
@@ -499,17 +499,18 @@ public interface CentralProcessor {
          * Gets a platform specific identification string representing this core. This
          * string requires user parsing to obtain meaningful information. As this is an
          * experimental feature, users should not rely on the format.
-         * <p>
-         * On Windows, returns the per-core Processor ID (CPUID).
-         * <p>
-         * On macOS, returns a compatibility string from the IO Registry identifying
-         * hybrid cores.
-         * <p>
-         * On Linux, returns the {@code MODALIAS} value for the core's driver.
-         * <p>
-         * For unimplemented operating systems, returns an empty string.
          *
-         * @return the identification string
+         * @return On Windows, returns the per-core Processor ID (CPUID).
+         *         <p>
+         *         On macOS, returns a compatibility string from the IO Registry
+         *         identifying hybrid cores.
+         *         <p>
+         *         On Linux, returns the {@code MODALIAS} value for the core's driver.
+         *         <p>
+         *         On OpenBSD, FreeBSD, and Solaris, returns a per-core CPU
+         *         identification string.
+         *         <p>
+         *         For unimplemented operating systems, returns an empty string.
          */
         public String getIdString() {
             return idString;

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2020-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -51,6 +51,7 @@ import oshi.software.os.linux.LinuxOperatingSystem;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 
 /**
  * A CPU as defined in Linux /proc.
@@ -153,7 +154,7 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected List<LogicalProcessor> initProcessorCounts() {
+    protected Pair<List<LogicalProcessor>, List<PhysicalProcessor>> initProcessorCounts() {
         List<LogicalProcessor> logProcs = new ArrayList<>();
         // Enumerate CPU topology from sysfs
         UdevContext udev = Udev.INSTANCE.udev_new();
@@ -189,7 +190,7 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
         if (logProcs.isEmpty()) {
             logProcs.add(new LogicalProcessor(0, 0, 0));
         }
-        return logProcs;
+        return new Pair<>(logProcs, null);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -66,8 +66,7 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(MacCentralProcessor.class);
 
     private final Supplier<String> vendor = memoize(MacCentralProcessor::platformExpert);
-    private final Supplier<Quartet<Integer, Integer, Long, Map<Integer, String>>> typeFamilyFreqCompat = memoize(
-            MacCentralProcessor::queryArmCpu);
+    private Quartet<Integer, Integer, Long, Map<Integer, String>> typeFamilyFreqCompat = queryArmCpu();
 
     private static final int ROSETTA_CPUTYPE = 0x00000007;
     private static final int ROSETTA_CPUFAMILY = 0x573b5eec;
@@ -96,10 +95,10 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
             // Intel Westmere chip (0x573b5eec), family 6, model 44, stepping 0.
             // Test if under Rosetta and generate correct chip
             if (family == ROSETTA_CPUFAMILY) {
-                type = typeFamilyFreqCompat.get().getA();
-                family = typeFamilyFreqCompat.get().getB();
+                type = typeFamilyFreqCompat.getA();
+                family = typeFamilyFreqCompat.getB();
             }
-            cpuFreq = typeFamilyFreqCompat.get().getC();
+            cpuFreq = typeFamilyFreqCompat.getC();
             // Translate to output
             cpuFamily = String.format("0x%08x", family);
             // Processor ID is an intel concept but CPU type + family conveys same info
@@ -139,7 +138,7 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
             logProcs.add(new LogicalProcessor(i, coreId, i * physicalPackageCount / logicalProcessorCount));
             cores.add(coreId);
         }
-        Map<Integer, String> compatMap = typeFamilyFreqCompat.get().getD();
+        Map<Integer, String> compatMap = typeFamilyFreqCompat.getD();
         List<PhysicalProcessor> physProcs = cores.stream().sorted().map(k -> {
             String compat = compatMap.get(k);
             int efficiency = 0; // default, for firestorm

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -141,9 +141,9 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
         Map<Integer, String> compatMap = queryArmCpu().getD();
         List<PhysicalProcessor> physProcs = cores.stream().sorted().map(k -> {
             String compat = compatMap.getOrDefault(k, "");
-            int efficiency = 0; // default, for firestorm
-            if (compat.toLowerCase().contains("icestorm")) {
-                efficiency = 1;
+            int efficiency = 0; // default, for E-core icestorm
+            if (compat.toLowerCase().contains("firestorm")) {
+                efficiency = 1; // P-core, more performance
             }
             return new PhysicalProcessor(k, efficiency, compat);
         }).collect(Collectors.toList());

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -51,6 +51,7 @@ import oshi.util.FormatUtil;
 import oshi.util.ParseUtil;
 import oshi.util.Util;
 import oshi.util.platform.mac.SysctlUtil;
+import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
 /**
@@ -123,7 +124,7 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected List<LogicalProcessor> initProcessorCounts() {
+    protected Pair<List<LogicalProcessor>, List<PhysicalProcessor>> initProcessorCounts() {
         int logicalProcessorCount = SysctlUtil.sysctl("hw.logicalcpu", 1);
         int physicalProcessorCount = SysctlUtil.sysctl("hw.physicalcpu", 1);
         int physicalPackageCount = SysctlUtil.sysctl("hw.packages", 1);
@@ -132,7 +133,7 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
             logProcs.add(new LogicalProcessor(i, i * physicalProcessorCount / logicalProcessorCount,
                     i * physicalPackageCount / logicalProcessorCount));
         }
-        return logProcs;
+        return new Pair<>(logProcs, null);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2021-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
@@ -110,7 +110,7 @@ final class AixCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected List<LogicalProcessor> initProcessorCounts() {
+    protected Pair<List<LogicalProcessor>, List<PhysicalProcessor>> initProcessorCounts() {
         this.config = PerfstatConfig.queryConfig();
 
         int physProcs = (int) config.numProcessors.max;
@@ -129,7 +129,7 @@ final class AixCentralProcessor extends AbstractCentralProcessor {
             logProcs.add(new LogicalProcessor(proc, proc / physProcs, nodePkg == null ? 0 : nodePkg.getB(),
                     nodePkg == null ? 0 : nodePkg.getA()));
         }
-        return logProcs;
+        return new Pair<>(logProcs, null);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2020-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -44,6 +44,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
+import oshi.util.tuples.Pair;
 
 /**
  * A CPU
@@ -106,13 +107,13 @@ final class FreeBsdCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected List<LogicalProcessor> initProcessorCounts() {
+    protected Pair<List<LogicalProcessor>, List<PhysicalProcessor>> initProcessorCounts() {
         List<LogicalProcessor> logProcs = parseTopology();
         // Force at least one processor
         if (logProcs.isEmpty()) {
             logProcs.add(new LogicalProcessor(0, 0, 0));
         }
-        return logProcs;
+        return new Pair<>(logProcs, null);
     }
 
     private static List<LogicalProcessor> parseTopology() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2021-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessor.java
@@ -122,7 +122,7 @@ public class OpenBsdCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected List<LogicalProcessor> initProcessorCounts() {
+    protected Pair<List<LogicalProcessor>, List<PhysicalProcessor>> initProcessorCounts() {
         // Iterate dmesg, look for lines:
         // cpu0: smt 0, core 0, package 0
         // cpu1: smt 0, core 1, package 0
@@ -146,7 +146,7 @@ public class OpenBsdCentralProcessor extends AbstractCentralProcessor {
         for (int i = 0; i < logicalProcessorCount; i++) {
             logProcs.add(new LogicalProcessor(i, coreMap.getOrDefault(i, 0), packageMap.getOrDefault(i, 0)));
         }
-        return logProcs;
+        return new Pair<>(logProcs, null);
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessor.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2021-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2021-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
@@ -39,6 +39,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.solaris.KstatUtil;
 import oshi.util.platform.unix.solaris.KstatUtil.KstatChain;
+import oshi.util.tuples.Pair;
 
 /**
  * A CPU
@@ -105,11 +106,11 @@ final class SolarisCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected List<LogicalProcessor> initProcessorCounts() {
+    protected Pair<List<LogicalProcessor>, List<PhysicalProcessor>> initProcessorCounts() {
         Map<Integer, Integer> numaNodeMap = mapNumaNodes();
         if (SolarisOperatingSystem.IS_11_4_OR_HIGHER) {
             // Use Kstat2 implementation
-            return initProcessorCounts2(numaNodeMap);
+            return new Pair<>(initProcessorCounts2(numaNodeMap), null);
         }
         List<LogicalProcessor> logProcs = new ArrayList<>();
         try (KstatChain kc = KstatUtil.openChain()) {
@@ -129,7 +130,7 @@ final class SolarisCentralProcessor extends AbstractCentralProcessor {
         if (logProcs.isEmpty()) {
             logProcs.add(new LogicalProcessor(0, 0, 0));
         }
-        return logProcs;
+        return new Pair<>(logProcs, null);
     }
 
     private static List<LogicalProcessor> initProcessorCounts2(Map<Integer, Integer> numaNodeMap) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
@@ -150,9 +150,10 @@ final class WindowsCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected List<LogicalProcessor> initProcessorCounts() {
+    protected Pair<List<LogicalProcessor>, List<PhysicalProcessor>> initProcessorCounts() {
         if (VersionHelpers.IsWindows7OrGreater()) {
-            List<LogicalProcessor> logProcs = LogicalProcessorInformation.getLogicalProcessorInformationEx();
+            Pair<List<LogicalProcessor>, List<PhysicalProcessor>> procs = LogicalProcessorInformation
+                    .getLogicalProcessorInformationEx();
             // Save numaNode,Processor lookup for future PerfCounter instance lookup
             // The processor number is based on the Processor Group, so we keep a separate
             // index by NUMA node.
@@ -161,7 +162,7 @@ final class WindowsCentralProcessor extends AbstractCentralProcessor {
             // 0-indexed list of all lps for array lookup
             int lp = 0;
             this.numaNodeProcToLogicalProcMap = new HashMap<>();
-            for (LogicalProcessor logProc : logProcs) {
+            for (LogicalProcessor logProc : procs.getA()) {
                 int node = logProc.getNumaNode();
                 // This list is grouped by NUMA node so a change in node will reset this counter
                 if (node != curNode) {
@@ -170,7 +171,7 @@ final class WindowsCentralProcessor extends AbstractCentralProcessor {
                 }
                 numaNodeProcToLogicalProcMap.put(String.format("%d,%d", logProc.getNumaNode(), procNum++), lp++);
             }
-            return logProcs;
+            return procs;
         } else {
             return LogicalProcessorInformation.getLogicalProcessorInformation();
         }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2020-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/CentralProcessorTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2020-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -80,13 +80,12 @@ class CentralProcessorTest {
     void testFrequencies() {
         long max = p.getMaxFreq();
         long[] curr = p.getCurrentFreq();
-        assertThat(
-                "Central Processor's logical processor frequency array length should be the same as its logical processor count",
+        assertThat("Logical processor frequency array length should be the same as its logical processor count",
                 p.getLogicalProcessorCount(), is(curr.length));
         if (max >= 0) {
             for (int i = 0; i < curr.length; i++) {
-                assertThat("Central Processor's logical processor frequency should be at most it's max frequency",
-                        curr[i], is(lessThanOrEqualTo(max)));
+                assertThat("Logical processor frequency should be at most it's max frequency", curr[i],
+                        is(lessThanOrEqualTo(max)));
             }
         }
     }
@@ -105,16 +104,14 @@ class CentralProcessorTest {
         assertThat("System's load averages length for 3 elements should equal 3", p.getSystemLoadAverage(3).length,
                 is(3));
 
-        assertThat("Central Processor's cpu load between ticks should equal the logical processor count",
-                p.getLogicalProcessorCount(), is(p.getProcessorCpuLoadBetweenTicks(procTicks).length));
+        assertThat("Cpu load between ticks should equal the logical processor count", p.getLogicalProcessorCount(),
+                is(p.getProcessorCpuLoadBetweenTicks(procTicks).length));
         for (int cpu = 0; cpu < p.getLogicalProcessorCount(); cpu++) {
-            assertThat(
-                    "Central Processor's cpu number " + cpu
-                            + "'s load between ticks should be inclusively between 0 and 1",
+            assertThat("Cpu number " + cpu + "'s load between ticks should be inclusively between 0 and 1",
                     p.getProcessorCpuLoadBetweenTicks(procTicks)[cpu],
                     is(both(greaterThanOrEqualTo(0d)).and(lessThanOrEqualTo(1d))));
             assertThat(
-                    "Central Processor's cpu number " + cpu
+                    "Cpu number " + cpu
                             + " should have the same amount of cpu-load-tick counters as there are TickType values",
                     TickType.values().length, is(p.getProcessorCpuLoadTicks()[cpu].length));
         }
@@ -122,19 +119,21 @@ class CentralProcessorTest {
 
     @Test
     void testCounts() {
-        assertThat(
-                "Central Processor's logical processor count should be at least as high as its physical processor count",
+        assertThat("Logical processor count should be at least as high as its physical processor count",
                 p.getLogicalProcessorCount(), is(greaterThanOrEqualTo(p.getPhysicalProcessorCount())));
-        assertThat("Central Processor's physical processor count should by higher than 0",
-                p.getPhysicalProcessorCount(), is(greaterThan(0)));
-        assertThat("Central Processor's physical processor count should be higher than its physical package count",
-                p.getPhysicalProcessorCount(), is(greaterThanOrEqualTo(p.getPhysicalPackageCount())));
-        assertThat("Central Processor's physical package count should be higher than 0", p.getPhysicalPackageCount(),
+        assertThat("Physical processor count should by higher than 0", p.getPhysicalProcessorCount(),
                 is(greaterThan(0)));
-        assertThat("Central Processor's context switch count should be 0 or higher", p.getContextSwitches(),
-                is(greaterThanOrEqualTo(0L)));
-        assertThat("Central Processor's interrupt count should be 0 or higher", p.getInterrupts(),
-                is(greaterThanOrEqualTo(0L)));
+        assertThat("Physical processor count should be higher than its physical package count",
+                p.getPhysicalProcessorCount(), is(greaterThanOrEqualTo(p.getPhysicalPackageCount())));
+        assertThat("Physical package count should be higher than 0", p.getPhysicalPackageCount(), is(greaterThan(0)));
+
+        assertThat("Logical processor list size should match count", p.getLogicalProcessors().size(),
+                is(p.getLogicalProcessorCount()));
+        assertThat("Physical processor list size should match count", p.getPhysicalProcessors().size(),
+                is(p.getPhysicalProcessorCount()));
+
+        assertThat("Context switch count should be 0 or higher", p.getContextSwitches(), is(greaterThanOrEqualTo(0L)));
+        assertThat("Interrupt count should be 0 or higher", p.getInterrupts(), is(greaterThanOrEqualTo(0L)));
         for (int lp = 0; lp < p.getLogicalProcessorCount(); lp++) {
             assertThat("Logical processor number is negative", p.getLogicalProcessors().get(lp).getProcessorNumber(),
                     is(greaterThanOrEqualTo(0)));


### PR DESCRIPTION
Adds a `getPhysicalProcessors()` method to `CentralProcessor` which returns a list.  Each `PhysicalProcessor` includes:
 - a core id
 - an efficiency measure to identify relative performance vs. efficiency tradeoffs
 - a string with processor identification information