### PR TITLE
Windows 2025

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -21,6 +21,10 @@ jobs:
       matrix:
         java: [11, 17]
         os: [windows-2019, windows-2022]
+        include:
+          - java: 21
+            os: 'windows-2025'
+            experimental: true
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
 


### PR DESCRIPTION
Add Windows 2025 / Java 21 combination to build matrix. Windows 2025 is in "Public Preview" so marking as experimental