### PR TITLE
Windows PerfMon GPU Engine Usage

### DIFF
--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/GraphicsUtilizationThread.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/GraphicsUtilizationThread.java
@@ -7,6 +7,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
+/**
+ * Utility to calculate graphics utilization via caching intervals of every
+ * 100ms
+ */
 public class GraphicsUtilizationThread extends Thread {
 
     /**
@@ -44,7 +48,8 @@ public class GraphicsUtilizationThread extends Thread {
     public void run() {
 
         // setup initial utilization values
-        Pair<List<String>, Map<ProcessInformation.GpuEngineProperty, List<Long>>> initialCounter = ProcessInformation.queryGpuCounters();
+        Pair<List<String>, Map<ProcessInformation.GpuEngineProperty, List<Long>>> initialCounter = ProcessInformation
+                .queryGpuCounters();
         Map<ProcessInformation.GpuEngineProperty, List<Long>> oldGpuEngineProperties = initialCounter.getB();
 
         gpuNames = initialCounter.getA();
@@ -58,16 +63,20 @@ public class GraphicsUtilizationThread extends Thread {
                 Thread.currentThread().interrupt();
             }
 
-            Pair<List<String>, Map<ProcessInformation.GpuEngineProperty, List<Long>>> newCounters = ProcessInformation.queryGpuCounters();
+            Pair<List<String>, Map<ProcessInformation.GpuEngineProperty, List<Long>>> newCounters = ProcessInformation
+                    .queryGpuCounters();
             Map<ProcessInformation.GpuEngineProperty, List<Long>> newGpuEngineProperties = newCounters.getB();
 
-            List<Long> newUtilizationBases = newGpuEngineProperties.get(ProcessInformation.GpuEngineProperty.UTILIZATION_BASE);
+            List<Long> newUtilizationBases = newGpuEngineProperties
+                    .get(ProcessInformation.GpuEngineProperty.UTILIZATION_BASE);
             List<Long> newUtilizations = newGpuEngineProperties.get(ProcessInformation.GpuEngineProperty.UTILIZATION);
 
-            // calculate utilization percentage via the difference between last 100ms and current utilization over the difference between their bases
+            // calculate utilization percentage via the difference between last 100ms and
+            // current utilization over the difference between their bases
             utilizationPercentages = IntStream.range(0, gpuNames.size())
-                .mapToDouble(i -> 100 * (newUtilizations.get(i) - utilizations.get(i)) / (double) (newUtilizationBases.get(i) - utilizationBases.get(i)))
-                .toArray();
+                    .mapToDouble(i -> 100 * (newUtilizations.get(i) - utilizations.get(i))
+                            / (double) (newUtilizationBases.get(i) - utilizationBases.get(i)))
+                    .toArray();
 
             // update old utilization counters to perform next interval computations
             utilizationBases = newUtilizationBases;

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/GraphicsUtilizationThread.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/GraphicsUtilizationThread.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package oshi.driver.windows.perfmon;
 
 import oshi.util.tuples.Pair;

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/GraphicsUtilizationThread.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/GraphicsUtilizationThread.java
@@ -1,0 +1,95 @@
+package oshi.driver.windows.perfmon;
+
+import oshi.util.tuples.Pair;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+public class GraphicsUtilizationThread extends Thread {
+
+    /**
+     * Gpu name corresponding to each engine
+     */
+    private List<String> gpuNames;
+
+    /**
+     * Old utilization values
+     */
+    private List<Long> utilizations;
+
+    /**
+     * Old utilization base
+     */
+    private List<Long> utilizationBases;
+
+    /**
+     * Calculated utilization percentages
+     */
+    private double[] utilizationPercentages;
+
+    /**
+     * Constructor
+     */
+    public GraphicsUtilizationThread() {
+        setName("OSHI Graphics Utilization daemon");
+        setDaemon(true);
+    }
+
+    /**
+     * Start the thread to compute GPU utilization
+     */
+    @Override
+    public void run() {
+
+        // setup initial utilization values
+        Pair<List<String>, Map<ProcessInformation.GpuEngineProperty, List<Long>>> initialCounter = ProcessInformation.queryGpuCounters();
+        Map<ProcessInformation.GpuEngineProperty, List<Long>> oldGpuEngineProperties = initialCounter.getB();
+
+        gpuNames = initialCounter.getA();
+        utilizationBases = oldGpuEngineProperties.get(ProcessInformation.GpuEngineProperty.UTILIZATION_BASE);
+        utilizations = oldGpuEngineProperties.get(ProcessInformation.GpuEngineProperty.UTILIZATION);
+
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                Thread.sleep(100L);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+
+            Pair<List<String>, Map<ProcessInformation.GpuEngineProperty, List<Long>>> newCounters = ProcessInformation.queryGpuCounters();
+            Map<ProcessInformation.GpuEngineProperty, List<Long>> newGpuEngineProperties = newCounters.getB();
+
+            List<Long> newUtilizationBases = newGpuEngineProperties.get(ProcessInformation.GpuEngineProperty.UTILIZATION_BASE);
+            List<Long> newUtilizations = newGpuEngineProperties.get(ProcessInformation.GpuEngineProperty.UTILIZATION);
+
+            // calculate utilization percentage via the difference between last 100ms and current utilization over the difference between their bases
+            utilizationPercentages = IntStream.range(0, gpuNames.size())
+                .mapToDouble(i -> 100 * (newUtilizations.get(i) - utilizations.get(i)) / (double) (newUtilizationBases.get(i) - utilizationBases.get(i)))
+                .toArray();
+
+            // update old utilization counters to perform next interval computations
+            utilizationBases = newUtilizationBases;
+            utilizations = newUtilizations;
+        }
+    }
+
+    /**
+     * Gpu Utilization percentage calculated over each 100ms interval
+     *
+     * @return utilization percentages
+     */
+    public double[] getUtilizationPercentages() {
+        return utilizationPercentages;
+    }
+
+    /**
+     * Gpu name array corresponding to each individual engine
+     *
+     * @return gpu names as list of strings
+     */
+    public List<String> getGpuNames() {
+        return gpuNames;
+    }
+}

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/GraphicsUtilizationThread.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/GraphicsUtilizationThread.java
@@ -25,7 +25,6 @@ package oshi.driver.windows.perfmon;
 
 import oshi.util.tuples.Pair;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/PerfmonConstants.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/PerfmonConstants.java
