### PR TITLE
Fetch CPU temperature, Fan speeds and CPU voltage by jLibreHardwareMonitor

### DIFF
--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -60,6 +60,11 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.pandalxb</groupId>
+            <artifactId>jLibreHardwareMonitor</artifactId>
+            <version>${jlibrehardwaremonitor.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensors.java
@@ -4,29 +4,35 @@
  */
 package oshi.hardware.platform.windows;
 
-import com.sun.jna.platform.win32.COM.COMException;
-import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import io.github.pandalxb.jlibrehardwaremonitor.config.ComputerConfig;
 import io.github.pandalxb.jlibrehardwaremonitor.manager.LibreHardwareManager;
 import io.github.pandalxb.jlibrehardwaremonitor.model.Sensor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.sun.jna.platform.win32.COM.COMException;
+import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
+
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.windows.wmi.*;
+import oshi.driver.windows.wmi.MSAcpiThermalZoneTemperature;
 import oshi.driver.windows.wmi.MSAcpiThermalZoneTemperature.TemperatureProperty;
+import oshi.driver.windows.wmi.OhmHardware;
 import oshi.driver.windows.wmi.OhmHardware.IdentifierProperty;
+import oshi.driver.windows.wmi.OhmSensor;
 import oshi.driver.windows.wmi.OhmSensor.ValueProperty;
+import oshi.driver.windows.wmi.Win32Fan;
 import oshi.driver.windows.wmi.Win32Fan.SpeedProperty;
+import oshi.driver.windows.wmi.Win32Processor;
 import oshi.driver.windows.wmi.Win32Processor.VoltProperty;
 import oshi.hardware.common.AbstractSensors;
 import oshi.util.platform.windows.WmiQueryHandler;
 import oshi.util.platform.windows.WmiUtil;
-
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Sensors from WMI or Open Hardware Monitor

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensors.java
@@ -4,40 +4,29 @@
  */
 package oshi.hardware.platform.windows;
 
-import java.util.Arrays;
+import com.sun.jna.platform.win32.COM.COMException;
+import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
+import io.github.pandalxb.jlibrehardwaremonitor.config.ComputerConfig;
+import io.github.pandalxb.jlibrehardwaremonitor.manager.LibreHardwareManager;
+import io.github.pandalxb.jlibrehardwaremonitor.model.Sensor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.windows.wmi.*;
+import oshi.driver.windows.wmi.MSAcpiThermalZoneTemperature.TemperatureProperty;
+import oshi.driver.windows.wmi.OhmHardware.IdentifierProperty;
+import oshi.driver.windows.wmi.OhmSensor.ValueProperty;
+import oshi.driver.windows.wmi.Win32Fan.SpeedProperty;
+import oshi.driver.windows.wmi.Win32Processor.VoltProperty;
+import oshi.hardware.common.AbstractSensors;
+import oshi.util.platform.windows.WmiQueryHandler;
+import oshi.util.platform.windows.WmiUtil;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import io.github.pandalxb.jlibrehardwaremonitor.config.ComputerConfig;
-import io.github.pandalxb.jlibrehardwaremonitor.manager.LibreHardwareManager;
-import io.github.pandalxb.jlibrehardwaremonitor.model.Sensor;
-import javafx.print.Collation;
-import org.apache.commons.collections4.CollectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.sun.jna.platform.win32.COM.COMException;
-import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
-
-import oshi.SystemInfo;
-import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.windows.wmi.MSAcpiThermalZoneTemperature;
-import oshi.driver.windows.wmi.MSAcpiThermalZoneTemperature.TemperatureProperty;
-import oshi.driver.windows.wmi.OhmHardware;
-import oshi.driver.windows.wmi.OhmHardware.IdentifierProperty;
-import oshi.driver.windows.wmi.OhmSensor;
-import oshi.driver.windows.wmi.OhmSensor.ValueProperty;
-import oshi.driver.windows.wmi.Win32Fan;
-import oshi.driver.windows.wmi.Win32Fan.SpeedProperty;
-import oshi.driver.windows.wmi.Win32Processor;
-import oshi.driver.windows.wmi.Win32Processor.VoltProperty;
-import oshi.hardware.HardwareAbstractionLayer;
-import oshi.hardware.Sensors;
-import oshi.hardware.common.AbstractSensors;
-import oshi.util.platform.windows.WmiQueryHandler;
-import oshi.util.platform.windows.WmiUtil;
 
 /**
  * Sensors from WMI or Open Hardware Monitor
@@ -321,17 +310,5 @@ final class WindowsSensors extends AbstractSensors {
             }
         }
         return 0d;
-    }
-
-    public static void main(String[] args) {
-        SystemInfo si = new SystemInfo();
-        HardwareAbstractionLayer hal = si.getHardware();
-        Sensors sensors = hal.getSensors();
-        double temp = sensors.getCpuTemperature();
-        System.out.println("CPU Temperature:" + temp);
-        int[] fans = sensors.getFanSpeeds();
-        System.out.println("Fan Speeds:" + Arrays.toString(fans));
-        double volts = sensors.getCpuVoltage();
-        System.out.println("CPU Voltage:" + volts);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sortpom-plugin.version>4.0.0</sortpom-plugin.version>
         <spotless-plugin.version>2.44.2</spotless-plugin.version>
+        <jlibrehardwaremonitor.version>1.0.1</jlibrehardwaremonitor.version>
         <!-- report only -->
         <maven-changelog-plugin.version>3.0.0-M1</maven-changelog-plugin.version>
         <maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>


### PR DESCRIPTION
Fetch CPU temperature, Fan speeds and CPU voltage by directly digging into the library LibreHardwareMonitorLib.dll(.NET 4.7.2 and above) or OpenHardwareMonitorLib.dll(.NET 2.0) without applications running on Windows platform.
See Issue #2791 
This pull request supports a new method to fetch sensors values in WindowsSensors.