### PR TITLE
Added support for Android OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * [#2180](https://github.com/oshi/oshi/pull/2180): Suppress log warnings for non-root procfs reads - [@dbwiddis](https://github.com/dbwiddis).
 * [#2181](https://github.com/oshi/oshi/pull/2181): Better handling of ARM CPU Names - [@dbwiddis](https://github.com/dbwiddis).
 
+##### New Features
+* [#2196](https://github.com/oshi/oshi/issues/2196): Added support for Android OS - [@milan-fabian](https://github.com/milan-fabian).
+
 # 6.2.0 (2022-06-26), 6.2.1 (2022-06-29), 6.2.2 (2022-07-20)
 
 ##### Performance improvement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [#2181](https://github.com/oshi/oshi/pull/2181): Better handling of ARM CPU Names - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### New Features
-* [#2196](https://github.com/oshi/oshi/issues/2196): Added support for Android OS - [@milan-fabian](https://github.com/milan-fabian).
+* [#2197](https://github.com/oshi/oshi/issues/2197): Added support for Android OS - [@milan-fabian](https://github.com/milan-fabian).
 
 # 6.2.0 (2022-06-26), 6.2.1 (2022-06-29), 6.2.2 (2022-07-20)
 

--- a/oshi-core-java11/pom.xml
+++ b/oshi-core-java11/pom.xml
@@ -89,10 +89,10 @@
                 <executions>
                     <execution>
                         <id>auto-clean</id>
-                        <phase>initialize</phase>
                         <goals>
                             <goal>clean</goal>
                         </goals>
+                        <phase>initialize</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -103,6 +103,7 @@ public class SystemInfo {
         case WINDOWS:
             return new WindowsOperatingSystem();
         case LINUX:
+        case ANDROID:
             return new LinuxOperatingSystem();
         case MACOS:
             return new MacOperatingSystem();
@@ -134,6 +135,7 @@ public class SystemInfo {
         case WINDOWS:
             return new WindowsHardwareAbstractionLayer();
         case LINUX:
+        case ANDROID:
             return new LinuxHardwareAbstractionLayer();
         case MACOS:
             return new MacHardwareAbstractionLayer();

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -91,7 +91,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         Udev lib = null;
         try {
             lib = Udev.INSTANCE;
-        } catch (UnsatisfiedLinkError e) {
+        } catch (UnsatisfiedLinkError | NoClassDefFoundError e) {
             // no udev
         }
         HAS_UDEV = lib != null;

--- a/src/site/markdown/FAQ.md
+++ b/src/site/markdown/FAQ.md
@@ -59,6 +59,7 @@ OSHI has been implemented and tested on the following systems.  Some features ma
 * OpenBSD 6.8
 * Solaris 11 (SunOS 5.11)
 * AIX 7.1 (POWER4)
+* Android 7.0 and higher
 
 ## How do I resolve `Pdh call failed with error code 0xC0000BB8` issues?
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -12,7 +12,7 @@ memory and CPU usage, disks and partitions, devices, sensors, etc.
 
 Supported platforms
 ---------------------------
-Windows • Linux • macOS • Unix (AIX, FreeBSD, OpenBSD, Solaris)
+Windows • Linux • macOS • Unix (AIX, FreeBSD, OpenBSD, Solaris) • Android
 
 Downloads and Dependency Management
 -----------------------------------


### PR DESCRIPTION
As Android is based on Linux, reusing LinuxOperatingSystem and LinuxHardwareAbstractionLayer works for the most important parts (CPU, RAM, system description etc.).

Tested on Android 7, 9 and 11.

Resolves https://github.com/oshi/oshi/issues/1533.
