### PR TITLE
Make use of Kstat2 configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##### Bug fixes / Improvements
 * [#2361](https://github.com/oshi/oshi/pull/2361): Convert per-process CPU ticks on Apple Silicon to milliseconds - [@dbwiddis](https://github.com/dbwiddis).
+* [#2362](https://github.com/oshi/oshi/pull/2362): Make use of Kstat2 configurable - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.4.0 (2022-12-02), 6.4.1 (2023-03-18)
 
@@ -15,7 +16,7 @@
 * [#2264](https://github.com/oshi/oshi/pull/2264): Don't assume ticks match logical processor count - [@dbwiddis](https://github.com/dbwiddis).
 * [#2292](https://github.com/oshi/oshi/pull/2292): Update to JNA 5.13.0 - [@dbwiddis](https://github.com/dbwiddis).
 * [#2315](https://github.com/oshi/oshi/pull/2315),
-* [#2318](https://github.com/oshi/oshi/pull/2318): Fix parsing generally and for FreeBSD cpu detection - [@decketron](https://github.com/decketron).
+  [#2318](https://github.com/oshi/oshi/pull/2318): Fix parsing generally and for FreeBSD cpu detection - [@decketron](https://github.com/decketron).
 * [#2327](https://github.com/oshi/oshi/pull/2327): Improve Udev exception handling - [@dbwiddis](https://github.com/dbwiddis).
 * [#2329](https://github.com/oshi/oshi/pull/2329): Allow using SLF4J 1 in OSGi containers - [@mshabarov](https://github.com/mshabarov).
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 The OSHI Project Contributors
+ * Copyright 2016-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.unix.solaris;
@@ -33,6 +33,7 @@ import oshi.software.os.OSSession;
 import oshi.software.os.OSThread;
 import oshi.util.Constants;
 import oshi.util.ExecutingCommand;
+import oshi.util.GlobalConfig;
 import oshi.util.Memoizer;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.solaris.KstatUtil;
@@ -54,6 +55,8 @@ public class SolarisOperatingSystem extends AbstractOperatingSystem {
         BUILD_NUMBER = split.length > 1 ? split[1] : "";
     }
 
+    private static final boolean ALLOW_KSTAT2 = GlobalConfig.get(GlobalConfig.OSHI_OS_SOLARIS_ALLOWKSTAT2, true);
+
     /**
      * This static field identifies if the kstat2 library (available in Solaris 11.4 or greater) can be loaded.
      */
@@ -61,7 +64,9 @@ public class SolarisOperatingSystem extends AbstractOperatingSystem {
     static {
         Kstat2 lib = null;
         try {
-            lib = Kstat2.INSTANCE;
+            if (ALLOW_KSTAT2) {
+                lib = Kstat2.INSTANCE;
+            }
         } catch (UnsatisfiedLinkError e) {
             // 11.3 or earlier, no kstat2
         }

--- a/oshi-core/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-core/src/main/java/oshi/util/GlobalConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 The OSHI Project Contributors
+ * Copyright 2019-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util;
@@ -45,6 +45,7 @@ public final class GlobalConfig {
     public static final String OSHI_OS_WINDOWS_PERFPROC_DIABLED = "oshi.os.windows.perfproc.disabled";
 
     public static final String OSHI_OS_UNIX_WHOCOMMAND = "oshi.os.unix.whoCommand";
+    public static final String OSHI_OS_SOLARIS_ALLOWKSTAT2 = "oshi.os.solaris.allowKstat2";
 
     private GlobalConfig() {
     }

--- a/oshi-core/src/main/resources/oshi.properties
+++ b/oshi-core/src/main/resources/oshi.properties
@@ -137,6 +137,13 @@ oshi.os.mac.sysctl.logwarning=false
 # use the command-line variant.  Defaults to false.
 oshi.os.unix.whoCommand=false
 
+# Solaris 11.4 deprecated the previous kstat API and introduced kstat2, with
+# additional features. OSHI uses the new API if it is available. However,
+# there may be a file descriptor leak when parallel GC is in use. Setting
+# this configuration to false will always use the original kstat API even if
+# Kstat2 is available.
+oshi.os.solaris.allowKstat2=true
+
 # The name of the System event log containing bootup event IDs 12 and 6005.
 #
 # This is used for a one-time calculation of system boot time that should be


### PR DESCRIPTION
Allows users to force use of the deprecated kstat API even if kstat2 is available

Fixes #2348 (or at least allows users to work around it)