### PR TITLE
[mvn] Add more secure checksums

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5
+-Daether.connector.smartChecksums=false


### PR DESCRIPTION
Noticed when looking into config for nvd that this was not present.  This does two things automatically.  The first option will ensure that when released to central, it will show sha-256 and sha-512.  Most major projects are now doing this.  The second option forces its hand to download more secure checksums.