### PR TITLE
fix #2639: getOwningProcessId sometimes return -1 on 64x linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 6.6.1 (in progress)
 
+##### Bug fixes / Improvements
+* [#2645](https://github.com/oshi/oshi/pull/2645): fix getOwningProcessId sometimes return -1 on 64x linux - [@yourancc](https://github.com/yourancc).
+
 # 6.6.0 (2024-04-13)
 
 ##### New Features

--- a/oshi-core/src/main/java/oshi/driver/linux/proc/ProcessStat.java
+++ b/oshi-core/src/main/java/oshi/driver/linux/proc/ProcessStat.java
@@ -435,8 +435,8 @@ public final class ProcessStat {
      *
      * @return a map with socket as the key and pid as the value
      */
-    public static Map<Integer, Integer> querySocketToPidMap() {
-        Map<Integer, Integer> pidMap = new HashMap<>();
+    public static Map<Long, Integer> querySocketToPidMap() {
+        Map<Long, Integer> pidMap = new HashMap<>();
         for (File f : getPidFiles()) {
             int pid = ParseUtil.parseIntOrDefault(f.getName(), -1);
             File[] fds = getFileDescriptorFiles(pid);
@@ -445,7 +445,7 @@ public final class ProcessStat {
                 if (symLink != null) {
                     Matcher m = SOCKET.matcher(symLink);
                     if (m.matches()) {
-                        pidMap.put(ParseUtil.parseIntOrDefault(m.group(1), -1), pid);
+                        pidMap.put(ParseUtil.parseLongOrDefault(m.group(1), -1L), pid);
                     }
                 }
             }

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
@@ -54,7 +54,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
     @Override
     public List<IPConnection> getConnections() {
         List<IPConnection> conns = new ArrayList<>();
-        Map<Integer, Integer> pidMap = ProcessStat.querySocketToPidMap();
+        Map<Long, Integer> pidMap = ProcessStat.querySocketToPidMap();
         conns.addAll(queryConnections("tcp", 4, pidMap));
         conns.addAll(queryConnections("tcp", 6, pidMap));
         conns.addAll(queryConnections("udp", 4, pidMap));
@@ -62,7 +62,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         return conns;
     }
 
-    private static List<IPConnection> queryConnections(String protocol, int ipver, Map<Integer, Integer> pidMap) {
+    private static List<IPConnection> queryConnections(String protocol, int ipver, Map<Long, Integer> pidMap) {
         List<IPConnection> conns = new ArrayList<>();
         for (String s : FileUtil.readFile(ProcPath.NET + "/" + protocol + (ipver == 6 ? "6" : ""))) {
             if (s.indexOf(':') >= 0) {
@@ -72,7 +72,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
                     Pair<byte[], Integer> fAddr = parseIpAddr(split[2]);
                     TcpState state = stateLookup(ParseUtil.hexStringToInt(split[3], 0));
                     Pair<Integer, Integer> txQrxQ = parseHexColonHex(split[4]);
-                    int inode = ParseUtil.parseIntOrDefault(split[9], 0);
+                    long inode = ParseUtil.parseLongOrDefault(split[9], 0);
                     conns.add(new IPConnection(protocol + ipver, lAddr.getA(), lAddr.getB(), fAddr.getA(), fAddr.getB(),
                             state, txQrxQ.getA(), txQrxQ.getB(), pidMap.getOrDefault(inode, -1)));
                 }


### PR DESCRIPTION
fix the issue(#2639 ) where the owning process ID sometimes returns -1 caused by it.