### PR TITLE
Add coverage reports for Windows and macOS to existing Linux

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # Baseline support, Current LTS, Current GA, Current EA
         java: [11, 17, 20, 21]
-        os: [macos-11, macos-12]
+        os: [macos-11, macos-12, macos-13]
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
 
@@ -40,3 +40,8 @@ jobs:
         run: ./mvnw clean test -B
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Coverage
+        if: contains(matrix.java, '11') && contains(matrix.os, 'macos-12')
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,7 +40,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos') || contains(matrix.java, '11') || contains(matrix.java, '17')
         run: ./mvnw test -B
       - name: Upload Coverage
-        if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '11')
+        if: contains(matrix.java, '11')
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -41,3 +41,8 @@ jobs:
         run: ./mvnw clean test -B
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Coverage
+        if: contains(matrix.java, '11') && contains(matrix.os, 'windows-2022')
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov can handle multiple coverage report uploads and merges the results.

Adding reporting for Windows and macOS to existing reports ~and removing the path excludes~.