### PR TITLE
Revert "Bump maven-compiler-plugin from 3.9.0 to 3.10.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <!-- Compile versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M2</maven-deploy-plugin.version>
         <nexus-staging-plugin.version>1.6.10</nexus-staging-plugin.version>
         <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>


### PR DESCRIPTION
Reverts oshi/oshi#1929

A change to the maven-compiler-plugin adds missing package-info files, but it seems to not work on Windows in conjunction with mvn-bnd-plugin.  Reverting until the next version.