### PR TITLE
Implement IOKit with no-code-change Util class

### DIFF
--- a/oshi-core-java25/src/main/java/oshi/ffm/mac/CoreFoundationFunctions.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/mac/CoreFoundationFunctions.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.mac;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandle;
+
+public final class CoreFoundationFunctions extends ForeignFunctions {
+
+    // CFAllocatorRef CFAllocatorGetDefault();
+
+    private static final MethodHandle CFAllocatorGetDefault = LINKER
+            .downcallHandle(SYMBOL_LOOKUP.findOrThrow("CFAllocatorGetDefault"), FunctionDescriptor.of(ADDRESS));
+
+    public static MemorySegment CFAllocatorGetDefault() throws Throwable {
+        return (MemorySegment) CFAllocatorGetDefault.invokeExact();
+    }
+
+    // void CFRelease(CFTypeRef cf);
+
+    private static final MethodHandle CFRelease = LINKER.downcallHandle(SYMBOL_LOOKUP.findOrThrow("CFRelease"),
+            FunctionDescriptor.ofVoid(ADDRESS));
+
+    public static void CFRelease(MemorySegment cf) throws Throwable {
+        CFRelease.invokeExact(cf);
+    }
+
+    // CFStringRef CFStringCreateWithCharacters(CFAllocatorRef alloc, const UniChar * chars, CFIndex numChars);
+
+    private static final MethodHandle CFStringCreateWithCharacters = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("CFStringCreateWithCharacters"),
+            FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, JAVA_LONG));
+
+    public static MemorySegment CFStringCreateWithCharacters(MemorySegment allocator, MemorySegment chars,
+            long numChars) throws Throwable {
+        return (MemorySegment) CFStringCreateWithCharacters.invokeExact(allocator, chars, numChars);
+    }
+
+    // CFIndex CFStringGetLength(CFStringRef theString);
+
+    private static final MethodHandle CFStringGetLength = LINKER
+            .downcallHandle(SYMBOL_LOOKUP.findOrThrow("CFStringGetLength"), FunctionDescriptor.of(JAVA_LONG, ADDRESS));
+
+    public static long CFStringGetLength(MemorySegment theString) throws Throwable {
+        return (long) CFStringGetLength.invokeExact(theString);
+    }
+
+    // Boolean CFStringGetCString(CFStringRef theString, char * buffer, CFIndex bufferSize, CFStringEncoding encoding);
+
+    private static final MethodHandle CFStringGetCString = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("CFStringGetCString"),
+            FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, ADDRESS, JAVA_LONG, JAVA_INT));
+
+    public static boolean CFStringGetCString(MemorySegment theString, MemorySegment buffer, long bufferSize,
+            int encoding) throws Throwable {
+        return (boolean) CFStringGetCString.invokeExact(theString, buffer, bufferSize, encoding);
+    }
+
+    // Boolean CFNumberGetValue(CFNumberRef number, CFNumberType theType, void * valuePtr);
+
+    private static final MethodHandle CFNumberGetValue = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("CFNumberGetValue"),
+            FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, JAVA_INT, ADDRESS));
+
+    public static boolean CFNumberGetValue(MemorySegment number, int theType, MemorySegment valuePtr) throws Throwable {
+        return (boolean) CFNumberGetValue.invokeExact(number, theType, valuePtr);
+    }
+
+    // CFIndex CFDataGetLength(CFDataRef theData);
+
+    private static final MethodHandle CFDataGetLength = LINKER
+            .downcallHandle(SYMBOL_LOOKUP.findOrThrow("CFDataGetLength"), FunctionDescriptor.of(JAVA_LONG, ADDRESS));
+
+    public static long CFDataGetLength(MemorySegment dataRef) throws Throwable {
+        return (long) CFDataGetLength.invokeExact(dataRef);
+    }
+
+    // const UInt8 * CFDataGetBytePtr(CFDataRef theData);
+
+    private static final MethodHandle CFDataGetBytePtr = LINKER
+            .downcallHandle(SYMBOL_LOOKUP.findOrThrow("CFDataGetBytePtr"), FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    public static MemorySegment CFDataGetBytePtr(MemorySegment dataRef) throws Throwable {
+        return (MemorySegment) CFDataGetBytePtr.invokeExact(dataRef);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/mac/CoreFoundationHeaders.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/mac/CoreFoundationHeaders.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.mac;
+
+public interface CoreFoundationHeaders {
+
+    int kCFNumberSInt8Type = 1;
+    int kCFNumberSInt16Type = 2;
+    int kCFNumberSInt32Type = 3;
+    int kCFNumberSInt64Type = 4;
+    int kCFNumberFloat32Type = 5;
+    int kCFNumberFloat64Type = 6;
+
+    int kCFStringEncodingUTF8 = 0x08000100;
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/mac/ForeignFunctions.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/mac/ForeignFunctions.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.mac;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static oshi.ffm.mac.MacSystemHeaders.MNAMELEN;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.SymbolLookup;
+
+public abstract class ForeignFunctions {
+
+    protected static final Linker LINKER = Linker.nativeLinker();
+    protected static final SymbolLookup SYMBOL_LOOKUP = SymbolLookup.loaderLookup();
+
+    protected ForeignFunctions() {
+    }
+
+    public static MemorySegment getStructFromNativePointer(MemorySegment pointer, StructLayout layout, Arena arena) {
+        if (pointer == null || pointer.equals(MemorySegment.NULL)) {
+            return null;
+        }
+        return MemorySegment.ofAddress(pointer.address()).reinterpret(layout.byteSize(), arena, null);
+    }
+
+    public static String getStringFromNativePointer(MemorySegment pointer, Arena arena) {
+        if (pointer == null || pointer.equals(MemorySegment.NULL)) {
+            return null;
+        }
+        return MemorySegment.ofAddress(pointer.address()).reinterpret(MNAMELEN, arena, null).getString(0);
+    }
+
+    public static byte[] getByteArrayFromNativePointer(MemorySegment pointer, long length, Arena arena) {
+        if (pointer == null || pointer.equals(MemorySegment.NULL)) {
+            return null;
+        }
+        MemorySegment bytesSegment = MemorySegment.ofAddress(pointer.address()).reinterpret(length, arena, null);
+        byte[] result = new byte[(int) length];
+        MemorySegment.copy(bytesSegment, JAVA_BYTE, 0, result, 0, (int) length);
+        return result;
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/mac/IOKit.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/mac/IOKit.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.mac;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static oshi.ffm.mac.CoreFoundationFunctions.CFAllocatorGetDefault;
+import static oshi.ffm.mac.CoreFoundationFunctions.CFDataGetBytePtr;
+import static oshi.ffm.mac.CoreFoundationFunctions.CFDataGetLength;
+import static oshi.ffm.mac.CoreFoundationFunctions.CFNumberGetValue;
+import static oshi.ffm.mac.CoreFoundationFunctions.CFStringCreateWithCharacters;
+import static oshi.ffm.mac.CoreFoundationFunctions.CFStringGetCString;
+import static oshi.ffm.mac.CoreFoundationFunctions.CFStringGetLength;
+import static oshi.ffm.mac.CoreFoundationHeaders.kCFNumberFloat64Type;
+import static oshi.ffm.mac.CoreFoundationHeaders.kCFNumberSInt32Type;
+import static oshi.ffm.mac.CoreFoundationHeaders.kCFNumberSInt64Type;
+import static oshi.ffm.mac.CoreFoundationHeaders.kCFStringEncodingUTF8;
+import static oshi.ffm.mac.ForeignFunctions.getByteArrayFromNativePointer;
+import static oshi.ffm.mac.IOKitFunctions.IOIteratorNext;
+import static oshi.ffm.mac.IOKitFunctions.IOObjectConformsTo;
+import static oshi.ffm.mac.IOKitFunctions.IOObjectRelease;
+import static oshi.ffm.mac.IOKitFunctions.IORegistryEntryCreateCFProperties;
+import static oshi.ffm.mac.IOKitFunctions.IORegistryEntryCreateCFProperty;
+import static oshi.ffm.mac.IOKitFunctions.IORegistryEntryGetChildEntry;
+import static oshi.ffm.mac.IOKitFunctions.IORegistryEntryGetChildIterator;
+import static oshi.ffm.mac.IOKitFunctions.IORegistryEntryGetName;
+import static oshi.ffm.mac.IOKitFunctions.IORegistryEntryGetParentEntry;
+import static oshi.ffm.mac.IOKitFunctions.IORegistryEntryGetRegistryEntryID;
+import static oshi.ffm.mac.IOKitFunctions.IORegistryEntrySearchCFProperty;
+import static oshi.ffm.mac.IOKitHeaders.kIOReturnNoDevice;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The I/O Kit framework implements non-kernel access to I/O Kit objects (drivers and nubs) through the device-interface
+ * mechanism.
+ */
+public interface IOKit {
+
+    class IOObject {
+        private final MemorySegment segment;
+
+        public IOObject(MemorySegment segment) {
+            this.segment = segment;
+        }
+
+        public MemorySegment segment() {
+            return segment;
+        }
+
+        public boolean isNull() {
+            return segment == null || segment.equals(MemorySegment.NULL);
+        }
+
+        public int release() {
+            if (isNull()) {
+                return 0;
+            }
+            try {
+                return IOObjectRelease(segment);
+            } catch (Throwable e) {
+                return -1;
+            }
+        }
+
+        public boolean conformsTo(String className) {
+            if (isNull()) {
+                return false;
+            }
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment classNameStr = arena.allocateFrom(className);
+                return IOObjectConformsTo(segment, classNameStr);
+            } catch (Throwable e) {
+                return false;
+            }
+        }
+    }
+
+    class IOIterator extends IOObject {
+        public IOIterator(MemorySegment segment) {
+            super(segment);
+        }
+
+        public IORegistryEntry next() {
+            if (isNull()) {
+                return null;
+            }
+            try {
+                MemorySegment nextObj = IOIteratorNext(segment());
+                return nextObj.equals(MemorySegment.NULL) ? null : new IORegistryEntry(nextObj);
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+
+        public List<IORegistryEntry> listEntries() {
+            List<IORegistryEntry> entries = new ArrayList<>();
+            if (isNull()) {
+                return entries;
+            }
+
+            IORegistryEntry entry;
+            while ((entry = next()) != null) {
+                entries.add(entry);
+            }
+            return entries;
+        }
+    }
+
+    class IORegistryEntry extends IOObject {
+        public IORegistryEntry(MemorySegment segment) {
+            super(segment);
+        }
+
+        public long getRegistryEntryID() {
+            if (isNull()) {
+                return 0;
+            }
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment idSeg = arena.allocate(ValueLayout.JAVA_LONG);
+                int result = IORegistryEntryGetRegistryEntryID(segment(), idSeg);
+                if (result != 0) {
+                    return 0;
+                }
+                return idSeg.get(ValueLayout.JAVA_LONG, 0);
+            } catch (Throwable e) {
+                return 0;
+            }
+        }
+
+        public String getName() {
+            if (isNull()) {
+                return null;
+            }
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment nameSeg = arena.allocate(128);
+                int result = IORegistryEntryGetName(segment(), nameSeg);
+                if (result != 0) {
+                    return null;
+                }
+                return nameSeg.getString(0);
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+
+        public IOIterator getChildIterator(String plane) {
+            if (isNull()) {
+                return null;
+            }
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment planeStr = arena.allocateFrom(plane);
+                MemorySegment iterSeg = arena.allocate(ADDRESS);
+                int result = IORegistryEntryGetChildIterator(segment(), planeStr, iterSeg);
+                if (result != 0) {
+                    return null;
+                }
+                MemorySegment iterator = iterSeg.get(ADDRESS, 0);
+                return iterator.equals(MemorySegment.NULL) ? null : new IOIterator(iterator);
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+
+        public IORegistryEntry getChildEntry(String plane) {
+            if (isNull()) {
+                return null;
+            }
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment planeStr = arena.allocateFrom(plane);
+                MemorySegment childSeg = arena.allocate(ADDRESS);
+                int result = IORegistryEntryGetChildEntry(segment(), planeStr, childSeg);
+                if (result == kIOReturnNoDevice || result != 0) {
+                    return null;
+                }
+                MemorySegment child = childSeg.get(ADDRESS, 0);
+                return child.equals(MemorySegment.NULL) ? null : new IORegistryEntry(child);
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+
+        public IORegistryEntry getParentEntry(String plane) {
+            if (isNull()) {
+                return null;
+            }
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment planeStr = arena.allocateFrom(plane);
+                MemorySegment parentSeg = arena.allocate(ADDRESS);
+                int result = IORegistryEntryGetParentEntry(segment(), planeStr, parentSeg);
+                if (result == kIOReturnNoDevice || result != 0) {
+                    return null;
+                }
+                MemorySegment parent = parentSeg.get(ADDRESS, 0);
+                return parent.equals(MemorySegment.NULL) ? null : new IORegistryEntry(parent);
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+
+        public MemorySegment createCFProperty(MemorySegment key) {
+            if (isNull()) {
+                return MemorySegment.NULL;
+            }
+            try {
+                MemorySegment allocator = CFAllocatorGetDefault();
+                return IORegistryEntryCreateCFProperty(segment(), key, allocator, 0);
+            } catch (Throwable e) {
+                return MemorySegment.NULL;
+            }
+        }
+
+        public MemorySegment createCFProperties() {
+            if (isNull()) {
+                return MemorySegment.NULL;
+            }
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment propsSeg = arena.allocate(ADDRESS);
+                MemorySegment allocator = CFAllocatorGetDefault();
+                int result = IORegistryEntryCreateCFProperties(segment(), propsSeg, allocator, 0);
+                if (result != 0) {
+                    return MemorySegment.NULL;
+                }
+                return propsSeg.get(ADDRESS, 0);
+            } catch (Throwable e) {
+                return MemorySegment.NULL;
+            }
+        }
+
+        public MemorySegment searchCFProperty(String plane, MemorySegment key, int options) {
+            if (isNull()) {
+                return MemorySegment.NULL;
+            }
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment planeStr = arena.allocateFrom(plane);
+                MemorySegment allocator = CFAllocatorGetDefault();
+                return IORegistryEntrySearchCFProperty(segment(), planeStr, key, allocator, options);
+            } catch (Throwable e) {
+                return MemorySegment.NULL;
+            }
+        }
+
+        // Property accessor methods
+        public String getStringProperty(String key) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment cfKey = createCFString(key, arena);
+                MemorySegment cfValue = null;
+                try {
+                    cfValue = createCFProperty(cfKey);
+                    if (cfValue.equals(MemorySegment.NULL)) {
+                        return null;
+                    }
+                    return getStringFromCFString(cfValue, arena);
+                } finally {
+                    releaseCFObjects(cfKey, cfValue);
+                }
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+
+        public Long getLongProperty(String key) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment cfKey = createCFString(key, arena);
+                MemorySegment cfValue = null;
+                try {
+                    cfValue = createCFProperty(cfKey);
+                    if (cfValue.equals(MemorySegment.NULL)) {
+                        return null;
+                    }
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_LONG);
+                    if (CFNumberGetValue(cfValue, kCFNumberSInt64Type, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_LONG, 0);
+                    }
+                    return null;
+                } finally {
+                    releaseCFObjects(cfKey, cfValue);
+                }
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+
+        public Integer getIntegerProperty(String key) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment cfKey = createCFString(key, arena);
+                MemorySegment cfValue = null;
+                try {
+                    cfValue = createCFProperty(cfKey);
+                    if (cfValue.equals(MemorySegment.NULL)) {
+                        return null;
+                    }
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_INT);
+                    if (CFNumberGetValue(cfValue, kCFNumberSInt32Type, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_INT, 0);
+                    }
+                    return null;
+                } finally {
+                    releaseCFObjects(cfKey, cfValue);
+                }
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+
+        public Double getDoubleProperty(String key) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment cfKey = createCFString(key, arena);
+                MemorySegment cfValue = null;
+                try {
+                    cfValue = createCFProperty(cfKey);
+                    if (cfValue.equals(MemorySegment.NULL)) {
+                        return null;
+                    }
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_DOUBLE);
+                    if (CFNumberGetValue(cfValue, kCFNumberFloat64Type, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_DOUBLE, 0);
+                    }
+                    return null;
+                } finally {
+                    releaseCFObjects(cfKey, cfValue);
+                }
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+
+        public byte[] getByteArrayProperty(String key) {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment cfKey = createCFString(key, arena);
+                MemorySegment cfValue = null;
+                try {
+                    cfValue = createCFProperty(cfKey);
+                    if (cfValue.equals(MemorySegment.NULL)) {
+                        return null;
+                    }
+                    long length = CFDataGetLength(cfValue);
+                    MemorySegment bytePtr = CFDataGetBytePtr(cfValue);
+                    return getByteArrayFromNativePointer(bytePtr, length, arena);
+                } finally {
+                    releaseCFObjects(cfKey, cfValue);
+                }
+            } catch (Throwable e) {
+                return null;
+            }
+        }
+
+        private static MemorySegment createCFString(String str, Arena arena) throws Throwable {
+            char[] chars = str.toCharArray();
+            MemorySegment charsSeg = arena.allocateFrom(ValueLayout.JAVA_CHAR, chars);
+
+            MemorySegment allocator = CFAllocatorGetDefault();
+            return CFStringCreateWithCharacters(allocator, charsSeg, chars.length);
+        }
+
+        private static String getStringFromCFString(MemorySegment cfString, Arena arena) throws Throwable {
+            if (cfString.equals(MemorySegment.NULL)) {
+                return null;
+            }
+
+            // Get length and allocate buffer
+            long length = CFStringGetLength(cfString);
+            long bufSize = length * 4 + 1; // UTF-8 can be up to 4 bytes per char + null terminator
+            MemorySegment buffer = arena.allocate(bufSize);
+
+            boolean success = CFStringGetCString(cfString, buffer, bufSize, kCFStringEncodingUTF8);
+            if (!success) {
+                return null;
+            }
+
+            return buffer.getString(0);
+        }
+    }
+
+    class IOService extends IORegistryEntry {
+        public IOService(MemorySegment segment) {
+            super(segment);
+        }
+    }
+
+    private static void releaseCFObjects(MemorySegment... cfObjects) {
+        for (MemorySegment segment : cfObjects) {
+            if (segment != null && !segment.equals(MemorySegment.NULL)) {
+                try {
+                    CoreFoundationFunctions.CFRelease(segment);
+                } catch (Throwable e) {
+                    // Ignore
+                }
+            }
+        }
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/mac/IOKitFunctions.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/mac/IOKitFunctions.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.mac;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
+import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandle;
+
+public final class IOKitFunctions extends ForeignFunctions {
+
+    private IOKitFunctions() {
+    }
+
+    /*
+     * IOKitLib.h
+     */
+
+    // kern_return_t IOMasterPort(mach_port_t bootstrapPort, mach_port_t *mainPort);
+
+    private static final MethodHandle IOMasterPort = LINKER.downcallHandle(SYMBOL_LOOKUP.findOrThrow("IOMasterPort"),
+            FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
+
+    public static int IOMasterPort(int bootstrapPort, MemorySegment port) throws Throwable {
+        return (int) IOMasterPort.invokeExact(bootstrapPort, port);
+    }
+
+    // io_registry_entry_t IORegistryGetRootEntry(mach_port_t mainPort);
+
+    private static final MethodHandle IORegistryGetRootEntry = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IORegistryGetRootEntry"), FunctionDescriptor.of(ADDRESS, JAVA_INT));
+
+    public static MemorySegment IORegistryGetRootEntry(int masterPort) throws Throwable {
+        return (MemorySegment) IORegistryGetRootEntry.invokeExact(masterPort);
+    }
+
+    // CFMutableDictionaryRef IOServiceNameMatching(const char *name);
+
+    private static final MethodHandle IOServiceNameMatching = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IOServiceNameMatching"), FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    public static MemorySegment IOServiceNameMatching(MemorySegment name) throws Throwable {
+        return (MemorySegment) IOServiceNameMatching.invokeExact(name);
+    }
+
+    // CFMutableDictionaryRef IOServiceMatching(const char *name);
+
+    private static final MethodHandle IOServiceMatching = LINKER
+            .downcallHandle(SYMBOL_LOOKUP.findOrThrow("IOServiceMatching"), FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    public static MemorySegment IOServiceMatching(MemorySegment name) throws Throwable {
+        return (MemorySegment) IOServiceMatching.invokeExact(name);
+    }
+
+    // io_service_t IOServiceGetMatchingService(mach_port_t mainPort, CFDictionaryRef matching);
+
+    private static final MethodHandle IOServiceGetMatchingService = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IOServiceGetMatchingService"),
+            FunctionDescriptor.of(ADDRESS, JAVA_INT, ADDRESS));
+
+    public static MemorySegment IOServiceGetMatchingService(int masterPort, MemorySegment matchingDict)
+            throws Throwable {
+        return (MemorySegment) IOServiceGetMatchingService.invokeExact(masterPort, matchingDict);
+    }
+
+    // kern_return_t IOServiceGetMatchingServices(mach_port_t mainPort, CFDictionaryRef matching, io_iterator_t
+    // *existing);
+
+    private static final MethodHandle IOServiceGetMatchingServices = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IOServiceGetMatchingServices"),
+            FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS, ADDRESS));
+
+    public static int IOServiceGetMatchingServices(int masterPort, MemorySegment matchingDict, MemorySegment iterator)
+            throws Throwable {
+        return (int) IOServiceGetMatchingServices.invokeExact(masterPort, matchingDict, iterator);
+    }
+
+    // CFMutableDictionaryRef IOBSDNameMatching(mach_port_t mainPort, uint32_t options, const char *bsdName);
+
+    private static final MethodHandle IOBSDNameMatching = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IOBSDNameMatching"),
+            FunctionDescriptor.of(ADDRESS, JAVA_INT, JAVA_INT, ADDRESS));
+
+    public static MemorySegment IOBSDNameMatching(int masterPort, int options, MemorySegment bsdName) throws Throwable {
+        return (MemorySegment) IOBSDNameMatching.invokeExact(masterPort, options, bsdName);
+    }
+
+    // kern_return_t IOObjectRelease(io_object_t object);
+
+    private static final MethodHandle IOObjectRelease = LINKER
+            .downcallHandle(SYMBOL_LOOKUP.findOrThrow("IOObjectRelease"), FunctionDescriptor.of(JAVA_INT, ADDRESS));
+
+    public static int IOObjectRelease(MemorySegment object) throws Throwable {
+        return (int) IOObjectRelease.invokeExact(object);
+    }
+
+    // boolean_t IOObjectConformsTo(io_object_t object, const io_name_t className);
+
+    private static final MethodHandle IOObjectConformsTo = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IOObjectConformsTo"), FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, ADDRESS));
+
+    public static boolean IOObjectConformsTo(MemorySegment object, MemorySegment className) throws Throwable {
+        return (boolean) IOObjectConformsTo.invokeExact(object, className);
+    }
+
+    // io_object_t IOIteratorNext(io_iterator_t iterator);
+
+    private static final MethodHandle IOIteratorNext = LINKER
+            .downcallHandle(SYMBOL_LOOKUP.findOrThrow("IOIteratorNext"), FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    public static MemorySegment IOIteratorNext(MemorySegment iterator) throws Throwable {
+        return (MemorySegment) IOIteratorNext.invokeExact(iterator);
+    }
+
+    // kern_return_t IORegistryEntryGetRegistryEntryID(io_registry_entry_t entry, uint64_t *entryID);
+
+    private static final MethodHandle IORegistryEntryGetRegistryEntryID = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IORegistryEntryGetRegistryEntryID"),
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+
+    public static int IORegistryEntryGetRegistryEntryID(MemorySegment entry, MemorySegment id) throws Throwable {
+        return (int) IORegistryEntryGetRegistryEntryID.invokeExact(entry, id);
+    }
+
+    // kern_return_t IORegistryEntryGetName(io_registry_entry_t entry, io_name_t name);
+
+    private static final MethodHandle IORegistryEntryGetName = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IORegistryEntryGetName"), FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+
+    public static int IORegistryEntryGetName(MemorySegment entry, MemorySegment name) throws Throwable {
+        return (int) IORegistryEntryGetName.invokeExact(entry, name);
+    }
+
+    // kern_return_t IORegistryEntryGetChildIterator(io_registry_entry_t entry, const io_name_t plane, io_iterator_t
+    // *iterator);
+
+    private static final MethodHandle IORegistryEntryGetChildIterator = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IORegistryEntryGetChildIterator"),
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS));
+
+    public static int IORegistryEntryGetChildIterator(MemorySegment entry, MemorySegment plane, MemorySegment iter)
+            throws Throwable {
+        return (int) IORegistryEntryGetChildIterator.invokeExact(entry, plane, iter);
+    }
+
+    // kern_return_t IORegistryEntryGetChildEntry(io_registry_entry_t entry, const io_name_t plane, io_registry_entry_t
+    // *child);
+
+    private static final MethodHandle IORegistryEntryGetChildEntry = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IORegistryEntryGetChildEntry"),
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS));
+
+    public static int IORegistryEntryGetChildEntry(MemorySegment entry, MemorySegment plane, MemorySegment child)
+            throws Throwable {
+        return (int) IORegistryEntryGetChildEntry.invokeExact(entry, plane, child);
+    }
+
+    // kern_return_t IORegistryEntryGetParentEntry(io_registry_entry_t entry, const io_name_t plane, io_registry_entry_t
+    // *parent);
+
+    private static final MethodHandle IORegistryEntryGetParentEntry = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IORegistryEntryGetParentEntry"),
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS));
+
+    public static int IORegistryEntryGetParentEntry(MemorySegment entry, MemorySegment plane, MemorySegment parent)
+            throws Throwable {
+        return (int) IORegistryEntryGetParentEntry.invokeExact(entry, plane, parent);
+    }
+
+    // CFTypeRef IORegistryEntryCreateCFProperty(io_registry_entry_t entry, CFStringRef key, CFAllocatorRef allocator,
+    // IOOptionBits
+    // options);
+
+    private static final MethodHandle IORegistryEntryCreateCFProperty = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IORegistryEntryCreateCFProperty"),
+            FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, ADDRESS, JAVA_INT));
+
+    public static MemorySegment IORegistryEntryCreateCFProperty(MemorySegment entry, MemorySegment key,
+            MemorySegment allocator, int options) throws Throwable {
+        return (MemorySegment) IORegistryEntryCreateCFProperty.invokeExact(entry, key, allocator, options);
+    }
+
+    // kern_return_t IORegistryEntryCreateCFProperties(io_registry_entry_t entry, CFMutableDictionaryRef *properties,
+    // CFAllocatorRef
+    // allocator, IOOptionBits options);
+
+    private static final MethodHandle IORegistryEntryCreateCFProperties = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IORegistryEntryCreateCFProperties"),
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS, JAVA_INT));
+
+    public static int IORegistryEntryCreateCFProperties(MemorySegment entry, MemorySegment properties,
+            MemorySegment allocator, int options) throws Throwable {
+        return (int) IORegistryEntryCreateCFProperties.invokeExact(entry, properties, allocator, options);
+    }
+
+    // CFTypeRef IORegistryEntrySearchCFProperty(io_registry_entry_t entry, const io_name_t plane, CFStringRef key,
+    // CFAllocatorRef
+    // allocator, IOOptionBits options);
+
+    private static final MethodHandle IORegistryEntrySearchCFProperty = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IORegistryEntrySearchCFProperty"),
+            FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS, JAVA_INT));
+
+    public static MemorySegment IORegistryEntrySearchCFProperty(MemorySegment entry, MemorySegment plane,
+            MemorySegment key, MemorySegment allocator, int options) throws Throwable {
+        return (MemorySegment) IORegistryEntrySearchCFProperty.invokeExact(entry, plane, key, allocator, options);
+    }
+
+    /*
+     * IOPowerSources.h
+     */
+
+    // CFTypeRef IOPSCopyPowerSourcesInfo(void);
+
+    private static final MethodHandle IOPSCopyPowerSourcesInfo = LINKER
+            .downcallHandle(SYMBOL_LOOKUP.findOrThrow("IOPSCopyPowerSourcesInfo"), FunctionDescriptor.of(ADDRESS));
+
+    public static MemorySegment IOPSCopyPowerSourcesInfo() throws Throwable {
+        return (MemorySegment) IOPSCopyPowerSourcesInfo.invokeExact();
+    }
+
+    // CFArrayRef IOPSCopyPowerSourcesList(CFTypeRef blob);
+
+    private static final MethodHandle IOPSCopyPowerSourcesList = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IOPSCopyPowerSourcesList"), FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    public static MemorySegment IOPSCopyPowerSourcesList(MemorySegment blob) throws Throwable {
+        return (MemorySegment) IOPSCopyPowerSourcesList.invokeExact(blob);
+    }
+
+    // CFDictionaryRef IOPSGetPowerSourceDescription(CFTypeRef blob, CFTypeRef ps);
+
+    private static final MethodHandle IOPSGetPowerSourceDescription = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IOPSGetPowerSourceDescription"),
+            FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS));
+
+    public static MemorySegment IOPSGetPowerSourceDescription(MemorySegment blob, MemorySegment ps) throws Throwable {
+        return (MemorySegment) IOPSGetPowerSourceDescription.invokeExact(blob, ps);
+    }
+
+    // CFTimeInterval IOPSGetTimeRemainingEstimate(void);
+
+    private static final MethodHandle IOPSGetTimeRemainingEstimate = LINKER.downcallHandle(
+            SYMBOL_LOOKUP.findOrThrow("IOPSGetTimeRemainingEstimate"), FunctionDescriptor.of(JAVA_DOUBLE));
+
+    public static double IOPSGetTimeRemainingEstimate() throws Throwable {
+        return (double) IOPSGetTimeRemainingEstimate.invokeExact();
+    }
+
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/mac/IOKitHeaders.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/mac/IOKitHeaders.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.mac;
+
+public interface IOKitHeaders {
+
+    int kIORegistryIterateRecursively = 0x00000001;
+    int kIORegistryIterateParents = 0x00000002;
+    int kIOReturnNoDevice = 0xe00002c0;
+    double kIOPSTimeRemainingUnlimited = -2.0;
+    double kIOPSTimeRemainingUnknown = -1.0;
+
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/mac/IOKitUtil.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/mac/IOKitUtil.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.mac;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.ffm.mac.MacSystemFunctions.mach_port_deallocate;
+import static oshi.ffm.mac.MacSystemFunctions.mach_task_self;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import oshi.ffm.mac.IOKit.IOIterator;
+import oshi.ffm.mac.IOKit.IORegistryEntry;
+import oshi.ffm.mac.IOKit.IOService;
+
+public final class IOKitUtil {
+
+    private IOKitUtil() {
+    }
+
+    /**
+     * Gets a pointer to the Mach Master Port.
+     *
+     * @return The master port.
+     *         <p>
+     *         Multiple calls to {@link #getMasterPort} will not result in leaking ports but it is considered good
+     *         programming practice to deallocate the port when you are finished with it, using mach_port_deallocate.
+     */
+    public static int getMasterPort() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment port = arena.allocate(JAVA_INT);
+            int result = IOKitFunctions.IOMasterPort(0, port);
+            if (result == 0) {
+                return port.get(JAVA_INT, 0);
+            }
+            return 0;
+        } catch (Throwable e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Gets the IO Registry root.
+     *
+     * @return a handle to the IORoot. Callers should release when finished.
+     */
+    public static IORegistryEntry getRoot() {
+        try {
+            int masterPort = getMasterPort();
+            MemorySegment root = IOKitFunctions.IORegistryGetRootEntry(masterPort);
+            deallocatePort(masterPort);
+            return root.equals(MemorySegment.NULL) ? null : new IORegistryEntry(root);
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    /**
+     * Opens a the first IOService matching a service name.
+     *
+     * @param serviceName The service name to match
+     * @return a handle to an IOService if successful, {@code null} if failed. Callers should release when finished.
+     */
+    public static IOService getMatchingService(String serviceName) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment nameStr = arena.allocateFrom(serviceName);
+            MemorySegment dict = IOKitFunctions.IOServiceMatching(nameStr);
+            if (dict != null && !dict.equals(MemorySegment.NULL)) {
+                return getMatchingService(dict);
+            }
+            return null;
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    /**
+     * Opens a the first IOService matching a dictionary.
+     *
+     * @param matchingDictionary The dictionary to match. This method will consume a reference to the dictionary.
+     * @return a handle to an IOService if successful, {@code null} if failed. Callers should release when finished.
+     */
+    public static IOService getMatchingService(MemorySegment matchingDictionary) {
+        try {
+            int masterPort = getMasterPort();
+            MemorySegment service = IOKitFunctions.IOServiceGetMatchingService(masterPort, matchingDictionary);
+            deallocatePort(masterPort);
+            return service.equals(MemorySegment.NULL) ? null : new IOService(service);
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    /**
+     * Convenience method to get IOService objects matching a service name.
+     *
+     * @param serviceName The service name to match
+     * @return a handle to an IOIterator if successful, {@code null} if failed. Callers should release when finished.
+     */
+    public static IOIterator getMatchingServices(String serviceName) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment nameStr = arena.allocateFrom(serviceName);
+            MemorySegment dict = IOKitFunctions.IOServiceMatching(nameStr);
+            if (dict != null && !dict.equals(MemorySegment.NULL)) {
+                return getMatchingServices(dict);
+            }
+            return null;
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    /**
+     * Convenience method to get IOService objects matching a dictionary.
+     *
+     * @param matchingDictionary The dictionary to match. This method will consume a reference to the dictionary.
+     * @return a handle to an IOIterator if successful, {@code null} if failed. Callers should release when finished.
+     */
+    public static IOIterator getMatchingServices(MemorySegment matchingDictionary) {
+        try (Arena arena = Arena.ofConfined()) {
+            int masterPort = getMasterPort();
+            MemorySegment iteratorSeg = arena.allocate(ADDRESS);
+
+            int result = IOKitFunctions.IOServiceGetMatchingServices(masterPort, matchingDictionary, iteratorSeg);
+            deallocatePort(masterPort);
+
+            if (result == 0) {
+                MemorySegment iterator = iteratorSeg.get(ADDRESS, 0);
+                if (!iterator.equals(MemorySegment.NULL)) {
+                    return new IOIterator(iterator);
+                }
+            }
+            return null;
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    /**
+     * Convenience method to get the IO dictionary matching a bsd name.
+     *
+     * @param bsdName The bsd name of the registry entry
+     * @return The dictionary ref if successful, {@code null} if failed. Callers should release when finished.
+     */
+    public static MemorySegment getBSDNameMatchingDict(String bsdName) {
+        try (Arena arena = Arena.ofConfined()) {
+            int masterPort = getMasterPort();
+            MemorySegment bsdNameStr = arena.allocateFrom(bsdName);
+            MemorySegment result = IOKitFunctions.IOBSDNameMatching(masterPort, 0, bsdNameStr);
+            deallocatePort(masterPort);
+            return result;
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    /**
+     * Deallocate a port
+     *
+     * @param port the port to deallocate
+     */
+    private static void deallocatePort(int port) {
+        try {
+            if (port != 0) {
+                mach_port_deallocate(mach_task_self(), port);
+            }
+        } catch (Throwable e) {
+            // Ignore
+        }
+    }
+}


### PR DESCRIPTION
Did my best to port JNA's IOKit classes to FFM, with the util class behaving identically.  

Implemented in one place (so far), now completely on FFM for MacOperatingSystem and MacOSProcess classes.