### PR TITLE
Allow opting out of udev usage via GlobalConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##### Bug fixes / Improvements
 * [#2559](https://github.com/oshi/oshi/pull/2559): Improve handling of missing JNA classes in LinuxOperatingSystem init - [@dbwiddis](https://github.com/dbwiddis).
+* [#2562](https://github.com/oshi/oshi/pull/2562): Allow opting out of use of udev via LinuxOperatingSystem- [@chadlwilson](https://github.com/chadlwilson).
 
 # 6.4.0 (2022-12-02), 6.4.1 (2023-03-18), 6.4.2 (2023-05-02), 6.4.3 (2023-06-06), 6.4.4 (2023-07-01), 6.4.5 (2023-08-20), 6.4.6 (2023-09-24), 6.4.7 (2023-11-01), 6.4.8 (2023-11-24), 6.4.9 (2023-12-10), 6.4.10 (2023-12-23)
 

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -46,6 +46,7 @@ import oshi.software.os.OSThread;
 import oshi.util.Constants;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
+import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
 import oshi.util.platform.linux.ProcPath;
 import oshi.util.tuples.Pair;
@@ -79,12 +80,16 @@ public class LinuxOperatingSystem extends AbstractOperatingSystem {
         boolean hasGettid = false;
         boolean hasSyscallGettid = false;
         try {
-            try {
-                @SuppressWarnings("unused")
-                Udev lib = Udev.INSTANCE;
-                hasUdev = true;
-            } catch (UnsatisfiedLinkError e) {
-                LOG.warn("Did not find udev library in operating system. Some features may not work.");
+            if (GlobalConfig.get(GlobalConfig.OSHI_OS_LINUX_ALLOWUDEV, true)) {
+                try {
+                    @SuppressWarnings("unused")
+                    Udev lib = Udev.INSTANCE;
+                    hasUdev = true;
+                } catch (UnsatisfiedLinkError e) {
+                    LOG.warn("Did not find udev library in operating system. Some features may not work.");
+                }
+            } else {
+                LOG.info("Loading of udev not allowed by configuration. Some features may not work.");
             }
 
             try {

--- a/oshi-core/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-core/src/main/java/oshi/util/GlobalConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 The OSHI Project Contributors
+ * Copyright 2019-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util;
@@ -29,6 +29,7 @@ public final class GlobalConfig {
     public static final String OSHI_PSEUDO_FILESYSTEM_TYPES = "oshi.pseudo.filesystem.types";
     public static final String OSHI_NETWORK_FILESYSTEM_TYPES = "oshi.network.filesystem.types";
 
+    public static final String OSHI_OS_LINUX_ALLOWUDEV = "oshi.os.linux.allowudev";
     public static final String OSHI_OS_LINUX_PROCFS_LOGWARNING = "oshi.os.linux.procfs.logwarning";
 
     public static final String OSHI_OS_MAC_SYSCTL_LOGWARNING = "oshi.os.mac.sysctl.logwarning";

--- a/oshi-core/src/main/resources/oshi.properties
+++ b/oshi-core/src/main/resources/oshi.properties
@@ -115,6 +115,13 @@ oshi.os.windows.perfproc.disabled=
 # PerfDisk counters used for HWDiskStore reads/writes/queue length/xfer time
 oshi.os.windows.perfdisk.disabled=
 
+# On Linux, use of udev is normally preferred for loading hardware information such as
+# USB devices, power sources, disk information etc. Some details can be loaded
+# via sysfs as a backup, but others require udev. To disable use of udev
+# and directly use the fallbacks (or omit details that otherwise require udev)
+# set this to false. Defaults to true.
+oshi.os.linux.allowudev=true
+
 # On Linux, most process metrics are read from the proc pseudo-filesystem.
 # On macOS, process environment is read via sysctl
 # When operating without elevated permissions, this results in frequent error


### PR DESCRIPTION
As discussed in https://github.com/oshi/oshi/discussions/2561#discussioncomment-8090621 adds a configuration option `oshi.os.linux.allowudev` (default: `true`) to actively disable use of udev to load more detailed device information.

- If we'd prefer to invert the property to be `_disabled` instead, I can do that too.
- Solaris `allowKstat2` uses a type of camel case format. I can follow that, but other properties don't use that (`logwarning`, `commandline` etc) so bit unsure which format to follow.
- I didn't add a specific test as it'd need a VM fork for the test due to the use of `static` (or some bytecode/classloader magic)

Validated that this does work for the specific use case in the discussion:

**After**
```
jvm 1    | 2024-01-11 12:50:14,683 INFO  [main] AgentStatusHttpd:66 - Agent status HTTP API server running on http://localhost:8152.
jvm 1    | 2024-01-11 12:50:16,428 WARN  [main] LinuxOperatingSystem:92 - Loading of udev not allowed by configuration. Some features may not work.
jvm 1    | 2024-01-11 12:50:16,830 INFO  [main] ThreadPoolTaskScheduler:166 - Initializing ExecutorService 'scheduler'
...
```

**Before** (in my somewhat broken frankenstein Alpine / glibc environment)
```
jvm 1    | 2024-01-11 12:51:59,916 INFO  [main] AgentStatusHttpd:66 - Agent status HTTP API server running on http://localhost:8152.
jvm 1    | #
jvm 1    | # A fatal error has been detected by the Java Runtime Environment:
...
```