### PR TITLE
Streamline modular artifact release process

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -12,13 +12,13 @@ on:
       - '**.yaml'
     
 jobs:
-  # Runs current branch on Windows, Linux, macOS with multiple JDKs
+  # Runs full project on JDK 8
   testmatrix:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Baseline support, Current LTS, Current GA, Current EA
-        java: [8, 11, 17, 18-ea]
+        # Baseline support
+        java: [8]
         os: [ubuntu-latest]
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
@@ -35,14 +35,36 @@ jobs:
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2          
+          restore-keys: ${{ runner.os }}-m2
       - name: Checkstyle
-        if: contains(matrix.java, '8')
         run: ./mvnw checkstyle:check
-      - name: Test with Maven
-        run: ./mvnw test -B -Dlicense.skip=true
-      - name: Report Coverage to Coveralls
-        if: contains(matrix.java, '8')
+      - name: Test with Maven and report Coverage to Coveralls
         run: ./mvnw test jacoco:report coveralls:report -q -Dlicense.skip=true -DrepoToken=$GITHUB_TOKEN -DserviceName=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Runs modular build on multiple JDKs
+  testmatrix11:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Current LTS, Current GA, Current EA
+        java: [11, 17, 18-ea]
+        os: [ubuntu-latest]
+      fail-fast: false
+    name: Modular build on JDK ${{ matrix.java }}, ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'zulu'
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-11-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-11-m2
+      - name: Test with Maven
+        run: ./mvnw11 test -B -Dlicense.skip=true

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -12,13 +12,13 @@ on:
       - '**.yaml'
     
 jobs:
-  # Runs current branch on Windows, Linux, macOS with multiple JDKs
+  # Runs full project on JDK 8
   testmatrix:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # Baseline support, Current LTS, Current GA, Current EA
-        java: [8, 11, 17, 18-ea]
+        java: [8]
         os: [macos-latest, macos-11]
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
@@ -38,5 +38,33 @@ jobs:
           restore-keys: ${{ runner.os }}-m2          
       - name: Test with Maven
         run: ./mvnw test -B  -Dlicense.skip=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Runs modular build on multiple JDKs
+  testmatrix11:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Baseline support, Current LTS, Current GA, Current EA
+        java: [11, 17, 18-ea]
+        os: [macos-latest, macos-11]
+      fail-fast: false
+    name: JDK ${{ matrix.java }}, ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-11-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-11-m2          
+      - name: Test with Maven
+        run: ./mvnw11 test -B  -Dlicense.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-11.0 unreliable for now
         os: [ubuntu-latest, macos-latest, windows-latest]
         java: [8]
       fail-fast: false
@@ -30,18 +29,32 @@ jobs:
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2          
+          restore-keys: ${{ runner.os }}-m2
       - name: Checkstyle
         if: contains(matrix.os, 'ubuntu')
         run: ./mvnw checkstyle:check
       - name: Test with Maven
         run: ./mvnw test -B -D"license.skip=true"
-      - name: Report Coverage to Coveralls for Pull Requests
-        if: contains(matrix.os, 'ubuntu')
-        run: ./mvnw test jacoco:report coveralls:report -q -Dlicense.skip=true -DrepoToken=$GITHUB_TOKEN -DserviceName=github -DpullRequest=$PR_NUMBER
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
-      - name: License
-        if: contains(matrix.os, 'ubuntu')
-        run: git fetch --unshallow && ./mvnw license:check
+  test11:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        java: [11]
+      fail-fast: false
+    name: Test Modular build on JDK ${{ matrix.java }}, ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'zulu'
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-11-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-11-m2
+      - name: Test with Maven
+        run: ./mvnw11 test -B -D"license.skip=true"

--- a/.github/workflows/sonatype.yaml
+++ b/.github/workflows/sonatype.yaml
@@ -11,8 +11,11 @@ on:
 
 jobs:
   build:
