### PR TITLE
Allow using SLF4J 1 in OSGi containers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
         <!-- Users of the Spring Boot Starter Parent should include this property in their POM -->
         <jna.version>5.13.0</jna.version>
         <slf4j.version>2.0.6</slf4j.version>
+        <osgi.slf4j.import.packages>org.slf4j;version="[1.7,3.0)"</osgi.slf4j.import.packages>
         <junit.version>5.9.2</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
         <!-- Compile versions -->
@@ -316,6 +317,7 @@
                     <version>${bnd-maven-plugin.version}</version>
                     <configuration>
                         <bnd><![CDATA[Export-Package: oshi.*;-noimport:=true;-split-package:=merge-first
+                        Import-Package: ${osgi.slf4j.import.packages}, *
                         Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                         -snapshot: SNAPSHOT]]></bnd>
                     </configuration>


### PR DESCRIPTION
Extends the SLF4J version range for OSGi environments, so SLF4J 1.7 for instance doesn't raise a conflicts with latest oshi-core.

Fixes https://github.com/oshi/oshi/issues/2326