### PR TITLE
[POC] Use CoreGraphics for MacDisplay

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplay.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplay.java
@@ -5,22 +5,35 @@
 package oshi.hardware.platform.mac;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sun.jna.Pointer;
+import com.sun.jna.PointerType;
+import com.sun.jna.platform.mac.CoreFoundation;
+import com.sun.jna.platform.mac.CoreFoundation.CFArrayRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFDataRef;
+import com.sun.jna.platform.mac.CoreFoundation.CFDictionaryRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFStringRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFTypeRef;
 import com.sun.jna.platform.mac.IOKit.IOIterator;
 import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
 import com.sun.jna.platform.mac.IOKitUtil;
+import com.sun.jna.ptr.IntByReference;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Display;
 import oshi.hardware.common.AbstractDisplay;
+import oshi.jna.platform.mac.CoreGraphics;
+import oshi.jna.platform.mac.CoreGraphics.*;
+import oshi.util.EdidUtil;
+import oshi.util.ParseUtil;
+import static oshi.util.FormatUtil.*;
 
 /**
  * A Display
@@ -30,6 +43,11 @@ final class MacDisplay extends AbstractDisplay {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacDisplay.class);
 
+    private static final CoreGraphics CG = CoreGraphics.INSTANCE;
+    private static final CoreFoundation CF = CoreFoundation.INSTANCE;
+
+    private Map<String, String> displayParams;
+
     /**
      * Constructor for MacDisplay.
      *
@@ -38,6 +56,17 @@ final class MacDisplay extends AbstractDisplay {
     MacDisplay(byte[] edid) {
         super(edid);
         LOG.debug("Initialized MacDisplay");
+    }
+
+    /**
+     * Constructor for MacDisplay.
+     *
+     * @param displayParams a map of the display's parameters
+     */
+    MacDisplay(Map<String, String> displayParams) {
+        super(new byte[128]);
+        this.displayParams = displayParams;
+        LOG.debug("Initialized MacDisplay with a map");
     }
 
     /**
@@ -51,6 +80,8 @@ final class MacDisplay extends AbstractDisplay {
         displays.addAll(getDisplaysFromService("IODisplayConnect", "IODisplayEDID", "IOService"));
         // Apple Silicon
         displays.addAll(getDisplaysFromService("IOPortTransportStateDisplayPort", "EDID", null));
+        // CoreGraphics API
+        displays.addAll(getDisplaysFromCoreGraphics());
 
         return displays;
     }
@@ -73,24 +104,26 @@ final class MacDisplay extends AbstractDisplay {
 
             while (sdService != null) {
                 IORegistryEntry propertySource = null;
-
                 try {
                     propertySource = childEntryName == null ? sdService : sdService.getChildEntry(childEntryName);
                     if (propertySource != null) {
-                        CFTypeRef edidRaw = propertySource.createCFProperty(cfEdid);
-                        if (edidRaw != null) {
-                            CFDataRef edid = new CFDataRef(edidRaw.getPointer());
-                            try {
-                                // EDID is a byte array of 128 bytes (or more)
-                                int length = edid.getLength();
-                                Pointer p = edid.getBytePtr();
-                                displays.add(new MacDisplay(p.getByteArray(0, length)));
-                            } finally {
-                                edid.release();
+                        try {
+                            CFTypeRef edidRaw = propertySource.createCFProperty(cfEdid);
+                            if (edidRaw != null) {
+                                CFDataRef edid = new CFDataRef(edidRaw.getPointer());
+                                try {
+                                    // EDID is a byte array of 128 bytes (or more)
+                                    int length = edid.getLength();
+                                    Pointer p = edid.getBytePtr();
+                                    displays.add(new MacDisplay(p.getByteArray(0, length)));
+                                } finally {
+                                    edid.release();
+                                }
                             }
-                        }
-                        if (childEntryName != null && propertySource != null) {
-                            propertySource.release();
+                        } finally {
+                            if (childEntryName != null) {
+                                propertySource.release();
+                            }
                         }
                     }
                 } finally {
@@ -102,5 +135,85 @@ final class MacDisplay extends AbstractDisplay {
             cfEdid.release();
         }
         return displays;
+    }
+
+    private static List<Display> getDisplaysFromCoreGraphics() {
+        List<Display> displays = new ArrayList<>();
+
+        IntByReference displayCount = new IntByReference();
+        int result = CoreGraphics.INSTANCE.CGGetActiveDisplayList(0, null, displayCount);
+        if (result != 0) {
+            System.err.println("Failed to get display count, error: " + formatError(result));
+            return displays;
+        }
+        int count = displayCount.getValue();
+        int[] displayArray = new int[count];
+        result = CoreGraphics.INSTANCE.CGGetActiveDisplayList(count, displayArray, displayCount);
+        if (result != 0) {
+            System.err.println("Failed to get displays, error: " + formatError(result));
+            return displays;
+        }
+        count = displayCount.getValue();
+        for (int i = 0; i < count; i++) {
+            Map<String, String> display = new HashMap<>();
+            display.put("VendorNumber", formatShort(CG.CGDisplayVendorNumber(displayArray[i])));
+            display.put("ModelNumber", formatShort(CG.CGDisplayModelNumber(displayArray[i])));
+            CGSize size = CG.CGDisplayScreenSize(displayArray[i]); // millimeters
+            display.put("ScreenSizeH", Integer.toString(roundToInt(size.width / 10d)));
+            display.put("ScreenSizeV", Integer.toString(roundToInt(size.height / 10d)));
+            display.put("ScreenSizeDiag", Double.toString(roundToInt(Math.sqrt(size.width * size.width + size.height * size.height))));
+            display.put("SerialNumber", formatError(CG.CGDisplaySerialNumber(displayArray[i])));
+            display.put("IsMain", Boolean.toString(CG.CGDisplayIsMain(displayArray[i])));
+            display.put("IsBuiltin", Boolean.toString(CG.CGDisplayIsBuiltin(displayArray[i])));
+            display.put("Rotation", Double.toString(CG.CGDisplayRotation(displayArray[i])));
+            display.put("ActivePixelsW", Long.toString(CG.CGDisplayPixelsWide(displayArray[i])));
+            display.put("ActivePixelsH", Long.toString(CG.CGDisplayPixelsHigh(displayArray[i])));
+            List<String> modes = new ArrayList<>();
+            // Using "Copy" methods requires releasing them
+            CFArrayRef modeArray = CG.CGDisplayCopyAllDisplayModes(displayArray[i], null);
+            try {
+                int modeCount = modeArray.getCount();
+                for (int m = 0; m < modeCount; m++) {
+                    CGDisplayModeRef mode = new CGDisplayModeRef(modeArray.getValueAtIndex(m));
+                    modes.add(String.format(Locale.ROOT, "%d x %d (%.1fHz)", mode.pixelWidth(), mode.pixelHeight(), mode.refreshRate()));
+                }
+            } finally {
+                CF.CFRelease(modeArray);
+            }
+            display.put("DisplayModes", String.join(", ", modes));
+            displays.add(new MacDisplay(display));
+        }
+        return displays;
+    }
+
+    private static String formatShort(int value) {
+        return String.format(Locale.ROOT, "%04X", value);
+    }
+
+    @Override
+    public String toString() {
+        if (displayParams == null) {
+            return EdidUtil.toString(getEdid());
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("  Manuf. ID=").append(displayParams.get("VendorNumber"));
+        sb.append(", Product ID=").append(displayParams.get("ModelNumber"));
+        sb.append(", Serial=").append(displayParams.get("SerialNumber"));
+        int hSize = ParseUtil.parseIntOrDefault(displayParams.get("ScreenSizeH"), 0);
+        int vSize = ParseUtil.parseIntOrDefault(displayParams.get("ScreenSizeV"), 0);
+        long diag = Math.round(ParseUtil.parseDoubleOrDefault(displayParams.get("ScreenSizeDiag"), 0) / 25.4);
+        sb.append("\n  ").append(hSize).append(" x ").append(vSize).append(" cm ");
+        sb.append(String.format(Locale.ROOT, "(%.1f\" x %.1f\" / %d\" diagonal)", hSize / 2.54, vSize / 2.54, diag));
+        sb.append("\n  Main Display: ").append(displayParams.containsKey("IsMain"));
+        sb.append("\n  Built In: ").append(displayParams.get("IsBuiltin"));
+        sb
+            .append("\n  Active Pixels: ")
+            .append(displayParams.get("ActivePixelsW"))
+            .append(" x ")
+            .append(displayParams.get("ActivePixelsH"));
+        sb.append("\n  Rotation: ").append(displayParams.get("Rotation"));
+        sb.append("\n  Display Modes: ").append(displayParams.get("DisplayModes"));
+
+        return sb.toString();
     }
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/CoreGraphics.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/CoreGraphics.java
@@ -6,10 +6,19 @@ package oshi.jna.platform.mac;
 
 import com.sun.jna.Library;
 import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.PointerType;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.platform.mac.CoreFoundation.CFArrayRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFDictionaryRef;
+import com.sun.jna.platform.mac.CoreFoundation.CFNumberType;
+import com.sun.jna.ptr.*;
+import com.sun.jna.ptr.DoubleByReference;
+import com.sun.jna.ptr.FloatByReference;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.LongByReference;
+import com.sun.jna.ptr.ShortByReference;
 
 import oshi.util.Util;
 
@@ -50,6 +59,9 @@ public interface CoreGraphics extends Library {
      */
     @FieldOrder({ "width", "height" })
     class CGSize extends Structure {
+
+        public static class ByValue extends CGSize implements Structure.ByValue {}
+
         public double width;
         public double height;
     }
