### PR TITLE
Fix AIX tests for virtual/unused drives

### DIFF
--- a/.github/workflows/aix.yaml
+++ b/.github/workflows/aix.yaml
@@ -37,7 +37,7 @@ jobs:
           rm -fR ~/.cache/JNA
           rm -fR ~/javashared*
           cd ~/git/oshi
-          export JAVA_HOME=/opt/ibm-semeru-open-17-jdk
+          export JAVA_HOME=~/java/jdk-17.0.8.1+1
           export PATH=$PATH:/opt/freeware/bin
           export MAVEN_OPTS="-Xshareclasses:none"
           git checkout master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.4.7 (in progress)
 
-* Your contribution here!
+##### Bug fixes / Improvements
+* [#2460](https://github.com/oshi/oshi/pull/2460): Fix AIX tests for virtual/unused drives - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.4.0 (2022-12-02), 6.4.1 (2023-03-18), 6.4.2 (2023-05-02), 6.4.3 (2023-06-06), 6.4.4 (2023-07-01), 6.4.5 (2023-08-20), 6.4.6 (2023-09-24)
 

--- a/oshi-core/src/test/java/oshi/driver/unix/aix/perfstat/PerfstatTest.java
+++ b/oshi-core/src/test/java/oshi/driver/unix/aix/perfstat/PerfstatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The OSHI Project Contributors
+ * Copyright 2022-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.unix.aix.perfstat;
@@ -7,6 +7,7 @@ package oshi.driver.unix.aix.perfstat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -55,7 +56,12 @@ class PerfstatTest {
         perfstat_disk_t[] disks = PerfstatDisk.queryDiskStats();
         assertThat("Should have at least one disk", disks.length, greaterThan(0));
         for (perfstat_disk_t disk : disks) {
-            assertThat("Should have a nonzero disk capacity", disk.size, greaterThan(0L));
+            // Virtual disks may give 0 capacity but also have 0 time
+            if (disk.time == 0) {
+                assertThat("Should have a nonnegative disk capacity", disk.size, greaterThanOrEqualTo(0L));
+            } else {
+                assertThat("Should have a nonzero disk capacity", disk.size, greaterThan(0L));
+            }
         }
     }
 


### PR DESCRIPTION
The AIX machine we use for testing includes two virtual optical drives with 0 size and other stats.

While there are multiple signals this isn't a "real" drive, the `time` stat (amount of time disk is active) seemed the least likely to exclude real disks.

Fixes #2437 
Fixes #2459 
