### PR TITLE
Add macOS 15 (Sequoia) to version properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.6.2 (in progress)
 
-* Your contribution here!
+##### Bug fixes / Improvements
+* [#2660](https://github.com/oshi/oshi/pull/2660): Add macOS 15 (Sequoia) to version properties - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26)
 

--- a/oshi-core/src/main/resources/oshi.macos.versions.properties
+++ b/oshi-core/src/main/resources/oshi.macos.versions.properties
@@ -1,4 +1,5 @@
 # Mapping of macOS version numbers to names
+15=Sequoia
 14=Sonoma
 13=Ventura
 12=Monterey


### PR DESCRIPTION
Because we need more vowels.