### PR TITLE
Reduce CpuStat.getSystemCpuLoadTicks memory allocation pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Your contribution here!
 
+##### Bug fixes / Improvements
+* [#2605](https://github.com/oshi/oshi/pull/2605): Reduce CpuStat.getSystemCpuLoadticks memory allocation pressure - [@chrisribble](https://github.com/chrisribble).
+
 # 6.5.0 (2024-03-10)
 
 ##### New Features

--- a/oshi-core/src/main/java/oshi/driver/linux/proc/CpuStat.java
+++ b/oshi-core/src/main/java/oshi/driver/linux/proc/CpuStat.java
@@ -32,12 +32,12 @@ public final class CpuStat {
         // first line is overall user,nice,system,idle,iowait,irq, etc.
         // cpu 3357 0 4313 1362393 ...
         String tickStr;
-        List<String> procStat = FileUtil.readFile(ProcPath.STAT);
-        if (!procStat.isEmpty()) {
-            tickStr = procStat.get(0);
-        } else {
+        List<String> procStat = FileUtil.readLines(ProcPath.STAT, 1);
+        if (procStat.isEmpty()) {
             return ticks;
         }
+        tickStr = procStat.get(0);
+
         // Split the line. Note the first (0) element is "cpu" so remaining
         // elements are offset by 1 from the enum index
         String[] tickArr = ParseUtil.whitespaces.split(tickStr);

--- a/oshi-core/src/main/java/oshi/driver/linux/proc/CpuStat.java
+++ b/oshi-core/src/main/java/oshi/driver/linux/proc/CpuStat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.linux.proc;

--- a/oshi-core/src/main/java/oshi/util/FileUtil.java
+++ b/oshi-core/src/main/java/oshi/util/FileUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 The OSHI Project Contributors
+ * Copyright 2016-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util;
@@ -91,11 +91,11 @@ public final class FileUtil {
     }
 
     /**
-     * Read count lines from a file. Intended primarily for Linux /proc filesystem to avoid recalculating file
-     * contents on iterative reads.
+     * Read count lines from a file. Intended primarily for Linux /proc filesystem to avoid recalculating file contents
+     * on iterative reads.
      *
      * @param filename The file to read
-     * @param count The number of lines to read
+     * @param count    The number of lines to read
      * @return A list of Strings representing the first count lines of the file, or an empty list if file could not be
      *         read or is empty
      */
@@ -104,11 +104,11 @@ public final class FileUtil {
     }
 
     /**
-     * Read count lines from a file. Intended primarily for Linux /proc filesystem to avoid recalculating file
-     * contents on iterative reads.
+     * Read count lines from a file. Intended primarily for Linux /proc filesystem to avoid recalculating file contents
+     * on iterative reads.
      *
-     * @param filename The file to read
-     * @param count The number of lines to read
+     * @param filename    The file to read
+     * @param count       The number of lines to read
      * @param reportError Whether to log errors reading the file
      * @return A list of Strings representing the first count lines of the file, or an empty list if file could not be
      *         read or is empty


### PR DESCRIPTION
Add a new method, FileUtil.readLines, which accepts a number of lines to read and allocates an ArrayList which contains a number of elements corresponding to the number of lines to be read. If file is not readable, return Collections.emptyList() to avoid allocating a list.

Use this new method in CpuStat.getSystemCpuLoadTicks to avoid allocating a String for each line in /proc/stat, instead allocating a single String and ArrayList with a capacity of one.

This reduces allocation of char[]'s to back the String for each line by two orders of magnitude (from a few kB to a few tens of bytes) on each call.