### PR TITLE
Use branch matching for OpenBSD JDK 11 lookup

### DIFF
--- a/.github/workflows/openbsd.yaml
+++ b/.github/workflows/openbsd.yaml
@@ -23,10 +23,10 @@ jobs:
           usesh: false
           mem: 2048
           # note default jdk for maven is 8, but some maven plugins no longer work
-          # the version is specific for the OBSD release, ic.7.3 ; there is no meta package like eg. "jdk-11"
+          # there is no meta package like eg. "jdk-11" but we can search by branch
           prepare: |
             pkg_add curl
-            pkg_add jdk-11.0.18.10.1p0v0
+            pkg_add jdk%11
             pkg_add maven
           run: |
             mvn clean test -B -Djacoco.skip=true


### PR DESCRIPTION
The special `package%branch` syntax appears to work to get the correct JDK 11.
`pkg_add jdk%11` installs `jdk-11.0.16.8.1v0`