### PR TITLE
Add Apple Silicon SMC sensor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ##### Bug fixes / Improvements
 * [#3086](https://github.com/oshi/oshi/pull/3086): DXGI-based VRAM detection for Windows GPU adapters - [@dbwiddis](https://github.com/dbwiddis).
 * [#3087](https://github.com/oshi/oshi/pull/3087): Filter disabled Windows GPU adapters and order by DXGI enumeration - [@dbwiddis](https://github.com/dbwiddis).
+* [#3091](https://github.com/oshi/oshi/pull/3091): Add Apple Silicon SMC sensor support - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.10.0 (2026-02-22)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
@@ -11,6 +11,12 @@ import com.sun.jna.platform.mac.IOKit.IOConnect;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.AbstractSensors;
 import oshi.util.platform.mac.SmcUtil;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_TEMP;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_VOLTAGE;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_VOLTAGE_AS;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEY_FAN_NUM;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEY_FAN_SPEED;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEYS_CPU_TEMP_AS;
 
 /**
  * Sensors from SMC
@@ -24,34 +30,56 @@ final class MacSensors extends AbstractSensors {
     @Override
     public double queryCpuTemperature() {
         IOConnect conn = SmcUtil.smcOpen();
-        double temp = SmcUtil.smcGetFloat(conn, SmcUtil.SMC_KEY_CPU_TEMP);
-        SmcUtil.smcClose(conn);
-        if (temp > 0d) {
-            return temp;
+        if (conn == null) {
+            return 0d;
         }
-        return 0d;
+        try {
+            double temp = SmcUtil.smcGetFirstFloat(conn, SMC_KEYS_CPU_TEMP_AS);
+            if (temp <= 0d) {
+                temp = SmcUtil.smcGetFloat(conn, SMC_KEY_CPU_TEMP);
+            }
+            return temp;
+        } finally {
+            SmcUtil.smcClose(conn);
+        }
     }
 
     @Override
     public int[] queryFanSpeeds() {
-        // If we don't have fan # try to get it
         IOConnect conn = SmcUtil.smcOpen();
-        if (this.numFans == 0) {
-            this.numFans = (int) SmcUtil.smcGetLong(conn, SmcUtil.SMC_KEY_FAN_NUM);
+        if (conn == null) {
+            return new int[this.numFans];
         }
-        int[] fanSpeeds = new int[this.numFans];
-        for (int i = 0; i < this.numFans; i++) {
-            fanSpeeds[i] = (int) SmcUtil.smcGetFloat(conn, String.format(Locale.ROOT, SmcUtil.SMC_KEY_FAN_SPEED, i));
+        try {
+            if (this.numFans == 0) {
+                this.numFans = (int) SmcUtil.smcGetLong(conn, SMC_KEY_FAN_NUM);
+            }
+            int[] fanSpeeds = new int[this.numFans];
+            for (int i = 0; i < this.numFans; i++) {
+                fanSpeeds[i] = (int) SmcUtil.smcGetFloat(conn, String.format(Locale.ROOT, SMC_KEY_FAN_SPEED, i));
+            }
+            return fanSpeeds;
+        } finally {
+            SmcUtil.smcClose(conn);
         }
-        SmcUtil.smcClose(conn);
-        return fanSpeeds;
     }
 
     @Override
     public double queryCpuVoltage() {
         IOConnect conn = SmcUtil.smcOpen();
-        double volts = SmcUtil.smcGetFloat(conn, SmcUtil.SMC_KEY_CPU_VOLTAGE) / 1000d;
-        SmcUtil.smcClose(conn);
-        return volts;
+        if (conn == null) {
+            return 0d;
+        }
+        try {
+            // Apple Silicon: VP0C is flt already in volts, no scaling needed
+            double volts = SmcUtil.smcGetFloat(conn, SMC_KEY_CPU_VOLTAGE_AS);
+            if (volts > 0d) {
+                return volts;
+            }
+            // Intel: VC0C is FPE2 in millivolts, divide by 1000 to get volts
+            return SmcUtil.smcGetFloat(conn, SMC_KEY_CPU_VOLTAGE) / 1000d;
+        } finally {
+            SmcUtil.smcClose(conn);
+        }
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.mac;
@@ -55,6 +55,11 @@ public final class SmcUtil {
     public static final String SMC_KEY_FAN_SPEED = "F%dAc";
     public static final String SMC_KEY_CPU_TEMP = "TC0P";
     public static final String SMC_KEY_CPU_VOLTAGE = "VC0C";
+
+    /** Apple Silicon keys, tried in order until one returns a positive value. */
+    public static final String[] SMC_KEYS_CPU_TEMP_AS = { "Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D" };
+    public static final String[] SMC_KEYS_GPU_TEMP_AS = { "Tg05", "Tg0D", "Tg0f", "Tg0j" };
+    public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
 
     public static final byte SMC_CMD_READ_BYTES = 5;
     public static final byte SMC_CMD_READ_KEYINFO = 9;
@@ -124,6 +129,23 @@ public final class SmcUtil {
             }
         }
         // Read failed
+        return 0d;
+    }
+
+    /**
+     * Get the first positive value from a list of SMC keys.
+     *
+     * @param conn The connection
+     * @param keys The keys to try in order
+     * @return The first value greater than 0, or 0 if all keys fail
+     */
+    public static double smcGetFirstFloat(IOConnect conn, String... keys) {
+        for (String key : keys) {
+            double val = smcGetFloat(conn, key);
+            if (val > 0d) {
+                return val;
+            }
+        }
         return 0d;
     }
 

--- a/oshi-demo/src/main/java/oshi/demo/SmcDump.java
+++ b/oshi-demo/src/main/java/oshi/demo/SmcDump.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.demo;
+
+import com.sun.jna.NativeLong;
+import com.sun.jna.platform.mac.IOKit.IOConnect;
+
+import java.util.Locale;
+
+import oshi.annotation.SuppressForbidden;
+import oshi.jna.ByRef.CloseableNativeLongByReference;
+import oshi.jna.platform.mac.IOKit;
+import oshi.jna.platform.mac.IOKit.SMCKeyData;
+import oshi.jna.platform.mac.IOKit.SMCVal;
+import oshi.util.ParseUtil;
+import oshi.util.platform.mac.SmcUtil;
+
+/**
+ * Dumps all readable SMC keys and their raw float values. Run on macOS to discover Apple Silicon key names for fans,
+ * voltage, and other sensors.
+ */
+public final class SmcDump {
+
+    private static final byte SMC_CMD_READ_INDEX = 8;
+    private static final IOKit IO = IOKit.INSTANCE;
+
+    private SmcDump() {
+    }
+
+    @SuppressForbidden(reason = "Using System.out in a demo class")
+    public static void main(String[] args) {
+        IOConnect conn = SmcUtil.smcOpen();
+        if (conn == null) {
+            System.err.println("Failed to open SMC connection"); // NOPMD
+            return;
+        }
+        try {
+            long keyCount = SmcUtil.smcGetLong(conn, "#KEY");
+            System.out.printf(Locale.ROOT, "Total SMC keys: %d%n%n", keyCount);
+            System.out.printf(Locale.ROOT, "%-6s %-6s %-8s %s%n", "Key", "Type", "Size", "Float value");
+            System.out.println("----------------------------------------------");
+
+            for (int i = 0; i < keyCount; i++) {
+                String keyName = readKeyAtIndex(conn, i);
+                if (keyName == null) {
+                    continue;
+                }
+                try (SMCVal val = new SMCVal()) {
+                    int result = SmcUtil.smcReadKey(conn, keyName, val);
+                    String typeName = result == 0 ? asciiType(val.dataType) : "?";
+                    int size = result == 0 ? val.dataSize : 0;
+                    double floatVal = SmcUtil.smcGetFloat(conn, keyName);
+                    char first = keyName.charAt(0);
+                    if (first == 'F' || first == 'V' || first == 'T' || floatVal != 0d) {
+                        System.out.printf(Locale.ROOT, "%-6s %-6s %-8d %.4f%n", keyName, typeName, size, floatVal);
+                    }
+                }
+            }
+        } finally {
+            SmcUtil.smcClose(conn);
+        }
+    }
+
+    private static String readKeyAtIndex(IOConnect conn, int index) {
+        try (SMCKeyData input = new SMCKeyData();
+                SMCKeyData output = new SMCKeyData();
+                CloseableNativeLongByReference size = new CloseableNativeLongByReference(
+                        new NativeLong(output.size()))) {
+            input.data8 = SMC_CMD_READ_INDEX;
+            input.data32 = index;
+            int result = IO.IOConnectCallStructMethod(conn, SmcUtil.KERNEL_INDEX_SMC, input,
+                    new NativeLong(input.size()), output, size);
+            if (result != 0) {
+                return null;
+            }
+            // Key is stored as a big-endian 4-byte int in output.key; convert to ASCII string
+            byte[] keyBytes = ParseUtil.longToByteArray(output.key, 4, 4);
+            StringBuilder sb = new StringBuilder(4);
+            for (byte b : keyBytes) {
+                sb.append((char) (b & 0xFF));
+            }
+            return sb.toString();
+        }
+    }
+
+    private static String asciiType(byte[] dataType) {
+        if (dataType == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (byte b : dataType) {
+            if (b == 0) {
+                break;
+            }
+            sb.append((char) b);
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Adds Apple Silicon (M-series) SMC key support for CPU temperature and voltage
sensors in `SmcUtil` and `MacSensors`, with probe-first fallback to Intel keys
for backward compatibility. Also fixes a null-pointer risk in `MacSensors` when
`smcOpen()` fails.

Phase 1 of https://github.com/oshi/oshi/issues/3090#issuecomment-4048942386

---

### Changes

#### `SmcUtil.java`
- Added `SMC_KEYS_CPU_TEMP_AS` — ordered array of Apple Silicon CPU die
  temperature keys (`Tp09`, `Tp0T`, `Tp01`, `Tp05`, `Tp0D`), derived from live
  SMC enumeration on Apple Silicon hardware
- Added `SMC_KEYS_GPU_TEMP_AS` — ordered array of Apple Silicon GPU temperature
  keys (`Tg05`, `Tg0D`, `Tg0f`, `Tg0j`) for future use
- Added `SMC_KEY_CPU_VOLTAGE_AS` — Apple Silicon CPU core voltage key (`VP0C`),
  type `flt`, already in volts (no scaling required)
- Added `smcGetFirstFloat(IOConnect conn, String... keys)` — iterates a list of
  keys and returns the first value `> 0`, or `0` if all fail

#### `MacSensors.java`
- `queryCpuTemperature()`: wrapped in `try/finally` with null-guard on
  connection; probes Apple Silicon keys first via `smcGetFirstFloat`, falls back
  to Intel `TC0P`
- `queryCpuVoltage()`: wrapped in `try/finally` with null-guard on connection;
  probes Apple Silicon `VP0C` first (no `/1000` scaling), falls back to Intel
  `VC0C / 1000`
- `queryFanSpeeds()`: unchanged — `FNum` and `F%dAc` keys work correctly on
  both architectures; zero fan speeds on fanless Apple Silicon models are
  accurate
- Replaced all `SmcUtil.SMC_KEY_*` qualified references with explicit static
  imports

---

### Motivation

Apple Silicon Macs use entirely different SMC key namespaces from Intel Macs.
The existing code only knew Intel keys (`TC0P`, `VC0C`), causing CPU temperature
and voltage to report `0` on all M-series hardware. As Apple Silicon is now the
majority of active Mac hardware, AS keys are probed first with Intel keys as the
fallback.

---

### Testing

Verified on Apple Silicon (M-series) hardware:

| Metric          | Before  | After     |
|-----------------|---------|-----------|
| CPU Temperature | `0.0°C` | `65.8°C`  |
| Fan Speeds      | `[0, 0]`| `[0, 0]`  |
| CPU Voltage     | `0.0V`  | `0.997V`  |

Fan speeds correctly report `[0, 0]` on fanless Apple Silicon models. Intel
behaviour is unchanged — the Intel key paths are still exercised when AS keys
return `0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apple Silicon-specific sensor support added for CPU temperature and voltage.
  * New macOS utility to enumerate and display SMC keys and readable sensor values.

* **Bug Fixes**
  * Improved error handling, null-safety, and resource cleanup for SMC sensor access.
  * Added fallback lookups to improve reliability of sensor readings across Mac hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->