### PR TITLE
Exclude CD-ROM from Windows FileSystem localOnly query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#2902](https://github.com/oshi/oshi/pull/2902): Deduplicate installed applications using Set across Windows, Linux, MacOS and Read both 32-bit, 64-bit Windows registry keys when fetching installed apps - [@rohan-coder02](https://github.com/rohan-coder02).
 * [#2908](https://github.com/oshi/oshi/pull/2908): Fix Windows cache size - [@lesley29](https://github.com/dbwiddis).
 * [#2912](https://github.com/oshi/oshi/pull/2912): Installed apps feature for AIX - [@rohan-coder02](https://github.com/rohan-coder02).
+* [#2926](https://github.com/oshi/oshi/pull/2926): Exclude CD-ROM from Windows FileSystem localOnly query - [@cesnekmichal](https://github.com/cesnekmichal).
 * [#2929](https://github.com/oshi/oshi/pull/2929): Improve Linux temperature sensor selection - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.8.0 (2025-03-22), 6.8.1 (2025-04-15), 6.8.2 (2025-05-31)

--- a/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32LogicalDisk.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32LogicalDisk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.wmi;
@@ -41,7 +41,7 @@ public final class Win32LogicalDisk {
         StringBuilder wmiClassName = new StringBuilder(WIN32_LOGICAL_DISK);
         boolean where = false;
         if (localOnly) {
-            wmiClassName.append(" WHERE DriveType = 3");
+            wmiClassName.append(" WHERE DriveType = 2 OR DriveType = 3 OR DriveType = 6");
             where = true;
         }
         if (nameToMatch != null) {

--- a/oshi-core/src/main/java/oshi/software/os/FileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/FileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 The OSHI Project Contributors
+ * Copyright 2016-2025 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os;
@@ -31,7 +31,7 @@ public interface FileSystem {
      * Instantiates a list of {@link oshi.software.os.OSFileStore} objects, representing a storage pool, device,
      * partition, volume, concrete file system or other implementation specific means of file storage.
      *
-     * @param localOnly If true, filters the list to only local file stores.
+     * @param localOnly If true, filters the list to only local file stores. On Windows, also excluded CD-ROM drives.
      *
      * @return A list of {@link oshi.software.os.OSFileStore} objects or an empty array if none are present.
      */


### PR DESCRIPTION
Improve reading logical local drives.

from: 
wmic logicaldisk where "DriveType!=4" get DeviceID, VolumeName, FileSystem, DriveType 
to: 
wmic logicaldisk where "DriveType=3" get DeviceID, VolumeName, FileSystem, DriveType

where
| DriveType | Meaning | 
| 0 | Unknown | 
| 1 | No root directory | 
| 2 | Removable disk (e.g., USB) | 
| 3 | Fixed disk (e.g., internal HDD/SSD) | 
| 4 | Network drive (e.g., \server\share) | 
| 5 | CD-ROM | 
| 6 | RAM disk |