@@ -64,6 +64,8 @@ public final class PerfmonConstants {
     static final String SYSTEM = "System";
     static final String WIN32_PERF_RAW_DATA_PERF_OS_SYSTEM = "Win32_PerfRawData_PerfOS_System";
 
+    static final String GPU_ENGINE = "GPU Engine";
+
     /**
      * Everything in this class is static, never instantiate it
      */

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessInformation.java
@@ -23,6 +23,12 @@
  */
 package oshi.driver.windows.perfmon;
 
+import static oshi.driver.windows.perfmon.PerfmonConstants.PROCESS;
+import static oshi.driver.windows.perfmon.PerfmonConstants.GPU_ENGINE;
+import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS;
+import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0;
+import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +38,6 @@ import oshi.util.platform.windows.PerfCounterQuery;
 import oshi.util.platform.windows.PerfCounterWildcardQuery;
 import oshi.util.platform.windows.PerfCounterWildcardQuery.PdhCounterWildcardProperty;
 import oshi.util.tuples.Pair;
-
-import static oshi.driver.windows.perfmon.PerfmonConstants.*;
 
 /**
  * Utility to query Process Information performance counter
@@ -117,7 +121,8 @@ public final class ProcessInformation {
      */
     public enum GpuEngineProperty implements PerfCounterWildcardQuery.PdhCounterWildcardProperty {
         NAME(PerfCounterQuery.NOT_TOTAL_INSTANCE),
-        UTILIZATION("Utilization Percentage"),
+        // Remaining elements define counters
+        UTILIZATION("Utilization Percentage"), //
         UTILIZATION_BASE("Utilization Percentage_Base");
 
         private final String counter;
@@ -145,7 +150,7 @@ public final class ProcessInformation {
             return new Pair<>(Collections.emptyList(), Collections.emptyMap());
         }
         return PerfCounterWildcardQuery.queryInstancesAndValues(ProcessPerformanceProperty.class, PROCESS,
-            WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL);
+                WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL);
     }
 
     /**
@@ -158,7 +163,7 @@ public final class ProcessInformation {
             return new Pair<>(Collections.emptyList(), Collections.emptyMap());
         }
         return PerfCounterWildcardQuery.queryInstancesAndValues(HandleCountProperty.class, PROCESS,
-            WIN32_PERFPROC_PROCESS);
+                WIN32_PERFPROC_PROCESS);
     }
 
     /**
@@ -171,7 +176,7 @@ public final class ProcessInformation {
             return new Pair<>(Collections.emptyList(), Collections.emptyMap());
         }
         return PerfCounterWildcardQuery.queryInstancesAndValues(IdleProcessorTimeProperty.class, PROCESS,
-            WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0);
+                WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0);
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessInformation.java
@@ -23,11 +23,6 @@
  */
 package oshi.driver.windows.perfmon;
 
