### PR TITLE
Installed apps feature for AIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # 6.8.3 (in progress)
 
-##### New Features
-
-* [#2912](https://github.com/oshi/oshi/pull/2912): Installed apps feature for AIX - [@rohan-coder02](https://github.com/rohan-coder02).
-
 ##### Bug fixes / Improvements
 * [#2902](https://github.com/oshi/oshi/pull/2902): Deduplicate installed applications using Set across Windows, Linux, MacOS and Read both 32-bit, 64-bit Windows registry keys when fetching installed apps - [@rohan-coder02](https://github.com/rohan-coder02).
 * [#2908](https://github.com/oshi/oshi/pull/2908): Fix Windows cache size - [@lesley29](https://github.com/dbwiddis).
+* [#2912](https://github.com/oshi/oshi/pull/2912): Installed apps feature for AIX - [@rohan-coder02](https://github.com/rohan-coder02).
 
 # 6.8.0 (2025-03-22), 6.8.1 (2025-04-15), 6.8.2 (2025-05-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 6.8.3 (in progress)
 
+##### New Features
+
+* [#2912](https://github.com/oshi/oshi/pull/2912): Installed apps feature for AIX - [@rohan-coder02](https://github.com/rohan-coder02).
+
 ##### Bug fixes / Improvements
 * [#2902](https://github.com/oshi/oshi/pull/2902): Deduplicate installed applications using Set across Windows, Linux, MacOS and Read both 32-bit, 64-bit Windows registry keys when fetching installed apps - [@rohan-coder02](https://github.com/rohan-coder02).
 * [#2908](https://github.com/oshi/oshi/pull/2908): Fix Windows cache size - [@lesley29](https://github.com/dbwiddis).

--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -6,7 +6,7 @@
     <suppress checks=".*" files="[\\/]demo[\\/].*"/>
 
     <!-- Intentional style breaks -->
-    <suppress checks="ConstantName" files="ParseUtil\.java" lines="101-121"/>
+    <suppress checks="ConstantName" files="ParseUtil\.java" lines="102-122"/>
     <suppress checks="VisibilityModifier" files="SmcUtil\.java"/>
 
     <!-- JNA convention  -->

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixInstalledApps.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixInstalledApps.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.regex.Pattern;
 
-public class AixInstalledApps {
+public final class AixInstalledApps {
 
     private static final Pattern COLON_PATTERN = Pattern.compile(":");
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixInstalledApps.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixInstalledApps.java
@@ -21,6 +21,9 @@ public class AixInstalledApps {
 
     private static final Pattern COLON_PATTERN = Pattern.compile(":");
 
+    private AixInstalledApps() {
+    }
+
     public static List<ApplicationInfo> queryInstalledApps() {
         // https://www.ibm.com/docs/en/aix/7.1.0?topic=l-lslpp-command
         List<String> output = ExecutingCommand.runNative("lslpp -Lc");
@@ -55,7 +58,9 @@ public class AixInstalledApps {
             long timestamp = 0;
             if (!buildDate.equals(Constants.UNKNOWN)) {
                 if (buildDate.matches("\\d{4}")) {
-                    timestamp = ParseUtil.parseDateToEpoch(buildDate, "YYWW");
+                    // Convert to ISO week date string (e.g., 1125 -> 2011-W25-2 for Monday)
+                    String isoWeekString = "20" + buildDate.substring(0, 2) + "-W" + buildDate.substring(2) + "-2";
+                    timestamp = ParseUtil.parseDateToEpoch(isoWeekString, "YYYY-'W'ww-e");
                 } else {
                     timestamp = ParseUtil.parseDateToEpoch(buildDate, "EEE MMM dd HH:mm:ss yyyy");
                 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixInstalledApps.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixInstalledApps.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.unix.aix;
+
+import oshi.software.os.ApplicationInfo;
+import oshi.util.Constants;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.regex.Pattern;
+
+public class AixInstalledApps {
+
+    private static final Pattern COLON_PATTERN = Pattern.compile(":");
+
+    public static List<ApplicationInfo> queryInstalledApps() {
+        // https://www.ibm.com/docs/en/aix/7.1.0?topic=l-lslpp-command
+        List<String> output = ExecutingCommand.runNative("lslpp -Lc");
+        return parseAixAppInfo(output);
+    }
+
+    private static List<ApplicationInfo> parseAixAppInfo(List<String> lines) {
+        Set<ApplicationInfo> appInfoSet = new LinkedHashSet<>();
+        String architecture = System.getProperty("os.arch");
+        boolean isFirstLine = true;
+        for (String line : lines) {
+            if (isFirstLine) {
+                isFirstLine = false;
+                continue; // Skip the first line as it consists column names
+            }
+            /*
+             * Sample output: (1) devices.chrp.IBM.lhca:devices.chrp.IBM.lhca.rte:7.1.5.30: : :C:F:Infiniband Logical
+             * HCA Runtime Environment: : : : : : :0:0:/:1837 (2) bash:bash-5.0.18-1:5.0.18-1: : :C:R:The GNU Bourne
+             * Again shell (bash) version 5.0.18: :/bin/rpm -e bash: : : : :0: :(none):Fri Sep 18 15:53:11 2020
+             */
+            // split by the colon character
+            String[] parts = COLON_PATTERN.split(line, -1); // -1 to keep empty fields
+            String name = ParseUtil.getStringValueOrUnknown(parts[0]);
+            if (name.equals(Constants.UNKNOWN)) {
+                continue;
+            }
+            String version = ParseUtil.getStringValueOrUnknown(parts[2]);
+            String vendor = Constants.UNKNOWN; // lslpp command does not provide vendor info, hence, assigning as
+            // unknown
+            // Build Date is of two formats YYWW and EEE MMM dd HH:mm:ss yyyy
+            String buildDate = ParseUtil.getStringValueOrUnknown(parts[17]);
+            long timestamp = 0;
+            if (!buildDate.equals(Constants.UNKNOWN)) {
+                if (buildDate.matches("\\d{4}")) {
+                    timestamp = ParseUtil.parseDateToEpoch(buildDate, "YYWW");
+                } else {
+                    timestamp = ParseUtil.parseDateToEpoch(buildDate, "EEE MMM dd HH:mm:ss yyyy");
+                }
+            }
+            String description = ParseUtil.getStringValueOrUnknown(parts[7].trim());
+            String installPath = ParseUtil.getStringValueOrUnknown(parts[16].trim());
+            Map<String, String> additionalInfo = new LinkedHashMap<>();
+            additionalInfo.put("architecture", architecture);
+            additionalInfo.put("description", description);
+            additionalInfo.put("installPath", installPath);
+            ApplicationInfo app = new ApplicationInfo(name, version, vendor, timestamp, additionalInfo);
+            appInfoSet.add(app);
+        }
+
+        return new ArrayList<>(appInfoSet);
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOperatingSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.unix.aix;
@@ -8,6 +8,7 @@ import static oshi.software.os.OSProcess.State.INVALID;
 import static oshi.software.os.OSService.State.RUNNING;
 import static oshi.software.os.OSService.State.STOPPED;
 import static oshi.util.Memoizer.defaultExpiration;
+import static oshi.util.Memoizer.installedAppsExpiration;
 import static oshi.util.Memoizer.memoize;
 
 import java.io.File;
@@ -31,6 +32,7 @@ import oshi.driver.unix.aix.perfstat.PerfstatConfig;
 import oshi.driver.unix.aix.perfstat.PerfstatProcess;
 import oshi.jna.platform.unix.AixLibc;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.os.ApplicationInfo;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
@@ -38,6 +40,7 @@ import oshi.software.os.OSProcess;
 import oshi.software.os.OSService;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
+import oshi.util.Memoizer;
 import oshi.util.ParseUtil;
 import oshi.util.Util;
 import oshi.util.tuples.Pair;
@@ -52,6 +55,8 @@ public class AixOperatingSystem extends AbstractOperatingSystem {
     private final Supplier<perfstat_partition_config_t> config = memoize(PerfstatConfig::queryConfig);
     private final Supplier<perfstat_process_t[]> procCpu = memoize(PerfstatProcess::queryProcesses,
             defaultExpiration());
+    private final Supplier<List<ApplicationInfo>> installedAppsSupplier = Memoizer
+            .memoize(AixInstalledApps::queryInstalledApps, installedAppsExpiration());
 
     private static final long BOOTTIME = querySystemBootTimeMillis() / 1000L;
 
@@ -257,5 +262,10 @@ public class AixOperatingSystem extends AbstractOperatingSystem {
             }
         }
         return services;
+    }
+
+    @Override
+    public List<ApplicationInfo> getInstalledApplications() {
+        return installedAppsSupplier.get();
     }
 }

--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -10,6 +10,7 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.LocalDate;
@@ -17,6 +18,8 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.IsoFields;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -1397,6 +1400,14 @@ public final class ParseUtil {
             return 0; // Default value if date is unknown or empty or null
         }
         try {
+            if (datePattern.equals("YYWW")) {
+                // convert this to a date i.e. the start of the week -> Monday
+                int year = 2000 + Integer.parseInt(dateString.substring(0, 2));
+                int week = Integer.parseInt(dateString.substring(2));
+                LocalDate weekStart = LocalDate.ofYearDay(year, 1).with(IsoFields.WEEK_OF_WEEK_BASED_YEAR, week)
+                        .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+                return weekStart.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            }
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern(datePattern, Locale.ROOT);
             // Determine whether the pattern includes time components
             if (datePattern.contains("H") || datePattern.contains("m") || datePattern.contains("s")) {

--- a/oshi-core/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-core/src/main/java/oshi/util/ParseUtil.java
@@ -10,16 +10,14 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
-import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
-import java.time.temporal.IsoFields;
-import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -1400,23 +1398,12 @@ public final class ParseUtil {
             return 0; // Default value if date is unknown or empty or null
         }
         try {
-            if (datePattern.equals("YYWW")) {
-                // convert this to a date i.e. the start of the week -> Monday
-                int year = 2000 + Integer.parseInt(dateString.substring(0, 2));
-                int week = Integer.parseInt(dateString.substring(2));
-                LocalDate weekStart = LocalDate.ofYearDay(year, 1).with(IsoFields.WEEK_OF_WEEK_BASED_YEAR, week)
-                        .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-                return weekStart.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
-            }
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(datePattern, Locale.ROOT);
-            // Determine whether the pattern includes time components
-            if (datePattern.contains("H") || datePattern.contains("m") || datePattern.contains("s")) {
-                LocalDateTime localDateTime = LocalDateTime.parse(dateString, formatter);
-                return localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-            } else {
-                LocalDate localDate = LocalDate.parse(dateString, formatter);
-                return localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
-            }
+            DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(datePattern)
+                    .parseDefaulting(ChronoField.HOUR_OF_DAY, 0).parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                    .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0).parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+                    .toFormatter(Locale.ROOT);
+            LocalDateTime localDateTime = LocalDateTime.parse(dateString, formatter);
+            return localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
         } catch (DateTimeParseException e) {
             LOG.trace("Unable to parse date string: " + dateString);
             return 0;

--- a/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/ParseUtilTest.java
@@ -796,6 +796,13 @@ class ParseUtilTest {
         assertThat("Parse dd/MM/yy, HH:mm", ParseUtil.parseDateToEpoch("01/01/24, 12:30", "dd/MM/yy, HH:mm"),
                 is(LocalDateTime.of(2024, 1, 1, 12, 30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()));
 
+        assertThat("Parse YYYY-'W'ww-e ISO week date", ParseUtil.parseDateToEpoch("2025-W25-2", "YYYY-'W'ww-e"),
+                is(LocalDate.of(2025, 6, 16).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()));
+
+        assertThat("Parse EEE MMM dd HH:mm:ss yyyy",
+                ParseUtil.parseDateToEpoch("Fri Sep 18 15:53:11 2020", "EEE MMM dd HH:mm:ss yyyy"), is(LocalDateTime
+                        .of(2020, 9, 18, 15, 53, 11).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()));
+
         assertThat("Parse empty date string", ParseUtil.parseDateToEpoch("", "yyyyMMdd"), is(0L));
 
         assertThat("Parse empty pattern", ParseUtil.parseDateToEpoch("20240101", ""), is(0L));


### PR DESCRIPTION
**Context**:

The standard `lslpp -Lc` command lists installed software in AIX.

**Code Changes**:

- Use `lslpp -Lc` to extract installed application data.
- Parse the following fields from each colon-separated line:
   - name → field index 0
   - version → index 2
   - description → index 7
   - installPath → index 16
   - timestamp → index 17 (can be either yyww or full datetime)
- Skip the first line (column headers).
- https://www.ibm.com/docs/en/aix/7.1.0?topic=l-lslpp-command

Column names -> https://community.unix.com/t/list-of-installed-applications/338886
The command lists installed software in AIX, but lacks explicit vendor information
In the PR `AixInstalledApps` class consists of the sample outputs from the command in comments

**Replication:**

Used AIX 7.1 ppc64.

Created a simple Java program that outputs the installed apps using the latest OSHI lib, after the following code change.
```
        SystemInfo si = new SystemInfo();
        List<ApplicationInfo> installedApplications = si.getOperatingSystem().getInstalledApplications();
        System.out.println("Size is " + installedApplications.size());
        for (ApplicationInfo applicationInfo : installedApplications) {
            System.out.println(applicationInfo.toString());
        }
```

Output:

```
Size is 918
AppInfo{name=ICU4C.rte, version=7.1.4.0, vendor=unknown, timestamp=1445212800000, additionalInfo={architecture=ppc64, description=International Components for Unicode, installPath=/}}
AppInfo{name=Java5.sdk, version=5.0.0.620, vendor=unknown, timestamp=0, additionalInfo={architecture=ppc64, description=Java SDK 32-bit, installPath=/}}
...
```