### PR TITLE
Fix failing CI

### DIFF
--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -172,8 +172,8 @@ public class SystemInfoTest { // NOSONAR squid:S5786
 
     private static void printInstalledApps(List<ApplicationInfo> installedApplications) {
         oshi.add("Apps: ");
-        for (ApplicationInfo app : installedApplications.subList(0, 5)) {
-            oshi.add(" " + app.toString());
+        for (int i = 0; i < 5 && i < installedApplications.size(); i++) {
+            oshi.add(" " + installedApplications.get(i).toString());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1018,6 +1018,18 @@
                 <module>oshi-core-java25</module>
                 <module>oshi-dist</module>
             </modules>
+            <!-- Temporarily disable forbidden APIs until signatures are available -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>de.thetaphi</groupId>
+                        <artifactId>forbiddenapis</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>checks</id>


### PR DESCRIPTION
Fixes failing CI:
 - SystemInfoTest didn't do a length check and is failing on sublist for installed apps when the list is empty (Unix tests)
 - Forbidden APIs check doesn't have jdk25 signatures yet. Temporarily skipping it in the java25 profile until they're available.