### PR TITLE
Move Linux HAL and hardware classes to oshi-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   [#3132](https://github.com/oshi/oshi/pull/3132),
   [#3133](https://github.com/oshi/oshi/pull/3133),
   [#3134](https://github.com/oshi/oshi/pull/3134),
-  [#3135](https://github.com/oshi/oshi/pull/3135): Create oshi-common module; move JNA-free common code to enable future FFM-only consumers - [@dbwiddis](https://github.com/dbwiddis).
+  [#3135](https://github.com/oshi/oshi/pull/3135),
+  [#3138](https://github.com/oshi/oshi/pull/3138): Create oshi-common module; move JNA-free common code to enable future FFM-only consumers - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug fixes / Improvements
 * [#3128](https://github.com/oshi/oshi/pull/3128): Fix Mac FFM TIMEVAL struct layout missing 4-byte trailing padding - [@dbwiddis](https://github.com/dbwiddis).

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -7,6 +7,8 @@ module com.github.oshi.common {
     exports oshi.annotation.concurrent;
     exports oshi.hardware;
     exports oshi.hardware.common;
+    exports oshi.hardware.common.platform.linux;
+    exports oshi.hardware.common.platform.unix;
     exports oshi.software.common;
     exports oshi.software.os;
     exports oshi.util;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxBaseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxBaseboard.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import static oshi.util.Memoizer.memoize;
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import static oshi.util.linux.ProcPath.CPUINFO;
 import static oshi.util.linux.ProcPath.LOADAVG;
@@ -47,7 +47,7 @@ import oshi.util.tuples.Quartet;
  * A CPU as defined in Linux /proc.
  */
 @ThreadSafe
-abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
+public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxCentralProcessor.class);
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxComputerSystem.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import static oshi.util.Memoizer.memoize;
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import static oshi.util.Memoizer.memoize;
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGlobalMemory.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import java.util.List;
 
@@ -12,12 +12,10 @@ import oshi.hardware.ComputerSystem;
 import oshi.hardware.Display;
 import oshi.hardware.GlobalMemory;
 import oshi.hardware.GraphicsCard;
-import oshi.hardware.Printer;
 import oshi.hardware.Sensors;
 import oshi.hardware.SoundCard;
 import oshi.hardware.common.AbstractHardwareAbstractionLayer;
-import oshi.hardware.platform.unix.UnixDisplay;
-import oshi.hardware.platform.unix.UnixPrinter;
+import oshi.hardware.common.platform.unix.UnixDisplay;
 
 /**
  * LinuxHardwareAbstractionLayer class.
@@ -52,12 +50,5 @@ public abstract class LinuxHardwareAbstractionLayer extends AbstractHardwareAbst
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
-        return LinuxGraphicsCard.getGraphicsCards();
-    }
-
-    @Override
-    public List<Printer> getPrinters() {
-        return UnixPrinter.getPrinters();
-    }
+    public abstract List<GraphicsCard> getGraphicsCards();
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroup.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -14,7 +14,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.linux.DevPath;
 
-class LinuxLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
+public class LinuxLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
 
     protected static final String BLOCK = "block";
     protected static final String DM_UUID = "DM_UUID";

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import java.io.File;
 import java.net.NetworkInterface;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxPowerSource.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import static oshi.util.Constants.UNKNOWN;
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSensors.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import java.io.File;
 import java.io.FileFilter;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSoundCard.java
@@ -2,7 +2,7 @@
  * Copyright 2018-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxUsbDevice.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.sort;
@@ -27,7 +27,7 @@ public class LinuxUsbDevice extends AbstractUsbDevice {
     }
 
     /**
-     * No-arg constructor required so that {@link LinuxUsbDeviceJNA} and {@code LinuxUsbDeviceFFM}, which extend this
+     * No-arg constructor required so that {@code LinuxUsbDeviceJNA} and {@code LinuxUsbDeviceFFM}, which extend this
      * class solely to inherit its static helper methods, can compile without an explicit constructor. Neither subclass
      * is ever instantiated; only this class is, via the full constructor.
      */

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxVirtualMemory.java
@@ -2,7 +2,7 @@
  * Copyright 2019-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/package-info.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides common Linux hardware implementations shared by JNA and FFM modules.
+ */
+package oshi.hardware.common.platform.linux;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
@@ -1,16 +1,16 @@
 /*
- * Copyright 2021-2022 The OSHI Project Contributors
+ * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix;
+package oshi.hardware.common.platform.unix;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.Xrandr;
 import oshi.hardware.Display;
 import oshi.hardware.common.AbstractDisplay;
+import oshi.util.driver.unix.Xrandr;
 
 /**
  * A Display

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/package-info.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides common Unix hardware implementations shared by JNA and FFM modules.
+ */
+package oshi.hardware.common.platform.unix;

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix;
+package oshi.util.driver.unix;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -9,6 +9,8 @@
 --add-opens
   com.github.oshi.common/oshi.software.common=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.hardware.common.platform.linux=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.util.driver.linux=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.util.driver.linux.proc=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxPowerSourceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxPowerSourceTest.java
@@ -2,7 +2,7 @@
  * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2022 The OSHI Project Contributors
+ * Copyright 2022-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix;
+package oshi.util.driver.unix;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
@@ -23,6 +23,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.linux.proc.AuxvFFM;
 import oshi.ffm.linux.LinuxLibcFunctions;
 import oshi.ffm.linux.UdevFunctions;
+import oshi.hardware.common.platform.linux.LinuxCentralProcessor;
 import oshi.software.os.linux.LinuxOperatingSystemFFM;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
@@ -20,6 +20,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
+import oshi.hardware.common.platform.linux.LinuxHWDiskStore;
 import oshi.util.Constants;
 import oshi.util.ParseUtil;
 import oshi.util.linux.DevPath;

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerFFM.java
@@ -7,13 +7,18 @@ package oshi.hardware.platform.linux;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.unix.CupsPrinter;
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.GlobalMemory;
+import oshi.hardware.GraphicsCard;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.LogicalVolumeGroup;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.PowerSource;
+import oshi.hardware.Printer;
 import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.linux.LinuxGlobalMemory;
+import oshi.hardware.common.platform.linux.LinuxHardwareAbstractionLayer;
 import oshi.software.os.linux.LinuxOperatingSystemFFM;
 
 /**
@@ -46,6 +51,16 @@ public final class LinuxHardwareAbstractionLayerFFM extends LinuxHardwareAbstrac
     @Override
     public List<HWDiskStore> getDiskStores() {
         return LinuxHWDiskStoreFFM.getDisks();
+    }
+
+    @Override
+    public List<GraphicsCard> getGraphicsCards() {
+        return LinuxGraphicsCard.getGraphicsCards();
+    }
+
+    @Override
+    public List<Printer> getPrinters() {
+        return CupsPrinter.getPrinters();
     }
 
     @Override

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupFFM.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.LogicalVolumeGroup;
+import oshi.hardware.common.platform.linux.LinuxLogicalVolumeGroup;
 import oshi.util.Util;
 import oshi.util.linux.DevPath;
 

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.NetworkIF;
+import oshi.hardware.common.platform.linux.LinuxNetworkIF;
 import oshi.util.Util;
 import oshi.util.linux.SysPath;
 

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceFFM.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.PowerSource;
+import oshi.hardware.common.platform.linux.LinuxPowerSource;
 import oshi.util.ParseUtil;
 
 /**

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceFFM.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.linux.LinuxUsbDevice;
 
 /**
  * Linux USB device helper using FFM/udev. Instantiates {@link LinuxUsbDevice} objects.

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorJNA.java
@@ -21,6 +21,7 @@ import com.sun.jna.platform.linux.Udev.UdevListEntry;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.linux.proc.AuxvJNA;
+import oshi.hardware.common.platform.linux.LinuxCentralProcessor;
 import oshi.jna.platform.linux.LinuxLibc;
 import oshi.software.os.linux.LinuxOperatingSystemJNA;
 import oshi.util.FileUtil;

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
@@ -23,6 +23,7 @@ import com.sun.jna.platform.linux.Udev.UdevListEntry;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
+import oshi.hardware.common.platform.linux.LinuxHWDiskStore;
 import oshi.util.Constants;
 import oshi.util.ParseUtil;
 import oshi.util.linux.DevPath;

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerJNA.java
@@ -9,11 +9,16 @@ import java.util.List;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.GlobalMemory;
+import oshi.hardware.GraphicsCard;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.LogicalVolumeGroup;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.PowerSource;
+import oshi.hardware.Printer;
 import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.linux.LinuxGlobalMemory;
+import oshi.hardware.common.platform.linux.LinuxHardwareAbstractionLayer;
+import oshi.hardware.platform.unix.UnixPrinter;
 import oshi.software.os.linux.LinuxOperatingSystemJNA;
 
 /**
@@ -51,6 +56,16 @@ public final class LinuxHardwareAbstractionLayerJNA extends LinuxHardwareAbstrac
     @Override
     public List<UsbDevice> getUsbDevices(boolean tree) {
         return LinuxUsbDeviceJNA.getUsbDevices(tree);
+    }
+
+    @Override
+    public List<GraphicsCard> getGraphicsCards() {
+        return LinuxGraphicsCard.getGraphicsCards();
+    }
+
+    @Override
+    public List<Printer> getPrinters() {
+        return UnixPrinter.getPrinters();
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupJNA.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import com.sun.jna.platform.linux.Udev;
 
 import oshi.hardware.LogicalVolumeGroup;
+import oshi.hardware.common.platform.linux.LinuxLogicalVolumeGroup;
 import oshi.util.Util;
 import oshi.util.linux.DevPath;
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFJNA.java
@@ -19,6 +19,7 @@ import com.sun.jna.platform.linux.Udev.UdevDevice;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.NetworkIF;
+import oshi.hardware.common.platform.linux.LinuxNetworkIF;
 import oshi.util.Util;
 import oshi.util.linux.SysPath;
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceJNA.java
@@ -20,6 +20,7 @@ import com.sun.jna.platform.linux.Udev.UdevListEntry;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.PowerSource;
+import oshi.hardware.common.platform.linux.LinuxPowerSource;
 import oshi.util.ParseUtil;
 
 /**

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceJNA.java
@@ -21,6 +21,7 @@ import com.sun.jna.platform.linux.Udev.UdevEnumerate;
 import com.sun.jna.platform.linux.Udev.UdevListEntry;
 
 import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.linux.LinuxUsbDevice;
 
 /**
  * Linux USB device helper using JNA/udev. Instantiates {@link LinuxUsbDevice} objects.

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixHardwareAbstractionLayer.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixHardwareAbstractionLayer.java
@@ -28,7 +28,7 @@ import oshi.hardware.Sensors;
 import oshi.hardware.SoundCard;
 import oshi.hardware.UsbDevice;
 import oshi.hardware.common.AbstractHardwareAbstractionLayer;
-import oshi.hardware.platform.unix.UnixDisplay;
+import oshi.hardware.common.platform.unix.UnixDisplay;
 import oshi.hardware.platform.unix.UnixPrinter;
 
 /**

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHardwareAbstractionLayer.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHardwareAbstractionLayer.java
@@ -20,8 +20,8 @@ import oshi.hardware.Sensors;
 import oshi.hardware.SoundCard;
 import oshi.hardware.UsbDevice;
 import oshi.hardware.common.AbstractHardwareAbstractionLayer;
+import oshi.hardware.common.platform.unix.UnixDisplay;
 import oshi.hardware.platform.unix.BsdNetworkIF;
-import oshi.hardware.platform.unix.UnixDisplay;
 import oshi.hardware.platform.unix.UnixPrinter;
 
 /**

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHardwareAbstractionLayer.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHardwareAbstractionLayer.java
@@ -20,8 +20,8 @@ import oshi.hardware.Sensors;
 import oshi.hardware.SoundCard;
 import oshi.hardware.UsbDevice;
 import oshi.hardware.common.AbstractHardwareAbstractionLayer;
+import oshi.hardware.common.platform.unix.UnixDisplay;
 import oshi.hardware.platform.unix.BsdNetworkIF;
-import oshi.hardware.platform.unix.UnixDisplay;
 import oshi.hardware.platform.unix.UnixPrinter;
 
 /**

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHardwareAbstractionLayer.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHardwareAbstractionLayer.java
@@ -20,7 +20,7 @@ import oshi.hardware.Sensors;
 import oshi.hardware.SoundCard;
 import oshi.hardware.UsbDevice;
 import oshi.hardware.common.AbstractHardwareAbstractionLayer;
-import oshi.hardware.platform.unix.UnixDisplay;
+import oshi.hardware.common.platform.unix.UnixDisplay;
 import oshi.hardware.platform.unix.UnixPrinter;
 
 /**


### PR DESCRIPTION
Moves the Linux hardware abstraction layer and all native-free Linux hardware base classes from `oshi-core` (`oshi.hardware.platform.linux`) to `oshi-common` (`oshi.hardware.common.platform.linux`), so both JNA and FFM subclasses extend from a shared module.

### HAL and dependencies

- `LinuxHardwareAbstractionLayer` (abstract) — `getPrinters()` removed (interface default returns empty list), `getGraphicsCards()` made abstract
- `LinuxComputerSystem`, `LinuxFirmware`, `LinuxBaseboard`, `LinuxSensors`, `LinuxSoundCard`
- `UnixDisplay` → `oshi.hardware.common.platform.unix`
- `Xrandr` driver → `oshi.util.driver.unix`

### Hardware base classes

| Class | Pattern |
|---|---|
| `LinuxCentralProcessor` | Base + JNA + FFM (made `public`) |
| `LinuxHWDiskStore` | Base + JNA + FFM |
| `LinuxLogicalVolumeGroup` | Base + JNA + FFM (made `public`) |
| `LinuxNetworkIF` | Base + JNA + FFM |
| `LinuxPowerSource` | Base + JNA + FFM |
| `LinuxUsbDevice` | Base + JNA + FFM |
| `LinuxGlobalMemory` | Single class, no native deps |
| `LinuxVirtualMemory` | Single class, no native deps |

### Not moved

`LinuxGraphicsCard` and `LinuxGpuStats` remain in `oshi-core` — `createStatsSession()` instantiates `LinuxGpuStats` which depends on `NvmlUtil` (JNA). These need a JNA/FFM split before they can move.

### Import updates

All JNA subclasses in `oshi-core` and FFM subclasses in `oshi-core-java25` updated with explicit imports for the relocated base classes. `LinuxPowerSourceTest` moved to `oshi-common` test tree. `module-info.java` already exported the target package from the prior HAL work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Module exports expanded to expose common Linux and Unix hardware packages
  * Graphics card and printer enumeration added for Linux platforms

* **Refactor**
  * Shared/common Linux/Unix hardware implementations reorganized for reuse
  * Driver utilities and platform-specific types consolidated under a unified package structure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->