### PR TITLE
NPE potentially caused by empty directories

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStore.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStore.java
@@ -272,8 +272,8 @@ public final class LinuxHWDiskStore extends AbstractHWDiskStore {
         }
         // Iterate the list and make the partitions unmodifiable
         for (HWDiskStore hwds : result) {
-            ((LinuxHWDiskStore) hwds).partitionList = Collections.unmodifiableList(hwds.getPartitions().stream()
-                    .sorted(Comparator.comparing(HWPartition::getName)).collect(Collectors.toList()));
+            ((LinuxHWDiskStore) hwds).partitionList = hwds.getPartitions().stream()
+                .sorted(Comparator.comparing(HWPartition::getName)).collect(Collectors.toUnmodifiableList());
         }
         return result;
     }
@@ -312,11 +312,11 @@ public final class LinuxHWDiskStore extends AbstractHWDiskStore {
     }
 
     private static String getPartitionNameForDmDevice(String vgName, String lvName) {
-        return new StringBuilder().append(DEV_LOCATION).append(vgName).append('/').append(lvName).toString();
+        return DEV_LOCATION + vgName + '/' + lvName;
     }
 
     private static String getMountPointOfDmDevice(String vgName, String lvName) {
-        return new StringBuilder().append(DEV_MAPPER).append(vgName).append('-').append(lvName).toString();
+        return DEV_MAPPER + vgName + '-' + lvName;
     }
 
     private static String getDependentNamesFromHoldersDirectory(String sysPath) {

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcess.java
@@ -280,9 +280,7 @@ public class AixOSProcess extends AbstractOSProcess {
         for (File lwpidFile : numericFiles) {
             int lwpidNum = ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0);
             AixLwpsInfo info = PsInfo.queryLwpsInfo(getProcessID(), lwpidNum);
-            if (info != null) {
-                mask |= info.pr_bindpro;
-            }
+            mask |= info.pr_bindpro;
         }
         mask &= affinityMask.get();
         return mask;
@@ -345,7 +343,7 @@ public class AixOSProcess extends AbstractOSProcess {
         this.startTime = info.pr_start.tv_sec * 1000L + info.pr_start.tv_nsec / 1_000_000L;
         // Avoid divide by zero for processes up less than a millisecond
         long elapsedTime = now - this.startTime;
-        this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
+        this.upTime = Math.max(elapsedTime, 1L);
         this.userTime = userSysCpuTime.getA();
         this.kernelTime = userSysCpuTime.getB();
         this.commandLineBackup = Native.toString(info.pr_psargs);


### PR DESCRIPTION
Think iterating
```
for (File f : dir.listFiles((f, name) -> name.toLowerCase().endsWith(".conf"))) {
```
potentially causes unhandled null pointer errors in

`LinuxOperatingSystem` and `MacOperatingSystem` which wraps `Arrays.asList(null)`

And included some tiny refactoring (maybe should have split out in a different PR but hard to spot a lot)