### PR TITLE
Fix Linux CPU thermal zone path string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.6.5 (in progress)
 
-* Your contribution here!
+##### Bug fixes / Improvements
+* [#2740](https://github.com/oshi/oshi/pull/2740): Fix Linux CPU thermal zone path string - [@1056227556](https://github.com/1056227556).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26), 6.6.2 (2024-07-21), 6.6.3 (2024-08-20), 6.6.4 (2024-09-15)
 

--- a/oshi-core/src/main/java/oshi/util/platform/linux/SysPath.java
+++ b/oshi-core/src/main/java/oshi/util/platform/linux/SysPath.java
@@ -29,7 +29,7 @@ public final class SysPath {
     public static final String MODEL = SYS + "firmware/devicetree/base/model";
     public static final String POWER_SUPPLY = SYS + "class/power_supply";
     public static final String HWMON = SYS + "class/hwmon/";
-    public static final String THERMAL = SYS + "class/thermal/thermal_zone";
+    public static final String THERMAL = SYS + "class/thermal/";
 
     private SysPath() {
     }


### PR DESCRIPTION
Fix the issue of not being able to obtain the CPU temperature due to the THERMAL value error in the Linux environment.