### PR TITLE
Do not log errors for reading process arguments on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug fixes / Improvements
 * [#2660](https://github.com/oshi/oshi/pull/2660): Add macOS 15 (Sequoia) to version properties - [@dbwiddis](https://github.com/dbwiddis).
 * [#2662](https://github.com/oshi/oshi/pull/2662): Only warn on duplicate properties files if they differ - [@dbwiddis](https://github.com/dbwiddis).
+* [#2692](https://github.com/oshi/oshi/pull/2692): Do not log errors for reading process arguments on Linux - [@wolfs](https://github.com/wolfs).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26)
 

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
@@ -128,7 +128,7 @@ public class LinuxOSProcess extends AbstractOSProcess {
 
     private List<String> queryArguments() {
         return Collections.unmodifiableList(ParseUtil.parseByteArrayToStrings(
-                FileUtil.readAllBytes(String.format(Locale.ROOT, ProcPath.PID_CMDLINE, getProcessID()))));
+                FileUtil.readAllBytes(String.format(Locale.ROOT, ProcPath.PID_CMDLINE, getProcessID()), LOG_PROCFS_WARNING)));
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/util/FileUtil.java
+++ b/oshi-core/src/main/java/oshi/util/FileUtil.java
@@ -155,17 +155,6 @@ public final class FileUtil {
      * Read an entire file at one time. Intended primarily for Linux /proc filesystem to avoid recalculating file
      * contents on iterative reads.
      *
-     * @param filename The file to read
-     * @return A byte array representing the file
-     */
-    public static byte[] readAllBytes(String filename) {
-        return readAllBytes(filename, true);
-    }
-
-    /**
-     * Read an entire file at one time. Intended primarily for Linux /proc filesystem to avoid recalculating file
-     * contents on iterative reads.
-     *
      * @param filename    The file to read
      * @param reportError Whether to log errors reading the file
      * @return A byte array representing the file


### PR DESCRIPTION
When the process is gone, there shouldn't be any error logging in the command line.

Fixes https://github.com/oshi/oshi/issues/2689