### PR TITLE
Handle binary registry values in WindowsGraphicsCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.9.3 (in progress)
 
-* Your contribution here!
+##### Bug fixes / Improvements
+* [#3064](https://github.com/oshi/oshi/pull/3064): Handle binary registry values in WindowsGraphicsCard - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.9.0 (2025-09-18), 6.9.1 (2025-10-18), 6.9.2 (2025-12-20)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.windows;
@@ -81,11 +81,13 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                 String versionInfo = RegistryUtil.getStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, DRIVER_VERSION);
                 long vram = 0L;
 
-                if (Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, QW_MEMORY_SIZE)) {
-                    vram = Advapi32Util.registryGetLongValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, QW_MEMORY_SIZE);
-                } else if (Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, MEMORY_SIZE)) {
-                    Object genericValue = Advapi32Util.registryGetValue(WinReg.HKEY_LOCAL_MACHINE, fullKey,
-                            MEMORY_SIZE);
+                String memKey = Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, QW_MEMORY_SIZE)
+                        ? QW_MEMORY_SIZE
+                        : (Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, MEMORY_SIZE)
+                                ? MEMORY_SIZE
+                                : null);
+                if (memKey != null) {
+                    Object genericValue = Advapi32Util.registryGetValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, memKey);
                     if (genericValue instanceof Long) {
                         vram = (long) genericValue;
                     } else if (genericValue instanceof Integer) {


### PR DESCRIPTION
Fixes #3063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
  * Fixed Windows graphics card memory detection for binary registry values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->