### PR TITLE
Split WindowsOSProcess into superclass with JNA/FFM subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#3128](https://github.com/oshi/oshi/pull/3128): Fix Mac FFM TIMEVAL struct layout missing 4-byte trailing padding - [@dbwiddis](https://github.com/dbwiddis).
 * [#3136](https://github.com/oshi/oshi/pull/3136): Push Linux USER_HZ and PAGE_SIZE into JNA/FFM OS subclasses; wire through HAL, processor, memory, process, and thread classes - [@dbwiddis](https://github.com/dbwiddis).
 * [#3139](https://github.com/oshi/oshi/pull/3139): Split LinuxGraphicsCard, LinuxGpuStats, and NvmlUtil across modules - [@dbwiddis](https://github.com/dbwiddis).
+* [#3141](https://github.com/oshi/oshi/pull/3141): Split WindowsOSProcess into superclass with JNA/FFM subclasses; add VersionHelpersFFM; remove TOKEN_DUPLICATE - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/Kernel32FFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/Kernel32FFM.java
@@ -5,6 +5,7 @@
 package oshi.ffm.windows;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
@@ -481,6 +482,51 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
         } catch (Throwable t) {
             LOG.debug("Kernel32FFM.LocalFree failed: {}", t.getMessage());
             return hMem;
+        }
+    }
+
+    private static final MethodHandle VerSetConditionMask = downcall(K32, "VerSetConditionMask", JAVA_LONG, JAVA_LONG,
+            JAVA_INT, JAVA_BYTE);
+
+    /**
+     * Sets the bits of a 64-bit value to indicate the comparison operator to use for a specified operating system
+     * version attribute.
+     *
+     * @param conditionMask A value to be passed as the dwlConditionMask parameter of VerifyVersionInfo
+     * @param typeMask      A mask that indicates the member of the OSVERSIONINFOEX structure whose comparison operator
+     *                      is being set
+     * @param condition     The operator to be used for the comparison
+     * @return The condition mask value
+     */
+    public static long VerSetConditionMask(long conditionMask, int typeMask, byte condition) {
+        try {
+            return (long) VerSetConditionMask.invokeExact(conditionMask, typeMask, condition);
+        } catch (Throwable t) {
+            LOG.debug("Kernel32FFM.VerSetConditionMask failed: {}", t.getMessage());
+            return 0L;
+        }
+    }
+
+    private static final MethodHandle VerifyVersionInfoW = downcall(K32, "VerifyVersionInfoW", JAVA_INT, ADDRESS,
+            JAVA_INT, JAVA_LONG);
+
+    /**
+     * Compares a set of operating system version requirements to the corresponding values for the currently running
+     * version of the system.
+     *
+     * @param lpVersionInformation A pointer to an OSVERSIONINFOEX structure containing the operating system version
+     *                             requirements to compare
+     * @param dwTypeMask           A mask that indicates the members of the OSVERSIONINFOEX structure to be tested
+     * @param dwlConditionMask     The type of comparison to be used for each lpVersionInformation member being compared
+     * @return true if the currently running operating system satisfies the specified requirements
+     */
+    public static boolean VerifyVersionInfoW(MemorySegment lpVersionInformation, int dwTypeMask,
+            long dwlConditionMask) {
+        try {
+            return isSuccess((int) VerifyVersionInfoW.invokeExact(lpVersionInformation, dwTypeMask, dwlConditionMask));
+        } catch (Throwable t) {
+            LOG.debug("Kernel32FFM.VerifyVersionInfoW failed: {}", t.getMessage());
+            return false;
         }
     }
 }

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/VersionHelpersFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/VersionHelpersFFM.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.windows;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import static oshi.ffm.windows.WinNTFFM.OSVERSIONINFOEX;
+import static oshi.ffm.windows.WinNTFFM.OSVERSIONINFOEX_MAJOR_VERSION_OFFSET;
+import static oshi.ffm.windows.WinNTFFM.OSVERSIONINFOEX_MINOR_VERSION_OFFSET;
+import static oshi.ffm.windows.WinNTFFM.OSVERSIONINFOEX_PRODUCT_TYPE_OFFSET;
+import static oshi.ffm.windows.WinNTFFM.OSVERSIONINFOEX_SP_MAJOR_OFFSET;
+import static oshi.ffm.windows.WinNTFFM.VER_EQUAL;
+import static oshi.ffm.windows.WinNTFFM.VER_GREATER_EQUAL;
+import static oshi.ffm.windows.WinNTFFM.VER_MAJORVERSION;
+import static oshi.ffm.windows.WinNTFFM.VER_MINORVERSION;
+import static oshi.ffm.windows.WinNTFFM.VER_NT_WORKSTATION;
+import static oshi.ffm.windows.WinNTFFM.VER_PRODUCT_TYPE;
+import static oshi.ffm.windows.WinNTFFM.VER_SERVICEPACKMAJOR;
+import static oshi.ffm.windows.WinNTFFM.WIN32_WINNT_VISTA;
+import static oshi.ffm.windows.WinNTFFM.WIN32_WINNT_WIN10;
+import static oshi.ffm.windows.WinNTFFM.WIN32_WINNT_WIN7;
+import static oshi.ffm.windows.WinNTFFM.WIN32_WINNT_WIN8;
+import static oshi.ffm.windows.WinNTFFM.WIN32_WINNT_WINBLUE;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * FFM port of the Windows SDK versionhelpers.h inline functions. Uses {@link Kernel32FFM#VerSetConditionMask} and
+ * {@link Kernel32FFM#VerifyVersionInfoW} to determine the current operating system version.
+ */
+public final class VersionHelpersFFM {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VersionHelpersFFM.class);
+
+    private static final int ERROR_OLD_WIN_VERSION = 0x47E;
+
+    private VersionHelpersFFM() {
+    }
+
+    /**
+     * Tests whether the current OS version matches, or is greater than, the provided version information.
+     *
+     * @param wMajorVersion     The major version to test
+     * @param wMinorVersion     The minor version to test
+     * @param wServicePackMajor The service pack to test
+     * @return true if the current OS version matches or is greater than the provided version
+     */
+    public static boolean IsWindowsVersionOrGreater(int wMajorVersion, int wMinorVersion, int wServicePackMajor) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment osvi = arena.allocate(OSVERSIONINFOEX);
+            osvi.fill((byte) 0);
+            osvi.set(JAVA_INT, 0, (int) OSVERSIONINFOEX.byteSize()); // dwOSVersionInfoSize
+            osvi.set(JAVA_INT, OSVERSIONINFOEX_MAJOR_VERSION_OFFSET, wMajorVersion);
+            osvi.set(JAVA_INT, OSVERSIONINFOEX_MINOR_VERSION_OFFSET, wMinorVersion);
+            osvi.set(JAVA_SHORT, OSVERSIONINFOEX_SP_MAJOR_OFFSET, (short) wServicePackMajor);
+
+            long dwlConditionMask = 0;
+            dwlConditionMask = Kernel32FFM.VerSetConditionMask(dwlConditionMask, VER_MAJORVERSION,
+                    (byte) VER_GREATER_EQUAL);
+            dwlConditionMask = Kernel32FFM.VerSetConditionMask(dwlConditionMask, VER_MINORVERSION,
+                    (byte) VER_GREATER_EQUAL);
+            dwlConditionMask = Kernel32FFM.VerSetConditionMask(dwlConditionMask, VER_SERVICEPACKMAJOR,
+                    (byte) VER_GREATER_EQUAL);
+
+            return Kernel32FFM.VerifyVersionInfoW(osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR,
+                    dwlConditionMask);
+        }
+    }
+
+    /**
+     * @return true if the current OS version matches, or is greater than, the Windows Vista version.
+     */
+    public static boolean IsWindowsVistaOrGreater() {
+        return IsWindowsVersionOrGreater((byte) (WIN32_WINNT_VISTA >>> 8), (byte) WIN32_WINNT_VISTA, 0);
+    }
+
+    /**
+     * @return true if the current OS version matches, or is greater than, the Windows 7 version.
+     */
+    public static boolean IsWindows7OrGreater() {
+        return IsWindowsVersionOrGreater((byte) (WIN32_WINNT_WIN7 >>> 8), (byte) WIN32_WINNT_WIN7, 0);
+    }
+
+    /**
+     * @return true if the current OS version matches, or is greater than, the Windows 8 version.
+     */
+    public static boolean IsWindows8OrGreater() {
+        return IsWindowsVersionOrGreater((byte) (WIN32_WINNT_WIN8 >>> 8), (byte) WIN32_WINNT_WIN8, 0);
+    }
+
+    /**
+     * @return true if the current OS version matches, or is greater than, the Windows 8.1 version.
+     */
+    public static boolean IsWindows8Point1OrGreater() {
+        return IsWindowsVersionOrGreater((byte) (WIN32_WINNT_WINBLUE >>> 8), (byte) WIN32_WINNT_WINBLUE, 0);
+    }
+
+    /**
+     * @return true if the current OS version matches, or is greater than, the Windows 10 version.
+     */
+    public static boolean IsWindows10OrGreater() {
+        return IsWindowsVersionOrGreater((byte) (WIN32_WINNT_WIN10 >>> 8), (byte) WIN32_WINNT_WIN10, 0);
+    }
+
+    /**
+     * @return true if the current OS is a Windows Server release.
+     */
+    public static boolean IsWindowsServer() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment osvi = arena.allocate(OSVERSIONINFOEX);
+            osvi.fill((byte) 0);
+            osvi.set(JAVA_INT, 0, (int) OSVERSIONINFOEX.byteSize()); // dwOSVersionInfoSize
+            osvi.set(JAVA_BYTE, OSVERSIONINFOEX_PRODUCT_TYPE_OFFSET, VER_NT_WORKSTATION);
+
+            long dwlConditionMask = Kernel32FFM.VerSetConditionMask(0, VER_PRODUCT_TYPE, (byte) VER_EQUAL);
+
+            if (Kernel32FFM.VerifyVersionInfoW(osvi, VER_PRODUCT_TYPE, dwlConditionMask)) {
+                // Product type IS VER_NT_WORKSTATION, so not a server
+                return false;
+            }
+            // VerifyVersionInfoW returned false; check why
+            int error = Kernel32FFM.GetLastError().orElse(0);
+            if (error == ERROR_OLD_WIN_VERSION) {
+                // Condition not met: product type is not VER_NT_WORKSTATION, so it is a server
+                return true;
+            }
+            LOG.debug("VerifyVersionInfoW failed with unexpected error code: {}", error);
+            return false;
+        }
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/WinNTFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/WinNTFFM.java
@@ -5,6 +5,8 @@
 package oshi.ffm.windows;
 
 import static java.lang.foreign.MemoryLayout.structLayout;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
