### PR TITLE
Split LinuxGraphicsCard, LinuxGpuStats, and NvmlUtil across modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ##### Bug fixes / Improvements
 * [#3128](https://github.com/oshi/oshi/pull/3128): Fix Mac FFM TIMEVAL struct layout missing 4-byte trailing padding - [@dbwiddis](https://github.com/dbwiddis).
 * [#3136](https://github.com/oshi/oshi/pull/3136): Push Linux USER_HZ and PAGE_SIZE into JNA/FFM OS subclasses; wire through HAL, processor, memory, process, and thread classes - [@dbwiddis](https://github.com/dbwiddis).
+* [#3139](https://github.com/oshi/oshi/pull/3139): Split LinuxGraphicsCard, LinuxGpuStats, and NvmlUtil across modules - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGpuStats.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import java.io.File;
 import java.util.Locale;
@@ -12,7 +12,6 @@ import oshi.hardware.GpuStats;
 import oshi.hardware.GpuTicks;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
-import oshi.util.gpu.NvmlUtil;
 
 /**
  * Linux {@link GpuStats} session. Dynamic metrics are sourced in priority order: NVML (NVIDIA GPUs), then sysfs DRM
@@ -22,26 +21,32 @@ import oshi.util.gpu.NvmlUtil;
  * <p>
  * GPU ticks are not available on Linux and always return {@code (0L, 0L)}. Shared memory is not available and always
  * returns -1.
+ *
+ * <p>
+ * Subclasses provide the NVML integration via JNA or FFM by implementing the {@code nvml*} methods.
  */
 @ThreadSafe
-final class LinuxGpuStats implements GpuStats {
+public abstract class LinuxGpuStats implements GpuStats {
 
     private final String drmDevicePath;
     private final String driverName;
     private final String pciBusId;
     private final String cardName;
 
-    // Cached at construction; empty string if not found
     private final String hwmonPath;
-    // Cached Intel gt0 path
     private final String gt0Path;
-
-    // Cached NVML device id; null means not yet resolved, empty string means unavailable
-    private String nvmlDeviceId;
 
     private boolean closed;
 
-    LinuxGpuStats(String drmDevicePath, String driverName, String pciBusId, String cardName) {
+    /**
+     * Constructor.
+     *
+     * @param drmDevicePath sysfs device path
+     * @param driverName    driver name
+     * @param pciBusId      PCI bus ID for NVML correlation
+     * @param cardName      card name for NVML fallback lookup
+     */
+    protected LinuxGpuStats(String drmDevicePath, String driverName, String pciBusId, String cardName) {
         this.drmDevicePath = drmDevicePath;
         this.driverName = driverName;
         this.pciBusId = pciBusId;
@@ -49,6 +54,134 @@ final class LinuxGpuStats implements GpuStats {
         this.hwmonPath = resolveHwmonPath(drmDevicePath);
         this.gt0Path = drmDevicePath.isEmpty() ? "" : drmDevicePath + "/../gt/gt0";
     }
+
+    /**
+     * Returns the PCI bus ID.
+     *
+     * @return PCI bus ID string
+     */
+    protected String getPciBusId() {
+        return pciBusId;
+    }
+
+    /**
+     * Returns the card name.
+     *
+     * @return card name string
+     */
+    protected String getCardName() {
+        return cardName;
+    }
+
+    // -------------------------------------------------------------------------
+    // Abstract NVML methods — implemented by JNA/FFM subclasses
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns whether NVML is available.
+     *
+     * @return true if NVML can be used
+     */
+    protected abstract boolean nvmlIsAvailable();
+
+    /**
+     * Finds the NVML device by PCI bus ID.
+     *
+     * @param busId PCI bus ID
+     * @return device identifier string, or {@code null}
+     */
+    protected abstract String nvmlFindDevice(String busId);
+
+    /**
+     * Finds the NVML device by GPU name.
+     *
+     * @param name GPU name
+     * @return device identifier string, or {@code null}
+     */
+    protected abstract String nvmlFindDeviceByName(String name);
+
+    /**
+     * Returns VRAM used in bytes via NVML, or -1.
+     *
+     * @param deviceId NVML device identifier
+     * @return bytes used or -1
+     */
+    protected abstract long nvmlGetVramUsed(String deviceId);
+
+    /**
+     * Returns GPU temperature via NVML, or -1.
+     *
+     * @param deviceId NVML device identifier
+     * @return temperature in °C or -1
+     */
+    protected abstract double nvmlGetTemperature(String deviceId);
+
+    /**
+     * Returns GPU power draw via NVML, or -1.
+     *
+     * @param deviceId NVML device identifier
+     * @return power in watts or -1
+     */
+    protected abstract double nvmlGetPowerDraw(String deviceId);
+
+    /**
+     * Returns GPU core clock via NVML, or -1.
+     *
+     * @param deviceId NVML device identifier
+     * @return core clock in MHz or -1
+     */
+    protected abstract long nvmlGetCoreClockMhz(String deviceId);
+
+    /**
+     * Returns GPU memory clock via NVML, or -1.
+     *
+     * @param deviceId NVML device identifier
+     * @return memory clock in MHz or -1
+     */
+    protected abstract long nvmlGetMemoryClockMhz(String deviceId);
+
+    /**
+     * Returns GPU fan speed via NVML, or -1.
+     *
+     * @param deviceId NVML device identifier
+     * @return fan speed percentage or -1
+     */
+    protected abstract double nvmlGetFanSpeedPercent(String deviceId);
+
+    // -------------------------------------------------------------------------
+    // NVML device resolution — cached
+    // -------------------------------------------------------------------------
+
+    // Cached NVML device id; null means not yet resolved, empty string means unavailable
+    private String nvmlDeviceId;
+
+    /**
+     * Resolves the NVML device identifier, caching the result.
+     *
+     * @return device identifier, or {@code null} if unavailable
+     */
+    protected String findNvmlDevice() {
+        if (nvmlDeviceId != null) {
+            return nvmlDeviceId.isEmpty() ? null : nvmlDeviceId;
+        }
+        if (!nvmlIsAvailable()) {
+            nvmlDeviceId = "";
+            return null;
+        }
+        String id = null;
+        if (!pciBusId.isEmpty()) {
+            id = nvmlFindDevice(pciBusId);
+        }
+        if (id == null) {
+            id = nvmlFindDeviceByName(cardName);
+        }
+        nvmlDeviceId = id != null ? id : "";
+        return id;
+    }
+
+    // -------------------------------------------------------------------------
+    // GpuStats implementation
+    // -------------------------------------------------------------------------
 
     @Override
     public synchronized void close() {
@@ -78,8 +211,6 @@ final class LinuxGpuStats implements GpuStats {
             return pct >= 0 ? pct : -1d;
         }
         if ("i915".equals(driver) || "xe".equals(driver)) {
-            // Approximates utilization as actual_freq / max_freq; not a true busy-time percentage
-            // but the best available metric without kernel tracepoints.
             long actual = FileUtil.getLongFromFile(gt0Path + "/rps_act_freq_mhz");
             long max = FileUtil.getLongFromFile(gt0Path + "/rps_max_freq_mhz");
             if (actual >= 0 && max > 0) {
@@ -94,7 +225,7 @@ final class LinuxGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            long val = NvmlUtil.getVramUsed(nvmlDevice);
+            long val = nvmlGetVramUsed(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -120,7 +251,7 @@ final class LinuxGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            double val = NvmlUtil.getTemperature(nvmlDevice);
+            double val = nvmlGetTemperature(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -139,7 +270,7 @@ final class LinuxGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            double val = NvmlUtil.getPowerDraw(nvmlDevice);
+            double val = nvmlGetPowerDraw(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -158,7 +289,7 @@ final class LinuxGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            long val = NvmlUtil.getCoreClockMhz(nvmlDevice);
+            long val = nvmlGetCoreClockMhz(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -188,7 +319,7 @@ final class LinuxGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            long val = NvmlUtil.getMemoryClockMhz(nvmlDevice);
+            long val = nvmlGetMemoryClockMhz(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -213,7 +344,7 @@ final class LinuxGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            double val = NvmlUtil.getFanSpeedPercent(nvmlDevice);
+            double val = nvmlGetFanSpeedPercent(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -237,25 +368,6 @@ final class LinuxGpuStats implements GpuStats {
             throw new IllegalStateException(
                     "GpuStats session has been closed. Obtain a new session via GraphicsCard.createStatsSession().");
         }
-    }
-
-    private String findNvmlDevice() {
-        if (nvmlDeviceId != null) {
-            return nvmlDeviceId.isEmpty() ? null : nvmlDeviceId;
-        }
-        if (!NvmlUtil.isAvailable()) {
-            nvmlDeviceId = "";
-            return null;
-        }
-        String id = null;
-        if (!pciBusId.isEmpty()) {
-            id = NvmlUtil.findDevice(pciBusId);
-        }
-        if (id == null) {
-            id = NvmlUtil.findDeviceByName(cardName);
-        }
-        nvmlDeviceId = id != null ? id : "";
-        return id;
     }
 
     private static String resolveHwmonPath(String drmDevicePath) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
@@ -2,15 +2,15 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.linux;
+package oshi.hardware.common.platform.linux;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.GraphicsCard;
-import oshi.hardware.GpuStats;
 import oshi.hardware.common.AbstractGraphicsCard;
 import oshi.util.Constants;
 import oshi.util.ExecutingCommand;
@@ -23,7 +23,7 @@ import oshi.util.tuples.Triplet;
  * Graphics card info obtained by lshw, with dynamic metrics from sysfs DRM driver files.
  */
 @ThreadSafe
-final class LinuxGraphicsCard extends AbstractGraphicsCard {
+public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
 
     private static final String DRM_PATH = "/sys/class/drm/";
 
@@ -49,34 +49,115 @@ final class LinuxGraphicsCard extends AbstractGraphicsCard {
      * @param driverName    driver name (e.g. "amdgpu"), or empty string if unknown
      * @param pciBusId      PCI bus ID for NVML correlation, or empty string if unknown
      */
-    LinuxGraphicsCard(String name, String deviceId, String vendor, String versionInfo, long vram, String drmDevicePath,
-            String driverName, String pciBusId) {
+    protected LinuxGraphicsCard(String name, String deviceId, String vendor, String versionInfo, long vram,
+            String drmDevicePath, String driverName, String pciBusId) {
         super(name, deviceId, vendor, versionInfo, vram);
         this.drmDevicePath = drmDevicePath;
         this.driverName = driverName;
         this.pciBusId = pciBusId;
     }
 
-    @Override
-    public GpuStats createStatsSession() {
-        return new LinuxGpuStats(drmDevicePath, driverName, pciBusId, getName());
+    /**
+     * Returns the sysfs device path.
+     *
+     * @return sysfs device path
+     */
+    protected String getDrmDevicePath() {
+        return drmDevicePath;
     }
 
     /**
-     * public method used by {@code AbstractHardwareAbstractionLayer} to access the graphics cards.
+     * Returns the driver name.
      *
-     * @return List of {@link LinuxGraphicsCard} objects.
+     * @return driver name
      */
-    public static List<GraphicsCard> getGraphicsCards() {
-        List<GraphicsCard> cardList = getGraphicsCardsFromLspci();
+    protected String getDriverName() {
+        return driverName;
+    }
+
+    /**
+     * Returns the PCI bus ID.
+     *
+     * @return PCI bus ID
+     */
+    protected String getPciBusId() {
+        return pciBusId;
+    }
+
+    /**
+     * Parsed graphics card attributes used to construct concrete subclass instances.
+     */
+    public static class Attrs {
+        private final String name;
+        private final String deviceId;
+        private final String vendor;
+        private final String versionInfo;
+        private final long vram;
+        private final String drmDevicePath;
+        private final String driverName;
+        private final String pciBusId;
+
+        Attrs(String name, String deviceId, String vendor, String versionInfo, long vram, String drmDevicePath,
+                String driverName, String pciBusId) {
+            this.name = name;
+            this.deviceId = deviceId;
+            this.vendor = vendor;
+            this.versionInfo = versionInfo;
+            this.vram = vram;
+            this.drmDevicePath = drmDevicePath;
+            this.driverName = driverName;
+            this.pciBusId = pciBusId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDeviceId() {
+            return deviceId;
+        }
+
+        public String getVendor() {
+            return vendor;
+        }
+
+        public String getVersionInfo() {
+            return versionInfo;
+        }
+
+        public long getVram() {
+            return vram;
+        }
+
+        public String getDrmDevicePath() {
+            return drmDevicePath;
+        }
+
+        public String getDriverName() {
+            return driverName;
+        }
+
+        public String getPciBusId() {
+            return pciBusId;
+        }
+    }
+
+    /**
+     * Queries graphics cards from lspci/lshw and constructs instances using the provided factory.
+     *
+     * @param factory function that creates a concrete {@link GraphicsCard} from parsed attributes
+     * @return list of graphics cards
+     */
+    public static List<GraphicsCard> getGraphicsCards(Function<Attrs, GraphicsCard> factory) {
+        List<GraphicsCard> cardList = getGraphicsCardsFromLspci(factory);
         if (cardList.isEmpty()) {
-            cardList = getGraphicsCardsFromLshw();
+            cardList = getGraphicsCardsFromLshw(factory);
         }
         return cardList;
     }
 
     // Faster, use as primary
-    private static List<GraphicsCard> getGraphicsCardsFromLspci() {
+    private static List<GraphicsCard> getGraphicsCardsFromLspci(Function<Attrs, GraphicsCard> factory) {
         List<GraphicsCard> cardList = new ArrayList<>();
         // Machine readable version
         List<String> lspci = ExecutingCommand.runNative("lspci -vnnm");
@@ -105,10 +186,10 @@ final class LinuxGraphicsCard extends AbstractGraphicsCard {
                 if (split.length < 2) {
                     // Save previous card
                     Triplet<String, String, String> drmInfo = findDrmInfo(lookupDevice);
-                    cardList.add(new LinuxGraphicsCard(name, deviceId, vendor,
+                    cardList.add(factory.apply(new Attrs(name, deviceId, vendor,
                             versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList),
                             lookupDevice != null ? queryLspciMemorySize(lookupDevice) : 0L, drmInfo.getA(),
-                            drmInfo.getB(), drmInfo.getC()));
+                            drmInfo.getB(), drmInfo.getC())));
                     versionInfoList.clear();
                     found = false;
                 } else {
@@ -134,10 +215,10 @@ final class LinuxGraphicsCard extends AbstractGraphicsCard {
         // If we haven't yet written the last card do so now
         if (found) {
             Triplet<String, String, String> drmInfo = findDrmInfo(lookupDevice);
-            cardList.add(new LinuxGraphicsCard(name, deviceId, vendor,
+            cardList.add(factory.apply(new Attrs(name, deviceId, vendor,
                     versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList),
                     lookupDevice != null ? queryLspciMemorySize(lookupDevice) : 0L, drmInfo.getA(), drmInfo.getB(),
-                    drmInfo.getC()));
+                    drmInfo.getC())));
         }
         return cardList;
     }
@@ -156,7 +237,7 @@ final class LinuxGraphicsCard extends AbstractGraphicsCard {
     }
 
     // Slower, use as backup
-    private static List<GraphicsCard> getGraphicsCardsFromLshw() {
+    private static List<GraphicsCard> getGraphicsCardsFromLshw(Function<Attrs, GraphicsCard> factory) {
         List<GraphicsCard> cardList = new ArrayList<>();
         List<String> lshw = ExecutingCommand.runPrivilegedNative("lshw -C display");
         String name = Constants.UNKNOWN;
@@ -172,9 +253,9 @@ final class LinuxGraphicsCard extends AbstractGraphicsCard {
                 // Save previous card
                 if (cardNum++ > 0) {
                     Triplet<String, String, String> drmInfo = findDrmInfo(busInfo);
-                    cardList.add(new LinuxGraphicsCard(name, deviceId, vendor,
+                    cardList.add(factory.apply(new Attrs(name, deviceId, vendor,
                             versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList), vram,
-                            drmInfo.getA(), drmInfo.getB(), drmInfo.getC()));
+                            drmInfo.getA(), drmInfo.getB(), drmInfo.getC())));
                 }
                 name = Constants.UNKNOWN;
                 deviceId = Constants.UNKNOWN;
@@ -203,9 +284,9 @@ final class LinuxGraphicsCard extends AbstractGraphicsCard {
         }
         if (cardNum > 0) {
             Triplet<String, String, String> drmInfo = findDrmInfo(busInfo);
-            cardList.add(new LinuxGraphicsCard(name, deviceId, vendor,
+            cardList.add(factory.apply(new Attrs(name, deviceId, vendor,
                     versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList), vram,
-                    drmInfo.getA(), drmInfo.getB(), drmInfo.getC()));
+                    drmInfo.getA(), drmInfo.getB(), drmInfo.getC())));
         }
         return cardList;
     }

--- a/oshi-core-java25/src/main/java/oshi/ffm/common/NvmlFunctions.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/common/NvmlFunctions.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.common;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.ffm.ForeignFunctions;
+
+/**
+ * FFM bindings for the NVIDIA Management Library (NVML).
+ */
+public final class NvmlFunctions extends ForeignFunctions {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NvmlFunctions.class);
+
+    private NvmlFunctions() {
+    }
+
+    // Constants matching NVML C header
+    /** Successful return code. */
+    public static final int NVML_SUCCESS = 0;
+    /** GPU temperature sensor type. */
+    public static final int NVML_TEMPERATURE_GPU = 0;
+    /** Graphics clock domain. */
+    public static final int NVML_CLOCK_GRAPHICS = 0;
+    /** Memory clock domain. */
+    public static final int NVML_CLOCK_MEM = 2;
+    /** Buffer size for device name queries. */
+    public static final int NVML_DEVICE_NAME_BUFFER_SIZE = 96;
+
+    // nvmlUtilization_t: { unsigned int gpu; unsigned int memory; }
+    /** Layout for nvmlUtilization_t struct. */
+    public static final StructLayout UTILIZATION_LAYOUT = MemoryLayout.structLayout(JAVA_INT.withName("gpu"),
+            JAVA_INT.withName("memory"));
+
+    // nvmlMemory_t: { unsigned long long total; unsigned long long free; unsigned long long used; }
+    /** Layout for nvmlMemory_t struct. */
+    public static final StructLayout MEMORY_LAYOUT = MemoryLayout.structLayout(JAVA_LONG.withName("total"),
+            JAVA_LONG.withName("free"), JAVA_LONG.withName("used"));
+
+    // nvmlPciInfo_t: { char busIdLegacy[16]; unsigned int domain, bus, device, pciDeviceId, pciSubSystemId;
+    // char busId[32]; }
+    /** Layout for nvmlPciInfo_t struct. */
+    public static final StructLayout PCI_INFO_LAYOUT = MemoryLayout.structLayout(
+            MemoryLayout.sequenceLayout(16, JAVA_BYTE).withName("busIdLegacy"), JAVA_INT.withName("domain"),
+            JAVA_INT.withName("bus"), JAVA_INT.withName("device"), JAVA_INT.withName("pciDeviceId"),
+            JAVA_INT.withName("pciSubSystemId"), MemoryLayout.sequenceLayout(32, JAVA_BYTE).withName("busId"));
+
+    // Method handles
+    private static final MethodHandle nvmlInit_v2;
+    private static final MethodHandle nvmlShutdown;
+    private static final MethodHandle nvmlDeviceGetCount_v2;
+    private static final MethodHandle nvmlDeviceGetHandleByIndex_v2;
+    private static final MethodHandle nvmlDeviceGetName;
+    private static final MethodHandle nvmlDeviceGetPciInfo_v3;
+    private static final MethodHandle nvmlDeviceGetUtilizationRates;
+    private static final MethodHandle nvmlDeviceGetMemoryInfo;
+    private static final MethodHandle nvmlDeviceGetTemperature;
+    private static final MethodHandle nvmlDeviceGetPowerUsage;
+    private static final MethodHandle nvmlDeviceGetClockInfo;
+    private static final MethodHandle nvmlDeviceGetFanSpeed;
+
+    private static final boolean AVAILABLE;
+
+    static {
+        boolean available = false;
+        MethodHandle hInit = null;
+        MethodHandle hShutdown = null;
+        MethodHandle hGetCount = null;
+        MethodHandle hGetHandle = null;
+        MethodHandle hGetName = null;
+        MethodHandle hGetPci = null;
+        MethodHandle hGetUtil = null;
+        MethodHandle hGetMem = null;
+        MethodHandle hGetTemp = null;
+        MethodHandle hGetPower = null;
+        MethodHandle hGetClock = null;
+        MethodHandle hGetFan = null;
+        try {
+            String libName = System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("win")
+                    ? "nvml"
+                    : "nvidia-ml";
+            SymbolLookup nvml = libraryLookup(libName);
+
+            hInit = LINKER.downcallHandle(nvml.findOrThrow("nvmlInit_v2"), FunctionDescriptor.of(JAVA_INT));
+            hShutdown = LINKER.downcallHandle(nvml.findOrThrow("nvmlShutdown"), FunctionDescriptor.of(JAVA_INT));
+            hGetCount = LINKER.downcallHandle(nvml.findOrThrow("nvmlDeviceGetCount_v2"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS));
+            hGetHandle = LINKER.downcallHandle(nvml.findOrThrow("nvmlDeviceGetHandleByIndex_v2"),
+                    FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
+            hGetName = LINKER.downcallHandle(nvml.findOrThrow("nvmlDeviceGetName"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, JAVA_INT));
+            hGetPci = LINKER.downcallHandle(nvml.findOrThrow("nvmlDeviceGetPciInfo_v3"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+            hGetUtil = LINKER.downcallHandle(nvml.findOrThrow("nvmlDeviceGetUtilizationRates"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+            hGetMem = LINKER.downcallHandle(nvml.findOrThrow("nvmlDeviceGetMemoryInfo"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+            hGetTemp = LINKER.downcallHandle(nvml.findOrThrow("nvmlDeviceGetTemperature"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS));
+            hGetPower = LINKER.downcallHandle(nvml.findOrThrow("nvmlDeviceGetPowerUsage"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+            hGetClock = LINKER.downcallHandle(nvml.findOrThrow("nvmlDeviceGetClockInfo"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS));
+            hGetFan = LINKER.downcallHandle(nvml.findOrThrow("nvmlDeviceGetFanSpeed"),
+                    FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+            available = true;
+            LOG.debug("NVML library loaded via FFM");
+        } catch (Throwable t) {
+            LOG.debug("NVML library not available via FFM: {}", t.getMessage());
+        }
+        nvmlInit_v2 = hInit;
+        nvmlShutdown = hShutdown;
+        nvmlDeviceGetCount_v2 = hGetCount;
+        nvmlDeviceGetHandleByIndex_v2 = hGetHandle;
+        nvmlDeviceGetName = hGetName;
+        nvmlDeviceGetPciInfo_v3 = hGetPci;
+        nvmlDeviceGetUtilizationRates = hGetUtil;
+        nvmlDeviceGetMemoryInfo = hGetMem;
+        nvmlDeviceGetTemperature = hGetTemp;
+        nvmlDeviceGetPowerUsage = hGetPower;
+        nvmlDeviceGetClockInfo = hGetClock;
+        nvmlDeviceGetFanSpeed = hGetFan;
+        AVAILABLE = available;
+    }
+
+    /**
+     * Returns whether the NVML native library was successfully loaded.
+     *
+     * @return true if the NVML library is available
+     */
+    public static boolean isAvailable() {
+        return AVAILABLE;
+    }
+
+    /**
+     * Calls nvmlInit_v2.
+     *
+     * @return NVML return code
+     */
+    public static int init() {
+        try {
+            return (int) nvmlInit_v2.invokeExact();
+        } catch (Throwable t) {
+            LOG.debug("nvmlInit_v2 failed: {}", t.getMessage());
+            return -1;
+        }
+    }
+
+    /**
+     * Calls nvmlShutdown.
+     *
+     * @return NVML return code
+     */
+    public static int shutdown() {
+        try {
+            return (int) nvmlShutdown.invokeExact();
+        } catch (Throwable t) {
+            LOG.debug("nvmlShutdown failed: {}", t.getMessage());
+            return -1;
+        }
+    }
+
+    /**
+     * Gets the device count.
+     *
+     * @param countSeg pointer to int to receive count
+     * @return NVML return code
+     */
+    public static int deviceGetCount(MemorySegment countSeg) {
+        try {
+            return (int) nvmlDeviceGetCount_v2.invokeExact(countSeg);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    /**
+     * Gets a device handle by index.
+     *
+     * @param index     device index
+     * @param handleSeg pointer to receive device handle
+     * @return NVML return code
+     */
+    public static int deviceGetHandleByIndex(int index, MemorySegment handleSeg) {
+        try {
+            return (int) nvmlDeviceGetHandleByIndex_v2.invokeExact(index, handleSeg);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    /**
+     * Gets the device name.
+     *
+     * @param device  device handle
+     * @param nameSeg buffer to receive name
+     * @param length  buffer length
+     * @return NVML return code
+     */
+    public static int deviceGetName(MemorySegment device, MemorySegment nameSeg, int length) {
+        try {
+            return (int) nvmlDeviceGetName.invokeExact(device, nameSeg, length);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    /**
+     * Gets PCI info for a device.
+     *
+     * @param device device handle
+     * @param pciSeg nvmlPciInfo_t struct to fill
+     * @return NVML return code
+     */
+    public static int deviceGetPciInfo(MemorySegment device, MemorySegment pciSeg) {
+        try {
+            return (int) nvmlDeviceGetPciInfo_v3.invokeExact(device, pciSeg);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    /**
+     * Gets utilization rates for a device.
+     *
+     * @param device  device handle
+     * @param utilSeg nvmlUtilization_t struct to fill
+     * @return NVML return code
+     */
+    public static int deviceGetUtilizationRates(MemorySegment device, MemorySegment utilSeg) {
+        try {
+            return (int) nvmlDeviceGetUtilizationRates.invokeExact(device, utilSeg);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    /**
+     * Gets memory info for a device.
+     *
+     * @param device device handle
+     * @param memSeg nvmlMemory_t struct to fill
+     * @return NVML return code
+     */
+    public static int deviceGetMemoryInfo(MemorySegment device, MemorySegment memSeg) {
+        try {
+            return (int) nvmlDeviceGetMemoryInfo.invokeExact(device, memSeg);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    /**
+     * Gets temperature for a device.
+     *
+     * @param device     device handle
+     * @param sensorType sensor type constant
+     * @param tempSeg    pointer to int to receive temperature
+     * @return NVML return code
+     */
+    public static int deviceGetTemperature(MemorySegment device, int sensorType, MemorySegment tempSeg) {
+        try {
+            return (int) nvmlDeviceGetTemperature.invokeExact(device, sensorType, tempSeg);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    /**
+     * Gets power usage for a device.
+     *
+     * @param device   device handle
+     * @param powerSeg pointer to int to receive power in milliwatts
+     * @return NVML return code
+     */
+    public static int deviceGetPowerUsage(MemorySegment device, MemorySegment powerSeg) {
+        try {
+            return (int) nvmlDeviceGetPowerUsage.invokeExact(device, powerSeg);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    /**
+     * Gets clock info for a device.
+     *
+     * @param device    device handle
+     * @param clockType clock type constant
+     * @param clockSeg  pointer to int to receive clock in MHz
+     * @return NVML return code
+     */
+    public static int deviceGetClockInfo(MemorySegment device, int clockType, MemorySegment clockSeg) {
+        try {
+            return (int) nvmlDeviceGetClockInfo.invokeExact(device, clockType, clockSeg);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    /**
+     * Gets fan speed for a device.
+     *
+     * @param device   device handle
+     * @param speedSeg pointer to int to receive fan speed percentage
+     * @return NVML return code
+     */
+    public static int deviceGetFanSpeed(MemorySegment device, MemorySegment speedSeg) {
+        try {
+            return (int) nvmlDeviceGetFanSpeed.invokeExact(device, speedSeg);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    /**
+     * Reads a null-terminated string from a byte sequence within a struct segment.
+     *
+     * @param seg    the struct segment
+     * @param offset byte offset of the char array field
+     * @param maxLen maximum length of the char array
+     * @return the string, or empty if null/empty
+     */
+    public static String readString(MemorySegment seg, long offset, int maxLen) {
+        for (int i = 0; i < maxLen; i++) {
+            if (seg.get(JAVA_BYTE, offset + i) == 0) {
+                if (i == 0) {
+                    return "";
+                }
+                return seg.getString(offset);
+            }
+        }
+        byte[] bytes = new byte[maxLen];
+        MemorySegment.copy(seg, JAVA_BYTE, offset, bytes, 0, maxLen);
+        return new String(bytes, java.nio.charset.StandardCharsets.UTF_8).trim();
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/common/package-info.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/common/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides FFM bindings for cross-platform native libraries.
+ */
+package oshi.ffm.common;

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxGpuStatsFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxGpuStatsFFM.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.linux;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.common.platform.linux.LinuxGpuStats;
+import oshi.util.gpu.NvmlUtilFFM;
+
+/**
+ * FFM-based Linux {@link LinuxGpuStats} subclass providing NVML integration via FFM.
+ */
+@ThreadSafe
+final class LinuxGpuStatsFFM extends LinuxGpuStats {
+
+    LinuxGpuStatsFFM(String drmDevicePath, String driverName, String pciBusId, String cardName) {
+        super(drmDevicePath, driverName, pciBusId, cardName);
+    }
+
+    @Override
+    protected boolean nvmlIsAvailable() {
+        return NvmlUtilFFM.isAvailable();
+    }
+
+    @Override
+    protected String nvmlFindDevice(String busId) {
+        return NvmlUtilFFM.findDevice(busId);
+    }
+
+    @Override
+    protected String nvmlFindDeviceByName(String name) {
+        return NvmlUtilFFM.findDeviceByName(name);
+    }
+
+    @Override
+    protected long nvmlGetVramUsed(String deviceId) {
+        return NvmlUtilFFM.getVramUsed(deviceId);
+    }
+
+    @Override
+    protected double nvmlGetTemperature(String deviceId) {
+        return NvmlUtilFFM.getTemperature(deviceId);
+    }
+
+    @Override
+    protected double nvmlGetPowerDraw(String deviceId) {
+        return NvmlUtilFFM.getPowerDraw(deviceId);
+    }
+
+    @Override
+    protected long nvmlGetCoreClockMhz(String deviceId) {
+        return NvmlUtilFFM.getCoreClockMhz(deviceId);
+    }
+
+    @Override
+    protected long nvmlGetMemoryClockMhz(String deviceId) {
+        return NvmlUtilFFM.getMemoryClockMhz(deviceId);
+    }
+
+    @Override
+    protected double nvmlGetFanSpeedPercent(String deviceId) {
+        return NvmlUtilFFM.getFanSpeedPercent(deviceId);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxGraphicsCardFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxGraphicsCardFFM.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.linux;
+
+import java.util.List;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.GpuStats;
+import oshi.hardware.GraphicsCard;
+import oshi.hardware.common.platform.linux.LinuxGraphicsCard;
+
+/**
+ * FFM-based Linux graphics card with NVML-backed GPU stats.
+ */
+@ThreadSafe
+final class LinuxGraphicsCardFFM extends LinuxGraphicsCard {
+
+    LinuxGraphicsCardFFM(String name, String deviceId, String vendor, String versionInfo, long vram,
+            String drmDevicePath, String driverName, String pciBusId) {
+        super(name, deviceId, vendor, versionInfo, vram, drmDevicePath, driverName, pciBusId);
+    }
+
+    @Override
+    public GpuStats createStatsSession() {
+        return new LinuxGpuStatsFFM(getDrmDevicePath(), getDriverName(), getPciBusId(), getName());
+    }
+
+    /**
+     * Gets graphics cards using FFM-based GPU stats.
+     *
+     * @return list of graphics cards
+     */
+    public static List<GraphicsCard> getGraphicsCards() {
+        return LinuxGraphicsCard
+                .getGraphicsCards(a -> new LinuxGraphicsCardFFM(a.getName(), a.getDeviceId(), a.getVendor(),
+                        a.getVersionInfo(), a.getVram(), a.getDrmDevicePath(), a.getDriverName(), a.getPciBusId()));
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerFFM.java
@@ -55,7 +55,7 @@ public final class LinuxHardwareAbstractionLayerFFM extends LinuxHardwareAbstrac
 
     @Override
     public List<GraphicsCard> getGraphicsCards() {
-        return LinuxGraphicsCard.getGraphicsCards();
+        return LinuxGraphicsCardFFM.getGraphicsCards();
     }
 
     @Override

--- a/oshi-core-java25/src/main/java/oshi/util/gpu/NvmlUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/gpu/NvmlUtilFFM.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.gpu;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.common.NvmlFunctions;
+
+/**
+ * FFM-based optional runtime binding to the NVIDIA Management Library (NVML). All methods return sentinel values
+ * ({@code -1} or {@code -1L}) when NVML is unavailable or a specific query fails.
+ */
+@ThreadSafe
+public final class NvmlUtilFFM {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NvmlUtilFFM.class);
+
+    private static volatile boolean devicesEnumerated = false;
+    private static volatile Set<String> deviceBusIds = Collections.emptySet();
+
+    private NvmlUtilFFM() {
+    }
+
+    private static boolean nvmlInit() {
+        if (!NvmlFunctions.isAvailable()) {
+            return false;
+        }
+        int ret = NvmlFunctions.init();
+        if (ret == NvmlFunctions.NVML_SUCCESS) {
+            return true;
+        }
+        LOG.debug("nvmlInit_v2 failed with code {}", ret);
+        return false;
+    }
+
+    private static void nvmlUninit() {
+        NvmlFunctions.shutdown();
+    }
+
+    private static void ensureDevicesEnumerated() {
+        if (devicesEnumerated) {
+            return;
+        }
+        Set<String> ids = enumerateDeviceBusIds();
+        if (ids != null) {
+            deviceBusIds = ids;
+            devicesEnumerated = true;
+            LOG.debug("NVML (FFM) enumerated {} device(s)", deviceBusIds.size());
+        }
+    }
+
+    private static Set<String> enumerateDeviceBusIds() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment countSeg = arena.allocate(JAVA_INT);
+            if (NvmlFunctions.deviceGetCount(countSeg) != NvmlFunctions.NVML_SUCCESS) {
+                return null;
+            }
+            int count = countSeg.get(JAVA_INT, 0);
+            Set<String> ids = new HashSet<>();
+            long busIdLegacyOffset = NvmlFunctions.PCI_INFO_LAYOUT
+                    .byteOffset(MemoryLayout.PathElement.groupElement("busIdLegacy"));
+            long busIdOffset = NvmlFunctions.PCI_INFO_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("busId"));
+            for (int i = 0; i < count; i++) {
+                MemorySegment handleSeg = arena.allocate(ADDRESS);
+                if (NvmlFunctions.deviceGetHandleByIndex(i, handleSeg) != NvmlFunctions.NVML_SUCCESS) {
+                    continue;
+                }
+                MemorySegment handle = handleSeg.get(ADDRESS, 0);
+                MemorySegment pciSeg = arena.allocate(NvmlFunctions.PCI_INFO_LAYOUT);
+                if (NvmlFunctions.deviceGetPciInfo(handle, pciSeg) == NvmlFunctions.NVML_SUCCESS) {
+                    String legacyId = NvmlFunctions.readString(pciSeg, busIdLegacyOffset, 16).toLowerCase(Locale.ROOT);
+                    if (!legacyId.isEmpty()) {
+                        ids.add(legacyId);
+                    }
+                    String busId = NvmlFunctions.readString(pciSeg, busIdOffset, 32).toLowerCase(Locale.ROOT);
+                    if (!busId.isEmpty()) {
+                        ids.add(busId);
+                    }
+                }
+            }
+            return Collections.unmodifiableSet(ids);
+        }
+    }
+
+    private static MemorySegment acquireHandleByBusId(String pciBusId, Arena arena) {
+        MemorySegment countSeg = arena.allocate(JAVA_INT);
+        if (NvmlFunctions.deviceGetCount(countSeg) != NvmlFunctions.NVML_SUCCESS) {
+            return null;
+        }
+        String needle = pciBusId.toLowerCase(Locale.ROOT);
+        int count = countSeg.get(JAVA_INT, 0);
+        long busIdLegacyOffset = NvmlFunctions.PCI_INFO_LAYOUT
+                .byteOffset(MemoryLayout.PathElement.groupElement("busIdLegacy"));
+        long busIdOffset = NvmlFunctions.PCI_INFO_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("busId"));
+        for (int i = 0; i < count; i++) {
+            MemorySegment handleSeg = arena.allocate(ADDRESS);
+            if (NvmlFunctions.deviceGetHandleByIndex(i, handleSeg) != NvmlFunctions.NVML_SUCCESS) {
+                continue;
+            }
+            MemorySegment handle = handleSeg.get(ADDRESS, 0);
+            MemorySegment pciSeg = arena.allocate(NvmlFunctions.PCI_INFO_LAYOUT);
+            if (NvmlFunctions.deviceGetPciInfo(handle, pciSeg) == NvmlFunctions.NVML_SUCCESS) {
+                String legacyId = NvmlFunctions.readString(pciSeg, busIdLegacyOffset, 16).toLowerCase(Locale.ROOT);
+                String busId = NvmlFunctions.readString(pciSeg, busIdOffset, 32).toLowerCase(Locale.ROOT);
+                if (busId.contains(needle) || needle.contains(busId) || legacyId.contains(needle)
+                        || needle.contains(legacyId)) {
+                    return handle;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static MemorySegment acquireHandleByName(String gpuName, Arena arena) {
+        MemorySegment countSeg = arena.allocate(JAVA_INT);
+        if (NvmlFunctions.deviceGetCount(countSeg) != NvmlFunctions.NVML_SUCCESS) {
+            return null;
+        }
+        String needle = gpuName.toLowerCase(Locale.ROOT);
+        int count = countSeg.get(JAVA_INT, 0);
+        for (int i = 0; i < count; i++) {
+            MemorySegment handleSeg = arena.allocate(ADDRESS);
+            if (NvmlFunctions.deviceGetHandleByIndex(i, handleSeg) != NvmlFunctions.NVML_SUCCESS) {
+                continue;
+            }
+            MemorySegment handle = handleSeg.get(ADDRESS, 0);
+            MemorySegment nameSeg = arena.allocate(NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE);
+            if (NvmlFunctions.deviceGetName(handle, nameSeg,
+                    NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE) == NvmlFunctions.NVML_SUCCESS) {
+                String name = nameSeg.getString(0).toLowerCase(Locale.ROOT);
+                if (name.contains(needle) || needle.contains(name)) {
+                    return handle;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static int countMatchesByName(String gpuName, Arena arena) {
+        MemorySegment countSeg = arena.allocate(JAVA_INT);
+        if (NvmlFunctions.deviceGetCount(countSeg) != NvmlFunctions.NVML_SUCCESS) {
+            return -1;
+        }
+        String needle = gpuName.toLowerCase(Locale.ROOT);
+        int total = countSeg.get(JAVA_INT, 0);
+        int matches = 0;
+        for (int i = 0; i < total; i++) {
+            MemorySegment handleSeg = arena.allocate(ADDRESS);
+            if (NvmlFunctions.deviceGetHandleByIndex(i, handleSeg) != NvmlFunctions.NVML_SUCCESS) {
+                continue;
+            }
+            MemorySegment nameSeg = arena.allocate(NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE);
+            if (NvmlFunctions.deviceGetName(handleSeg.get(ADDRESS, 0), nameSeg,
+                    NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE) == NvmlFunctions.NVML_SUCCESS) {
+                String name = nameSeg.getString(0).toLowerCase(Locale.ROOT);
+                if (name.contains(needle) || needle.contains(name)) {
+                    matches++;
+                }
+            }
+        }
+        return matches;
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API — mirrors NvmlUtil (JNA) exactly
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns whether the NVML native library was successfully loaded.
+     *
+     * @return true if the NVML library is available
+     */
+    public static boolean isAvailable() {
+        return NvmlFunctions.isAvailable();
+    }
+
+    /**
+     * Finds the stable PCI bus ID string for the NVML device whose bus ID contains the given fragment.
+     *
+     * @param pciBusId PCI bus ID fragment
+     * @return matched PCI bus ID string, or {@code null} if not found
+     */
+    public static String findDevice(String pciBusId) {
+        if (!NvmlFunctions.isAvailable() || pciBusId == null || pciBusId.isEmpty()) {
+            return null;
+        }
+        boolean init = nvmlInit();
+        if (!init) {
+            return null;
+        }
+        try {
+            ensureDevicesEnumerated();
+            String needle = pciBusId.toLowerCase(Locale.ROOT);
+            for (String id : deviceBusIds) {
+                if (id.contains(needle) || needle.contains(id)) {
+                    return id;
+                }
+            }
+            return null;
+        } finally {
+            nvmlUninit();
+        }
+    }
+
+    /**
+     * Finds the stable PCI bus ID string for the NVML device whose name matches the given GPU name.
+     *
+     * @param gpuName GPU name string
+     * @return PCI bus ID string, or {@code null} if not found
+     */
+    public static String findDeviceByName(String gpuName) {
+        if (!NvmlFunctions.isAvailable() || gpuName == null || gpuName.isEmpty()) {
+            return null;
+        }
+        boolean init = nvmlInit();
+        if (!init) {
+            return null;
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            ensureDevicesEnumerated();
+            int matchCount = countMatchesByName(gpuName, arena);
+            if (matchCount <= 0) {
+                return null;
+            }
+            if (matchCount > 1) {
+                LOG.warn("NVML name match for '{}' is ambiguous ({} devices match); use PCI bus ID for reliable"
+                        + " device identification", gpuName, matchCount);
+                return null;
+            }
+            MemorySegment handle = acquireHandleByName(gpuName, arena);
+            if (handle == null) {
+                return null;
+            }
+            long busIdLegacyOffset = NvmlFunctions.PCI_INFO_LAYOUT
+                    .byteOffset(MemoryLayout.PathElement.groupElement("busIdLegacy"));
+            MemorySegment pciSeg = arena.allocate(NvmlFunctions.PCI_INFO_LAYOUT);
+            if (NvmlFunctions.deviceGetPciInfo(handle, pciSeg) == NvmlFunctions.NVML_SUCCESS) {
+                String busId = NvmlFunctions.readString(pciSeg, busIdLegacyOffset, 16).toLowerCase(Locale.ROOT);
+                if (!busId.isEmpty()) {
+                    return busId;
+                }
+            }
+            return null;
+        } finally {
+            nvmlUninit();
+        }
+    }
+
+    /**
+     * Returns GPU core utilization percentage (0–100), or -1 if unavailable.
+     *
+     * @param deviceId stable device identifier
+     * @return utilization percentage or -1
+     */
+    public static double getGpuUtilization(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) {
+            return -1d;
+        }
+        boolean init = nvmlInit();
+        if (!init) {
+            return -1d;
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment device = acquireHandleByBusId(deviceId, arena);
+            if (device == null) {
+                return -1d;
+            }
+            MemorySegment utilSeg = arena.allocate(NvmlFunctions.UTILIZATION_LAYOUT);
+            if (NvmlFunctions.deviceGetUtilizationRates(device, utilSeg) == NvmlFunctions.NVML_SUCCESS) {
+                return utilSeg.get(JAVA_INT, 0);
+            }
+            return -1d;
+        } finally {
+            nvmlUninit();
+        }
+    }
+
+    /**
+     * Returns VRAM used in bytes, or -1 if unavailable.
+     *
+     * @param deviceId stable device identifier
+     * @return bytes used or -1
+     */
+    public static long getVramUsed(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) {
+            return -1L;
+        }
+        boolean init = nvmlInit();
+        if (!init) {
+            return -1L;
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment device = acquireHandleByBusId(deviceId, arena);
+            if (device == null) {
+                return -1L;
+            }
+            MemorySegment memSeg = arena.allocate(NvmlFunctions.MEMORY_LAYOUT);
+            if (NvmlFunctions.deviceGetMemoryInfo(device, memSeg) == NvmlFunctions.NVML_SUCCESS) {
+                return memSeg.get(JAVA_LONG,
+                        NvmlFunctions.MEMORY_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("used")));
+            }
+            return -1L;
+        } finally {
+            nvmlUninit();
+        }
+    }
+
+    /**
+     * Returns GPU temperature in degrees Celsius, or -1 if unavailable.
+     *
+     * @param deviceId stable device identifier
+     * @return temperature in °C or -1
+     */
+    public static double getTemperature(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) {
+            return -1d;
+        }
+        boolean init = nvmlInit();
+        if (!init) {
+            return -1d;
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment device = acquireHandleByBusId(deviceId, arena);
+            if (device == null) {
+                return -1d;
+            }
+            MemorySegment tempSeg = arena.allocate(JAVA_INT);
+            if (NvmlFunctions.deviceGetTemperature(device, NvmlFunctions.NVML_TEMPERATURE_GPU,
+                    tempSeg) == NvmlFunctions.NVML_SUCCESS) {
+                return tempSeg.get(JAVA_INT, 0);
+            }
+            return -1d;
+        } finally {
+            nvmlUninit();
+        }
+    }
+
+    /**
+     * Returns GPU power draw in watts, or -1 if unavailable.
+     *
+     * @param deviceId stable device identifier
+     * @return power in watts or -1
+     */
+    public static double getPowerDraw(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) {
+            return -1d;
+        }
+        boolean init = nvmlInit();
+        if (!init) {
+            return -1d;
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment device = acquireHandleByBusId(deviceId, arena);
+            if (device == null) {
+                return -1d;
+            }
+            MemorySegment powerSeg = arena.allocate(JAVA_INT);
+            if (NvmlFunctions.deviceGetPowerUsage(device, powerSeg) == NvmlFunctions.NVML_SUCCESS) {
+                return powerSeg.get(JAVA_INT, 0) / 1000.0;
+            }
+            return -1d;
+        } finally {
+            nvmlUninit();
+        }
+    }
+
+    /**
+     * Returns GPU core clock speed in MHz, or -1 if unavailable.
+     *
+     * @param deviceId stable device identifier
+     * @return core clock in MHz or -1
+     */
+    public static long getCoreClockMhz(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) {
+            return -1L;
+        }
+        boolean init = nvmlInit();
+        if (!init) {
+            return -1L;
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment device = acquireHandleByBusId(deviceId, arena);
+            if (device == null) {
+                return -1L;
+            }
+            MemorySegment clockSeg = arena.allocate(JAVA_INT);
+            if (NvmlFunctions.deviceGetClockInfo(device, NvmlFunctions.NVML_CLOCK_GRAPHICS,
+                    clockSeg) == NvmlFunctions.NVML_SUCCESS) {
+                return clockSeg.get(JAVA_INT, 0);
+            }
+            return -1L;
+        } finally {
+            nvmlUninit();
+        }
+    }
+
+    /**
+     * Returns GPU memory clock speed in MHz, or -1 if unavailable.
+     *
+     * @param deviceId stable device identifier
+     * @return memory clock in MHz or -1
+     */
+    public static long getMemoryClockMhz(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) {
+            return -1L;
+        }
+        boolean init = nvmlInit();
+        if (!init) {
+            return -1L;
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment device = acquireHandleByBusId(deviceId, arena);
+            if (device == null) {
+                return -1L;
+            }
+            MemorySegment clockSeg = arena.allocate(JAVA_INT);
+            if (NvmlFunctions.deviceGetClockInfo(device, NvmlFunctions.NVML_CLOCK_MEM,
+                    clockSeg) == NvmlFunctions.NVML_SUCCESS) {
+                return clockSeg.get(JAVA_INT, 0);
+            }
+            return -1L;
+        } finally {
+            nvmlUninit();
+        }
+    }
+
+    /**
+     * Returns GPU fan speed as a percentage (0–100), or -1 if unavailable.
+     *
+     * @param deviceId stable device identifier
+     * @return fan speed percentage or -1
+     */
+    public static double getFanSpeedPercent(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) {
+            return -1d;
+        }
+        boolean init = nvmlInit();
+        if (!init) {
+            return -1d;
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment device = acquireHandleByBusId(deviceId, arena);
+            if (device == null) {
+                return -1d;
+            }
+            MemorySegment speedSeg = arena.allocate(JAVA_INT);
+            if (NvmlFunctions.deviceGetFanSpeed(device, speedSeg) == NvmlFunctions.NVML_SUCCESS) {
+                return speedSeg.get(JAVA_INT, 0);
+            }
+            return -1d;
+        } finally {
+            nvmlUninit();
+        }
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGpuStatsJNA.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.linux;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.common.platform.linux.LinuxGpuStats;
+import oshi.util.gpu.NvmlUtilJNA;
+
+/**
+ * JNA-based Linux {@link LinuxGpuStats} subclass providing NVML integration via JNA.
+ */
+@ThreadSafe
+final class LinuxGpuStatsJNA extends LinuxGpuStats {
+
+    LinuxGpuStatsJNA(String drmDevicePath, String driverName, String pciBusId, String cardName) {
+        super(drmDevicePath, driverName, pciBusId, cardName);
+    }
+
+    @Override
+    protected boolean nvmlIsAvailable() {
+        return NvmlUtilJNA.isAvailable();
+    }
+
+    @Override
+    protected String nvmlFindDevice(String busId) {
+        return NvmlUtilJNA.findDevice(busId);
+    }
+
+    @Override
+    protected String nvmlFindDeviceByName(String name) {
+        return NvmlUtilJNA.findDeviceByName(name);
+    }
+
+    @Override
+    protected long nvmlGetVramUsed(String deviceId) {
+        return NvmlUtilJNA.getVramUsed(deviceId);
+    }
+
+    @Override
+    protected double nvmlGetTemperature(String deviceId) {
+        return NvmlUtilJNA.getTemperature(deviceId);
+    }
+
+    @Override
+    protected double nvmlGetPowerDraw(String deviceId) {
+        return NvmlUtilJNA.getPowerDraw(deviceId);
+    }
+
+    @Override
+    protected long nvmlGetCoreClockMhz(String deviceId) {
+        return NvmlUtilJNA.getCoreClockMhz(deviceId);
+    }
+
+    @Override
+    protected long nvmlGetMemoryClockMhz(String deviceId) {
+        return NvmlUtilJNA.getMemoryClockMhz(deviceId);
+    }
+
+    @Override
+    protected double nvmlGetFanSpeedPercent(String deviceId) {
+        return NvmlUtilJNA.getFanSpeedPercent(deviceId);
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGraphicsCardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGraphicsCardJNA.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.linux;
+
+import java.util.List;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.GpuStats;
+import oshi.hardware.GraphicsCard;
+import oshi.hardware.common.platform.linux.LinuxGraphicsCard;
+
+/**
+ * JNA-based Linux graphics card with NVML-backed GPU stats.
+ */
+@ThreadSafe
+final class LinuxGraphicsCardJNA extends LinuxGraphicsCard {
+
+    LinuxGraphicsCardJNA(String name, String deviceId, String vendor, String versionInfo, long vram,
+            String drmDevicePath, String driverName, String pciBusId) {
+        super(name, deviceId, vendor, versionInfo, vram, drmDevicePath, driverName, pciBusId);
+    }
+
+    @Override
+    public GpuStats createStatsSession() {
+        return new LinuxGpuStatsJNA(getDrmDevicePath(), getDriverName(), getPciBusId(), getName());
+    }
+
+    /**
+     * Gets graphics cards using JNA-based GPU stats.
+     *
+     * @return list of graphics cards
+     */
+    public static List<GraphicsCard> getGraphicsCards() {
+        return LinuxGraphicsCard
+                .getGraphicsCards(a -> new LinuxGraphicsCardJNA(a.getName(), a.getDeviceId(), a.getVendor(),
+                        a.getVersionInfo(), a.getVram(), a.getDrmDevicePath(), a.getDriverName(), a.getPciBusId()));
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerJNA.java
@@ -60,7 +60,7 @@ public final class LinuxHardwareAbstractionLayerJNA extends LinuxHardwareAbstrac
 
     @Override
     public List<GraphicsCard> getGraphicsCards() {
-        return LinuxGraphicsCard.getGraphicsCards();
+        return LinuxGraphicsCardJNA.getGraphicsCards();
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGpuStats.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGpuStats.java
@@ -23,7 +23,7 @@ import oshi.driver.windows.wmi.LhmSensor.LhmSensorProperty;
 import oshi.hardware.GpuStats;
 import oshi.hardware.GpuTicks;
 import oshi.util.gpu.AdlUtil;
-import oshi.util.gpu.NvmlUtil;
+import oshi.util.gpu.NvmlUtilJNA;
 import oshi.util.platform.windows.WmiUtil;
 import oshi.util.tuples.Pair;
 
@@ -195,7 +195,7 @@ final class WindowsGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            double val = NvmlUtil.getTemperature(nvmlDevice);
+            double val = NvmlUtilJNA.getTemperature(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -215,7 +215,7 @@ final class WindowsGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            double val = NvmlUtil.getPowerDraw(nvmlDevice);
+            double val = NvmlUtilJNA.getPowerDraw(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -239,7 +239,7 @@ final class WindowsGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            long val = NvmlUtil.getCoreClockMhz(nvmlDevice);
+            long val = NvmlUtilJNA.getCoreClockMhz(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -260,7 +260,7 @@ final class WindowsGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            long val = NvmlUtil.getMemoryClockMhz(nvmlDevice);
+            long val = NvmlUtilJNA.getMemoryClockMhz(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -281,7 +281,7 @@ final class WindowsGpuStats implements GpuStats {
         checkOpen();
         String nvmlDevice = findNvmlDevice();
         if (nvmlDevice != null) {
-            double val = NvmlUtil.getFanSpeedPercent(nvmlDevice);
+            double val = NvmlUtilJNA.getFanSpeedPercent(nvmlDevice);
             if (val >= 0) {
                 return val;
             }
@@ -331,16 +331,16 @@ final class WindowsGpuStats implements GpuStats {
         if (cachedNvmlDevice != null) {
             return cachedNvmlDevice.isEmpty() ? null : cachedNvmlDevice;
         }
-        if (!NvmlUtil.isAvailable()) {
+        if (!NvmlUtilJNA.isAvailable()) {
             cachedNvmlDevice = "";
             return null;
         }
         String id = null;
         if (!pciBusId.isEmpty()) {
-            id = NvmlUtil.findDevice(pciBusId);
+            id = NvmlUtilJNA.findDevice(pciBusId);
         }
         if (id == null) {
-            id = NvmlUtil.findDeviceByName(cardName);
+            id = NvmlUtilJNA.findDeviceByName(cardName);
         }
         cachedNvmlDevice = id != null ? id : "";
         return id;

--- a/oshi-core/src/main/java/oshi/util/gpu/NvmlUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/NvmlUtilJNA.java
@@ -39,9 +39,9 @@ import oshi.jna.common.Nvml.NvmlUtilization;
  * GraphicsCard instances.
  */
 @ThreadSafe
-public final class NvmlUtil {
+public final class NvmlUtilJNA {
 
-    private static final Logger LOG = LoggerFactory.getLogger(NvmlUtil.class);
+    private static final Logger LOG = LoggerFactory.getLogger(NvmlUtilJNA.class);
 
     // -------------------------------------------------------------------------
     // Library loading (holder pattern — loads the .dll/.so once)
@@ -72,7 +72,7 @@ public final class NvmlUtil {
     private static volatile boolean devicesEnumerated = false;
     private static volatile Set<String> deviceBusIds = Collections.emptySet();
 
-    private NvmlUtil() {
+    private NvmlUtilJNA() {
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Move native-free logic for `LinuxGraphicsCard` and `LinuxGpuStats` to oshi-common as abstract classes, with JNA subclasses in oshi-core and FFM subclasses in oshi-core-java25.

### NvmlUtil split
- Rename `NvmlUtil` → `NvmlUtilJNA` in oshi-core
- Create `NvmlUtilFFM` in oshi-core-java25 with identical public API
- Create `NvmlFunctions` FFM bindings for the NVML library (lazy-loaded, struct layouts, method handles)

### LinuxGpuStats split
- Move sysfs/hwmon/DRM logic to abstract `LinuxGpuStats` in oshi-common
- Define abstract `nvml*()` methods for NVML operations
- `LinuxGpuStatsJNA` delegates to `NvmlUtilJNA`
- `LinuxGpuStatsFFM` delegates to `NvmlUtilFFM`

### LinuxGraphicsCard split
- Move to oshi-common as `public abstract` class
- Add `Attrs` inner class (JDK 8 compatible) to bundle graphics card attributes
- Parameterize `getGraphicsCards()` with `Function<Attrs, GraphicsCard>` factory so JNA/FFM subclasses provide their concrete type
- `LinuxGraphicsCardJNA` and `LinuxGraphicsCardFFM` override `createStatsSession()` to return their respective `LinuxGpuStats` subclass

### Other updates
- `LinuxHardwareAbstractionLayerJNA` → uses `LinuxGraphicsCardJNA`
- `LinuxHardwareAbstractionLayerFFM` → uses `LinuxGraphicsCardFFM`
- `WindowsGpuStats` → uses `NvmlUtilJNA`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored Linux GPU monitoring components into abstract base classes supporting multiple native binding strategies.
  * Added Foreign Function & Memory (FFM) API support for NVML bindings as a modern alternative to JNA (Java 25+).
  * Separated and clarified JNA and FFM implementations for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->