### PR TITLE
Replace FlyCI macOS runners with GitHub macOS runners

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -20,9 +20,6 @@ jobs:
         # Baseline support, Current LTS, Current GA, Current EA
         java: [11, 17, 21]
         os: [macos-11, macos-12, macos-13, macos-14]
-        include:
-          - os: flyci-macos-large-latest-m1
-            java: 21
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         java: [11, 17, 21]
         include:
-          - os: flyci-macos-large-latest-m1
+          - os: macos-latest
             java: 21
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}


### PR DESCRIPTION
This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).