@@ -40,6 +42,43 @@ public interface WinNTFFM {
     int OPEN_EXISTING = 3;
     int FILE_ATTRIBUTE_NORMAL = 0x00000080;
     long INVALID_HANDLE_VALUE = -1L;
+
+    // Version comparison constants
+    int VER_EQUAL = 1;
+    int VER_GREATER_EQUAL = 3;
+    int VER_MINORVERSION = 0x0000001;
+    int VER_MAJORVERSION = 0x0000002;
+    int VER_SERVICEPACKMAJOR = 0x0000020;
+    int VER_PRODUCT_TYPE = 0x0000080;
+    byte VER_NT_WORKSTATION = 0x0000001;
+
+    // Windows version constants (encoded as major << 8 | minor)
+    short WIN32_WINNT_WINXP = 0x0501;
+    short WIN32_WINNT_VISTA = 0x0600;
+    short WIN32_WINNT_WIN7 = 0x0601;
+    short WIN32_WINNT_WIN8 = 0x0602;
+    short WIN32_WINNT_WINBLUE = 0x0603;
+    short WIN32_WINNT_WIN10 = 0x0A00;
+
+    // OSVERSIONINFOEX structure: 284 bytes
+    // dwOSVersionInfoSize(4) + dwMajorVersion(4) + dwMinorVersion(4) + dwBuildNumber(4) + dwPlatformId(4)
+    // + szCSDVersion(128 chars = 256 bytes) + wServicePackMajor(2) + wServicePackMinor(2)
+    // + wSuiteMask(2) + wProductType(1) + wReserved(1)
+    StructLayout OSVERSIONINFOEX = structLayout(JAVA_INT.withName("dwOSVersionInfoSize"),
+            JAVA_INT.withName("dwMajorVersion"), JAVA_INT.withName("dwMinorVersion"),
+            JAVA_INT.withName("dwBuildNumber"), JAVA_INT.withName("dwPlatformId"),
+            MemoryLayout.sequenceLayout(128, JAVA_CHAR).withName("szCSDVersion"),
+            JAVA_SHORT.withName("wServicePackMajor"), JAVA_SHORT.withName("wServicePackMinor"),
+            JAVA_SHORT.withName("wSuiteMask"), JAVA_BYTE.withName("wProductType"), JAVA_BYTE.withName("wReserved"));
+
+    long OSVERSIONINFOEX_MAJOR_VERSION_OFFSET = OSVERSIONINFOEX
+            .byteOffset(MemoryLayout.PathElement.groupElement("dwMajorVersion"));
+    long OSVERSIONINFOEX_MINOR_VERSION_OFFSET = OSVERSIONINFOEX
+            .byteOffset(MemoryLayout.PathElement.groupElement("dwMinorVersion"));
+    long OSVERSIONINFOEX_SP_MAJOR_OFFSET = OSVERSIONINFOEX
+            .byteOffset(MemoryLayout.PathElement.groupElement("wServicePackMajor"));
+    long OSVERSIONINFOEX_PRODUCT_TYPE_OFFSET = OSVERSIONINFOEX
+            .byteOffset(MemoryLayout.PathElement.groupElement("wProductType"));
 
     StructLayout EVENTLOGRECORD = structLayout(JAVA_INT.withName("Length"), JAVA_INT.withName("Reserved"),
             JAVA_INT.withName("RecordNumber"), JAVA_INT.withName("TimeGenerated"), JAVA_INT.withName("TimeWritten"),

--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -24,281 +24,49 @@ import static oshi.ffm.windows.NtDllFFM.UPP_ENVIRONMENT_SIZE_OFFSET;
 import static oshi.ffm.windows.NtDllFFM.readUnicodeString;
 import static oshi.ffm.windows.WinNTFFM.PROCESS_QUERY_INFORMATION;
 import static oshi.ffm.windows.WinNTFFM.PROCESS_VM_READ;
+import static oshi.ffm.windows.WinNTFFM.TOKEN_QUERY;
 import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SUSPENDED;
-import static oshi.util.Memoizer.memoize;
 
-import java.io.File;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.windows.registry.ProcessPerformanceData;
-import oshi.driver.windows.registry.ProcessWtsData;
 import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
 import oshi.driver.windows.registry.ThreadPerformanceData;
-import oshi.driver.windows.wmi.Win32Process;
-import oshi.driver.windows.wmi.Win32Process.CommandLineProperty;
-import oshi.driver.windows.wmi.Win32ProcessCached;
 import oshi.ffm.windows.Advapi32FFM;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.ffm.windows.NtDllFFM;
 import oshi.ffm.windows.Shell32FFM;
+import oshi.ffm.windows.VersionHelpersFFM;
 import oshi.ffm.windows.WinErrorFFM;
-import oshi.software.common.AbstractOSProcess;
-import oshi.software.os.OSThread;
 import oshi.util.Constants;
-import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
-import oshi.util.platform.windows.WmiUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
 /**
- * OSProcess implementation using FFM (Foreign Function and Memory API)
+ * FFM-based Windows OS process implementation.
  */
 @ThreadSafe
-public class WindowsOSProcessFFM extends AbstractOSProcess {
+public class WindowsOSProcessFFM extends WindowsOSProcess {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsOSProcessFFM.class);
 
-    private static final boolean USE_BATCH_COMMANDLINE = GlobalConfig
-            .get(GlobalConfig.OSHI_OS_WINDOWS_COMMANDLINE_BATCH, false);
+    private static final boolean IS_VISTA_OR_GREATER = VersionHelpersFFM.IsWindowsVistaOrGreater();
+    private static final boolean IS_WINDOWS7_OR_GREATER = VersionHelpersFFM.IsWindows7OrGreater();
 
-    private static final boolean USE_PROCSTATE_SUSPENDED = GlobalConfig
-            .get(GlobalConfig.OSHI_OS_WINDOWS_PROCSTATE_SUSPENDED, false);
-
-    private static final boolean IS_VISTA_OR_GREATER = isWindowsVistaOrGreater();
-    private static final boolean IS_WINDOWS7_OR_GREATER = isWindows7OrGreater();
-
-    // track the OperatingSystem object that created this
-    private final WindowsOperatingSystemFFM os;
-
-    private Supplier<Pair<String, String>> userInfo = memoize(this::queryUserInfo);
-    private Supplier<Pair<String, String>> groupInfo = memoize(this::queryGroupInfo);
-    private Supplier<String> currentWorkingDirectory = memoize(this::queryCwd);
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<List<String>> args = memoize(this::queryArguments);
-    private Supplier<Triplet<String, String, Map<String, String>>> cwdCmdEnv = memoize(
-            this::queryCwdCommandlineEnvironment);
-    private Map<Integer, ThreadPerformanceData.PerfCounterBlock> tcb;
-
-    private String name;
-    private String path;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long workingSetSize;
-    private long privateWorkingSetSize;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
-    private long openFiles;
-    private int bitness;
-    private long pageFaults;
-
-    public WindowsOSProcessFFM(int pid, WindowsOperatingSystemFFM os,
+    public WindowsOSProcessFFM(int pid, WindowsOperatingSystem os,
             Map<Integer, ProcessPerformanceData.PerfCounterBlock> processMap, Map<Integer, WtsInfo> processWtsMap,
             Map<Integer, ThreadPerformanceData.PerfCounterBlock> threadMap) {
-        super(pid);
-        // Save a copy of OS creating this object for later use
-        this.os = os;
-        // Initially set to match OS bitness. If 64 will check later for 32-bit process
-        this.bitness = os.getBitness();
-        // Initialize thread counters
-        this.tcb = threadMap;
-        updateAttributes(processMap.get(pid), processWtsMap.get(pid));
-    }
-
-    private static boolean isWindowsVistaOrGreater() {
-        String osVersion = System.getProperty("os.version");
-        if (osVersion != null) {
-            String[] parts = osVersion.split("\\.");
-            if (parts.length >= 1) {
-                int major = ParseUtil.parseIntOrDefault(parts[0], 0);
-                return major >= 6;
-            }
-        }
-        return true; // Assume modern Windows
-    }
-
-    private static boolean isWindows7OrGreater() {
-        String osVersion = System.getProperty("os.version");
-        if (osVersion != null) {
-            String[] parts = osVersion.split("\\.");
-            if (parts.length >= 2) {
-                int major = ParseUtil.parseIntOrDefault(parts[0], 0);
-                int minor = ParseUtil.parseIntOrDefault(parts[1], 0);
-                return major > 6 || (major == 6 && minor >= 1);
-            }
-        }
-        return true; // Assume modern Windows
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return args.get();
-    }
-
-    @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return cwdCmdEnv.get().getC();
-    }
-
-    @Override
-    public String getCurrentWorkingDirectory() {
-        return currentWorkingDirectory.get();
-    }
-
-    @Override
-    public String getUser() {
-        return userInfo.get().getA();
-    }
-
-    @Override
-    public String getUserID() {
-        return userInfo.get().getB();
-    }
-
-    @Override
-    public String getGroup() {
-        return groupInfo.get().getA();
-    }
-
-    @Override
-    public String getGroupID() {
-        return groupInfo.get().getB();
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.workingSetSize;
-    }
-
-    @Override
-    public long getPrivateResidentMemory() {
-        return this.privateWorkingSetSize;
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * On Windows, delegates to {@link #getPrivateResidentMemory()} for backwards compatibility with prior behavior that
-     * returned the Private Working Set.
-     */
-    @Deprecated
-    @Override
-    public long getResidentSetSize() {
-        return getPrivateResidentMemory();
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
-    }
-
-    @Override
-    public long getOpenFiles() {
-        return this.openFiles;
-    }
-
-    @Override
-    public long getSoftOpenFileLimit() {
-        return WindowsFileSystem.MAX_WINDOWS_HANDLES;
-    }
-
-    @Override
-    public long getHardOpenFileLimit() {
-        return WindowsFileSystem.MAX_WINDOWS_HANDLES;
-    }
-
-    @Override
-    public int getBitness() {
-        return this.bitness;
+        super(pid, os, processMap, processWtsMap, threadMap);
     }
 
     @Override
@@ -320,82 +88,9 @@ public class WindowsOSProcessFFM extends AbstractOSProcess {
     }
 
     @Override
-    public long getMinorFaults() {
-        return this.pageFaults;
-    }
-
-    @Override
-    public List<OSThread> getThreadDetails() {
-        Map<Integer, ThreadPerformanceData.PerfCounterBlock> threads = tcb == null
-                ? queryMatchingThreads(Collections.singleton(this.getProcessID()))
-                : tcb;
-        return threads.entrySet().stream().parallel()
-                .filter(entry -> entry.getValue().getOwningProcessID() == this.getProcessID())
-                .map(entry -> new WindowsOSThread(getProcessID(), entry.getKey(), this.name, entry.getValue()))
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        try {
-            Set<Integer> pids = Collections.singleton(this.getProcessID());
-            // Get data from the registry if possible
-            Map<Integer, ProcessPerformanceData.PerfCounterBlock> pcb = ProcessPerformanceData
-                    .buildProcessMapFromRegistry(null);
-            // otherwise performance counters with WMI backup
-            if (pcb == null) {
-                pcb = ProcessPerformanceData.buildProcessMapFromPerfCounters(pids);
-            }
-            if (USE_PROCSTATE_SUSPENDED) {
-                this.tcb = queryMatchingThreads(pids);
-            }
-            Map<Integer, WtsInfo> wts = ProcessWtsData.queryProcessWtsMap(pids);
-            return updateAttributes(pcb.get(this.getProcessID()), wts.get(this.getProcessID()));
-        } catch (Throwable t) {
+    protected boolean updateAttributes(ProcessPerformanceData.PerfCounterBlock pcb, WtsInfo wts) {
+        if (!super.updateAttributes(pcb, wts)) {
             return false;
-        }
-    }
-
-    private boolean updateAttributes(ProcessPerformanceData.PerfCounterBlock pcb, WtsInfo wts) {
-        if (pcb == null) {
-            this.state = INVALID;
-            return false;
-        }
-        this.name = pcb.getName();
-        this.path = wts != null ? wts.getPath() : ""; // Empty string for Win7+
-        this.parentProcessID = pcb.getParentProcessID();
-        this.threadCount = wts != null ? wts.getThreadCount() : 0;
-        this.priority = pcb.getPriority();
-        this.virtualSize = wts != null ? wts.getVirtualSize() : 0L;
-        this.workingSetSize = pcb.getWorkingSetSize();
-        this.privateWorkingSetSize = pcb.getPrivateWorkingSetSize();
-        this.kernelTime = wts != null ? wts.getKernelTime() : 0L;
-        this.userTime = wts != null ? wts.getUserTime() : 0L;
-        this.startTime = pcb.getStartTime();
-        this.upTime = pcb.getUpTime();
-        this.bytesRead = pcb.getBytesRead();
-        this.bytesWritten = pcb.getBytesWritten();
-        this.openFiles = wts != null ? wts.getOpenFiles() : 0L;
-        this.pageFaults = pcb.getPageFaults();
-
-        // There are only 3 possible Process states on Windows: RUNNING, SUSPENDED, or
-        // UNKNOWN. Processes are considered running unless all of their threads are
-        // SUSPENDED.
-        this.state = RUNNING;
-        if (this.tcb != null) {
-            // If user hasn't enabled this in properties, we ignore
-            int pid = this.getProcessID();
-            // If any thread is NOT suspended, set running
-            for (ThreadPerformanceData.PerfCounterBlock tpd : this.tcb.values()) {
-                if (tpd.getOwningProcessID() == pid) {
-                    if (tpd.getThreadWaitReason() == 5) {
-                        this.state = SUSPENDED;
-                    } else {
-                        this.state = RUNNING;
-                        break;
-                    }
-                }
-            }
         }
 
         // Get a handle to the process for various extended info. Only gets
@@ -405,17 +100,17 @@ public class WindowsOSProcessFFM extends AbstractOSProcess {
             MemorySegment pHandle = pHandleOpt.get();
             try (Arena arena = Arena.ofConfined()) {
                 // Test for 32-bit process on 64-bit windows
-                if (IS_VISTA_OR_GREATER && this.bitness == 64) {
+                if (IS_VISTA_OR_GREATER && getBitness() == 64) {
                     MemorySegment wow64 = arena.allocate(JAVA_INT);
                     if (Kernel32FFM.IsWow64Process(pHandle, wow64) && wow64.get(JAVA_INT, 0) > 0) {
-                        this.bitness = 32;
+                        setBitness(32);
                     }
                 }
                 // EXECUTABLEPATH
                 if (IS_WINDOWS7_OR_GREATER) {
                     Optional<String> pathOpt = Kernel32FFM.QueryFullProcessImageName(pHandle, 0, arena);
                     if (pathOpt.isPresent()) {
-                        this.path = pathOpt.get();
+                        setPath(pathOpt.get());
                     }
                     // Don't set INVALID on path failure - process is still valid
                 }
@@ -424,39 +119,11 @@ public class WindowsOSProcessFFM extends AbstractOSProcess {
             }
         }
 
-        return !this.state.equals(INVALID);
+        return !getState().equals(State.INVALID);
     }
 
-    private Map<Integer, ThreadPerformanceData.PerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
-        // fetch from registry
-        Map<Integer, ThreadPerformanceData.PerfCounterBlock> threads = ThreadPerformanceData
-                .buildThreadMapFromRegistry(pids);
-        // otherwise performance counters with WMI backup
-        if (threads == null) {
-            threads = ThreadPerformanceData.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
-        }
-        return threads;
-    }
-
-    private String queryCommandLine() {
-        // Try to fetch from process memory
-        if (!cwdCmdEnv.get().getB().isEmpty()) {
-            return cwdCmdEnv.get().getB();
-        }
-        // If using batch mode fetch from WMI Cache
-        if (USE_BATCH_COMMANDLINE) {
-            return Win32ProcessCached.getInstance().getCommandLine(getProcessID(), getStartTime());
-        }
-        // If no cache enabled, query line by line
-        WmiResult<CommandLineProperty> commandLineProcs = Win32Process
-                .queryCommandLines(Collections.singleton(getProcessID()));
-        if (commandLineProcs.getResultCount() > 0) {
-            return WmiUtil.getString(commandLineProcs, CommandLineProperty.COMMANDLINE, 0);
-        }
-        return "";
-    }
-
-    private List<String> queryArguments() {
+    @Override
+    protected List<String> queryArguments() {
         String cl = getCommandLine();
         if (!cl.isEmpty()) {
             return Shell32FFM.CommandLineToArgv(cl);
@@ -464,23 +131,8 @@ public class WindowsOSProcessFFM extends AbstractOSProcess {
         return Collections.emptyList();
     }
 
-    private String queryCwd() {
-        // Try to fetch from process memory
-        if (!cwdCmdEnv.get().getA().isEmpty()) {
-            return cwdCmdEnv.get().getA();
-        }
-        // For executing process, set CWD
-        if (getProcessID() == this.os.getProcessId()) {
-            String cwd = new File(".").getAbsolutePath();
-            // trim off trailing "."
-            if (!cwd.isEmpty()) {
-                return cwd.substring(0, cwd.length() - 1);
-            }
-        }
-        return "";
-    }
-
-    private Pair<String, String> queryUserInfo() {
+    @Override
+    protected Pair<String, String> queryUserInfo() {
         Pair<String, String> pair = null;
         Optional<MemorySegment> pHandleOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION, false, getProcessID());
         if (pHandleOpt.isPresent()) {
@@ -488,8 +140,7 @@ public class WindowsOSProcessFFM extends AbstractOSProcess {
             MemorySegment hToken = null;
             try (Arena arena = Arena.ofConfined()) {
                 MemorySegment hTokenPtr = arena.allocate(ADDRESS);
-                if (Advapi32FFM.OpenProcessToken(pHandle, 0x0008 | 0x0002, hTokenPtr)) { // TOKEN_QUERY |
-                                                                                         // TOKEN_DUPLICATE
+                if (Advapi32FFM.OpenProcessToken(pHandle, TOKEN_QUERY, hTokenPtr)) {
                     hToken = hTokenPtr.get(ADDRESS, 0);
                     pair = getTokenAccountInfo(hToken, TokenUser, arena);
                 } else {
@@ -509,13 +160,11 @@ public class WindowsOSProcessFFM extends AbstractOSProcess {
                 Kernel32FFM.CloseHandle(pHandle);
             }
         }
-        if (pair == null) {
-            return new Pair<>(Constants.UNKNOWN, Constants.UNKNOWN);
-        }
-        return pair;
+        return pair != null ? pair : defaultPair();
     }
 
-    private Pair<String, String> queryGroupInfo() {
+    @Override
+    protected Pair<String, String> queryGroupInfo() {
         Pair<String, String> pair = null;
         Optional<MemorySegment> pHandleOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION, false, getProcessID());
         if (pHandleOpt.isPresent()) {
@@ -523,8 +172,7 @@ public class WindowsOSProcessFFM extends AbstractOSProcess {
             MemorySegment hToken = null;
             try (Arena arena = Arena.ofConfined()) {
                 MemorySegment hTokenPtr = arena.allocate(ADDRESS);
-                if (Advapi32FFM.OpenProcessToken(pHandle, 0x0008 | 0x0002, hTokenPtr)) { // TOKEN_QUERY |
-                                                                                         // TOKEN_DUPLICATE
+                if (Advapi32FFM.OpenProcessToken(pHandle, TOKEN_QUERY, hTokenPtr)) {
                     hToken = hTokenPtr.get(ADDRESS, 0);
                     pair = getTokenAccountInfo(hToken, TokenPrimaryGroup, arena);
                 } else {
@@ -544,10 +192,7 @@ public class WindowsOSProcessFFM extends AbstractOSProcess {
                 Kernel32FFM.CloseHandle(pHandle);
             }
         }
-        if (pair == null) {
-            return new Pair<>(Constants.UNKNOWN, Constants.UNKNOWN);
-        }
-        return pair;
+        return pair != null ? pair : defaultPair();
     }
 
     private Pair<String, String> getTokenAccountInfo(MemorySegment hToken, int tokenInfoClass, Arena arena)
@@ -613,8 +258,8 @@ public class WindowsOSProcessFFM extends AbstractOSProcess {
         return new Pair<>(accountName, sidString);
     }
 
-    private Triplet<String, String, Map<String, String>> queryCwdCommandlineEnvironment() {
-        // Get the process handle
+    @Override
+    protected Triplet<String, String, Map<String, String>> queryCwdCommandlineEnvironment() {
         Optional<MemorySegment> hOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false,
                 getProcessID());
         if (hOpt.isPresent()) {
@@ -698,10 +343,6 @@ public class WindowsOSProcessFFM extends AbstractOSProcess {
             }
         }
         return defaultCwdCommandlineEnvironment();
-    }
-
-    private static Triplet<String, String, Map<String, String>> defaultCwdCommandlineEnvironment() {
-        return new Triplet<>("", "", Collections.emptyMap());
     }
 
     private static boolean isWow(MemorySegment h, Arena arena) {

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
@@ -10,7 +10,6 @@ import static oshi.software.os.OSProcess.State.SUSPENDED;
 import static oshi.util.Memoizer.memoize;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -18,22 +17,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.sun.jna.Memory;
-import com.sun.jna.Pointer;
-import com.sun.jna.platform.win32.Advapi32;
-import com.sun.jna.platform.win32.Advapi32Util;
-import com.sun.jna.platform.win32.Advapi32Util.Account;
-import com.sun.jna.platform.win32.Kernel32;
-import com.sun.jna.platform.win32.Kernel32Util;
-import com.sun.jna.platform.win32.Shell32Util;
-import com.sun.jna.platform.win32.VersionHelpers;
-import com.sun.jna.platform.win32.Win32Exception;
-import com.sun.jna.platform.win32.WinError;
-import com.sun.jna.platform.win32.WinNT;
-import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -44,38 +27,26 @@ import oshi.driver.windows.registry.ThreadPerformanceData;
 import oshi.driver.windows.wmi.Win32Process;
 import oshi.driver.windows.wmi.Win32Process.CommandLineProperty;
 import oshi.driver.windows.wmi.Win32ProcessCached;
-import oshi.jna.ByRef.CloseableHANDLEByReference;
-import oshi.jna.ByRef.CloseableIntByReference;
-import oshi.jna.ByRef.CloseableULONGptrByReference;
-import oshi.jna.platform.windows.NtDll;
-import oshi.jna.platform.windows.NtDll.UNICODE_STRING;
 import oshi.software.common.AbstractOSProcess;
 import oshi.software.os.OSThread;
 import oshi.util.Constants;
 import oshi.util.GlobalConfig;
-import oshi.util.ParseUtil;
 import oshi.util.platform.windows.WmiUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
 /**
- * OSProcess implementation
+ * Common base class for Windows OS process implementations, containing shared fields, getters, and non-native methods.
  */
 @ThreadSafe
-public class WindowsOSProcess extends AbstractOSProcess {
+public abstract class WindowsOSProcess extends AbstractOSProcess {
 
-    private static final Logger LOG = LoggerFactory.getLogger(WindowsOSProcess.class);
-
-    private static final boolean USE_BATCH_COMMANDLINE = GlobalConfig
+    protected static final boolean USE_BATCH_COMMANDLINE = GlobalConfig
             .get(GlobalConfig.OSHI_OS_WINDOWS_COMMANDLINE_BATCH, false);
 
-    private static final boolean USE_PROCSTATE_SUSPENDED = GlobalConfig
+    protected static final boolean USE_PROCSTATE_SUSPENDED = GlobalConfig
             .get(GlobalConfig.OSHI_OS_WINDOWS_PROCSTATE_SUSPENDED, false);
 
-    private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
-    private static final boolean IS_WINDOWS7_OR_GREATER = VersionHelpers.IsWindows7OrGreater();
-
-    // track the OperatingSystem object that created this
     private final WindowsOperatingSystem os;
 
     private Supplier<Pair<String, String>> userInfo = memoize(this::queryUserInfo);
@@ -88,7 +59,7 @@ public class WindowsOSProcess extends AbstractOSProcess {
     private Map<Integer, ThreadPerformanceData.PerfCounterBlock> tcb;
 
     private String name;
-    private String path;
+    private String path = "";
     private State state = INVALID;
     private int parentProcessID;
     private int threadCount;
@@ -106,17 +77,32 @@ public class WindowsOSProcess extends AbstractOSProcess {
     private int bitness;
     private long pageFaults;
 
-    public WindowsOSProcess(int pid, WindowsOperatingSystem os,
+    protected WindowsOSProcess(int pid, WindowsOperatingSystem os,
             Map<Integer, ProcessPerformanceData.PerfCounterBlock> processMap, Map<Integer, WtsInfo> processWtsMap,
             Map<Integer, ThreadPerformanceData.PerfCounterBlock> threadMap) {
         super(pid);
-        // Save a copy of OS creating this object for later use
         this.os = os;
-        // Initially set to match OS bitness. If 64 will check later for 32-bit process
         this.bitness = os.getBitness();
-        // Initialize thread counters
         this.tcb = threadMap;
         updateAttributes(processMap.get(pid), processWtsMap.get(pid));
+    }
+
+    /**
+     * Returns the {@link WindowsOperatingSystem} instance associated with this process.
+     *
+     * @return the operating system instance
+     */
+    protected WindowsOperatingSystem getOs() {
+        return this.os;
+    }
+
+    /**
+     * Returns the memoized CWD/CommandLine/Environment triplet.
+     *
+     * @return the triplet
+     */
+    protected Triplet<String, String, Map<String, String>> getCwdCmdEnv() {
+        return cwdCmdEnv.get();
     }
 
     @Override
@@ -267,22 +253,6 @@ public class WindowsOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public long getAffinityMask() {
-        final HANDLE pHandle = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION, false, getProcessID());
-        if (pHandle != null) {
-            try (CloseableULONGptrByReference processAffinity = new CloseableULONGptrByReference();
-                    CloseableULONGptrByReference systemAffinity = new CloseableULONGptrByReference()) {
-                if (Kernel32.INSTANCE.GetProcessAffinityMask(pHandle, processAffinity, systemAffinity)) {
-                    return Pointer.nativeValue(processAffinity.getValue().toPointer());
-                }
-            } finally {
-                Kernel32.INSTANCE.CloseHandle(pHandle);
-            }
-        }
-        return 0L;
-    }
-
-    @Override
     public long getMinorFaults() {
         return this.pageFaults;
     }
@@ -315,32 +285,41 @@ public class WindowsOSProcess extends AbstractOSProcess {
         return updateAttributes(pcb.get(this.getProcessID()), wts.get(this.getProcessID()));
     }
 
-    private boolean updateAttributes(ProcessPerformanceData.PerfCounterBlock pcb, WtsInfo wts) {
+    /**
+     * Updates process attributes from performance counter and WTS data, then performs native-specific updates.
+     * Subclasses should call {@code super.updateAttributes(pcb, wts)} and then perform native handle-based updates.
+     *
+     * @param pcb Performance counter block for this process, or null if unavailable
+     * @param wts WTS info for this process, or null if unavailable
+     * @return true if the process is valid after the update
+     */
+    protected boolean updateAttributes(ProcessPerformanceData.PerfCounterBlock pcb, WtsInfo wts) {
+        if (pcb == null) {
+            this.state = INVALID;
+            return false;
+        }
         this.name = pcb.getName();
-        this.path = wts.getPath(); // Empty string for Win7+
         this.parentProcessID = pcb.getParentProcessID();
-        this.threadCount = wts.getThreadCount();
         this.priority = pcb.getPriority();
-        this.virtualSize = wts.getVirtualSize();
         this.workingSetSize = pcb.getWorkingSetSize();
         this.privateWorkingSetSize = pcb.getPrivateWorkingSetSize();
-        this.kernelTime = wts.getKernelTime();
-        this.userTime = wts.getUserTime();
         this.startTime = pcb.getStartTime();
         this.upTime = pcb.getUpTime();
         this.bytesRead = pcb.getBytesRead();
         this.bytesWritten = pcb.getBytesWritten();
-        this.openFiles = wts.getOpenFiles();
         this.pageFaults = pcb.getPageFaults();
+        if (wts != null) {
+            this.path = wts.getPath();
+            this.threadCount = wts.getThreadCount();
+            this.virtualSize = wts.getVirtualSize();
+            this.kernelTime = wts.getKernelTime();
+            this.userTime = wts.getUserTime();
+            this.openFiles = wts.getOpenFiles();
+        }
 
-        // There are only 3 possible Process states on Windows: RUNNING, SUSPENDED, or
-        // UNKNOWN. Processes are considered running unless all of their threads are
-        // SUSPENDED.
         this.state = RUNNING;
         if (this.tcb != null) {
-            // If user hasn't enabled this in properties, we ignore
             int pid = this.getProcessID();
-            // If any thread is NOT suspended, set running
             for (ThreadPerformanceData.PerfCounterBlock tpd : this.tcb.values()) {
                 if (tpd.getOwningProcessID() == pid) {
                     if (tpd.getThreadWaitReason() == 5) {
@@ -353,39 +332,39 @@ public class WindowsOSProcess extends AbstractOSProcess {
             }
         }
 
-        // Get a handle to the process for various extended info. Only gets
-        // current user unless running as administrator
-        final HANDLE pHandle = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION, false, getProcessID());
-        if (pHandle != null) {
-            try {
-                // Test for 32-bit process on 64-bit windows
-                if (IS_VISTA_OR_GREATER && this.bitness == 64) {
-                    try (CloseableIntByReference wow64 = new CloseableIntByReference()) {
-                        if (Kernel32.INSTANCE.IsWow64Process(pHandle, wow64) && wow64.getValue() > 0) {
-                            this.bitness = 32;
-                        }
-                    }
-                }
-                try { // EXECUTABLEPATH
-                    if (IS_WINDOWS7_OR_GREATER) {
-                        this.path = Kernel32Util.QueryFullProcessImageName(pHandle, 0);
-                    }
-                } catch (Win32Exception e) {
-                    this.state = INVALID;
-                }
-            } finally {
-                Kernel32.INSTANCE.CloseHandle(pHandle);
-            }
-        }
-
         return !this.state.equals(INVALID);
     }
 
-    private Map<Integer, ThreadPerformanceData.PerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
-        // fetch from registry
+    /**
+     * Sets the process bitness. Used by subclasses to update after WOW64 check.
+     *
+     * @param bitness the bitness to set
+     */
+    protected void setBitness(int bitness) {
+        this.bitness = bitness;
+    }
+
+    /**
+     * Sets the process executable path. Used by subclasses to update after native query.
+     *
+     * @param path the path to set
+     */
+    protected void setPath(String path) {
+        this.path = path;
+    }
+
+    /**
+     * Sets the process state. Used by subclasses to mark a process as invalid.
+     *
+     * @param state the state to set
+     */
+    protected void setState(State state) {
+        this.state = state;
+    }
+
+    protected Map<Integer, ThreadPerformanceData.PerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
         Map<Integer, ThreadPerformanceData.PerfCounterBlock> threads = ThreadPerformanceData
                 .buildThreadMapFromRegistry(pids);
-        // otherwise performance counters with WMI backup
         if (threads == null) {
             threads = ThreadPerformanceData.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
         }
@@ -393,15 +372,12 @@ public class WindowsOSProcess extends AbstractOSProcess {
     }
 
     private String queryCommandLine() {
-        // Try to fetch from process memory
         if (!cwdCmdEnv.get().getB().isEmpty()) {
             return cwdCmdEnv.get().getB();
         }
-        // If using batch mode fetch from WMI Cache
         if (USE_BATCH_COMMANDLINE) {
             return Win32ProcessCached.getInstance().getCommandLine(getProcessID(), getStartTime());
         }
-        // If no cache enabled, query line by line
         WmiResult<CommandLineProperty> commandLineProcs = Win32Process
                 .queryCommandLines(Collections.singleton(getProcessID()));
         if (commandLineProcs.getResultCount() > 0) {
@@ -410,23 +386,19 @@ public class WindowsOSProcess extends AbstractOSProcess {
         return "";
     }
 
-    private List<String> queryArguments() {
-        String cl = getCommandLine();
-        if (!cl.isEmpty()) {
-            return Arrays.asList(Shell32Util.CommandLineToArgv(cl));
-        }
-        return Collections.emptyList();
-    }
+    /**
+     * Queries the argument list for this process.
+     *
+     * @return the list of arguments
+     */
+    protected abstract List<String> queryArguments();
 
     private String queryCwd() {
-        // Try to fetch from process memory
         if (!cwdCmdEnv.get().getA().isEmpty()) {
             return cwdCmdEnv.get().getA();
         }
-        // For executing process, set CWD
         if (getProcessID() == this.os.getProcessId()) {
             String cwd = new File(".").getAbsolutePath();
-            // trim off trailing "."
             if (!cwd.isEmpty()) {
                 return cwd.substring(0, cwd.length() - 1);
             }
@@ -434,149 +406,32 @@ public class WindowsOSProcess extends AbstractOSProcess {
         return "";
     }
 
-    private Pair<String, String> queryUserInfo() {
-        Pair<String, String> pair = null;
-        final HANDLE pHandle = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION, false, getProcessID());
-        if (pHandle != null) {
-            try (CloseableHANDLEByReference phToken = new CloseableHANDLEByReference()) {
-                try {
-                    if (Advapi32.INSTANCE.OpenProcessToken(pHandle, WinNT.TOKEN_DUPLICATE | WinNT.TOKEN_QUERY,
-                            phToken)) {
-                        Account account = Advapi32Util.getTokenAccount(phToken.getValue());
-                        pair = new Pair<>(account.name, account.sidString);
-                    } else {
-                        int error = Kernel32.INSTANCE.GetLastError();
-                        // Access denied errors are common. Fail silently.
-                        if (error != WinError.ERROR_ACCESS_DENIED) {
-                            LOG.error("Failed to get process token for process {}: {}", getProcessID(),
-                                    Kernel32.INSTANCE.GetLastError());
-                        }
-                    }
-                } catch (Win32Exception e) {
-                    LOG.warn("Failed to query user info for process {} ({}): {}", getProcessID(), getName(),
-                            e.getMessage());
-                } finally {
-                    final HANDLE token = phToken.getValue();
-                    if (token != null) {
-                        Kernel32.INSTANCE.CloseHandle(token);
-                    }
-                    Kernel32.INSTANCE.CloseHandle(pHandle);
-                }
-            }
-        }
-        if (pair == null) {
-            return new Pair<>(Constants.UNKNOWN, Constants.UNKNOWN);
-        }
-        return pair;
-    }
+    /**
+     * Queries user account information for this process.
+     *
+     * @return a pair of (account name, SID string)
+     */
+    protected abstract Pair<String, String> queryUserInfo();
 
-    private Pair<String, String> queryGroupInfo() {
-        Pair<String, String> pair = null;
-        final HANDLE pHandle = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION, false, getProcessID());
-        if (pHandle != null) {
-            try (CloseableHANDLEByReference phToken = new CloseableHANDLEByReference()) {
-                if (Advapi32.INSTANCE.OpenProcessToken(pHandle, WinNT.TOKEN_DUPLICATE | WinNT.TOKEN_QUERY, phToken)) {
-                    Account account = Advapi32Util.getTokenPrimaryGroup(phToken.getValue());
-                    pair = new Pair<>(account.name, account.sidString);
-                } else {
-                    int error = Kernel32.INSTANCE.GetLastError();
-                    // Access denied errors are common. Fail silently.
-                    if (error != WinError.ERROR_ACCESS_DENIED) {
-                        LOG.error("Failed to get process token for process {}: {}", getProcessID(),
-                                Kernel32.INSTANCE.GetLastError());
-                    }
-                }
-                final HANDLE token = phToken.getValue();
-                if (token != null) {
-                    Kernel32.INSTANCE.CloseHandle(token);
-                }
-                Kernel32.INSTANCE.CloseHandle(pHandle);
-            }
-        }
-        if (pair == null) {
-            return new Pair<>(Constants.UNKNOWN, Constants.UNKNOWN);
-        }
-        return pair;
-    }
+    /**
+     * Queries group account information for this process.
+     *
+     * @return a pair of (group name, SID string)
+     */
+    protected abstract Pair<String, String> queryGroupInfo();
 
-    private Triplet<String, String, Map<String, String>> queryCwdCommandlineEnvironment() {
-        // Get the process handle
-        HANDLE h = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION | WinNT.PROCESS_VM_READ, false,
-                getProcessID());
-        if (h != null) {
-            try {
-                // Can't check 32-bit procs from a 64-bit one
-                if (WindowsOperatingSystem.isX86() == WindowsOperatingSystem.isWow(h)) {
-                    try (CloseableIntByReference nRead = new CloseableIntByReference()) {
-                        // Start by getting the address of the PEB
-                        NtDll.PROCESS_BASIC_INFORMATION pbi = new NtDll.PROCESS_BASIC_INFORMATION();
-                        int ret = NtDll.INSTANCE.NtQueryInformationProcess(h, NtDll.PROCESS_BASIC_INFORMATION,
-                                pbi.getPointer(), pbi.size(), nRead);
-                        if (ret != 0) {
-                            return defaultCwdCommandlineEnvironment();
-                        }
-                        pbi.read();
+    /**
+     * Queries the current working directory, command line, and environment variables from process memory.
+     *
+     * @return a triplet of (cwd, commandLine, environmentVariables)
+     */
+    protected abstract Triplet<String, String, Map<String, String>> queryCwdCommandlineEnvironment();
 
-                        // Now fetch the PEB
-                        NtDll.PEB peb = new NtDll.PEB();
-                        Kernel32.INSTANCE.ReadProcessMemory(h, pbi.PebBaseAddress, peb.getPointer(), peb.size(), nRead);
-                        if (nRead.getValue() == 0) {
-                            return defaultCwdCommandlineEnvironment();
-                        }
-                        peb.read();
-
-                        // Now fetch the Process Parameters structure containing our data
-                        NtDll.RTL_USER_PROCESS_PARAMETERS upp = new NtDll.RTL_USER_PROCESS_PARAMETERS();
-                        Kernel32.INSTANCE.ReadProcessMemory(h, peb.ProcessParameters, upp.getPointer(), upp.size(),
-                                nRead);
-                        if (nRead.getValue() == 0) {
-                            return defaultCwdCommandlineEnvironment();
-                        }
-                        upp.read();
-
-                        // Get CWD and Command Line strings here
-                        String cwd = readUnicodeString(h, upp.CurrentDirectory.DosPath);
-                        String cl = readUnicodeString(h, upp.CommandLine);
-
-                        // Fetch the Environment Strings
-                        int envSize = upp.EnvironmentSize.intValue();
-                        if (envSize > 0) {
-                            try (Memory buffer = new Memory(envSize)) {
-                                Kernel32.INSTANCE.ReadProcessMemory(h, upp.Environment, buffer, envSize, nRead);
-                                if (nRead.getValue() > 0) {
-                                    char[] env = buffer.getCharArray(0, envSize / 2);
-                                    Map<String, String> envMap = ParseUtil.parseCharArrayToStringMap(env);
-                                    // First entry in Environment is "=::=::\"
-                                    envMap.remove("");
-                                    return new Triplet<>(cwd, cl, Collections.unmodifiableMap(envMap));
-                                }
-                            }
-                        }
-                        return new Triplet<>(cwd, cl, Collections.emptyMap());
-                    }
-                }
-            } finally {
-                Kernel32.INSTANCE.CloseHandle(h);
-            }
-        }
-        return defaultCwdCommandlineEnvironment();
-    }
-
-    private static Triplet<String, String, Map<String, String>> defaultCwdCommandlineEnvironment() {
+    protected static Triplet<String, String, Map<String, String>> defaultCwdCommandlineEnvironment() {
         return new Triplet<>("", "", Collections.emptyMap());
     }
 
-    private static String readUnicodeString(HANDLE h, UNICODE_STRING s) {
-        if (s.Length > 0) {
-            // Add space for null terminator
-            try (Memory m = new Memory(s.Length + 2L); CloseableIntByReference nRead = new CloseableIntByReference()) {
-                m.clear(); // really only need null in last 2 bytes but this is easier
-                Kernel32.INSTANCE.ReadProcessMemory(h, s.Buffer, m, s.Length, nRead);
-                if (nRead.getValue() > 0) {
-                    return m.getWideString(0);
-                }
-            }
-        }
-        return "";
+    protected static Pair<String, String> defaultPair() {
+        return new Pair<>(Constants.UNKNOWN, Constants.UNKNOWN);
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.windows;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Advapi32;
+import com.sun.jna.platform.win32.Advapi32Util;
+import com.sun.jna.platform.win32.Advapi32Util.Account;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.Kernel32Util;
+import com.sun.jna.platform.win32.Shell32Util;
+import com.sun.jna.platform.win32.VersionHelpers;
+import com.sun.jna.platform.win32.Win32Exception;
+import com.sun.jna.platform.win32.WinError;
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.windows.registry.ProcessPerformanceData;
+import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
+import oshi.driver.windows.registry.ThreadPerformanceData;
+import oshi.jna.ByRef.CloseableHANDLEByReference;
+import oshi.jna.ByRef.CloseableIntByReference;
+import oshi.jna.ByRef.CloseableULONGptrByReference;
+import oshi.jna.platform.windows.NtDll;
+import oshi.jna.platform.windows.NtDll.UNICODE_STRING;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
+import oshi.util.tuples.Triplet;
+
+/**
+ * JNA-based Windows OS process implementation.
+ */
+@ThreadSafe
+public class WindowsOSProcessJNA extends WindowsOSProcess {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsOSProcessJNA.class);
+
+    private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
+    private static final boolean IS_WINDOWS7_OR_GREATER = VersionHelpers.IsWindows7OrGreater();
+
+    public WindowsOSProcessJNA(int pid, WindowsOperatingSystem os,
+            Map<Integer, ProcessPerformanceData.PerfCounterBlock> processMap, Map<Integer, WtsInfo> processWtsMap,
+            Map<Integer, ThreadPerformanceData.PerfCounterBlock> threadMap) {
+        super(pid, os, processMap, processWtsMap, threadMap);
+    }
+
+    @Override
+    public long getAffinityMask() {
+        final HANDLE pHandle = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION, false, getProcessID());
+        if (pHandle != null) {
+            try (CloseableULONGptrByReference processAffinity = new CloseableULONGptrByReference();
+                    CloseableULONGptrByReference systemAffinity = new CloseableULONGptrByReference()) {
+                if (Kernel32.INSTANCE.GetProcessAffinityMask(pHandle, processAffinity, systemAffinity)) {
+                    return Pointer.nativeValue(processAffinity.getValue().toPointer());
+                }
+            } finally {
+                Kernel32.INSTANCE.CloseHandle(pHandle);
+            }
+        }
+        return 0L;
+    }
+
+    @Override
+    protected boolean updateAttributes(ProcessPerformanceData.PerfCounterBlock pcb, WtsInfo wts) {
+        if (!super.updateAttributes(pcb, wts)) {
+            return false;
+        }
+
+        final HANDLE pHandle = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION, false, getProcessID());
+        if (pHandle != null) {
+            try {
+                // Test for 32-bit process on 64-bit windows
+                if (IS_VISTA_OR_GREATER && getBitness() == 64) {
+                    try (CloseableIntByReference wow64 = new CloseableIntByReference()) {
+                        if (Kernel32.INSTANCE.IsWow64Process(pHandle, wow64) && wow64.getValue() > 0) {
+                            setBitness(32);
+                        }
+                    }
+                }
+                try { // EXECUTABLEPATH
+                    if (IS_WINDOWS7_OR_GREATER) {
+                        setPath(Kernel32Util.QueryFullProcessImageName(pHandle, 0));
+                    }
+                } catch (Win32Exception e) {
+                    // Best-effort path lookup; leave process state and path untouched on failure
+                }
+            } finally {
+                Kernel32.INSTANCE.CloseHandle(pHandle);
+            }
+        }
+
+        return !getState().equals(State.INVALID);
+    }
+
+    @Override
+    protected List<String> queryArguments() {
+        String cl = getCommandLine();
+        if (!cl.isEmpty()) {
+            return Arrays.asList(Shell32Util.CommandLineToArgv(cl));
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    protected Pair<String, String> queryUserInfo() {
+        Pair<String, String> pair = null;
+        final HANDLE pHandle = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION, false, getProcessID());
+        if (pHandle != null) {
+            try (CloseableHANDLEByReference phToken = new CloseableHANDLEByReference()) {
+                try {
+                    if (Advapi32.INSTANCE.OpenProcessToken(pHandle, WinNT.TOKEN_QUERY, phToken)) {
+                        Account account = Advapi32Util.getTokenAccount(phToken.getValue());
+                        pair = new Pair<>(account.name, account.sidString);
+                    } else {
+                        int error = Kernel32.INSTANCE.GetLastError();
+                        // Access denied errors are common. Fail silently.
+                        if (error != WinError.ERROR_ACCESS_DENIED) {
+                            LOG.error("Failed to get process token for process {}: {}", getProcessID(), error);
+                        }
+                    }
+                } catch (Win32Exception e) {
+                    LOG.warn("Failed to query user info for process {} ({}): {}", getProcessID(), getName(),
+                            e.getMessage());
+                } finally {
+                    final HANDLE token = phToken.getValue();
+                    if (token != null) {
+                        Kernel32.INSTANCE.CloseHandle(token);
+                    }
+                    Kernel32.INSTANCE.CloseHandle(pHandle);
+                }
+            }
+        }
+        return pair != null ? pair : defaultPair();
+    }
+
+    @Override
+    protected Pair<String, String> queryGroupInfo() {
+        Pair<String, String> pair = null;
+        final HANDLE pHandle = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION, false, getProcessID());
+        if (pHandle != null) {
+            try (CloseableHANDLEByReference phToken = new CloseableHANDLEByReference()) {
+                try {
+                    if (Advapi32.INSTANCE.OpenProcessToken(pHandle, WinNT.TOKEN_QUERY, phToken)) {
+                        Account account = Advapi32Util.getTokenPrimaryGroup(phToken.getValue());
+                        pair = new Pair<>(account.name, account.sidString);
+                    } else {
+                        int error = Kernel32.INSTANCE.GetLastError();
+                        // Access denied errors are common. Fail silently.
+                        if (error != WinError.ERROR_ACCESS_DENIED) {
+                            LOG.error("Failed to get process token for process {}: {}", getProcessID(), error);
+                        }
+                    }
+                } catch (Win32Exception e) {
+                    LOG.warn("Failed to query group info for process {} ({}): {}", getProcessID(), getName(),
+                            e.getMessage());
+                } finally {
+                    final HANDLE token = phToken.getValue();
+                    if (token != null) {
+                        Kernel32.INSTANCE.CloseHandle(token);
+                    }
+                    Kernel32.INSTANCE.CloseHandle(pHandle);
+                }
+            }
+        }
+        return pair != null ? pair : defaultPair();
+    }
+
+    @Override
+    protected Triplet<String, String, Map<String, String>> queryCwdCommandlineEnvironment() {
+        HANDLE h = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION | WinNT.PROCESS_VM_READ, false,
+                getProcessID());
+        if (h != null) {
+            try {
+                // Can't check 32-bit procs from a 64-bit one
+                if (WindowsOperatingSystem.isX86() == WindowsOperatingSystem.isWow(h)) {
+                    try (CloseableIntByReference nRead = new CloseableIntByReference()) {
+                        // Start by getting the address of the PEB
+                        NtDll.PROCESS_BASIC_INFORMATION pbi = new NtDll.PROCESS_BASIC_INFORMATION();
+                        int ret = NtDll.INSTANCE.NtQueryInformationProcess(h, NtDll.PROCESS_BASIC_INFORMATION,
+                                pbi.getPointer(), pbi.size(), nRead);
+                        if (ret != 0) {
+                            return defaultCwdCommandlineEnvironment();
+                        }
+                        pbi.read();
+
+                        // Now fetch the PEB
+                        NtDll.PEB peb = new NtDll.PEB();
+                        Kernel32.INSTANCE.ReadProcessMemory(h, pbi.PebBaseAddress, peb.getPointer(), peb.size(), nRead);
+                        if (nRead.getValue() == 0) {
+                            return defaultCwdCommandlineEnvironment();
+                        }
+                        peb.read();
+
+                        // Now fetch the Process Parameters structure containing our data
+                        NtDll.RTL_USER_PROCESS_PARAMETERS upp = new NtDll.RTL_USER_PROCESS_PARAMETERS();
+                        Kernel32.INSTANCE.ReadProcessMemory(h, peb.ProcessParameters, upp.getPointer(), upp.size(),
+                                nRead);
+                        if (nRead.getValue() == 0) {
+                            return defaultCwdCommandlineEnvironment();
+                        }
+                        upp.read();
+
+                        // Get CWD and Command Line strings here
+                        String cwd = readUnicodeString(h, upp.CurrentDirectory.DosPath);
+                        String cl = readUnicodeString(h, upp.CommandLine);
+
+                        // Fetch the Environment Strings
+                        int envSize = upp.EnvironmentSize.intValue();
+                        if (envSize > 0) {
+                            try (Memory buffer = new Memory(envSize)) {
+                                Kernel32.INSTANCE.ReadProcessMemory(h, upp.Environment, buffer, envSize, nRead);
+                                if (nRead.getValue() > 0) {
+                                    char[] env = buffer.getCharArray(0, envSize / 2);
+                                    Map<String, String> envMap = ParseUtil.parseCharArrayToStringMap(env);
+                                    // First entry in Environment is "=::=::\"
+                                    envMap.remove("");
+                                    return new Triplet<>(cwd, cl, Collections.unmodifiableMap(envMap));
+                                }
+                            }
+                        }
+                        return new Triplet<>(cwd, cl, Collections.emptyMap());
+                    }
+                }
+            } finally {
+                Kernel32.INSTANCE.CloseHandle(h);
+            }
+        }
+        return defaultCwdCommandlineEnvironment();
+    }
+
+    private static String readUnicodeString(HANDLE h, UNICODE_STRING s) {
+        if (s.Length > 0) {
+            // Add space for null terminator
+            try (Memory m = new Memory(s.Length + 2L); CloseableIntByReference nRead = new CloseableIntByReference()) {
+                m.clear(); // really only need null in last 2 bytes but this is easier
+                Kernel32.INSTANCE.ReadProcessMemory(h, s.Buffer, m, s.Length, nRead);
+                if (nRead.getValue() > 0) {
+                    return m.getWideString(0);
+                }
+            }
+        }
+        return "";
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.windows;
@@ -33,6 +33,7 @@ import com.sun.jna.platform.win32.Advapi32;
 import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.Advapi32Util.EventLogIterator;
 import com.sun.jna.platform.win32.Advapi32Util.EventLogRecord;
+import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.Psapi;
 import com.sun.jna.platform.win32.Tlhelp32;
@@ -45,7 +46,6 @@ import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinNT.LUID;
 import com.sun.jna.platform.win32.Winsvc;
-import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.windows.EnumWindows;
@@ -320,7 +320,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         final Map<Integer, ProcessPerformanceData.PerfCounterBlock> finalProcessMap = processMap;
         final Map<Integer, ThreadPerformanceData.PerfCounterBlock> finalThreadMap = threadMap;
         return mapKeys.stream().parallel()
-                .map(pid -> new WindowsOSProcess(pid, this, finalProcessMap, processWtsMap, finalThreadMap))
+                .map(pid -> new WindowsOSProcessJNA(pid, this, finalProcessMap, processWtsMap, finalThreadMap))
                 .filter(VALID_PROCESS).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
- Extract common `WindowsOSProcess` abstract superclass with shared fields (private + setters), getters, and non-native methods (`queryCommandLine`, `queryCwd`, `queryMatchingThreads`, `getThreadDetails`, `updateAttributes`)
- Rename existing `WindowsOSProcess` to `WindowsOSProcessJNA` extending the new superclass
- Update `WindowsOSProcessFFM` to extend the new superclass
- Add `VersionHelpersFFM` — FFM port of JNA's `VersionHelpers` using native `VerSetConditionMask`/`VerifyVersionInfoW` from kernel32, replacing the `os.version` string-parsing workaround
- Add `OSVERSIONINFOEX` struct layout and `VER_*`/`WIN32_WINNT_*` constants to `WinNTFFM`
- Add `VerSetConditionMask` and `VerifyVersionInfoW` bindings to `Kernel32FFM`
- Remove unnecessary `TOKEN_DUPLICATE` from `OpenProcessToken` calls in both JNA and FFM — only `TOKEN_QUERY` is needed for `GetTokenInformation`
- Replace magic `0x0008` with `TOKEN_QUERY` constant import in FFM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows version-detection helpers (Vista, 7, 8, 8.1, 10) and Server detection.
  * Added alternative native bindings/backends to improve Windows API access.

* **Refactor**
  * Restructured Windows process handling to support multiple backends and improved process info retrieval (affinity, bitness, path, arguments, user/group, CWD, environment) with safer fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->