### PR TITLE
Improve Windows baseboard model identification

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,6 @@ jobs:
         if: contains(matrix.os, 'ubuntu') && contains(matrix.java, '11')
         run: ./mvnw compile forbiddenapis:check forbiddenapis:testCheck
       - name: Test with Maven
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos') || contains(matrix.java, '11') || contains(matrix.java, '17')
         run: ./mvnw test -B
       - name: Upload Coverage
         if: contains(matrix.java, '11')

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -15,11 +15,10 @@ jobs:
   # Runs current branch with multiple JDKs
   testmatrix:
     runs-on: ${{ matrix.os }}
-    # disable on windows JDK18+ until junit-platform-maven-plugin fix
-    # https://github.com/sormuras/junit-platform-maven-plugin/issues/95
+  continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
         os: [windows-2019, windows-2022]
         include:
           - java: 21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 6.7.1 (in progress)
 
-* Your contribution here
+##### Bug fixes / Improvements
+* [#2835](https://github.com/oshi/oshi/pull/2835): Configure bnd-maven-plugin to make librehardwaremonitor optional - [@merks](https://github.com/merks).
+* [#2838](https://github.com/oshi/oshi/pull/2838): Improve Windows baseboard model identification - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.7.0 (2025-02-25)
 

--- a/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32BaseBoard.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32BaseBoard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.wmi;
@@ -24,7 +24,7 @@ public final class Win32BaseBoard {
      * Baseboard description properties.
      */
     public enum BaseBoardProperty {
-        MANUFACTURER, MODEL, VERSION, SERIALNUMBER;
+        MANUFACTURER, MODEL, PRODUCT, VERSION, SERIALNUMBER;
     }
 
     private Win32BaseBoard() {

--- a/oshi-core/src/main/java/oshi/hardware/Sensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/Sensors.java
@@ -17,10 +17,10 @@ import oshi.annotation.concurrent.ThreadSafe;
  * Windows information is generally retrieved via Windows Management Instrumentation (WMI). Unfortunately, most hardware
  * providers do not publish sensor values to WMI. OSHI attempts to retrieve values from
  * <a href="https://github.com/LibreHardwareMonitor/LibreHardwareMonitor">LibreHardwareMonitor</a> if the optional
- * <a href="https://github.com/pandalxb/jLibreHardwareMonitor">jLibreHardwareMonitor</a> dependency is included. Otherwise, OSHI attempts to retrieve values from
- * <a href="https://openhardwaremonitor.org/">Open Hardware Monitor</a> if it is running. Otherwise, OSHI retrieves via
- * the Microsoft API, which may require elevated permissions and still may provide no results or unchanging results
- * depending on the motherboard manufacturer.
+ * <a href="https://github.com/pandalxb/jLibreHardwareMonitor">jLibreHardwareMonitor</a> dependency is included.
+ * Otherwise, OSHI attempts to retrieve values from <a href="https://openhardwaremonitor.org/">Open Hardware Monitor</a>
+ * if it is running. Otherwise, OSHI retrieves via the Microsoft API, which may require elevated permissions and still
+ * may provide no results or unchanging results depending on the motherboard manufacturer.
  */
 @ThreadSafe
 public interface Sensors {

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsBaseboard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsBaseboard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 The OSHI Project Contributors
+ * Copyright 2016-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.windows;
@@ -57,6 +57,10 @@ final class WindowsBaseboard extends AbstractBaseboard {
         if (win32BaseBoard.getResultCount() > 0) {
             manufacturer = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.MANUFACTURER, 0);
             model = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.MODEL, 0);
+            String product = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.PRODUCT, 0);
+            if (!Util.isBlank(product)) {
+                model = Util.isBlank(model) ? product : (model + " (" + product + ")");
+            }
             version = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.VERSION, 0);
             serialNumber = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.SERIALNUMBER, 0);
         }


### PR DESCRIPTION
Adds the PRODUCT field on Win32_Baseboard as a backup for (or amplification of) the MODEL field.

Fixes #2831 