### PR TITLE
Don't WARN log on missing optional dependency

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.windows;
@@ -356,6 +356,8 @@ final class WindowsSensors extends AbstractSensors {
 
             Method querySensorsMethod = libreHardwareManagerClass.getMethod("querySensors", String.class, String.class);
             return (List<?>) querySensorsMethod.invoke(instance, hardwareType, sensorType);
+        } catch (ClassNotFoundException e) {
+            LOG.trace("jLibreHardwareMonitor not available: {}", e.getMessage());
         } catch (Exception e) {
             LOG.warn(REFLECT_EXCEPTION_MSG, e.getMessage());
         }


### PR DESCRIPTION
Gets rid of this log noise when jLibreHardwareMonitor isn't a dependency:

```
SystemInfoTest - Checking Sensors...
Warning: 2026-03-29 18:43:38.148 [WARN] WindowsSensors - Reflect exception: io.github.pandalxb.jlibrehardwaremonitor.config.ComputerConfig
Warning: 2026-03-29 18:43:38.171 [WARN] WindowsSensors - Reflect exception: io.github.pandalxb.jlibrehardwaremonitor.config.ComputerConfig
Warning: 2026-03-29 18:43:38.186 [WARN] WindowsSensors - Reflect exception: io.github.pandalxb.jlibrehardwaremonitor.config.ComputerConfig
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for scenarios where hardware sensor monitoring libraries are unavailable, with enhanced diagnostic logging to provide clearer information when sensors cannot be detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->