### PR TITLE
Split Linux Who driver into common/JNA/FFM, add FFM utmpx and systemd

### DIFF
--- a/oshi-common/src/main/java/oshi/util/driver/linux/Who.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Who.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.driver.linux;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.os.OSSession;
+import oshi.util.Constants;
+import oshi.util.ExecutingCommand;
+
+/**
+ * Utility to query logged in users using the {@code who} command with Linux date format parsing, falling back to Unix
+ * format.
+ */
+@ThreadSafe
+public final class Who {
+
+    // oshi pts/0 2020-05-14 21:23 (192.168.1.23)
+    private static final Pattern WHO_FORMAT_LINUX = Pattern
+            .compile("(\\S+)\\s+(\\S+)\\s+(\\d{4}-\\d{2}-\\d{2})\\s+(\\d{2}:\\d{2})\\s*(?:\\((.+)\\))?");
+    private static final DateTimeFormatter WHO_DATE_FORMAT_LINUX = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm",
+            Locale.ROOT);
+
+    private Who() {
+    }
+
+    /**
+     * Query {@code who} to get logged in users, trying Linux date format first, then Unix format.
+     *
+     * @return A list of logged in user sessions
+     */
+    public static synchronized List<OSSession> queryWho() {
+        List<OSSession> whoList = new ArrayList<>();
+        for (String s : ExecutingCommand.runNative("who")) {
+            if (!matchLinux(whoList, s)) {
+                oshi.util.driver.unix.Who.matchUnix(whoList, s);
+            }
+        }
+        return whoList;
+    }
+
+    /**
+     * Attempt to match Linux WHO format and add to the list.
+     *
+     * @param whoList the list to add to
+     * @param s       the string to match
+     * @return true if successful, false otherwise
+     */
+    private static boolean matchLinux(List<OSSession> whoList, String s) {
+        Matcher m = WHO_FORMAT_LINUX.matcher(s);
+        if (m.matches()) {
+            try {
+                whoList.add(new OSSession(m.group(1), m.group(2),
+                        LocalDateTime.parse(m.group(3) + " " + m.group(4), WHO_DATE_FORMAT_LINUX)
+                                .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                        m.group(5) == null ? Constants.UNKNOWN : m.group(5)));
+                return true;
+            } catch (DateTimeParseException | NullPointerException e) {
+                // shouldn't happen if regex matches and OS is producing sensible dates
+            }
+        }
+        return false;
+    }
+}

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Who.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Who.java
@@ -20,22 +20,14 @@ import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.os.OSSession;
-import oshi.util.Constants;
 import oshi.util.ExecutingCommand;
-import oshi.util.PlatformEnum;
 
 /**
- * Utility to query logged in users.
+ * Utility to query logged in users using the {@code who} command with Unix date format parsing.
  */
 @ThreadSafe
 public final class Who {
 
-    // sample format:
-    // oshi pts/0 2020-05-14 21:23 (192.168.1.23)
-    private static final Pattern WHO_FORMAT_LINUX = Pattern
-            .compile("(\\S+)\\s+(\\S+)\\s+(\\d{4}-\\d{2}-\\d{2})\\s+(\\d{2}:\\d{2})\\s*(?:\\((.+)\\))?");
-    private static final DateTimeFormatter WHO_DATE_FORMAT_LINUX = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm",
-            Locale.ROOT);
     // oshi ttys000 May 4 23:50 (192.168.1.23)
     // middle 12 characters from Thu Nov 24 18:22:48 1986
     private static final Pattern WHO_FORMAT_UNIX = Pattern
