### PR TITLE
Trim the trailing NUL of /proc/device-tree/model

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -134,7 +134,7 @@ final class LinuxCentralProcessor extends AbstractCentralProcessor {
             }
         }
         if (cpuName.isEmpty()) {
-            cpuName = FileUtil.getStringFromFile(MODEL);
+            cpuName = FileUtil.getStringFromFile(MODEL).trim();
         }
         if (cpuName.contains("Hz")) {
             // if Name contains CPU vendor frequency, ignore cpuinfo and use it


### PR DESCRIPTION
The `/proc/device-tree/model` file usually ends with NUL, but oshi does not trim it.

For example, for the Raspberry Pi 4B, the content of this file is `"Raspberry Pi 4 Model B Rev 1.4\0"`. 

This causes `new oshi.SystemInfo().getHardware().getProcessor().getProcessorIdentifier().getName()` to return a NUL-terminated string if oshi cannot obtain the processor name from `/proc/cpuinfo`.

![image](https://github.com/user-attachments/assets/f621d6f5-09c9-4073-be88-8352cb1323fe)

We should trim the string to avoid this.