### PR TITLE
Improve performance using parallel streams for processes and threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#2179](https://github.com/oshi/oshi/pull/2179): Update JUnit EnabledOnOS for OpenBSD and FreeBSD - [@dbwiddis](https://github.com/dbwiddis).
 * [#2180](https://github.com/oshi/oshi/pull/2180): Suppress log warnings for non-root procfs reads - [@dbwiddis](https://github.com/dbwiddis).
 * [#2181](https://github.com/oshi/oshi/pull/2181): Better handling of ARM CPU Names - [@dbwiddis](https://github.com/dbwiddis).
+* [#2204](https://github.com/oshi/oshi/pull/2204): Improve performance using parallel streams for processes and threads - [@adrian-kong](https://github.com/adrian-kong).
 
 ##### New Features
 * [#2197](https://github.com/oshi/oshi/issues/2197): Added support for Android OS - [@milan-fabian](https://github.com/milan-fabian).

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -154,7 +154,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
         List<NetworkInterface> interfaces = getAllNetworkInterfaces();
 
         return includeLocalInterfaces ? interfaces
-                : getAllNetworkInterfaces().stream().filter(networkInterface1 -> !isLocalInterface(networkInterface1))
+                : getAllNetworkInterfaces().stream().parallel().filter(networkInterface1 -> !isLocalInterface(networkInterface1))
                         .collect(Collectors.toList());
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -155,8 +155,8 @@ public abstract class AbstractNetworkIF implements NetworkIF {
         List<NetworkInterface> interfaces = getAllNetworkInterfaces();
 
         return includeLocalInterfaces ? interfaces
-                : getAllNetworkInterfaces().stream().parallel()
-                        .filter(ni -> !isLocalInterface(ni)).collect(Collectors.toList());
+                : getAllNetworkInterfaces().stream().parallel().filter(ni -> !isLocalInterface(ni))
+                        .collect(Collectors.toList());
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -155,7 +156,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
 
         return includeLocalInterfaces ? interfaces
                 : getAllNetworkInterfaces().stream().parallel()
-                        .filter(networkInterface1 -> !isLocalInterface(networkInterface1)).collect(Collectors.toList());
+                        .filter(Predicate.not(AbstractNetworkIF::isLocalInterface)).collect(Collectors.toList());
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -154,8 +154,8 @@ public abstract class AbstractNetworkIF implements NetworkIF {
         List<NetworkInterface> interfaces = getAllNetworkInterfaces();
 
         return includeLocalInterfaces ? interfaces
-                : getAllNetworkInterfaces().stream().parallel().filter(networkInterface1 -> !isLocalInterface(networkInterface1))
-                        .collect(Collectors.toList());
+                : getAllNetworkInterfaces().stream().parallel()
+                        .filter(networkInterface1 -> !isLocalInterface(networkInterface1)).collect(Collectors.toList());
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2020-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -156,7 +156,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
 
         return includeLocalInterfaces ? interfaces
                 : getAllNetworkInterfaces().stream().parallel()
-                        .filter(Predicate.not(AbstractNetworkIF::isLocalInterface)).collect(Collectors.toList());
+                        .filter(ni -> !isLocalInterface(ni)).collect(Collectors.toList());
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/OSThread.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSThread.java
@@ -25,10 +25,25 @@ package oshi.software.os;
 
 import oshi.software.os.OSProcess.State;
 
+import java.util.function.Predicate;
+
 /**
  * Represents a Thread/Task on the operating system.
  */
 public interface OSThread {
+
+    /**
+     * Constants which may be used to filter Thread lists in
+     */
+    final class ThreadFiltering {
+        private ThreadFiltering() {
+        }
+
+        /**
+         * Exclude processes with {@link State#INVALID} process state.
+         */
+        public static final Predicate<OSThread> VALID_THREAD = p -> !p.getState().equals(State.INVALID);
+    }
 
     /**
      * The thread id. The meaning of this value is OS-dependent.

--- a/oshi-core/src/main/java/oshi/software/os/OSThread.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSThread.java
@@ -33,7 +33,7 @@ import java.util.function.Predicate;
 public interface OSThread {
 
     /**
-     * Constants which may be used to filter Thread lists in
+     * Constants which may be used to filter Thread lists
      */
     final class ThreadFiltering {
         private ThreadFiltering() {

--- a/oshi-core/src/main/java/oshi/software/os/OSThread.java
+++ b/oshi-core/src/main/java/oshi/software/os/OSThread.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
+ * Copyright (c) 2020-2022 The OSHI Project Contributors: https://github.com/oshi/oshi/graphs/contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
@@ -247,7 +247,7 @@ public class LinuxOSProcess extends AbstractOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        return ProcessStat.getThreadIds(getProcessID()).stream().map(id -> new LinuxOSThread(getProcessID(), id))
+        return ProcessStat.getThreadIds(getProcessID()).stream().parallel().map(id -> new LinuxOSThread(getProcessID(), id))
                 .collect(Collectors.toList());
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
@@ -247,8 +247,8 @@ public class LinuxOSProcess extends AbstractOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        return ProcessStat.getThreadIds(getProcessID()).stream().parallel().map(id -> new LinuxOSThread(getProcessID(), id))
-                .collect(Collectors.toList());
+        return ProcessStat.getThreadIds(getProcessID()).stream().parallel()
+                .map(id -> new LinuxOSThread(getProcessID(), id)).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
@@ -24,6 +24,7 @@
 package oshi.software.os.linux;
 
 import static oshi.software.os.OSProcess.State.INVALID;
+import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 import static oshi.util.Memoizer.memoize;
 
 import java.io.File;
@@ -248,7 +249,7 @@ public class LinuxOSProcess extends AbstractOSProcess {
     @Override
     public List<OSThread> getThreadDetails() {
         return ProcessStat.getThreadIds(getProcessID()).stream().parallel()
-                .map(id -> new LinuxOSThread(getProcessID(), id)).collect(Collectors.toList());
+                .map(id -> new LinuxOSThread(getProcessID(), id)).filter(VALID_THREAD).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcess.java
@@ -264,11 +264,11 @@ public class MacOSProcess extends AbstractOSProcess {
     @Override
     public List<OSThread> getThreadDetails() {
         long now = System.currentTimeMillis();
-        return ThreadInfo.queryTaskThreads(getProcessID()).stream().parallel().map(stat->{
+        return ThreadInfo.queryTaskThreads(getProcessID()).stream().parallel().map(stat -> {
             // For long running threads the start time calculation can overestimate
             long start = Math.max(now - stat.getUpTime(), getStartTime());
             return new MacOSThread(getProcessID(), stat.getThreadId(), stat.getState(), stat.getSystemTime(),
-                stat.getUserTime(), start, now - start, stat.getPriority());
+                    stat.getUserTime(), start, now - start, stat.getPriority());
         }).collect(Collectors.toList());
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcess.java
@@ -30,6 +30,7 @@ import static oshi.software.os.OSProcess.State.SLEEPING;
 import static oshi.software.os.OSProcess.State.STOPPED;
 import static oshi.software.os.OSProcess.State.WAITING;
 import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
@@ -38,7 +39,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.List;
+import java.util.Collections;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -298,7 +302,7 @@ public class AixOSProcess extends AbstractOSProcess {
 
         return Arrays.stream(numericFiles).parallel()
                 .map(lwpidFile -> new AixOSThread(getProcessID(), ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
-                .filter(thread -> thread.getState() != INVALID).collect(Collectors.toList());
+                .filter(VALID_THREAD).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcess.java
@@ -38,10 +38,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -290,24 +289,16 @@ public class AixOSProcess extends AbstractOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        List<OSThread> threads = new ArrayList<>();
-
         // Get process files in proc
         File directory = new File(String.format("/proc/%d/lwp", getProcessID()));
         File[] numericFiles = directory.listFiles(file -> Constants.DIGITS.matcher(file.getName()).matches());
         if (numericFiles == null) {
-            return threads;
+            return Collections.emptyList();
         }
 
-        // Iterate files
-        for (File lwpidFile : numericFiles) {
-            int lwpidNum = ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0);
-            OSThread thread = new AixOSThread(getProcessID(), lwpidNum);
-            if (thread.getState() != INVALID) {
-                threads.add(thread);
-            }
-        }
-        return threads;
+        return Arrays.stream(numericFiles).parallel()
+            .map(lwpidFile -> new AixOSThread(getProcessID(), ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
+            .filter(thread -> thread.getState() != INVALID).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcess.java
@@ -297,8 +297,8 @@ public class AixOSProcess extends AbstractOSProcess {
         }
 
         return Arrays.stream(numericFiles).parallel()
-            .map(lwpidFile -> new AixOSThread(getProcessID(), ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
-            .filter(thread -> thread.getState() != INVALID).collect(Collectors.toList());
+                .map(lwpidFile -> new AixOSThread(getProcessID(), ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
+                .filter(thread -> thread.getState() != INVALID).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
@@ -30,6 +30,7 @@ import static oshi.software.os.OSProcess.State.SLEEPING;
 import static oshi.software.os.OSProcess.State.STOPPED;
 import static oshi.software.os.OSProcess.State.WAITING;
 import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 import static oshi.util.Memoizer.memoize;
 
 import java.util.ArrayList;
@@ -337,10 +338,11 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
         if (getProcessID() >= 0) {
             psCommand += " -p " + getProcessID();
         }
-        Predicate<Map<PsThreadColumns, String>> columnPRI = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
+        Predicate<Map<PsThreadColumns, String>> hasColumnsPri = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' ')).filter(columnPRI)
-                .map(threadMap -> new FreeBsdOSThread(getProcessID(), threadMap)).collect(Collectors.toList());
+                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .filter(hasColumnsPri).map(threadMap -> new FreeBsdOSThread(getProcessID(), threadMap))
+                .filter(VALID_THREAD).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -336,9 +337,10 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
         if (getProcessID() >= 0) {
             psCommand += " -p " + getProcessID();
         }
+        Predicate<Map<PsThreadColumns, String>> columnPRI = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
                 .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-                .filter(threadMap -> threadMap.containsKey(PsThreadColumns.PRI))
+                .filter(columnPRI)
                 .map(threadMap -> new FreeBsdOSThread(getProcessID(), threadMap)).collect(Collectors.toList());
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
@@ -337,10 +337,9 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
             psCommand += " -p " + getProcessID();
         }
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-            .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-            .filter(threadMap -> threadMap.containsKey(PsThreadColumns.PRI))
-            .map(threadMap -> new FreeBsdOSThread(getProcessID(), threadMap))
-            .collect(Collectors.toList());
+                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .filter(threadMap -> threadMap.containsKey(PsThreadColumns.PRI))
+                .map(threadMap -> new FreeBsdOSThread(getProcessID(), threadMap)).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
@@ -339,8 +339,7 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
         }
         Predicate<Map<PsThreadColumns, String>> columnPRI = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-                .filter(columnPRI)
+                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' ')).filter(columnPRI)
                 .map(threadMap -> new FreeBsdOSThread(getProcessID(), threadMap)).collect(Collectors.toList());
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -153,11 +153,11 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
             psCommand += " -p " + pid;
         }
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-            .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' '))
-            .filter(psMap -> psMap.containsKey(PsKeywords.ARGS))
-            .map(psMap -> new FreeBsdOSProcess(
-                pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap))
-            .collect(Collectors.toList());
+                .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' '))
+                .filter(psMap -> psMap.containsKey(PsKeywords.ARGS))
+                .map(psMap -> new FreeBsdOSProcess(
+                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -155,8 +155,7 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
 
         Predicate<Map<PsKeywords, String>> keywordARGS = psMap -> psMap.containsKey(PsKeywords.ARGS);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' '))
-                .filter(keywordARGS)
+                .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ')).filter(keywordARGS)
                 .map(psMap -> new FreeBsdOSProcess(
                         pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap))
                 .collect(Collectors.toList());

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -147,14 +148,15 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
     }
 
     private static List<OSProcess> getProcessListFromPS(int pid) {
-        List<OSProcess> procs = new ArrayList<>();
         String psCommand = "ps -awwxo " + PS_COMMAND_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
         }
+
+        Predicate<Map<PsKeywords, String>> keywordARGS = psMap -> psMap.containsKey(PsKeywords.ARGS);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
                 .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' '))
-                .filter(psMap -> psMap.containsKey(PsKeywords.ARGS))
+                .filter(keywordARGS)
                 .map(psMap -> new FreeBsdOSProcess(
                         pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap))
                 .collect(Collectors.toList());

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -25,6 +25,7 @@ package oshi.software.os.unix.freebsd;
 
 import static oshi.software.os.OSService.State.RUNNING;
 import static oshi.software.os.OSService.State.STOPPED;
+import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -44,12 +45,12 @@ import oshi.driver.unix.freebsd.Who;
 import oshi.jna.platform.unix.FreeBsdLibc;
 import oshi.jna.platform.unix.FreeBsdLibc.Timeval;
 import oshi.software.common.AbstractOperatingSystem;
-import oshi.software.os.FileSystem;
-import oshi.software.os.InternetProtocolStats;
-import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
 import oshi.software.os.OSSession;
+import oshi.software.os.InternetProtocolStats;
+import oshi.software.os.FileSystem;
+import oshi.software.os.OSService;
+import oshi.software.os.NetworkParams;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
@@ -153,12 +154,12 @@ public class FreeBsdOperatingSystem extends AbstractOperatingSystem {
             psCommand += " -p " + pid;
         }
 
-        Predicate<Map<PsKeywords, String>> keywordARGS = psMap -> psMap.containsKey(PsKeywords.ARGS);
+        Predicate<Map<PsKeywords, String>> hasKeywordArgs = psMap -> psMap.containsKey(PsKeywords.ARGS);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ')).filter(keywordARGS)
+                .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ')).filter(hasKeywordArgs)
                 .map(psMap -> new FreeBsdOSProcess(
                         pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap))
-                .collect(Collectors.toList());
+                .filter(VALID_PROCESS).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcess.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -353,9 +354,10 @@ public class OpenBsdOSProcess extends AbstractOSProcess {
         if (getProcessID() >= 0) {
             psCommand += " -p " + getProcessID();
         }
+        Predicate<Map<PsThreadColumns, String>> columnARGS = threadMap -> threadMap.containsKey(PsThreadColumns.ARGS);
         return ExecutingCommand.runNative(psCommand).stream().skip(1)
                 .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-                .filter(threadMap -> threadMap.containsKey(PsThreadColumns.ARGS))
+                .filter(columnARGS)
                 .map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap)).collect(Collectors.toList());
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcess.java
@@ -356,8 +356,7 @@ public class OpenBsdOSProcess extends AbstractOSProcess {
         }
         Predicate<Map<PsThreadColumns, String>> columnARGS = threadMap -> threadMap.containsKey(PsThreadColumns.ARGS);
         return ExecutingCommand.runNative(psCommand).stream().skip(1)
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-                .filter(columnARGS)
+                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' ')).filter(columnARGS)
                 .map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap)).collect(Collectors.toList());
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcess.java
@@ -30,6 +30,7 @@ import static oshi.software.os.OSProcess.State.SLEEPING;
 import static oshi.software.os.OSProcess.State.STOPPED;
 import static oshi.software.os.OSProcess.State.WAITING;
 import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 import static oshi.util.Memoizer.memoize;
 
 import java.util.ArrayList;
@@ -354,10 +355,12 @@ public class OpenBsdOSProcess extends AbstractOSProcess {
         if (getProcessID() >= 0) {
             psCommand += " -p " + getProcessID();
         }
-        Predicate<Map<PsThreadColumns, String>> columnARGS = threadMap -> threadMap.containsKey(PsThreadColumns.ARGS);
+        Predicate<Map<PsThreadColumns, String>> hasColumnsArgs = threadMap -> threadMap
+                .containsKey(PsThreadColumns.ARGS);
         return ExecutingCommand.runNative(psCommand).stream().skip(1)
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' ')).filter(columnARGS)
-                .map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap)).collect(Collectors.toList());
+                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .filter(hasColumnsArgs).map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap))
+                .filter(VALID_THREAD).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcess.java
@@ -354,10 +354,9 @@ public class OpenBsdOSProcess extends AbstractOSProcess {
             psCommand += " -p " + getProcessID();
         }
         return ExecutingCommand.runNative(psCommand).stream().skip(1)
