### PR TITLE
Enable configurable prioritization of thermal zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.6.6 (in progress)
 
 * Your contribution here!
+* [#2793](https://github.com/oshi/oshi/pull/2793), Enable configurable prioritization of thermal zones - [@joerg1985](https://github.com/joerg1985).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26), 6.6.2 (2024-07-21), 6.6.3 (2024-08-20), 6.6.4 (2024-09-15), 6.6.5 (2024-09-16)
 

--- a/oshi-core/src/main/resources/oshi.properties
+++ b/oshi-core/src/main/resources/oshi.properties
@@ -267,3 +267,7 @@ oshi.os.openbsd.filesystem.path.excludes=/tmp**,/dev
 
 oshi.os.solaris.filesystem.path.excludes=/system**,/tmp**,/dev,/dev/fd**
 oshi.os.solaris.filesystem.volume.excludes=rpool
+
+# List of types inside /sys/class/thermal/thermal_zone*/type to detect as CPU temperature.
+# The order of entries in the list does represent the priority, the first match will be used.
+oshi.os.linux.sensors.cpuTemperature.types=cpu-thermal,x86_pkg_temp


### PR DESCRIPTION
This PR will add a priority to the thermal zones, in the past the last termal zone found was reported as CPU temp.
In my local system this resolves to the sensor on the M2 disk, this might be the reason for #2791 too.

The priority is defined in a local list and unmapped types are treated as lowest priority.
In case there are multiple sensor with the same priority the last one does win, like in the past.