### PR TITLE
Reduce redundant logging on perf counter failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ##### Bug fixes / Improvements
 * [#2711](https://github.com/oshi/oshi/pull/2711): Do not log error on macOS for hw.nperflevels - [@Puppy4C](https://github.com/Puppy4C).
 * [#2722](https://github.com/oshi/oshi/pull/2722): Fix speed value for LinuxNetworkIF - [@Puppy4C](https://github.com/Puppy4C).
-* [#2724](https://github.com/oshi/oshi/pull/2724): Clarify IO bytes documentation on OSProcess - [@dbwiddis](https://github.com/Pup).
+* [#2724](https://github.com/oshi/oshi/pull/2724): Clarify IO bytes documentation on OSProcess - [@dbwiddis](https://github.com/dbwiddis).
+* [#2725](https://github.com/oshi/oshi/pull/2725): Reduce redundant logging on perf counter failures - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26), 6.6.2 (2024-07-21), 6.6.3 (2024-08-20)
 

--- a/oshi-core/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-core/src/main/java/oshi/util/GlobalConfig.java
@@ -47,6 +47,7 @@ public final class GlobalConfig {
     public static final String OSHI_OS_WINDOWS_PERFDISK_DIABLED = "oshi.os.windows.perfdisk.disabled";
     public static final String OSHI_OS_WINDOWS_PERFOS_DIABLED = "oshi.os.windows.perfos.disabled";
     public static final String OSHI_OS_WINDOWS_PERFPROC_DIABLED = "oshi.os.windows.perfproc.disabled";
+    public static final String OSHI_OS_WINDOWS_PERF_DISABLE_ALL_ON_FAILURE = "oshi.os.windows.perf.disable.all.on.failure";
 
     public static final String OSHI_OS_UNIX_WHOCOMMAND = "oshi.os.unix.whoCommand";
     public static final String OSHI_OS_SOLARIS_ALLOWKSTAT2 = "oshi.os.solaris.allowKstat2";

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 The OSHI Project Contributors
+ * Copyright 2019-2024 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.windows;
@@ -75,7 +75,7 @@ public final class PerfCounterQuery {
                 return valueMap;
             }
             // If we are here, query failed
-            LOG.warn("Disabling further attempts to query {}.", perfObject);
+            LOG.info("Disabling further attempts to query {}.", perfObject);
             FAILED_QUERY_CACHE.add(perfObject);
         }
         return queryValuesFromWMI(propertyEnum, perfWmiClass);
@@ -183,7 +183,7 @@ public final class PerfCounterQuery {
                     String.format(Locale.ROOT, "0x%x", e.getHR().intValue()),
                     "See https://support.microsoft.com/en-us/help/300956/how-to-manually-rebuild-performance-counter-library-values");
         } catch (PdhException e) {
-            LOG.warn("Unable to localize {} performance counter.  Error {}.", perfObject,
+            LOG.debug("Unable to localize {} performance counter.  Error {}.", perfObject,
                     String.format(Locale.ROOT, "0x%x", e.getErrorCode()));
         }
         if (localized.isEmpty()) {

--- a/oshi-core/src/main/resources/oshi.properties
+++ b/oshi-core/src/main/resources/oshi.properties
@@ -120,6 +120,9 @@ oshi.os.windows.perfproc.disabled=
 # PerfDisk counters used for HWDiskStore reads/writes/queue length/xfer time
 oshi.os.windows.perfdisk.disabled=
 
+# Assume any performance counter failure means all counters will fail and revert to WMI backup
+oshi.os.windows.perf.disable.all.on.failure=false
+
 # Whether to use the Legacy Processor performance counters for System CPU ticks instead of
 # Processor Information (since Windows 7). These counters are not processor-group aware
 # and may give incorrect results on systems with more than 64 logical processors. Normally on


### PR DESCRIPTION
Reduces redundant WARN logs on performance counter failures:
 - Initial failure error code message reduced to DEBUG
 - Disabling counters message reduced to INFO
 - Added config property to disable all counters and use WMI on a failure of any one

Fixes #2721