-            .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-            .filter(threadMap -> threadMap.containsKey(PsThreadColumns.ARGS))
-            .map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap))
-            .collect(Collectors.toList());
+                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .filter(threadMap -> threadMap.containsKey(PsThreadColumns.ARGS))
+                .map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap)).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcess.java
@@ -323,10 +323,9 @@ public class SolarisOSProcess extends AbstractOSProcess {
             return Collections.emptyList();
         }
 
-        return Arrays.stream(numericFiles).parallel()
-            .map(lwpidFile ->new SolarisOSThread(getProcessID(),  ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
-            .filter(thread -> thread.getState() != INVALID)
-            .collect(Collectors.toList());
+        return Arrays.stream(numericFiles).parallel().map(
+                lwpidFile -> new SolarisOSThread(getProcessID(), ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
+                .filter(thread -> thread.getState() != INVALID).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcess.java
@@ -38,10 +38,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -317,24 +316,17 @@ public class SolarisOSProcess extends AbstractOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        List<OSThread> threads = new ArrayList<>();
-
         // Get process files in proc
         File directory = new File(String.format("/proc/%d/lwp", getProcessID()));
         File[] numericFiles = directory.listFiles(file -> Constants.DIGITS.matcher(file.getName()).matches());
         if (numericFiles == null) {
-            return threads;
+            return Collections.emptyList();
         }
 
-        // Iterate files
-        for (File lwpidFile : numericFiles) {
-            int lwpidNum = ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0);
-            OSThread thread = new SolarisOSThread(getProcessID(), lwpidNum);
-            if (thread.getState() != INVALID) {
-                threads.add(thread);
-            }
-        }
-        return threads;
+        return Arrays.stream(numericFiles).parallel()
+            .map(lwpidFile ->new SolarisOSThread(getProcessID(),  ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
+            .filter(thread -> thread.getState() != INVALID)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcess.java
@@ -30,6 +30,7 @@ import static oshi.software.os.OSProcess.State.SLEEPING;
 import static oshi.software.os.OSProcess.State.STOPPED;
 import static oshi.software.os.OSProcess.State.WAITING;
 import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
@@ -38,7 +39,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Map;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -325,7 +329,7 @@ public class SolarisOSProcess extends AbstractOSProcess {
 
         return Arrays.stream(numericFiles).parallel().map(
                 lwpidFile -> new SolarisOSThread(getProcessID(), ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
-                .filter(thread -> thread.getState() != INVALID).collect(Collectors.toList());
+                .filter(VALID_THREAD).collect(Collectors.toList());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
@@ -287,7 +287,7 @@ public class WindowsOSProcess extends AbstractOSProcess {
         if (threads == null) {
             return Collections.emptyList();
         }
-        return threads.entrySet().stream()
+        return threads.entrySet().stream().parallel()
                 .map(entry -> new WindowsOSThread(getProcessID(), entry.getKey(), this.name, entry.getValue()))
                 .collect(Collectors.toList());
     }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -26,6 +26,7 @@ package oshi.software.os.windows;
 import static oshi.software.os.OSService.State.OTHER;
 import static oshi.software.os.OSService.State.RUNNING;
 import static oshi.software.os.OSService.State.STOPPED;
+import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
@@ -337,11 +338,11 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         Set<Integer> mapKeys = new HashSet<>(processWtsMap.keySet());
         mapKeys.retainAll(processMap.keySet());
 
-        Map<Integer, ProcessPerformanceData.PerfCounterBlock> finalProcessMap = processMap;
-        Map<Integer, ThreadPerformanceData.PerfCounterBlock> finalThreadMap = threadMap;
+        final Map<Integer, ProcessPerformanceData.PerfCounterBlock> finalProcessMap = processMap;
+        final Map<Integer, ThreadPerformanceData.PerfCounterBlock> finalThreadMap = threadMap;
         return mapKeys.stream().parallel()
                 .map(pid -> new WindowsOSProcess(pid, this, finalProcessMap, processWtsMap, finalThreadMap))
-                .collect(Collectors.toList());
+                .filter(VALID_PROCESS).collect(Collectors.toList());
     }
 
     private static Map<Integer, ProcessPerformanceData.PerfCounterBlock> queryProcessMapFromRegistry() {

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -336,11 +337,11 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         Set<Integer> mapKeys = new HashSet<>(processWtsMap.keySet());
         mapKeys.retainAll(processMap.keySet());
 
-        List<OSProcess> processList = new ArrayList<>();
-        for (Integer pid : mapKeys) {
-            processList.add(new WindowsOSProcess(pid, this, processMap, processWtsMap, threadMap));
-        }
-        return processList;
+        Map<Integer, ProcessPerformanceData.PerfCounterBlock> finalProcessMap = processMap;
+        Map<Integer, ThreadPerformanceData.PerfCounterBlock> finalThreadMap = threadMap;
+        return mapKeys.stream().parallel()
+            .map(pid -> new WindowsOSProcess(pid, this, finalProcessMap, processWtsMap, finalThreadMap))
+            .collect(Collectors.toList());
     }
 
     private static Map<Integer, ProcessPerformanceData.PerfCounterBlock> queryProcessMapFromRegistry() {

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -340,8 +340,8 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         Map<Integer, ProcessPerformanceData.PerfCounterBlock> finalProcessMap = processMap;
         Map<Integer, ThreadPerformanceData.PerfCounterBlock> finalThreadMap = threadMap;
         return mapKeys.stream().parallel()
-            .map(pid -> new WindowsOSProcess(pid, this, finalProcessMap, processWtsMap, finalThreadMap))
-            .collect(Collectors.toList());
+                .map(pid -> new WindowsOSProcess(pid, this, finalProcessMap, processWtsMap, finalThreadMap))
+                .collect(Collectors.toList());
     }
 
     private static Map<Integer, ProcessPerformanceData.PerfCounterBlock> queryProcessMapFromRegistry() {


### PR DESCRIPTION
Not sure if this was done, 

Adds parallel on every stream call 
Fixes #2196 

@dbwiddis I'm not actually sure when parallel should be used according to
https://www.baeldung.com/java-when-to-use-parallel-stream
so I have never actually used this method, is it necessary to use `.parallel` on every stream call?