### PR TITLE
Move Linux OS classes to oshi-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   [#3133](https://github.com/oshi/oshi/pull/3133),
   [#3134](https://github.com/oshi/oshi/pull/3134),
   [#3135](https://github.com/oshi/oshi/pull/3135),
-  [#3138](https://github.com/oshi/oshi/pull/3138): Create oshi-common module; move JNA-free common code to enable future FFM-only consumers - [@dbwiddis](https://github.com/dbwiddis).
+  [#3138](https://github.com/oshi/oshi/pull/3138),
+  [#3140](https://github.com/oshi/oshi/pull/3140): Create oshi-common module; move JNA-free common code to enable future FFM-only consumers - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug fixes / Improvements
 * [#3128](https://github.com/oshi/oshi/pull/3128): Fix Mac FFM TIMEVAL struct layout missing 4-byte trailing padding - [@dbwiddis](https://github.com/dbwiddis).

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module com.github.oshi.common {
     exports oshi.hardware.common.platform.linux;
     exports oshi.hardware.common.platform.unix;
     exports oshi.software.common;
+    exports oshi.software.common.os.linux;
     exports oshi.software.os;
     exports oshi.util;
     exports oshi.util.driver.linux;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxFileSystem.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.linux;
+package oshi.software.common.os.linux;
 
 import java.io.File;
 import java.io.IOException;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInstalledApps.java
@@ -1,22 +1,22 @@
 /*
- * Copyright 2025 The OSHI Project Contributors
+ * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.linux;
-
-import oshi.software.os.ApplicationInfo;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+package oshi.software.common.os.linux;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.LinkedHashSet;
-import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import oshi.software.os.ApplicationInfo;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
 
 public final class LinuxInstalledApps {
 

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInternetProtocolStats.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.linux;
+package oshi.software.common.os.linux;
 
 import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
 import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxNetworkParams.java
@@ -2,7 +2,7 @@
  * Copyright 2017-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.linux;
+package oshi.software.common.os.linux;
 
 import java.util.List;
 
@@ -16,7 +16,7 @@ import oshi.util.ParseUtil;
  * {@link #getDomainName()} and {@link #getHostName()} via native calls.
  */
 @ThreadSafe
-abstract class LinuxNetworkParams extends AbstractNetworkParams {
+public abstract class LinuxNetworkParams extends AbstractNetworkParams {
 
     private static final String IPV4_DEFAULT_DEST = "0.0.0.0"; // NOSONAR
     private static final String IPV6_DEFAULT_DEST = "::/0";

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSFileStore.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.linux;
+package oshi.software.common.os.linux;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOSFileStore;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.linux;
+package oshi.software.common.os.linux;
 
 import static oshi.software.os.OSProcess.State.INVALID;
 import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSThread.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.linux;
+package oshi.software.common.os.linux;
 
 import java.util.Locale;
 import java.util.Map;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.linux;
+package oshi.software.common.os.linux;
 
 import static oshi.software.os.OSService.State.RUNNING;
 import static oshi.software.os.OSService.State.STOPPED;
@@ -23,14 +23,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.linux.WhoJNA;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.ApplicationInfo;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSProcess.State;
 import oshi.software.os.OSService;
-import oshi.software.os.OSSession;
 import oshi.software.os.OSThread;
 import oshi.util.Constants;
 import oshi.util.ExecutingCommand;
@@ -125,11 +123,6 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
     @Override
     public InternetProtocolStats getInternetProtocolStats() {
         return new LinuxInternetProtocolStats();
-    }
-
-    @Override
-    public List<OSSession> getSessions() {
-        return USE_WHO_COMMAND ? oshi.util.driver.linux.Who.queryWho() : WhoJNA.queryUtxent();
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/package-info.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides common (native-free) Linux operating system implementations shared by JNA and FFM modules.
+ */
+package oshi.software.common.os.linux;

--- a/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxFileSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxFileSystemFFM.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.linux.LinuxLibcFunctions;
+import oshi.software.common.os.linux.LinuxFileSystem;
 
 /**
  * FFM-based Linux file system implementation. Implements {@code statvfs} via FFM.

--- a/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.ffm.linux.LinuxLibcFunctions;
+import oshi.software.common.os.linux.LinuxNetworkParams;
 
 /**
  * FFM-based Linux network parameters. Overrides {@code gethostname} and {@code getaddrinfo} calls to use FFM.

--- a/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.linux.LinuxLibcFunctions;
+import oshi.software.common.os.linux.LinuxOSProcess;
+import oshi.software.common.os.linux.LinuxOperatingSystem;
 
 /**
  * FFM-based Linux OS process. Implements {@code getrlimit} via FFM.

--- a/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
@@ -20,6 +20,7 @@ import oshi.driver.linux.WhoFFM;
 import oshi.driver.linux.proc.AuxvFFM;
 import oshi.ffm.linux.LinuxLibcFunctions;
 import oshi.ffm.linux.UdevFunctions;
+import oshi.software.common.os.linux.LinuxOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxFileSystemJNA.java
@@ -11,6 +11,7 @@ import com.sun.jna.Native;
 import com.sun.jna.platform.linux.LibC;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.os.linux.LinuxFileSystem;
 
 /**
  * JNA-based Linux file system implementation. Implements {@code statvfs} via JNA.

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParamsJNA.java
@@ -20,6 +20,7 @@ import oshi.jna.ByRef.CloseablePointerByReference;
 import oshi.jna.platform.linux.LinuxLibc;
 import oshi.jna.platform.unix.CLibrary;
 import oshi.jna.platform.unix.CLibrary.Addrinfo;
+import oshi.software.common.os.linux.LinuxNetworkParams;
 
 /**
  * JNA-based Linux network parameters. Implements {@code getDomainName} via {@code getaddrinfo} and {@code getHostName}

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcessJNA.java
@@ -8,6 +8,8 @@ import com.sun.jna.platform.unix.Resource;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.platform.linux.LinuxLibc;
+import oshi.software.common.os.linux.LinuxOSProcess;
+import oshi.software.common.os.linux.LinuxOperatingSystem;
 
 /**
  * JNA-based Linux OS process. Implements {@code getrlimit} via JNA.

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystemJNA.java
@@ -7,6 +7,7 @@ package oshi.software.os.linux;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -17,13 +18,16 @@ import com.sun.jna.platform.linux.LibC;
 import com.sun.jna.platform.linux.Udev;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.linux.WhoJNA;
 import oshi.driver.linux.proc.AuxvJNA;
 import oshi.jna.Struct.CloseableSysinfo;
 import oshi.jna.platform.linux.LinuxLibc;
+import oshi.software.common.os.linux.LinuxOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSProcess.State;
+import oshi.software.os.OSSession;
 import oshi.util.ExecutingCommand;
 import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
@@ -97,6 +101,11 @@ public class LinuxOperatingSystemJNA extends LinuxOperatingSystem {
         HAS_SYSCALL_GETTID = hasSyscallGettid;
         USER_HZ = userHz;
         PAGE_SIZE = pageSz;
+    }
+
+    @Override
+    public List<OSSession> getSessions() {
+        return USE_WHO_COMMAND ? oshi.util.driver.linux.Who.queryWho() : WhoJNA.queryUtxent();
     }
 
     @Override


### PR DESCRIPTION
Move 8 Linux OS classes from `oshi-core` (`oshi.software.os.linux`) to `oshi-common` (`oshi.software.common.os.linux`).

### Abstract base classes
- `LinuxOperatingSystem`
- `LinuxOSProcess`
- `LinuxFileSystem`
- `LinuxNetworkParams` (made `public` for cross-package subclass access)

### Native-free classes (moved directly)
- `LinuxOSThread`
- `LinuxOSFileStore`
- `LinuxInternetProtocolStats`
- `LinuxInstalledApps`

### Notable changes
- Removed `getSessions()` from `LinuxOperatingSystem` since it depended on `WhoJNA`. Both `LinuxOperatingSystemJNA` and `LinuxOperatingSystemFFM` already override it with their respective `Who` implementations; the `AbstractOperatingSystem` default provides a safe fallback.
- Added `getSessions()` override to `LinuxOperatingSystemJNA` (previously inherited from the base).
- Updated all JNA and FFM subclasses with imports from the new `oshi.software.common.os.linux` package.
- Exported `oshi.software.common.os.linux` from `oshi-common` module-info.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized platform-specific implementation code and consolidated shared components for improved code organization and maintainability across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->