### PR TITLE
add missing = to a key-value pair from oshi.architecture.properties

### DIFF
--- a/oshi-core/src/main/resources/oshi.architecture.properties
+++ b/oshi-core/src/main/resources/oshi.architecture.properties
@@ -65,7 +65,7 @@ hw_impl.0xc0=Ampere
 6.90=Silvermont
 6.87=Knights Landing
 6.86=Broadwell (Server)
-6.85.10 Cooper Lake
+6.85.10=Cooper Lake
 6.85.7=Cascade Lake
 6.85.6=Cascade Lake
 6.85.5=Cascade Lake


### PR DESCRIPTION
See issue #2892