### PR TITLE
Update pom file copying for consistency, use JDK 24 for testing

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # Baseline support, Current LTS, Current GA, Current EA
-        java: [11, 21, 23]
+        java: [11, 21, 24]
         os: [macos-13, macos-14]
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,10 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 17, 21]
-        include:
-          - os: macos-latest
-            java: 21
+        java: [11, 21, 24]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     steps:

--- a/.github/workflows/sonatype.yaml
+++ b/.github/workflows/sonatype.yaml
@@ -24,6 +24,6 @@ jobs:
         with:
           cache: maven
           distribution: temurin
-          java-version: 21
+          java-version: 24
       - name: Deploy to Sonatype
         run: ./mvnw deploy -Djacoco.skip=true -DskipTests -B --settings ./.mvn/settings.xml

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [11, 21, 24]
         os: [windows-2019, windows-2022]
         include:
           - java: 21

--- a/oshi-core-java25/pom.xml
+++ b/oshi-core-java25/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -17,6 +15,7 @@
     <description>oshi-core implementation using FFM</description>
 
     <properties>
+        <oshi.core.basedir>${main.basedir}/oshi-core</oshi.core.basedir>
         <maven.compiler.source>24</maven.compiler.source>
         <maven.compiler.target>24</maven.compiler.target>
         <maven.compiler.testSource>24</maven.compiler.testSource>
@@ -63,6 +62,16 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${oshi.core.basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>${oshi.core.basedir}/src/test/resources</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -70,27 +79,27 @@
                 <executions>
                     <execution>
                         <id>add-sources</id>
-                        <phase>generate-sources</phase>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
+                        <phase>generate-sources</phase>
                         <configuration>
                             <sources>
                                 <!-- Copy source files from oshi-core -->
-                                <source>${project.basedir}/../oshi-core/src/main/java</source>
+                                <source>${oshi.core.basedir}/src/main/java</source>
                             </sources>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>add-module-descriptor</id>
-                        <phase>generate-sources</phase>
+                        <id>add-test-sources</id>
                         <goals>
-                            <goal>add-source</goal>
+                            <goal>add-test-source</goal>
                         </goals>
+                        <phase>generate-test-sources</phase>
                         <configuration>
                             <sources>
-                                <!-- copy module-info.java from java11 -->
-                                <source>${project.basedir}/../oshi-core-java11/src/main/java/module-info.java</source>
+                                <!-- Copy test files from oshi-core -->
+                                <source>${oshi.core.basedir}/src/test/java</source>
                             </sources>
                         </configuration>
                     </execution>

--- a/oshi-core-java25/src/main/java/module-info.java
+++ b/oshi-core-java25/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/**
+ * This module provides access to the OSHI API and utility functions.
+ */
+module com.github.oshi {
+    // API
+    exports oshi;
+    exports oshi.hardware;
+    exports oshi.software.os;
+    exports oshi.util;
+
+    // JNA needs reflective access to Structure and ByReference subclasses
+    opens oshi.jna to com.sun.jna;
+    opens oshi.jna.platform.linux to com.sun.jna;
+    opens oshi.jna.platform.mac to com.sun.jna;
+    opens oshi.jna.platform.windows to com.sun.jna;
+    opens oshi.jna.platform.unix to com.sun.jna;
+
+    // dependencies
+    requires com.sun.jna;
+    requires com.sun.jna.platform;
+    requires transitive java.desktop;
+    requires org.slf4j;
+}

--- a/oshi-core-java25/src/test/java/module-info.test
+++ b/oshi-core-java25/src/test/java/module-info.test
@@ -1,0 +1,49 @@
+--add-opens
+  com.github.oshi/oshi=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.hardware=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.software.os=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.util=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.linux=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.linux.proc=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.mac=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.mac.disk=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.mac.net=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.unix=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.unix.aix=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.unix.aix.perfstat=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.unix.freebsd=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.unix.freebsd.disk=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.unix.openbsd.disk=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.unix.solaris=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.unix.solaris.disk=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.unix.solaris.kstat=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.windows=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.windows.perfmon=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.windows.registry=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.windows.wmi=org.junit.platform.commons
+
+--add-modules
+  org.hamcrest,org.slf4j.simple
+--add-reads
+  com.github.oshi=org.junit.jupiter.api,org.hamcrest

--- a/oshi-dist/pom.xml
+++ b/oshi-dist/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>oshi-core-java25</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>oshi-demo</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -975,10 +975,9 @@
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
-            <!-- Only include java11 and dist modules on Java 11+ -->
+            <!-- Only include java11 modules on Java 11+ -->
             <modules>
                 <module>oshi-core-java11</module>
-                <module>oshi-dist</module>
             </modules>
             <!-- Restrict the API to be compatible with Java 8 -->
             <properties>
@@ -992,8 +991,10 @@
             <activation>
                 <jdk>[24,)</jdk>
             </activation>
+            <!-- Only include java25 and dist modules on Java 24+ (TODO 25+) -->
             <modules>
                 <module>oshi-core-java25</module>
+                <module>oshi-dist</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
- Aligns java25 pom properties to java11 format for consistency
- Creates new copies of java25 modular artifacts for better interaction with testing framework
- Moves dist publication to java25 profile
- Adds JDK24 to testing matrices
