### PR TITLE
Fetch CPU temperature, Fan speeds and CPU voltage by jLibreHardwareMonitor

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -18,6 +18,9 @@
         pkg="com\.sun\.(jna|jna\..*)"
         regex="true" />
 
+    <!-- jlibrehardwaremonitor -->
+    <allow pkg="io.github.pandalxb.jlibrehardwaremonitor" />
+
     <!-- slf4j -->
     <allow pkg="org.slf4j" />
 

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -35,6 +35,9 @@
     <allow pkg="com.sun.jna.platform.win32.COM.util.annotation" />
     <allow pkg="com.sun.jna.platform.wince" />
 
+    <!-- jlibrehardwaremonitor -->
+    <allow pkg="io.github.pandalxb.jlibrehardwaremonitor" />
+
     <!-- slf4j -->
     <allow pkg="org.slf4j" />
 

--- a/oshi-core-java11/pom.xml
+++ b/oshi-core-java11/pom.xml
@@ -68,6 +68,11 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.pandalxb</groupId>
+            <artifactId>jLibreHardwareMonitor</artifactId>
+            <version>${jlibrehardwaremonitor.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/oshi-core-java11/src/main/java/module-info.java
+++ b/oshi-core-java11/src/main/java/module-info.java
@@ -19,5 +19,6 @@ module com.github.oshi {
     requires com.sun.jna;
     requires com.sun.jna.platform;
     requires transitive java.desktop;
+    requires io.github.pandalxb.jlibrehardwaremonitor;
     requires org.slf4j;
 }

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -60,6 +60,11 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.pandalxb</groupId>
+            <artifactId>jLibreHardwareMonitor</artifactId>
+            <version>${jlibrehardwaremonitor.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <sortpom-plugin.version>4.0.0</sortpom-plugin.version>
         <spotless-plugin.version>2.44.2</spotless-plugin.version>
+        <jlibrehardwaremonitor.version>1.0.2</jlibrehardwaremonitor.version>
         <!-- report only -->
         <maven-changelog-plugin.version>3.0.0-M1</maven-changelog-plugin.version>
         <maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
@@ -724,6 +725,8 @@
                                         <allowedImport>java.**</allowedImport>
                                         <!-- Allow known dependencies -->
                                         <allowedImport>com.sun.jna.**</allowedImport>
+                                        <allowedImport>io.github.pandalxb.jlibrehardwaremonitor.**</allowedImport>
+                                        <allowedImport>org.apache.**</allowedImport>
                                         <allowedImport>org.slf4j.**</allowedImport>
                                         <allowedImport>org.junit.jupiter.api.**</allowedImport>
                                         <allowedImport>static org.hamcrest.**</allowedImport>


### PR DESCRIPTION
Fetch CPU temperature, Fan speeds and CPU voltage by directly digging into the library LibreHardwareMonitorLib.dll(.NET 4.7.2 and above) or OpenHardwareMonitorLib.dll(.NET 2.0) without applications running on Windows platform.
See issue #2791 
This pull request supports a new method to fetch sensors values and fixes code duplication and warning in WindowsSensors.