### PR TITLE
KstatUtil.java: test for UnsatisfiedLinkError for KStat2

### DIFF
--- a/oshi-core/src/main/java/oshi/util/platform/unix/solaris/KstatUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/solaris/KstatUtil.java
@@ -305,7 +305,14 @@ public final class KstatUtil {
      */
     public static Object[] queryKstat2(String mapStr, String... names) {
         Object[] result = new Object[names.length];
-        Kstat2MatcherList matchers = new Kstat2MatcherList();
+        Kstat2MatcherList matchers = null;
+        try {
+            matchers = new Kstat2MatcherList();
+        } catch (java.lang.UnsatisfiedLinkError e) {
+            LOG.debug("Is this Solaris 11.4+? Failed to get stats on {} for names {}: {}", mapStr, Arrays.toString(names), e.getMessage());
+            return result;
+        }
+
         KstatUtil.CHAIN.lock();
         try {
             matchers.addMatcher(Kstat2.KSTAT2_M_STRING, mapStr);
@@ -342,7 +349,14 @@ public final class KstatUtil {
     public static List<Object[]> queryKstat2List(String beforeStr, String afterStr, String... names) {
         List<Object[]> results = new ArrayList<>();
         int s = 0;
-        Kstat2MatcherList matchers = new Kstat2MatcherList();
+        Kstat2MatcherList matchers = null;
+        try {
+            matchers = new Kstat2MatcherList();
+        } catch (java.lang.UnsatisfiedLinkError e) {
+            LOG.debug("Is this Solaris 11.4+? Failed to get stats on {} for names {}: {}", mapStr, Arrays.toString(names), e.getMessage());
+            return result;
+        }
+
         KstatUtil.CHAIN.lock();
         try {
             matchers.addMatcher(Kstat2.KSTAT2_M_GLOB, beforeStr + "*" + afterStr);


### PR DESCRIPTION
KStat2.java says callers should "test for UnsatisfiedLinkError" since "Kstat2 is available in Solaris 11.4 and later."
Running an oshi consumer on an older Solaris, or in its illumos siblings, crashes due to JNA, e.g.:
````
Exception in thread "main" java.lang.UnsatisfiedLinkError: Unable to load library 'kstat2':
ld.so.1: java: fatal: libkstat2.so: open failed: No such file or directory
Native library (sunos-x86-64/libkstat2.so) not found in resource path ([file:/export/home/abuild/jenkins-swarm/swarm-client-3.31.jar])
...
        Suppressed: java.lang.UnsatisfiedLinkError: ld.so.1: java: fatal: libkstat2.so: open failed: No such file or directory
                at com.sun.jna.Native.open(Native Method)
                at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:191)
                ... 16 more
````