### PR TITLE
Handle 4 years digit format on macOS system_profiler output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.8.2 (in progress)
 
-* Your contribution here!
+##### Bug fixes / Improvements
+* [#2889](https://github.com/oshi/oshi/pull/2889): Include fallback on macos getInstalledApps for systems with 4 year digits on date format - [@dyorgio](https://github.com/dyorgio).
 
 # 6.8.0 (2025-03-22), 6.8.1 (2025-04-15)
 

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInstalledApps.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInstalledApps.java
@@ -68,6 +68,10 @@ public final class MacInstalledApps {
 
         String lastModified = details.getOrDefault("Last Modified", Constants.UNKNOWN);
         long lastModifiedEpoch = ParseUtil.parseDateToEpoch(lastModified, "dd/MM/yy, HH:mm");
+        if (lastModifiedEpoch == 0) {
+            // Fallback to 4 digits year format
+            lastModifiedEpoch = ParseUtil.parseDateToEpoch(lastModified, "dd/MM/yyyy, HH:mm");
+        }
 
         // Additional info map
         Map<String, String> additionalInfo = new HashMap<>();


### PR DESCRIPTION
Some macOS installations have 4 digits years on Last Modified dates of system_profiler SPApplicationsDataType output.
This commit includes a fallback to theses scenarios.