### PR TITLE
Don't assume ticks match logical processor count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#2259](https://github.com/oshi/oshi/pull/2259): Cache AIX partition list to reduce disk reads from lspv - [@dbwiddis](https://github.com/dbwiddis).
 * [#2260](https://github.com/oshi/oshi/pull/2260): Use regex to pre-filter to parseable CPU numbers for ARM Macs - [@dbwiddis](https://github.com/dbwiddis).
 * [#2262](https://github.com/oshi/oshi/pull/2262): Consistent treatment of AIX tick lengths - [@dbwiddis](https://github.com/dbwiddis).
+* [#2263](https://github.com/oshi/oshi/pull/2263): Don't assume ticks match logical processor count - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.3.0 (2022-10-16), 6.3.1 (2022-10-30), 6.3.2 (2022-11-16)
 

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -203,8 +203,8 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
     @Override
     public double getSystemCpuLoadBetweenTicks(long[] oldTicks) {
         if (oldTicks.length != TickType.values().length) {
-            throw new IllegalArgumentException(
-                    "Tick array " + oldTicks.length + " should have " + TickType.values().length + " elements");
+            throw new IllegalArgumentException("Provited tick array length " + oldTicks.length + " should have "
+                    + TickType.values().length + " elements");
         }
         long[] ticks = getSystemCpuLoadTicks();
         // Calculate total
@@ -222,12 +222,11 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
 
     @Override
     public double[] getProcessorCpuLoadBetweenTicks(long[][] oldTicks) {
-        if (oldTicks.length != this.logicalProcessorCount || oldTicks[0].length != TickType.values().length) {
-            throw new IllegalArgumentException(
-                    "Tick array " + oldTicks.length + " should have " + this.logicalProcessorCount
-                            + " arrays, each of which has " + TickType.values().length + " elements");
-        }
         long[][] ticks = getProcessorCpuLoadTicks();
+        if (oldTicks.length != ticks.length || oldTicks[0].length != TickType.values().length) {
+            throw new IllegalArgumentException("Provided tick array length " + oldTicks.length + " should be "
+                    + ticks.length + ", each subarray having " + TickType.values().length + " elements");
+        }
         double[] load = new double[ticks.length];
         for (int cpu = 0; cpu < ticks.length; cpu++) {
             long total = 0;


### PR DESCRIPTION
This should finally fix the AIX tests!