### PR TITLE
Handle Processor Utility 32-bit counter rollover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#1944](https://github.com/oshi/oshi/pull/1944): Get page size, hz, and feature bits from Linux aux vector - [@dbwiddis](https://github.com/dbwiddis).
 * [#1945](https://github.com/oshi/oshi/pull/1945): Refactor all binary file reading to use ByteBuffers - [@dbwiddis](https://github.com/dbwiddis).
 * [#1949](https://github.com/oshi/oshi/pull/1949): Refine Processor Utility calculations for more precision - [@dbwiddis](https://github.com/dbwiddis).
+* [#1950](https://github.com/oshi/oshi/pull/1950): Handle Processor Utility 32-bit counter rollover - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here
 
 # 6.1.0 (2022-01-20), 6.1.1 (2022-02-13), 6.1.2 (2022-02-14), 6.1.3 (2022-02-22)

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessorInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessorInformation.java
@@ -29,7 +29,6 @@ import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_C
 import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_NOT_TOTAL;
 import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_TOTAL;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -53,9 +52,6 @@ public final class ProcessorInformation {
 
     public static final boolean USE_CPU_UTILITY = VersionHelpers.IsWindows8OrGreater()
             && GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_CPU_UTILITY, false);
-    private static final Map<ProcessorCapacityTickCountProperty, List<Long>> INITIAL_CAPACITY_TICKS = USE_CPU_UTILITY
-            ? queryProcessorCapacityCounters().getB()
-            : Collections.emptyMap();
 
     /**
      * Processor performance counters
@@ -182,15 +178,6 @@ public final class ProcessorInformation {
     public static Pair<List<String>, Map<ProcessorCapacityTickCountProperty, List<Long>>> queryProcessorCapacityCounters() {
         return PerfCounterWildcardQuery.queryInstancesAndValues(ProcessorCapacityTickCountProperty.class,
                 PROCESSOR_INFORMATION, WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL);
-    }
-
-    /**
-     * Returns initial processor capacity performance counters.
-     *
-     * @return initial Performance Counters for processor capacity.
-     */
-    public static Map<ProcessorCapacityTickCountProperty, List<Long>> queryInitialProcessorCapacityCounters() {
-        return INITIAL_CAPACITY_TICKS;
     }
 
     /**

--- a/oshi-core/src/main/resources/oshi.properties
+++ b/oshi-core/src/main/resources/oshi.properties
@@ -45,6 +45,12 @@ oshi.os.windows.procstate.suspended=false
 # at 100%) and will measure "work completed" rather than "processor time not idle".
 # In the case load exceeds 100%, it is possible for "idle" ticks to decrease, 
 # i.e., the change between ticks would result in "negative idle time".
+#
+# Note that the base counter required for this calculation rolls over approximately
+# every two hours. OSHI's code is robust for reasonably short ("minutes" or less)
+# polling intervals. If your application remains idle for over an hour before
+# polling for CPU usage, instantiating a new SystemInfo object before collecting
+# ticks will mitigate these problems.
 oshi.os.windows.cpu.utility=false
 
 # Whether to attempt to fetch Windows performance counter data for processes

--- a/src/site/markdown/FAQ.md
+++ b/src/site/markdown/FAQ.md
@@ -91,6 +91,10 @@ Features which change CPU frequency such as Intel Speed Step, Intel Turbo Boost,
 
 If you desire OSHI's output to match the Task Manager, you may optionally enable this setting in the configuration file, or by calling `GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_CPU_UTILITY, true);` shortly after startup (at least before the first instantiation of the Central Processor class). Note that OSHI will not cap its CPU Usage calculation at 100%, giving you more information than the Windows Task Manager if the "work completed" metric is important to you.
 
+Note that the base counter required for this calculation rolls over approximately every two hours. OSHI's code is robust for
+reasonably short ("minutes" or less) polling intervals. If your application remains idle for over an hour before polling for
+CPU usage, instantiating a new SystemInfo object before collecting ticks will mitigate these problems.
+
 ## Why does OSHI's Process CPU usage differ from the Windows Task Manager?
 
 CPU usage is generally calculated as (active time / active+idle time). On a multi-processor system, the "idle" time can be accrued on each/any of the logical processors.


### PR DESCRIPTION
Moves the initial tick storage into the WindowsCentralProcessor object so it can be effectively reset with a new SystemInfo object.

Detects base counter rollover via negative delta (will catch most problems with reasonably frequent polling) or non-sane tick ratio.  Documents suggestion to handle other edge cases.