### PR TITLE
Add FFM-based CUPS printer implementation for Unix-like systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#3109](https://github.com/oshi/oshi/pull/3109),
   [#3110](https://github.com/oshi/oshi/pull/3110),
   [#3111](https://github.com/oshi/oshi/pull/3111): Migrate mac HardwareAbstractionLayer JNA to FFM - [@dbwiddis](https://github.com/dbwiddis).
+* [#3113](https://github.com/oshi/oshi/pull/3113): Implement FFM-based CUPS printer support for macOS - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.10.0 (2026-02-22)
 

--- a/oshi-core-java25/src/main/java/oshi/ffm/unix/CupsFunctions.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/unix/CupsFunctions.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.unix;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+
+import oshi.ffm.ForeignFunctions;
+
+/**
+ * FFM bindings for the CUPS (Common Unix Printing System) library.
+ * <p>
+ * CUPS is available as {@code libcups} on Linux and macOS (via the dyld shared cache as {@code libcups.dylib}).
+ */
+public final class CupsFunctions extends ForeignFunctions {
+
+    private CupsFunctions() {
+    }
+
+    /** IPP printer state: idle. */
+    public static final int IPP_PRINTER_IDLE = 3;
+    /** IPP printer state: processing (printing). */
+    public static final int IPP_PRINTER_PROCESSING = 4;
+    /** IPP printer state: stopped. */
+    public static final int IPP_PRINTER_STOPPED = 5;
+
+    /** Printer type bit flag indicating a remote (network) printer. */
+    public static final int CUPS_PRINTER_REMOTE = 0x0002;
+
+    /**
+     * Layout of {@code cups_dest_t}:
+     *
+     * <pre>
+     * typedef struct {
+     *     char          *name;        // Printer or class name
+     *     char          *instance;    // Local instance name or NULL
+     *     int           is_default;   // Is this printer the default?
+     *     int           num_options;  // Number of options
+     *     cups_option_t *options;     // Options
+     * } cups_dest_t;
+     * </pre>
+     */
+    public static final StructLayout CUPS_DEST_T = MemoryLayout.structLayout(ADDRESS.withName("name"),
+            ADDRESS.withName("instance"), JAVA_INT.withName("is_default"), JAVA_INT.withName("num_options"),
+            ADDRESS.withName("options"));
+
+    /** VarHandle for the {@code name} field of {@code cups_dest_t}. */
+    public static final VarHandle CUPS_DEST_NAME = CUPS_DEST_T.varHandle(MemoryLayout.PathElement.groupElement("name"));
+    /** VarHandle for the {@code is_default} field of {@code cups_dest_t}. */
+    public static final VarHandle CUPS_DEST_IS_DEFAULT = CUPS_DEST_T
+            .varHandle(MemoryLayout.PathElement.groupElement("is_default"));
+    /** VarHandle for the {@code num_options} field of {@code cups_dest_t}. */
+    public static final VarHandle CUPS_DEST_NUM_OPTIONS = CUPS_DEST_T
+            .varHandle(MemoryLayout.PathElement.groupElement("num_options"));
+    /** VarHandle for the {@code options} field of {@code cups_dest_t}. */
+    public static final VarHandle CUPS_DEST_OPTIONS = CUPS_DEST_T
+            .varHandle(MemoryLayout.PathElement.groupElement("options"));
+
+    private static final SymbolLookup CUPS_LIBRARY;
+    private static final boolean AVAILABLE;
+
+    // int cupsGetDests(cups_dest_t **dests);
+    private static final MethodHandle cupsGetDests;
+    // void cupsFreeDests(int num_dests, cups_dest_t *dests);
+    private static final MethodHandle cupsFreeDests;
+    // const char *cupsGetOption(const char *name, int num_options, cups_option_t *options);
+    private static final MethodHandle cupsGetOption;
+    // const char *cupsGetDefault(void);
+    private static final MethodHandle cupsGetDefault;
+
+    static {
+        SymbolLookup lookup = null;
+        boolean available = false;
+        MethodHandle hGetDests = null;
+        MethodHandle hFreeDests = null;
+        MethodHandle hGetOption = null;
+        MethodHandle hGetDefault = null;
+        try {
+            lookup = libraryLookup("cups");
+            hGetDests = LINKER.downcallHandle(lookup.findOrThrow("cupsGetDests"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS));
+            hFreeDests = LINKER.downcallHandle(lookup.findOrThrow("cupsFreeDests"),
+                    FunctionDescriptor.ofVoid(JAVA_INT, ADDRESS));
+            hGetOption = LINKER.downcallHandle(lookup.findOrThrow("cupsGetOption"),
+                    FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_INT, ADDRESS));
+            hGetDefault = LINKER.downcallHandle(lookup.findOrThrow("cupsGetDefault"), FunctionDescriptor.of(ADDRESS));
+            available = true;
+        } catch (Throwable e) {
+            // libcups not available or symbol binding failed; callers should fall back to lpstat
+        }
+        CUPS_LIBRARY = lookup;
+        AVAILABLE = available;
+        cupsGetDests = hGetDests;
+        cupsFreeDests = hFreeDests;
+        cupsGetOption = hGetOption;
+        cupsGetDefault = hGetDefault;
+    }
+
+    /**
+     * Returns whether the CUPS library was successfully loaded and all symbols bound.
+     *
+     * @return {@code true} if libcups is available
+     */
+    public static boolean isAvailable() {
+        return AVAILABLE;
+    }
+
+    /**
+     * Gets all available CUPS destinations (printers and classes).
+     *
+     * @param dests a pointer-to-pointer that will be set to the allocated destination array
+     * @return the number of destinations, or 0 on failure
+     * @throws Throwable if the native call fails
+     */
+    public static int cupsGetDests(MemorySegment dests) throws Throwable {
+        return (int) cupsGetDests.invokeExact(dests);
+    }
+
+    /**
+     * Frees the memory allocated by {@link #cupsGetDests}.
+     *
+     * @param numDests the number of destinations returned by {@link #cupsGetDests}
+     * @param dests    the destination array pointer
+     * @throws Throwable if the native call fails
+     */
+    public static void cupsFreeDests(int numDests, MemorySegment dests) throws Throwable {
+        cupsFreeDests.invokeExact(numDests, dests);
+    }
+
+    /**
+     * Gets the value of a named option from a destination's options array.
+     *
+     * @param name       the option name as a native string segment
+     * @param numOptions the number of options
+     * @param options    pointer to the options array
+     * @return a native segment pointing to the option value string, or a NULL segment if not found
+     * @throws Throwable if the native call fails
+     */
+    public static MemorySegment cupsGetOption(MemorySegment name, int numOptions, MemorySegment options)
+            throws Throwable {
+        return (MemorySegment) cupsGetOption.invokeExact(name, numOptions, options);
+    }
+
+    /**
+     * Gets the default printer name.
+     *
+     * @return a native segment pointing to the default printer name, or a NULL segment if none is set
+     * @throws Throwable if the native call fails
+     */
+    public static MemorySegment cupsGetDefault() throws Throwable {
+        return (MemorySegment) cupsGetDefault.invokeExact();
+    }
+
+    /**
+     * Convenience method to read a named option value from a destination's options segment.
+     *
+     * @param optionName the option name
+     * @param numOptions the number of options in the array
+     * @param options    the native options pointer
+     * @param arena      the arena to allocate the name string in
+     * @return the option value, or an empty string if not found
+     */
+    public static String getOption(String optionName, int numOptions, MemorySegment options, Arena arena) {
+        try {
+            MemorySegment nameSegment = arena.allocateFrom(optionName);
+            MemorySegment result = cupsGetOption(nameSegment, numOptions, options);
+            if (result == null || result.equals(MemorySegment.NULL)) {
+                return "";
+            }
+            return getStringFromNativePointer(result, arena);
+        } catch (Throwable e) {
+            return "";
+        }
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/unix/CupsPrinter.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/unix/CupsPrinter.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.unix;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.Immutable;
+import oshi.ffm.ForeignFunctions;
+import oshi.hardware.Printer;
+import oshi.hardware.common.AbstractPrinter;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+/**
+ * CUPS-based printer implementation using the Java FFM API. Uses libcups if available, otherwise falls back to the
+ * {@code lpstat} command.
+ */
+@Immutable
+public final class CupsPrinter extends AbstractPrinter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CupsPrinter.class);
+
+    // Local URI schemes for directly-attached or local printers
+    private static final List<String> LOCAL_URI_PREFIXES = List.of("usb:", "parallel:", "serial:", "file:", "direct:",
+            "hp:", "lpd://127.", "lpd://localhost", "socket://127.", "socket://localhost");
+
+    CupsPrinter(String name, String driverName, String description, PrinterStatus status, String statusReason,
+            boolean isDefault, boolean isLocal, String portName) {
+        super(name, driverName, description, status, statusReason, isDefault, isLocal, portName);
+    }
+
+    /**
+     * Gets printers using CUPS. Uses libcups via FFM if available, otherwise falls back to the {@code lpstat} command.
+     *
+     * @return a list of printers
+     */
+    public static List<Printer> getPrinters() {
+        if (CupsFunctions.isAvailable()) {
+            return getPrintersFromLibCups();
+        }
+        LOG.debug("libcups not available, falling back to lpstat.");
+        return getPrintersFromLpstat();
+    }
+
+    private static List<Printer> getPrintersFromLibCups() {
+        List<Printer> printers = new ArrayList<>();
+        try (Arena arena = Arena.ofConfined()) {
+            // cupsGetDests(cups_dest_t **dests) — allocate a pointer slot to receive the array pointer
+            MemorySegment ptrSlot = arena.allocate(ADDRESS);
+            int numDests = CupsFunctions.cupsGetDests(ptrSlot);
+            if (numDests <= 0) {
+                return printers;
+            }
+            MemorySegment destsPtr = ptrSlot.get(ADDRESS, 0);
+            if (destsPtr == null || destsPtr.equals(MemorySegment.NULL)) {
+                return printers;
+            }
+            try {
+                MemorySegment destsArray = destsPtr.reinterpret(CupsFunctions.CUPS_DEST_T.byteSize() * numDests, arena,
+                        null);
+                for (int i = 0; i < numDests; i++) {
+                    long offset = i * CupsFunctions.CUPS_DEST_T.byteSize();
+                    MemorySegment dest = destsArray.asSlice(offset, CupsFunctions.CUPS_DEST_T.byteSize());
+
+                    MemorySegment namePtr = (MemorySegment) CupsFunctions.CUPS_DEST_NAME.get(dest, 0L);
+                    if (namePtr == null || namePtr.equals(MemorySegment.NULL)) {
+                        continue;
+                    }
+                    String name = ForeignFunctions.getStringFromNativePointer(namePtr, arena);
+                    int isDefaultInt = (int) CupsFunctions.CUPS_DEST_IS_DEFAULT.get(dest, 0L);
+                    boolean isDefault = isDefaultInt != 0;
+                    int numOptions = (int) CupsFunctions.CUPS_DEST_NUM_OPTIONS.get(dest, 0L);
+                    MemorySegment options = (MemorySegment) CupsFunctions.CUPS_DEST_OPTIONS.get(dest, 0L);
+
+                    String deviceUri = CupsFunctions.getOption("device-uri", numOptions, options, arena);
+                    String printerInfo = CupsFunctions.getOption("printer-info", numOptions, options, arena);
+                    String printerMakeModel = CupsFunctions.getOption("printer-make-and-model", numOptions, options,
+                            arena);
+                    String printerState = CupsFunctions.getOption("printer-state", numOptions, options, arena);
+                    String stateReasons = CupsFunctions.getOption("printer-state-reasons", numOptions, options, arena);
+                    String printerTypeStr = CupsFunctions.getOption("printer-type", numOptions, options, arena);
+
+                    PrinterStatus status = parseStateFromCups(printerState, stateReasons);
+                    String statusReason = "none".equals(stateReasons) ? "" : stateReasons;
+                    int printerType = ParseUtil.parseIntOrDefault(printerTypeStr, 0);
+                    boolean isLocal = (printerType & CupsFunctions.CUPS_PRINTER_REMOTE) == 0;
+
+                    printers.add(new CupsPrinter(name, printerMakeModel, printerInfo, status, statusReason, isDefault,
+                            isLocal, deviceUri));
+                }
+            } finally {
+                CupsFunctions.cupsFreeDests(numDests, destsPtr);
+            }
+
+        } catch (Throwable e) {
+            LOG.warn("Failed to query printers from libcups: {}", e.getMessage(), e);
+        }
+        return printers;
+    }
+
+    private static PrinterStatus parseStateFromCups(String state, String stateReasons) {
+        if (!stateReasons.isEmpty() && !"none".equals(stateReasons)) {
+            String lower = stateReasons.toLowerCase(Locale.ROOT);
+            if (lower.contains("error") || lower.contains("fault")) {
+                return PrinterStatus.ERROR;
+            }
+        }
+        if (state.isEmpty()) {
+            return PrinterStatus.UNKNOWN;
+        }
+        switch (ParseUtil.parseIntOrDefault(state, -1)) {
+            case CupsFunctions.IPP_PRINTER_IDLE:
+                return PrinterStatus.IDLE;
+            case CupsFunctions.IPP_PRINTER_PROCESSING:
+                return PrinterStatus.PRINTING;
+            case CupsFunctions.IPP_PRINTER_STOPPED:
+                return PrinterStatus.OFFLINE;
+            default:
+                return PrinterStatus.UNKNOWN;
+        }
+    }
+
+    private static List<Printer> getPrintersFromLpstat() {
+        List<Printer> printers = new ArrayList<>();
+        String defaultPrinter = getDefaultPrinter();
+        Map<String, String> portMap = parsePortMap();
+        Map<String, String> descriptionMap = parseDescriptionMap();
+
+        for (String line : ExecutingCommand.runNative(new String[] { "lpstat", "-p" })) {
+            if (line.startsWith("printer ")) {
+                String[] parts = line.split("\\s+");
+                if (parts.length >= 3) {
+                    String name = parts[1];
+                    PrinterStatus status = parseStatusFromLpstat(line);
+                    boolean isDefault = name.equals(defaultPrinter);
+                    String portName = portMap.getOrDefault(name, "");
+                    boolean isLocal = isLocalUri(portName);
+                    String driverName = getDriverForPrinter(name);
+                    String description = descriptionMap.getOrDefault(name, "");
+                    String statusReason = getStatusReasonFromLpstat(line);
+                    printers.add(new CupsPrinter(name, driverName, description, status, statusReason, isDefault,
+                            isLocal, portName));
+                }
+            }
+        }
+        return printers;
+    }
+
+    private static Map<String, String> parsePortMap() {
+        Map<String, String> map = new HashMap<>();
+        for (String line : ExecutingCommand.runNative(new String[] { "lpstat", "-v" })) {
+            if (line.contains("device for")) {
+                int forIdx = line.indexOf("device for ") + 11;
+                int colonIdx = line.indexOf(':', forIdx);
+                if (colonIdx > forIdx) {
+                    map.put(line.substring(forIdx, colonIdx).trim(), line.substring(colonIdx + 1).trim());
+                }
+            }
+        }
+        return map;
+    }
+
+    private static Map<String, String> parseDescriptionMap() {
+        Map<String, String> map = new HashMap<>();
+        String currentPrinter = null;
+        for (String line : ExecutingCommand.runNative(new String[] { "lpstat", "-l", "-p" })) {
+            if (line.startsWith("printer ")) {
+                String[] parts = line.split("\\s+");
+                if (parts.length >= 2) {
+                    currentPrinter = parts[1];
+                }
+            } else if (currentPrinter != null && line.trim().startsWith("Description:")) {
+                map.put(currentPrinter, line.substring(line.indexOf(':') + 1).trim());
+            }
+        }
+        return map;
+    }
+
+    private static String getDriverForPrinter(String printerName) {
+        for (String line : ExecutingCommand.runNative(new String[] { "lpoptions", "-p", printerName })) {
+            int idx = line.indexOf("printer-make-and-model='");
+            if (idx >= 0) {
+                int start = idx + 24;
+                int end = line.indexOf('\'', start);
+                if (end > start) {
+                    return line.substring(start, end);
+                }
+            }
+        }
+        return "";
+    }
+
+    private static String getDefaultPrinter() {
+        for (String line : ExecutingCommand.runNative(new String[] { "lpstat", "-d" })) {
+            if (line.contains("default destination:")) {
+                String[] parts = line.split(":", 2);
+                if (parts.length >= 2) {
+                    return parts[1].trim();
+                }
+            }
+        }
+        return "";
+    }
+
+    private static PrinterStatus parseStatusFromLpstat(String line) {
+        String lower = line.toLowerCase(Locale.ROOT);
+        if (lower.contains("disabled") || lower.contains("not accepting")) {
+            return PrinterStatus.OFFLINE;
+        } else if (lower.contains("printing")) {
+            return PrinterStatus.PRINTING;
+        } else if (lower.contains("idle")) {
+            return PrinterStatus.IDLE;
+        } else if (lower.contains("error") || lower.contains("fault")) {
+            return PrinterStatus.ERROR;
+        }
+        return PrinterStatus.UNKNOWN;
+    }
+
+    private static String getStatusReasonFromLpstat(String line) {
+        int dashIdx = line.indexOf(" - ");
+        return dashIdx > 0 ? line.substring(dashIdx + 3).trim() : "";
+    }
+
+    private static boolean isLocalUri(String uri) {
+        if (uri.startsWith("/dev")) {
+            return true;
+        }
+        for (String prefix : LOCAL_URI_PREFIXES) {
+            if (uri.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/unix/package-info.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/unix/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides FFM access to system libraries for Unix-like systems.
+ */
+package oshi.ffm.unix;

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerFFM.java
@@ -7,6 +7,7 @@ package oshi.hardware.platform.mac;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.unix.CupsPrinter;
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.ComputerSystem;
 import oshi.hardware.Display;
@@ -15,11 +16,17 @@ import oshi.hardware.GlobalMemory;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.PowerSource;
+import oshi.hardware.Printer;
 import oshi.hardware.Sensors;
 import oshi.hardware.UsbDevice;
 
 @ThreadSafe
 public final class MacHardwareAbstractionLayerFFM extends MacHardwareAbstractionLayer {
+    @Override
+    public List<Printer> getPrinters() {
+        return CupsPrinter.getPrinters();
+    }
+
     @Override
     public CentralProcessor createProcessor() {
         return new MacCentralProcessorFFM();


### PR DESCRIPTION
This PR replaces the last remaining JNA usage in the macOS FFM code path — printer enumeration — with a native FFM implementation, and lays the groundwork for future Linux FFM printer support.

## New oshi.ffm.unix package

- `CupsFunctions`: FFM bindings for libcups: `cups_dest_t` struct layout with VarHandles for each field, downcall handles for `cupsGetDests`, `cupsFreeDests`, `cupsGetOption`, and `cupsGetDefault`. Library loading is attempted at class initialization; `isAvailable()` allows callers to detect failure and fall back gracefully. On macOS, libcups.dylib is resolved via the dyld shared cache (no framework lookup needed); on Linux it resolves as libcups.so.
- `CupsPrinter`: AbstractPrinter implementation that mirrors `UnixPrinter` faithfully: uses `CupsFunctions` when libcups is available, falls back to lpstat command parsing otherwise. The `cupsGetDests` pointer-to-pointer pattern allocates an `ADDRESS` slot, reads the returned array pointer, reinterprets it as a `cups_dest_t` array, then passes the original pointer to cupsFreeDests.

## MacHardwareAbstractionLayerFFM

Overrides `getPrinters()` to call `CupsPrinter.getPrinters()` instead of the JNA-based `UnixPrinter.getPrinters()`, completing the removal of JNA from the macOS FFM hardware code path.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CUPS-based printer discovery on Unix/macOS with richer details: device URI, driver info, printer status, default flag, and local/remote detection; falls back to lpstat/lpoptions when CUPS is unavailable.
  * macOS hardware layer now returns printers via the new discovery implementation.
* **Documentation**
  * Changelog updated with the new CUPS-based printer support entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->