### PR TITLE
Fix ForbiddenAPIs for test classes

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -40,7 +40,7 @@ jobs:
         run: ./mvnw checkstyle:check
       - name: Forbidden APIs
         if: contains(matrix.java, '11')
-        run: ./mvnw compile forbiddenapis:check
+        run: ./mvnw compile forbiddenapis:check forbiddenapis:testCheck
       - name: Test with Maven
         run: ./mvnw test -B
       - name: Report Coverage to Coveralls

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,7 @@ jobs:
         run: ./mvnw checkstyle:check
       - name: Forbidden APIs
         if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '11')
-        run: ./mvnw compile forbiddenapis:check
+        run: ./mvnw compile forbiddenapis:check forbiddenapis:testCheck
       - name: Test with Maven
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos') || contains(matrix.java, '11') || contains(matrix.java, '17')
         run: ./mvnw test -B

--- a/oshi-core/src/test/java/oshi/util/FormatUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/FormatUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 The OSHI Project Contributors
+ * Copyright 2016-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util;
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.Test;
  */
 class FormatUtilTest {
 
-    private static char DECIMAL_SEPARATOR = new DecimalFormatSymbols().getDecimalSeparator();
+    private static final char DECIMAL_SEPARATOR = DecimalFormatSymbols.getInstance(Locale.ROOT).getDecimalSeparator();
 
     /**
      * Test format bytes.

--- a/oshi-core/src/test/java/oshi/util/GlobalConfigTest.java
+++ b/oshi-core/src/test/java/oshi/util/GlobalConfigTest.java
@@ -100,7 +100,7 @@ class GlobalConfigTest {
     void testPropertyExceptionMessage() {
         set(PROPERTY, "test");
         assertThat(new PropertyException(PROPERTY).getMessage(),
-                is(format("Invalid property: \"%s\" = test", PROPERTY)));
+                is(format(Locale.ROOT, "Invalid property: \"%s\" = test", PROPERTY)));
     }
 
     private Properties propertiesWith(String value) {
@@ -146,11 +146,11 @@ class GlobalConfigTest {
         }
 
         private String failureMessage(Object def) {
-            return format(FAILURE_MESSAGE_TEMPLATE, property, def);
+            return format(Locale.ROOT, FAILURE_MESSAGE_TEMPLATE, property, def);
         }
 
         private String defaultFailureMessage(Object def) {
-            return format(DEFAULT_FAILURE_MESSAGE_TEMPLATE, PROPERTY, def);
+            return format(Locale.ROOT, DEFAULT_FAILURE_MESSAGE_TEMPLATE, PROPERTY, def);
         }
     }
 }

--- a/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -638,7 +639,7 @@ class ParseUtilTest {
 
     @Test
     void parseByteArrayToStrings() {
-        byte[] bytes = "foo bar".getBytes();
+        byte[] bytes = "foo bar".getBytes(StandardCharsets.US_ASCII);
         bytes[3] = 0;
         List<String> list = ParseUtil.parseByteArrayToStrings(bytes);
         assertThat(list, contains("foo", "bar"));
@@ -658,7 +659,7 @@ class ParseUtilTest {
 
     @Test
     void parseByteArrayToStringMap() {
-        byte[] bytes = "foo=1 bar=2".getBytes();
+        byte[] bytes = "foo=1 bar=2".getBytes(StandardCharsets.US_ASCII);
         bytes[5] = 0;
         Map<String, String> map = ParseUtil.parseByteArrayToStringMap(bytes);
         assertThat(map.keySet(), containsInAnyOrder("foo", "bar"));
@@ -673,7 +674,7 @@ class ParseUtilTest {
         assertThat(map.get("foo"), is("1"));
         assertThat(map.get("bar"), is(""));
 
-        bytes = "foo=1 bar=2".getBytes();
+        bytes = "foo=1 bar=2".getBytes(StandardCharsets.US_ASCII);
         bytes[5] = 0;
         bytes[6] = 0;
         map = ParseUtil.parseByteArrayToStringMap(bytes);


### PR DESCRIPTION
The check runs during the verify phase, which was failing snapshot deployment.  Added the check to CI for test as well as main to catch it earlier.