### PR TITLE
Optimize netstat calls using /proc files (Issue #2826)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#2838](https://github.com/oshi/oshi/pull/2838): Improve Windows baseboard model identification - [@dbwiddis](https://github.com/dbwiddis).
 * [#2841](https://github.com/oshi/oshi/pull/2841): Resolve Windows Server 2025 on older JDKs - [@dbwiddis](https://github.com/dbwiddis).
 * [#2843](https://github.com/oshi/oshi/pull/2843): Allow System Properties to override oshi.properties values - [@dbwiddis](https://github.com/dbwiddis).
+* [#2848](https://github.com/oshi/oshi/pull/2846): Optimize netstat calls using /proc files - [@rohan-coder02](https://github.com/rohan-coder02).
 
 # 6.7.0 (2025-02-25)
 

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 The OSHI Project Contributors
+ * Copyright 2020-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.linux;
@@ -18,14 +18,12 @@ import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
 import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.linux.proc.ProcessStat;
-import oshi.driver.unix.NetStat;
 import oshi.software.common.AbstractInternetProtocolStats;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
@@ -43,98 +41,101 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
     private final String UDP6 = "Udp6";
 
     private enum TcpStat {
-        CurrEstab, ActiveOpens, PassiveOpens, AttemptFails, EstabResets, OutSegs, InSegs, RetransSegs, InErrs, OutRsts
+        TcpColon, RtoAlgorithm, RtoMin, RtoMax, MaxConn, ActiveOpens, PassiveOpens, AttemptFails, EstabResets,
+        CurrEstab, InSegs, OutSegs, RetransSegs, InErrs, OutRsts, InCsumErrors;
     }
 
     private enum UdpStat {
-        OutDatagrams, InDatagrams, NoPorts, InErrors
+        UdpColon, OutDatagrams, InDatagrams, NoPorts, InErrors, RcvbufErrors, SndbufErrors, InCsumErrors, IgnoredMulti,
+        MemErrors;
     }
 
     @Override
     public TcpStats getTCPv4Stats() {
         byte[] fileBytes = FileUtil.readAllBytes(ProcPath.SNMP, true);
-        String content = new String(fileBytes);
-        List<String> lines = Arrays.asList(content.split("\\n"));
+        List<String> lines = ParseUtil.parseByteArrayToStrings(fileBytes);
         Map<TcpStat, Long> tcpData = new EnumMap<>(TcpStat.class);
 
-        for (int line = 0; line < lines.size() - 1; line++) {
+        for (int line = 0; line < lines.size() - 1; line += 2) {
             if (lines.get(line).startsWith(TCP_COLON) && lines.get(line + 1).startsWith(TCP_COLON)) {
-                String[] headers = lines.get(line).split("\\s+");
-                String[] values = lines.get(line + 1).split("\\s+");
-                for (int header = 1; header < headers.length; header++) {
-                    try {
-                        TcpStat key = TcpStat.valueOf(headers[header]);
-                        long value = Long.parseLong(values[header]);
-                        tcpData.put(key, value);
-                    } catch (IllegalArgumentException e) {
-                        // Ignore fields that are not in TcpStat enum
+                Map<TcpStat, String> parsedData = ParseUtil.stringToEnumMap(TcpStat.class, lines.get(line + 1), ' ');
+                for (Map.Entry<TcpStat, String> entry : parsedData.entrySet()) {
+                    if (entry.getKey().equals(TcpStat.TcpColon)) {
+                        continue; // Skip "Tcp:"
                     }
+                    tcpData.put(entry.getKey(), Long.parseLong(entry.getValue()));
                 }
                 break;
             }
         }
 
         return new TcpStats(tcpData.getOrDefault(TcpStat.CurrEstab, 0L), tcpData.getOrDefault(TcpStat.ActiveOpens, 0L),
-            tcpData.getOrDefault(TcpStat.PassiveOpens, 0L), tcpData.getOrDefault(TcpStat.AttemptFails, 0L),
-            tcpData.getOrDefault(TcpStat.EstabResets, 0L), tcpData.getOrDefault(TcpStat.OutSegs, 0L),
-            tcpData.getOrDefault(TcpStat.InSegs, 0L), tcpData.getOrDefault(TcpStat.RetransSegs, 0L),
-            tcpData.getOrDefault(TcpStat.InErrs, 0L), tcpData.getOrDefault(TcpStat.OutRsts, 0L));
+                tcpData.getOrDefault(TcpStat.PassiveOpens, 0L), tcpData.getOrDefault(TcpStat.AttemptFails, 0L),
+                tcpData.getOrDefault(TcpStat.EstabResets, 0L), tcpData.getOrDefault(TcpStat.OutSegs, 0L),
+                tcpData.getOrDefault(TcpStat.InSegs, 0L), tcpData.getOrDefault(TcpStat.RetransSegs, 0L),
+                tcpData.getOrDefault(TcpStat.InErrs, 0L), tcpData.getOrDefault(TcpStat.OutRsts, 0L));
     }
 
     @Override
     public UdpStats getUDPv4Stats() {
         byte[] fileBytes = FileUtil.readAllBytes(ProcPath.SNMP, true);
-        String content = new String(fileBytes);
-        List<String> lines = Arrays.asList(content.split("\\n"));
+        List<String> lines = ParseUtil.parseByteArrayToStrings(fileBytes);
         Map<UdpStat, Long> udpData = new EnumMap<>(UdpStat.class);
 
-        for (int line = 0; line < lines.size() - 1; line++) {
+        for (int line = 0; line < lines.size() - 1; line += 2) {
             if (lines.get(line).startsWith(UDP_COLON) && lines.get(line + 1).startsWith(UDP_COLON)) {
-                String[] headers = lines.get(line).split("\\s+");
-                String[] values = lines.get(line + 1).split("\\s+");
-                for (int header = 1; header < headers.length; header++) {
-                    try {
-                        UdpStat key = UdpStat.valueOf(headers[header]);
-                        long value = Long.parseLong(values[header]);
-                        udpData.put(key, value);
-                    } catch (IllegalArgumentException e) {
-                        // Ignore fields that are not in UdpStat enum
+                Map<UdpStat, String> parsedData = ParseUtil.stringToEnumMap(UdpStat.class, lines.get(line + 1), ' ');
+                for (Map.Entry<UdpStat, String> entry : parsedData.entrySet()) {
+                    if (entry.getKey().equals(UdpStat.UdpColon)) {
+                        continue; // Skip "Udp:"
                     }
+                    udpData.put(entry.getKey(), Long.parseLong(entry.getValue()));
                 }
                 break;
             }
         }
 
         return new UdpStats(udpData.getOrDefault(UdpStat.OutDatagrams, 0L),
-            udpData.getOrDefault(UdpStat.InDatagrams, 0L), udpData.getOrDefault(UdpStat.NoPorts, 0L),
-            udpData.getOrDefault(UdpStat.InErrors, 0L));
+                udpData.getOrDefault(UdpStat.InDatagrams, 0L), udpData.getOrDefault(UdpStat.NoPorts, 0L),
+                udpData.getOrDefault(UdpStat.InErrors, 0L));
     }
 
     @Override
     public UdpStats getUDPv6Stats() {
         byte[] fileBytes = FileUtil.readAllBytes(ProcPath.SNMP6, true);
-        String content = new String(fileBytes);
-        List<String> lines = Arrays.asList(content.split("\\n"));
-        Map<UdpStat, Long> udpData = new EnumMap<>(UdpStat.class);
+        List<String> lines = ParseUtil.parseByteArrayToStrings(fileBytes);
+        long inDatagrams = 0, noPorts = 0, inErrors = 0, outDatagrams = 0;
+        int foundUDPv6StatsCount = 0;
 
-        for (String line : lines) {
-            String[] parts = line.split("\\t");
-            if (parts.length == 2 && parts[0].startsWith(UDP6)) {
-                try {
-                    // Remove "Udp6" prefix and map to enum
-                    String keyName = parts[0].substring(4);
-                    UdpStat key = UdpStat.valueOf(keyName);
-                    long value = Long.parseLong(parts[1]);
-                    udpData.put(key, value);
-                } catch (IllegalArgumentException e) {
-                    // Ignore fields that are not in UdpStat enum
+        // Traverse bottom-to-top for efficiency as the /etc/proc/snmp6 file follows sequential format -> ip6, icmp6,
+        // udp6 stats
+        for (int line = lines.size() - 1; line >= 0 && foundUDPv6StatsCount < 4; line--) {
+            if (lines.get(line).startsWith(UDP6)) {
+                String[] parts = lines.get(line).split("\\s+");
+                switch (parts[0]) {
+                case "Udp6InDatagrams":
+                    inDatagrams = Long.parseLong(parts[1]);
+                    foundUDPv6StatsCount++;
+                    break;
+                case "Udp6NoPorts":
+                    noPorts = Long.parseLong(parts[1]);
+                    foundUDPv6StatsCount++;
+                    break;
+                case "Udp6InErrors":
+                    inErrors = Long.parseLong(parts[1]);
+                    foundUDPv6StatsCount++;
+                    break;
+                case "Udp6OutDatagrams":
+                    outDatagrams = Long.parseLong(parts[1]);
+                    foundUDPv6StatsCount++;
+                    break;
+                default:
+                    break;
                 }
             }
         }
 
-        return new UdpStats(udpData.getOrDefault(UdpStat.OutDatagrams, 0L),
-            udpData.getOrDefault(UdpStat.InDatagrams, 0L), udpData.getOrDefault(UdpStat.NoPorts, 0L),
-            udpData.getOrDefault(UdpStat.InErrors, 0L));
+        return new UdpStats(inDatagrams, noPorts, inErrors, outDatagrams);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxInternetProtocolStats.java
@@ -18,6 +18,8 @@ import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
 import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,19 +38,103 @@ import oshi.util.tuples.Pair;
 @ThreadSafe
 public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
 
+    private final String TCP_COLON = "Tcp:";
+    private final String UDP_COLON = "Udp:";
+    private final String UDP6 = "Udp6";
+
+    private enum TcpStat {
+        CurrEstab, ActiveOpens, PassiveOpens, AttemptFails, EstabResets, OutSegs, InSegs, RetransSegs, InErrs, OutRsts
+    }
+
+    private enum UdpStat {
+        OutDatagrams, InDatagrams, NoPorts, InErrors
+    }
+
     @Override
     public TcpStats getTCPv4Stats() {
-        return NetStat.queryTcpStats("netstat -st4");
+        byte[] fileBytes = FileUtil.readAllBytes(ProcPath.SNMP, true);
+        String content = new String(fileBytes);
+        List<String> lines = Arrays.asList(content.split("\\n"));
+        Map<TcpStat, Long> tcpData = new EnumMap<>(TcpStat.class);
+
+        for (int line = 0; line < lines.size() - 1; line++) {
+            if (lines.get(line).startsWith(TCP_COLON) && lines.get(line + 1).startsWith(TCP_COLON)) {
+                String[] headers = lines.get(line).split("\\s+");
+                String[] values = lines.get(line + 1).split("\\s+");
+                for (int header = 1; header < headers.length; header++) {
+                    try {
+                        TcpStat key = TcpStat.valueOf(headers[header]);
+                        long value = Long.parseLong(values[header]);
+                        tcpData.put(key, value);
+                    } catch (IllegalArgumentException e) {
+                        // Ignore fields that are not in TcpStat enum
+                    }
+                }
+                break;
+            }
+        }
+
+        return new TcpStats(tcpData.getOrDefault(TcpStat.CurrEstab, 0L), tcpData.getOrDefault(TcpStat.ActiveOpens, 0L),
+            tcpData.getOrDefault(TcpStat.PassiveOpens, 0L), tcpData.getOrDefault(TcpStat.AttemptFails, 0L),
+            tcpData.getOrDefault(TcpStat.EstabResets, 0L), tcpData.getOrDefault(TcpStat.OutSegs, 0L),
+            tcpData.getOrDefault(TcpStat.InSegs, 0L), tcpData.getOrDefault(TcpStat.RetransSegs, 0L),
+            tcpData.getOrDefault(TcpStat.InErrs, 0L), tcpData.getOrDefault(TcpStat.OutRsts, 0L));
     }
 
     @Override
     public UdpStats getUDPv4Stats() {
-        return NetStat.queryUdpStats("netstat -su4");
+        byte[] fileBytes = FileUtil.readAllBytes(ProcPath.SNMP, true);
+        String content = new String(fileBytes);
+        List<String> lines = Arrays.asList(content.split("\\n"));
+        Map<UdpStat, Long> udpData = new EnumMap<>(UdpStat.class);
+
+        for (int line = 0; line < lines.size() - 1; line++) {
+            if (lines.get(line).startsWith(UDP_COLON) && lines.get(line + 1).startsWith(UDP_COLON)) {
+                String[] headers = lines.get(line).split("\\s+");
+                String[] values = lines.get(line + 1).split("\\s+");
+                for (int header = 1; header < headers.length; header++) {
+                    try {
+                        UdpStat key = UdpStat.valueOf(headers[header]);
+                        long value = Long.parseLong(values[header]);
+                        udpData.put(key, value);
+                    } catch (IllegalArgumentException e) {
+                        // Ignore fields that are not in UdpStat enum
+                    }
+                }
+                break;
+            }
+        }
+
+        return new UdpStats(udpData.getOrDefault(UdpStat.OutDatagrams, 0L),
+            udpData.getOrDefault(UdpStat.InDatagrams, 0L), udpData.getOrDefault(UdpStat.NoPorts, 0L),
+            udpData.getOrDefault(UdpStat.InErrors, 0L));
     }
 
     @Override
     public UdpStats getUDPv6Stats() {
-        return NetStat.queryUdpStats("netstat -su6");
+        byte[] fileBytes = FileUtil.readAllBytes(ProcPath.SNMP6, true);
+        String content = new String(fileBytes);
+        List<String> lines = Arrays.asList(content.split("\\n"));
+        Map<UdpStat, Long> udpData = new EnumMap<>(UdpStat.class);
+
+        for (String line : lines) {
+            String[] parts = line.split("\\t");
+            if (parts.length == 2 && parts[0].startsWith(UDP6)) {
+                try {
+                    // Remove "Udp6" prefix and map to enum
+                    String keyName = parts[0].substring(4);
+                    UdpStat key = UdpStat.valueOf(keyName);
+                    long value = Long.parseLong(parts[1]);
+                    udpData.put(key, value);
+                } catch (IllegalArgumentException e) {
+                    // Ignore fields that are not in UdpStat enum
+                }
+            }
+        }
+
+        return new UdpStats(udpData.getOrDefault(UdpStat.OutDatagrams, 0L),
+            udpData.getOrDefault(UdpStat.InDatagrams, 0L), udpData.getOrDefault(UdpStat.NoPorts, 0L),
+            udpData.getOrDefault(UdpStat.InErrors, 0L));
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -1221,7 +1221,7 @@ public final class ParseUtil {
         int end = 0;
         // Iterate characters
         do {
-            // If we've reached a delimiter or the end of the array, add to list
+            // If we've reached a delimiter or the end of the array or new line (linux), add to list
             if (end == bytes.length || bytes[end] == 0 || bytes[end] == '\n') {
                 // Zero length string means two nulls, we're done
                 if (start == end) {

--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -1222,7 +1222,7 @@ public final class ParseUtil {
         // Iterate characters
         do {
             // If we've reached a delimiter or the end of the array, add to list
-            if (end == bytes.length || bytes[end] == 0) {
+            if (end == bytes.length || bytes[end] == 0 || bytes[end] == '\n') {
                 // Zero length string means two nulls, we're done
                 if (start == end) {
                     break;

--- a/oshi-core/src/main/java/oshi/util/platform/linux/ProcPath.java
+++ b/oshi-core/src/main/java/oshi/util/platform/linux/ProcPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 The OSHI Project Contributors
+ * Copyright 2020-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.linux;

--- a/oshi-core/src/main/java/oshi/util/platform/linux/ProcPath.java
+++ b/oshi-core/src/main/java/oshi/util/platform/linux/ProcPath.java
@@ -41,6 +41,8 @@ public final class ProcPath {
     public static final String PID_STATM = PROC + "/%d/statm";
     public static final String PID_STATUS = PROC + "/%d/status";
     public static final String SELF_STAT = PROC + "/self/stat";
+    public static final String SNMP = NET + "/snmp";
+    public static final String SNMP6 = NET + "/snmp6";
     public static final String STAT = PROC + "/stat";
     public static final String SYS_FS_FILE_NR = PROC + "/sys/fs/file-nr";
     public static final String SYS_FS_FILE_MAX = PROC + "/sys/fs/file-max";


### PR DESCRIPTION
### Title:

Optimize calls to netstat by using /proc files (Issue #2826)

### Description:

This PR optimizes the retrieval of network statistics by replacing external netstat calls with direct file reads from /proc/net/snmp (TCPv4 and UDPv4) and /proc/net/snmp6 (UDPv6).

### Changes Made:

- Replaced netstat calls with parsing /proc/net/snmp (TCPv4 and UDPv4) and /proc/net/snmp6 (UDPv6)
- Updated LinuxInternetProtocolStats.java to extract TCP and UDP statistics 

### Testing Done:

- Verified that the extracted TCP/UDP statistics match the output from cat /proc/net/snmp and cat /proc/net/snmp6
- Confirmed correctness by comparing values before and after changes
- Tested on various flavors of Linux such as Redhat, Amazon Linux 2, etc by creating a simple Java App and printing the TCP and UDP stats
