### PR TITLE
Use automatic name only for oshi-core

### DIFF
--- a/oshi-core-shaded/pom.xml
+++ b/oshi-core-shaded/pom.xml
@@ -22,7 +22,6 @@
 
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <automatic.module.name>com.github.oshi.shaded</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -76,7 +75,6 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <sourcepath>../oshi-core/src/main/java</sourcepath>
                             <includeDependencySources>true</includeDependencySources>
                             <dependencySourceIncludes>
                                 <!-- include ONLY dependencies I control -->

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -21,17 +21,14 @@
     </scm>
 
     <properties>
-        <!-- Users of the Spring Boot Starter Parent should include this property
-            in their POM -->
+        <!-- Users of the Spring Boot Starter Parent should include this property in their POM -->
         <jna.version>5.10.0</jna.version>
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <automatic.module.name>com.github.oshi</automatic.module.name>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!-- Due to critical nature of OSHI jna usage, set to dependency management
-                to help influence usage -->
+            <!-- Due to critical nature of OSHI jna usage, set to dependency management to help influence usage -->
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
@@ -77,4 +74,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.github.oshi</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/oshi-demo/pom.xml
+++ b/oshi-demo/pom.xml
@@ -24,7 +24,6 @@
         <main.basedir>${project.parent.basedir}</main.basedir>
         <jackson.version>2.13.1</jackson.version>
         <jfreechart.version>1.5.3</jfreechart.version>
-        <automatic.module.name>com.github.oshi.demo</automatic.module.name>
     </properties>
 
     <dependencies>

--- a/oshi-dist/pom.xml
+++ b/oshi-dist/pom.xml
@@ -20,7 +20,6 @@
 
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <automatic.module.name>com.github.oshi.dist</automatic.module.name>
     </properties>
 
     <!-- NOTE: These dependency declarations are only required to sort this project 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         <checkstyle.config.location>config/checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>config/checkstyle-suppressions.xml</checkstyle.suppressions.location>
-        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
         <!-- tools -->
         <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
@@ -294,7 +294,7 @@
                                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                                 <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                             </manifest>
-                            <manifestEntries>
+                            <manifestEntries combine.children="append">
                                 <Build-Time>${maven.build.timestamp}</Build-Time>
                                 <Copyright>${copyright}</Copyright>
                                 <Git-Revision>${git.commit.id}</Git-Revision>
@@ -303,7 +303,6 @@
                                 <Os-Version>${os.version}</Os-Version>
                                 <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
                                 <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
-                                <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
                             </manifestEntries>
                         </archive>
                     </configuration>
@@ -417,14 +416,11 @@
                         </archive>
                     </configuration>
                     <executions>
-                        <!-- ! here we override the super-pom attach-sources execution 
-                            id which ! calls sources:jar goal. That goals forks the lifecycle, ! causing the 
-                            generate-sources phase to be called twice for the install goal. ! Starting with 
-                            Maven 3.4.0 (https://issues.apache.org/jira/browse/MNG-5940) ! this is not needed 
-                            anymore. -->
-                        <!-- except that OSSRH fails with no sources with this 
-                            excluded <execution> <id>attach-sources</id> <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase> 
-                            </execution> -->
+                        <!-- Here we override the super-pom attach-sources execution id which calls sources:jar goal. That 
+                            goals forks the lifecycle, causing the generate-sources phase to be called twice for the install goal. Starting with Maven 
+                            3.4.0 (https://issues.apache.org/jira/browse/MNG-5940) this is not needed anymore. -->
+                        <!-- except that OSSRH fails with no sources with this excluded <execution> <id>attach-sources</id> 
+                            <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase> </execution> -->
                     </executions>
                 </plugin>
                 <!-- External Tools -->
@@ -636,8 +632,7 @@
                                         module path</reason>
                                     <includeTestCode>true</includeTestCode>
                                     <bannedImports>
-                                        <!-- Disallow all imports except explicitly 
-                                            allowed -->
+                                        <!-- Disallow all imports except explicitly allowed -->
                                         <bannedImport>**</bannedImport>
                                     </bannedImports>
                                     <allowedImports>
@@ -924,8 +919,8 @@
             <build>
                 <pluginManagement>
                     <plugins>
-                        <!--This plugin's configuration is used to store Eclipse 
-                            m2e settings only. It has no influence on the Maven build itself. -->
+                        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on 
+                            the Maven build itself. -->
                         <plugin>
                             <groupId>org.eclipse.m2e</groupId>
                             <artifactId>lifecycle-mapping</artifactId>
@@ -1046,8 +1041,8 @@
                                 <configuration>
                                     <keyname>${gpg.keyname}</keyname>
                                     <passphraseServerId>${gpg.keyname}</passphraseServerId>
-                                    <!-- GPG 2.1 requires pinentry-mode to be set 
-                                        to loopback in order to pick up the gpg.passphrase value defined in Maven settings.xml. -->
+                                    <!-- GPG 2.1 requires pinentry-mode to be set to loopback in order to pick up the gpg.passphrase 
+                                        value defined in Maven settings.xml. -->
                                     <gpgArguments>
                                         <arg>--pinentry-mode</arg>
                                         <arg>loopback</arg>


### PR DESCRIPTION
Fixes #1145 

When a module creating a shaded JAR using `maven-shade-plugin` has a manifest in `maven-jar-plugin` that includes an Automatic Module Name, the `maven-javadoc-plugin` fails (since 3.2.0).

Fixed by using inheritance with appending for the manifest, and only including the Automatic Module Name in the `oshi-core` artifact.