### PR TITLE
Push USER_HZ and PAGE_SIZE down into JNA/FFM OS subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ##### Bug fixes / Improvements
 * [#3128](https://github.com/oshi/oshi/pull/3128): Fix Mac FFM TIMEVAL struct layout missing 4-byte trailing padding - [@dbwiddis](https://github.com/dbwiddis).
+* [#3136](https://github.com/oshi/oshi/pull/3136): Push Linux USER_HZ and PAGE_SIZE into JNA/FFM OS subclasses; wire through HAL, processor, memory, process, and thread classes - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
@@ -23,6 +23,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.linux.proc.AuxvFFM;
 import oshi.ffm.linux.LinuxLibcFunctions;
 import oshi.ffm.linux.UdevFunctions;
+import oshi.software.os.linux.LinuxOperatingSystemFFM;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.driver.linux.proc.Auxv;
@@ -36,6 +37,10 @@ import oshi.util.tuples.Quartet;
 public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxCentralProcessorFFM.class);
+
+    public LinuxCentralProcessorFFM() {
+        super(LinuxOperatingSystemFFM.hz());
+    }
 
     @Override
     protected long queryHwcap() {

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerFFM.java
@@ -8,11 +8,13 @@ import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.LogicalVolumeGroup;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.PowerSource;
 import oshi.hardware.UsbDevice;
+import oshi.software.os.linux.LinuxOperatingSystemFFM;
 
 /**
  * FFM-based hardware abstraction layer for Linux. Extends {@link LinuxHardwareAbstractionLayer}, overriding methods as
@@ -20,6 +22,11 @@ import oshi.hardware.UsbDevice;
  */
 @ThreadSafe
 public final class LinuxHardwareAbstractionLayerFFM extends LinuxHardwareAbstractionLayer {
+
+    @Override
+    public GlobalMemory createMemory() {
+        return new LinuxGlobalMemory(LinuxOperatingSystemFFM.pageSize());
+    }
 
     @Override
     public CentralProcessor createProcessor() {

--- a/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
@@ -9,18 +9,22 @@ import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.nio.file.Files;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.linux.proc.AuxvFFM;
 import oshi.ffm.linux.LinuxLibcFunctions;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.software.os.FileSystem;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSProcess.State;
+import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.driver.linux.proc.Auxv;
 import oshi.util.linux.ProcPath;
 
 /**
@@ -36,6 +40,45 @@ import oshi.util.linux.ProcPath;
 public class LinuxOperatingSystemFFM extends LinuxOperatingSystem {
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxOperatingSystemFFM.class);
+
+    private static final long USER_HZ;
+    private static final long PAGE_SIZE;
+    static {
+        Map<Integer, Long> auxv = AuxvFFM.queryAuxv();
+        long hz = auxv.getOrDefault(Auxv.AT_CLKTCK, 0L);
+        USER_HZ = hz > 0 ? hz : ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf CLK_TCK"), 100L);
+        long pagesz = auxv.getOrDefault(Auxv.AT_PAGESZ, 0L);
+        PAGE_SIZE = pagesz > 0 ? pagesz
+                : ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf PAGE_SIZE"), 4096L);
+    }
+
+    /**
+     * Gets Jiffies per second, useful for converting ticks to milliseconds and vice versa.
+     *
+     * @return Jiffies per second.
+     */
+    public static long hz() {
+        return USER_HZ;
+    }
+
+    /**
+     * Gets Page Size, for converting memory stats from pages to bytes.
+     *
+     * @return Page Size in bytes.
+     */
+    public static long pageSize() {
+        return PAGE_SIZE;
+    }
+
+    @Override
+    public long getHz() {
+        return USER_HZ;
+    }
+
+    @Override
+    public long getPageSize() {
+        return PAGE_SIZE;
+    }
 
     /**
      * Identifies if the udev library was successfully loaded and all symbols bound via FFM. Also respects the

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
-import oshi.software.os.linux.LinuxOperatingSystem;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
@@ -51,6 +50,12 @@ import oshi.util.tuples.Quartet;
 abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxCentralProcessor.class);
+
+    private final long hz;
+
+    protected LinuxCentralProcessor(long hz) {
+        this.hz = hz;
+    }
 
     @Override
     protected ProcessorIdentifier queryProcessorId() {
@@ -387,13 +392,11 @@ abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
 
     @Override
     public long[] querySystemCpuLoadTicks() {
-        // convert the Linux Jiffies to Milliseconds.
         long[] ticks = CpuStat.getSystemCpuLoadTicks();
         // In rare cases, /proc/stat reading fails. If so, try again.
         if (LongStream.of(ticks).sum() == 0) {
             ticks = CpuStat.getSystemCpuLoadTicks();
         }
-        long hz = LinuxOperatingSystem.getHz();
         for (int i = 0; i < ticks.length; i++) {
             ticks[i] = ticks[i] * 1000L / hz;
         }
@@ -519,8 +522,6 @@ abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
         if (LongStream.of(ticks[0]).sum() == 0) {
             ticks = CpuStat.getProcessorCpuLoadTicks(getLogicalProcessorCount());
         }
-        // convert the Linux Jiffies to Milliseconds.
-        long hz = LinuxOperatingSystem.getHz();
         for (int i = 0; i < ticks.length; i++) {
             for (int j = 0; j < ticks[i].length; j++) {
                 ticks[i][j] = ticks[i][j] * 1000L / hz;

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorJNA.java
@@ -22,6 +22,7 @@ import com.sun.jna.platform.linux.Udev.UdevListEntry;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.linux.proc.AuxvJNA;
 import oshi.jna.platform.linux.LinuxLibc;
+import oshi.software.os.linux.LinuxOperatingSystemJNA;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.driver.linux.proc.Auxv;
@@ -33,6 +34,10 @@ import oshi.util.tuples.Quartet;
  */
 @ThreadSafe
 final class LinuxCentralProcessorJNA extends LinuxCentralProcessor {
+
+    LinuxCentralProcessorJNA() {
+        super(LinuxOperatingSystemJNA.hz());
+    }
 
     @Override
     protected Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyWithUdev() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGlobalMemory.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGlobalMemory.java
@@ -13,7 +13,6 @@ import java.util.function.Supplier;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.AbstractGlobalMemory;
-import oshi.software.os.linux.LinuxOperatingSystem;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.linux.ProcPath;
@@ -25,7 +24,16 @@ import oshi.util.tuples.Pair;
 @ThreadSafe
 public final class LinuxGlobalMemory extends AbstractGlobalMemory {
 
-    private static final long PAGE_SIZE = LinuxOperatingSystem.getPageSize();
+    private final long pageSize;
+
+    /**
+     * Constructor.
+     *
+     * @param pageSize the system page size in bytes
+     */
+    public LinuxGlobalMemory(long pageSize) {
+        this.pageSize = pageSize;
+    }
 
     private final Supplier<Pair<Long, Long>> availTotal = memoize(LinuxGlobalMemory::readMemInfo, defaultExpiration());
 
@@ -43,7 +51,7 @@ public final class LinuxGlobalMemory extends AbstractGlobalMemory {
 
     @Override
     public long getPageSize() {
-        return PAGE_SIZE;
+        return pageSize;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayer.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayer.java
@@ -31,14 +31,10 @@ public abstract class LinuxHardwareAbstractionLayer extends AbstractHardwareAbst
     }
 
     @Override
-    public GlobalMemory createMemory() {
-        return new LinuxGlobalMemory();
-    }
+    public abstract GlobalMemory createMemory();
 
     @Override
-    public CentralProcessor createProcessor() {
-        return new LinuxCentralProcessorJNA();
-    }
+    public abstract CentralProcessor createProcessor();
 
     @Override
     public Sensors createSensors() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerJNA.java
@@ -7,11 +7,14 @@ package oshi.hardware.platform.linux;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.LogicalVolumeGroup;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.PowerSource;
 import oshi.hardware.UsbDevice;
+import oshi.software.os.linux.LinuxOperatingSystemJNA;
 
 /**
  * JNA-based Linux hardware abstraction layer. Extends {@link LinuxHardwareAbstractionLayer}, overriding methods as FFM
@@ -19,6 +22,16 @@ import oshi.hardware.UsbDevice;
  */
 @ThreadSafe
 public final class LinuxHardwareAbstractionLayerJNA extends LinuxHardwareAbstractionLayer {
+
+    @Override
+    public GlobalMemory createMemory() {
+        return new LinuxGlobalMemory(LinuxOperatingSystemJNA.pageSize());
+    }
+
+    @Override
+    public CentralProcessor createProcessor() {
+        return new LinuxCentralProcessorJNA();
+    }
 
     @Override
     public List<LogicalVolumeGroup> getLogicalVolumeGroups() {

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcess.java
@@ -260,7 +260,8 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
     @Override
     public List<OSThread> getThreadDetails() {
         return ProcessStat.getThreadIds(getProcessID()).stream().parallel()
-                .map(id -> new LinuxOSThread(getProcessID(), id)).filter(VALID_THREAD).collect(Collectors.toList());
+                .map(id -> new LinuxOSThread(getProcessID(), id, getOs())).filter(VALID_THREAD)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -387,8 +388,8 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         // BOOTTIME is in seconds and start time from proc/pid/stat is in jiffies.
         // Combine units to jiffies and convert to millijiffies before hz division to
         // avoid precision loss without having to cast
-        this.startTime = (LinuxOperatingSystem.BOOTTIME * LinuxOperatingSystem.getHz()
-                + statArray[ProcPidStat.START_TIME.ordinal()]) * 1000L / LinuxOperatingSystem.getHz();
+        this.startTime = (LinuxOperatingSystem.getBootTime() * getOs().getHz()
+                + statArray[ProcPidStat.START_TIME.ordinal()]) * 1000L / getOs().getHz();
         // BOOT_TIME could be up to 500ms off and start time up to 5ms off. A process
         // that has started within last 505ms could produce a future start time/negative
         // up time, so insert a sanity check.
@@ -405,15 +406,15 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         if (statmFields.length > 2) {
             long resident = ParseUtil.parseLongOrDefault(statmFields[1], 0L);
             long shared = ParseUtil.parseLongOrDefault(statmFields[2], 0L);
-            long pageSize = LinuxOperatingSystem.getPageSize();
+            long pageSize = getOs().getPageSize();
             this.residentSetSize = resident * pageSize;
             this.privateResidentMemory = (resident - shared) * pageSize;
         } else {
-            this.residentSetSize = statArray[ProcPidStat.RSS.ordinal()] * LinuxOperatingSystem.getPageSize();
+            this.residentSetSize = statArray[ProcPidStat.RSS.ordinal()] * getOs().getPageSize();
             this.privateResidentMemory = this.residentSetSize;
         }
-        this.kernelTime = statArray[ProcPidStat.KERNEL_TIME.ordinal()] * 1000L / LinuxOperatingSystem.getHz();
-        this.userTime = statArray[ProcPidStat.USER_TIME.ordinal()] * 1000L / LinuxOperatingSystem.getHz();
+        this.kernelTime = statArray[ProcPidStat.KERNEL_TIME.ordinal()] * 1000L / getOs().getHz();
+        this.userTime = statArray[ProcPidStat.USER_TIME.ordinal()] * 1000L / getOs().getHz();
         this.minorFaults = statArray[ProcPidStat.MINOR_FAULTS.ordinal()];
         this.majorFaults = statArray[ProcPidStat.MAJOR_FAULTS.ordinal()];
         long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(status.get("nonvoluntary_ctxt_switches"), 0L);

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSThread.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSThread.java
@@ -31,6 +31,7 @@ public class LinuxOSThread extends AbstractOSThread {
     }
 
     private final int threadId;
+    private final LinuxOperatingSystem os;
     private String name;
     private State state = State.INVALID;
     private long minorFaults;
@@ -43,9 +44,10 @@ public class LinuxOSThread extends AbstractOSThread {
     private long upTime;
     private int priority;
 
-    public LinuxOSThread(int processId, int tid) {
+    public LinuxOSThread(int processId, int tid, LinuxOperatingSystem os) {
         super(processId);
         this.threadId = tid;
+        this.os = os;
         updateAttributes();
     }
 
@@ -128,8 +130,8 @@ public class LinuxOSThread extends AbstractOSThread {
         // BOOTTIME is in seconds and start time from proc/pid/stat is in jiffies.
         // Combine units to jiffies and convert to millijiffies before hz division to
         // avoid precision loss without having to cast
-        this.startTime = (LinuxOperatingSystem.BOOTTIME * LinuxOperatingSystem.getHz()
-                + statArray[LinuxOSThread.ThreadPidStat.START_TIME.ordinal()]) * 1000L / LinuxOperatingSystem.getHz();
+        this.startTime = (LinuxOperatingSystem.getBootTime() * os.getHz()
+                + statArray[LinuxOSThread.ThreadPidStat.START_TIME.ordinal()]) * 1000L / os.getHz();
         // BOOT_TIME could be up to 500ms off and start time up to 5ms off. A process
         // that has started within last 505ms could produce a future start time/negative
         // up time, so insert a sanity check.
@@ -143,8 +145,8 @@ public class LinuxOSThread extends AbstractOSThread {
         long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(status.get("nonvoluntary_ctxt_switches"), 0L);
         this.contextSwitches = voluntaryContextSwitches + nonVoluntaryContextSwitches;
         this.state = ProcessStat.getState(status.getOrDefault("State", "U").charAt(0));
-        this.kernelTime = statArray[ThreadPidStat.KERNEL_TIME.ordinal()] * 1000L / LinuxOperatingSystem.getHz();
-        this.userTime = statArray[ThreadPidStat.USER_TIME.ordinal()] * 1000L / LinuxOperatingSystem.getHz();
+        this.kernelTime = statArray[ThreadPidStat.KERNEL_TIME.ordinal()] * 1000L / os.getHz();
+        this.userTime = statArray[ThreadPidStat.USER_TIME.ordinal()] * 1000L / os.getHz();
         this.upTime = now - startTime;
         this.priority = (int) statArray[ThreadPidStat.PRIORITY.ordinal()];
         return true;

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.linux.Who;
-import oshi.driver.linux.proc.AuxvJNA;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.ApplicationInfo;
 import oshi.software.os.InternetProtocolStats;
@@ -38,7 +37,6 @@ import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.Memoizer;
 import oshi.util.ParseUtil;
-import oshi.util.driver.linux.proc.Auxv;
 import oshi.util.driver.linux.proc.CpuStat;
 import oshi.util.driver.linux.proc.ProcessStat;
 import oshi.util.driver.linux.proc.UpTime;
@@ -66,33 +64,11 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
             .memoize(LinuxInstalledApps::queryInstalledApps, installedAppsExpiration());
 
     /**
-     * Jiffies per second, used for process time counters.
-     */
-    private static final long USER_HZ;
-    private static final long PAGE_SIZE;
-    static {
-        Map<Integer, Long> auxv = AuxvJNA.queryAuxv();
-        long hz = auxv.getOrDefault(Auxv.AT_CLKTCK, 0L);
-        if (hz > 0) {
-            USER_HZ = hz;
-        } else {
-            USER_HZ = ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf CLK_TCK"), 100L);
-        }
-        long pagesz = auxv.getOrDefault(Auxv.AT_PAGESZ, 0L);
-        if (pagesz > 0) {
-            PAGE_SIZE = pagesz;
-        } else {
-            PAGE_SIZE = ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf PAGE_SIZE"), 4096L);
-        }
-    }
-
-    /**
      * OS Name for manufacturer
      */
     private static final String OS_NAME = ExecutingCommand.getFirstAnswer("uname -o");
 
-    // Package private for access from LinuxOSProcess
-    static final long BOOTTIME;
+    private static final long BOOTTIME;
     static {
         long tempBT = CpuStat.getBootTime();
         // If above fails, current time minus uptime.
@@ -229,7 +205,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public OSThread getCurrentThread() {
-        return new LinuxOSThread(getProcessId(), getThreadId());
+        return new LinuxOSThread(getProcessId(), getThreadId(), this);
     }
 
     @Override
@@ -544,16 +520,21 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      *
      * @return Jiffies per second.
      */
-    public static long getHz() {
-        return USER_HZ;
-    }
+    public abstract long getHz();
 
     /**
      * Gets Page Size, for converting memory stats from pages to bytes
      *
      * @return Page Size
      */
-    public static long getPageSize() {
-        return PAGE_SIZE;
+    public abstract long getPageSize();
+
+    /**
+     * Gets the system boot time in seconds since the epoch.
+     *
+     * @return Boot time in seconds since the epoch.
+     */
+    public static long getBootTime() {
+        return BOOTTIME;
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystemJNA.java
@@ -7,6 +7,7 @@ package oshi.software.os.linux;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,14 +17,17 @@ import com.sun.jna.platform.linux.LibC;
 import com.sun.jna.platform.linux.Udev;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.linux.proc.AuxvJNA;
 import oshi.jna.Struct.CloseableSysinfo;
 import oshi.jna.platform.linux.LinuxLibc;
 import oshi.software.os.FileSystem;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSProcess.State;
+import oshi.util.ExecutingCommand;
 import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
+import oshi.util.driver.linux.proc.Auxv;
 import oshi.util.linux.ProcPath;
 
 /**
@@ -37,16 +41,27 @@ public class LinuxOperatingSystemJNA extends LinuxOperatingSystem {
 
     /** This static field identifies if the udev library can be loaded. */
     public static final boolean HAS_UDEV;
+    private static final long USER_HZ;
+    private static final long PAGE_SIZE;
     /** This static field identifies if the gettid function is in the c library. */
     public static final boolean HAS_GETTID;
     /** This static field identifies if the syscall for gettid returns sane results. */
     public static final boolean HAS_SYSCALL_GETTID;
 
     static {
+        long userHz = 100L;
+        long pageSz = 4096L;
         boolean hasUdev = false;
         boolean hasGettid = false;
         boolean hasSyscallGettid = false;
         try {
+            Map<Integer, Long> auxv = AuxvJNA.queryAuxv();
+            long hz = auxv.getOrDefault(Auxv.AT_CLKTCK, 0L);
+            userHz = hz > 0 ? hz
+                    : ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf CLK_TCK"), 100L);
+            long pagesz = auxv.getOrDefault(Auxv.AT_PAGESZ, 0L);
+            pageSz = pagesz > 0 ? pagesz
+                    : ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf PAGE_SIZE"), 4096L);
             if (GlobalConfig.get(GlobalConfig.OSHI_OS_LINUX_ALLOWUDEV, true)) {
                 try {
                     @SuppressWarnings("unused")
@@ -80,6 +95,8 @@ public class LinuxOperatingSystemJNA extends LinuxOperatingSystem {
         HAS_UDEV = hasUdev;
         HAS_GETTID = hasGettid;
         HAS_SYSCALL_GETTID = hasSyscallGettid;
+        USER_HZ = userHz;
+        PAGE_SIZE = pageSz;
     }
 
     @Override
@@ -123,6 +140,34 @@ public class LinuxOperatingSystemJNA extends LinuxOperatingSystem {
         } catch (IOException e) {
             return 0;
         }
+    }
+
+    /**
+     * Gets Jiffies per second, useful for converting ticks to milliseconds and vice versa.
+     *
+     * @return Jiffies per second.
+     */
+    public static long hz() {
+        return USER_HZ;
+    }
+
+    /**
+     * Gets Page Size, for converting memory stats from pages to bytes.
+     *
+     * @return Page Size in bytes.
+     */
+    public static long pageSize() {
+        return PAGE_SIZE;
+    }
+
+    @Override
+    public long getHz() {
+        return USER_HZ;
+    }
+
+    @Override
+    public long getPageSize() {
+        return PAGE_SIZE;
     }
 
     @Override


### PR DESCRIPTION
Separate the Auxv-dependent USER_HZ and PAGE_SIZE constants from the common LinuxOperatingSystem superclass into LinuxOperatingSystemJNA and LinuxOperatingSystemFFM, each using their respective AuxvJNA/AuxvFFM implementations. This removes the last JNA dependency from the common Linux OS superclass for these values.

## Changes

### LinuxOperatingSystem (common superclass)
- Remove static `USER_HZ`/`PAGE_SIZE` fields and `AuxvJNA` dependency
- Make `getHz()` and `getPageSize()` abstract instance methods
- Make `BOOTTIME` private with a `getBootTime()` static getter
- Pass `this` to `LinuxOSThread` constructor from `getCurrentThread()`

### LinuxOperatingSystemJNA / LinuxOperatingSystemFFM
- Add `USER_HZ`/`PAGE_SIZE` static fields via `AuxvJNA`/`AuxvFFM`
- Expose `hz()` and `pageSize()` static methods for other JNA/FFM classes
- Override instance `getHz()`/`getPageSize()`

### LinuxOSProcess / LinuxOSThread (common)
- Use `getOs().getHz()`, `getOs().getPageSize()`, `LinuxOperatingSystem.getBootTime()` instead of static calls
- `LinuxOSThread` receives `LinuxOperatingSystem` in constructor

### LinuxCentralProcessor / LinuxGlobalMemory (common)
- `LinuxCentralProcessor` takes `hz` constructor parameter; JNA/FFM subclasses pass their respective `hz()` static value
- `LinuxGlobalMemory` takes `pageSize` constructor parameter

### LinuxHardwareAbstractionLayer
- Make `createMemory()` and `createProcessor()` abstract
- JNA/FFM HALs override, passing appropriate static values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Linux clock-tick (USER_HZ) and page-size are now determined by platform-specific OS implementations and propagated through processor, memory, process, and thread components; memory/processor creation is delegated to platform-specific HAL implementations for more consistent, flexible behavior.
* **Documentation**
  * Changelog updated to reflect these platform-specific improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->