### PR TITLE
Use regex to pre-filter to parseable CPU numbers for ARM Macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug fixes / Improvements
 * [#2258](https://github.com/oshi/oshi/pull/2258): Ensure constant AIX processor tick count array - [@dbwiddis](https://github.com/dbwiddis).
 * [#2259](https://github.com/oshi/oshi/pull/2259): Cache AIX partition list to reduce disk reads from lspv - [@dbwiddis](https://github.com/dbwiddis).
+* [#2260](https://github.com/oshi/oshi/pull/2260): Use regex to pre-filter to parseable CPU numbers for ARM Macs - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.3.0 (2022-10-16), 6.3.1 (2022-10-30), 6.3.2 (2022-11-16)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -50,6 +52,7 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
     private static final int M1_CPUFAMILY = 0x1b588bb3;
     private static final int M2_CPUFAMILY = 0xda33d83d;
     private static final long DEFAULT_FREQUENCY = 2_400_000_000L;
+    private static final Pattern CPU_N = Pattern.compile("^cpu(\\d+)");
 
     private final Supplier<String> vendor = memoize(MacCentralProcessor::platformExpert);
     private final boolean isArmCpu = isArmCpu();
@@ -291,8 +294,9 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
         if (iter != null) {
             IORegistryEntry cpu = iter.next();
             while (cpu != null) {
-                if (cpu.getName().toLowerCase().startsWith("cpu")) {
-                    int procId = ParseUtil.getFirstIntValue(cpu.getName());
+                Matcher m = CPU_N.matcher(cpu.getName().toLowerCase());
+                if (m.matches()) {
+                    int procId = ParseUtil.parseIntOrDefault(m.group(1), 0);
                     // Compatible key is null-delimited C string array in byte array
                     byte[] data = cpu.getByteArrayProperty("compatible");
                     if (data != null) {


### PR DESCRIPTION
Fixes #2255 