### PR TITLE
Resolve Windows Server 2025 on older JDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug fixes / Improvements
 * [#2835](https://github.com/oshi/oshi/pull/2835): Configure bnd-maven-plugin to make librehardwaremonitor optional - [@merks](https://github.com/merks).
 * [#2838](https://github.com/oshi/oshi/pull/2838): Improve Windows baseboard model identification - [@dbwiddis](https://github.com/dbwiddis).
+* [#2841](https://github.com/oshi/oshi/pull/2841): Resolve Windows Server 2025 on older JDKs - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.7.0 (2025-02-25)
 

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OSHI Project Contributors
+ * Copyright 2016-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.windows;
@@ -155,8 +155,15 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         // Older JDKs don't recognize Win11 and Server2022
         if ("10".equals(version) && buildNumber.compareTo("22000") >= 0) {
             version = "11";
-        } else if ("Server 2019".equals(version) && buildNumber.compareTo("20347") > 0) {
+        }
+        if ("Server 2016".equals(version) && buildNumber.compareTo("17762") > 0) {
+            version = "Server 2019";
+        }
+        if ("Server 2019".equals(version) && buildNumber.compareTo("20347") > 0) {
             version = "Server 2022";
+        }
+        if ("Server 2022".equals(version) && buildNumber.compareTo("26039") > 0) {
+            version = "Server 2025";
         }
         return new Pair<>("Windows", new OSVersionInfo(version, codeName, buildNumber));
     }


### PR DESCRIPTION
Users who keep their JDKs up to date (like GitHub runners) already have proper parsing, but for earlier patch versions of the JDK, this accomplishes the same logic.