### PR TITLE
Add isElevated, getSystemBootTime, getThreadCount, getThreadId functions in WindowsOperatingSystemFFM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ##### New Features
 * [#2925](https://github.com/oshi/oshi/pull/2925): Introduced oshi-core-java25 module that intends to provide FFM support - [@rohan-coder02](https://github.com/rohan-coder02).
 * [#2949](https://github.com/oshi/oshi/pull/2949): Implement MacOperatingSystem using FFM - [@dbwiddis](https://github.com/dbwiddis).
-* [#2959](https://github.com/oshi/oshi/pull/2925): Implement WindowsOperatingSystem using FFM - [@rohan-coder02](https://github.com/rohan-coder02).
+* [#2959](https://github.com/oshi/oshi/pull/2959): Implement WindowsOperatingSystem using FFM - [@rohan-coder02](https://github.com/rohan-coder02).
+* [#2968](https://github.com/oshi/oshi/pull/2968): Add isElevated, getSystemBootTime, getThreadCount, getThreadId to WindowsOperatingSystemFFM - [@rohan-coder02](https://github.com/rohan-coder02).
 
 ##### Bug fixes / Improvements
 * [#2946](https://github.com/oshi/oshi/pull/2946): Add Hyper-V VM mac address - [@chunzhennn](https://github.com/chunzhennn).

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/Advapi32FFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/Advapi32FFM.java
@@ -86,8 +86,6 @@ public final class Advapi32FFM extends WindowsForeignFunctions {
                 Kernel32FFM.CloseHandle(hToken);
             }
         } catch (Throwable t) {
-            System.out.println("4");
-            System.out.println(t.getMessage());
             LOG.debug("Advapi32FFM.isCurrentProcessElevated failed", t);
             return false;
         }

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/Advapi32FFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/Advapi32FFM.java
@@ -4,15 +4,22 @@
  */
 package oshi.ffm.windows;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
+import java.util.Optional;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 public final class Advapi32FFM extends WindowsForeignFunctions {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Advapi32FFM.class);
 
     private static final SymbolLookup ADV = lib("Advapi32");
 
@@ -24,6 +31,68 @@ public final class Advapi32FFM extends WindowsForeignFunctions {
                 (int) AdjustTokenPrivileges.invokeExact(hToken, 0, tkp, 0, MemorySegment.NULL, MemorySegment.NULL));
     }
 
+    private static final MethodHandle CloseEventLog = downcall(ADV, "CloseEventLog", JAVA_INT, ADDRESS);
+
+    public static void CloseEventLog(MemorySegment hEventLog) {
+        try {
+            CloseEventLog.invokeExact(hEventLog);
+        } catch (Throwable t) {
+            LOG.debug("Advapi32FFM.CloseEventLog failed: {}", t.getMessage());
+        }
+    }
+
+    private static final MethodHandle GetTokenInformation = downcall(ADV, "GetTokenInformation", JAVA_INT, ADDRESS,
+            JAVA_INT, ADDRESS, JAVA_INT, ADDRESS);
+
+    public static boolean GetTokenInformation(MemorySegment hToken, int tokenInfoClass, MemorySegment tokenInfo,
+            int tokenInfoLength, MemorySegment returnLength) throws Throwable {
+        return isSuccess((int) GetTokenInformation.invokeExact(hToken, tokenInfoClass, tokenInfo, tokenInfoLength,
+                returnLength));
+    }
+
+    public static boolean isCurrentProcessElevated() {
+        try (Arena arena = Arena.ofConfined()) {
+
+            Optional<MemorySegment> hProcessOpt = Kernel32FFM.GetCurrentProcess();
+            if (hProcessOpt.isEmpty()) {
+                return false;
+            }
+            MemorySegment hProcess = hProcessOpt.get();
+
+            MemorySegment hTokenPtr = arena.allocate(ADDRESS);
+
+            if (!OpenProcessToken(hProcess, WinNTFFM.TOKEN_QUERY, hTokenPtr)) {
+                return false;
+            }
+
+            MemorySegment hToken = hTokenPtr.get(ADDRESS, 0);
+
+            try {
+                MemorySegment elevation = arena.allocate(WinNTFFM.TOKEN_ELEVATION);
+                MemorySegment returnLength = arena.allocate(JAVA_INT);
+
+                boolean success = GetTokenInformation(hToken, WinNTFFM.TokenElevation, elevation,
+                        (int) WinNTFFM.TOKEN_ELEVATION.byteSize(), returnLength);
+
+                if (!success) {
+                    return false;
+                }
+
+                int tokenIsElevated = elevation.get(JAVA_INT,
+                        WinNTFFM.TOKEN_ELEVATION.byteOffset(MemoryLayout.PathElement.groupElement("TokenIsElevated")));
+
+                return tokenIsElevated > 0;
+            } finally {
+                Kernel32FFM.CloseHandle(hToken);
+            }
+        } catch (Throwable t) {
+            System.out.println("4");
+            System.out.println(t.getMessage());
+            LOG.debug("Advapi32FFM.isCurrentProcessElevated failed", t);
+            return false;
+        }
+    }
+
     private static final MethodHandle LookupPrivilegeValue = downcall(ADV, "LookupPrivilegeValueW", JAVA_INT, ADDRESS,
             ADDRESS, ADDRESS);
 
@@ -32,11 +101,49 @@ public final class Advapi32FFM extends WindowsForeignFunctions {
         return isSuccess((int) LookupPrivilegeValue.invokeExact(MemorySegment.NULL, nameSeg, luid));
     }
 
+    private static final MethodHandle OpenEventLog = downcall(ADV, "OpenEventLogW", ADDRESS, ADDRESS, ADDRESS);
+
+    public static Optional<MemorySegment> OpenEventLog(MemorySegment serverName, MemorySegment sourceName)
+            throws Throwable {
+        MemorySegment handle = (MemorySegment) OpenEventLog.invokeExact(serverName, sourceName);
+        if (handle == null || handle.equals(MemorySegment.NULL)) {
+            return Optional.empty();
+        }
+        return Optional.of(handle);
+    }
+
+    public static Optional<MemorySegment> OpenEventLog(Arena arena, String source) {
+        try {
+            MemorySegment lpSource = WindowsForeignFunctions.toWideString(arena, source);
+            MemorySegment handle = (MemorySegment) OpenEventLog.invokeExact(MemorySegment.NULL, lpSource);
+            if (handle.address() == 0) {
+                return Optional.empty();
+            }
+            return Optional.of(handle);
+        } catch (Throwable t) {
+            return Optional.empty();
+        }
+    }
+
     private static final MethodHandle OpenProcessToken = downcall(ADV, "OpenProcessToken", JAVA_INT, ADDRESS, JAVA_INT,
             ADDRESS);
 
     public static boolean OpenProcessToken(MemorySegment process, int desiredAccess, MemorySegment hTokenOut)
             throws Throwable {
         return isSuccess((int) OpenProcessToken.invokeExact(process, desiredAccess, hTokenOut));
+    }
+
+    private static final MethodHandle ReadEventLog = downcall(ADV, "ReadEventLogW", JAVA_INT, ADDRESS, JAVA_INT,
+            JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, ADDRESS);
+
+    public static boolean ReadEventLog(MemorySegment hEventLog, int flags, MemorySegment buffer, int bufSize,
+            MemorySegment bytesRead, MemorySegment minBytesNeeded) {
+        try {
+            return isSuccess(
+                    (int) ReadEventLog.invokeExact(hEventLog, flags, 0, buffer, bufSize, bytesRead, minBytesNeeded));
+        } catch (Throwable t) {
+            LOG.debug("Advapi32FFM.ReadEventLog failed: {}", t.getMessage());
+            return false;
+        }
     }
 }

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/Kernel32FFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/Kernel32FFM.java
@@ -68,6 +68,18 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
         }
     }
 
+    private static final MethodHandle GetCurrentThreadId = downcall(K32, "GetCurrentThreadId", JAVA_INT);
+
+    public static OptionalInt GetCurrentThreadId() {
+        try {
+            int tid = (int) GetCurrentThreadId.invokeExact();
+            return OptionalInt.of(tid);
+        } catch (Throwable t) {
+            LOG.debug("Kernel32FFM.GetCurrentThreadId failed: {}", t.getMessage());
+            return OptionalInt.empty();
+        }
+    }
+
     private static final MethodHandle GetTickCount = downcall(K32, "GetTickCount64", JAVA_LONG);
 
     public static OptionalLong GetTickCount() {

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/PsapiFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/PsapiFFM.java
@@ -1,4 +1,24 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
 package oshi.ffm.windows;
 
-public class PsapiFFM {
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+public final class PsapiFFM extends WindowsForeignFunctions {
+
+    private static final SymbolLookup PSAPI = lib("Psapi");
+
+    private static final MethodHandle GetPerformanceInfo = downcall(PSAPI, "GetPerformanceInfo", JAVA_INT, ADDRESS,
+            JAVA_INT);
+
+    public static boolean GetPerformanceInfo(MemorySegment pPerfInfo, int size) throws Throwable {
+        return isSuccess((int) GetPerformanceInfo.invokeExact(pPerfInfo, size));
+    }
 }

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/PsapiFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/PsapiFFM.java
@@ -1,0 +1,4 @@
+package oshi.ffm.windows;
+
+public class PsapiFFM {
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/WinNTFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/WinNTFFM.java
@@ -7,21 +7,49 @@ package oshi.ffm.windows;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.StructLayout;
 
+import static java.lang.foreign.MemoryLayout.structLayout;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
 public interface WinNTFFM {
 
+    int EVENTLOG_BACKWARDS_READ = 0x0008;
+    int EVENTLOG_SEQUENTIAL_READ = 0x0001;
     int SE_PRIVILEGE_ENABLED = 0x00000002;
     int TOKEN_QUERY = 0x0008;
     int TOKEN_ADJUST_PRIVILEGES = 0x0020;
+    int TokenElevation = 20;
 
-    StructLayout LUID = MemoryLayout.structLayout(JAVA_INT.withName("LowPart"), JAVA_INT.withName("HighPart"));
+    StructLayout EVENTLOGRECORD = structLayout(JAVA_INT.withName("Length"), JAVA_INT.withName("Reserved"),
+            JAVA_INT.withName("RecordNumber"), JAVA_INT.withName("TimeGenerated"), JAVA_INT.withName("TimeWritten"),
+            JAVA_INT.withName("EventID"), JAVA_SHORT.withName("EventType"), JAVA_SHORT.withName("NumStrings"),
+            JAVA_SHORT.withName("EventCategory"), JAVA_SHORT.withName("ReservedFlags"), MemoryLayout.paddingLayout(4),
+            JAVA_INT.withName("ClosingRecordNumber"), JAVA_INT.withName("StringOffset"),
+            JAVA_INT.withName("UserSidLength"), JAVA_INT.withName("UserSidOffset"), JAVA_INT.withName("DataLength"),
+            JAVA_INT.withName("DataOffset"));
 
-    StructLayout LUID_AND_ATTRIBUTES = MemoryLayout.structLayout(LUID.withName("Luid"),
-            JAVA_INT.withName("Attributes"));
+    StructLayout LUID = structLayout(JAVA_INT.withName("LowPart"), JAVA_INT.withName("HighPart"));
 
-    StructLayout TOKEN_PRIVILEGES = MemoryLayout.structLayout(JAVA_INT.withName("PrivilegeCount"),
+    StructLayout LUID_AND_ATTRIBUTES = structLayout(LUID.withName("Luid"), JAVA_INT.withName("Attributes"));
+
+    StructLayout PERFORMANCE_INFORMATION = structLayout(JAVA_INT.withName("cb"), MemoryLayout.paddingLayout(4),
+            JAVA_LONG.withName("CommitTotal"), JAVA_LONG.withName("CommitLimit"), JAVA_LONG.withName("CommitPeak"),
+            JAVA_LONG.withName("PhysicalTotal"), JAVA_LONG.withName("PhysicalAvailable"),
+            JAVA_LONG.withName("SystemCache"), JAVA_LONG.withName("KernelTotal"), JAVA_LONG.withName("KernelPaged"),
+            JAVA_LONG.withName("KernelNonpaged"), JAVA_LONG.withName("PageSize"), JAVA_INT.withName("HandleCount"),
+            JAVA_INT.withName("ProcessCount"), JAVA_INT.withName("ThreadCount"), MemoryLayout.paddingLayout(4));
+
+    StructLayout TOKEN_PRIVILEGES = structLayout(JAVA_INT.withName("PrivilegeCount"),
             LUID_AND_ATTRIBUTES.withName("Privileges"));
+
+    StructLayout TOKEN_ELEVATION = structLayout(JAVA_INT.withName("TokenIsElevated"));
+
+    long OFFSET_TIME_GENERATED = EVENTLOGRECORD.byteOffset(MemoryLayout.PathElement.groupElement("TimeGenerated"));
+
+    long OFFSET_EVENTID = EVENTLOGRECORD.byteOffset(MemoryLayout.PathElement.groupElement("EventID"));
+
+    long OFFSET_LENGTH = EVENTLOGRECORD.byteOffset(MemoryLayout.PathElement.groupElement("Length"));
 
     long TOKEN_PRIVILEGES_PRIVILEGE_COUNT_OFFSET = TOKEN_PRIVILEGES
             .byteOffset(MemoryLayout.PathElement.groupElement("PrivilegeCount"));
@@ -31,4 +59,5 @@ public interface WinNTFFM {
 
     long TOKEN_PRIVILEGES_ATTRIBUTES_OFFSET = TOKEN_PRIVILEGES.byteOffset(
             MemoryLayout.PathElement.groupElement("Privileges"), MemoryLayout.PathElement.groupElement("Attributes"));
+
 }

--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -9,32 +9,26 @@ import org.slf4j.LoggerFactory;
 import oshi.ffm.windows.Advapi32FFM;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.ffm.windows.PsapiFFM;
-import oshi.ffm.windows.WindowsForeignFunctions;
 import oshi.ffm.windows.WinNTFFM;
-import oshi.util.GlobalConfig;
+import oshi.util.platform.windows.Advapi32UtilFFM;
+import oshi.util.platform.windows.Kernel32UtilFFM;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static oshi.ffm.windows.Kernel32FFM.GetLastError;
 import static oshi.ffm.windows.WinNTFFM.PERFORMANCE_INFORMATION;
 import static oshi.ffm.windows.WindowsForeignFunctions.setupTokenPrivileges;
-import static oshi.util.Memoizer.memoize;
 
 public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsOperatingSystemFFM.class);
 
-    private static Supplier<String> systemLog = memoize(WindowsOperatingSystemFFM::querySystemLog,
-            TimeUnit.HOURS.toNanos(1));
-
-    private static final long BOOTTIME = querySystemBootTime();
+    private static final long BOOTTIME = Advapi32UtilFFM.querySystemBootTime();
 
     static {
         enableDebugPrivilege();
@@ -85,7 +79,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
 
     @Override
     public boolean isElevated() {
-        return Advapi32FFM.isCurrentProcessElevated();
+        return Advapi32UtilFFM.isCurrentProcessElevated();
     }
 
     @Override
@@ -100,11 +94,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
 
     @Override
     public long getSystemUptime() {
-        return querySystemUptime();
-    }
-
-    private static long querySystemUptime() {
-        return Kernel32FFM.GetTickCount().orElse(-1) / 1000L;
+        return Kernel32UtilFFM.querySystemUptime();
     }
 
     public int getThreadCount() {
@@ -131,91 +121,5 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     @Override
     public int getThreadId() {
         return Kernel32FFM.GetCurrentThreadId().orElse(-1);
-    }
-
-    private static long querySystemBootTime() {
-        String eventLog = systemLog.get();
-        try (Arena arena = Arena.ofConfined()) {
-            Optional<MemorySegment> hEventLogOpt = Advapi32FFM.OpenEventLog(arena, eventLog);
-            if (hEventLogOpt.isEmpty()) {
-                LOG.warn("Unable to open system Event Log. Falling back to uptime.");
-                return System.currentTimeMillis() / 1000L - querySystemUptime();
-            }
-
-            MemorySegment hEventLog = hEventLogOpt.get();
-
-            int bufSize = 64 * 1024;
-            MemorySegment buffer = arena.allocate(bufSize);
-            MemorySegment bytesRead = arena.allocate(JAVA_INT);
-            MemorySegment minBytesNeeded = arena.allocate(JAVA_INT);
-
-            long event6005Time = 0L;
-
-            long OFFSET_EVENTID = WinNTFFM.OFFSET_EVENTID;
-            long OFFSET_TIME_GENERATED = WinNTFFM.OFFSET_TIME_GENERATED;
-            long OFFSET_LENGTH = WinNTFFM.OFFSET_LENGTH;
-
-            while (Advapi32FFM.ReadEventLog(hEventLog,
-                    WinNTFFM.EVENTLOG_BACKWARDS_READ | WinNTFFM.EVENTLOG_SEQUENTIAL_READ, buffer, bufSize, bytesRead,
-                    minBytesNeeded)) {
-
-                int read = bytesRead.get(JAVA_INT, 0);
-                int offset = 0;
-
-                while (offset < read) {
-                    MemorySegment record = buffer.asSlice(offset, WinNTFFM.EVENTLOGRECORD.byteSize());
-
-                    int eventId = record.get(JAVA_INT, (int) OFFSET_EVENTID);
-                    long timeGenerated = Integer.toUnsignedLong(record.get(JAVA_INT, (int) OFFSET_TIME_GENERATED));
-
-                    if (eventId == 12) { // system boot
-                        Advapi32FFM.CloseEventLog(hEventLog);
-                        return timeGenerated;
-                    } else if (eventId == 6005) { // event log startup
-                        if (event6005Time > 0) {
-                            Advapi32FFM.CloseEventLog(hEventLog);
-                            return event6005Time;
-                        }
-                        event6005Time = timeGenerated;
-                    }
-
-                    // Advance to next record
-                    int length = record.get(JAVA_INT, (int) OFFSET_LENGTH);
-                    offset += length;
-                }
-            }
-
-            Advapi32FFM.CloseEventLog(hEventLog);
-
-            if (event6005Time > 0) {
-                return event6005Time;
-            }
-        }
-
-        // Fallback: approximate boot time from uptime
-        return System.currentTimeMillis() / 1000L - querySystemUptime();
-    }
-
-    private static String querySystemLog() {
-        String systemLog = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_EVENTLOG, "System");
-        if (systemLog.isEmpty()) {
-            return null;
-        }
-
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment sourceName = WindowsForeignFunctions.toWideString(arena, systemLog);
-
-            Optional<MemorySegment> hEventLog = Advapi32FFM.OpenEventLog(MemorySegment.NULL, sourceName);
-            if (hEventLog.isEmpty()) {
-                LOG.warn("Unable to open configured system Event log \"{}\". Calculating boot time from uptime.",
-                        systemLog);
-                return null;
-            }
-
-            return systemLog;
-        } catch (Throwable t) {
-            LOG.error("Exception while opening system event log", t);
-            return null;
-        }
     }
 }

--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -8,19 +8,33 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import oshi.ffm.windows.Advapi32FFM;
 import oshi.ffm.windows.Kernel32FFM;
+import oshi.ffm.windows.PsapiFFM;
+import oshi.ffm.windows.WindowsForeignFunctions;
 import oshi.ffm.windows.WinNTFFM;
+import oshi.util.GlobalConfig;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static oshi.ffm.windows.Kernel32FFM.GetLastError;
+import static oshi.ffm.windows.WinNTFFM.PERFORMANCE_INFORMATION;
 import static oshi.ffm.windows.WindowsForeignFunctions.setupTokenPrivileges;
+import static oshi.util.Memoizer.memoize;
 
 public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsOperatingSystemFFM.class);
+
+    private static Supplier<String> systemLog = memoize(WindowsOperatingSystemFFM::querySystemLog,
+            TimeUnit.HOURS.toNanos(1));
+
+    private static final long BOOTTIME = querySystemBootTime();
 
     static {
         enableDebugPrivilege();
@@ -70,8 +84,18 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     }
 
     @Override
+    public boolean isElevated() {
+        return Advapi32FFM.isCurrentProcessElevated();
+    }
+
+    @Override
     public int getProcessId() {
         return Kernel32FFM.GetCurrentProcessId().orElse(-1);
+    }
+
+    @Override
+    public long getSystemBootTime() {
+        return BOOTTIME;
     }
 
     @Override
@@ -81,5 +105,117 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
 
     private static long querySystemUptime() {
         return Kernel32FFM.GetTickCount().orElse(-1) / 1000L;
+    }
+
+    public int getThreadCount() {
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment perfInfo = arena.allocate(PERFORMANCE_INFORMATION);
+            int size = (int) PERFORMANCE_INFORMATION.byteSize();
+            perfInfo.set(JAVA_INT, PERFORMANCE_INFORMATION.byteOffset(MemoryLayout.PathElement.groupElement("cb")),
+                    size);
+            if (!PsapiFFM.GetPerformanceInfo(perfInfo, size)) {
+                LOG.error("Failed to get Performance Info. Error code: {}", GetLastError());
+                return 0;
+            }
+
+            int threadCount = perfInfo.get(JAVA_INT,
+                    PERFORMANCE_INFORMATION.byteOffset(MemoryLayout.PathElement.groupElement("ThreadCount")));
+            return threadCount;
+        } catch (Throwable t) {
+            LOG.error("Exception getting thread count", t);
+            return 0;
+        }
+    }
+
+    @Override
+    public int getThreadId() {
+        return Kernel32FFM.GetCurrentThreadId().orElse(-1);
+    }
+
+    private static long querySystemBootTime() {
+        String eventLog = systemLog.get();
+        try (Arena arena = Arena.ofConfined()) {
+            Optional<MemorySegment> hEventLogOpt = Advapi32FFM.OpenEventLog(arena, eventLog);
+            if (hEventLogOpt.isEmpty()) {
+                LOG.warn("Unable to open system Event Log. Falling back to uptime.");
+                return System.currentTimeMillis() / 1000L - querySystemUptime();
+            }
+
+            MemorySegment hEventLog = hEventLogOpt.get();
+
+            int bufSize = 64 * 1024;
+            MemorySegment buffer = arena.allocate(bufSize);
+            MemorySegment bytesRead = arena.allocate(JAVA_INT);
+            MemorySegment minBytesNeeded = arena.allocate(JAVA_INT);
+
+            long event6005Time = 0L;
+
+            long OFFSET_EVENTID = WinNTFFM.OFFSET_EVENTID;
+            long OFFSET_TIME_GENERATED = WinNTFFM.OFFSET_TIME_GENERATED;
+            long OFFSET_LENGTH = WinNTFFM.OFFSET_LENGTH;
+
+            while (Advapi32FFM.ReadEventLog(hEventLog,
+                    WinNTFFM.EVENTLOG_BACKWARDS_READ | WinNTFFM.EVENTLOG_SEQUENTIAL_READ, buffer, bufSize, bytesRead,
+                    minBytesNeeded)) {
+
+                int read = bytesRead.get(JAVA_INT, 0);
+                int offset = 0;
+
+                while (offset < read) {
+                    MemorySegment record = buffer.asSlice(offset, WinNTFFM.EVENTLOGRECORD.byteSize());
+
+                    int eventId = record.get(JAVA_INT, (int) OFFSET_EVENTID);
+                    long timeGenerated = Integer.toUnsignedLong(record.get(JAVA_INT, (int) OFFSET_TIME_GENERATED));
+
+                    if (eventId == 12) { // system boot
+                        Advapi32FFM.CloseEventLog(hEventLog);
+                        return timeGenerated;
+                    } else if (eventId == 6005) { // event log startup
+                        if (event6005Time > 0) {
+                            Advapi32FFM.CloseEventLog(hEventLog);
+                            return event6005Time;
+                        }
+                        event6005Time = timeGenerated;
+                    }
+
+                    // Advance to next record
+                    int length = record.get(JAVA_INT, (int) OFFSET_LENGTH);
+                    offset += length;
+                }
+            }
+
+            Advapi32FFM.CloseEventLog(hEventLog);
+
+            if (event6005Time > 0) {
+                return event6005Time;
+            }
+        }
+
+        // Fallback: approximate boot time from uptime
+        return System.currentTimeMillis() / 1000L - querySystemUptime();
+    }
+
+    private static String querySystemLog() {
+        String systemLog = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_EVENTLOG, "System");
+        if (systemLog.isEmpty()) {
+            return null;
+        }
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment sourceName = WindowsForeignFunctions.toWideString(arena, systemLog);
+
+            Optional<MemorySegment> hEventLog = Advapi32FFM.OpenEventLog(MemorySegment.NULL, sourceName);
+            if (hEventLog.isEmpty()) {
+                LOG.warn("Unable to open configured system Event log \"{}\". Calculating boot time from uptime.",
+                        systemLog);
+                return null;
+            }
+
+            return systemLog;
+        } catch (Throwable t) {
+            LOG.error("Exception while opening system event log", t);
+            return null;
+        }
     }
 }

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/Advapi32UtilFFM.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.platform.windows;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import oshi.ffm.windows.Advapi32FFM;
+import oshi.ffm.windows.Kernel32FFM;
+import oshi.ffm.windows.WinNTFFM;
+import oshi.ffm.windows.WindowsForeignFunctions;
+import oshi.util.GlobalConfig;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.ffm.windows.Advapi32FFM.GetTokenInformation;
+import static oshi.ffm.windows.Advapi32FFM.OpenProcessToken;
+import static oshi.util.Memoizer.memoize;
+
+public final class Advapi32UtilFFM {
+
+    private Advapi32UtilFFM() {
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(Advapi32UtilFFM.class);
+
+    private static Supplier<String> systemLog = memoize(Advapi32UtilFFM::querySystemLog, TimeUnit.HOURS.toNanos(1));
+
+    public static boolean isCurrentProcessElevated() {
+        try (Arena arena = Arena.ofConfined()) {
+
+            Optional<MemorySegment> hProcessOpt = Kernel32FFM.GetCurrentProcess();
+            if (hProcessOpt.isEmpty()) {
+                return false;
+            }
+            MemorySegment hProcess = hProcessOpt.get();
+
+            MemorySegment hTokenPtr = arena.allocate(ADDRESS);
+
+            if (!OpenProcessToken(hProcess, WinNTFFM.TOKEN_QUERY, hTokenPtr)) {
+                return false;
+            }
+
+            MemorySegment hToken = hTokenPtr.get(ADDRESS, 0);
+
+            try {
+                MemorySegment elevation = arena.allocate(WinNTFFM.TOKEN_ELEVATION);
+                MemorySegment returnLength = arena.allocate(JAVA_INT);
+
+                boolean success = GetTokenInformation(hToken, WinNTFFM.TokenElevation, elevation,
+                        (int) WinNTFFM.TOKEN_ELEVATION.byteSize(), returnLength);
+
+                if (!success) {
+                    return false;
+                }
+
+                int tokenIsElevated = elevation.get(JAVA_INT,
+                        WinNTFFM.TOKEN_ELEVATION.byteOffset(MemoryLayout.PathElement.groupElement("TokenIsElevated")));
+
+                return tokenIsElevated > 0;
+            } finally {
+                Kernel32FFM.CloseHandle(hToken);
+            }
+        } catch (Throwable t) {
+            LOG.debug("Advapi32FFM.isCurrentProcessElevated failed", t);
+            return false;
+        }
+    }
+
+    public static long querySystemBootTime() {
+        String eventLog = systemLog.get();
+        try (Arena arena = Arena.ofConfined()) {
+            Optional<MemorySegment> hEventLogOpt = Advapi32FFM.OpenEventLog(arena, eventLog);
+            if (hEventLogOpt.isEmpty()) {
+                LOG.warn("Unable to open system Event Log. Falling back to uptime.");
+                return System.currentTimeMillis() / 1000L - Kernel32UtilFFM.querySystemUptime();
+            }
+
+            MemorySegment hEventLog = hEventLogOpt.get();
+
+            int bufSize = 64 * 1024;
+            MemorySegment buffer = arena.allocate(bufSize);
+            MemorySegment bytesRead = arena.allocate(JAVA_INT);
+            MemorySegment minBytesNeeded = arena.allocate(JAVA_INT);
+
+            long event6005Time = 0L;
+
+            long OFFSET_EVENTID = WinNTFFM.OFFSET_EVENTID;
+            long OFFSET_TIME_GENERATED = WinNTFFM.OFFSET_TIME_GENERATED;
+            long OFFSET_LENGTH = WinNTFFM.OFFSET_LENGTH;
+
+            while (Advapi32FFM.ReadEventLog(hEventLog,
+                    WinNTFFM.EVENTLOG_BACKWARDS_READ | WinNTFFM.EVENTLOG_SEQUENTIAL_READ, buffer, bufSize, bytesRead,
+                    minBytesNeeded)) {
+
+                int read = bytesRead.get(JAVA_INT, 0);
+                int offset = 0;
+
+                while (offset < read) {
+                    MemorySegment record = buffer.asSlice(offset, WinNTFFM.EVENTLOGRECORD.byteSize());
+
+                    int eventId = record.get(JAVA_INT, (int) OFFSET_EVENTID);
+                    long timeGenerated = Integer.toUnsignedLong(record.get(JAVA_INT, (int) OFFSET_TIME_GENERATED));
+
+                    if (eventId == 12) { // system boot
+                        Advapi32FFM.CloseEventLog(hEventLog);
+                        return timeGenerated;
+                    } else if (eventId == 6005) { // event log startup
+                        if (event6005Time > 0) {
+                            Advapi32FFM.CloseEventLog(hEventLog);
+                            return event6005Time;
+                        }
+                        event6005Time = timeGenerated;
+                    }
+
+                    // Advance to next record
+                    int length = record.get(JAVA_INT, (int) OFFSET_LENGTH);
+                    offset += length;
+                }
+            }
+
+            Advapi32FFM.CloseEventLog(hEventLog);
+
+            if (event6005Time > 0) {
+                return event6005Time;
+            }
+        } catch (Throwable t) {
+            LOG.error("Exception while querying system boottime, fallback to boot time from uptime", t);
+        }
+        // Fallback: approximate boot time from uptime
+        return System.currentTimeMillis() / 1000L - Kernel32UtilFFM.querySystemUptime();
+    }
+
+    public static String querySystemLog() {
+        String systemLog = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_EVENTLOG, "System");
+        if (systemLog.isEmpty()) {
+            return null;
+        }
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment sourceName = WindowsForeignFunctions.toWideString(arena, systemLog);
+
+            Optional<MemorySegment> hEventLog = Advapi32FFM.OpenEventLog(MemorySegment.NULL, sourceName);
+            if (hEventLog.isEmpty()) {
+                LOG.warn("Unable to open configured system Event log \"{}\". Calculating boot time from uptime.",
+                        systemLog);
+                return null;
+            }
+
+            return systemLog;
+        } catch (Throwable t) {
+            LOG.error("Exception while opening system event log", t);
+            return null;
+        }
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/Kernel32UtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/Kernel32UtilFFM.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.platform.windows;
+
+import oshi.ffm.windows.Kernel32FFM;
+
+public final class Kernel32UtilFFM {
+
+    private Kernel32UtilFFM() {
+    }
+
+    public static long querySystemUptime() {
+        return Kernel32FFM.GetTickCount().orElse(-1) / 1000L;
+    }
+}


### PR DESCRIPTION
### Added Functions

_isElevated()_ – Checks whether the current process is running with elevated (administrator) privileges.
_getSystemBootTime()_ – Retrieves the system boot time via native Windows APIs.
_getThreadCount()_ – Returns the total number of threads in the system using GetPerformanceInfo.
_getThreadId()_ – Obtains the current thread ID via GetCurrentThreadId.

### Testing

+ To confirm correctness, the new FFM-based methods were compared against the existing OSHI implementation and both outputs match
```
       System.out.println("below outputs from OSHI FFM");
     
       WindowsOperatingSystemFFM ffm = new WindowsOperatingSystemFFM();

        System.out.println("isElevated " + ffm.isElevated());
        System.out.println("getSystemBootTime " + ffm.getSystemBootTime());
        System.out.println("getThreadCount " + ffm.getThreadCount());
        System.out.println("getThreadId " + ffm.getThreadId());

        System.out.println("below outputs from old OSHI");

        WindowsOperatingSystem jna = new WindowsOperatingSystem();

        System.out.println("isElevated " + jna.isElevated());
        System.out.println("getSystemBootTime " + jna.getSystemBootTime());
        System.out.println("getThreadCount " + jna.getThreadCount());
        System.out.println("getThreadId " + jna.getThreadId());
```
+ Output
```
below outputs from OSHI FFM

isElevated true
getSystemBootTime 1756396238
getThreadCount 1144
getThreadId 660

below outputs from old OSHI

isElevated true
getSystemBootTime 1756396238
getThreadCount 1144
getThreadId 660
```