### PR TITLE
Bump jackson-databind to 2.14.0-rc1

### DIFF
--- a/oshi-demo/pom.xml
+++ b/oshi-demo/pom.xml
@@ -14,7 +14,7 @@
     <name>oshi-demo</name>
 
     <properties>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.14.0-rc1</jackson.version>
         <jfreechart.version>1.5.3</jfreechart.version>
     </properties>
 


### PR DESCRIPTION
Wouldn't normally bump to a RC but this is getting flagged for security.   We aren't vulnerable as we haven't opted in to the setting, but I figure why not update to make the warning go away? 

Curious if there's a way to tell Renovate to do this update without changing configs...

https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426