### PR TITLE
Fetch CPU temperature, Fan speeds and CPU voltage by jLibreHardwareMonitor

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -18,6 +18,12 @@
         pkg="com\.sun\.(jna|jna\..*)"
         regex="true" />
 
+    <!-- jlibrehardwaremonitor -->
+    <allow pkg="io.github.pandalxb.jlibrehardwaremonitor" />
+
+    <!-- apache -->
+    <allow pkg="org.apache" />
+
     <!-- slf4j -->
     <allow pkg="org.slf4j" />
 

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -35,6 +35,12 @@
     <allow pkg="com.sun.jna.platform.win32.COM.util.annotation" />
     <allow pkg="com.sun.jna.platform.wince" />
 
+    <!-- jlibrehardwaremonitor -->
+    <allow pkg="io.github.pandalxb.jlibrehardwaremonitor" />
+
+    <!-- apache -->
+    <allow pkg="org.apache" />
+
     <!-- slf4j -->
     <allow pkg="org.slf4j" />
 

--- a/oshi-core-java11/pom.xml
+++ b/oshi-core-java11/pom.xml
@@ -68,6 +68,11 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.pandalxb</groupId>
+            <artifactId>jLibreHardwareMonitor</artifactId>
+            <version>${jlibrehardwaremonitor.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/oshi-core-java11/src/main/java/module-info.java
+++ b/oshi-core-java11/src/main/java/module-info.java
@@ -19,5 +19,9 @@ module com.github.oshi {
     requires com.sun.jna;
     requires com.sun.jna.platform;
     requires transitive java.desktop;
+    requires io.github.pandalxb.jlibrehardwaremonitor.config;
+    requires io.github.pandalxb.jlibrehardwaremonitor.manager;
+    requires io.github.pandalxb.jlibrehardwaremonitor.model;
+    requires org.apache.commons.collections4;
     requires org.slf4j;
 }

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -60,6 +60,11 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.pandalxb</groupId>
+            <artifactId>jLibreHardwareMonitor</artifactId>
+            <version>${jlibrehardwaremonitor.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensors.java
@@ -4,9 +4,15 @@
  */
 package oshi.hardware.platform.windows;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
+import io.github.pandalxb.jlibrehardwaremonitor.config.ComputerConfig;
+import io.github.pandalxb.jlibrehardwaremonitor.manager.LibreHardwareManager;
+import io.github.pandalxb.jlibrehardwaremonitor.model.Sensor;
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +35,7 @@ import oshi.util.platform.windows.WmiQueryHandler;
 import oshi.util.platform.windows.WmiUtil;
 
 /**
- * Sensors from WMI or Open Hardware Monitor
+ * Sensors from WMI or Open Hardware Monitor or Libre Hardware Monitor
  */
 @ThreadSafe
 final class WindowsSensors extends AbstractSensors {
@@ -44,6 +50,13 @@ final class WindowsSensors extends AbstractSensors {
         // as it will give the most accurate results and the time to query (or
         // attempt) is trivial
         double tempC = getTempFromOHM();
+        if (tempC > 0d) {
+            return tempC;
+        }
+
+        // Fetch value from library LibreHardwareMonitorLib.dll(.NET 4.7.2 and above) or OpenHardwareMonitorLib.dll(.NET 2.0)
+        // without applications running
+        tempC = getTempFromLHM();
         if (tempC > 0d) {
             return tempC;
         }
@@ -87,6 +100,23 @@ final class WindowsSensors extends AbstractSensors {
         return 0;
     }
 
+    private static double getTempFromLHM() {
+        LibreHardwareManager instance = LibreHardwareManager.getInstance(ComputerConfig.getInstance().setCpuEnabled(true).setMotherboardEnabled(true));
+        List<Sensor> sensors = instance.querySensors("CPU", "Temperature");
+        if(CollectionUtils.isNotEmpty(sensors)) {
+            double sum = 0;
+            int validCount = 0;
+            for (Sensor sensor : sensors) {
+                if(!sensor.getName().contains("Max") && !sensor.getName().contains("Average") && sensor.getValue() > 0) {
+                    sum += sensor.getValue();
+                    validCount++;
+                }
+            }
+            return validCount > 0 ? sum / validCount : 0;
+        }
+        return 0;
+    }
+
     private static double getTempFromWMI() {
         double tempC = 0d;
         long tempK = 0L;
@@ -107,6 +137,13 @@ final class WindowsSensors extends AbstractSensors {
     public int[] queryFanSpeeds() {
         // Attempt to fetch value from Open Hardware Monitor if it is running
         int[] fanSpeeds = getFansFromOHM();
+        if (fanSpeeds.length > 0) {
+            return fanSpeeds;
+        }
+
+        // Fetch value from library LibreHardwareMonitorLib.dll(.NET 4.7.2 and above) or OpenHardwareMonitorLib.dll(.NET 2.0)
+        // without applications running
+        fanSpeeds = getFansFromLHM();
         if (fanSpeeds.length > 0) {
             return fanSpeeds;
         }
@@ -152,6 +189,18 @@ final class WindowsSensors extends AbstractSensors {
         return new int[0];
     }
 
+    private static int[] getFansFromLHM() {
+        LibreHardwareManager instance = LibreHardwareManager.getInstance(ComputerConfig.getInstance().setCpuEnabled(true).setMotherboardEnabled(true));
+        List<Sensor> sensors = instance.querySensors("SuperIO", "Fan");
+        if(CollectionUtils.isNotEmpty(sensors)) {
+            List<Sensor> validSensors = sensors.stream().filter(sensor -> sensor.getValue() > 0).collect(Collectors.toList());
+            if(CollectionUtils.isNotEmpty(validSensors)) {
+                return validSensors.stream().mapToInt(sensor -> (int) sensor.getValue()).toArray();
+            }
+        }
+        return new int[0];
+    }
+
     private static int[] getFansFromWMI() {
         WmiResult<SpeedProperty> fan = Win32Fan.querySpeed();
         if (fan.getResultCount() > 1) {
@@ -169,6 +218,13 @@ final class WindowsSensors extends AbstractSensors {
     public double queryCpuVoltage() {
         // Attempt to fetch value from Open Hardware Monitor if it is running
         double volts = getVoltsFromOHM();
+        if (volts > 0d) {
+            return volts;
+        }
+
+        // Fetch value from library LibreHardwareMonitorLib.dll(.NET 4.7.2 and above) or OpenHardwareMonitorLib.dll(.NET 2.0)
+        // without applications running
+        volts = getVoltsFromLHM();
         if (volts > 0d) {
             return volts;
         }
@@ -215,6 +271,23 @@ final class WindowsSensors extends AbstractSensors {
             }
         }
         return 0d;
+    }
+
+    private static double getVoltsFromLHM() {
+        LibreHardwareManager instance = LibreHardwareManager.getInstance(ComputerConfig.getInstance().setCpuEnabled(true).setMotherboardEnabled(true));
+        List<Sensor> sensors = instance.querySensors("CPU", "Voltage");
+        if(CollectionUtils.isNotEmpty(sensors)) {
+            double sum = 0;
+            int validCount = 0;
+            for (Sensor sensor : sensors) {
+                if(sensor.getValue() > 0) {
+                    sum += sensor.getValue();
+                    validCount++;
+                }
+            }
+            return validCount > 0 ? sum / validCount : 0;
+        }
+        return 0;
     }
 
     private static double getVoltsFromWMI() {

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sortpom-plugin.version>4.0.0</sortpom-plugin.version>
         <spotless-plugin.version>2.44.2</spotless-plugin.version>
+        <jlibrehardwaremonitor.version>1.0.1</jlibrehardwaremonitor.version>
         <!-- report only -->
         <maven-changelog-plugin.version>3.0.0-M1</maven-changelog-plugin.version>
         <maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
@@ -724,6 +725,8 @@
                                         <allowedImport>java.**</allowedImport>
                                         <!-- Allow known dependencies -->
                                         <allowedImport>com.sun.jna.**</allowedImport>
+                                        <allowedImport>io.github.pandalxb.jlibrehardwaremonitor.**</allowedImport>
+                                        <allowedImport>org.apache.**</allowedImport>
                                         <allowedImport>org.slf4j.**</allowedImport>
                                         <allowedImport>org.junit.jupiter.api.**</allowedImport>
                                         <allowedImport>static org.hamcrest.**</allowedImport>


### PR DESCRIPTION
Fetch CPU temperature, Fan speeds and CPU voltage by directly digging into the library LibreHardwareMonitorLib.dll(.NET 4.7.2 and above) or OpenHardwareMonitorLib.dll(.NET 2.0) without applications running on Windows platform.
See issue #2791 
This pull request supports a new method to fetch sensors values in WindowsSensors.