### PR TITLE
Move macOS OperatingSystem tree to oshi-common

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -38,7 +38,7 @@
     <suppress checks="JavadocPackage" files=".*FFM\.java"/>
 
     <!-- Protected final fields initialized in constructor -->
-    <suppress checks="VisibilityModifier" files="MacOperatingSystem\.java" lines="53-57"/>
+    <suppress checks="VisibilityModifier" files="MacOperatingSystem\.java" lines="52-56"/>
 
     <!-- Imports for classes linked in javadocs -->
     <suppress checks="UnusedImports" files="(CentralProcessor|OSDesktopWindow|OSProcess)\.java"/>

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacFileSystem.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.mac;
+
+import java.nio.file.PathMatcher;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractFileSystem;
+import oshi.util.FileSystemUtil;
+
+/**
+ * Common constants and configuration for macOS file system implementations.
+ */
+@ThreadSafe
+public abstract class MacFileSystem extends AbstractFileSystem {
+
+    public static final String OSHI_MAC_FS_PATH_EXCLUDES = "oshi.os.mac.filesystem.path.excludes";
+    public static final String OSHI_MAC_FS_PATH_INCLUDES = "oshi.os.mac.filesystem.path.includes";
+    public static final String OSHI_MAC_FS_VOLUME_EXCLUDES = "oshi.os.mac.filesystem.volume.excludes";
+    public static final String OSHI_MAC_FS_VOLUME_INCLUDES = "oshi.os.mac.filesystem.volume.includes";
+
+    protected static final List<PathMatcher> FS_PATH_EXCLUDES = FileSystemUtil
+            .loadAndParseFileSystemConfig(OSHI_MAC_FS_PATH_EXCLUDES);
+    protected static final List<PathMatcher> FS_PATH_INCLUDES = FileSystemUtil
+            .loadAndParseFileSystemConfig(OSHI_MAC_FS_PATH_INCLUDES);
+    protected static final List<PathMatcher> FS_VOLUME_EXCLUDES = FileSystemUtil
+            .loadAndParseFileSystemConfig(OSHI_MAC_FS_VOLUME_EXCLUDES);
+    protected static final List<PathMatcher> FS_VOLUME_INCLUDES = FileSystemUtil
+            .loadAndParseFileSystemConfig(OSHI_MAC_FS_VOLUME_INCLUDES);
+
+    // Regexp matcher for /dev/disk0s2 etc.
+    protected static final Pattern LOCAL_DISK = Pattern.compile("/dev/disk\\d+(s\\d+)?");
+
+    // User specifiable flags.
+    protected static final int MNT_RDONLY = 0x00000001;
+    protected static final int MNT_SYNCHRONOUS = 0x00000002;
+    protected static final int MNT_NOEXEC = 0x00000004;
+    protected static final int MNT_NOSUID = 0x00000008;
+    protected static final int MNT_NODEV = 0x00000010;
+    protected static final int MNT_UNION = 0x00000020;
+    protected static final int MNT_ASYNC = 0x00000040;
+    protected static final int MNT_CPROTECT = 0x00000080;
+    protected static final int MNT_EXPORTED = 0x00000100;
+    protected static final int MNT_QUARANTINE = 0x00000400;
+    protected static final int MNT_LOCAL = 0x00001000;
+    protected static final int MNT_QUOTA = 0x00002000;
+    protected static final int MNT_ROOTFS = 0x00004000;
+    protected static final int MNT_DOVOLFS = 0x00008000;
+    protected static final int MNT_DONTBROWSE = 0x00100000;
+    protected static final int MNT_IGNORE_OWNERSHIP = 0x00200000;
+    protected static final int MNT_AUTOMOUNTED = 0x00400000;
+    protected static final int MNT_JOURNALED = 0x00800000;
+    protected static final int MNT_NOUSERXATTR = 0x01000000;
+    protected static final int MNT_DEFWRITE = 0x02000000;
+    protected static final int MNT_MULTILABEL = 0x04000000;
+    protected static final int MNT_NOATIME = 0x10000000;
+
+    protected static final Map<Integer, String> OPTIONS_MAP = new HashMap<>();
+    static {
+        OPTIONS_MAP.put(MNT_SYNCHRONOUS, "synchronous");
+        OPTIONS_MAP.put(MNT_NOEXEC, "noexec");
+        OPTIONS_MAP.put(MNT_NOSUID, "nosuid");
+        OPTIONS_MAP.put(MNT_NODEV, "nodev");
+        OPTIONS_MAP.put(MNT_UNION, "union");
+        OPTIONS_MAP.put(MNT_ASYNC, "asynchronous");
+        OPTIONS_MAP.put(MNT_CPROTECT, "content-protection");
+        OPTIONS_MAP.put(MNT_EXPORTED, "exported");
+        OPTIONS_MAP.put(MNT_QUARANTINE, "quarantined");
+        OPTIONS_MAP.put(MNT_LOCAL, "local");
+        OPTIONS_MAP.put(MNT_QUOTA, "quotas");
+        OPTIONS_MAP.put(MNT_ROOTFS, "rootfs");
+        OPTIONS_MAP.put(MNT_DOVOLFS, "volfs");
+        OPTIONS_MAP.put(MNT_DONTBROWSE, "nobrowse");
+        OPTIONS_MAP.put(MNT_IGNORE_OWNERSHIP, "noowners");
+        OPTIONS_MAP.put(MNT_AUTOMOUNTED, "automounted");
+        OPTIONS_MAP.put(MNT_JOURNALED, "journaled");
+        OPTIONS_MAP.put(MNT_NOUSERXATTR, "nouserxattr");
+        OPTIONS_MAP.put(MNT_DEFWRITE, "defwrite");
+        OPTIONS_MAP.put(MNT_MULTILABEL, "multilabel");
+        OPTIONS_MAP.put(MNT_NOATIME, "noatime");
+    }
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -2,13 +2,13 @@
  * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.mac;
+package oshi.software.common.os.mac;
 
-import java.util.ArrayList;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSFileStore.java
@@ -2,17 +2,17 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.mac;
+package oshi.software.common.os.mac;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOSFileStore;
 import oshi.software.os.OSFileStore;
 
 /**
- * OSFileStore implementation
+ * Common OSFileStore fields and getters for macOS implementations.
  */
 @ThreadSafe
-public class MacOSFileStore extends AbstractOSFileStore {
+public abstract class MacOSFileStore extends AbstractOSFileStore {
 
     private String logicalVolume;
     private String description;
@@ -24,7 +24,7 @@ public class MacOSFileStore extends AbstractOSFileStore {
     private long freeInodes;
     private long totalInodes;
 
-    public MacOSFileStore(String name, String volume, String label, String mount, String options, String uuid,
+    protected MacOSFileStore(String name, String volume, String label, String mount, String options, String uuid,
             boolean local, String logicalVolume, String description, String fsType, long freeSpace, long usableSpace,
             long totalSpace, long freeInodes, long totalInodes) {
         super(name, volume, label, mount, options, uuid, local);
@@ -78,21 +78,19 @@ public class MacOSFileStore extends AbstractOSFileStore {
         return this.totalInodes;
     }
 
-    @Override
-    public boolean updateAttributes() {
-        for (OSFileStore fileStore : MacFileSystem.getFileStoreMatching(getName(), isLocal())) {
-            if (getVolume().equals(fileStore.getVolume()) && getMount().equals(fileStore.getMount())) {
-                this.logicalVolume = fileStore.getLogicalVolume();
-                this.description = fileStore.getDescription();
-                this.fsType = fileStore.getType();
-                this.freeSpace = fileStore.getFreeSpace();
-                this.usableSpace = fileStore.getUsableSpace();
-                this.totalSpace = fileStore.getTotalSpace();
-                this.freeInodes = fileStore.getFreeInodes();
-                this.totalInodes = fileStore.getTotalInodes();
-                return true;
-            }
-        }
-        return false;
+    /**
+     * Copies attributes from another file store into this one.
+     *
+     * @param fileStore the source file store
+     */
+    protected void updateFrom(OSFileStore fileStore) {
+        this.logicalVolume = fileStore.getLogicalVolume();
+        this.description = fileStore.getDescription();
+        this.fsType = fileStore.getType();
+        this.freeSpace = fileStore.getFreeSpace();
+        this.usableSpace = fileStore.getUsableSpace();
+        this.totalSpace = fileStore.getTotalSpace();
+        this.freeInodes = fileStore.getFreeInodes();
+        this.totalInodes = fileStore.getTotalInodes();
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
@@ -2,7 +2,7 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.mac;
+package oshi.software.common.os.mac;
 
 import static oshi.software.os.OSService.State.RUNNING;
 import static oshi.software.os.OSService.State.STOPPED;
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOperatingSystem;
-import oshi.software.common.os.mac.MacOSThread;
 import oshi.software.os.ApplicationInfo;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSService;
@@ -43,7 +42,7 @@ import oshi.util.Util;
 @ThreadSafe
 public abstract class MacOperatingSystem extends AbstractOperatingSystem {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MacOperatingSystemJNA.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MacOperatingSystem.class);
 
     public static final String MACOS_VERSIONS_PROPERTIES = "oshi.macos.versions.properties";
 

--- a/oshi-core-java25/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
@@ -38,6 +38,7 @@ import oshi.ffm.mac.DiskArbitration.DADiskRef;
 import oshi.ffm.mac.DiskArbitration.DASessionRef;
 import oshi.ffm.mac.IOKit.IOIterator;
 import oshi.ffm.mac.IOKit.IORegistryEntry;
+import oshi.software.common.os.mac.MacFileSystem;
 import oshi.software.os.OSFileStore;
 import oshi.util.FileSystemUtil;
 import oshi.util.platform.mac.CFUtilFFM;

--- a/oshi-core-java25/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.mac.WhoFFM;
 import oshi.driver.mac.WindowInfoFFM;
+import oshi.software.common.os.mac.MacOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
@@ -6,13 +6,10 @@ package oshi.software.os.mac;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.PathMatcher;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -34,7 +31,7 @@ import com.sun.jna.platform.mac.SystemB;
 import com.sun.jna.platform.mac.SystemB.Statfs;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.common.AbstractFileSystem;
+import oshi.software.common.os.mac.MacFileSystem;
 import oshi.software.os.OSFileStore;
 import oshi.util.FileSystemUtil;
 import oshi.util.platform.mac.CFUtil;
@@ -46,83 +43,16 @@ import oshi.util.platform.mac.SysctlUtil;
  * /Volumes directory.
  */
 @ThreadSafe
-public class MacFileSystem extends AbstractFileSystem {
+public class MacFileSystemJNA extends MacFileSystem {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MacFileSystem.class);
-
-    public static final String OSHI_MAC_FS_PATH_EXCLUDES = "oshi.os.mac.filesystem.path.excludes";
-    public static final String OSHI_MAC_FS_PATH_INCLUDES = "oshi.os.mac.filesystem.path.includes";
-    public static final String OSHI_MAC_FS_VOLUME_EXCLUDES = "oshi.os.mac.filesystem.volume.excludes";
-    public static final String OSHI_MAC_FS_VOLUME_INCLUDES = "oshi.os.mac.filesystem.volume.includes";
-
-    protected static final List<PathMatcher> FS_PATH_EXCLUDES = FileSystemUtil
-            .loadAndParseFileSystemConfig(OSHI_MAC_FS_PATH_EXCLUDES);
-    protected static final List<PathMatcher> FS_PATH_INCLUDES = FileSystemUtil
-            .loadAndParseFileSystemConfig(OSHI_MAC_FS_PATH_INCLUDES);
-    protected static final List<PathMatcher> FS_VOLUME_EXCLUDES = FileSystemUtil
-            .loadAndParseFileSystemConfig(OSHI_MAC_FS_VOLUME_EXCLUDES);
-    protected static final List<PathMatcher> FS_VOLUME_INCLUDES = FileSystemUtil
-            .loadAndParseFileSystemConfig(OSHI_MAC_FS_VOLUME_INCLUDES);
-
-    // Regexp matcher for /dev/disk1 etc.
-    protected static final Pattern LOCAL_DISK = Pattern.compile("/dev/disk\\d");
-
-    // User specifiable flags.
-    protected static final int MNT_RDONLY = 0x00000001;
-    protected static final int MNT_SYNCHRONOUS = 0x00000002;
-    protected static final int MNT_NOEXEC = 0x00000004;
-    protected static final int MNT_NOSUID = 0x00000008;
-    protected static final int MNT_NODEV = 0x00000010;
-    protected static final int MNT_UNION = 0x00000020;
-    protected static final int MNT_ASYNC = 0x00000040;
-    protected static final int MNT_CPROTECT = 0x00000080;
-    protected static final int MNT_EXPORTED = 0x00000100;
-    protected static final int MNT_QUARANTINE = 0x00000400;
-    protected static final int MNT_LOCAL = 0x00001000;
-    protected static final int MNT_QUOTA = 0x00002000;
-    protected static final int MNT_ROOTFS = 0x00004000;
-    protected static final int MNT_DOVOLFS = 0x00008000;
-    protected static final int MNT_DONTBROWSE = 0x00100000;
-    protected static final int MNT_IGNORE_OWNERSHIP = 0x00200000;
-    protected static final int MNT_AUTOMOUNTED = 0x00400000;
-    protected static final int MNT_JOURNALED = 0x00800000;
-    protected static final int MNT_NOUSERXATTR = 0x01000000;
-    protected static final int MNT_DEFWRITE = 0x02000000;
-    protected static final int MNT_MULTILABEL = 0x04000000;
-    protected static final int MNT_NOATIME = 0x10000000;
-
-    protected static final Map<Integer, String> OPTIONS_MAP = new HashMap<>();
-    static {
-        OPTIONS_MAP.put(MNT_SYNCHRONOUS, "synchronous");
-        OPTIONS_MAP.put(MNT_NOEXEC, "noexec");
-        OPTIONS_MAP.put(MNT_NOSUID, "nosuid");
-        OPTIONS_MAP.put(MNT_NODEV, "nodev");
-        OPTIONS_MAP.put(MNT_UNION, "union");
-        OPTIONS_MAP.put(MNT_ASYNC, "asynchronous");
-        OPTIONS_MAP.put(MNT_CPROTECT, "content-protection");
-        OPTIONS_MAP.put(MNT_EXPORTED, "exported");
-        OPTIONS_MAP.put(MNT_QUARANTINE, "quarantined");
-        OPTIONS_MAP.put(MNT_LOCAL, "local");
-        OPTIONS_MAP.put(MNT_QUOTA, "quotas");
-        OPTIONS_MAP.put(MNT_ROOTFS, "rootfs");
-        OPTIONS_MAP.put(MNT_DOVOLFS, "volfs");
-        OPTIONS_MAP.put(MNT_DONTBROWSE, "nobrowse");
-        OPTIONS_MAP.put(MNT_IGNORE_OWNERSHIP, "noowners");
-        OPTIONS_MAP.put(MNT_AUTOMOUNTED, "automounted");
-        OPTIONS_MAP.put(MNT_JOURNALED, "journaled");
-        OPTIONS_MAP.put(MNT_NOUSERXATTR, "nouserxattr");
-        OPTIONS_MAP.put(MNT_DEFWRITE, "defwrite");
-        OPTIONS_MAP.put(MNT_MULTILABEL, "multilabel");
-        OPTIONS_MAP.put(MNT_NOATIME, "noatime");
-    }
+    private static final Logger LOG = LoggerFactory.getLogger(MacFileSystemJNA.class);
 
     @Override
     public List<OSFileStore> getFileStores(boolean localOnly) {
-        // List of file systems
         return getFileStoreMatching(null, localOnly);
     }
 
-    // Called by MacOSFileStore
+    // Called by MacOSFileStoreJNA
     static List<OSFileStore> getFileStoreMatching(String nameToMatch, boolean localOnly) {
         List<OSFileStore> fsList = new ArrayList<>();
 
@@ -229,7 +159,7 @@ public class MacFileSystem extends AbstractFileSystem {
                         continue;
                     }
 
-                    fsList.add(new MacOSFileStore(name, volume, name, path, options.toString(),
+                    fsList.add(new MacOSFileStoreJNA(name, volume, name, path, options.toString(),
                             uuid == null ? "" : uuid, isLocal, "", description, type, file.getFreeSpace(),
                             file.getUsableSpace(), file.getTotalSpace(), fs[f].f_ffree, fs[f].f_files));
                 }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
@@ -54,21 +54,21 @@ import oshi.util.tuples.Pair;
  * Internet Protocol Stats implementation
  */
 @ThreadSafe
-public class MacInternetProtocolStats extends AbstractInternetProtocolStats {
+public class MacInternetProtocolStatsJNA extends AbstractInternetProtocolStats {
 
     private boolean isElevated;
 
-    public MacInternetProtocolStats(boolean elevated) {
+    public MacInternetProtocolStatsJNA(boolean elevated) {
         this.isElevated = elevated;
     }
 
     private Supplier<Pair<Long, Long>> establishedv4v6 = memoize(NetStat::queryTcpnetstat, defaultExpiration());
-    private Supplier<BsdTcpstat> tcpstat = memoize(MacInternetProtocolStats::queryTcpstat, defaultExpiration());
-    private Supplier<BsdUdpstat> udpstat = memoize(MacInternetProtocolStats::queryUdpstat, defaultExpiration());
+    private Supplier<BsdTcpstat> tcpstat = memoize(MacInternetProtocolStatsJNA::queryTcpstat, defaultExpiration());
+    private Supplier<BsdUdpstat> udpstat = memoize(MacInternetProtocolStatsJNA::queryUdpstat, defaultExpiration());
     // With elevated permissions use tcpstat only
     // Backup estimate get ipstat and subtract off udp
-    private Supplier<BsdIpstat> ipstat = memoize(MacInternetProtocolStats::queryIpstat, defaultExpiration());
-    private Supplier<BsdIp6stat> ip6stat = memoize(MacInternetProtocolStats::queryIp6stat, defaultExpiration());
+    private Supplier<BsdIpstat> ipstat = memoize(MacInternetProtocolStatsJNA::queryIpstat, defaultExpiration());
+    private Supplier<BsdIp6stat> ip6stat = memoize(MacInternetProtocolStatsJNA::queryIp6stat, defaultExpiration());
 
     @Override
     public TcpStats getTCPv4Stats() {

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParamsJNA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 The OSHI Project Contributors
+ * Copyright 2017-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.mac;
@@ -25,12 +25,12 @@ import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 /**
- * MacNetworkParams class.
+ * MacNetworkParamsJNA class.
  */
 @ThreadSafe
-final class MacNetworkParams extends AbstractNetworkParams {
+final class MacNetworkParamsJNA extends AbstractNetworkParams {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MacNetworkParams.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MacNetworkParamsJNA.class);
 
     private static final SystemB SYS = SystemB.INSTANCE;
 

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSFileStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSFileStoreJNA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.mac;
@@ -9,12 +9,12 @@ import oshi.software.common.os.mac.MacOSFileStore;
 import oshi.software.os.OSFileStore;
 
 /**
- * OSFileStore implementation using FFM (no JNA dependency).
+ * OSFileStore implementation
  */
 @ThreadSafe
-public class MacOSFileStoreFFM extends MacOSFileStore {
+public class MacOSFileStoreJNA extends MacOSFileStore {
 
-    public MacOSFileStoreFFM(String name, String volume, String label, String mount, String options, String uuid,
+    public MacOSFileStoreJNA(String name, String volume, String label, String mount, String options, String uuid,
             boolean local, String logicalVolume, String description, String fsType, long freeSpace, long usableSpace,
             long totalSpace, long freeInodes, long totalInodes) {
         super(name, volume, label, mount, options, uuid, local, logicalVolume, description, fsType, freeSpace,
@@ -23,7 +23,7 @@ public class MacOSFileStoreFFM extends MacOSFileStore {
 
     @Override
     public boolean updateAttributes() {
-        for (OSFileStore fileStore : MacFileSystemFFM.getFileStoreMatching(getName(), isLocal())) {
+        for (OSFileStore fileStore : MacFileSystemJNA.getFileStoreMatching(getName(), isLocal())) {
             if (getVolume().equals(fileStore.getVolume()) && getMount().equals(fileStore.getMount())) {
                 updateFrom(fileStore);
                 return true;

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
@@ -45,6 +45,7 @@ import oshi.jna.Struct.CloseableRUsageInfoV2;
 import oshi.jna.Struct.CloseableVnodePathInfo;
 import oshi.software.common.AbstractOSProcess;
 import oshi.software.common.os.mac.MacOSThread;
+import oshi.software.common.os.mac.MacOperatingSystem;
 import oshi.software.os.OSThread;
 import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
@@ -55,9 +56,9 @@ import oshi.util.tuples.Pair;
  * OSProcess implementation
  */
 @ThreadSafe
-public class MacOSProcess extends AbstractOSProcess {
+public class MacOSProcessJNA extends AbstractOSProcess {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MacOSProcess.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MacOSProcessJNA.class);
 
     private static final int ARGMAX = SysctlUtil.sysctl("kern.argmax", 0);
     private static final long TICKS_PER_MS;
@@ -138,7 +139,7 @@ public class MacOSProcess extends AbstractOSProcess {
     private long majorFaults;
     private long contextSwitches;
 
-    public MacOSProcess(int pid, int major, int minor, MacOperatingSystem os) {
+    public MacOSProcessJNA(int pid, int major, int minor, MacOperatingSystem os) {
         super(pid);
         this.majorVersion = major;
         this.minorVersion = minor;

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystemJNA.java
@@ -1,15 +1,21 @@
 /*
- * Copyright 2016-2025 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.mac;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import com.sun.jna.platform.mac.SystemB;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.mac.Who;
 import oshi.driver.mac.WindowInfo;
 import oshi.jna.Struct;
 import oshi.jna.Struct.CloseableTimeval;
+import oshi.software.common.os.mac.MacOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
@@ -20,10 +26,6 @@ import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.platform.mac.SysctlUtil;
 import oshi.util.tuples.Pair;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * macOS, previously Mac OS X and later OS X) is a series of proprietary graphical operating systems developed and
@@ -65,12 +67,12 @@ public class MacOperatingSystemJNA extends MacOperatingSystem {
 
     @Override
     public FileSystem getFileSystem() {
-        return new MacFileSystem();
+        return new MacFileSystemJNA();
     }
 
     @Override
     public InternetProtocolStats getInternetProtocolStats() {
-        return new MacInternetProtocolStats(isElevated());
+        return new MacInternetProtocolStatsJNA(isElevated());
     }
 
     @Override
@@ -107,7 +109,7 @@ public class MacOperatingSystemJNA extends MacOperatingSystem {
 
     @Override
     public OSProcess getProcess(int pid) {
-        OSProcess proc = new MacOSProcess(pid, this.major, this.minor, this);
+        OSProcess proc = new MacOSProcessJNA(pid, this.major, this.minor, this);
         return proc.getState().equals(OSProcess.State.INVALID) ? null : proc;
     }
 
@@ -143,7 +145,7 @@ public class MacOperatingSystemJNA extends MacOperatingSystem {
 
     @Override
     public NetworkParams getNetworkParams() {
-        return new MacNetworkParams();
+        return new MacNetworkParamsJNA();
     }
 
     @Override


### PR DESCRIPTION
Continues the macOS oshi-common migration from #3144 by moving the entire `MacOperatingSystem` class tree and adding JNA suffixes to all remaining JNA-only classes for naming consistency.

### Moved to oshi-common (`oshi.software.common.os.mac`)

| Class | Notes |
|---|---|
| `MacInstalledApps` | Clean move |
| `MacOperatingSystem` | Fixed LOG bug: was `MacOperatingSystemJNA.class`, now `MacOperatingSystem.class` |
| `MacFileSystem` | New abstract base with shared constants, config fields, mount flags, and `OPTIONS_MAP` |
| `MacOSFileStore` | New abstract base with shared fields, constructor, getters, and `updateFrom()` helper |

### Split into JNA/FFM pairs

| Common base (oshi-common) | JNA (oshi-core) | FFM (oshi-core-java25) |
|---|---|---|
| `MacFileSystem` | `MacFileSystemJNA` (new name) | `MacFileSystemFFM` (now extends common base) |
| `MacOSFileStore` | `MacOSFileStoreJNA` (new name) | `MacOSFileStoreFFM` (now extends common base, deduplicated) |

### JNA suffix renames (oshi-core)

| Old name | New name |
|---|---|
| `MacOSProcess` | `MacOSProcessJNA` |
| `MacInternetProtocolStats` | `MacInternetProtocolStatsJNA` |
| `MacNetworkParams` | `MacNetworkParamsJNA` |

### Other changes
- Updated checkstyle suppression line range for `MacOperatingSystem.java`
- Updated all references in `MacOperatingSystemJNA`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized macOS components into clearer abstraction layers and shared base types for filesystem handling.
  * Renamed and separated JNA-specific implementations for improved clarity.
  * Moved several macOS classes to the common macOS package and adjusted visibility and update patterns.

* **Chores**
  * Updated copyright years and cleaned up imports.
  * Adjusted code style/configuration suppressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->