### PR TITLE
Remove automatic license checks except PR workflow

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -37,6 +37,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Test with Maven
-        run: ./mvnw test -B  -Dlicense.skip=true
+        run: ./mvnw test -B -Dlicense.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [8,11]
+        java: [8, 11]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     steps:
@@ -33,5 +33,8 @@ jobs:
       - name: Checkstyle
         if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '8')
         run: ./mvnw checkstyle:check
+      - name: Checkstyle
+        if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '8')
+        run: git fetch --unshallow && ./mvnw license:check
       - name: Test with Maven
         run: ./mvnw test -B -D"license.skip=true"

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 8
           distribution: 'zulu'
       - uses: webfactory/ssh-agent@master
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,6 @@
                                     <exclude>**/*.yml</exclude>
                                     <exclude>**/*.yaml</exclude>
                                     <exclude>**/cov-analysis*/**</exclude>
-                                    <exclude>**/checkout/**</exclude>
                                 </excludes>
                             </licenseSet>
                         </licenseSets>
@@ -721,18 +720,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.github.ekryd.sortpom</groupId>
                 <artifactId>sortpom-maven-plugin</artifactId>
                 <version>${sortpom-plugin.version}</version>
@@ -744,7 +731,6 @@
                     <nrOfIndentSpace>4</nrOfIndentSpace>
                     <expandEmptyElements>false</expandEmptyElements>
                     <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-                    <indentSchemaLocation>true</indentSchemaLocation>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Removed all automatic license checking in the POM and added an explicit license:check call in the PR workflow.  Eclipse wasn't happy with its earlier lifecycle placement and in reality it just doesn't need to be run that often.  PRs should catch most issues, and I've got my own local macro that does license:check, sortpom:sort, and spotless:apply regularly.

Also switched site workflow to run on jdk8.  The site build was failing on the java11 javadocs -- seems the config I put in needed to be in `<build>` for the release but in `<reporting>` for site.  Rather than duplicate the config, it's easy just to not generate the redundant or unnecessary content for the modules built in the JDK11+ profile by running the workflow on JDK 8.