### PR TITLE
[pom] Add adjustment to 'content' for release profile with scm plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1164,6 +1164,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-scm-publish-plugin</artifactId>
+                        <configuration>
+                            <!-- no need for site:stage, use target/site or target/checkout/target/site on release -->
+                            <content>${project.reporting.outputDirectory}</content>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>scm-publish</id>


### PR DESCRIPTION
fails if using default staging, use this to ensure it picks up site as it varies with release.


During release, tested now, this failed without this setting.  Added this in the release portion so running site site:deploy scm-publish:publish-scm will still work without issue.  What I don't know is if any of the site is missed.  Testing thus far is on release of project(s) that are themselves one pom relying on a super pom stored elsewhere.  I'm not sure how multi module works during release.  So @dbwiddis you will want to watch out on next release to see if this along with what was merged arleady does in fact update all portions of the site.  Like you, I don't have something really specific to release yet so I'm not sure if you or I will make it this far first on multi module.
