### PR TITLE
[DRAFT] Re-tooling the profiling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,10 +82,10 @@
     <properties>
         <copyright>2010 - 2022</copyright>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.testSource>1.8</maven.compiler.testSource>
-        <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.testSource>8</maven.compiler.testSource>
+        <maven.compiler.testTarget>8</maven.compiler.testTarget>
         <maven.min-version>3.3.9</maven.min-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
@@ -1136,6 +1136,16 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>jdk11on</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>${maven.compiler.target}</maven.compiler.release>
+                <maven.compiler.testRelease>${maven.compiler.testTarget}</maven.compiler.testRelease>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <modules>
         <module>oshi-core</module>
-        <!-- other modules added by default profile -->
+        <!-- other modules added by jdk8 profile -->
     </modules>
 
     <scm>
@@ -854,17 +854,6 @@
     </reporting>
 
     <profiles>
-        <!-- Default module configuration for java8 build -->
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>oshi-demo</module>
-                <module>oshi-dist</module>
-            </modules>
-        </profile>
         <!-- Custom configuration for Java11 build -->
         <profile>
             <id>java11</id>
@@ -1094,6 +1083,10 @@
             <activation>
                 <jdk>1.8</jdk>
             </activation>
+            <modules>
+                <module>oshi-demo</module>
+                <module>oshi-dist</module>
+            </modules>
             <properties>
                 <!-- Animal Sniffer for jdk 8 -->
                 <animal-sniffer-maven-plugin.version>1.20</animal-sniffer-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <signature.artifact>java18</signature.artifact>
-        <signature.version>1.0</signature.version>
         <!-- Base directory, overwrite in submodules -->
         <main.basedir>${project.basedir}</main.basedir>
         <!-- Dependency versions -->
@@ -150,7 +148,6 @@
         <!-- Misc. -->
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
         <wagon-maven-plugin.version>2.0.2</wagon-maven-plugin.version>
-        <animal-sniffer-maven-plugin.version>1.20</animal-sniffer-maven-plugin.version>
         <dependency-check-maven.version>6.5.3</dependency-check-maven.version>
         <puppycrawl.checkstyle.version>9.2.1</puppycrawl.checkstyle.version>
         <m2e.lifecycle-mapping.version>1.0.0</m2e.lifecycle-mapping.version>
@@ -556,18 +553,6 @@
                     <version>${wagon-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>${animal-sniffer-maven-plugin.version}</version>
-                    <configuration>
-                        <signature>
-                            <groupId>org.codehaus.mojo.signature</groupId>
-                            <artifactId>${signature.artifact}</artifactId>
-                            <version>${signature.version}</version>
-                        </signature>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${dependency-check-maven.version}</version>
@@ -689,19 +674,6 @@
                                 </RestrictImports>
                             </rules>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>test-sniffer</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>test</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -902,21 +874,6 @@
                 <maven.compiler.testSource>11</maven.compiler.testSource>
                 <maven.compiler.testTarget>11</maven.compiler.testTarget>
             </properties>
-            <build>
-                <plugins>
-                    <!-- animal-sniffer doesn't work past JDK8 -->
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>animal-sniffer-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>test-sniffer</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>checks</id>
@@ -1126,6 +1083,54 @@
                                         <arg>loopback</arg>
                                     </gpgArguments>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <!-- Animal Sniffer for jdk 8 -->
+                <animal-sniffer-maven-plugin.version>1.20</animal-sniffer-maven-plugin.version>
+
+                <!-- Signature Settings -->
+                <signature.artifact>java18</signature.artifact>
+                <signature.version>1.0</signature.version>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>animal-sniffer-maven-plugin</artifactId>
+                            <version>${animal-sniffer-maven-plugin.version}</version>
+                            <configuration>
+                                <signature>
+                                    <groupId>org.codehaus.mojo.signature</groupId>
+                                    <artifactId>${signature.artifact}</artifactId>
+                                    <version>${signature.version}</version>
+                                </signature>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-maven-plugin</artifactId>
+                        <version>${animal-sniffer-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>test-sniffer</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <phase>test</phase>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
Default activation in same pom can be with the activeByDefault or specific jdk in usage but not both.  To better setup usage here to split jdk 8 vs 11, this has been retooled.  To understand what is activated, on current master run 'mvn help:active-profiles', then try the very first commit to see that the 'default' profile is no longer activated.  This is normal maven behaviour.

- Commit 1 makes animal sniffer only run when activated by jdk 8 usage.  See 1.
- Commit 2 adds maven compiler release properties picking up off of maven.compiler target options for jdk 11+.  Additionally, modern '8' is used to indicate java 8 instead of '1.8'.
- Commit 3 is required to occur in removing default profile that won't run now but begs a larger discussion.  See 2.

1) With jdk 11+ as we are now with build, it is entirely unnecessary to even build jdk 8 but rather rely on perfect cross compilation.  We can drop animal sniffer entirely this way by simply dropping this profile and then removing any jdk 8 build usage unless there is some specific reason not to.

2) Since modular build currently is using java11 profile, the default profile is not run.  That means demo / dist are not produced during modular build.  I don't currently see why that case is necessary.  This however means that in order to actually allow that still, jdk 11+ build cannot build the modules either.  This clearly becomes an issue with how maven handles modules in that it won't reliably allow splitting them on profiles.  Further, this is bad practice to have profiles build other modules for the exact reason that some releases will just skip delivery.

The last point is why this is 'draft' for now.  I feel after a few hours getting here, its safe to pass this over to @dbwiddis to think about overall.  I think there is most likely something in modular path causing some issue and we need to further address that before this can happen so all modules are built at all times as maven wants.