### PR TITLE
Add package ID to PhysicalProcessor object for uniqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 6.1.0 (in progress)
 
 ##### New Features
-* [#1851](https://github.com/oshi/oshi/pull/1851): Add PhysicalProcessor class to expose hybrid processor topology - [@dbwiddis](https://github.com/dbwiddis).
+* [#1851](https://github.com/oshi/oshi/pull/1851),
+  [#1858](https://github.com/oshi/oshi/pull/1858): Add PhysicalProcessor class to expose hybrid processor topology - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug fixes / Improvements
 * [#1831](https://github.com/oshi/oshi/pull/1831): Improve Solaris and AIX process listing using procfs - [@dbwiddis](https://github.com/dbwiddis).

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -440,18 +440,31 @@ public interface CentralProcessor {
      */
     @Immutable
     class PhysicalProcessor {
+        private final int physicalPackageNumber;
         private final int physicalProcessorNumber;
         private final int efficiency;
         private final String idString;
 
-        public PhysicalProcessor(int physicalProcessorNumber) {
-            this(physicalProcessorNumber, 0, "");
+        public PhysicalProcessor(int physicalPackageNumber, int physicalProcessorNumber) {
+            this(physicalPackageNumber, physicalProcessorNumber, 0, "");
         }
 
-        public PhysicalProcessor(int physicalProcessorNumber, int efficiency, String idString) {
+        public PhysicalProcessor(int physicalPackageNumber, int physicalProcessorNumber, int efficiency,
+                String idString) {
+            this.physicalPackageNumber = physicalPackageNumber;
             this.physicalProcessorNumber = physicalProcessorNumber;
             this.efficiency = efficiency;
             this.idString = idString;
+        }
+
+        /**
+         * Gets the package id. This is also the physical package number which
+         * corresponds to {@link LogicalProcessor#getPhysicalPackageNumber()}.
+         *
+         * @return the physicalProcessorNumber
+         */
+        public int getPhysicalPackageNumber() {
+            return physicalPackageNumber;
         }
 
         /**
@@ -518,8 +531,8 @@ public interface CentralProcessor {
 
         @Override
         public String toString() {
-            return "PhysicalProcessor [coreNumber=" + physicalProcessorNumber + ", efficiency=" + efficiency
-                    + ", idString=" + idString + "]";
+            return "PhysicalProcessor [package/core=" + physicalPackageNumber + "/" + physicalProcessorNumber
+                    + ", efficiency=" + efficiency + ", idString=" + idString + "]";
         }
     }
 


### PR DESCRIPTION
A 4-package 8-core machine has only core_id 0 and 1 in each of the packages