### PR TITLE
Improve handling of missing JNA classes in LinuxOperatingSystem init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.4.11 (in progress)
 
-* Your contribution here!
+##### Bug fixes / Improvements
+* [#2559](https://github.com/oshi/oshi/pull/2559): Improve handling of missing JNA classes in LinuxOperatingSystem init - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.4.0 (2022-12-02), 6.4.1 (2023-03-18), 6.4.2 (2023-05-02), 6.4.3 (2023-06-06), 6.4.4 (2023-07-01), 6.4.5 (2023-08-20), 6.4.6 (2023-09-24), 6.4.7 (2023-11-01), 6.4.8 (2023-11-24), 6.4.9 (2023-12-10), 6.4.10 (2023-12-23)
 


### PR DESCRIPTION
Catch all `NoClassDefFoundError` to give better logs on missing JNA classes when initializing LinuxOperatingSystem.