### PR TITLE
Fallback or log warning to avoid exception with no udev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug fixes / Improvements
 * [#2016](https://github.com/oshi/oshi/pull/2016): Make disabled counter check robust to invalid registry types - [@dbwiddis](https://github.com/dbwiddis).
 * [#2033](https://github.com/oshi/oshi/pull/2033): Graceful fallback for CPU Topology without udev - [@dbwiddis](https://github.com/dbwiddis).
+* [#2034](https://github.com/oshi/oshi/pull/2034): Fallback or log warning to avoid exception with no udev - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.1.0 (2022-01-20), 6.1.1 (2022-02-13), 6.1.2 (2022-02-14), 6.1.3 (2022-02-22), 6.1.4 (2022-03-01), 6.1.5 (2022-03-15), 6.1.6 (2022-04-10)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStore.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStore.java
@@ -23,6 +23,8 @@
  */
 package oshi.hardware.platform.linux;
 
+import static oshi.software.os.linux.LinuxOperatingSystem.HAS_UDEV;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,6 +34,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sun.jna.platform.linux.Udev;
 import com.sun.jna.platform.linux.Udev.UdevContext;
@@ -53,6 +58,8 @@ import oshi.util.platform.linux.ProcPath;
  */
 @ThreadSafe
 public final class LinuxHWDiskStore extends AbstractHWDiskStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxHWDiskStore.class);
 
     private static final String BLOCK = "block";
     private static final String DISK = "disk";
@@ -160,6 +167,10 @@ public final class LinuxHWDiskStore extends AbstractHWDiskStore {
     }
 
     private static List<HWDiskStore> getDisks(LinuxHWDiskStore storeToUpdate) {
+        if (!HAS_UDEV) {
+            LOG.warn("Disk Store information requires libudev, which is not present.");
+            return Collections.emptyList();
+        }
         LinuxHWDiskStore store = null;
         List<HWDiskStore> result = new ArrayList<>();
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroup.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroup.java
@@ -23,13 +23,19 @@
  */
 package oshi.hardware.platform.linux;
 
+import static oshi.software.os.linux.LinuxOperatingSystem.HAS_UDEV;
+
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sun.jna.platform.linux.Udev;
 
@@ -40,6 +46,8 @@ import oshi.util.ParseUtil;
 import oshi.util.Util;
 
 final class LinuxLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxLogicalVolumeGroup.class);
 
     private static final String BLOCK = "block";
     private static final String DM_UUID = "DM_UUID";
@@ -52,6 +60,10 @@ final class LinuxLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
     }
 
     static List<LogicalVolumeGroup> getLogicalVolumeGroups() {
+        if (!HAS_UDEV) {
+            LOG.warn("Logical Volume Group information requires libudev, which is not present.");
+            return Collections.emptyList();
+        }
         Map<String, Map<String, Set<String>>> logicalVolumesMap = new HashMap<>();
         Map<String, Set<String>> physicalVolumesMap = new HashMap<>();
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxPowerSource.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxPowerSource.java
@@ -23,10 +23,16 @@
  */
 package oshi.hardware.platform.linux;
 
+import static oshi.software.os.linux.LinuxOperatingSystem.HAS_UDEV;
+
 import java.io.File;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sun.jna.platform.linux.Udev;
 import com.sun.jna.platform.linux.Udev.UdevContext;
@@ -46,6 +52,8 @@ import oshi.util.ParseUtil;
 @ThreadSafe
 public final class LinuxPowerSource extends AbstractPowerSource {
 
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxPowerSource.class);
+
     public LinuxPowerSource(String psName, String psDeviceName, double psRemainingCapacityPercent,
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
@@ -64,6 +72,10 @@ public final class LinuxPowerSource extends AbstractPowerSource {
      * @return An array of PowerSource objects representing batteries, etc.
      */
     public static List<PowerSource> getPowerSources() {
+        if (!HAS_UDEV) {
+            LOG.warn("Power Source information requires libudev, which is not present.");
+            return Collections.emptyList();
+        }
         String psName;
         String psDeviceName;
         double psRemainingCapacityPercent = -1d;

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxUsbDevice.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxUsbDevice.java
@@ -23,11 +23,16 @@
  */
 package oshi.hardware.platform.linux;
 
+import static oshi.software.os.linux.LinuxOperatingSystem.HAS_UDEV;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sun.jna.platform.linux.Udev;
 import com.sun.jna.platform.linux.Udev.UdevDevice;
@@ -43,6 +48,8 @@ import oshi.hardware.common.AbstractUsbDevice;
  */
 @Immutable
 public class LinuxUsbDevice extends AbstractUsbDevice {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxUsbDevice.class);
 
     private static final String SUBSYSTEM_USB = "usb";
     private static final String DEVTYPE_USB_DEVICE = "usb_device";
@@ -90,6 +97,10 @@ public class LinuxUsbDevice extends AbstractUsbDevice {
     }
 
     private static List<UsbDevice> getUsbDevices() {
+        if (!HAS_UDEV) {
+            LOG.warn("USB Device information requires libudev, which is not present.");
+            return Collections.emptyList();
+        }
         // Build a list of devices with no parent; these will be the roots
         List<String> usbControllers = new ArrayList<>();
 


### PR DESCRIPTION
Follow up to #2033 to test for udev presence rather than throwing exception.  Added graceful fallback for network info and log warnings for other implementations. 