### PR TITLE
Improve performance of thread details query for a single process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug fixes / Improvements
 * [#2460](https://github.com/oshi/oshi/pull/2460): Fix AIX tests for virtual/unused drives - [@dbwiddis](https://github.com/dbwiddis).
 * [#2480](https://github.com/oshi/oshi/pull/2480): Use sysfs as a backup for Linux power supply without udev - [@dbwiddis](https://github.com/dbwiddis).
+* [#2487](https://github.com/oshi/oshi/pull/2487): Improve performance of thread details query for a single process - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.4.0 (2022-12-02), 6.4.1 (2023-03-18), 6.4.2 (2023-05-02), 6.4.3 (2023-06-06), 6.4.4 (2023-07-01), 6.4.5 (2023-08-20), 6.4.6 (2023-09-24)
 

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/PerfmonConstants.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/PerfmonConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The OSHI Project Contributors
+ * Copyright 2022-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.perfmon;
@@ -31,6 +31,7 @@ public final class PerfmonConstants {
     static final String WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0 = "Win32_PerfRawData_PerfProc_Process WHERE IDProcess=0";
 
     static final String THREAD = "Thread";
+    static final String WIN32_PERF_RAW_DATA_PERF_PROC_THREAD = "Win32_PerfRawData_PerfProc_Thread";
     static final String WIN32_PERF_RAW_DATA_PERF_PROC_THREAD_WHERE_NOT_NAME_LIKE_TOTAL = "Win32_PerfRawData_PerfProc_Thread WHERE NOT Name LIKE \"%_Total\"";
 
     // For Vista- ... Older systems just have processor #

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/PerfmonDisabled.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/PerfmonDisabled.java
@@ -24,9 +24,11 @@ public final class PerfmonDisabled {
 
     private static final Logger LOG = LoggerFactory.getLogger(PerfmonDisabled.class);
 
-    static final boolean PERF_OS_DISABLED = isDisabled(GlobalConfig.OSHI_OS_WINDOWS_PERFOS_DIABLED, "PerfOS");
-    static final boolean PERF_PROC_DISABLED = isDisabled(GlobalConfig.OSHI_OS_WINDOWS_PERFPROC_DIABLED, "PerfProc");
-    static final boolean PERF_DISK_DISABLED = isDisabled(GlobalConfig.OSHI_OS_WINDOWS_PERFDISK_DIABLED, "PerfDisk");
+    public static final boolean PERF_OS_DISABLED = isDisabled(GlobalConfig.OSHI_OS_WINDOWS_PERFOS_DIABLED, "PerfOS");
+    public static final boolean PERF_PROC_DISABLED = isDisabled(GlobalConfig.OSHI_OS_WINDOWS_PERFPROC_DIABLED,
+            "PerfProc");
+    public static final boolean PERF_DISK_DISABLED = isDisabled(GlobalConfig.OSHI_OS_WINDOWS_PERFDISK_DIABLED,
+            "PerfDisk");
 
     /**
      * Everything in this class is static, never instantiate it

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/ThreadInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/ThreadInformation.java
@@ -1,14 +1,15 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.perfmon;
 
 import static oshi.driver.windows.perfmon.PerfmonConstants.THREAD;
+import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_PROC_THREAD;
 import static oshi.driver.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_PROC_THREAD_WHERE_NOT_NAME_LIKE_TOTAL;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -62,10 +63,20 @@ public final class ThreadInformation {
      * @return Thread counters for each thread.
      */
     public static Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> queryThreadCounters() {
-        if (PerfmonDisabled.PERF_PROC_DISABLED) {
-            return new Pair<>(Collections.emptyList(), Collections.emptyMap());
-        }
         return PerfCounterWildcardQuery.queryInstancesAndValues(ThreadPerformanceProperty.class, THREAD,
                 WIN32_PERF_RAW_DATA_PERF_PROC_THREAD_WHERE_NOT_NAME_LIKE_TOTAL);
+    }
+
+    /**
+     * Returns thread counters filtered to the specified process name.
+     *
+     * @param name The process name to filter
+     *
+     * @return Thread counters for each thread.
+     */
+    public static Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> queryThreadCounters(String name) {
+        String procName = name.toLowerCase(Locale.ROOT);
+        return PerfCounterWildcardQuery.queryInstancesAndValues(ThreadPerformanceProperty.class, THREAD,
+                WIN32_PERF_RAW_DATA_PERF_PROC_THREAD + " WHERE Name LIKE \\\"" + procName + "\\\"", procName + "/*");
     }
 }

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/ThreadInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/ThreadInformation.java
@@ -68,14 +68,22 @@ public final class ThreadInformation {
     }
 
     /**
-     * Returns thread counters filtered to the specified process name.
+     * Returns thread counters filtered to the specified process name and thread.
      *
-     * @param name The process name to filter
+     * @param name      The process name to filter
+     * @param threadNum The thread number to match. -1 matches all threads.
      *
      * @return Thread counters for each thread.
      */
-    public static Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> queryThreadCounters(String name) {
+    public static Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> queryThreadCounters(String name,
+            int threadNum) {
         String procName = name.toLowerCase(Locale.ROOT);
+        if (threadNum >= 0) {
+            return PerfCounterWildcardQuery.queryInstancesAndValues(
+                    ThreadPerformanceProperty.class, THREAD, WIN32_PERF_RAW_DATA_PERF_PROC_THREAD
+                            + " WHERE Name LIKE \\\"" + procName + "\\\" AND IDThread=" + threadNum,
+                    procName + "/" + threadNum);
+        }
         return PerfCounterWildcardQuery.queryInstancesAndValues(ThreadPerformanceProperty.class, THREAD,
                 WIN32_PERF_RAW_DATA_PERF_PROC_THREAD + " WHERE Name LIKE \\\"" + procName + "\\\"", procName + "/*");
     }

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessPerformanceData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessPerformanceData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.registry;
@@ -89,6 +89,19 @@ public final class ProcessPerformanceData {
      *         information.
      */
     public static Map<Integer, PerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids) {
+        return buildProcessMapFromPerfCounters(pids, null);
+    }
+
+    /**
+     * Query PerfMon for process performance counters
+     *
+     * @param pids     An optional collection of process IDs to filter the list to. May be null for no filtering.
+     * @param procName Filter by this process name.
+     * @return A map with Process ID as the key and a {@link PerfCounterBlock} object populated with performance counter
+     *         information.
+     */
+    public static Map<Integer, PerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids,
+            String procName) {
         Map<Integer, PerfCounterBlock> processMap = new HashMap<>();
         Pair<List<String>, Map<ProcessPerformanceProperty, List<Long>>> instanceValues = ProcessInformation
                 .queryProcessCounters();

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceData.java
@@ -17,6 +17,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.windows.perfmon.PerfmonDisabled;
 import oshi.driver.windows.perfmon.ThreadInformation;
 import oshi.driver.windows.perfmon.ThreadInformation.ThreadPerformanceProperty;
+import oshi.util.Util;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
@@ -92,12 +93,27 @@ public final class ThreadPerformanceData {
      *         information.
      */
     public static Map<Integer, PerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids) {
+        return buildThreadMapFromPerfCounters(pids, null, -1);
+    }
+
+    /**
+     * Query PerfMon for thread performance counters
+     *
+     * @param pids      An optional collection of process IDs to filter the list to. May be null for no filtering.
+     * @param procName  Limit the matches to processes matching the given name.
+     * @param threadNum Limit the matches to threads matching the given thread. Use -1 to match all threads.
+     * @return A map with Thread ID as the key and a {@link PerfCounterBlock} object populated with performance counter
+     *         information.
+     */
+    public static Map<Integer, PerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids,
+            String procName, int threadNum) {
         if (PerfmonDisabled.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }
         Map<Integer, PerfCounterBlock> threadMap = new HashMap<>();
-        Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> instanceValues = ThreadInformation
-                .queryThreadCounters();
+        Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> instanceValues = Util.isBlank(procName)
+                ? ThreadInformation.queryThreadCounters()
+                : ThreadInformation.queryThreadCounters(procName, threadNum);
         long now = System.currentTimeMillis(); // 1970 epoch
         List<String> instances = instanceValues.getA();
         Map<ThreadPerformanceProperty, List<Long>> valueMap = instanceValues.getB();

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceData.java
@@ -5,6 +5,7 @@
 package oshi.driver.windows.registry;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +14,7 @@ import com.sun.jna.platform.win32.WinBase.FILETIME;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.windows.perfmon.PerfmonDisabled;
 import oshi.driver.windows.perfmon.ThreadInformation;
 import oshi.driver.windows.perfmon.ThreadInformation.ThreadPerformanceProperty;
 import oshi.util.tuples.Pair;
@@ -90,6 +92,9 @@ public final class ThreadPerformanceData {
      *         information.
      */
     public static Map<Integer, PerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids) {
+        if (PerfmonDisabled.PERF_PROC_DISABLED) {
+            return Collections.emptyMap();
+        }
         Map<Integer, PerfCounterBlock> threadMap = new HashMap<>();
         Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> instanceValues = ThreadInformation
                 .queryThreadCounters();

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
@@ -268,13 +268,8 @@ public class WindowsOSProcess extends AbstractOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        // Get data from the registry if possible
         Map<Integer, ThreadPerformanceData.PerfCounterBlock> threads = ThreadPerformanceData
-                .buildThreadMapFromRegistry(Collections.singleton(getProcessID()));
-        // otherwise performance counters with WMI backup
-        if (threads == null) {
-            threads = ThreadPerformanceData.buildThreadMapFromPerfCounters(Collections.singleton(this.getProcessID()));
-        }
+                .buildThreadMapFromPerfCounters(Collections.singleton(this.getProcessID()), this.getName(), -1);
         return threads.entrySet().stream().parallel()
                 .map(entry -> new WindowsOSThread(getProcessID(), entry.getKey(), this.name, entry.getValue()))
                 .collect(Collectors.toList());

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThread.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2023 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.windows;
@@ -99,14 +99,10 @@ public class WindowsOSThread extends AbstractOSThread {
     @Override
     public boolean updateAttributes() {
         Set<Integer> pids = Collections.singleton(getOwningProcessId());
-        // Get data from the registry if possible
+        String procName = this.name.split("/")[0];
         Map<Integer, ThreadPerformanceData.PerfCounterBlock> threads = ThreadPerformanceData
-                .buildThreadMapFromRegistry(pids);
-        // otherwise performance counters with WMI backup
-        if (threads == null) {
-            threads = ThreadPerformanceData.buildThreadMapFromPerfCounters(pids);
-        }
-        return updateAttributes(this.name.split("/")[0], threads.get(getThreadId()));
+                .buildThreadMapFromPerfCounters(pids, procName, getThreadId());
+        return updateAttributes(procName, threads.get(getThreadId()));
     }
 
     private boolean updateAttributes(String procName, PerfCounterBlock pcb) {

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -54,14 +54,34 @@ public final class PerfCounterWildcardQuery {
      * @param perfObject   The PDH object for this counter; all counters on this object will be refreshed at the same
      *                     time
      * @param perfWmiClass The WMI PerfData_RawData_* class corresponding to the PDH object
-     * @return An pair containing a list of instances and an {@link EnumMap} of the corresponding values indexed by
+     * @return A pair containing a list of instances and an {@link EnumMap} of the corresponding values indexed by
      *         {@code propertyEnum} on success, or an empty list and empty map if both PDH and WMI queries failed.
      */
     public static <T extends Enum<T>> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
             Class<T> propertyEnum, String perfObject, String perfWmiClass) {
+        return queryInstancesAndValues(propertyEnum, perfObject, perfWmiClass, null);
+    }
+
+    /**
+     * Query the a Performance Counter using PDH, with WMI backup on failure, for values corresponding to the property
+     * enum.
+     *
+     * @param <T>          The enum type of {@code propertyEnum}
+     * @param propertyEnum An enum which implements
+     *                     {@link oshi.util.platform.windows.PerfCounterQuery.PdhCounterProperty} and contains the WMI
+     *                     field (Enum value) and PDH Counter string (instance and counter)
+     * @param perfObject   The PDH object for this counter; all counters on this object will be refreshed at the same
+     *                     time
+     * @param perfWmiClass The WMI PerfData_RawData_* class corresponding to the PDH object
+     * @param customFilter a custom instance filter to use. If null, uses the first element of the property enum
+     * @return A pair containing a list of instances and an {@link EnumMap} of the corresponding values indexed by
+     *         {@code propertyEnum} on success, or an empty list and empty map if both PDH and WMI queries failed.
+     */
+    public static <T extends Enum<T>> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
+            Class<T> propertyEnum, String perfObject, String perfWmiClass, String customFilter) {
         if (!FAILED_QUERY_CACHE.contains(perfObject)) {
             Pair<List<String>, Map<T, List<Long>>> instancesAndValuesMap = queryInstancesAndValuesFromPDH(propertyEnum,
-                    perfObject);
+                    perfObject, customFilter);
             if (!instancesAndValuesMap.getA().isEmpty()) {
                 return instancesAndValuesMap;
             }
@@ -86,13 +106,33 @@ public final class PerfCounterWildcardQuery {
      */
     public static <T extends Enum<T>> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromPDH(
             Class<T> propertyEnum, String perfObject) {
+        return queryInstancesAndValuesFromPDH(propertyEnum, perfObject, null);
+    }
+
+    /**
+     * Query the a Performance Counter using PDH for values corresponding to the property enum.
+     *
+     * @param <T>          The enum type of {@code propertyEnum}
+     * @param propertyEnum An enum which implements
+     *                     {@link oshi.util.platform.windows.PerfCounterQuery.PdhCounterProperty} and contains the WMI
+     *                     field (Enum value) and PDH Counter string (instance and counter)
+     * @param perfObject   The PDH object for this counter; all counters on this object will be refreshed at the same
+     *                     time
+     * @param customFilter a custom instance filter to use. If null, uses the first element of the property enum
+     * @return An pair containing a list of instances and an {@link EnumMap} of the corresponding values indexed by
+     *         {@code propertyEnum} on success, or an empty list and empty map if the PDH query failed.
+     */
+    public static <T extends Enum<T>> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromPDH(
+            Class<T> propertyEnum, String perfObject, String customFilter) {
         T[] props = propertyEnum.getEnumConstants();
         if (props.length < 2) {
             throw new IllegalArgumentException("Enum " + propertyEnum.getName()
                     + " must have at least two elements, an instance filter and a counter.");
         }
-        String instanceFilter = ((PdhCounterWildcardProperty) propertyEnum.getEnumConstants()[0]).getCounter()
-                .toLowerCase(Locale.ROOT);
+        String instanceFilter = Util.isBlank(customFilter)
+                ? ((PdhCounterWildcardProperty) propertyEnum.getEnumConstants()[0]).getCounter()
+                        .toLowerCase(Locale.ROOT)
+                : customFilter;
         // Localize the perfObject using different variable for the EnumObjectItems
         // Will still use unlocalized perfObject for the query
         String perfObjectLocalized = PerfCounterQuery.localizeIfNeeded(perfObject, true);

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -85,10 +85,13 @@ public final class PerfCounterWildcardQuery {
             if (!instancesAndValuesMap.getA().isEmpty()) {
                 return instancesAndValuesMap;
             }
-            // If we are here, query failed
-            LOG.warn("Disabling further attempts to query {}.", perfObject);
-            FAILED_QUERY_CACHE.add(perfObject);
+            // If we are here, query returned no results
+            if (Util.isBlank(customFilter)) {
+                LOG.warn("Disabling further attempts to query {}.", perfObject);
+                FAILED_QUERY_CACHE.add(perfObject);
+            }
         }
+        System.out.println("XXX Query with filter [" + customFilter + "] failed. Querying WMI: " + perfWmiClass);
         return queryInstancesAndValuesFromWMI(propertyEnum, perfWmiClass);
     }
 
@@ -133,9 +136,11 @@ public final class PerfCounterWildcardQuery {
                 ? ((PdhCounterWildcardProperty) propertyEnum.getEnumConstants()[0]).getCounter()
                         .toLowerCase(Locale.ROOT)
                 : customFilter;
+        System.out.println("Instance filter: " + instanceFilter);
         // Localize the perfObject using different variable for the EnumObjectItems
         // Will still use unlocalized perfObject for the query
         String perfObjectLocalized = PerfCounterQuery.localizeIfNeeded(perfObject, true);
+        System.out.println("Perf object: " + perfObjectLocalized);
 
         // Get list of instances
         PdhEnumObjectItems objectItems = null;

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -91,7 +91,6 @@ public final class PerfCounterWildcardQuery {
                 FAILED_QUERY_CACHE.add(perfObject);
             }
         }
-        System.out.println("XXX Query with filter [" + customFilter + "] failed. Querying WMI: " + perfWmiClass);
         return queryInstancesAndValuesFromWMI(propertyEnum, perfWmiClass);
     }
 
@@ -136,11 +135,9 @@ public final class PerfCounterWildcardQuery {
                 ? ((PdhCounterWildcardProperty) propertyEnum.getEnumConstants()[0]).getCounter()
                         .toLowerCase(Locale.ROOT)
                 : customFilter;
-        System.out.println("Instance filter: " + instanceFilter);
         // Localize the perfObject using different variable for the EnumObjectItems
         // Will still use unlocalized perfObject for the query
         String perfObjectLocalized = PerfCounterQuery.localizeIfNeeded(perfObject, true);
-        System.out.println("Perf object: " + perfObjectLocalized);
 
         // Get list of instances
         PdhEnumObjectItems objectItems = null;

--- a/oshi-core/src/main/resources/oshi.properties
+++ b/oshi-core/src/main/resources/oshi.properties
@@ -25,11 +25,10 @@ oshi.os.windows.commandline.batch=false
 
 # Whether to update the OSProcess state on Windows to SUSPENDED if all its
 # threads are suspended. This requires querying thread states and can impact
-# performance (Process list queries can take much longer) but if desired is
-# better done once than for each process. Users may still determine this value
-# themselves by querying thread details, but this method is extremely slow if
-# done for every process. Enabling this will provide a more efficient (but
-# still slow) update if this information is of value. Defaults to false.
+# performance as Process list queries can take much longer. Users may still
+# determine this value themselves by querying process thread details and
+# checking if all are suspended, but may use this switch if they desire this
+# check done for many processes at once.
 oshi.os.windows.procstate.suspended=false
 
 # Whether to use "Processor Utility" for System and per-processor CPU Load ticks

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import oshi.driver.windows.perfmon.ThreadInformation;
-import oshi.driver.windows.perfmon.ThreadInformation.ThreadPerformanceProperty;
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.CentralProcessor.PhysicalProcessor;
 import oshi.hardware.CentralProcessor.ProcessorCache;
@@ -55,7 +53,6 @@ import oshi.software.os.OperatingSystem.ProcessFiltering;
 import oshi.software.os.OperatingSystem.ProcessSorting;
 import oshi.util.FormatUtil;
 import oshi.util.Util;
-import oshi.util.tuples.Pair;
 
 /**
  * A demonstration of access to many of OSHI's capabilities
@@ -320,13 +317,6 @@ public class SystemInfoTest { // NOSONAR squid:S5786
                     FormatUtil.formatBytes(p.getResidentSetSize()), p.getName()));
         }
         OSProcess p = os.getProcess(os.getProcessId());
-        System.out.println("XXX TESTING XXX");
-        Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> nameFilter = ThreadInformation
-                .queryThreadCounters(p.getName());
-        oshi.add("Query with name: ");
-        for (String s : nameFilter.getA()) {
-            oshi.add("  " + s);
-        }
         oshi.add("Current process arguments: ");
         for (String s : p.getArguments()) {
             oshi.add("  " + s);

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import oshi.driver.windows.perfmon.ThreadInformation;
+import oshi.driver.windows.perfmon.ThreadInformation.ThreadPerformanceProperty;
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.CentralProcessor.PhysicalProcessor;
 import oshi.hardware.CentralProcessor.ProcessorCache;
@@ -53,6 +55,7 @@ import oshi.software.os.OperatingSystem.ProcessFiltering;
 import oshi.software.os.OperatingSystem.ProcessSorting;
 import oshi.util.FormatUtil;
 import oshi.util.Util;
+import oshi.util.tuples.Pair;
 
 /**
  * A demonstration of access to many of OSHI's capabilities
@@ -317,6 +320,13 @@ public class SystemInfoTest { // NOSONAR squid:S5786
                     FormatUtil.formatBytes(p.getResidentSetSize()), p.getName()));
         }
         OSProcess p = os.getProcess(os.getProcessId());
+        System.out.println("XXX TESTING XXX");
+        Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> nameFilter = ThreadInformation
+                .queryThreadCounters(p.getName());
+        oshi.add("Query with name: ");
+        for (String s : nameFilter.getA()) {
+            oshi.add("  " + s);
+        }
         oshi.add("Current process arguments: ");
         for (String s : p.getArguments()) {
             oshi.add("  " + s);


### PR DESCRIPTION
Bypasses registry query for thread details (which can't be filtered) and directly queries performance monitors only for the requested process when getting process thread details.  

```
[INFO] Trying the old way:
[INFO]   Total time: 805ms
[INFO] Trying the new way:
[INFO]   Total time: 47ms
```

Fixes #2483 