### PR TITLE
Fix speed value for LinuxNetworkIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 6.6.4 (in progress)
 
 * Your contribution here!
+##### Bug fixes / Improvements
+* [#2722](https://github.com/oshi/oshi/pull/2722): Fix speed value for LinuxNetworkIF - [@Puppy4C](https://github.com/Puppy4C).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26), 6.6.2 (2024-07-21), 6.6.3 (2024-08-20)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIF.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIF.java
@@ -208,9 +208,9 @@ public final class LinuxNetworkIF extends AbstractNetworkIF {
         this.inErrors = FileUtil.getUnsignedLongFromFile(name + "/statistics/rx_errors");
         this.collisions = FileUtil.getUnsignedLongFromFile(name + "/statistics/collisions");
         this.inDrops = FileUtil.getUnsignedLongFromFile(name + "/statistics/rx_dropped");
-        long speedMiB = FileUtil.getUnsignedLongFromFile(name + "/speed");
+        long speedMbps = FileUtil.getUnsignedLongFromFile(name + "/speed");
         // speed may be -1 from file.
-        this.speed = speedMiB < 0 ? 0 : speedMiB << 20;
+        this.speed = speedMbps < 0 ? 0 : speedMbps * 1000000L;
         this.ifAlias = FileUtil.getStringFromFile(name + "/ifalias");
         this.ifOperStatus = parseIfOperStatus(FileUtil.getStringFromFile(name + "/operstate"));
 


### PR DESCRIPTION
The output result of  `/sys/class/net/<card>/speed` is in Mbps and needs to be converted to bps