### PR TITLE
Fix Site Build

### DIFF
--- a/oshi-core/src/main/java/oshi/driver/windows/DxgiAdapterInfo.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/DxgiAdapterInfo.java
@@ -11,7 +11,7 @@ import java.util.Locale;
  *
  * <p>
  * Populated by {@link oshi.jna.platform.windows.WindowsDxgi#queryAdapters()} and used by
- * {@link oshi.hardware.platform.windows.WindowsGraphicsCard} to supply accurate VRAM values.
+ * {@code oshi.hardware.platform.windows.WindowsGraphicsCard} to supply accurate VRAM values.
  * {@code DedicatedVideoMemory} from {@code DXGI_ADAPTER_DESC} is the authoritative Windows API source for dedicated GPU
  * memory; it is not subject to the 2 GiB cap that affects the 32-bit registry value
  * {@code HardwareInformation.MemorySize}.

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGraphicsCard.java
@@ -63,9 +63,9 @@ final class LinuxGraphicsCard extends AbstractGraphicsCard {
     }
 
     /**
-     * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the graphics cards.
+     * public method used by {@code AbstractHardwareAbstractionLayer} to access the graphics cards.
      *
-     * @return List of {@link oshi.hardware.platform.linux.LinuxGraphicsCard} objects.
+     * @return List of {@link LinuxGraphicsCard} objects.
      */
     public static List<GraphicsCard> getGraphicsCards() {
         List<GraphicsCard> cardList = getGraphicsCardsFromLspci();

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxSoundCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxSoundCard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 The OSHI Project Contributors
+ * Copyright 2018-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.linux;
@@ -137,9 +137,9 @@ final class LinuxSoundCard extends AbstractSoundCard {
     }
 
     /**
-     * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the sound cards.
+     * public method used by {@code AbstractHardwareAbstractionLayer} to access the sound cards.
      *
-     * @return List of {@link oshi.hardware.platform.linux.LinuxSoundCard} objects.
+     * @return List of {@link LinuxSoundCard} objects.
      */
     public static List<SoundCard> getSoundCards() {
         List<SoundCard> soundCards = new ArrayList<>();

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGraphicsCard.java
@@ -44,9 +44,9 @@ final class MacGraphicsCard extends AbstractGraphicsCard {
     }
 
     /**
-     * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the graphics cards.
+     * public method used by {@code AbstractHardwareAbstractionLayer} to access the graphics cards.
      *
-     * @return List of {@link oshi.hardware.platform.mac.MacGraphicsCard} objects.
+     * @return List of {@link MacGraphicsCard} objects.
      */
     public static List<GraphicsCard> getGraphicsCards() {
         List<GraphicsCard> cardList = new ArrayList<>();

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSoundCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSoundCard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 The OSHI Project Contributors
+ * Copyright 2018-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
@@ -33,9 +33,9 @@ final class MacSoundCard extends AbstractSoundCard {
     }
 
     /**
-     * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the sound cards.
+     * public method used by {@code AbstractHardwareAbstractionLayer} to access the sound cards.
      *
-     * @return List of {@link oshi.hardware.platform.mac.MacSoundCard} objects.
+     * @return List of {@link MacSoundCard} objects.
      */
     public static List<SoundCard> getSoundCards() {
         List<SoundCard> soundCards = new ArrayList<>();

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdGraphicsCard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.unix.freebsd;
@@ -37,9 +37,9 @@ final class FreeBsdGraphicsCard extends AbstractGraphicsCard {
     }
 
     /**
-     * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the graphics cards.
+     * public method used by {@code AbstractHardwareAbstractionLayer} to access the graphics cards.
      *
-     * @return List of {@link oshi.hardware.platform.unix.freebsd.FreeBsdGraphicsCard} objects.
+     * @return List of {@link FreeBsdGraphicsCard} objects.
      */
     public static List<GraphicsCard> getGraphicsCards() {
         List<GraphicsCard> cardList = new ArrayList<>();

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdGraphicsCard.java
@@ -39,9 +39,9 @@ final class OpenBsdGraphicsCard extends AbstractGraphicsCard {
     }
 
     /**
-     * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the graphics cards.
+     * public method used by {@code AbstractHardwareAbstractionLayer} to access the graphics cards.
      *
-     * @return List of {@link oshi.hardware.platform.unix.openbsd.OpenBsdGraphicsCard} objects.
+     * @return List of {@link OpenBsdGraphicsCard} objects.
      */
     public static List<GraphicsCard> getGraphicsCards() {
         List<GraphicsCard> cardList = new ArrayList<>();

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisGraphicsCard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.unix.solaris;
@@ -36,9 +36,9 @@ final class SolarisGraphicsCard extends AbstractGraphicsCard {
     }
 
     /**
-     * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the graphics cards.
+     * public method used by {@code AbstractHardwareAbstractionLayer} to access the graphics cards.
      *
-     * @return List of {@link oshi.hardware.platform.unix.solaris.SolarisGraphicsCard} objects.
+     * @return List of {@link SolarisGraphicsCard} objects.
      */
     public static List<GraphicsCard> getGraphicsCards() {
         List<GraphicsCard> cardList = new ArrayList<>();

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -127,13 +127,13 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
     }
 
     /**
-     * public method used by {@link oshi.hardware.common.AbstractHardwareAbstractionLayer} to access the graphics cards.
+     * public method used by {@code AbstractHardwareAbstractionLayer} to access the graphics cards.
      *
      * <p>
      * When DXGI is available, ghost adapters are excluded and the list is ordered with the primary desktop adapter
      * first. On systems without DXGI, all registry entries are returned in registry key order.
      *
-     * @return List of {@link oshi.hardware.platform.windows.WindowsGraphicsCard} objects.
+     * @return List of {@link WindowsGraphicsCard} objects.
      */
     public static List<GraphicsCard> getGraphicsCards() {
         // Query DXGI once. Fails gracefully to empty list if unavailable.

--- a/oshi-core/src/main/java/oshi/software/os/OperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/OperatingSystem.java
@@ -340,9 +340,9 @@ public interface OperatingSystem {
      * without introducing any additional conflicts. Users should note, however, that other operating system code may
      * access the same native code.
      * <p>
-     * The {@link oshi.driver.unix.Who#queryWho()} method produces similar output parsing the output of the
-     * Posix-standard {@code who} command, and may internally employ reentrant code on some platforms. Users may opt to
-     * use this command-line variant by default using the {@code oshi.os.unix.whoCommand} configuration property.
+     * The {@code Who#queryWho()} method produces similar output parsing the output of the Posix-standard {@code who}
+     * command, and may internally employ reentrant code on some platforms. Users may opt to use this command-line
+     * variant by default using the {@code oshi.os.unix.whoCommand} configuration property.
      *
      * @return A list of {@link oshi.software.os.OSSession} objects representing logged-in users
      */

--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,12 @@
                         </archive>
                         <source>8</source>
                         <sourcepath>src/main/java</sourcepath>
-                        <detectLinks>true</detectLinks>
+                        <detectLinks>false</detectLinks>
+                        <links>
+                            <link>https://java-native-access.github.io/jna/${jna.version}/javadoc/</link>
+                            <link>https://javadoc.io/doc/org.junit.jupiter/junit-jupiter-api/${junit.version}/</link>
+                            <link>https://javadoc.io/doc/org.hamcrest/hamcrest/${hamcrest.version}/</link>
+                        </links>
                         <detectJavaApiLink>false</detectJavaApiLink>
                     </configuration>
                 </plugin>
@@ -585,31 +590,7 @@
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${dependency-check-maven.version}</version>
                 </plugin>
-                <!-- Eclipse -->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>${m2e.lifecycle-mapping.version}</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-enforcer-plugin</artifactId>
-                                        <versionRange>[1.0.0,)</versionRange>
-                                        <goals>
-                                            <goal>enforce</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
+
             </plugins>
         </pluginManagement>
         <plugins>
@@ -929,6 +910,45 @@
     </reporting>
 
     <profiles>
+        <!-- Eclipse IDE only: lifecycle-mapping is not in Maven Central -->
+        <profile>
+            <id>m2e</id>
+            <activation>
+                <property>
+                    <name>m2e.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.eclipse.m2e</groupId>
+                            <artifactId>lifecycle-mapping</artifactId>
+                            <version>${m2e.lifecycle-mapping.version}</version>
+                            <configuration>
+                                <lifecycleMappingMetadata>
+                                    <pluginExecutions>
+                                        <pluginExecution>
+                                            <pluginExecutionFilter>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-enforcer-plugin</artifactId>
+                                                <versionRange>[1.0.0,)</versionRange>
+                                                <goals>
+                                                    <goal>enforce</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore />
+                                            </action>
+                                        </pluginExecution>
+                                    </pluginExecutions>
+                                </lifecycleMappingMetadata>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
         <profile>
             <id>java11</id>
             <activation>


### PR DESCRIPTION
Failing on oshi-core-java11 with a fully qualified link to a non-published page.

Also tuned up javadoc links to dependencies and isolated the eclipse import into its own profile.

Cherry-picked from 6ae37f0116065bbf09b5534bf68692450c1fd02b which was just used to successfully publish the site.

@hazendaz FYI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved and standardized Javadoc formatting across hardware abstraction classes.

* **Chores**
  * Updated Maven Javadoc plugin configuration to explicitly configure external documentation links for dependencies.
  * Added Eclipse IDE Maven lifecycle mapping profile for improved IDE integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->