### PR TITLE
Fetch CPU temperature, Fan speeds and CPU voltage by jLibreHardwareMonitor

### DIFF
--- a/oshi-core-java11/pom.xml
+++ b/oshi-core-java11/pom.xml
@@ -68,6 +68,11 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.pandalxb</groupId>
+            <artifactId>jLibreHardwareMonitor</artifactId>
+            <version>${jlibrehardwaremonitor.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -60,6 +60,11 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.pandalxb</groupId>
+            <artifactId>jLibreHardwareMonitor</artifactId>
+            <version>${jlibrehardwaremonitor.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sortpom-plugin.version>4.0.0</sortpom-plugin.version>
         <spotless-plugin.version>2.44.2</spotless-plugin.version>
+        <jlibrehardwaremonitor.version>1.0.1</jlibrehardwaremonitor.version>
         <!-- report only -->
         <maven-changelog-plugin.version>3.0.0-M1</maven-changelog-plugin.version>
         <maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>


### PR DESCRIPTION
Fetch CPU temperature, Fan speeds and CPU voltage by directly digging into the library LibreHardwareMonitorLib.dll(.NET 4.7.2 and above) or OpenHardwareMonitorLib.dll(.NET 2.0) without applications running on Windows platform.
See issue #2791 
This pull request supports a new method to fetch sensors values in WindowsSensors.