### PR TITLE
Filter disabled Windows GPU adapters and order by DXGI enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * [#3082](https://github.com/oshi/oshi/pull/3082): Add `getResidentMemory()` and `getPrivateResidentMemory()` to OSProcess, separating true RSS from the private/footprint memory shown by graphical system monitors. Deprecate `getResidentSetSize()` - [@dyorgio](https://github.com/dyorgio), [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug fixes / Improvements
-* [#3086](https://github.com/oshi/oshi/pull/3086): DXGI-based VRAM detection for Windows GPU adapters — [@dbwiddis](https://github.com/dbwiddis).
+* [#3086](https://github.com/oshi/oshi/pull/3086): DXGI-based VRAM detection for Windows GPU adapters - [@dbwiddis](https://github.com/dbwiddis).
+* [#3087](https://github.com/oshi/oshi/pull/3087): Filter disabled Windows GPU adapters and order by DXGI enumeration - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.10.0 (2026-02-22)
 

--- a/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32VideoController.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32VideoController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.wmi;
@@ -24,7 +24,7 @@ public final class Win32VideoController {
      * Video Controller properties
      */
     public enum VideoControllerProperty {
-        ADAPTERCOMPATIBILITY, ADAPTERRAM, DRIVERVERSION, NAME, PNPDEVICEID;
+        ADAPTERCOMPATIBILITY, ADAPTERRAM, CONFIGMANAGERERRORCODE, DRIVERVERSION, NAME, PNPDEVICEID;
     }
 
     private Win32VideoController() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -6,6 +6,7 @@ package oshi.hardware.platform.windows;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TreeMap;
 
 import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
@@ -35,16 +36,21 @@ import oshi.util.tuples.Triplet;
  * <p>
  * VRAM detection priority:
  * <ol>
- * <li>{@code DXGI_ADAPTER_DESC.DedicatedVideoMemory} — the authoritative Windows API value, not subject to the 2 GiB
- * cap that affects the 32-bit registry field.</li>
- * <li>{@code HardwareInformation.qwMemorySize} (64-bit registry value) — used when DXGI enumeration is unavailable or
- * no adapter match is found.</li>
+ * <li>{@code DXGI_ADAPTER_DESC.DedicatedVideoMemory}: the authoritative Windows API value, not subject to the 2 GiB cap
+ * that affects the 32-bit registry field.</li>
+ * <li>{@code HardwareInformation.qwMemorySize} (64-bit registry value): used when DXGI enumeration is unavailable or no
+ * adapter match is found.</li>
  * </ol>
  *
  * <p>
  * {@code HardwareInformation.MemorySize} (32-bit) is intentionally not used: Windows writes the sentinel value
  * {@code 0x7FFFF000} (~2 GiB) into this field for GPUs with more than 2 GiB of dedicated VRAM, making it unreliable for
  * modern discrete GPUs.
+ *
+ * <p>
+ * When DXGI is available, ghost adapters (stale registry entries from hardware no longer present) are excluded because
+ * {@code IDXGIFactory::EnumAdapters} only enumerates physically present adapters. The returned list is ordered to match
+ * DXGI enumeration order, which places the primary desktop adapter first.
  */
 @Immutable
 final class WindowsGraphicsCard extends AbstractGraphicsCard {
@@ -75,16 +81,25 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
     /**
      * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the graphics cards.
      *
+     * <p>
+     * When DXGI is available, ghost adapters are excluded and the list is ordered with the primary desktop adapter
+     * first. On systems without DXGI, all registry entries are returned in registry key order.
+     *
      * @return List of {@link oshi.hardware.platform.windows.WindowsGraphicsCard} objects.
      */
     public static List<GraphicsCard> getGraphicsCards() {
-        List<GraphicsCard> cardList = new ArrayList<>();
+        // Query DXGI once. Fails gracefully to empty list if unavailable.
+        List<DxgiAdapterInfo> dxgiAdapters = WindowsDxgi.queryAdapters();
+        boolean dxgiAvailable = !dxgiAdapters.isEmpty();
+        // Mutable copy for match-and-consume (prevents same adapter matching two registry entries).
+        List<DxgiAdapterInfo> remainingDxgi = new ArrayList<>(dxgiAdapters);
 
-        // Query DXGI once for all adapters. Fails gracefully to empty list if unavailable.
-        // Use a mutable copy so matched entries can be consumed, preventing the same
-        // DxgiAdapterInfo from being assigned to two registry cards with identical PCI IDs
-        // (e.g. identical multi-GPU configurations).
-        List<DxgiAdapterInfo> dxgiAdapters = new ArrayList<>(WindowsDxgi.queryAdapters());
+        // When DXGI is available, collect cards keyed by their DXGI enumeration index so the
+        // final list is ordered primary-adapter-first (DXGI guarantees adapter 0 is the primary
+        // desktop adapter). Registry entries with no DXGI match are ghost adapters and excluded.
+        // When DXGI is unavailable, fall back to simple insertion order.
+        TreeMap<Integer, GraphicsCard> dxgiOrdered = new TreeMap<>();
+        List<GraphicsCard> cardList = new ArrayList<>();
 
         int index = 1;
         String[] keys = Advapi32Util.registryGetKeys(WinReg.HKEY_LOCAL_MACHINE, DISPLAY_DEVICES_REGISTRY_PATH);
@@ -116,12 +131,15 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                 // legitimate DedicatedVideoMemory == 0 (e.g. a software/render-only adapter) is
                 // preserved and does not trigger the registry fallback.
                 long vram = -1L;
-                DxgiAdapterInfo dxgiMatch = WindowsDxgi.findMatch(dxgiAdapters, pciVendorId, pciDeviceId, name);
+                int dxgiIndex = -1;
+                DxgiAdapterInfo dxgiMatch = WindowsDxgi.findMatch(remainingDxgi, pciVendorId, pciDeviceId, name);
                 if (dxgiMatch != null) {
                     vram = dxgiMatch.getDedicatedVideoMemory();
-                    // Consume the matched entry so it cannot be assigned to a second registry card
-                    // with the same PCI IDs (e.g. identical multi-GPU configurations).
-                    dxgiAdapters.remove(dxgiMatch);
+                    dxgiIndex = dxgiAdapters.indexOf(dxgiMatch);
+                } else if (dxgiAvailable) {
+                    // DXGI is available but this registry entry has no matching adapter:
+                    // it is a ghost device (stale driver from hardware no longer present). Skip it.
+                    continue;
                 }
 
                 // Fallback: 64-bit registry value qwMemorySize, only when DXGI had no match.
@@ -138,10 +156,22 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                 // HardwareInformation.MemorySize (32-bit) is intentionally omitted: Windows caps
                 // it at 0x7FFFF000 (~2 GiB) for GPUs with more VRAM, making it unreliable.
 
-                cardList.add(new WindowsGraphicsCard(Util.isBlank(name) ? Constants.UNKNOWN : name,
+                GraphicsCard card = new WindowsGraphicsCard(Util.isBlank(name) ? Constants.UNKNOWN : name,
                         Util.isBlank(deviceId) ? Constants.UNKNOWN : deviceId,
                         Util.isBlank(vendor) ? Constants.UNKNOWN : vendor,
-                        Util.isBlank(versionInfo) ? Constants.UNKNOWN : versionInfo, vram));
+                        Util.isBlank(versionInfo) ? Constants.UNKNOWN : versionInfo, vram);
+                // Remove dxgiMatch from remainingDxgi only after the card is successfully
+                // constructed. This ensures that if earlier registry reads in this try block
+                // throw a Win32Exception, dxgiMatch remains in remainingDxgi and is still
+                // available for subsequent iterations or WMI fallback processing.
+                if (dxgiMatch != null) {
+                    remainingDxgi.remove(dxgiMatch);
+                }
+                if (dxgiIndex >= 0) {
+                    dxgiOrdered.put(dxgiIndex, card);
+                } else {
+                    cardList.add(card);
+                }
             } catch (Win32Exception e) {
                 if (e.getErrorCode() != WinError.ERROR_ACCESS_DENIED) {
                     // Ignore access denied errors, re-throw others
@@ -150,10 +180,14 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
             }
         }
 
-        if (cardList.isEmpty()) {
-            return getGraphicsCardsFromWmi(dxgiAdapters);
+        // Merge: DXGI-ordered cards first (primary adapter at index 0), then any non-DXGI cards.
+        List<GraphicsCard> result = new ArrayList<>(dxgiOrdered.values());
+        result.addAll(cardList);
+
+        if (result.isEmpty()) {
+            return getGraphicsCardsFromWmi(remainingDxgi);
         }
-        return cardList;
+        return result;
     }
 
     /**
@@ -171,8 +205,20 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
     private static List<GraphicsCard> getGraphicsCardsFromWmi(List<DxgiAdapterInfo> dxgiAdapters) {
         List<GraphicsCard> cardList = new ArrayList<>();
         if (IS_VISTA_OR_GREATER) {
+            boolean dxgiAvailable = !dxgiAdapters.isEmpty();
+            // dxgiAdapters is not mutated; remainingDxgi is the working copy consumed during matching.
+            // dxgiAdapters is retained as the stable reference for indexOf ordering lookups.
+            List<DxgiAdapterInfo> remainingDxgi = new ArrayList<>(dxgiAdapters);
+            TreeMap<Integer, GraphicsCard> dxgiOrdered = new TreeMap<>();
+
             WmiResult<VideoControllerProperty> cards = Win32VideoController.queryVideoController();
             for (int index = 0; index < cards.getResultCount(); index++) {
+                // ConfigManagerErrorCode 0 = working properly; non-zero = disabled/error (ghost device).
+                // When DXGI is unavailable, keep all entries for maximum compatibility.
+                if (dxgiAvailable
+                        && WmiUtil.getUint32(cards, VideoControllerProperty.CONFIGMANAGERERRORCODE, index) != 0) {
+                    continue;
+                }
                 String name = WmiUtil.getString(cards, VideoControllerProperty.NAME, index);
                 Triplet<String, String, String> idPair = ParseUtil.parseDeviceIdToVendorProductSerial(
                         WmiUtil.getString(cards, VideoControllerProperty.PNPDEVICEID, index));
@@ -198,17 +244,27 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                         WmiUtil.getString(cards, VideoControllerProperty.PNPDEVICEID, index));
                 int pciVendorId = pciIds == null ? 0 : pciIds.getA();
                 int pciDeviceId = pciIds == null ? 0 : pciIds.getB();
-                DxgiAdapterInfo dxgiMatch = WindowsDxgi.findMatch(dxgiAdapters, pciVendorId, pciDeviceId, name);
+                DxgiAdapterInfo dxgiMatch = WindowsDxgi.findMatch(remainingDxgi, pciVendorId, pciDeviceId, name);
                 long vram;
+                int dxgiIndex = -1;
                 if (dxgiMatch != null) {
                     vram = dxgiMatch.getDedicatedVideoMemory();
-                    dxgiAdapters.remove(dxgiMatch);
+                    dxgiIndex = dxgiAdapters.indexOf(dxgiMatch);
+                    remainingDxgi.remove(dxgiMatch);
                 } else {
                     vram = WmiUtil.getUint32asLong(cards, VideoControllerProperty.ADAPTERRAM, index);
                 }
-                cardList.add(new WindowsGraphicsCard(Util.isBlank(name) ? Constants.UNKNOWN : name, deviceId,
-                        Util.isBlank(vendor) ? Constants.UNKNOWN : vendor, versionInfo, vram));
+                GraphicsCard card = new WindowsGraphicsCard(Util.isBlank(name) ? Constants.UNKNOWN : name, deviceId,
+                        Util.isBlank(vendor) ? Constants.UNKNOWN : vendor, versionInfo, vram);
+                if (dxgiIndex >= 0) {
+                    dxgiOrdered.put(dxgiIndex, card);
+                } else {
+                    cardList.add(card);
+                }
             }
+            List<GraphicsCard> result = new ArrayList<>(dxgiOrdered.values());
+            result.addAll(cardList);
+            return result;
         }
         return cardList;
     }

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/WindowsDxgi.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/WindowsDxgi.java
@@ -54,7 +54,7 @@ public final class WindowsDxgi {
     private static final com.sun.jna.platform.win32.Guid.IID IID_IDXGI_FACTORY = new com.sun.jna.platform.win32.Guid.IID(
             "{7B7166EC-21C7-44AE-B21A-C9AE321AE369}");
 
-    // DXGI_ERROR_NOT_FOUND — returned by EnumAdapters when index is out of range
+    // DXGI_ERROR_NOT_FOUND: returned by EnumAdapters when index is out of range
     private static final int DXGI_ERROR_NOT_FOUND = 0x887A0002;
 
     private WindowsDxgi() {


### PR DESCRIPTION
When DXGI is available, `getGraphicsCards()` now excludes ghost adapters (stale registry/WMI entries from hardware no longer physically present) and returns the list ordered by DXGI enumeration order, which guarantees the primary desktop adapter is first.

- Registry path: registry entries with no matching DXGI adapter are skipped
- WMI fallback path: entries with `ConfigManagerErrorCode != 0` are skipped; DXGI ordering applied when adapters are available
- When DXGI is unavailable, existing behavior is preserved (all entries, registry key order)

Fixes #2670



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filtered out disabled/ghost Windows GPU adapters and improved DXGI-based ordering for more accurate graphics card detection
  * Improved fallback behavior and VRAM handling when DXGI is unavailable

* **Documentation**
  * Updated changelog entry formatting and added a new note about filtering and DXGI ordering
  * Updated copyright year and minor DXGI docs/comments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->