### PR TITLE
Use settings properties for NVD API key

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -31,10 +31,11 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build site
-        run: ./mvnw site site:stage -DskipTests -DnvdApiKey=${{ secrets.NVD_API_KEY }}
+        run: ./mvnw site site:stage -Djacoco.skip=true -DskipTests -B --settings ./.mvn/settings.xml
         env:
           CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       - name: Deploy Site to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:

--- a/.github/workflows/sonatype.yaml
+++ b/.github/workflows/sonatype.yaml
@@ -16,6 +16,7 @@ jobs:
     env:
       CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
       CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+      NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -2,6 +2,16 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+    <profiles>
+        <profile>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
+            </properties>
+        </profile>
+    </profiles>
     <servers>
         <server>
             <id>ossrh</id>


### PR DESCRIPTION
Puts the NVD API key in a property in the settings.xml allowing both site deployment and my local release process (with the key hardcoded in my local settings rather than an env variable) to work without any additional configuration.