### PR TITLE
 fix #2521: Wrong VRam value 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.4.9 (in progress)
 
 * Your contribution here!
+* [#2533](https://github.com/oshi/oshi/pull/2533): Changed GPU info gathering mechanism on Windows - [@komelgman](https://github.com/komelgman).
 
 # 6.4.0 (2022-12-02), 6.4.1 (2023-03-18), 6.4.2 (2023-05-02), 6.4.3 (2023-06-06), 6.4.4 (2023-07-01), 6.4.5 (2023-08-20), 6.4.6 (2023-09-24), 6.4.7 (2023-11-01), 6.4.8 (2023-11-24)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -93,7 +93,8 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                     if (genericValue instanceof Long || genericValue instanceof Integer) {
                         vram = (long) genericValue;
                     } else if (genericValue instanceof byte[]) {
-                        vram = memSizeBinaryToLong((byte[]) genericValue);
+                        bytes = (byte[]) genericValue;
+                        vram = ParseUtil.byteArrayToLong(bytes, bytes.length);
                     }
                 }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -67,6 +67,7 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
     public static List<GraphicsCard> getGraphicsCards() {
         List<GraphicsCard> cardList = new ArrayList<>();
 
+        int index = 1;
         String[] keys = Advapi32Util.registryGetKeys(WinReg.HKEY_LOCAL_MACHINE, DISPLAY_DEVICES_REGISTRY_PATH);
         for (String key : keys) {
             if (!key.startsWith("0")) {
@@ -80,7 +81,6 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                 }
 
                 String name = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, DRIVER_DESC);
-                // int index = 1; outside the loop
                 String deviceId = "VideoController" + index++;
                 String vendor = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, VENDOR);
                 String versionInfo = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, DRIVER_VERSION);
@@ -92,11 +92,11 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                     Object genericValue = Advapi32Util.registryGetValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, MEMORY_SIZE);
                     if (genericValue instanceof Long) {
                         vram = (long) genericValue;
-                    else if (genericValue instanceof Integer) {
+                    } else if (genericValue instanceof Integer) {
                         vram = Integer.toUnsignedLong((int) genericValue);
                     } else if (genericValue instanceof byte[]) {
-                        bytes = (byte[]) genericValue;
-                        vram = ParseUtil.byteArrayToLong(bytes, bytes.length);
+                        byte[] bytes = (byte[]) genericValue;
+                        vram = ParseUtil.byteArrayToLong(bytes, bytes.length, false);
                     }
                 }
 
@@ -119,23 +119,6 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
         }
         return cardList;
     }
-
-    // Note: not found spec, working for my Intel UHD embedded gpu
-    private static long memSizeBinaryToLong(byte[] bytes) {
-        long result = 0;
-
-        if (bytes.length > 8) {
-            LOG.debug("byte[] to long: Oops! bytes length > 8");
-            return 0;
-        }
-
-        for (byte i = 0; i < bytes.length; ++i) {
-            result += (long) (bytes[i] & 255) << 8 * i;
-        }
-
-        return result;
-    }
-
 
     // fall back if something went wrong
     private static List<GraphicsCard> getGraphicsCardsFromWmi() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -7,8 +7,15 @@ package oshi.hardware.platform.windows;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.sun.jna.platform.win32.VersionHelpers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
+import com.sun.jna.platform.win32.VersionHelpers;
+import com.sun.jna.platform.win32.Win32Exception;
+import com.sun.jna.platform.win32.WinError;
+import com.sun.jna.platform.win32.WinReg;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.driver.windows.wmi.Win32VideoController;
@@ -27,7 +34,17 @@ import oshi.util.tuples.Triplet;
 @Immutable
 final class WindowsGraphicsCard extends AbstractGraphicsCard {
 
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsGraphicsCard.class);
+
     private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
