### PR TITLE
Detect Windows Server 2022 in older JDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ##### New Features
 * [#2218](https://github.com/oshi/oshi/pull/2218): Added system-wide per-process file descriptor limits - [@gitseti](https://github.com/gitseti)
 
+##### Bug fixes / Improvements
+* [#2224](https://github.com/oshi/oshi/pull/2224): Detect Windows Server 2022 in older JDKs - [@dbwiddis](https://github.com/dbwiddis).
+
 # 6.3.0 (2022-10-16)
 
 ##### New Features

--- a/oshi-core/src/main/java/oshi/software/os/OperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/OperatingSystem.java
@@ -347,13 +347,7 @@ public interface OperatingSystem {
         private final String versionStr;
 
         public OSVersionInfo(String version, String codeName, String buildNumber) {
-            // Insider Preview Windows 11 is marked as Windows 10 build 22000
-            // Temporary code until JDK os.name matches up
-            if ("10".equals(version) && buildNumber.compareTo("22000") >= 0) {
-                this.version = "11";
-            } else {
-                this.version = version;
-            }
+            this.version = version;
             this.codeName = codeName;
             this.buildNumber = buildNumber;
 

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -142,7 +142,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
 
         String sp = null;
         int suiteMask = 0;
-        String buildNumber = null;
+        String buildNumber = "";
         WmiResult<OSVersionProperty> versionInfo = Win32OperatingSystem.queryOsVersion();
         if (versionInfo.getResultCount() > 0) {
             sp = WmiUtil.getString(versionInfo, OSVersionProperty.CSDVERSION, 0);
@@ -153,6 +153,12 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
             buildNumber = WmiUtil.getString(versionInfo, OSVersionProperty.BUILDNUMBER, 0);
         }
         String codeName = parseCodeName(suiteMask);
+        // Older JDKs don't recognize Win11 and Server2022
+        if ("10".equals(version) && buildNumber.compareTo("22000") >= 0) {
+            version = "11";
+        } else if ("Server 2019".equals(version) && buildNumber.compareTo("20347") > 0) {
+            version = "Server 2022";
+        }
         return new Pair<>("Windows", new OSVersionInfo(version, codeName, buildNumber));
     }
 


### PR DESCRIPTION
Fixes #2223 