### PR TITLE
Convert per-process CPU ticks on Apple Silicon to ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.4.2 (in progress)
 
-* Your contribution here!
+##### Bug fixes / Improvements
+* [#2361](https://github.com/oshi/oshi/pull/2361): Convert per-process CPU ticks on Apple Silicon to milliseconds - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.4.0 (2022-12-02), 6.4.1 (2023-03-18)
 

--- a/oshi-demo/src/main/java/oshi/demo/gui/ProcessPanel.java
+++ b/oshi-demo/src/main/java/oshi/demo/gui/ProcessPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.demo.gui;
@@ -156,8 +156,8 @@ public class ProcessPanel extends OshiJPanel { // NOSONAR squid:S110
             procArr[i][2] = p.getThreadCount();
             if (perProc.isSelected()) {
                 procArr[i][3] = String.format("%.1f",
-                        100d * p.getProcessCpuLoadBetweenTicks(priorSnapshotMap.get(pid)) / cpuCount);
-                procArr[i][4] = String.format("%.1f", 100d * p.getProcessCpuLoadCumulative() / cpuCount);
+                        100d * p.getProcessCpuLoadBetweenTicks(priorSnapshotMap.get(pid)) * cpuCount);
+                procArr[i][4] = String.format("%.1f", 100d * p.getProcessCpuLoadCumulative() * cpuCount);
             } else {
                 procArr[i][3] = String.format("%.1f",
                         100d * p.getProcessCpuLoadBetweenTicks(priorSnapshotMap.get(pid)));


### PR DESCRIPTION
Clock ticks on Apple Sillicon are 24 million per nanosecond, which impacts the per-process ticks.  Also fixed a math bug in the demo GUI.

Fixes #2346 