### PR TITLE
PDH wildcard counters need localized instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 6.2.1 (in progress)
 
 ##### Bug fixes / Improvements
-* [#2088](https://github.com/oshi/oshi/pull/2088): Catch exception and log warning for corrupt performance counters - [@dbwiddis](https://github.com/dbwiddis).
+* [#2089](https://github.com/oshi/oshi/pull/2089): PDH wild card counters need English objects but localized instances - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.2.0 (2022-06-26)
 

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
@@ -56,9 +56,8 @@ public final class PerfCounterQuery {
     // Use a thread safe set to cache failed pdh queries
     private static final Set<String> FAILED_QUERY_CACHE = ConcurrentHashMap.newKeySet();
 
-    // For XP, use a map to cache localization strings
-    private static final ConcurrentHashMap<String, String> LOCALIZE_CACHE = IS_VISTA_OR_GREATER ? null
-            : new ConcurrentHashMap<>();
+    // A map to cache localization strings
+    private static final ConcurrentHashMap<String, String> LOCALIZE_CACHE = new ConcurrentHashMap<>();
 
     /*
      * Multiple classes use these constants
@@ -125,7 +124,7 @@ public final class PerfCounterQuery {
     public static <T extends Enum<T>> Map<T, Long> queryValuesFromPDH(Class<T> propertyEnum, String perfObject) {
         T[] props = propertyEnum.getEnumConstants();
         // If pre-Vista, localize the perfObject
-        String perfObjectLocalized = PerfCounterQuery.localizeIfNeeded(perfObject);
+        String perfObjectLocalized = PerfCounterQuery.localizeIfNeeded(perfObject, false);
         EnumMap<T, PerfCounter> counterMap = new EnumMap<>(propertyEnum);
         EnumMap<T, Long> valueMap = new EnumMap<>(propertyEnum);
         try (PerfCounterQueryHandler pdhQueryHandler = new PerfCounterQueryHandler()) {
@@ -201,11 +200,13 @@ public final class PerfCounterQuery {
      *
      * @param perfObject
      *            A String to localize
+     * @param force
+     *            If true, always localize
      * @return The localized string if localization successful, or the original
      *         string otherwise.
      */
-    public static String localizeIfNeeded(String perfObject) {
-        return IS_VISTA_OR_GREATER ? perfObject
+    public static String localizeIfNeeded(String perfObject, boolean force) {
+        return !force && IS_VISTA_OR_GREATER ? perfObject
                 : LOCALIZE_CACHE.computeIfAbsent(perfObject, PerfCounterQuery::localizeUsingPerfIndex);
     }
 

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -123,8 +123,9 @@ public final class PerfCounterWildcardQuery {
         }
         String instanceFilter = ((PdhCounterWildcardProperty) propertyEnum.getEnumConstants()[0]).getCounter()
                 .toLowerCase();
-        // If pre-Vista, localize the perfObject
-        String perfObjectLocalized = PerfCounterQuery.localizeIfNeeded(perfObject);
+        // Localize the perfObject using different variable for the EnumObjectItems
+        // Will still use unlocalized perfObject for the query
+        String perfObjectLocalized = PerfCounterQuery.localizeIfNeeded(perfObject, true);
 
         // Get list of instances
         PdhEnumObjectItems objectItems = null;


### PR DESCRIPTION
Fix in #1662 was overzealous; we need localized instances for wildcard queries but English object names.