@@ -67,8 +79,57 @@ public interface CoreGraphics extends Library {
             Util.freeMemory(getPointer());
         }
     }
+        
+    class CGDisplayModeRef  extends PointerType {
+        public CGDisplayModeRef() {
+            super();
+        }
 
+        public CGDisplayModeRef(Pointer p) {
+            super(p);
+        }
+
+        public long pixelHeight() {
+            return INSTANCE.CGDisplayModeGetPixelHeight(this);
+        }
+        public long pixelWidth() {
+            return INSTANCE.CGDisplayModeGetPixelWidth(this);
+        }
+        public double refreshRate() {
+            return INSTANCE.CGDisplayModeGetRefreshRate(this);            
+        }
+    }
+    
     CFArrayRef CGWindowListCopyWindowInfo(int option, int relativeToWindow);
 
     boolean CGRectMakeWithDictionaryRepresentation(CFDictionaryRef dict, CGRect rect);
+
+    int CGGetActiveDisplayList(int maxDisplays, int[] activeDisplays, IntByReference displayCount);
+
+    int CGDisplayVendorNumber(int display);
+
+    int CGDisplayModelNumber(int display);
+
+    int CGDisplaySerialNumber(int display);
+
+    CGSize.ByValue CGDisplayScreenSize(int display);
+
+    boolean CGDisplayIsMain(int display);
+
+    boolean CGDisplayIsBuiltin(int display);
+
+    double CGDisplayRotation(int diaplay);
+
+    long CGDisplayPixelsHigh(int display);
+
+    long CGDisplayPixelsWide(int display);
+
+    CFArrayRef CGDisplayCopyAllDisplayModes(int display, CFDictionaryRef options);
+    
+    long CGDisplayModeGetPixelHeight(CGDisplayModeRef mode);
+
+    long CGDisplayModeGetPixelWidth(CGDisplayModeRef mode);
+
+    double CGDisplayModeGetRefreshRate(CGDisplayModeRef mode);
+
 }

