### PR TITLE
Properly parse CPU vendor when lscpu not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.6.3 (in progress)
 
-* Your contribution here!
+##### Bug fixes / Improvements
+* [#2704](https://github.com/oshi/oshi/pull/2704): Properly parse CPU vendor when lscpu not available - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26), 6.6.2 (2024-07-21)
 

--- a/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/CentralProcessor.java
@@ -878,8 +878,7 @@ public interface CentralProcessor {
 
         private String queryVendorFromImplementer(String cpuVendor) {
             Properties archProps = FileUtil.readPropertiesFromFilename(OSHI_ARCHITECTURE_PROPERTIES);
-            String vendor = archProps.getProperty("hw_impl." + this.cpuVendor);
-            return (vendor == null ? cpuVendor : vendor);
+            return archProps.getProperty("hw_impl." + cpuVendor, cpuVendor);
         }
 
         @Override


### PR DESCRIPTION
Uses the method parameter for the map lookup instead of the (uninitialized) vendor.  

Fixes #2703 (and properly fixes the original #2513 bug)