### PR TITLE
Fix the license name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
     </organization>
     <licenses>
         <license>
-            <name>SPDX-License-Identifier: MIT</name>
+            <!-- SPDX-License-Identifier: MIT -->
+            <name>MIT</name>
             <url>https://opensource.org/licenses/MIT</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
I think the license name should not include the `SPDX-License-Identifier:` prefix