### PR TITLE
Restore optional legacy method of calculating Windows System CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ##### Bug fixes / Improvements
 * [#2704](https://github.com/oshi/oshi/pull/2704): Properly parse CPU vendor when lscpu not available - [@dbwiddis](https://github.com/dbwiddis).
+* [#2705](https://github.com/oshi/oshi/pull/2705): Restore optional legacy method of calculating Windows System CPU - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26), 6.6.2 (2024-07-21)
 

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessorInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessorInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.perfmon;
@@ -133,6 +133,32 @@ public final class ProcessorInformation {
         }
     }
 
+    /**
+     * System performance counters
+     */
+    public enum SystemTickCountProperty implements PdhCounterProperty {
+        PERCENTDPCTIME(PerfCounterQuery.TOTAL_INSTANCE, "% DPC Time"), //
+        PERCENTINTERRUPTTIME(PerfCounterQuery.TOTAL_INSTANCE, "% Interrupt Time");
+
+        private final String instance;
+        private final String counter;
+
+        SystemTickCountProperty(String instance, String counter) {
+            this.instance = instance;
+            this.counter = counter;
+        }
+
+        @Override
+        public String getInstance() {
+            return instance;
+        }
+
+        @Override
+        public String getCounter() {
+            return counter;
+        }
+    }
+
     private ProcessorInformation() {
     }
 
@@ -149,6 +175,16 @@ public final class ProcessorInformation {
                 PROCESSOR_INFORMATION, WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL)
                 : PerfCounterWildcardQuery.queryInstancesAndValues(ProcessorTickCountProperty.class, PROCESSOR,
                         WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_NOT_TOTAL);
+    }
+
+    /**
+     * Returns system performance counters.
+     *
+     * @return Performance Counters for the total of all processors.
+     */
+    public static Map<SystemTickCountProperty, Long> querySystemCounters() {
+        return PerfCounterQuery.queryValues(SystemTickCountProperty.class, PROCESSOR,
+                WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_TOTAL);
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-core/src/main/java/oshi/util/GlobalConfig.java
@@ -40,6 +40,7 @@ public final class GlobalConfig {
     public static final String OSHI_OS_WINDOWS_PROCSTATE_SUSPENDED = "oshi.os.windows.procstate.suspended";
     public static final String OSHI_OS_WINDOWS_COMMANDLINE_BATCH = "oshi.os.windows.commandline.batch";
     public static final String OSHI_OS_WINDOWS_HKEYPERFDATA = "oshi.os.windows.hkeyperfdata";
+    public static final String OSHI_OS_WINDOWS_LEGACY_SYSTEM_COUNTERS = "oshi.os.windows.legacy.system.counters";
     public static final String OSHI_OS_WINDOWS_LOADAVERAGE = "oshi.os.windows.loadaverage";
     public static final String OSHI_OS_WINDOWS_CPU_UTILITY = "oshi.os.windows.cpu.utility";
 

--- a/oshi-core/src/main/resources/oshi.properties
+++ b/oshi-core/src/main/resources/oshi.properties
@@ -120,6 +120,13 @@ oshi.os.windows.perfproc.disabled=
 # PerfDisk counters used for HWDiskStore reads/writes/queue length/xfer time
 oshi.os.windows.perfdisk.disabled=
 
+# Whether to use the Legacy Processor performance counters for System CPU ticks instead of
+# Processor Information (since Windows 7). These counters are not processor-group aware
+# and may give incorrect results on systems with more than 64 logical processors. Normally on
+# Windows the system ticks are obtained by summing up per-processor counters, but on
+# some systems, service accounts can not read those values without specific permission.
+oshi.os.windows.legacy.system.counters=false
+
 # On Linux, use of udev is normally preferred for loading hardware information such as
 # USB devices, power sources, disk information etc. Some details can be loaded
 # via sysfs as a backup, but others require udev. To disable use of udev


### PR DESCRIPTION
Restores the System CPU code removed in #1400 under an optional configuration.

This method may give inaccurate results when there is more than one processor group (more than 64 processors) but may be necessary for service accounts to read values without special permissions.