--- a/oshi-core/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-core/src/main/java/oshi/util/EdidUtil.java
@@ -72,8 +72,10 @@ public final class EdidUtil {
     }
 
     private static String getAlphaNumericOrHex(byte b) {
-        return Character.isLetterOrDigit((char) b) ? String.format(Locale.ROOT, "%s", (char) b)
-                : String.format(Locale.ROOT, "%02X", b);
+        char c = (char) (b & 0xFF); // Ensure unsigned conversion
+        return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+            ? String.format(Locale.ROOT, "%c", c)
+            : String.format(Locale.ROOT, "%02X", b & 0xFF);
     }
 
     /**


### PR DESCRIPTION
Doing some experimenting with CoreGraphics in support of #2951 

Current Output:
```
Displays:
 Display 0:
  Manuf. ID=GSM, Product ID=76f6, Digital, Serial=0000C5FE, ManufDate=2/2019, EDID v1.3
  80 x 34 cm (31.5 x 13.4 in)
  Preferred Timing: Clock 319MHz, Active Pixels 3440x1440 
  Preferred Timing: Clock 265MHz, Active Pixels 3440x1440 
  Range Limits: Field Rate 56-61 Hz vertical, 30-90 Hz horizontal, Max clock: 320 MHz
  Monitor Name: LG ULTRAWIDE
 Display 1:
  Manuf. ID=1E6D, Product ID=76F6, Serial=0x0000C5FE
  80 x 34 cm (31.5" x 13.4" / 34" diagonal)
  Main Display: true
  Built In: false
  Active Pixels: 3440 x 1440
  Rotation: 0.0
  Display Modes: 800 x 600 (60.0Hz), 1024 x 768 (60.0Hz), 1024 x 768 (50.0Hz), 1024 x 768 (30.0Hz), 1280 x 536 (60.0Hz), 1280 x 536 (50.0Hz), 1280 x 536 (30.0Hz),
   1280 x 720 (60.0Hz), 1280 x 720 (50.0Hz), 1280 x 800 (60.0Hz), 1280 x 960 (60.0Hz), 1280 x 960 (50.0Hz), 1280 x 960 (30.0Hz), 1280 x 1024 (60.0Hz), 
   1344 x 562 (60.0Hz), 1344 x 562 (50.0Hz), 1344 x 562 (30.0Hz), 1344 x 1008 (60.0Hz), 1344 x 1008 (50.0Hz), 1344 x 1008 (30.0Hz), 1600 x 670 (60.0Hz), 
   1600 x 670 (50.0Hz), 1600 x 670 (30.0Hz), 1600 x 900 (60.0Hz), 1600 x 1200 (60.0Hz), 1600 x 1200 (50.0Hz), 1600 x 1200 (30.0Hz), 1680 x 1050 (60.0Hz), 
   1720 x 720 (60.0Hz), 1720 x 720 (50.0Hz), 1720 x 720 (30.0Hz), 1920 x 804 (60.0Hz), 1920 x 804 (50.0Hz), 1920 x 804 (30.0Hz), 1920 x 1080 (60.0Hz), 
   1920 x 1080 (50.0Hz), 2048 x 858 (60.0Hz), 2048 x 858 (50.0Hz), 2048 x 858 (30.0Hz), 2560 x 1080 (60.0Hz), 2560 x 1080 (50.0Hz), 3440 x 1440 (60.0Hz), 
   3440 x 1440 (50.0Hz), 3440 x 1440 (30.0Hz), 640 x 480 (60.0Hz), 720 x 480 (60.0Hz), 720 x 576 (50.0Hz), 1024 x 768 (60.0Hz)
 Display 2:
  Manuf. ID=0610, Product ID=A050, Serial=0xFD626D62
  34 x 22 cm (13.4" x 8.7" / 16" diagonal)
  Main Display: true
  Built In: true
  Active Pixels: 1728 x 1117
  Rotation: 0.0
  Display Modes: 1920 x 1200 (120.0Hz), 1920 x 1200 (60.0Hz), 1920 x 1200 (59.9Hz), 1920 x 1200 (50.0Hz), 1920 x 1200 (48.0Hz), 1920 x 1200 (47.9Hz), 
   2336 x 1460 (120.0Hz), 2336 x 1460 (60.0Hz), 2336 x 1460 (59.9Hz), 2336 x 1460 (50.0Hz), 2336 x 1460 (48.0Hz), 2336 x 1460 (47.9Hz), 2336 x 1510 (120.0Hz), 
   2336 x 1510 (60.0Hz), 2336 x 1510 (59.9Hz), 2336 x 1510 (50.0Hz), 2336 x 1510 (48.0Hz), 2336 x 1510 (47.9Hz), 2560 x 1600 (120.0Hz), 2560 x 1600 (60.0Hz), 
   2560 x 1600 (59.9Hz), 2560 x 1600 (50.0Hz), 2560 x 1600 (48.0Hz), 2560 x 1600 (47.9Hz), 2624 x 1640 (120.0Hz), 2624 x 1640 (60.0Hz), 2624 x 1640 (59.9Hz), 
   2624 x 1640 (50.0Hz), 2624 x 1640 (48.0Hz), 2624 x 1640 (47.9Hz), 2624 x 1696 (120.0Hz), 2624 x 1696 (60.0Hz), 2624 x 1696 (59.9Hz), 2624 x 1696 (50.0Hz), 
   2624 x 1696 (48.0Hz), 2624 x 1696 (47.9Hz), 2992 x 1870 (120.0Hz), 2992 x 1870 (60.0Hz), 2992 x 1870 (59.9Hz), 2992 x 1870 (50.0Hz), 2992 x 1870 (48.0Hz), 
   2992 x 1870 (47.9Hz), 2992 x 1934 (120.0Hz), 2992 x 1934 (60.0Hz), 2992 x 1934 (59.9Hz), 2992 x 1934 (50.0Hz), 2992 x 1934 (48.0Hz), 2992 x 1934 (47.9Hz), 
   3456 x 2160 (120.0Hz), 3456 x 2160 (60.0Hz), 3456 x 2160 (59.9Hz), 3456 x 2160 (50.0Hz), 3456 x 2160 (48.0Hz), 3456 x 2160 (47.9Hz), 3456 x 2234 (120.0Hz), 
   3456 x 2234 (60.0Hz), 3456 x 2234 (59.9Hz), 3456 x 2234 (50.0Hz), 3456 x 2234 (48.0Hz), 3456 x 2234 (47.9Hz)
```
Display 0 is the EDID-based fetch.

Display 1 is CoreGraphics fetched and matches display 0 (same product ID and serial #) as well as dimensions and active pixels.

Display 2 is my built-in display (Built In: true!).  Interestingly its active pixels don't match the system profiler output for it, they are half of the official value.  Maybe a Retina thing?
```
> system_profiler SPDisplaysDataType          

Graphics/Displays:

    Apple M3 Pro:

      Chipset Model: Apple M3 Pro
      Type: GPU
      Bus: Built-In
      Total Number of Cores: 18
      Vendor: Apple (0x106b)
      Metal Support: Metal 3
      Displays:
        LG ULTRAWIDE:
          Resolution: 3440 x 1440 (UWQHD - Ultra-Wide Quad HD)
          UI Looks like: 3440 x 1440 @ 50.00Hz
          Main Display: Yes
          Mirror: Off
          Online: Yes
          Rotation: Supported
        Color LCD:
          Display Type: Built-in Liquid Retina XDR Display
          Resolution: 3456 x 2234 Retina
          Mirror: Off
          Online: Yes
          Automatically Adjust Brightness: Yes
          Connection Type: Internal
```

Anyway, looks like a lot of info we can use to add / cross-reference.