### PR TITLE
Revert "Fix Kstat2 array mappings"

### DIFF
--- a/oshi-core/src/main/java/oshi/jna/platform/unix/Kstat2.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/unix/Kstat2.java
@@ -298,21 +298,11 @@ public interface Kstat2 extends Library {
                 case KSTAT2_NVVT_INT:
                     return nv.data.integerVal;
                 case KSTAT2_NVVT_INTS:
-                    Pointer[] intPtrArray = nv.data.integers.addr.getPointerArray(0, nv.data.integers.len);
-                    long[] integerArr = new long[intPtrArray.length];
-                    for (int i = 0; i < integerArr.length; i++) {
-                        integerArr[i] = intPtrArray[i].getLong(0);
-                    }
-                    return integerArr;
+                    return nv.data.integers.addr.getLongArray(0, nv.data.integers.len);
                 case KSTAT2_NVVT_STR:
-                    return nv.data.stringVal;
+                    return nv.data.strings.addr.getString(0);
                 case KSTAT2_NVVT_STRS:
-                    Pointer[] strPtrArray = nv.data.strings.addr.getPointerArray(0, nv.data.strings.len);
-                    String[] stringArray = new String[strPtrArray.length];
-                    for (int i = 0; i < stringArray.length; i++) {
-                        stringArray[i] = strPtrArray[i].getString(0);
-                    }
-                    return stringArray;
+                    return nv.data.strings.addr.getStringArray(0, nv.data.strings.len);
                 default:
                     return null;
                 }
@@ -337,7 +327,6 @@ public interface Kstat2 extends Library {
             public Kstat2Map map;
             public long integerVal;
             public IntegersArr integers;
-            public String stringVal;
             public StringsArr strings;
 
             @FieldOrder({ "addr", "len" })
@@ -376,8 +365,6 @@ public interface Kstat2 extends Library {
                 data.setType(IntegersArr.class);
                 break;
             case KSTAT2_NVVT_STR:
-                data.setType(String.class);
-                break;
             case KSTAT2_NVVT_STRS:
                 data.setType(StringsArr.class);
                 break;


### PR DESCRIPTION
Reverts oshi/oshi#1964

Seems it was correct the old way.