-import static oshi.driver.windows.perfmon.PerfmonConstants.PROCESS;
-import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS;
-import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0;
-import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +32,8 @@ import oshi.util.platform.windows.PerfCounterQuery;
 import oshi.util.platform.windows.PerfCounterWildcardQuery;
 import oshi.util.platform.windows.PerfCounterWildcardQuery.PdhCounterWildcardProperty;
 import oshi.util.tuples.Pair;
+
+import static oshi.driver.windows.perfmon.PerfmonConstants.*;
 
 /**
  * Utility to query Process Information performance counter
@@ -115,6 +112,26 @@ public final class ProcessInformation {
         }
     }
 
+    /**
+     * Graphics Processor performance counters
+     */
+    public enum GpuEngineProperty implements PerfCounterWildcardQuery.PdhCounterWildcardProperty {
+        NAME(PerfCounterQuery.NOT_TOTAL_INSTANCE),
+        UTILIZATION("Utilization Percentage"),
+        UTILIZATION_BASE("Utilization Percentage_Base");
+
+        private final String counter;
+
+        GpuEngineProperty(String counter) {
+            this.counter = counter;
+        }
+
+        @Override
+        public String getCounter() {
+            return counter;
+        }
+    }
+
     private ProcessInformation() {
     }
 
@@ -128,7 +145,7 @@ public final class ProcessInformation {
             return new Pair<>(Collections.emptyList(), Collections.emptyMap());
         }
         return PerfCounterWildcardQuery.queryInstancesAndValues(ProcessPerformanceProperty.class, PROCESS,
-                WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL);
+            WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL);
     }
 
     /**
@@ -141,7 +158,7 @@ public final class ProcessInformation {
             return new Pair<>(Collections.emptyList(), Collections.emptyMap());
         }
         return PerfCounterWildcardQuery.queryInstancesAndValues(HandleCountProperty.class, PROCESS,
-                WIN32_PERFPROC_PROCESS);
+            WIN32_PERFPROC_PROCESS);
     }
 
     /**
@@ -154,6 +171,16 @@ public final class ProcessInformation {
             return new Pair<>(Collections.emptyList(), Collections.emptyMap());
         }
         return PerfCounterWildcardQuery.queryInstancesAndValues(IdleProcessorTimeProperty.class, PROCESS,
-                WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0);
+            WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0);
     }
+
+    /**
+     * Returns gpu performance counters
+     *
+     * @return Gpu performance counters
+     */
+    public static Pair<List<String>, Map<GpuEngineProperty, List<Long>>> queryGpuCounters() {
+        return PerfCounterWildcardQuery.queryInstancesAndValuesFromPDH(GpuEngineProperty.class, GPU_ENGINE);
+    }
+
 }

--- a/oshi-core/src/test/java/oshi/PerfMonGpuEngineTest.java
+++ b/oshi-core/src/test/java/oshi/PerfMonGpuEngineTest.java
@@ -1,56 +1,21 @@
 package oshi;
 
-import oshi.util.platform.windows.PerfCounterQuery;
-import oshi.util.platform.windows.PerfCounterWildcardQuery;
-import oshi.util.tuples.Pair;
+import oshi.driver.windows.perfmon.GraphicsUtilizationThread;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.Arrays;
 
 public class PerfMonGpuEngineTest {
 
-    public enum GpuEngineProperty implements PerfCounterWildcardQuery.PdhCounterWildcardProperty {
-        NAME(PerfCounterQuery.NOT_TOTAL_INSTANCE),
-        UTILIZATION("Utilization Percentage"),
-        UTILIZATION_BASE("Utilization Percentage_Base");
-
-        private final String counter;
-
-        GpuEngineProperty(String counter) {
-            this.counter = counter;
-        }
-
-        @Override
-        public String getCounter() {
-            return counter;
-        }
-    }
-
     public static void main(String[] args) throws Exception {
-        while (true) {
-            Pair<List<String>, Map<GpuEngineProperty, List<Long>>> initial = PerfCounterWildcardQuery.queryInstancesAndValuesFromPDH(GpuEngineProperty.class, "GPU Engine");
 
-            Thread.sleep(100);
+        GraphicsUtilizationThread gpuUtilizationThread = new GraphicsUtilizationThread();
 
-            Pair<List<String>, Map<GpuEngineProperty, List<Long>>> other = PerfCounterWildcardQuery.queryInstancesAndValuesFromPDH(GpuEngineProperty.class, "GPU Engine");
+        gpuUtilizationThread.start();
 
-            List<Long> baseA = initial.getB().get(GpuEngineProperty.UTILIZATION_BASE);
-            List<Long> baseB = other.getB().get(GpuEngineProperty.UTILIZATION_BASE);
-            List<Long> baseDifference = IntStream.range(0, baseA.size())
-                .mapToObj(i -> baseB.get(i) - baseA.get(i))
-                .collect(Collectors.toList());
+        Thread.sleep(1000L);
 
-            List<Long> utilizationA = initial.getB().get(GpuEngineProperty.UTILIZATION);
-            List<Long> utilizationB = other.getB().get(GpuEngineProperty.UTILIZATION);
-            List<Double> utilization = IntStream.range(0, utilizationA.size())
-                .mapToObj(i -> 100 * (utilizationB.get(i) - utilizationA.get(i)) / (double) baseDifference.get(i))
-                .collect(Collectors.toList());
+        System.out.println(Arrays.toString(gpuUtilizationThread.getUtilizationPercentages()));
 
-            System.out.println(utilization);
-            Thread.sleep(100);
 
-        }
     }
 }

