### PR TITLE
[pom] Skip license plugin during release cycle as code is shallowed cloned

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1149,6 +1149,14 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- Skip license plugin during release as maven release is now shallow cloned -->
+                    <plugin>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
If I recall, I had gotten this documented and noted on license plugin sometime ago.