### PR TITLE
Add GH `macos-14` to teh MacOS buildmatrix

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # Baseline support, Current LTS, Current GA, Current EA
         java: [11, 17, 21]
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-11, macos-12, macos-13, macos-14]
         include:
           - os: flyci-macos-large-latest-m1
             java: 21


### PR DESCRIPTION
According to the blog posts this is now generally available for public repositories and utilises the M1 cpu.

- https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
- https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

Let's see how it compares to `flyci-macos-large-latest-m1`