### PR TITLE
Revise utility ticks calculation to retain precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug fixes / Improvements
 * [#1944](https://github.com/oshi/oshi/pull/1944): Get page size, hz, and feature bits from Linux aux vector - [@dbwiddis](https://github.com/dbwiddis).
 * [#1945](https://github.com/oshi/oshi/pull/1945): Refactor all binary file reading to use ByteBuffers - [@dbwiddis](https://github.com/dbwiddis).
+* [#1949](https://github.com/oshi/oshi/pull/1949): Refine Processor Utility calculations for more precision - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here
 
 # 6.1.0 (2022-01-20), 6.1.1 (2022-02-13), 6.1.2 (2022-02-14), 6.1.3 (2022-02-22)


### PR DESCRIPTION
See #1948 for the problem this finally tries to fix.  Rearranged the calculations to work almost exclusively with deltas