### PR TITLE
Add FileUtilFFM and split Auxv into common/JNA/FFM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * [#3130](https://github.com/oshi/oshi/pull/3130),
   [#3132](https://github.com/oshi/oshi/pull/3132),
   [#3133](https://github.com/oshi/oshi/pull/3133),
-  [#3134](https://github.com/oshi/oshi/pull/3134): Create oshi-common module; move JNA-free common code to enable future FFM-only consumers - [@dbwiddis](https://github.com/dbwiddis).
+  [#3134](https://github.com/oshi/oshi/pull/3134),
+  [#3135](https://github.com/oshi/oshi/pull/3135): Create oshi-common module; move JNA-free common code to enable future FFM-only consumers - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug fixes / Improvements
 * [#3128](https://github.com/oshi/oshi/pull/3128): Fix Mac FFM TIMEVAL struct layout missing 4-byte trailing padding - [@dbwiddis](https://github.com/dbwiddis).

--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/Auxv.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/Auxv.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.driver.linux.proc;
+
+/**
+ * Constants for the Linux auxiliary vector ({@code /proc/self/auxv}).
+ *
+ * @see <a href="https://github.com/torvalds/linux/blob/v3.19/include/uapi/linux/auxvec.h">auxvec.h</a>
+ */
+public final class Auxv {
+
+    private Auxv() {
+    }
+
+    /** end of vector */
+    public static final int AT_NULL = 0;
+    /** system page size */
+    public static final int AT_PAGESZ = 6;
+    /** arch dependent hints at CPU capabilities */
+    public static final int AT_HWCAP = 16;
+    /** frequency at which times() increments */
+    public static final int AT_CLKTCK = 17;
+}

--- a/oshi-core-java25/src/main/java/module-info.java
+++ b/oshi-core-java25/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module com.github.oshi {
     // API
     exports oshi;
     exports oshi.ffm;
+    exports oshi.ffm.util;
     exports oshi.util.gpu;
     exports oshi.util.platform.mac;
     exports oshi.util.platform.windows;

--- a/oshi-core-java25/src/main/java/oshi/driver/linux/proc/AuxvFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/linux/proc/AuxvFFM.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.linux.proc;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.util.FileUtilFFM;
+import oshi.util.FileUtil;
+import oshi.util.driver.linux.proc.Auxv;
+import oshi.util.linux.ProcPath;
+
+/**
+ * FFM-based utility to read the auxiliary vector from {@code /proc/self/auxv}.
+ */
+@ThreadSafe
+public final class AuxvFFM {
+
+    private AuxvFFM() {
+    }
+
+    /**
+     * Retrieve the auxiliary vector for the current process
+     *
+     * @return A map of auxiliary vector keys to their respective values
+     * @see <a href= "https://github.com/torvalds/linux/blob/v3.19/include/uapi/linux/auxvec.h">auxvec.h</a>
+     */
+    public static Map<Integer, Long> queryAuxv() {
+        ByteBuffer buff = FileUtil.readAllBytesAsBuffer(ProcPath.AUXV);
+        Map<Integer, Long> auxvMap = new HashMap<>();
+        int key;
+        do {
+            key = (int) FileUtilFFM.readNativeLongFromBuffer(buff);
+            if (key != Auxv.AT_NULL) {
+                auxvMap.put(key, FileUtilFFM.readNativeLongFromBuffer(buff));
+            }
+        } while (key != Auxv.AT_NULL);
+        return auxvMap;
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -14,6 +14,7 @@ import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
 import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 
@@ -33,6 +34,15 @@ public abstract class ForeignFunctions {
 
     /** Symbol lookup for libraries already loaded into the current process. */
     protected static final SymbolLookup SYMBOL_LOOKUP = SymbolLookup.loaderLookup();
+
+    /** The size in bytes of the C {@code long} type on this platform. */
+    public static final long NATIVE_LONG_SIZE = ((ValueLayout) LINKER.canonicalLayouts().get("long")).byteSize();
+
+    /** The size in bytes of the C {@code size_t} type on this platform. */
+    public static final long NATIVE_SIZE_T_SIZE = ((ValueLayout) LINKER.canonicalLayouts().get("size_t")).byteSize();
+
+    /** The size in bytes of a native pointer on this platform. */
+    public static final long NATIVE_POINTER_SIZE = ValueLayout.ADDRESS.byteSize();
 
     /** Not intended for instantiation. */
     protected ForeignFunctions() {

--- a/oshi-core-java25/src/main/java/oshi/ffm/util/FileUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/util/FileUtilFFM.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.util;
+
+import java.nio.ByteBuffer;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.ForeignFunctions;
+import oshi.util.FileUtil;
+
+/**
+ * FFM-specific extensions to {@link FileUtil} for reading native types from buffers.
+ */
+@ThreadSafe
+public final class FileUtilFFM {
+
+    private FileUtilFFM() {
+    }
+
+    /**
+     * Reads a native {@code long} value from a ByteBuffer, using the platform's native long size.
+     *
+     * @param buff The bytebuffer to read from
+     * @return The next value as a Java long
+     */
+    public static long readNativeLongFromBuffer(ByteBuffer buff) {
+        return ForeignFunctions.NATIVE_LONG_SIZE == 4 ? FileUtil.readIntFromBuffer(buff)
+                : FileUtil.readLongFromBuffer(buff);
+    }
+
+    /**
+     * Reads a native {@code size_t} value from a ByteBuffer, using the platform's native size_t size.
+     *
+     * @param buff The bytebuffer to read from
+     * @return The next value as a Java long
+     */
+    public static long readSizeTFromBuffer(ByteBuffer buff) {
+        return ForeignFunctions.NATIVE_SIZE_T_SIZE == 4 ? Integer.toUnsignedLong(FileUtil.readIntFromBuffer(buff))
+                : FileUtil.readLongFromBuffer(buff);
+    }
+
+    /**
+     * Reads a native pointer value from a ByteBuffer, using the platform's native pointer size.
+     *
+     * @param buff The bytebuffer to read from
+     * @return The next value as a Java long representing the pointer address, or 0 if insufficient data
+     */
+    public static long readPointerFromBuffer(ByteBuffer buff) {
+        if (buff.position() <= buff.limit() - ForeignFunctions.NATIVE_POINTER_SIZE) {
+            return ForeignFunctions.NATIVE_POINTER_SIZE == 4 ? Integer.toUnsignedLong(buff.getInt()) : buff.getLong();
+        }
+        return 0L;
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
@@ -7,10 +7,8 @@ package oshi.hardware.platform.linux;
 import static oshi.software.os.linux.LinuxOperatingSystemFFM.HAS_UDEV;
 
 import java.lang.foreign.Arena;
-import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -22,11 +20,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.linux.proc.AuxvFFM;
 import oshi.ffm.linux.LinuxLibcFunctions;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
-import oshi.util.linux.ProcPath;
+import oshi.util.driver.linux.proc.Auxv;
 import oshi.util.tuples.Quartet;
 
 /**
@@ -38,26 +37,9 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxCentralProcessorFFM.class);
 
-    private static final int AT_HWCAP = 16;
-    private static final long NATIVE_LONG_SIZE = ((ValueLayout) Linker.nativeLinker().canonicalLayouts().get("long"))
-            .byteSize();
-
     @Override
     protected long queryHwcap() {
-        ByteBuffer buff = FileUtil.readAllBytesAsBuffer(ProcPath.AUXV);
-        int key;
-        do {
-            key = (int) readNativeLong(buff);
-            long value = readNativeLong(buff);
-            if (key == AT_HWCAP) {
-                return value;
-            }
-        } while (key > 0);
-        return 0L;
-    }
-
-    private static long readNativeLong(ByteBuffer buff) {
-        return NATIVE_LONG_SIZE == 4 ? FileUtil.readIntFromBuffer(buff) : FileUtil.readLongFromBuffer(buff);
+        return AuxvFFM.queryAuxv().getOrDefault(Auxv.AT_HWCAP, 0L);
     }
 
     @Override

--- a/oshi-core-java25/src/test/java/module-info.test
+++ b/oshi-core-java25/src/test/java/module-info.test
@@ -3,6 +3,8 @@
 --add-opens
   com.github.oshi/oshi.ffm=org.junit.platform.commons
 --add-opens
+  com.github.oshi/oshi.ffm.util=org.junit.platform.commons
+--add-opens
   com.github.oshi/oshi.jna.util=org.junit.platform.commons
 
 --add-modules

--- a/oshi-core-java25/src/test/java/oshi/ffm/util/FileUtilFFMTest.java
+++ b/oshi-core-java25/src/test/java/oshi/ffm/util/FileUtilFFMTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.ffm.ForeignFunctions;
+
+class FileUtilFFMTest {
+
+    @Test
+    void testNativeSizeConstants() {
+        assertThat("NATIVE_LONG_SIZE should be 4 or 8", ForeignFunctions.NATIVE_LONG_SIZE, is(oneOf(4L, 8L)));
+        assertThat("NATIVE_SIZE_T_SIZE should be 4 or 8", ForeignFunctions.NATIVE_SIZE_T_SIZE, is(oneOf(4L, 8L)));
+        assertThat("NATIVE_POINTER_SIZE should be 4 or 8", ForeignFunctions.NATIVE_POINTER_SIZE, is(oneOf(4L, 8L)));
+    }
+
+    @Test
+    void testReadNativeLongFromBuffer() {
+        ByteBuffer buff = ByteBuffer.allocate(8).order(ByteOrder.nativeOrder());
+        buff.putLong(0x0000_0000_0000_002AL);
+        buff.flip();
+        long value = FileUtilFFM.readNativeLongFromBuffer(buff);
+        assertEquals(42L, value);
+    }
+
+    @Test
+    void testReadSizeTFromBuffer() {
+        ByteBuffer buff = ByteBuffer.allocate(8).order(ByteOrder.nativeOrder());
+        buff.putLong(0x0000_0000_0000_0007L);
+        buff.flip();
+        long value = FileUtilFFM.readSizeTFromBuffer(buff);
+        assertEquals(7L, value);
+    }
+
+    @Test
+    void testReadPointerFromBuffer() {
+        ByteBuffer buff = ByteBuffer.allocate(8).order(ByteOrder.nativeOrder());
+        buff.putLong(0x0000_0000_DEAD_BEEFL);
+        buff.flip();
+        long value = FileUtilFFM.readPointerFromBuffer(buff);
+        if (ForeignFunctions.NATIVE_POINTER_SIZE == 4) {
+            // 32-bit: reads 4 bytes as unsigned
+            assertEquals(0xDEAD_BEEFL, value);
+        } else {
+            assertEquals(0x0000_0000_DEAD_BEEFL, value);
+        }
+    }
+
+    @Test
+    void testReadPointerFromEmptyBuffer() {
+        ByteBuffer buff = ByteBuffer.allocate(0);
+        assertEquals(0L, FileUtilFFM.readPointerFromBuffer(buff));
+    }
+}

--- a/oshi-core/src/main/java/oshi/driver/linux/proc/AuxvJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/linux/proc/AuxvJNA.java
@@ -11,29 +11,17 @@ import java.util.Map;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.util.FileUtilJNA;
 import oshi.util.FileUtil;
+import oshi.util.driver.linux.proc.Auxv;
 import oshi.util.linux.ProcPath;
 
 /**
- * Utility to read auxiliary vector from {@code /proc/self/auxv}
+ * JNA-based utility to read the auxiliary vector from {@code /proc/self/auxv}.
  */
 @ThreadSafe
-public final class Auxv {
+public final class AuxvJNA {
 
-    private Auxv() {
+    private AuxvJNA() {
     }
-
-    /**
-     * system page size
-     */
-    public static final int AT_PAGESZ = 6;
-    /**
-     * arch dependent hints at CPU capabilities
-     */
-    public static final int AT_HWCAP = 16;
-    /**
-     * frequency at which times() increments
-     */
-    public static final int AT_CLKTCK = 17;
 
     /**
      * Retrieve the auxiliary vector for the current process
@@ -47,11 +35,10 @@ public final class Auxv {
         int key;
         do {
             key = FileUtilJNA.readNativeLongFromBuffer(buff).intValue();
-            if (key > 0) {
+            if (key != Auxv.AT_NULL) {
                 auxvMap.put(key, FileUtilJNA.readNativeLongFromBuffer(buff).longValue());
             }
-        } while (key > 0);
+        } while (key != Auxv.AT_NULL);
         return auxvMap;
-
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorJNA.java
@@ -20,10 +20,11 @@ import com.sun.jna.platform.linux.Udev.UdevEnumerate;
 import com.sun.jna.platform.linux.Udev.UdevListEntry;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.linux.proc.Auxv;
+import oshi.driver.linux.proc.AuxvJNA;
 import oshi.jna.platform.linux.LinuxLibc;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.driver.linux.proc.Auxv;
 import oshi.util.tuples.Quartet;
 
 /**
@@ -143,7 +144,7 @@ final class LinuxCentralProcessorJNA extends LinuxCentralProcessor {
 
     @Override
     protected long queryHwcap() {
-        return Auxv.queryAuxv().getOrDefault(Auxv.AT_HWCAP, 0L);
+        return AuxvJNA.queryAuxv().getOrDefault(Auxv.AT_HWCAP, 0L);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.linux.Who;
-import oshi.driver.linux.proc.Auxv;
+import oshi.driver.linux.proc.AuxvJNA;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.ApplicationInfo;
 import oshi.software.os.InternetProtocolStats;
@@ -38,6 +38,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.Memoizer;
 import oshi.util.ParseUtil;
+import oshi.util.driver.linux.proc.Auxv;
 import oshi.util.driver.linux.proc.CpuStat;
 import oshi.util.driver.linux.proc.ProcessStat;
 import oshi.util.driver.linux.proc.UpTime;
@@ -70,14 +71,14 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
     private static final long USER_HZ;
     private static final long PAGE_SIZE;
     static {
-        Map<Integer, Long> auxv = Auxv.queryAuxv();
+        Map<Integer, Long> auxv = AuxvJNA.queryAuxv();
         long hz = auxv.getOrDefault(Auxv.AT_CLKTCK, 0L);
         if (hz > 0) {
             USER_HZ = hz;
         } else {
             USER_HZ = ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf CLK_TCK"), 100L);
         }
-        long pagesz = Auxv.queryAuxv().getOrDefault(Auxv.AT_PAGESZ, 0L);
+        long pagesz = auxv.getOrDefault(Auxv.AT_PAGESZ, 0L);
         if (pagesz > 0) {
             PAGE_SIZE = pagesz;
         } else {

--- a/oshi-core/src/test/java/oshi/driver/linux/proc/AuxvJNATest.java
+++ b/oshi-core/src/test/java/oshi/driver/linux/proc/AuxvJNATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The OSHI Project Contributors
+ * Copyright 2022-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.linux.proc;
@@ -14,12 +14,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import oshi.util.driver.linux.proc.Auxv;
+
 @EnabledOnOs(OS.LINUX)
-class AuxvTest {
+class AuxvJNATest {
     @Test
     void testQueryAuxv() {
-        Map<Integer, Long> auxv = Auxv.queryAuxv();
-        assertNotNull("Aux vector should not be null");
+        Map<Integer, Long> auxv = AuxvJNA.queryAuxv();
+        assertNotNull(auxv, "Aux vector should not be null");
         assertThat("Clock Ticks should be positive", auxv.getOrDefault(Auxv.AT_CLKTCK, 0L), greaterThan(0L));
         assertThat("Page Size should be positive", auxv.getOrDefault(Auxv.AT_PAGESZ, 0L), greaterThan(0L));
     }


### PR DESCRIPTION
Adds FFM equivalents for native buffer-reading utilities and splits the Linux auxiliary vector driver into common, JNA, and FFM components.

## Native size constants

Adds three constants to `ForeignFunctions`, derived from FFM's `Linker.nativeLinker().canonicalLayouts()`:
- `NATIVE_LONG_SIZE` — size of C `long`
- `NATIVE_SIZE_T_SIZE` — size of C `size_t`
- `NATIVE_POINTER_SIZE` — size of a native pointer

These replace the use of JNA's `Native.LONG_SIZE`, `Native.SIZE_T_SIZE`, and `Native.POINTER_SIZE` in FFM code paths.

## FileUtilFFM

New class `oshi.ffm.util.FileUtilFFM` in oshi-core-java25, mirroring the buffer-reading methods from `FileUtilJNA`:
- `readNativeLongFromBuffer` — reads a C `long` from a `ByteBuffer`
- `readSizeTFromBuffer` — reads a C `size_t` from a `ByteBuffer`
- `readPointerFromBuffer` — reads a native pointer from a `ByteBuffer`

## Auxv split

The Linux auxiliary vector driver (`/proc/self/auxv`) is split into three parts:

| Module | Class | Contents |
|---|---|---|
| oshi-common | `oshi.util.driver.linux.proc.Auxv` | Constants only (`AT_PAGESZ`, `AT_HWCAP`, `AT_CLKTCK`) |
| oshi-core | `oshi.driver.linux.proc.AuxvJNA` | `queryAuxv()` using `FileUtilJNA.readNativeLongFromBuffer` |
| oshi-core-java25 | `oshi.driver.linux.proc.AuxvFFM` | `queryAuxv()` using `FileUtilFFM.readNativeLongFromBuffer` |

## Other changes

- `LinuxCentralProcessorFFM.queryHwcap()` now delegates to `AuxvFFM.queryAuxv()` instead of inline parsing, removing the local `AT_HWCAP` constant and `readNativeLong` method
- Fixed a wasteful double-call in `LinuxOperatingSystem` where `Auxv.queryAuxv()` was called twice in the static initializer (once for `USER_HZ`, once for `PAGE_SIZE`) — now reuses the map


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Foreign Function & Memory (FFM) support to query Linux auxiliary vectors and read native-sized values.

* **Refactor**
  * Split auxiliary-vector handling into separate JNA and FFM backends.
  * Introduced platform-native size constants and FFM-specific buffer helpers.

* **Tests**
  * Added tests validating native-size detection and FFM buffer decoding.

* **Documentation**
  * Minor changelog entry adjustments for the upcoming release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->