+    public static final String ADAPTER_STRING = "HardwareInformation.AdapterString";
+    public static final String DRIVER_DESC = "DriverDesc";
+    public static final String DRIVER_VERSION = "DriverVersion";
+    public static final String VENDOR = "ProviderName";
+    public static final String QW_MEMORY_SIZE = "HardwareInformation.qwMemorySize";
+    public static final String MEMORY_SIZE = "HardwareInformation.MemorySize";
+    public static final String DISPLAY_DEVICES_REGISTRY_PATH =
+        "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\";
 
     /**
      * Constructor for WindowsGraphicsCard
@@ -48,6 +65,79 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
      * @return List of {@link oshi.hardware.platform.windows.WindowsGraphicsCard} objects.
      */
     public static List<GraphicsCard> getGraphicsCards() {
+        List<GraphicsCard> cardList = new ArrayList<>();
+
+        String[] keys = Advapi32Util.registryGetKeys(WinReg.HKEY_LOCAL_MACHINE, DISPLAY_DEVICES_REGISTRY_PATH);
+        for (String key : keys) {
+            if (!key.startsWith("0")) {
+                continue;
+            }
+
+            try {
+                String fullKey = DISPLAY_DEVICES_REGISTRY_PATH + key;
+                if (!Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, ADAPTER_STRING)) {
+                    continue;
+                }
+
+                String name = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, DRIVER_DESC);
+                String deviceId = null; // Note: not found proper key in registry
+                String vendor = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, VENDOR);
+                String versionInfo = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, DRIVER_VERSION);
+                long vram = 0L;
+
+                if (Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, QW_MEMORY_SIZE)) {
+                    vram = Advapi32Util.registryGetLongValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, QW_MEMORY_SIZE);
+                } else if (Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, MEMORY_SIZE)) {
+                    Object o = Advapi32Util.registryGetValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, MEMORY_SIZE);
+                    if (o instanceof Long || o instanceof Integer) {
+                        vram = (long) o;
+                    } else if (o instanceof byte[]) {
+                        vram = memSizeBinaryToLong((byte[])o);
+                    }
+                }
+
+                cardList.add(new WindowsGraphicsCard(
+                    Util.isBlank(name) ? Constants.UNKNOWN : name,
+                    Util.isBlank(deviceId) ? Constants.UNKNOWN : deviceId,
+                    Util.isBlank(vendor) ? Constants.UNKNOWN : vendor,
+                    Util.isBlank(versionInfo) ? Constants.UNKNOWN : versionInfo,
+                    vram));
+            } catch (Win32Exception e) {
+                if (e.getErrorCode() != WinError.ERROR_ACCESS_DENIED) {
+                    // Ignore access denied errors, re-throw others
+                    throw e;
+                }
+            }
+        }
+
+        if (cardList.isEmpty()) {
+            return getGraphicsCardsFromWmi();
+        }
+        return cardList;
+    }
+
+    // Note: not found spec, working for my Intel UHD embedded gpu
+    private static long memSizeBinaryToLong(byte[] bytes) {
+        long result = 0;
+
+        if (bytes.length > 8) {
+            LOG.debug("byte[] to long: Oops! bytes length > 8");
+            return 0;
+        }
+
+        for (byte i = 0; i < bytes.length; ++i) {
+            result += (long) (bytes[i] & 255) << 8 * i;
+        }
+
+        return result;
+    }
+
+    /**
+     * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the graphics cards.
+     *
+     * @return List of {@link oshi.hardware.platform.windows.WindowsGraphicsCard} objects.
+     */
+    public static List<GraphicsCard> getGraphicsCardsFromWmi() {
         List<GraphicsCard> cardList = new ArrayList<>();
         if (IS_VISTA_OR_GREATER) {
             WmiResult<VideoControllerProperty> cards = Win32VideoController.queryVideoController();

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -88,11 +88,11 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                 if (Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, QW_MEMORY_SIZE)) {
                     vram = Advapi32Util.registryGetLongValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, QW_MEMORY_SIZE);
                 } else if (Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, MEMORY_SIZE)) {
-                    Object o = Advapi32Util.registryGetValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, MEMORY_SIZE);
-                    if (o instanceof Long || o instanceof Integer) {
-                        vram = (long) o;
-                    } else if (o instanceof byte[]) {
-                        vram = memSizeBinaryToLong((byte[])o);
+                    Object genericValue = Advapi32Util.registryGetValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, MEMORY_SIZE);
+                    if (genericValue instanceof Long || genericValue instanceof Integer) {
+                        vram = (long) genericValue;
+                    } else if (genericValue instanceof byte[]) {
+                        vram = memSizeBinaryToLong((byte[]) genericValue);
                     }
                 }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -80,7 +80,8 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                 }
 
                 String name = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, DRIVER_DESC);
-                String deviceId = null; // Note: not found proper key in registry
+                // int index = 1; outside the loop
+                String deviceId = "VideoController" + index++;
                 String vendor = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, VENDOR);
                 String versionInfo = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, DRIVER_VERSION);
                 long vram = 0L;

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -90,8 +90,10 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                     vram = Advapi32Util.registryGetLongValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, QW_MEMORY_SIZE);
                 } else if (Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, MEMORY_SIZE)) {
                     Object genericValue = Advapi32Util.registryGetValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, MEMORY_SIZE);
-                    if (genericValue instanceof Long || genericValue instanceof Integer) {
+                    if (genericValue instanceof Long) {
                         vram = (long) genericValue;
+                    else if (genericValue instanceof Integer) {
+                        vram = Integer.toUnsignedLong((int) genericValue);
                     } else if (genericValue instanceof byte[]) {
                         bytes = (byte[]) genericValue;
                         vram = ParseUtil.byteArrayToLong(bytes, bytes.length);

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -132,12 +132,9 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
         return result;
     }
 
-    /**
-     * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the graphics cards.
-     *
-     * @return List of {@link oshi.hardware.platform.windows.WindowsGraphicsCard} objects.
-     */
-    public static List<GraphicsCard> getGraphicsCardsFromWmi() {
+
+    // fall back if something went wrong
+    private static List<GraphicsCard> getGraphicsCardsFromWmi() {
         List<GraphicsCard> cardList = new ArrayList<>();
         if (IS_VISTA_OR_GREATER) {
             WmiResult<VideoControllerProperty> cards = Win32VideoController.queryVideoController();


### PR DESCRIPTION
fix #2521: 
Changed GPU info gathering mecahism for Windows.
Using Win Registy values, instead of Win32 api calls, so now vram more than 4GiB can be detected properly