### PR TITLE
feat: add jbang catalog for demo apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,29 @@ git clone https://github.com/oshi/oshi.git && cd oshi
 
 Some settings are configurable in the [`oshi.properties`](https://github.com/oshi/oshi/blob/master/oshi-core/src/main/resources/oshi.properties) file, which may also be manipulated using the [`GlobalConfig`](https://oshi.github.io/oshi/oshi-core/apidocs/oshi/util/GlobalConfig.html) class or using Java System Properties. This should be done at startup, as configuration is not thread-safe and OSHI does not guarantee re-reading the configuration during operation.
 
+Demo
+----
+
 The `oshi-demo` artifact includes [several proof-of-concept examples](https://github.com/oshi/oshi/blob/master/oshi-demo/src/main/java/oshi/demo/) of using OSHI to obtain information, including a basic Swing GUI.
+
+You can run some of the demos using `jbang`, you can list the available demos with:
+
+```sh
+jbang alias list oshi/oshi
+```
+
+and then run the demo you want to run, for example:
+
+```sh
+jbang json@oshi/oshi
+```
+
+or 
+
+```sh
+jbang gui@oshi/oshi
+```
+
 
 Supported Features
 ------------------

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,31 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "json": {
+      "script-ref": "com.github.oshi:oshi-demo:RELEASE",
+      "main": "oshi.demo.Json",
+      "java-agents": []
+    },
+    "gui": {
+      "script-ref": "com.github.oshi:oshi-demo:RELEASE",
+      "main": "oshi.demo.OshiGui",
+      "java-agents": []
+    },
+    "detectvm": {
+      "script-ref": "com.github.oshi:oshi-demo:RELEASE",
+      "main": "oshi.demo.DetectVM",
+      "java-agents": []
+    },
+    "id": {
+      "script-ref": "com.github.oshi:oshi-demo:RELEASE",
+      "main": "oshi.demo.ComputerID",
+      "java-agents": []
+    },
+    "diskstore": {
+      "script-ref": "com.github.oshi:oshi-demo:RELEASE",
+      "main": "oshi.demo.DiskStoreForPath",
+      "java-agents": []
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
you can run demo apps using jbang like `jbang -m oshi.demo.OshiGui com.github.oshi:oshi-demo:RELEASE` which is nice, but this commit just makes it a tad easier to run some of the demo apps using jbang.

when this is committed you should be able to do: `jbang alias list oshi/oshi` and get something like:

```
detectvm@oshi/oshi
   com.github.oshi:oshi-demo:RELEASE
         Main Class: oshi.demo.DetectVM
diskstore@oshi/oshi
   com.github.oshi:oshi-demo:RELEASE
         Main Class: oshi.demo.DiskStoreForPath
gui@oshi/oshi
   com.github.oshi:oshi-demo:RELEASE
         Main Class: oshi.demo.OshiGui
id@oshi/oshi
   com.github.oshi:oshi-demo:RELEASE
         Main Class: oshi.demo.ComputerID
json@oshi/oshi
   com.github.oshi:oshi-demo:RELEASE
         Main Class: oshi.demo.Json
```

which means you can now run each of these with just `jbang gui@oshi/oshi` 

Which I think is nice :)


