### PR TITLE
Include 3D controller ([0302]) in Linux GPU detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.7.2 (in progress)
 
-* Your contribution here!
+##### Bug fixes / Improvements
+* [#2849](https://github.com/oshi/oshi/pull/2846): Include 3D controller ([0302]) in Linux GPU detection - [@lesley29](https://github.com/lesley29).
 
 # 6.7.0 (2025-02-25), 6.7.1 (2025-03-12)
 
@@ -15,7 +16,6 @@
 * [#2841](https://github.com/oshi/oshi/pull/2841): Resolve Windows Server 2025 on older JDKs - [@dbwiddis](https://github.com/dbwiddis).
 * [#2843](https://github.com/oshi/oshi/pull/2843): Allow System Properties to override oshi.properties values - [@dbwiddis](https://github.com/dbwiddis).
 * [#2848](https://github.com/oshi/oshi/pull/2846): Optimize netstat calls using /proc files - [@rohan-coder02](https://github.com/rohan-coder02).
-* [#2849](https://github.com/oshi/oshi/pull/2846): Include 3D controller ([0302]) in Linux GPU detection - [@lesley29](https://github.com/lesley29).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26), 6.6.2 (2024-07-21), 6.6.3 (2024-08-20), 6.6.4 (2024-09-15), 6.6.5 (2024-09-16), 6.6.6 (2025-01-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2841](https://github.com/oshi/oshi/pull/2841): Resolve Windows Server 2025 on older JDKs - [@dbwiddis](https://github.com/dbwiddis).
 * [#2843](https://github.com/oshi/oshi/pull/2843): Allow System Properties to override oshi.properties values - [@dbwiddis](https://github.com/dbwiddis).
 * [#2848](https://github.com/oshi/oshi/pull/2846): Optimize netstat calls using /proc files - [@rohan-coder02](https://github.com/rohan-coder02).
+* [#2849](https://github.com/oshi/oshi/pull/2846): Include 3D controller ([0302]) in Linux GPU detection - [@lesley29](https://github.com/lesley29).
 
 # 6.6.0 (2024-04-13), 6.6.1 (2024-05-26), 6.6.2 (2024-07-21), 6.6.3 (2024-08-20), 6.6.4 (2024-09-15), 6.6.5 (2024-09-16), 6.6.6 (2025-01-25)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGraphicsCard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.linux;
@@ -61,8 +61,8 @@ final class LinuxGraphicsCard extends AbstractGraphicsCard {
         for (String line : lspci) {
             String[] split = line.trim().split(":", 2);
             String prefix = split[0];
-            // Skip until line contains "VGA"
-            if (prefix.equals("Class") && line.contains("VGA")) {
+            // Skip until line contains "VGA" or "3D controller"
+            if (prefix.equals("Class") && (line.contains("VGA") || line.contains("3D controller"))) {
                 found = true;
             } else if (prefix.equals("Device") && !found && split.length > 1) {
                 lookupDevice = split[1].trim();


### PR DESCRIPTION
This PR extends the Linux GPU detection logic to recognize 3D controller devices (class [0302]) in addition to the existing VGA class check. Many discrete NVIDIA GPUs (such as the RTX A2000) are now reported as "3D controller" instead of "VGA", causing OSHI to miss them when multiple GPUs are present, for instance, in systems with both an integrated GPU and a discrete GPU. In cases where only a single GPU is present, the current code falls back to using `lshw` to retrieve GPU info, which usually works as expected. However, because the lspci-based detection is used first, the discrete dGPU isn’t detected unless we also check for the 3d controller class. For example, consider this `lspci` output for two cards:
```
Class: VGA compatible controller [0300] 
Vendor: Intel Corporation [8086] 
Device: Alder Lake-P GT2 [Iris Xe Graphics] [46a6]
...
Class: 3D controller [0302]
Vendor: NVIDIA Corporation [10de]
Device: GA107GLM [RTX A2000 ...]
```

**Note on tests**
I noticed in the commit history that there was an attempt to add a mocking library for testing `ExecutingCommand.runNative`, but it was eventually removed. Since this is a small fix, I validated it locally instead of introducing a new mocking framework. If there’s a preferred approach to testing this functionality, please let me know and I’ll adjust accordingly.