--- a/oshi-core/src/test/java/oshi/PerfMonGpuEngineTest.java
+++ b/oshi-core/src/test/java/oshi/PerfMonGpuEngineTest.java
@@ -1,0 +1,62 @@
+package oshi;
+
+import oshi.util.platform.windows.PerfCounterQuery;
+import oshi.util.platform.windows.PerfCounterWildcardQuery;
+import oshi.util.tuples.Pair;
+
+import java.util.List;
+import java.util.Map;
+
+public class PerfMonGpuEngineTest {
+
+    public enum GpuEngineProperty implements PerfCounterWildcardQuery.PdhCounterWildcardProperty {
+        NAME(PerfCounterQuery.NOT_TOTAL_INSTANCE),
+        RUNNING_TIME("Running Time"),
+        UTILIZATION("Utilization Percentage");
+
+        private final String counter;
+
+        GpuEngineProperty(String counter) {
+            this.counter = counter;
+        }
+
+        @Override
+        public String getCounter() {
+            return counter;
+        }
+    }
+
+    // hmmmmm individual instance dont look right......
+    public enum GpuEngineProperty2 implements PerfCounterQuery.PdhCounterProperty {
+        UTILIZATION("pid_10472_luid_0x00000000_0x0000f814_phys_0_eng_0_engtype_3d", "Utilization Percentage");
+
+        private final String instance;
+        private final String counter;
+
+        GpuEngineProperty2(String instance, String counter) {
+            this.counter = counter;
+            this.instance = instance;
+        }
+
+        @Override
+        public String getInstance() {
+            return instance;
+        }
+
+        @Override
+        public String getCounter() {
+            return counter;
+        }
+    }
+
+    public static void main(String[] args) {
+//        Pair<List<String>, Map<GpuEngineProperty, List<Long>>> result = PerfCounterWildcardQuery.queryInstancesAndValuesFromPDH(GpuEngineProperty.class, "GPU Engine");
+
+//        System.out.println(result.getA());
+//        System.out.println(result.getB());
+//        System.out.println(result.getA().size());
+//        System.out.println(result.getB().get(GpuEngineProperty.UTILIZATION).size());
+
+        System.out.println(PerfCounterQuery.queryValuesFromPDH(GpuEngineProperty2.class, "GPU Engine"));
+    }
+}

--- a/oshi-core/src/test/java/oshi/PerfMonGpuEngineTest.java
+++ b/oshi-core/src/test/java/oshi/PerfMonGpuEngineTest.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package oshi;
 
 import oshi.driver.windows.perfmon.GraphicsUtilizationThread;
@@ -15,7 +38,6 @@ public class PerfMonGpuEngineTest {
         Thread.sleep(1000L);
 
         System.out.println(Arrays.toString(gpuUtilizationThread.getUtilizationPercentages()));
-
 
     }
 }

--- a/oshi-core/src/test/java/oshi/driver/windows/perfmon/GraphicsUtilizationTest.java
+++ b/oshi-core/src/test/java/oshi/driver/windows/perfmon/GraphicsUtilizationTest.java
@@ -21,23 +21,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package oshi;
+package oshi.driver.windows.perfmon;
 
