### PR TITLE
Add macOS 26 (Tahoe) codename mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ##### Bug fixes / Improvements
 * [#2946](https://github.com/oshi/oshi/pull/2946): Add Hyper-V VM mac address - [@chunzhennn](https://github.com/chunzhennn).
 * [#2960](https://github.com/oshi/oshi/pull/2949): Include Apple Silicon MacDisplaly registry options - [@dbwiddis](https://github.com/dbwiddis).
+* [#2966](https://github.com/oshi/oshi/pull/2966): Add macOS 26 (Tahoe) codename mapping - [@zacharee](https://github.com/zacharee).
 
 # 6.8.0 (2025-03-22), 6.8.1 (2025-04-15), 6.8.2 (2025-05-31), 6.8.3 (2025-08-16)
 

--- a/oshi-core/src/main/resources/oshi.macos.versions.properties
+++ b/oshi-core/src/main/resources/oshi.macos.versions.properties
@@ -1,4 +1,7 @@
 # Mapping of macOS version numbers to names
+26=Tahoe
+# Early betas of Tahoe used 16
+16=Tahoe
 15=Sequoia
 14=Sonoma
 13=Ventura


### PR DESCRIPTION
Adds macOS Tahoe's version mapping to `oshi.macos.versions.properties`.