### PR TITLE
Modify API description of Sensors

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/Sensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/Sensors.java
@@ -28,6 +28,8 @@ public interface Sensors {
      * CPU Temperature
      *
      * @return CPU Temperature in degrees Celsius if available, 0 or {@link Double#NaN} otherwise.
+     *         <p>
+     *         See notes on <a href="https://www.oshi.ooo/oshi-core-java11/apidocs/com.github.oshi/oshi/hardware/Sensors.html">Sensors</a>.
      */
     double getCpuTemperature();
 

--- a/oshi-core/src/main/java/oshi/hardware/Sensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/Sensors.java
@@ -17,8 +17,8 @@ import oshi.annotation.concurrent.ThreadSafe;
  * Windows information is generally retrieved via Windows Management Instrumentation (WMI). Unfortunately, most hardware
  * providers do not publish sensor values to WMI. OSHI attempts to retrieve values from
  * <a href="https://github.com/LibreHardwareMonitor/LibreHardwareMonitor">LibreHardwareMonitor</a> if the optional
- * <code>jLibreHardwareMonitor</code> dependency is included. Otherwise OSHI attempts to retrieve values from
- * <a href="https://openhardwaremonitor.org/">Open Hardware Monitor</a> if it is running. Otherwise OSHI retrieves via
+ * <a href="https://github.com/pandalxb/jLibreHardwareMonitor">jLibreHardwareMonitor</a> dependency is included. Otherwise, OSHI attempts to retrieve values from
+ * <a href="https://openhardwaremonitor.org/">Open Hardware Monitor</a> if it is running. Otherwise, OSHI retrieves via
  * the Microsoft API, which may require elevated permissions and still may provide no results or unchanging results
  * depending on the motherboard manufacturer.
  */
@@ -28,11 +28,6 @@ public interface Sensors {
      * CPU Temperature
      *
      * @return CPU Temperature in degrees Celsius if available, 0 or {@link Double#NaN} otherwise.
-     *         <p>
-     *         On Windows, if not running Open Hardware Monitor, requires elevated permissions and hardware BIOS that
-     *         supports publishing to WMI. In this case, returns the temperature of the "Thermal Zone" which may be
-     *         different than CPU temperature obtained from other sources. In addition, some motherboards may only
-     *         refresh this value on certain events.
      */
     double getCpuTemperature();
 

--- a/oshi-core/src/main/java/oshi/hardware/Sensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/Sensors.java
@@ -29,7 +29,7 @@ public interface Sensors {
      *
      * @return CPU Temperature in degrees Celsius if available, 0 or {@link Double#NaN} otherwise.
      *         <p>
-     *         See notes on <a href="https://www.oshi.ooo/oshi-core-java11/apidocs/com.github.oshi/oshi/hardware/Sensors.html">Sensors</a>.
+     *         See notes on {@link Sensors}.
      */
     double getCpuTemperature();
 


### PR DESCRIPTION
Add a link to jLibreHardwareMonitor so users know how to include this dependency and remove the duplicate description of getCpuTemperature about OHM.