-    if: github.repository_owner == 'oshi' && ! contains(toJSON(github.event.head_commit.message), '[maven-release-plugin]')
+    if: github.repository_owner == 'oshi' && ! contains(toJSON(github.event.head_commit.message), '[maven-release-plugin] prepare release')
     runs-on: ubuntu-latest
+    env:
+      CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+      CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}      
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -22,6 +25,5 @@ jobs:
           distribution: 'zulu'
       - name: Deploy to Sonatype
         run: ./mvnw deploy -Djacoco.skip=true -Dlicense.skip=true -DskipTests -B --settings ./.mvn/settings.xml
-        env:
-          CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
-          CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+      - name: Deploy java11 artifacts to Sonatype
+        run: ./mvnw11 clean deploy -Djacoco.skip=true -Dlicense.skip=true -DskipTests -B --settings ./.mvn/settings.xml

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,44 +9,61 @@ Releasing OSHI
 
 * Other than during releases, the version number in the pom.xml should end in -SNAPSHOT
 * A GitHub Action deploys snapshots for pushes to the master branch. Snapshot releases may also be
-manually deployed using `mvn clean deploy`
+manually deployed using `mvn clean deploy` and `./mvnw11 clean deploy`
+    * Note the `mvnw11` script doesn't work on Windows. You can manually execute the commands in the script.
 
 ### Prepare
 
 * Make sure tests pass on all configured CI operating systems. 
