### PR TITLE
[pom] Define general taglist setup to get rid of warning (legacy warning meant not setup)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,47 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>taglist-maven-plugin</artifactId>
                     <version>${taglist-maven-plugin.version}</version>
+                    <configuration>
+                        <tagListOptions>
+                            <tagClasses>
+                                <tagClass>
+                                    <displayName>FIXME Work</displayName>
+                                    <tags>
+                                        <tag>
+                                            <matchString>fixme</matchString>
+                                            <matchType>ignoreCase</matchType>
+                                        </tag>
+                                        <tag>
+                                            <matchString>@fixme</matchString>
+                                            <matchType>ignoreCase</matchType>
+                                        </tag>
+                                    </tags>
+                                </tagClass>
+                                <tagClass>
+                                    <displayName>Todo Work</displayName>
+                                    <tags>
+                                        <tag>
+                                            <matchString>todo</matchString>
+                                            <matchType>ignoreCase</matchType>
+                                        </tag>
+                                        <tag>
+                                            <matchString>@todo</matchString>
+                                            <matchType>ignoreCase</matchType>
+                                        </tag>
+                                    </tags>
+                                </tagClass>
+                                <tagClass>
+                                    <displayName>Deprecated Work</displayName>
+                                    <tags>
+                                        <tag>
+                                            <matchString>@deprecated</matchString>
+                                            <matchType>ignoreCase</matchType>
+                                        </tag>
+                                    </tags>
+                                </tagClass>
+                           </tagClasses>
+                        </tagListOptions>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This plugin emits a warning if not setup properly.  This is the default setup.  While they just released a new cut they haven't done anything that might assist at making this default unfortunately so adding it so the warning goes away on site generation.