-import oshi.driver.windows.perfmon.GraphicsUtilizationThread;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import oshi.util.Util;
 
-import java.util.Arrays;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.notNullValue;
 
-public class PerfMonGpuEngineTest {
+@EnabledOnOs(OS.WINDOWS)
+public class GraphicsUtilizationTest {
 
-    public static void main(String[] args) throws Exception {
-
+    @Test
+    void testQueryUtilizationPercentage() {
         GraphicsUtilizationThread gpuUtilizationThread = new GraphicsUtilizationThread();
-
         gpuUtilizationThread.start();
-
-        Thread.sleep(1000L);
-
-        System.out.println(Arrays.toString(gpuUtilizationThread.getUtilizationPercentages()));
-
+        assertThat("Failed because utilization percentages is already initialized",
+                gpuUtilizationThread.getUtilizationPercentages(), nullValue());
+        Util.sleep(10000L);
+        assertThat("Failed because utilization percentages is not initialized",
+                gpuUtilizationThread.getUtilizationPercentages(), notNullValue());
     }
 }

--- a/oshi-core/src/test/java/oshi/driver/windows/perfmon/GraphicsUtilizationTest.java
+++ b/oshi-core/src/test/java/oshi/driver/windows/perfmon/GraphicsUtilizationTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.notNullValue;
 
 @EnabledOnOs(OS.WINDOWS)
-public class GraphicsUtilizationTest {
+class GraphicsUtilizationTest {
 
     @Test
     void testQueryUtilizationPercentage() {


### PR DESCRIPTION
Adding Windows GPU Utilization Percentage as per #2112

---

Tried to draft up something basic logic/script verifying for GPU Engine / Utilization Percentage in PerfMon like the other PerfCounters but ran into some weird numbers (not sure if I made a mistake in the code...) 

---

Taking some instance `pid_10472_luid_0x00000000_0x0000f814_phys_0_eng_0_engtype_3d` that I found in `Get-Counter -Counter "\GPU Engine(*)\Utilization Percentage"`...

```shell
Get-Counter -Counter "\GPU Engine(pid_10472_luid_0x00000000_0x0000f814_phys_0_eng_0_engtype_3d)\Utilization Percentage"
```
gives `3.05119782746321` in powershell but using this script returns `2237473511`, changes a bit but looks like the result of:
```shell
Get-Counter -Counter "\GPU Engine(pid_10472_luid_0x00000000_0x0000f814_phys_0_eng_0_engtype_3d)\Running Time"
```

It also looks like using the WildcardQuery gives
```
{RUNNING_TIME=[2074738846, 0, 0, 0, 0, 11338102288, 0, 0, 0, 0, 0, 0, 0, 3196630, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5466, 0, 7160799, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 162739, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7607, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 39585, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9453, 5273, 9142, 1321, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1886491788, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 52307, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 589916896, 0, 0, 0, 0, 0, 4294745, 0, 0, 0, 0, 0, 4881145, 0, 0, 0, 9161068, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16413, 0, 4948, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3607614, 0, 0, 0, 0, 7934, 0, 0, 0, 0, 0, 402, 764, 61286, 2460900533, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 115478, 0, 0, 75059346, 0, 0, 14940, 0, 0, 0, 0, 0, 22012, 0, 0, 0, 18956634, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1731002, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13422, 0, 19054, 0, 0, 0, 0, 0, 0, 13177, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 201858519, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 771442, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 661929671, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3502, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 421490027, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 119978079, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 207149, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8067, 0, 879036, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5585, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 
UTILIZATION=[2074738846, 0, 0, 0, 0, 11338102288, 0, 0, 0, 0, 0, 0, 0, 3196630, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5466, 0, 7160799, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 162739, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7607, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 39585, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9453, 5273, 9142, 1321, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1886491788, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 52307, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 589916896, 0, 0, 0, 0, 0, 4294745, 0, 0, 0, 0, 0, 4881145, 0, 0, 0, 9161068, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16413, 0, 4948, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3607614, 0, 0, 0, 0, 7934, 0, 0, 0, 0, 0, 402, 764, 61286, 2460900533, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 115478, 0, 0, 75059346, 0, 0, 14940, 0, 0, 0, 0, 0, 22012, 0, 0, 0, 18956634, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1731002, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13422, 0, 19054, 0, 0, 0, 0, 0, 0, 13177, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 201858519, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 771442, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 661929671, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3502, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 421490027, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 119978079, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 207149, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8067, 0, 879036, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5585, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
```
basically two identical lists.

Wasn't sure if I was doing something wrong here with the enums...