### PR TITLE
[site] Rework site so it works from local

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,8 +234,8 @@
                     <version>${maven-scm-publish-plugin.version}</version>
                     <configuration>
                         <checkoutDirectory>${user.home}/maven-sites/${project.name}</checkoutDirectory>
-                        <!-- no need for site:stage, use target/site -->
-                        <content>${project.reporting.outputDirectory}</content>
+                        <!-- need site:stage to collect multimodule project -->
+                        <content>${project.output.directory}/staging/site</content>
                         <scmBranch>gh-pages</scmBranch>
                         <tryUpdate>true</tryUpdate>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,7 @@
                     <configuration>
                         <checkoutDirectory>${user.home}/maven-sites/oshi</checkoutDirectory>
                         <scmBranch>gh-pages</scmBranch>
+                        <skipDeletedFiles>true</skipDeletedFiles>
                         <tryUpdate>true</tryUpdate>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,6 @@
         <versions-maven-plugin.version>2.10.0</versions-maven-plugin.version>
         <!-- Misc. -->
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
-        <wagon-maven-plugin.version>2.0.2</wagon-maven-plugin.version>
         <animal-sniffer-maven-plugin.version>1.21</animal-sniffer-maven-plugin.version>
         <dependency-check-maven.version>7.0.4</dependency-check-maven.version>
         <puppycrawl.checkstyle.version>10.1</puppycrawl.checkstyle.version>
@@ -616,12 +615,6 @@
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
                     <version>${sonar-maven-plugin.version}</version>
-                </plugin>
-                <!-- Wagon -->
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>wagon-maven-plugin</artifactId>
-                    <version>${wagon-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.owasp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
                     <configuration>
                         <checkoutDirectory>${user.home}/maven-sites/${project.name}</checkoutDirectory>
                         <!-- need site:stage to collect multimodule project -->
-                        <content>${project.output.directory}/staging/site</content>
+                        <content>${project.build.directory}/staging/site</content>
                         <scmBranch>gh-pages</scmBranch>
                         <tryUpdate>true</tryUpdate>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -234,8 +234,6 @@
                     <version>${maven-scm-publish-plugin.version}</version>
                     <configuration>
                         <checkoutDirectory>${user.home}/maven-sites/oshi</checkoutDirectory>
-                        <!-- need site:stage to collect multimodule project -->
-                        <content>${project.build.directory}/staging</content>
                         <scmBranch>gh-pages</scmBranch>
                         <tryUpdate>true</tryUpdate>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -233,9 +233,9 @@
                     <artifactId>maven-scm-publish-plugin</artifactId>
                     <version>${maven-scm-publish-plugin.version}</version>
                     <configuration>
-                        <checkoutDirectory>${user.home}/maven-sites/${project.name}</checkoutDirectory>
+                        <checkoutDirectory>${user.home}/maven-sites/oshi</checkoutDirectory>
                         <!-- need site:stage to collect multimodule project -->
-                        <content>${project.build.directory}/staging/site</content>
+                        <content>${project.build.directory}/staging</content>
                         <scmBranch>gh-pages</scmBranch>
                         <tryUpdate>true</tryUpdate>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
     </modules>
 
     <scm>
-        <connection>scm:git:git@github.com:oshi/oshi.git</connection>
-        <developerConnection>scm:git:git@github.com:oshi/oshi.git</developerConnection>
+        <connection>scm:git:ssh://git@github.com/oshi/oshi.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:oshi/oshi.git</developerConnection>
         <tag>HEAD</tag>
         <url>https://github.com/oshi/oshi.git</url>
     </scm>
@@ -74,7 +74,7 @@
         <site>
             <id>gh-pages</id>
             <name>OSHI GitHub Pages</name>
-            <url>scp://oshi.github.io/oshi/</url>
+            <url>scm:git:ssh://git@github.com/oshi/oshi.git</url>
         </site>
     </distributionManagement>
 
@@ -107,9 +107,9 @@
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+        <maven-scm-publish-plugin.version>3.1.0</maven-scm-publish-plugin.version>
         <maven-site-plugin.version>3.11.0</maven-site-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-        <wagon-ssh.version>3.5.1</wagon-ssh.version>
         <maven-fluido-skin.version>1.10.0</maven-fluido-skin.version>
         <!-- build plugins -->
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
@@ -217,18 +217,29 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>${maven-site-plugin.version}</version>
+                    <configuration>
+                        <!-- don't deploy site with maven-site-plugin (instead use scm publish during release) -->
+                        <skipDeploy>true</skipDeploy>
+                    </configuration>
                     <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.wagon</groupId>
-                            <artifactId>wagon-ssh</artifactId>
-                            <version>${wagon-ssh.version}</version>
-                        </dependency>
                         <dependency>
                             <groupId>org.apache.maven.skins</groupId>
                             <artifactId>maven-fluido-skin</artifactId>
                             <version>${maven-fluido-skin.version}</version>
                         </dependency>
                     </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-scm-publish-plugin</artifactId>
+                    <version>${maven-scm-publish-plugin.version}</version>
+                    <configuration>
+                        <checkoutDirectory>${user.home}/maven-sites/${project.name}</checkoutDirectory>
+                        <!-- no need for site:stage, use target/site -->
+                        <content>${project.reporting.outputDirectory}</content>
+                        <scmBranch>gh-pages</scmBranch>
+                        <tryUpdate>true</tryUpdate>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1156,6 +1167,20 @@
                         <configuration>
                             <skip>true</skip>
                         </configuration>
+                    </plugin>
+                    <!-- deploy site with maven-scm-publish-plugin -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-scm-publish-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>scm-publish</id>
+                                <goals>
+                                    <goal>publish-scm</goal>
+                                </goals>
+                                <phase>site-deploy</phase>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -19,6 +19,7 @@
         </links>
         <menu name="User guide">
             <item href="README.html" name="Overview" />
+            <item href="oshi-core-java11/apidocs/" name="Javadocs" />
             <item href="FAQ.html" name="Frequently Asked Questions" />
             <item href="Performance.html" name="Performance Considerations" />
             <item href="Upgrading.html" name="Major Version Breaking Changes" />


### PR DESCRIPTION
Note: Added maven scm publish plugin as it appears maven is going towards that being way to publish.  It does not help the slow checkout issue but deploy is skipped right now outside 'site' branch so this does no harm either.  Will come back to this as they refine process at a future date.

I am not sure if this config will affect the site.yaml file.  We would need to confirm that.  It also is forcing some of underlying items on site plugin so scm used is consistent.  

wagon-ssh is deprecated and removed in version 2 as I have here for scm.  This works through unwrapping (ie scm contains git which contains ssh).  Ultimately this makes it match the other distribution setup.  The site will work this way on release if wanted but long time to process.  Using scm plublish is separate if you were running site manually and then using that to deploy it.  To keep this separated from the current settings.xml, new entry to align to it.

If nothing more than awareness, this is where I had gotten which I think is better but this would have no impact now that it is now used.