### PR TITLE
Fix parsing Loongson CPU names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##### Bug fixes / Improvements
 * [#2443](https://github.com/oshi/oshi/pull/2443): Include IPConnections on Mac that listen on both IPv4 and IPv6 protocols - [@rieck0](https://github.com/rieck0).
+* [#2446](https://github.com/oshi/oshi/pull/2446): Ignore case when parsing cpuinfo - [@Glavo](https://github.com/Glavo).
 
 # 6.4.0 (2022-12-02), 6.4.1 (2023-03-18), 6.4.2 (2023-05-02), 6.4.3 (2023-06-06), 6.4.4 (2023-07-01), 6.4.5 (2023-08-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ##### Bug fixes / Improvements
 * [#2443](https://github.com/oshi/oshi/pull/2443): Include IPConnections on Mac that listen on both IPv4 and IPv6 protocols - [@rieck0](https://github.com/rieck0).
-* [#2446](https://github.com/oshi/oshi/pull/2446): Ignore case when parsing cpuinfo - [@Glavo](https://github.com/Glavo).
+* [#2446](https://github.com/oshi/oshi/pull/2446): Fix parsing Loongson CPU names - [@Glavo](https://github.com/Glavo).
 
 # 6.4.0 (2022-12-02), 6.4.1 (2023-03-18), 6.4.2 (2023-05-02), 6.4.3 (2023-06-06), 6.4.4 (2023-07-01), 6.4.5 (2023-08-20)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -81,13 +81,13 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
                 }
                 continue;
             }
-            switch (splitLine[0]) {
+            switch (splitLine[0].toLowerCase()) {
             case "vendor_id":
-            case "CPU implementer":
+            case "cpu implementer":
                 cpuVendor = splitLine[1];
                 break;
             case "model name":
-            case "Processor": // some ARM chips
+            case "processor": // some ARM chips
                 // May be a processor number. Check for a space.
                 if (splitLine[1].indexOf(' ') > 0) {
                     cpuName = splitLine[1];
@@ -105,26 +105,26 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
             case "stepping":
                 cpuStepping = splitLine[1];
                 break;
-            case "CPU variant":
+            case "cpu variant":
                 if (!armStepping.toString().startsWith("r")) {
                     // CPU variant format always starts with 0x
                     int rev = ParseUtil.parseLastInt(splitLine[1], 0);
                     armStepping.insert(0, "r" + rev);
                 }
                 break;
-            case "CPU revision":
+            case "cpu revision":
                 if (!armStepping.toString().contains("p")) {
                     armStepping.append('p').append(splitLine[1]);
                 }
                 break;
             case "model":
-            case "CPU part":
+            case "cpu part":
                 cpuModel = splitLine[1];
                 break;
             case "cpu family":
                 cpuFamily = splitLine[1];
                 break;
-            case "cpu MHz":
+            case "cpu mhz":
                 cpuFreq = ParseUtil.parseHertz(splitLine[1]);
                 break;
             default:

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -89,8 +89,8 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
                 break;
             case "model name":
             case "processor": // some ARM chips
-                // May be a processor number. Check for a space.
-                if (splitLine[1].indexOf(' ') > 0) {
+                // Ignore processor number
+                if (!splitLine[1].matches("[0-9]+")) {
                     cpuName = splitLine[1];
                 }
                 break;

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -20,6 +20,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -81,7 +82,7 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
                 }
                 continue;
             }
-            switch (splitLine[0].toLowerCase()) {
+            switch (splitLine[0].toLowerCase(Locale.ROOT)) {
             case "vendor_id":
             case "cpu implementer":
                 cpuVendor = splitLine[1];


### PR DESCRIPTION
On some platforms, the case of cpuinfo entry names does not match the names hardcoded in oshi.
For example, `/proc/cpuinfo` on linux loongarch64 looks like this:

```
system type             : generic-loongson-machine

processor               : 0
package                 : 0
core                    : 1
global_id               : 0
CPU Family              : Loongson-64bit
Model Name              : Loongson-3A6000
CPU Revision            : 0x00
FPU Revision            : 0x00
CPU MHz                 : 2500.00
BogoMIPS                : 5000.00
TLB Entries             : 2112
Address Sizes           : 48 bits physical, 48 bits virtual
ISA                     : loongarch32 loongarch64
Features                : cpucfg lam ual fpu lsx lasx crc32 complex crypto lvz lbt_x86 lbt_arm lbt_mips
Hardware Watchpoint     : yes, iwatch count: 8, dwatch count: 4
```
This causes oshi to be unable to obtain some CPU information.

This PR fixes the issue.