@@ -48,56 +40,26 @@ public final class Who {
     }
 
     /**
-     * Query {@code who} to get logged in users
+     * Query {@code who} to get logged in users, parsing Unix date format.
      *
      * @return A list of logged in user sessions
      */
     public static synchronized List<OSSession> queryWho() {
         List<OSSession> whoList = new ArrayList<>();
-        List<String> who = ExecutingCommand.runNative("who");
-        for (String s : who) {
-            boolean matched = false;
-            if (PlatformEnum.getCurrentPlatform() == PlatformEnum.LINUX) {
-                matched = matchLinux(whoList, s);
-            }
-            if (!matched) {
-                matchUnix(whoList, s);
-            }
+        for (String s : ExecutingCommand.runNative("who")) {
+            matchUnix(whoList, s);
         }
         return whoList;
     }
 
     /**
-     * Attempt to match Linux WHO format and add to the list
+     * Attempt to match Unix WHO format and add to the list.
      *
      * @param whoList the list to add to
      * @param s       the string to match
      * @return true if successful, false otherwise
      */
-    private static boolean matchLinux(List<OSSession> whoList, String s) {
-        Matcher m = WHO_FORMAT_LINUX.matcher(s);
-        if (m.matches()) {
-            try {
-                whoList.add(new OSSession(m.group(1), m.group(2),
-                        LocalDateTime.parse(m.group(3) + " " + m.group(4), WHO_DATE_FORMAT_LINUX)
-                                .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                        m.group(5) == null ? Constants.UNKNOWN : m.group(5)));
-                return true;
-            } catch (DateTimeParseException | NullPointerException e) {
-                // shouldn't happen if regex matches and OS is producing sensible dates
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Attempt to match Unix WHO format and add to the list
-     *
-     * @param whoList the list to add to
-     * @param s       the string to match
-     * @return true if successful, false otherwise
-     */
-    private static boolean matchUnix(List<OSSession> whoList, String s) {
+    public static boolean matchUnix(List<OSSession> whoList, String s) {
         Matcher m = WHO_FORMAT_UNIX.matcher(s);
         if (m.matches()) {
             try {

--- a/oshi-core-java25/src/main/java/oshi/driver/linux/WhoFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/linux/WhoFFM.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.linux;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static java.util.Objects.nonNull;
+import static oshi.ffm.linux.LinuxLibcFunctions.LOGIN_PROCESS;
+import static oshi.ffm.linux.LinuxLibcFunctions.USER_PROCESS;
+import static oshi.util.Util.isSessionValid;
+
+import java.io.File;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.linux.LinuxLibcFunctions;
+import oshi.ffm.linux.SystemdFunctions;
+import oshi.software.os.OSSession;
+import oshi.util.Constants;
+import oshi.util.FileUtil;
+import oshi.util.GlobalConfig;
+import oshi.util.ParseUtil;
+
+/**
+ * FFM-based utility to query logged in users on Linux.
+ */
+@ThreadSafe
+public final class WhoFFM {
+
+    private static boolean useSystemd = SystemdFunctions.isAvailable()
+            && GlobalConfig.get(GlobalConfig.OSHI_OS_LINUX_ALLOWSYSTEMD, true);
+
+    private WhoFFM() {
+    }
+
+    /**
+     * Query {@code getutxent} to get logged in users.
+     *
+     * @return A list of logged in user sessions
+     */
+    public static synchronized List<OSSession> queryUtxent() {
+        // Try systemd first if available
+        if (useSystemd) {
+            try {
+                List<OSSession> systemdSessions = querySystemdNative();
+                if (!systemdSessions.isEmpty()) {
+                    return systemdSessions;
+                }
+            } catch (Throwable t) {
+                useSystemd = false;
+            }
+        }
+
+        List<OSSession> whoList = new ArrayList<>();
+        try (Arena arena = Arena.ofConfined()) {
+            LinuxLibcFunctions.setutxent();
+            try {
+                MemorySegment utPtr;
+                while ((utPtr = LinuxLibcFunctions.getutxent()) != null) {
+                    MemorySegment ut = utPtr.reinterpret(LinuxLibcFunctions.UTMPX_LAYOUT.byteSize(), arena, null);
+                    short type = LinuxLibcFunctions.utmpxType(ut);
+                    if (type == USER_PROCESS || type == LOGIN_PROCESS) {
+                        String user = LinuxLibcFunctions.utmpxUser(ut);
+                        String device = LinuxLibcFunctions.utmpxLine(ut);
+                        String host = ParseUtil.parseUtAddrV6toIP(LinuxLibcFunctions.utmpxAddrV6(ut));
+                        long loginTime = LinuxLibcFunctions.utmpxLoginTime(ut);
+                        if (!isSessionValid(user, device, loginTime)) {
+                            return oshi.util.driver.linux.Who.queryWho();
+                        }
+                        whoList.add(new OSSession(user, device, loginTime, host));
+                    }
+                }
+            } finally {
+                LinuxLibcFunctions.endutxent();
+            }
+        } catch (Throwable e) {
+            return oshi.util.driver.linux.Who.queryWho();
+        }
+
+        // If utmp returned no sessions, try systemd file fallback
+        if (whoList.isEmpty()) {
+            whoList = querySystemdFiles();
+            if (whoList.isEmpty()) {
+                return oshi.util.driver.linux.Who.queryWho();
+            }
+        }
+        return whoList;
+    }
+
+    private static List<OSSession> querySystemdNative() throws Throwable {
+        List<OSSession> sessionList = new ArrayList<>();
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment sessionsPtr = arena.allocate(ADDRESS);
+            int count = SystemdFunctions.sdGetSessions(sessionsPtr);
+            if (count <= 0) {
+                return sessionList;
+            }
+
+            MemorySegment sessions = sessionsPtr.get(ADDRESS, 0);
+            if (sessions.equals(MemorySegment.NULL)) {
+                return sessionList;
+            }
+
+            try {
+                // Read array of string pointers
+                MemorySegment ptrArray = sessions.reinterpret((long) count * ADDRESS.byteSize(), arena, null);
+                for (int i = 0; i < count; i++) {
+                    MemorySegment sessionIdPtr = ptrArray.getAtIndex(ADDRESS, i);
+                    if (sessionIdPtr.equals(MemorySegment.NULL)) {
+                        continue;
+                    }
+                    try {
+                        String sessionId = sessionIdPtr.reinterpret(256, arena, null).getString(0);
+                        OSSession session = queryOneSession(sessionId, arena);
+                        if (session != null) {
+                            sessionList.add(session);
+                        }
+                    } catch (Exception e) {
+                        // Skip invalid session
+                    }
+                }
+            } finally {
+                // Free each string, then the array
+                MemorySegment ptrArray = sessions.reinterpret((long) count * ADDRESS.byteSize(), arena, null);
+                for (int i = 0; i < count; i++) {
+                    MemorySegment ptr = ptrArray.getAtIndex(ADDRESS, i);
+                    if (!ptr.equals(MemorySegment.NULL)) {
+                        SystemdFunctions.free(ptr);
+                    }
+                }
+                SystemdFunctions.free(sessions);
+            }
+        }
+        return sessionList;
+    }
+
+    private static OSSession queryOneSession(String sessionId, Arena arena) throws Throwable {
+        MemorySegment sessionSeg = arena.allocateFrom(sessionId);
+
+        // Get username (required)
+        MemorySegment usernamePtr = arena.allocate(ADDRESS);
+        if (SystemdFunctions.sdSessionGetUsername(sessionSeg, usernamePtr) != 0) {
+            return null;
+        }
+        MemorySegment usernameRaw = usernamePtr.get(ADDRESS, 0);
+        if (usernameRaw.equals(MemorySegment.NULL)) {
+            return null;
+        }
+        String user = SystemdFunctions.readAndFreeString(usernameRaw, arena);
+        if (user == null) {
+            return null;
+        }
+
+        // Get start time (required)
+        MemorySegment usecSeg = arena.allocate(JAVA_LONG);
+        if (SystemdFunctions.sdSessionGetStartTime(sessionSeg, usecSeg) != 0) {
+            return null;
+        }
+        long loginTime = usecSeg.get(JAVA_LONG, 0) / 1000L; // μs to ms
+
+        // Get TTY (optional, default to session ID)
+        String tty = sessionId;
+        MemorySegment ttyPtr = arena.allocate(ADDRESS);
+        if (SystemdFunctions.sdSessionGetTty(sessionSeg, ttyPtr) == 0) {
+            MemorySegment ttyRaw = ttyPtr.get(ADDRESS, 0);
+            if (!ttyRaw.equals(MemorySegment.NULL)) {
+                String t = SystemdFunctions.readAndFreeString(ttyRaw, arena);
+                if (t != null) {
+                    tty = t;
+                }
+            }
+        }
+
+        // Get remote host (optional)
+        String remoteHost = "";
+        MemorySegment hostPtr = arena.allocate(ADDRESS);
+        if (SystemdFunctions.sdSessionGetRemoteHost(sessionSeg, hostPtr) == 0) {
+            MemorySegment hostRaw = hostPtr.get(ADDRESS, 0);
+            if (!hostRaw.equals(MemorySegment.NULL)) {
+                String h = SystemdFunctions.readAndFreeString(hostRaw, arena);
+                if (h != null) {
+                    remoteHost = h;
+                }
+            }
+        }
+
+        if (!isSessionValid(user, tty, loginTime)) {
+            return null;
+        }
+        return new OSSession(user, tty, loginTime, remoteHost);
+    }
+
+    private static List<OSSession> querySystemdFiles() {
+        List<OSSession> sessionList = new ArrayList<>();
+        File sessionsDir = new File("/run/systemd/sessions");
+        if (sessionsDir.exists() && sessionsDir.isDirectory()) {
+            File[] sessionFiles = sessionsDir.listFiles(file -> Constants.DIGITS.matcher(file.getName()).matches());
+            if (nonNull(sessionFiles)) {
+                for (File sessionFile : sessionFiles) {
+                    try {
+                        Map<String, String> sessionMap = FileUtil.getKeyValueMapFromFile(sessionFile.getPath(), "=");
+                        String user = sessionMap.get("USER");
+                        if (nonNull(user) && !user.isEmpty()) {
+                            String tty = sessionMap.getOrDefault("TTY", sessionFile.getName());
+                            String remoteHost = sessionMap.getOrDefault("REMOTE_HOST", "");
+                            long loginTime = 0L;
+                            String realtime = sessionMap.get("REALTIME");
+                            if (nonNull(realtime)) {
+                                loginTime = ParseUtil.parseLongOrDefault(realtime, 0L) / 1000L;
+                            }
+                            if (loginTime == 0L) {
+                                loginTime = sessionFile.lastModified();
+                            }
+                            if (isSessionValid(user, tty, loginTime)) {
+                                sessionList.add(new OSSession(user, tty, loginTime, remoteHost));
+                            }
+                        }
+                    } catch (Exception e) {
+                        // Skip invalid session files
+                    }
+                }
+            }
+        }
+        return sessionList;
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/linux/LinuxLibcFunctions.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/linux/LinuxLibcFunctions.java
@@ -5,6 +5,7 @@
 package oshi.ffm.linux;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
@@ -151,8 +152,60 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
     private static final VarHandle ADDRINFO_CANONNAME = ADDRINFO_LAYOUT
             .varHandle(MemoryLayout.PathElement.groupElement("ai_canonname"));
 
+    // ---- utmpx constants and layout (64-bit Linux) ----
+
+    /** utmpx entry type: session leader of a logged in user. */
+    public static final short LOGIN_PROCESS = 6;
+    /** utmpx entry type: normal process. */
+    public static final short USER_PROCESS = 7;
+
+    static final int UT_LINESIZE = 32;
+    static final int UT_NAMESIZE = 32;
+    static final int UT_HOSTSIZE = 256;
+
+    /**
+     * {@code struct utmpx} layout (64-bit Linux).
+     *
+     * <pre>
+     *   short   ut_type      (2)
+     *   pad                  (2)
+     *   int     ut_pid       (4)
+     *   char    ut_line[32]  (32)
+     *   char    ut_id[4]     (4)
+     *   char    ut_user[32]  (32)
+     *   char    ut_host[256] (256)
+     *   short[2] ut_exit     (4)
+     *   int     ut_session   (4)
+     *   int     tv_sec       (4)
+     *   int     tv_usec      (4)
+     *   int[4]  ut_addr_v6   (16)
+     *   char[20] reserved    (20)
+     *   total = 384
+     * </pre>
+     */
+    public static final StructLayout UTMPX_LAYOUT = MemoryLayout.structLayout(JAVA_SHORT.withName("ut_type"),
+            MemoryLayout.paddingLayout(2), JAVA_INT.withName("ut_pid"),
+            MemoryLayout.sequenceLayout(UT_LINESIZE, JAVA_BYTE).withName("ut_line"),
+            MemoryLayout.sequenceLayout(4, JAVA_BYTE).withName("ut_id"),
+            MemoryLayout.sequenceLayout(UT_NAMESIZE, JAVA_BYTE).withName("ut_user"),
+            MemoryLayout.sequenceLayout(UT_HOSTSIZE, JAVA_BYTE).withName("ut_host"),
+            MemoryLayout.sequenceLayout(2, JAVA_SHORT).withName("ut_exit"), JAVA_INT.withName("ut_session"),
+            JAVA_INT.withName("tv_sec"), JAVA_INT.withName("tv_usec"),
+            MemoryLayout.sequenceLayout(4, JAVA_INT).withName("ut_addr_v6"),
+            MemoryLayout.sequenceLayout(20, JAVA_BYTE).withName("reserved"));
+
+    private static final VarHandle UTMPX_TYPE = UTMPX_LAYOUT
+            .varHandle(MemoryLayout.PathElement.groupElement("ut_type"));
+    private static final VarHandle UTMPX_TV_SEC = UTMPX_LAYOUT
+            .varHandle(MemoryLayout.PathElement.groupElement("tv_sec"));
+    private static final VarHandle UTMPX_TV_USEC = UTMPX_LAYOUT
+            .varHandle(MemoryLayout.PathElement.groupElement("tv_usec"));
+
     // ---- Method handles ----
 
+    private static final MethodHandle setutxent;
+    private static final MethodHandle getutxent;
+    private static final MethodHandle endutxent;
     private static final MethodHandle getpid;
     private static final MethodHandle gettid;
     private static final MethodHandle syscall;
@@ -172,6 +225,9 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
         // rather than libraryLookup("c") which fails on Linux (libc.so vs libc.so.6).
         SymbolLookup libc = LINKER.defaultLookup();
 
+        setutxent = LINKER.downcallHandle(libc.findOrThrow("setutxent"), FunctionDescriptor.ofVoid());
+        getutxent = LINKER.downcallHandle(libc.findOrThrow("getutxent"), FunctionDescriptor.of(ADDRESS));
+        endutxent = LINKER.downcallHandle(libc.findOrThrow("endutxent"), FunctionDescriptor.ofVoid());
         getpid = LINKER.downcallHandle(libc.findOrThrow("getpid"), FunctionDescriptor.of(JAVA_INT));
         // syscall(SYS_GETTID) — declare with one fixed arg; no extra args needed for gettid
         syscall = LINKER.downcallHandle(libc.findOrThrow("syscall"), FunctionDescriptor.of(JAVA_LONG, JAVA_LONG),
@@ -209,6 +265,90 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
      */
     public static boolean hasGettid() {
         return HAS_GETTID;
+    }
+
+    /**
+     * Calls {@code setutxent()} to rewind the utmpx database.
+     *
+     * @throws Throwable if the native call fails
+     */
+    public static void setutxent() throws Throwable {
+        setutxent.invokeExact();
+    }
+
+    /**
+     * Calls {@code getutxent()} to read the next entry from the utmpx database.
+     *
+     * @return a pointer to the utmpx structure, or {@code null} if no more entries
+     * @throws Throwable if the native call fails
+     */
+    public static MemorySegment getutxent() throws Throwable {
+        MemorySegment result = (MemorySegment) getutxent.invokeExact();
+        return result.equals(MemorySegment.NULL) ? null : result;
+    }
+
+    /**
+     * Calls {@code endutxent()} to close the utmpx database.
+     *
+     * @throws Throwable if the native call fails
+     */
+    public static void endutxent() throws Throwable {
+        endutxent.invokeExact();
+    }
+
+    /**
+     * Reads {@code ut_type} from a utmpx segment.
+     *
+     * @param ut segment populated by {@link #getutxent()}
+     * @return the entry type
+     */
+    public static short utmpxType(MemorySegment ut) {
+        return (short) UTMPX_TYPE.get(ut, 0L);
+    }
+
+    /**
+     * Reads {@code ut_user} from a utmpx segment.
+     *
+     * @param ut segment populated by {@link #getutxent()}
+     * @return the username string
+     */
+    public static String utmpxUser(MemorySegment ut) {
+        return ut.asSlice(UTMPX_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("ut_user")), UT_NAMESIZE)
+                .getString(0);
+    }
+
+    /**
+     * Reads {@code ut_line} from a utmpx segment.
+     *
+     * @param ut segment populated by {@link #getutxent()}
+     * @return the device name string
+     */
+    public static String utmpxLine(MemorySegment ut) {
+        return ut.asSlice(UTMPX_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("ut_line")), UT_LINESIZE)
+                .getString(0);
+    }
+
+    /**
+     * Reads {@code ut_addr_v6} from a utmpx segment as a 4-element int array.
+     *
+     * @param ut segment populated by {@link #getutxent()}
+     * @return the IPv6/IPv4 address as 4 ints
+     */
+    public static int[] utmpxAddrV6(MemorySegment ut) {
+        long offset = UTMPX_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("ut_addr_v6"));
+        return ut.asSlice(offset, 16).toArray(JAVA_INT);
+    }
+
+    /**
+     * Reads the login time from a utmpx segment as epoch milliseconds.
+     *
+     * @param ut segment populated by {@link #getutxent()}
+     * @return login time in milliseconds since epoch
+     */
+    public static long utmpxLoginTime(MemorySegment ut) {
+        int tvSec = (int) UTMPX_TV_SEC.get(ut, 0L);
+        int tvUsec = (int) UTMPX_TV_USEC.get(ut, 0L);
+        return tvSec * 1000L + tvUsec / 1000L;
     }
 
     /**

--- a/oshi-core-java25/src/main/java/oshi/ffm/linux/SystemdFunctions.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/linux/SystemdFunctions.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.linux;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.ffm.ForeignFunctions;
+
+/**
+ * FFM bindings for libsystemd session query functions.
+ */
+public final class SystemdFunctions extends ForeignFunctions {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SystemdFunctions.class);
+
+    private SystemdFunctions() {
+    }
+
+    private static final MethodHandle sd_get_sessions;
+    private static final MethodHandle sd_session_get_username;
+    private static final MethodHandle sd_session_get_start_time;
+    private static final MethodHandle sd_session_get_tty;
+    private static final MethodHandle sd_session_get_remote_host;
+    private static final MethodHandle free;
+
+    private static final boolean AVAILABLE;
+
+    static {
+        boolean available = false;
+        MethodHandle hGetSessions = null;
+        MethodHandle hGetUsername = null;
+        MethodHandle hGetStartTime = null;
+        MethodHandle hGetTty = null;
+        MethodHandle hGetRemoteHost = null;
+        MethodHandle hFree = null;
+        try {
+            SymbolLookup systemd = libraryLookup("systemd");
+            SymbolLookup libc = LINKER.defaultLookup();
+
+            // int sd_get_sessions(char ***sessions)
+            hGetSessions = LINKER.downcallHandle(systemd.findOrThrow("sd_get_sessions"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS));
+            // int sd_session_get_username(const char *session, char **username)
+            hGetUsername = LINKER.downcallHandle(systemd.findOrThrow("sd_session_get_username"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+            // int sd_session_get_start_time(const char *session, uint64_t *usec)
+            hGetStartTime = LINKER.downcallHandle(systemd.findOrThrow("sd_session_get_start_time"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+            // int sd_session_get_tty(const char *session, char **tty)
+            hGetTty = LINKER.downcallHandle(systemd.findOrThrow("sd_session_get_tty"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+            // int sd_session_get_remote_host(const char *session, char **remote_host)
+            hGetRemoteHost = LINKER.downcallHandle(systemd.findOrThrow("sd_session_get_remote_host"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+            // void free(void *ptr)
+            hFree = LINKER.downcallHandle(libc.findOrThrow("free"), FunctionDescriptor.ofVoid(ADDRESS));
+            available = true;
+        } catch (Throwable t) {
+            LOG.debug("libsystemd not available via FFM: {}", t.toString());
+        }
+        sd_get_sessions = hGetSessions;
+        sd_session_get_username = hGetUsername;
+        sd_session_get_start_time = hGetStartTime;
+        sd_session_get_tty = hGetTty;
+        sd_session_get_remote_host = hGetRemoteHost;
+        free = hFree;
+        AVAILABLE = available;
+    }
+
+    /**
+     * Returns whether libsystemd was successfully loaded.
+     *
+     * @return true if all systemd symbols were bound
+     */
+    public static boolean isAvailable() {
+        return AVAILABLE;
+    }
+
+    /**
+     * Calls {@code sd_get_sessions(char ***sessions)}.
+     *
+     * @param sessionsPtr pointer-to-pointer output segment
+     * @return number of sessions on success, negative errno on failure
+     * @throws Throwable if the native call fails
+     */
+    public static int sdGetSessions(MemorySegment sessionsPtr) throws Throwable {
+        return (int) sd_get_sessions.invokeExact(sessionsPtr);
+    }
+
+    /**
+     * Calls {@code sd_session_get_username(session, &amp;username)}.
+     *
+     * @param session     session ID segment (null-terminated)
+     * @param usernamePtr pointer-to-pointer output segment
+     * @return 0 on success, negative errno on failure
+     * @throws Throwable if the native call fails
+     */
+    public static int sdSessionGetUsername(MemorySegment session, MemorySegment usernamePtr) throws Throwable {
+        return (int) sd_session_get_username.invokeExact(session, usernamePtr);
+    }
+
+    /**
+     * Calls {@code sd_session_get_start_time(session, &amp;usec)}.
+     *
+     * @param session session ID segment (null-terminated)
+     * @param usecPtr pointer to uint64_t output
+     * @return 0 on success, negative errno on failure
+     * @throws Throwable if the native call fails
+     */
+    public static int sdSessionGetStartTime(MemorySegment session, MemorySegment usecPtr) throws Throwable {
+        return (int) sd_session_get_start_time.invokeExact(session, usecPtr);
+    }
+
+    /**
+     * Calls {@code sd_session_get_tty(session, &amp;tty)}.
+     *
+     * @param session session ID segment (null-terminated)
+     * @param ttyPtr  pointer-to-pointer output segment
+     * @return 0 on success, negative errno on failure
+     * @throws Throwable if the native call fails
+     */
+    public static int sdSessionGetTty(MemorySegment session, MemorySegment ttyPtr) throws Throwable {
+        return (int) sd_session_get_tty.invokeExact(session, ttyPtr);
+    }
+
+    /**
+     * Calls {@code sd_session_get_remote_host(session, &amp;remote_host)}.
+     *
+     * @param session       session ID segment (null-terminated)
+     * @param remoteHostPtr pointer-to-pointer output segment
+     * @return 0 on success, negative errno on failure
+     * @throws Throwable if the native call fails
+     */
+    public static int sdSessionGetRemoteHost(MemorySegment session, MemorySegment remoteHostPtr) throws Throwable {
+        return (int) sd_session_get_remote_host.invokeExact(session, remoteHostPtr);
+    }
+
+    /**
+     * Calls {@code free(ptr)} to release memory allocated by systemd.
+     *
+     * @param ptr the pointer to free
+     * @throws Throwable if the native call fails
+     */
+    public static void free(MemorySegment ptr) throws Throwable {
+        free.invokeExact(ptr);
+    }
+
+    /**
+     * Reads a null-terminated string from a pointer and frees the pointer.
+     *
+     * @param ptr   the pointer to a C string allocated by systemd
+     * @param arena arena to scope the reinterpret
+     * @return the Java string, or {@code null} if the pointer is NULL
+     * @throws Throwable if the native call fails
+     */
+    public static String readAndFreeString(MemorySegment ptr, Arena arena) throws Throwable {
+        if (ptr == null || ptr.equals(MemorySegment.NULL)) {
+            return null;
+        }
+        try {
+            return getStringFromNativePointer(ptr, arena);
+        } finally {
+            free(ptr);
+        }
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
@@ -9,12 +9,14 @@ import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.linux.WhoFFM;
 import oshi.driver.linux.proc.AuxvFFM;
 import oshi.ffm.linux.LinuxLibcFunctions;
 import oshi.ffm.linux.UdevFunctions;
@@ -22,6 +24,7 @@ import oshi.software.os.FileSystem;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSProcess.State;
+import oshi.software.os.OSSession;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.driver.linux.proc.Auxv;
@@ -99,6 +102,11 @@ public class LinuxOperatingSystemFFM extends LinuxOperatingSystem {
             }
         }
         HAS_SYSCALL_GETTID = hasSyscallGettid;
+    }
+
+    @Override
+    public List<OSSession> getSessions() {
+        return USE_WHO_COMMAND ? oshi.util.driver.linux.Who.queryWho() : WhoFFM.queryUtxent();
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/driver/linux/WhoJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/linux/WhoJNA.java
@@ -36,13 +36,13 @@ import oshi.util.ParseUtil;
  * Utility to query logged in users.
  */
 @ThreadSafe
-public final class Who {
+public final class WhoJNA {
 
     private static final LinuxLibc LIBC = LinuxLibc.INSTANCE;
 
     private static boolean useSystemd = GlobalConfig.get(GlobalConfig.OSHI_OS_LINUX_ALLOWSYSTEMD, true);
 
-    private Who() {
+    private WhoJNA() {
     }
 
     /**
@@ -78,7 +78,7 @@ public final class Who {
                     long loginTime = ut.ut_tv.tv_sec * 1000L + ut.ut_tv.tv_usec / 1000L;
                     // Sanity check. If errors, default to who command line
                     if (!isSessionValid(user, device, loginTime)) {
-                        return oshi.util.driver.unix.Who.queryWho();
+                        return oshi.util.driver.linux.Who.queryWho();
                     }
                     whoList.add(new OSSession(user, device, loginTime, host));
                 }
@@ -93,7 +93,7 @@ public final class Who {
             whoList = querySystemdFiles();
             if (whoList.isEmpty()) {
                 // Final fallback to who command
-                return oshi.util.driver.unix.Who.queryWho();
+                return oshi.util.driver.linux.Who.queryWho();
             }
         }
         return whoList;

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystem.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.linux.Who;
+import oshi.driver.linux.WhoJNA;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.ApplicationInfo;
 import oshi.software.os.InternetProtocolStats;
@@ -129,7 +129,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public List<OSSession> getSessions() {
-        return USE_WHO_COMMAND ? super.getSessions() : Who.queryUtxent();
+        return USE_WHO_COMMAND ? oshi.util.driver.linux.Who.queryWho() : WhoJNA.queryUtxent();
     }
 
     @Override

--- a/oshi-core/src/test/java/oshi/driver/linux/WhoTest.java
+++ b/oshi-core/src/test/java/oshi/driver/linux/WhoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 The OSHI Project Contributors
+ * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.linux;
@@ -21,7 +21,7 @@ import oshi.software.os.OSSession;
 class WhoTest {
     @Test
     void testQueryUtxent() {
-        for (OSSession session : Who.queryUtxent()) {
+        for (OSSession session : WhoJNA.queryUtxent()) {
             assertThat("Session login time should be greater than 0", session.getLoginTime(), is(greaterThan(0L)));
             assertThat("Session login time should be less than current time", session.getLoginTime(),
                     is(lessThan(System.currentTimeMillis())));


### PR DESCRIPTION
Split the Linux Who session-query driver across all three modules and create FFM equivalents for the JNA utmpx and systemd native bindings.

### oshi-common
- oshi.util.driver.unix.Who — Removed Linux-specific date parsing and PlatformEnum dependency; now Unix-only. Made matchUnix public for cross-package use.
- oshi.util.driver.linux.Who — New. Parses who command output trying Linux date format first, falling back to matchUnix per line. Serves as command-line fallback for all Linux native implementations.

### oshi-core
- oshi.driver.linux.Who → oshi.driver.linux.WhoJNA — Renamed. Fallback references updated to oshi.util.driver.linux.Who.queryWho().
- LinuxOperatingSystem.getSessions() — Uses WhoJNA.queryUtxent() and oshi.util.driver.linux.Who.queryWho() (no longer delegates to super.getSessions()).

### oshi-core-java25
- LinuxLibcFunctions — Added Linux utmpx struct layout (384 bytes, verified against glibc header), LOGIN_PROCESS/USER_PROCESS constants, setutxent/getutxent/endutxent FFM bindings, and field accessor methods.
- SystemdFunctions — New. FFM bindings for sd_get_sessions, sd_session_get_username, sd_session_get_start_time, sd_session_get_tty, sd_session_get_remote_host, with lazy loading and availability check.
- oshi.driver.linux.WhoFFM — New. FFM port of the Linux Who driver: systemd native (gated by oshi.os.linux.allowsystemd), utmpx via FFM, systemd file fallback, who command fallback.
- LinuxOperatingSystemFFM — Added getSessions() override using WhoFFM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced session query mechanism with multiple fallback implementations for improved reliability across different Linux configurations. Added support for systemd-based session queries with fallback to utmpx and native command-based approaches.

* **Tests**
  * Updated test references to reflect refactored implementation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->