### PR TITLE
Fixes manufacturer ID parsing logic in getManufacturerID()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.6.7 (in progress)
 
 * Your contribution here
+* [#2805](https://github.com/oshi/oshi/pull/2805): Fix EdidUtil.getManufacturerID() not reading all bits of id - [@JonathanTheDev](https://github.com/JonathanTheDev).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26), 6.6.2 (2024-07-21), 6.6.3 (2024-08-20), 6.6.4 (2024-09-15), 6.6.5 (2024-09-16), 6.6.6 (2025-01-25)
 

--- a/oshi-core/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-core/src/main/java/oshi/util/EdidUtil.java
@@ -40,8 +40,8 @@ public final class EdidUtil {
                 Integer.toBinaryString(edid[9] & 0xFF)).replace(' ', '0');
         LOG.debug("Manufacurer ID: {}", temp);
         return String.format(Locale.ROOT, "%s%s%s", (char) (64 + Integer.parseInt(temp.substring(1, 6), 2)),
-                (char) (64 + Integer.parseInt(temp.substring(7, 11), 2)),
-                (char) (64 + Integer.parseInt(temp.substring(12, 16), 2))).replace("@", "");
+                (char) (64 + Integer.parseInt(temp.substring(6, 11), 2)),
+                (char) (64 + Integer.parseInt(temp.substring(11, 16), 2))).replace("@", "");
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-core/src/main/java/oshi/util/EdidUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OSHI Project Contributors
+ * Copyright 2016-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util;

--- a/oshi-core/src/test/java/oshi/util/EdidUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/EdidUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 The OSHI Project Contributors
+ * Copyright 2016-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util;

--- a/oshi-core/src/test/java/oshi/util/EdidUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/EdidUtilTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 class EdidUtilTest {
 
     private static final String EDID_HEADER = "00FFFFFFFFFFFF00";
-    private static final String EDID_MANUFID = "0610";
+    private static final String EDID_MANUFID = "06af";
     private static final String EDID_PRODCODE = "2792";
     private static final String EDID_SERIAL = "250C2C16";
     private static final String EDID_WKYR = "2C16";
@@ -43,7 +43,7 @@ class EdidUtilTest {
 
     @Test
     void testGetEdidAttrs() {
-        assertThat("manufacturerId", EdidUtil.getManufacturerID(EDID), is("A"));
+        assertThat("manufacturerId", EdidUtil.getManufacturerID(EDID), is("AUO"));
         assertThat("productId", EdidUtil.getProductID(EDID), is("9227"));
         assertThat("serialNo", EdidUtil.getSerialNo(EDID), is("162C0C25"));
         assertThat("week", EdidUtil.getWeek(EDID), is((byte) 44));


### PR DESCRIPTION
 It used to miss a few bits on the second and third, see issue #2803. 

This pull request changes the substring in the method to include the right bits.