### PR TITLE
fix undefined symbol: gettid #2389

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##### Bug fixes / Improvements
 * [#2377](https://github.com/oshi/oshi/pull/2377): Graceful fallback for macOS Process user or group name - [@dbwiddis](https://github.com/dbwiddis).
+* [#2393](https://github.com/oshi/oshi/pull/2393): Get threadId by syscall when not have gettid - [@silencewood](https://github.com/silencewood).
 * [#2394](https://github.com/oshi/oshi/pull/2394): Fix bit shifting in CPUID calculation - [@dbwiddis](https://github.com/dbwiddis).
 * [#2396](https://github.com/oshi/oshi/pull/2396): Add command-line fallbacks for udev and sysfs processor info - [@dbwiddis](https://github.com/dbwiddis).
 

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 The OSHI Project Contributors
+ * Copyright 2019-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.jna.platform.linux;
@@ -20,6 +20,11 @@ import oshi.jna.platform.unix.CLibrary;
 public interface LinuxLibc extends LibC, CLibrary {
 
     LinuxLibc INSTANCE = Native.load("c", LinuxLibc.class);
+
+    /**
+     * SYS_gettid Defined in /usr/include/asm/unistd_32.h or /usr/include/asm/unistd_64.h
+     */
+    NativeLong SYS_GETTID = new NativeLong(Platform.is64Bit() ? (Platform.isARM() ? 178 : 186) : 224);
 
     /**
      * Return type for getutxent()
@@ -77,20 +82,13 @@ public interface LinuxLibc extends LibC, CLibrary {
     int gettid();
 
     /**
-     * SYS_gettid
-     * Defined in /usr/include/asm/unistd_32.h or /usr/include/asm/unistd_64.h
-     */
-    int SYS_GETTID = Platform.is64Bit() ? (Platform.isARM() ? 178 : 186) : 224;
-
-    /**
-     * syscall()  performs the system call whose assembly language interface has the specified number with the specified
+     * syscall() performs the system call whose assembly language interface has the specified number with the specified
      * arguments.
      *
      * @param number sys call number
-     * @param args sys call arguments
-     * @return The return value is defined by the system call being invoked.  In general, a 0 return value indicates success.   A  -1  return  value  indicates  an
-     *        error, and an error code is stored in errno.
+     * @param args   sys call arguments
+     * @return The return value is defined by the system call being invoked. In general, a 0 return value indicates
+     *         success. A -1 return value indicates an error, and an error code is stored in errno.
      */
-    NativeLong syscall(int number, Object... args);
-
+    NativeLong syscall(NativeLong number, Object... args);
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
@@ -4,7 +4,9 @@
  */
 package oshi.jna.platform.linux;
 
+import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
+import com.sun.jna.Platform;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.platform.linux.LibC;
@@ -66,11 +68,17 @@ public interface LinuxLibc extends LibC, CLibrary {
      */
     LinuxUtmpx getutxent();
 
+    int SYS_gettid = Platform.is64Bit() ? 186 : 224;
+
     /**
-     * Returns the caller's thread ID (TID). In a single-threaded process, the thread ID is equal to the process ID. In
-     * a multithreaded process, all threads have the same PID, but each one has a unique TID.
-     *
-     * @return the thread ID of the calling thread.
+     * syscall()  performs the system call whose assembly language interface has the specified number with the specified arguments.  Symbolic constants for
+     * system calls can be found in the header file <sys/syscall.h>.
+     * @param number
+     * @param args
+     * @return The return value is defined by the system call being invoked.  In general, a 0 return value indicates success.   A  -1  return  value  indicates  an
+     *        error, and an error code is stored in errno.
+     * @throws LastErrorException
      */
-    int gettid();
+    int syscall(int number, Object... args) throws LastErrorException;
+
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
@@ -71,8 +71,9 @@ public interface LinuxLibc extends LibC, CLibrary {
     int SYS_gettid = Platform.is64Bit() ? 186 : 224;
 
     /**
-     * syscall()  performs the system call whose assembly language interface has the specified number with the specified arguments.  Symbolic constants for
-     * system calls can be found in the header file <sys/syscall.h>.
+     * syscall()  performs the system call whose assembly language interface has the specified number with the specified
+     * arguments.
+     *
      * @param number
      * @param args
      * @return The return value is defined by the system call being invoked.  In general, a 0 return value indicates success.   A  -1  return  value  indicates  an

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
@@ -5,6 +5,7 @@
 package oshi.jna.platform.linux;
 
 import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
 import com.sun.jna.Platform;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
@@ -68,10 +69,18 @@ public interface LinuxLibc extends LibC, CLibrary {
     LinuxUtmpx getutxent();
 
     /**
+     * Returns the caller's thread ID (TID). In a single-threaded process, the thread ID is equal to the process ID. In
+     * a multithreaded process, all threads have the same PID, but each one has a unique TID.
+     *
+     * @return the thread ID of the calling thread.
+     */
+    int gettid();
+
+    /**
      * SYS_gettid
      * Defined in /usr/include/asm/unistd_32.h or /usr/include/asm/unistd_64.h
      */
-    int SYS_GETTID = Platform.is64Bit() ? 186 : 224;
+    int SYS_GETTID = Platform.is64Bit() ? (Platform.isARM() ? 178 : 186) : 224;
 
     /**
      * syscall()  performs the system call whose assembly language interface has the specified number with the specified
@@ -82,6 +91,6 @@ public interface LinuxLibc extends LibC, CLibrary {
      * @return The return value is defined by the system call being invoked.  In general, a 0 return value indicates success.   A  -1  return  value  indicates  an
      *        error, and an error code is stored in errno.
      */
-    int syscall(int number, Object... args);
+    NativeLong syscall(int number, Object... args);
 
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
@@ -4,7 +4,6 @@
  */
 package oshi.jna.platform.linux;
 
-import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
 import com.sun.jna.Structure;
@@ -68,18 +67,21 @@ public interface LinuxLibc extends LibC, CLibrary {
      */
     LinuxUtmpx getutxent();
 
-    int SYS_gettid = Platform.is64Bit() ? 186 : 224;
+    /**
+     * SYS_gettid
+     * Defined in /usr/include/asm/unistd_32.h or /usr/include/asm/unistd_64.h
+     */
+    int SYS_GETTID = Platform.is64Bit() ? 186 : 224;
 
     /**
      * syscall()  performs the system call whose assembly language interface has the specified number with the specified
      * arguments.
      *
-     * @param number
-     * @param args
+     * @param number sys call number
+     * @param args sys call arguments
      * @return The return value is defined by the system call being invoked.  In general, a 0 return value indicates success.   A  -1  return  value  indicates  an
      *        error, and an error code is stored in errno.
-     * @throws LastErrorException
      */
-    int syscall(int number, Object... args) throws LastErrorException;
+    int syscall(int number, Object... args);
 
 }

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -262,7 +262,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public int getThreadId() {
-        return LinuxLibc.INSTANCE.syscall(LinuxLibc.SYS_gettid);
+        return LinuxLibc.INSTANCE.syscall(LinuxLibc.SYS_GETTID);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -262,7 +262,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public int getThreadId() {
-        return LinuxLibc.INSTANCE.gettid();
+        return LinuxLibc.INSTANCE.syscall(LinuxLibc.SYS_gettid);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -85,6 +85,18 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         HAS_UDEV = hasUdev;
     }
 
+    public static final boolean HAS_GETTID;
+    static {
+        boolean hasGettid = false;
+        try {
+            LinuxLibc.INSTANCE.gettid();
+            hasGettid = true;
+        } catch (UnsatisfiedLinkError e) {
+            LOG.warn("Did not find gettid. Use syscall to get threadId.");
+        }
+        HAS_GETTID = hasGettid;
+    }
+
     /**
      * Jiffies per second, used for process time counters.
      */
@@ -262,7 +274,7 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public int getThreadId() {
-        return LinuxLibc.INSTANCE.syscall(LinuxLibc.SYS_GETTID);
+        return HAS_GETTID ? LinuxLibc.INSTANCE.gettid() : LinuxLibc.INSTANCE.syscall(LinuxLibc.SYS_GETTID).intValue();
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -8,6 +8,8 @@ import static oshi.software.os.OSService.State.RUNNING;
 import static oshi.software.os.OSService.State.STOPPED;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -85,6 +87,9 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         HAS_UDEV = hasUdev;
     }
 
+    /**
+     * This static field identifies if the gettid function is in the c library.
+     */
     public static final boolean HAS_GETTID;
     static {
         boolean hasGettid = false;
@@ -92,9 +97,25 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
             LinuxLibc.INSTANCE.gettid();
             hasGettid = true;
         } catch (UnsatisfiedLinkError e) {
-            LOG.warn("Did not find gettid. Use syscall to get threadId.");
+            LOG.debug("Did not find gettid function in operating system. Using fallbacks.");
         }
         HAS_GETTID = hasGettid;
+    }
+
+    /**
+     * This static field identifies if the syscall for gettid returns sane results.
+     */
+    public static final boolean HAS_SYSCALL_GETTID;
+    static {
+        boolean hasSyscallGettid = HAS_GETTID;
+        if (!HAS_GETTID) {
+            try {
+                hasSyscallGettid = LinuxLibc.INSTANCE.syscall(LinuxLibc.SYS_GETTID).intValue() > 0;
+            } catch (UnsatisfiedLinkError e) {
+                LOG.debug("Did not find working syscall gettid function in operating system. Using procfs");
+            }
+        }
+        HAS_SYSCALL_GETTID = hasSyscallGettid;
     }
 
     /**
@@ -274,7 +295,16 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public int getThreadId() {
-        return HAS_GETTID ? LinuxLibc.INSTANCE.gettid() : LinuxLibc.INSTANCE.syscall(LinuxLibc.SYS_GETTID).intValue();
+        if (HAS_SYSCALL_GETTID) {
+            return HAS_GETTID ? LinuxLibc.INSTANCE.gettid()
+                    : LinuxLibc.INSTANCE.syscall(LinuxLibc.SYS_GETTID).intValue();
+        }
+        try {
+            return ParseUtil.parseIntOrDefault(
+                    Files.readSymbolicLink(new File(ProcPath.THREAD_SELF).toPath()).getFileName().toString(), 0);
+        } catch (IOException e) {
+            return 0;
+        }
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/util/platform/linux/ProcPath.java
+++ b/oshi-core/src/main/java/oshi/util/platform/linux/ProcPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.linux;
@@ -48,6 +48,7 @@ public final class ProcPath {
     public static final String TASK_COMM = TASK_PATH + "/%d/comm";
     public static final String TASK_STATUS = TASK_PATH + "/%d/status";
     public static final String TASK_STAT = TASK_PATH + "/%d/stat";
+    public static final String THREAD_SELF = PROC + "/thread-self";
     public static final String UPTIME = PROC + "/uptime";
     public static final String VERSION = PROC + "/version";
     public static final String VMSTAT = PROC + "/vmstat";


### PR DESCRIPTION
#2389 
gettid
Glibc does not provide a wrapper for this system call; call it using syscall(2).

       #define _GNU_SOURCE
       #include <unistd.h>
       #include <sys/syscall.h>
       #include <sys/types.h>

       int
       main(int argc, char *argv[])
       {
           pid_t tid;

           tid = syscall(SYS_gettid);
       }