### PR TITLE
Linux ARM 64 runner

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         java: [11, 17, 21]
         os: [ubuntu-latest]
+        include:
+          - java: 17
+            os: 'ubuntu-24.04-arm'
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
 


### PR DESCRIPTION
Add a Linux arm64 / Java 17 combo to the build matrix

These are now available in "Public Preview": https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/