### PR TITLE
Address some Coverity Scan issues

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 The OSHI Project Contributors
+ * Copyright 2017-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.windows;
@@ -18,6 +18,7 @@ import com.sun.jna.platform.win32.IPHlpAPI.FIXED_INFO;
 import com.sun.jna.platform.win32.IPHlpAPI.IP_ADDR_STRING;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.Kernel32Util;
+import com.sun.jna.platform.win32.Win32Exception;
 import com.sun.jna.platform.win32.WinError;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -85,7 +86,11 @@ final class WindowsNetworkParams extends AbstractNetworkParams {
 
     @Override
     public String getHostName() {
-        return Kernel32Util.getComputerName();
+        try {
+            return Kernel32Util.getComputerName();
+        } catch (Win32Exception e) {
+            return super.getHostName();
+        }
     }
 
     @Override

--- a/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
@@ -17,9 +17,11 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -424,11 +426,15 @@ class ParseUtilTest {
     @Test
     void testParseCimDateTimeToOffset() {
         String cimDateTime = "20160513072950.782000-420";
+        OffsetDateTime parsedTime = ParseUtil.parseCimDateTimeToOffset(cimDateTime);
+        assertNotNull(parsedTime);
         // 2016-05-13T07:29:50 == 1463124590
         // Add 420 minutes to get unix seconds
         Instant timeInst = Instant.ofEpochMilli(1463124590_782L + 60 * 420_000L);
-        assertThat(ParseUtil.parseCimDateTimeToOffset(cimDateTime).toInstant(), is(timeInst));
-        assertThat(ParseUtil.parseCimDateTimeToOffset("Not a datetime").toInstant(), is(Instant.EPOCH));
+        assertThat(parsedTime.toInstant(), is(timeInst));
+        OffsetDateTime badParsingTime = ParseUtil.parseCimDateTimeToOffset("Not a datetime");
+        assertNotNull(badParsingTime);
+        assertThat(badParsingTime.toInstant(), is(Instant.EPOCH));
     }
 
     @Test


### PR DESCRIPTION
1. WindowsNetworkParams didn't fall back to superClass on failure like all the other OS's.
2. May as well assert not null to get a CIMDateTime parsing test failure rather than relying on the NPE to fail the test.