### PR TITLE
Add getFeatureFlags method to CentralProcessor interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 6.4.14 (in progress)
+# 6.5.0 (in progress)
 
-* Your contribution here!
+* [#2592](https://github.com/oshi/oshi/pull/2592): Add getFeatureFlags method to CentralProcessor API - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.4.0 (2022-12-02), 6.4.1 (2023-03-18), 6.4.2 (2023-05-02), 6.4.3 (2023-06-06), 6.4.4 (2023-07-01), 6.4.5 (2023-08-20), 6.4.6 (2023-09-24), 6.4.7 (2023-11-01), 6.4.8 (2023-11-24), 6.4.9 (2023-12-10), 6.4.10 (2023-12-23), 6.4.11 (2024-01-11), 6.4.12 (2024-02-10), 6.4.13 (2024-02-25)
 

--- a/oshi-core/src/main/java/oshi/driver/linux/proc/CpuInfo.java
+++ b/oshi-core/src/main/java/oshi/driver/linux/proc/CpuInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.linux.proc;
@@ -7,6 +7,8 @@ package oshi.driver.linux.proc;
 import static oshi.util.platform.linux.ProcPath.CPUINFO;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.Constants;
@@ -119,5 +121,12 @@ public final class CpuInfo {
         default:
             return Constants.UNKNOWN;
         }
+    }
+
+    public static List<String> queryFeatureFlags() {
+        return FileUtil.readFile(CPUINFO).stream().filter(f -> {
+            String s = f.toLowerCase(Locale.ROOT);
+            return s.startsWith("flags") || s.startsWith("features");
+        }).distinct().collect(Collectors.toList());
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OSHI Project Contributors
+ * Copyright 2016-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware;
@@ -96,6 +96,24 @@ public interface CentralProcessor {
      * @return An {@code UnmodifiabeList} of processor caches.
      */
     List<ProcessorCache> getProcessorCaches();
+
+    /**
+     * Returns a list of platform-specific strings which identify CPU Feature Flags. This string requires user parsing
+     * to obtain meaningful information.
+     *
+     * @return On Windows, returns a list of values for which the {@code IsProcessorFeaturePresent()} function evaluates
+     *         to true.
+     *         <p>
+     *         On macOS x86, returns relevant {@code sysctl.machdep.feature} values. On Apple Silicon, returns relevant
+     *         {@code sysctl hw.optional.arm.FEAT} values.
+     *         <p>
+     *         On Linux, returns the {@code flags} and/or {@code features} fields from {@code /proc/cpuinfo}.
+     *         <p>
+     *         On OpenBSD, FreeBSD, and Solaris, returns {@code dmesg} output containing the word {@code Feature}.
+     *         <p>
+     *         For unimplemented operating systems, returns an empty list.
+     */
+    List<String> getFeatureFlags();
 
     /**
      * Returns the "recent cpu usage" for the whole system by counting ticks from {@link #getSystemCpuLoadTicks()}

--- a/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OSHI Project Contributors
+ * Copyright 2016-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.common;
@@ -29,7 +29,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.linux.proc.Auxv;
 import oshi.hardware.CentralProcessor;
 import oshi.util.ParseUtil;
-import oshi.util.tuples.Triplet;
+import oshi.util.tuples.Quartet;
 
 /**
  * A CPU.
@@ -59,12 +59,13 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
     private final List<LogicalProcessor> logicalProcessors;
     private final List<PhysicalProcessor> physicalProcessors;
     private final List<ProcessorCache> processorCaches;
+    private final List<String> featureFlags;
 
     /**
      * Create a Processor
      */
     protected AbstractCentralProcessor() {
-        Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> processorLists = initProcessorCounts();
+        Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> processorLists = initProcessorCounts();
         // Populate logical processor lists.
         this.logicalProcessors = Collections.unmodifiableList(processorLists.getA());
         if (processorLists.getB() == null) {
@@ -88,14 +89,15 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
         this.logicalProcessorCount = this.logicalProcessors.size();
         this.physicalProcessorCount = this.physicalProcessors.size();
         this.physicalPackageCount = physPkgs.size();
+        this.featureFlags = Collections.unmodifiableList(processorLists.getD());
     }
 
     /**
-     * Updates logical and physical processor counts and arrays
+     * Initializes logical and physical processor lists and feature flags.
      *
-     * @return An array of initialized Logical Processors and Physical Processors.
+     * @return Lists of initialized Logical Processors, Physical Processors, Processor Caches, and Feature Flags.
      */
-    protected abstract Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> initProcessorCounts();
+    protected abstract Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts();
 
     /**
      * Updates logical and physical processor counts and arrays
@@ -178,6 +180,11 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
     @Override
     public List<ProcessorCache> getProcessorCaches() {
         return this.processorCaches;
+    }
+
+    @Override
+    public List<String> getFeatureFlags() {
+        return this.featureFlags;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -49,7 +49,6 @@ import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.Util;
 import oshi.util.tuples.Quartet;
-import oshi.util.tuples.Triplet;
 
 /**
  * A CPU as defined in Linux /proc.
@@ -168,7 +167,7 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
         // Attempt to read from sysfs
         Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> topology = HAS_UDEV
                 ? readTopologyFromUdev()
@@ -198,7 +197,9 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
                     return new PhysicalProcessor(pkgId, coreId, e.getValue(), modAliasMap.getOrDefault(e.getKey(), ""));
                 }).collect(Collectors.toList());
 
-        return new Triplet<>(logProcs, physProcs, caches);
+        // FIXME: Iterate proc/cpuinfo to populate flags and features
+        List<String> featureFlags = Collections.emptyList();
+        return new Quartet<>(logProcs, physProcs, caches, featureFlags);
     }
 
     private static Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyFromUdev() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -39,6 +39,7 @@ import com.sun.jna.platform.linux.Udev.UdevListEntry;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.linux.Lshw;
+import oshi.driver.linux.proc.CpuInfo;
 import oshi.driver.linux.proc.CpuStat;
 import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
@@ -196,9 +197,7 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
                     int coreId = e.getKey() & 0xffff;
                     return new PhysicalProcessor(pkgId, coreId, e.getValue(), modAliasMap.getOrDefault(e.getKey(), ""));
                 }).collect(Collectors.toList());
-
-        // FIXME: Iterate proc/cpuinfo to populate flags and features
-        List<String> featureFlags = Collections.emptyList();
+        List<String> featureFlags = CpuInfo.queryFeatureFlags();
         return new Quartet<>(logProcs, physProcs, caches, featureFlags);
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OSHI Project Contributors
+ * Copyright 2016-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
@@ -9,6 +9,7 @@ import static oshi.util.Memoizer.memoize;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -40,7 +41,7 @@ import oshi.util.FormatUtil;
 import oshi.util.ParseUtil;
 import oshi.util.Util;
 import oshi.util.platform.mac.SysctlUtil;
-import oshi.util.tuples.Triplet;
+import oshi.util.tuples.Quartet;
 
 /**
  * A CPU.
@@ -132,7 +133,7 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
         int logicalProcessorCount = SysctlUtil.sysctl("hw.logicalcpu", 1);
         int physicalProcessorCount = SysctlUtil.sysctl("hw.physicalcpu", 1);
         int physicalPackageCount = SysctlUtil.sysctl("hw.packages", 1);
@@ -156,7 +157,9 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
             return new PhysicalProcessor(k >> 16, k & 0xffff, efficiency, compat);
         }).collect(Collectors.toList());
         List<ProcessorCache> caches = orderedProcCaches(getCacheValues(perflevels));
-        return new Triplet<>(logProcs, physProcs, caches);
+        // FIXME: Iterate sysctl to populate
+        List<String> featureFlags = Collections.emptyList();
+        return new Quartet<>(logProcs, physProcs, caches, featureFlags);
     }
 
     private Set<ProcessorCache> getCacheValues(int perflevels) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
@@ -120,11 +120,7 @@ final class AixCentralProcessor extends AbstractCentralProcessor {
             logProcs.add(new LogicalProcessor(proc, physProc, nodePkg == null ? 0 : nodePkg.getB(),
                     nodePkg == null ? 0 : nodePkg.getA()));
         }
-        // FIXME: $ lsattr -El proc0
-        // smt_enabled true Processor SMT enabled False
-        // or systemcfg() for VMX
-        List<String> featureFlags = Collections.emptyList();
-        return new Quartet<>(logProcs, null, getCachesForModel(physProcs), featureFlags);
+        return new Quartet<>(logProcs, null, getCachesForModel(physProcs), Collections.emptyList());
     }
 
     private List<ProcessorCache> getCachesForModel(int cores) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixCentralProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.unix.aix;
@@ -9,6 +9,7 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -29,7 +30,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
-import oshi.util.tuples.Triplet;
+import oshi.util.tuples.Quartet;
 
 /**
  * A CPU
@@ -93,7 +94,7 @@ final class AixCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
         this.config = PerfstatConfig.queryConfig();
 
         // Reporting "online" or "active" values can lead to nonsense so we go with max
@@ -119,7 +120,11 @@ final class AixCentralProcessor extends AbstractCentralProcessor {
             logProcs.add(new LogicalProcessor(proc, physProc, nodePkg == null ? 0 : nodePkg.getB(),
                     nodePkg == null ? 0 : nodePkg.getA()));
         }
-        return new Triplet<>(logProcs, null, getCachesForModel(physProcs));
+        // FIXME: $ lsattr -El proc0
+        // smt_enabled true Processor SMT enabled False
+        // or systemcfg() for VMX
+        List<String> featureFlags = Collections.emptyList();
+        return new Quartet<>(logProcs, null, getCachesForModel(physProcs), featureFlags);
     }
 
     private List<ProcessorCache> getCachesForModel(int cores) {
@@ -176,6 +181,10 @@ final class AixCentralProcessor extends AbstractCentralProcessor {
         //
         // ~/git/oshi$ pmcycles -m
         // This machine runs at 1000 MHz
+
+        // FIXME change to this as pmcycles requires root
+        // $ lsattr -El proc0
+        // frequency 3425000000 Processor Speed False
 
         long[] freqs = new long[getLogicalProcessorCount()];
         Arrays.fill(freqs, -1);

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -1,10 +1,11 @@
 /*
- * Copyright 2016-2023 The OSHI Project Contributors
+ * Copyright 2016-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.unix.freebsd;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -31,7 +32,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
-import oshi.util.tuples.Triplet;
+import oshi.util.tuples.Quartet;
 
 /**
  * A CPU
@@ -103,7 +104,7 @@ final class FreeBsdCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
         List<LogicalProcessor> logProcs = parseTopology();
         // Force at least one processor
         if (logProcs.isEmpty()) {
@@ -131,7 +132,9 @@ final class FreeBsdCentralProcessor extends AbstractCentralProcessor {
         }
         List<PhysicalProcessor> physProcs = dmesg.isEmpty() ? null : createProcListFromDmesg(logProcs, dmesg);
         List<ProcessorCache> caches = getCacheInfoFromLscpu();
-        return new Triplet<>(logProcs, physProcs, caches);
+        // FIXME: Iterate dmesg to populate
+        List<String> featureFlags = Collections.emptyList();
+        return new Quartet<>(logProcs, physProcs, caches, featureFlags);
     }
 
     private List<ProcessorCache> getCacheInfoFromLscpu() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 The OSHI Project Contributors
+ * Copyright 2021-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.unix.openbsd;
@@ -21,6 +21,7 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -42,6 +43,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
 import oshi.util.tuples.Pair;
+import oshi.util.tuples.Quartet;
 import oshi.util.tuples.Triplet;
 
 /**
@@ -102,7 +104,7 @@ public class OpenBsdCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
         // Iterate dmesg, look for lines:
         // cpu0: smt 0, core 0, package 0
         // cpu1: smt 0, core 1, package 0
@@ -180,7 +182,9 @@ public class OpenBsdCentralProcessor extends AbstractCentralProcessor {
             }
         }
         List<PhysicalProcessor> physProcs = cpuMap.isEmpty() ? null : createProcListFromDmesg(logProcs, cpuMap);
-        return new Triplet<>(logProcs, physProcs, orderedProcCaches(caches));
+        // FIXME: Iterate dmesg to populate
+        List<String> featureFlags = Collections.emptyList();
+        return new Quartet<>(logProcs, physProcs, orderedProcCaches(caches), featureFlags);
     }
 
     private ProcessorCache parseCacheStr(String cacheStr) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OSHI Project Contributors
+ * Copyright 2016-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.unix.solaris;
@@ -8,6 +8,7 @@ import static oshi.software.os.unix.solaris.SolarisOperatingSystem.HAS_KSTAT2;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -24,7 +25,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.solaris.KstatUtil;
 import oshi.util.platform.unix.solaris.KstatUtil.KstatChain;
-import oshi.util.tuples.Triplet;
+import oshi.util.tuples.Quartet;
 
 /**
  * A CPU
@@ -91,24 +92,26 @@ final class SolarisCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+        List<LogicalProcessor> logProcs;
         Map<Integer, Integer> numaNodeMap = mapNumaNodes();
         if (HAS_KSTAT2) {
             // Use Kstat2 implementation
-            return new Triplet<>(initProcessorCounts2(numaNodeMap), null, null);
-        }
-        List<LogicalProcessor> logProcs = new ArrayList<>();
-        try (KstatChain kc = KstatUtil.openChain()) {
-            List<Kstat> kstats = kc.lookupAll(CPU_INFO, -1, null);
+            logProcs = initProcessorCounts2(numaNodeMap);
+        } else {
+            logProcs = new ArrayList<>();
+            try (KstatChain kc = KstatUtil.openChain()) {
+                List<Kstat> kstats = kc.lookupAll(CPU_INFO, -1, null);
 
-            for (Kstat ksp : kstats) {
-                if (ksp != null && kc.read(ksp)) {
-                    int procId = logProcs.size(); // 0-indexed
-                    String chipId = KstatUtil.dataLookupString(ksp, "chip_id");
-                    String coreId = KstatUtil.dataLookupString(ksp, "core_id");
-                    LogicalProcessor logProc = new LogicalProcessor(procId, ParseUtil.parseIntOrDefault(coreId, 0),
-                            ParseUtil.parseIntOrDefault(chipId, 0), numaNodeMap.getOrDefault(procId, 0));
-                    logProcs.add(logProc);
+                for (Kstat ksp : kstats) {
+                    if (ksp != null && kc.read(ksp)) {
+                        int procId = logProcs.size(); // 0-indexed
+                        String chipId = KstatUtil.dataLookupString(ksp, "chip_id");
+                        String coreId = KstatUtil.dataLookupString(ksp, "core_id");
+                        LogicalProcessor logProc = new LogicalProcessor(procId, ParseUtil.parseIntOrDefault(coreId, 0),
+                                ParseUtil.parseIntOrDefault(chipId, 0), numaNodeMap.getOrDefault(procId, 0));
+                        logProcs.add(logProc);
+                    }
                 }
             }
         }
@@ -129,9 +132,11 @@ final class SolarisCentralProcessor extends AbstractCentralProcessor {
             }
         }
         if (dmesg.isEmpty()) {
-            return new Triplet<>(logProcs, null, null);
+            return new Quartet<>(logProcs, null, null, Collections.emptyList());
         }
-        return new Triplet<>(logProcs, createProcListFromDmesg(logProcs, dmesg), null);
+        // FIXME: Iterate dmesg to populate
+        List<String> featureFlags = Collections.emptyList();
+        return new Quartet<>(logProcs, createProcListFromDmesg(logProcs, dmesg), null, featureFlags);
     }
 
     private static List<LogicalProcessor> initProcessorCounts2(Map<Integer, Integer> numaNodeMap) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessor.java
@@ -134,8 +134,7 @@ final class SolarisCentralProcessor extends AbstractCentralProcessor {
         if (dmesg.isEmpty()) {
             return new Quartet<>(logProcs, null, null, Collections.emptyList());
         }
-        // FIXME: Iterate dmesg to populate
-        List<String> featureFlags = Collections.emptyList();
+        List<String> featureFlags = ExecutingCommand.runNative("isainfo -x");
         return new Quartet<>(logProcs, createProcListFromDmesg(logProcs, dmesg), null, featureFlags);
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
@@ -7,19 +7,19 @@ package oshi.hardware.platform.windows;
 import static oshi.util.Memoizer.memoize;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
+import oshi.jna.platform.windows.Kernel32.ProcessorFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sun.jna.platform.win32.Advapi32Util;
-import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.PowrProf.POWER_INFORMATION_LEVEL;
 import com.sun.jna.platform.win32.VersionHelpers;
 import com.sun.jna.platform.win32.Win32Exception;
@@ -40,6 +40,7 @@ import oshi.driver.windows.wmi.Win32Processor;
 import oshi.driver.windows.wmi.Win32Processor.ProcessorIdProperty;
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.jna.Struct.CloseableSystemInfo;
+import oshi.jna.platform.windows.Kernel32;
 import oshi.jna.platform.windows.PowrProf;
 import oshi.jna.platform.windows.PowrProf.ProcessorPowerInformation;
 import oshi.util.GlobalConfig;
@@ -188,8 +189,9 @@ final class WindowsCentralProcessor extends AbstractCentralProcessor {
         } else {
             lpi = LogicalProcessorInformation.getLogicalProcessorInformation();
         }
-        // FIXME: iterate values for IsProcessorFeaturePresent call
-        List<String> featureFlags = Collections.emptyList();
+        List<String> featureFlags = Arrays.stream(ProcessorFeature.values())
+                .filter(f -> Kernel32.INSTANCE.IsProcessorFeaturePresent(f.value())).map(ProcessorFeature::name)
+                .collect(Collectors.toList());
         return new Quartet<>(lpi.getA(), lpi.getB(), lpi.getC(), featureFlags);
     }
 

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/Kernel32.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/Kernel32.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2024 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.jna.platform.windows;
+
+import com.sun.jna.Native;
+
+/**
+ * Kernel32. This class should be considered non-API as it may be removed if/when its code is incorporated into the JNA
+ * project.
+ */
+public interface Kernel32 extends com.sun.jna.platform.win32.Kernel32 {
+    /** Constant <code>INSTANCE</code> */
+    Kernel32 INSTANCE = Native.load("Kernel32", Kernel32.class);
+
+    enum ProcessorFeature {
+        PF_FLOATING_POINT_PRECISION_ERRATA(0), PF_FLOATING_POINT_EMULATED(1), PF_COMPARE_EXCHANGE_DOUBLE(2),
+        PF_MMX_INSTRUCTIONS_AVAILABLE(3), PF_PPC_MOVEMEM_64BIT_OK(4), PF_ALPHA_BYTE_INSTRUCTIONS(5),
+        PF_XMMI_INSTRUCTIONS_AVAILABLE(6), PF_3DNOW_INSTRUCTIONS_AVAILABLE(7), PF_RDTSC_INSTRUCTION_AVAILABLE(8),
+        PF_PAE_ENABLED(9), PF_XMMI64_INSTRUCTIONS_AVAILABLE(10), PF_SSE_DAZ_MODE_AVAILABLE(11), PF_NX_ENABLED(12),
+        PF_SSE3_INSTRUCTIONS_AVAILABLE(13), PF_COMPARE_EXCHANGE128(14), PF_COMPARE64_EXCHANGE128(15),
+        PF_CHANNELS_ENABLED(16), PF_XSAVE_ENABLED(17), PF_ARM_VFP_32_REGISTERS_AVAILABLE(18),
+        PF_ARM_NEON_INSTRUCTIONS_AVAILABLE(19), PF_SECOND_LEVEL_ADDRESS_TRANSLATION(20), PF_VIRT_FIRMWARE_ENABLED(21),
+        PF_RDWRFSGSBASE_AVAILABLE(22), PF_FASTFAIL_AVAILABLE(23), PF_ARM_DIVIDE_INSTRUCTION_AVAILABLE(24),
+        PF_ARM_64BIT_LOADSTORE_ATOMIC(25), PF_ARM_EXTERNAL_CACHE_AVAILABLE(26), PF_ARM_FMAC_INSTRUCTIONS_AVAILABLE(27),
+        PF_RDRAND_INSTRUCTION_AVAILABLE(28), PF_ARM_V8_INSTRUCTIONS_AVAILABLE(29),
+        PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE(30), PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE(31),
+        PF_RDTSCP_INSTRUCTION_AVAILABLE(32), PF_RDPID_INSTRUCTION_AVAILABLE(33),
+        PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE(34), PF_SSSE3_INSTRUCTIONS_AVAILABLE(36),
+        PF_SSE4_1_INSTRUCTIONS_AVAILABLE(37), PF_SSE4_2_INSTRUCTIONS_AVAILABLE(38), PF_AVX_INSTRUCTIONS_AVAILABLE(39),
+        PF_AVX2_INSTRUCTIONS_AVAILABLE(40), PF_AVX512F_INSTRUCTIONS_AVAILABLE(41),
+        PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE(43), PF_ARM_V83_JSCVT_INSTRUCTIONS_AVAILABLE(44),
+        PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE(45);
+
+        private final int value;
+
+        ProcessorFeature(int value) {
+            this.value = value;
+        }
+
+        /**
+         * @return the value
+         */
+        public int value() {
+            return value;
+        }
+    }
+
+    /**
+     * Determines whether the specified processor feature is supported by the current computer.
+     *
+     * @param ProcessorFeature The processor feature to be tested. This parameter can be one of the values in
+     *                         {@link ProcessorFeature}.
+     * @return If the feature is supported, the return value is true. If the feature is not supported, the return value
+     *         is false. If the HAL does not support detection of the feature, whether or not the hardware supports the
+     *         feature, the return value is also false.
+     */
+    boolean IsProcessorFeaturePresent(int ProcessorFeature);
+}

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SysctlUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SysctlUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 The OSHI Project Contributors
+ * Copyright 2016-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.mac;
@@ -88,16 +88,32 @@ public final class SysctlUtil {
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(String name, String def) {
+        return sysctl(name, def, true);
+    }
+
+    /**
+     * Executes a sysctl call with a String result
+     *
+     * @param name       name of the sysctl
+     * @param def        default String value
+     * @param logWarning whether to log the warning if not available
+     * @return The String result of the call if successful; the default otherwise
+     */
+    public static String sysctl(String name, String def, boolean logWarning) {
         // Call first time with null pointer to get value of size
         try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
             if (0 != SystemB.INSTANCE.sysctlbyname(name, null, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
+                if (logWarning) {
+                    LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
+                }
                 return def;
             }
             // Add 1 to size for null terminated string
             try (Memory p = new Memory(size.longValue() + 1L)) {
                 if (0 != SystemB.INSTANCE.sysctlbyname(name, p, size, null, size_t.ZERO)) {
-                    LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
+                    if (logWarning) {
+                        LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
+                    }
                     return def;
                 }
                 return p.getString(0);

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OSHI Project Contributors
+ * Copyright 2016-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi;
@@ -295,6 +295,12 @@ public class SystemInfoTest { // NOSONAR squid:S5786
                 sb.append(FormatUtil.formatHertz(freqs[i]));
             }
             oshi.add(sb.toString());
+        }
+        if (!processor.getFeatureFlags().isEmpty()) {
+            oshi.add("CPU Features:");
+            for (String features : processor.getFeatureFlags()) {
+                oshi.add("  " + features);
+            }
         }
     }
 


### PR DESCRIPTION
Adds feature flags to Central Processor
 - [x] Windows
 - [x] macOS
 - [x] Linux
 - [x] FreeBSD
 - [x] OpenBSD
 - [x] Solaris

Can't find anything helpful for AIX

Fixes #2589 