### PR TITLE
Configure bnd-maven-plugin to make librehardwaremonitor optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@
                     <version>${bnd-maven-plugin.version}</version>
                     <configuration>
                         <bnd><![CDATA[Export-Package: oshi.*;-noimport:=true;-split-package:=merge-first
-                        Import-Package: ${osgi.slf4j.import.packages}, *
+                        Import-Package: io.github.pandalxb.jlibrehardwaremonitor.*;resolution:=optional, ${osgi.slf4j.import.packages}, *
                         Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                         -snapshot: SNAPSHOT]]></bnd>
                     </configuration>


### PR DESCRIPTION
https://github.com/oshi/oshi/issues/2834