-* Manually run tests on any non-covered OS using `mvn clean test`.
+* Manually run tests on any non-CI-covered OS using `mvn clean test`.
 * Review [SonarQube](https://sonarcloud.io/dashboard?id=com.github.oshi%3Aoshi-parent) for any bugs.
 * Choose an appropriate [version number](https://semver.org/) for the release
- 	* Proactively change version numbers in the download links on [README.md](README.md).
-	* Copy [README.md](README.md) to [src/site/markdown/README.md](src/site/markdown/README.md)
-		* HTML-escape `&`, `<`, and `>` in any links in the site version
-	* Change "Next" or in-progress version in [CHANGELOG.md](CHANGELOG.md) to this new version.
-	* Move "Your contribution here." to a new empty "Next" section
-	* Commit changes as a "prep for x.x release"
+    * Proactively change version numbers in the download links on [README.md](README.md).
+    * Copy [README.md](README.md) to [src/site/markdown/README.md](src/site/markdown/README.md)
+        * HTML-escape `&`, `<`, and `>` in any links in the site version
+    * Change "Next" or in-progress version in [CHANGELOG.md](CHANGELOG.md) to this new version.
+    * Move "Your contribution here." to a new empty "Next" section
+    * Commit changes as a "prep for x.x release"
 
-### Release
+### Release Modular Artifacts
 
-* See [this page](https://central.sonatype.org/pages/apache-maven.html#performing-a-release-deployment-with-the-maven-release-plugin) for a summary of the below steps
+Performing this release first is preferred: this can be done after the non-modular build, but requires backing out the release commits.
+* `git branch -D java11`
+    * Delete any existing local java11 branch: 
+* `git checkout -b java11`
+    * Create and checkout a new java11 branch 
+* Run the commands in the first portion of the `mvnw11` script (up to, but not including, running the maven wrapper).
+    * This will update the `pom.xml` files as needed for the java11 release.
+* `git commit ...` 
+    * Commit the copied and changed files (the `module-info.*` and `pom.xml` files)
+* `git push upstream +java11`
+    * Force-push the branch upstream 
+* `mvn release:...  -P java11`
+    * Follow all the below steps for a non-modular release, substituting the `mvnw11` wrapper script for `mvn`.  It is not necessary to publish the java11 tag as a release.
+
+### Release Non-Modular Artifacts
+
+See [this page](https://central.sonatype.org/pages/apache-maven.html#performing-a-release-deployment-with-the-maven-release-plugin) for a summary of the below steps
 * `mvn clean deploy`
-	* Do a final snapshot release and fix any errors in the javadocs
-	* If license headers are rewritten as part of this deployment, commit the changes
+    * Do a final snapshot release and fix any errors in the javadocs
+    * If license headers are rewritten as part of this deployment, commit the changes
 * `mvn release:clean`
-	* Takes a few seconds
+    * Takes a few seconds
 * `mvn release:prepare`
-	* Takes a few minutes
-	* This will ask for the version being released, removing -SNAPSHOT
-	* This will suggest the next version, increment appropriately
+    * Takes a few minutes
+    * This will ask for the version being released, removing -SNAPSHOT
+    * This will suggest the next version, increment appropriately
 * `mvn release:perform`
-	* Takes a few minutes. 
-	* This pushes the release to the [OSSRH](https://oss.sonatype.org/) staging repository
-	* This also pushes to [gh_pages](https://oshi.github.io/oshi)
+    * Takes a few minutes. 
+    * This pushes the release to the [OSSRH](https://oss.sonatype.org/) staging repository
+    * This also pushes to [gh_pages](https://oshi.github.io/oshi)
 * Log on to [Nexus](https://oss.sonatype.org/) and [release the deployment from OSSRH to the Central Repository](https://central.sonatype.org/pages/releasing-the-deployment.html).
 	
 * Add a title and release notes [to the tag](https://github.com/oshi/oshi/tags) on GitHub and publish the release to make it current.
 
-* Repeat all of the above steps on the `java11` branch, after cherry-picking recent commits.
+### Ongoing Maintenance
 
-* As development progresses, update version in [pom.xml](pom.xml) using -SNAPSHOT appended to the new version using [Semantic Versioning](https://semver.org/) standards:
-	* Increment major version (x.0) for API-breaking changes or additions
-	* Increment minor version (x.1) for substantive additions, bugfixes and changes that are backwards compatible
-	* Increment patch version (x.x.1) for minor bugfixes or changes that are backwards compatible
+As development progresses, update version in [pom.xml](pom.xml) using -SNAPSHOT appended to the new version using [Semantic Versioning](https://semver.org/) standards:
+* Increment major version (x.0) for API-breaking changes or additions
+* Increment minor version (x.1) for substantive additions, bugfixes and changes that are backwards compatible
+* Increment patch version (x.x.1) for minor bugfixes or changes that are backwards compatible

--- a/config/module-info.java
+++ b/config/module-info.java
@@ -1,0 +1,19 @@
+module com.github.oshi {
+    // API
+    exports oshi;
+    exports oshi.hardware;
+    exports oshi.software.os;
+    exports oshi.util;
+
+    // JNA needs reflective access to Structure subclasses
+    opens oshi.jna.platform.linux to com.sun.jna;
+    opens oshi.jna.platform.mac to com.sun.jna;
+    opens oshi.jna.platform.windows to com.sun.jna;
+    opens oshi.jna.platform.unix to com.sun.jna;
+
+    // dependencies
+    requires com.sun.jna;
+    requires com.sun.jna.platform;
+    requires transitive java.desktop;
+    requires org.slf4j;
+}

--- a/config/module-info.test
+++ b/config/module-info.test
@@ -1,0 +1,25 @@
+--add-opens
+  com.github.oshi/oshi=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.hardware=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.software.os=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.util=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.linux=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.linux.proc=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.mac=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.windows.perfmon=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.windows.wmi=org.junit.platform.commons
+
+--add-modules 
+  org.hamcrest
+--add-reads
+  com.github.oshi=org.hamcrest
+--add-reads
+  com.github.oshi=org.junit.jupiter.api

--- a/mvnw11
+++ b/mvnw11
@@ -1,0 +1,46 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Maven Script for OSHI -java11 builds
+#
+# Wraps the maven wrapper with customizations not possible in pom.xml 
+# Works around limitaiton that artifactId must be a constant
+# Ensures pom uploaded has correct dependency versions
+# Cleans up changes when complete
+
+echo "Copying module descriptor to source directory..."
+cp config/module-info.java oshi-core/src/main/java/module-info.java
+cp config/module-info.test oshi-core/src/test/java/module-info.test
+
+echo "Updating artifactId in POM files..."
+sed -i.bak -e 's/oshi-parent/oshi-parent-java11/g' pom.xml
+sed -i.bak -e 's/oshi-parent/oshi-parent-java11/g' oshi-core/pom.xml
+sed -i.bak -e 's/oshi-core/oshi-core-java11/g' oshi-core/pom.xml
+
+echo "Updating modular dependencies in POM files..."
+sed -i.bak -e 's/${slf4j.version}/2.0.0-alpha6/g' oshi-core/pom.xml
+sed -i.bak -e 's/>jna</>jna-jpms</g' oshi-core/pom.xml
+sed -i.bak -e 's/>jna-platform</>jna-platform-jpms</g' oshi-core/pom.xml
+rm pom.xml.bak
+rm oshi-core/pom.xml.bak
+
+#
+# Run commands above this line when preparing for a full release
+#
+
+echo "Running maven with java11 profile and arguments: \"$@\""
+echo "> ./mvnw \"$@\" -P java11"
+./mvnw "$@" -P java11
+
+echo "Cleaning up..."
+rm oshi-core/src/main/java/module-info.java
+rm oshi-core/src/test/java/module-info.test
+sed -i.bak -e 's/oshi-parent-java11/oshi-parent/g' pom.xml 
+sed -i.bak -e 's/oshi-parent-java11/oshi-parent/g' oshi-core/pom.xml
+sed -i.bak -e 's/oshi-core-java11/oshi-core/g' oshi-core/pom.xml
+sed -i.bak -e 's/2.0.0-alpha6/${slf4j.version}/g' oshi-core/pom.xml
+sed -i.bak -e 's/jna-jpms/jna/g' oshi-core/pom.xml
+sed -i.bak -e 's/jna-platform-jpms/jna-platform/g' oshi-core/pom.xml
+rm pom.xml.bak
+rm oshi-core/pom.xml.bak
+
+echo "All done!"

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -21,17 +21,13 @@
     </scm>
 
     <properties>
-        <!-- Users of the Spring Boot Starter Parent should include this property
-            in their POM -->
-        <jna.version>5.10.0</jna.version>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <automatic.module.name>com.github.oshi</automatic.module.name>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!-- Due to critical nature of OSHI jna usage, set to dependency management
-                to help influence usage -->
+            <!-- Due to critical nature of OSHI jna usage, set to dependency management to help influence usage -->
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,7 @@
 
     <modules>
         <module>oshi-core</module>
-        <module>oshi-core-shaded</module>
-        <module>oshi-demo</module>
-        <module>oshi-dist</module>
+        <!-- other modules added by default profile -->
     </modules>
 
     <scm>
@@ -95,6 +93,8 @@
         <!-- Base directory, overwrite in submodules -->
         <main.basedir>${project.basedir}</main.basedir>
         <!-- Dependency versions -->
+        <!-- Users of the Spring Boot Starter Parent should include this property in their POM -->
+        <jna.version>5.10.0</jna.version>
         <slf4j.version>1.7.33</slf4j.version>
         <junit.version>5.8.2</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -417,14 +417,11 @@
                         </archive>
                     </configuration>
                     <executions>
-                        <!-- ! here we override the super-pom attach-sources execution 
-                            id which ! calls sources:jar goal. That goals forks the lifecycle, ! causing the 
-                            generate-sources phase to be called twice for the install goal. ! Starting with 
-                            Maven 3.4.0 (https://issues.apache.org/jira/browse/MNG-5940) ! this is not needed 
-                            anymore. -->
-                        <!-- except that OSSRH fails with no sources with this 
-                            excluded <execution> <id>attach-sources</id> <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase> 
-                            </execution> -->
+                        <!-- ! here we override the super-pom attach-sources execution id which ! calls sources:jar goal. 
+                            That goals forks the lifecycle, ! causing the generate-sources phase to be called twice for the install goal. ! Starting 
+                            with Maven 3.4.0 (https://issues.apache.org/jira/browse/MNG-5940) ! this is not needed anymore. -->
+                        <!-- except that OSSRH fails with no sources with this excluded <execution> <id>attach-sources</id> 
+                            <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase> </execution> -->
                     </executions>
                 </plugin>
                 <!-- External Tools -->
@@ -455,8 +452,10 @@
                                     <exclude>**/MavenWrapperDownloader.java</exclude>
                                     <exclude>mvnw</exclude>
                                     <exclude>mvnw.cmd</exclude>
+                                    <exclude>mvnw11</exclude>
                                     <exclude>.editorconfig</exclude>
                                     <exclude>.gitattributes</exclude>
+                                    <exclude>**/module-info.*</exclude>
                                     <exclude>**/*.PNG</exclude>
                                     <exclude>*.xml</exclude>
                                     <exclude>*.yml</exclude>
@@ -636,8 +635,7 @@
                                         module path</reason>
                                     <includeTestCode>true</includeTestCode>
                                     <bannedImports>
-                                        <!-- Disallow all imports except explicitly 
-                                            allowed -->
+                                        <!-- Disallow all imports except explicitly allowed -->
                                         <bannedImport>**</bannedImport>
                                     </bannedImports>
                                     <allowedImports>
@@ -825,6 +823,43 @@
     </reporting>
 
     <profiles>
+        <!-- Default module configuration for java8 build -->
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>oshi-core-shaded</module>
+                <module>oshi-demo</module>
+                <module>oshi-dist</module>
+            </modules>
+        </profile>
+        <!-- Custom configuration for Java11 build -->
+        <profile>
+            <id>java11</id>
+            <properties>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <maven.compiler.testSource>11</maven.compiler.testSource>
+                <maven.compiler.testTarget>11</maven.compiler.testTarget>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- animal-sniffer doesn't work past JDK8 -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>test-sniffer</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>checks</id>
             <build>
@@ -880,7 +915,6 @@
                             </execution>
                         </executions>
                     </plugin>
-
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
@@ -924,8 +958,8 @@
             <build>
                 <pluginManagement>
                     <plugins>
-                        <!--This plugin's configuration is used to store Eclipse 
-                            m2e settings only. It has no influence on the Maven build itself. -->
+                        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on 
+                            the Maven build itself. -->
                         <plugin>
                             <groupId>org.eclipse.m2e</groupId>
                             <artifactId>lifecycle-mapping</artifactId>
@@ -1046,8 +1080,8 @@
                                 <configuration>
                                     <keyname>${gpg.keyname}</keyname>
                                     <passphraseServerId>${gpg.keyname}</passphraseServerId>
-                                    <!-- GPG 2.1 requires pinentry-mode to be set 
-                                        to loopback in order to pick up the gpg.passphrase value defined in Maven settings.xml. -->
+                                    <!-- GPG 2.1 requires pinentry-mode to be set to loopback in order to pick up the gpg.passphrase 
+                                        value defined in Maven settings.xml. -->
                                     <gpgArguments>
                                         <arg>--pinentry-mode</arg>
                                         <arg>loopback</arg>


### PR DESCRIPTION
See #1862 for some background.

These changes greatly simplify the maintenance and release of the modular artifacts by eliminating the need to maintain a separate branch.  A new branch is only needed for releasing (due to version change commits).
 - Uses a `java11` profile to customize the pom:
   - Controls which maven modules are used
   - Updates properties for compiler source and target levels
   - Ignores the incompatible animal-sniffer plugin
 - Adds a `mvnw11` script that wraps the maven wrapper
   - Copies module descriptor and modular test files for the modular build and cleans them up afterwards
   - Updates artifactID in required pom files since that can't be done in a profile and reverts afterward
   - Updates dependencies in the pom that will be uploaded with the deployment so downstream projects get the correct (modular) versions
