### PR TITLE
Move macOS Hardware superclasses to oshi-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * [#3141](https://github.com/oshi/oshi/pull/3141): Split WindowsOSProcess into superclass with JNA/FFM subclasses; add VersionHelpersFFM; remove TOKEN_DUPLICATE - [@dbwiddis](https://github.com/dbwiddis).
 * [#3143](https://github.com/oshi/oshi/pull/3143): Move PerfmonConstants, WindowsPowerSource, and WindowsOSFileStore to oshi-common; set up Windows driver, hardware, and software packages - [@dbwiddis](https://github.com/dbwiddis).
 * [#3144](https://github.com/oshi/oshi/pull/3144): Move ThreadInfo, MacSoundCard, and MacOSThread to oshi-common; set up macOS driver, hardware, and software packages - [@dbwiddis](https://github.com/dbwiddis).
+* [#3145](https://github.com/oshi/oshi/pull/3145): Move macOS OperatingSystem tree to oshi-common; split MacFileSystem and MacOSFileStore; add JNA suffix to remaining OS classes - [@dbwiddis](https://github.com/dbwiddis).
+* [#3146](https://github.com/oshi/oshi/pull/3146): Move macOS Hardware superclasses to oshi-common; split MacBaseboard, MacComputerSystem, and MacGraphicsCard; add JNA suffix to MacSensors - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -20,8 +20,6 @@
     <suppress checks="ParameterName" files="[\\/]jna[\\/].*"/>
     <suppress checks="TypeName" files="[\\/]jna[\\/].*"/>
 
-    <suppress checks="MethodName" files="MacGlobalMemory\.java" lines="137"/>
-
     <!-- FFM convention -->
     <suppress checks="InterfaceIsType" files="[\\/]ffm[\\/].*"/>
     <suppress checks="ConstantName" files="[\\/]ffm[\\/].*"/>

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxUsbDevice.java
@@ -27,9 +27,9 @@ public class LinuxUsbDevice extends AbstractUsbDevice {
     }
 
     /**
-     * No-arg constructor required so that {@code LinuxUsbDeviceJNA} and {@code LinuxUsbDeviceFFM}, which extend this
-     * class solely to inherit its static helper methods, can compile without an explicit constructor. Neither subclass
-     * is ever instantiated; only this class is, via the full constructor.
+     * No-arg constructor required so that subclasses, which extend this class solely to inherit its static helper
+     * methods, can compile without an explicit constructor. No subclass is ever instantiated; only this class is, via
+     * the full constructor.
      */
     protected LinuxUsbDevice() {
         this("", "", "", "", "", "", emptyList());

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacBaseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacBaseboard.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import static oshi.util.Memoizer.memoize;
+
+import java.util.function.Supplier;
+
+import oshi.annotation.concurrent.Immutable;
+import oshi.hardware.common.AbstractBaseboard;
+import oshi.util.tuples.Quartet;
+
+/**
+ * Baseboard data obtained from ioreg
+ */
+@Immutable
+public abstract class MacBaseboard extends AbstractBaseboard {
+
+    private final Supplier<Quartet<String, String, String, String>> manufModelVersSerial = memoize(this::queryPlatform);
+
+    @Override
+    public String getManufacturer() {
+        return manufModelVersSerial.get().getA();
+    }
+
+    @Override
+    public String getModel() {
+        return manufModelVersSerial.get().getB();
+    }
+
+    @Override
+    public String getVersion() {
+        return manufModelVersSerial.get().getC();
+    }
+
+    @Override
+    public String getSerialNumber() {
+        return manufModelVersSerial.get().getD();
+    }
+
+    protected abstract Quartet<String, String, String, String> queryPlatform();
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacComputerSystem.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import static oshi.util.Memoizer.memoize;
+
+import java.util.function.Supplier;
+
+import oshi.annotation.concurrent.Immutable;
+import oshi.hardware.common.AbstractComputerSystem;
+import oshi.util.tuples.Quartet;
+
+/**
+ * Hardware data obtained from ioreg.
+ */
+@Immutable
+public abstract class MacComputerSystem extends AbstractComputerSystem {
+
+    private final Supplier<Quartet<String, String, String, String>> manufacturerModelSerialUUID = memoize(
+            this::platformExpert);
+
+    @Override
+    public String getManufacturer() {
+        return manufacturerModelSerialUUID.get().getA();
+    }
+
+    @Override
+    public String getModel() {
+        return manufacturerModelSerialUUID.get().getB();
+    }
+
+    @Override
+    public String getSerialNumber() {
+        return manufacturerModelSerialUUID.get().getC();
+    }
+
+    @Override
+    public String getHardwareUUID() {
+        return manufacturerModelSerialUUID.get().getD();
+    }
+
+    protected abstract Quartet<String, String, String, String> platformExpert();
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2025 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.mac;
+package oshi.hardware.common.platform.mac;
 
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
@@ -10,11 +10,6 @@ import static oshi.util.Memoizer.memoize;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.sun.jna.Native;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.PhysicalMemory;
@@ -28,9 +23,7 @@ import oshi.util.ParseUtil;
  * Memory obtained by host_statistics (vm_stat) and sysctl.
  */
 @ThreadSafe
-abstract class MacGlobalMemory extends AbstractGlobalMemory {
-
-    private static final Logger LOG = LoggerFactory.getLogger(MacGlobalMemory.class);
+public abstract class MacGlobalMemory extends AbstractGlobalMemory {
 
     private final Supplier<Long> available = memoize(this::queryVmStats, defaultExpiration());
 
@@ -125,16 +118,13 @@ abstract class MacGlobalMemory extends AbstractGlobalMemory {
         return sysctl("hw.memsize", 0L);
     }
 
-    private long queryPageSize() {
-        long hostPageSize = host_page_size();
-        if (hostPageSize > 0) {
-            return hostPageSize;
-        }
-        LOG.error("Failed to get host page size. Error code: {}", Native.getLastError());
-        return 4098L;
-    }
-
-    protected abstract long host_page_size();
+    /**
+     * Queries the host page size. Implementations should return the page size on success, or {@code 4096L} as a
+     * fallback on failure.
+     *
+     * @return the page size in bytes
+     */
+    protected abstract long queryPageSize();
 
     protected abstract VirtualMemory createVirtualMemory();
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGraphicsCard.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.mac;
+package oshi.hardware.common.platform.mac;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,45 +10,24 @@ import java.util.Locale;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.GraphicsCard;
-import oshi.hardware.GpuStats;
 import oshi.hardware.common.AbstractGraphicsCard;
 import oshi.util.Constants;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.platform.mac.SysctlUtil;
 
 /**
  * Graphics card info obtained by system_profiler SPDisplaysDataType.
  */
 @ThreadSafe
-final class MacGraphicsCard extends AbstractGraphicsCard {
+public abstract class MacGraphicsCard extends AbstractGraphicsCard {
 
-    private static final boolean IS_APPLE_SILICON = "aarch64".equals(System.getProperty("os.arch"));
+    protected static final boolean IS_APPLE_SILICON = "aarch64".equals(System.getProperty("os.arch"));
 
-    /**
-     * Constructor for MacGraphicsCard
-     *
-     * @param name        The name
-     * @param deviceId    The device ID
-     * @param vendor      The vendor
-     * @param versionInfo The version info
-     * @param vram        The VRAM
-     */
-    MacGraphicsCard(String name, String deviceId, String vendor, String versionInfo, long vram) {
+    protected MacGraphicsCard(String name, String deviceId, String vendor, String versionInfo, long vram) {
         super(name, deviceId, vendor, versionInfo, vram);
     }
 
-    @Override
-    public GpuStats createStatsSession() {
-        return new MacGpuStats(IS_APPLE_SILICON, getName());
-    }
-
-    /**
-     * public method used by {@code AbstractHardwareAbstractionLayer} to access the graphics cards.
-     *
-     * @return List of {@link MacGraphicsCard} objects.
-     */
-    public static List<GraphicsCard> getGraphicsCards() {
+    protected static List<GraphicsCard> parseGraphicsCards(GraphicsCardFactory factory, SysctlLong sysctl) {
         List<GraphicsCard> cardList = new ArrayList<>();
         List<String> sp = ExecutingCommand.runNative("system_profiler SPDisplaysDataType");
         String name = Constants.UNKNOWN;
@@ -63,9 +42,9 @@ final class MacGraphicsCard extends AbstractGraphicsCard {
                 String prefix = split[0].toLowerCase(Locale.ROOT);
                 if (prefix.equals("chipset model")) {
                     if (cardNum++ > 0) {
-                        cardList.add(new MacGraphicsCard(name, deviceId, vendor,
+                        cardList.add(factory.create(name, deviceId, vendor,
                                 versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList),
-                                resolveVram(vram, name)));
+                                resolveVram(vram, name, sysctl)));
                         deviceId = Constants.UNKNOWN;
                         vendor = Constants.UNKNOWN;
                         vram = 0;
@@ -84,20 +63,30 @@ final class MacGraphicsCard extends AbstractGraphicsCard {
             }
         }
         if (cardNum > 0) {
-            cardList.add(new MacGraphicsCard(name, deviceId, vendor,
+            cardList.add(factory.create(name, deviceId, vendor,
                     versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList),
-                    resolveVram(vram, name)));
+                    resolveVram(vram, name, sysctl)));
         }
         return cardList;
     }
 
-    private static long resolveVram(long parsedVram, String chipsetName) {
+    private static long resolveVram(long parsedVram, String chipsetName, SysctlLong sysctl) {
         if (parsedVram > 0) {
             return parsedVram;
         }
         if (chipsetName.contains("Apple")) {
-            return SysctlUtil.sysctl("hw.memsize", 0L);
+            return sysctl.get("hw.memsize", 0L);
         }
         return parsedVram;
+    }
+
+    @FunctionalInterface
+    protected interface GraphicsCardFactory {
+        GraphicsCard create(String name, String deviceId, String vendor, String versionInfo, long vram);
+    }
+
+    @FunctionalInterface
+    protected interface SysctlLong {
+        long get(String name, long defaultValue);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacHardwareAbstractionLayer.java
@@ -2,17 +2,14 @@
  * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.mac;
+package oshi.hardware.common.platform.mac;
 
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.LogicalVolumeGroup;
-import oshi.hardware.Printer;
 import oshi.hardware.SoundCard;
 import oshi.hardware.common.AbstractHardwareAbstractionLayer;
-import oshi.hardware.common.platform.mac.MacSoundCard;
-import oshi.hardware.platform.unix.UnixPrinter;
 
 /**
  * MacHardwareAbstractionLayer class.
@@ -28,10 +25,5 @@ public abstract class MacHardwareAbstractionLayer extends AbstractHardwareAbstra
     @Override
     public List<SoundCard> getSoundCards() {
         return MacSoundCard.getSoundCards();
-    }
-
-    @Override
-    public List<Printer> getPrinters() {
-        return UnixPrinter.getPrinters();
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacLogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacLogicalVolumeGroup.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2021-2022 The OSHI Project Contributors
+ * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.mac;
+package oshi.hardware.common.platform.mac;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -16,7 +16,10 @@ import oshi.hardware.LogicalVolumeGroup;
 import oshi.hardware.common.AbstractLogicalVolumeGroup;
 import oshi.util.ExecutingCommand;
 
-final class MacLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
+/**
+ * MacLogicalVolumeGroup class.
+ */
+public final class MacLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
 
     private static final String DISKUTIL_CS_LIST = "diskutil cs list";
     private static final String LOGICAL_VOLUME_GROUP = "Logical Volume Group";
@@ -64,7 +67,8 @@ final class MacLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
             }
         }
         return logicalVolumesMap.entrySet().stream()
-                .map(e -> new MacLogicalVolumeGroup(e.getKey(), e.getValue(), physicalVolumesMap.get(e.getKey())))
+                .map(e -> new MacLogicalVolumeGroup(e.getKey(), e.getValue(),
+                        physicalVolumesMap.getOrDefault(e.getKey(), Collections.emptySet())))
                 .collect(Collectors.toList());
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.mac;
+package oshi.hardware.common.platform.mac;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.sort;
@@ -27,9 +27,9 @@ public class MacUsbDevice extends AbstractUsbDevice {
     }
 
     /**
-     * No-arg constructor required so that {@link MacUsbDeviceJNA} and {@code MacUsbDeviceFFM}, which extend this class
-     * solely to inherit its static helper methods, can compile without an explicit constructor. Neither subclass is
-     * ever instantiated; only this class is, via the full constructor.
+     * No-arg constructor required so that subclasses, which extend this class solely to inherit its static helper
+     * methods, can compile without an explicit constructor. No subclass is ever instantiated; only this class is, via
+     * the full constructor.
      */
     protected MacUsbDevice() {
         this("", "", "", "", "", "", emptyList());

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacVirtualMemory.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2019-2025 The OSHI Project Contributors
+ * Copyright 2019-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.mac;
+package oshi.hardware.common.platform.mac;
 
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
@@ -17,7 +17,7 @@ import oshi.util.tuples.Pair;
  * Memory obtained by host_statistics (vm_stat) and sysctl.
  */
 @ThreadSafe
-abstract class MacVirtualMemory extends AbstractVirtualMemory {
+public abstract class MacVirtualMemory extends AbstractVirtualMemory {
 
     private final MacGlobalMemory global;
 
@@ -30,7 +30,7 @@ abstract class MacVirtualMemory extends AbstractVirtualMemory {
      *
      * @param macGlobalMemory The parent global memory class instantiating this
      */
-    MacVirtualMemory(MacGlobalMemory macGlobalMemory) {
+    protected MacVirtualMemory(MacGlobalMemory macGlobalMemory) {
         this.global = macGlobalMemory;
     }
 

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacBaseboardFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacBaseboardFFM.java
@@ -4,14 +4,11 @@
  */
 package oshi.hardware.platform.mac;
 
-import static oshi.util.Memoizer.memoize;
-
 import java.nio.charset.StandardCharsets;
-import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.ffm.mac.IOKit.IORegistryEntry;
-import oshi.hardware.common.AbstractBaseboard;
+import oshi.hardware.common.platform.mac.MacBaseboard;
 import oshi.util.Constants;
 import oshi.util.Util;
 import oshi.util.platform.mac.IOKitUtilFFM;
@@ -21,32 +18,10 @@ import oshi.util.tuples.Quartet;
  * Baseboard data obtained from ioreg
  */
 @Immutable
-final class MacBaseboardFFM extends AbstractBaseboard {
-
-    private final Supplier<Quartet<String, String, String, String>> manufModelVersSerial = memoize(
-            MacBaseboardFFM::queryPlatform);
+final class MacBaseboardFFM extends MacBaseboard {
 
     @Override
-    public String getManufacturer() {
-        return manufModelVersSerial.get().getA();
-    }
-
-    @Override
-    public String getModel() {
-        return manufModelVersSerial.get().getB();
-    }
-
-    @Override
-    public String getVersion() {
-        return manufModelVersSerial.get().getC();
-    }
-
-    @Override
-    public String getSerialNumber() {
-        return manufModelVersSerial.get().getD();
-    }
-
-    private static Quartet<String, String, String, String> queryPlatform() {
+    protected Quartet<String, String, String, String> queryPlatform() {
         String manufacturer = null;
         String model = null;
         String version = null;

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacComputerSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacComputerSystemFFM.java
@@ -4,16 +4,13 @@
  */
 package oshi.hardware.platform.mac;
 
-import static oshi.util.Memoizer.memoize;
-
 import java.nio.charset.StandardCharsets;
-import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.ffm.mac.IOKit.IORegistryEntry;
 import oshi.hardware.Baseboard;
 import oshi.hardware.Firmware;
-import oshi.hardware.common.AbstractComputerSystem;
+import oshi.hardware.common.platform.mac.MacComputerSystem;
 import oshi.util.Constants;
 import oshi.util.Util;
 import oshi.util.platform.mac.IOKitUtilFFM;
@@ -23,30 +20,7 @@ import oshi.util.tuples.Quartet;
  * Hardware data obtained from ioreg.
  */
 @Immutable
-final class MacComputerSystemFFM extends AbstractComputerSystem {
-
-    private final Supplier<Quartet<String, String, String, String>> manufacturerModelSerialUUID = memoize(
-            MacComputerSystemFFM::platformExpert);
-
-    @Override
-    public String getManufacturer() {
-        return manufacturerModelSerialUUID.get().getA();
-    }
-
-    @Override
-    public String getModel() {
-        return manufacturerModelSerialUUID.get().getB();
-    }
-
-    @Override
-    public String getSerialNumber() {
-        return manufacturerModelSerialUUID.get().getC();
-    }
-
-    @Override
-    public String getHardwareUUID() {
-        return manufacturerModelSerialUUID.get().getD();
-    }
+final class MacComputerSystemFFM extends MacComputerSystem {
 
     @Override
     public Firmware createFirmware() {
@@ -58,7 +32,8 @@ final class MacComputerSystemFFM extends AbstractComputerSystem {
         return new MacBaseboardFFM();
     }
 
-    private static Quartet<String, String, String, String> platformExpert() {
+    @Override
+    protected Quartet<String, String, String, String> platformExpert() {
         String manufacturer = null;
         String model = null;
         String serialNumber = null;

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryFFM.java
@@ -1,18 +1,8 @@
 /*
- * Copyright 2025 The OSHI Project Contributors
+ * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import oshi.annotation.concurrent.ThreadSafe;
-import oshi.ffm.mac.MacSystemFunctions;
-import oshi.hardware.VirtualMemory;
-import oshi.util.platform.mac.SysctlUtilFFM;
-
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
@@ -20,6 +10,18 @@ import static oshi.ffm.mac.MacSystem.VM_FREE_COUNT;
 import static oshi.ffm.mac.MacSystem.VM_INACTIVE_COUNT;
 import static oshi.ffm.mac.MacSystem.VM_STATISTICS;
 import static oshi.ffm.mac.MacSystemFunctions.mach_host_self;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.mac.MacSystemFunctions;
+import oshi.hardware.VirtualMemory;
+import oshi.hardware.common.platform.mac.MacGlobalMemory;
+import oshi.util.platform.mac.SysctlUtilFFM;
 
 @ThreadSafe
 final class MacGlobalMemoryFFM extends MacGlobalMemory {
@@ -50,17 +52,19 @@ final class MacGlobalMemoryFFM extends MacGlobalMemory {
     }
 
     @Override
-    protected long host_page_size() {
+    protected long queryPageSize() {
+        int result = -1;
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment pageSize = arena.allocate(JAVA_LONG);
-            int result = MacSystemFunctions.host_page_size(mach_host_self(), pageSize);
+            result = MacSystemFunctions.host_page_size(mach_host_self(), pageSize);
             if (result == 0) {
                 return pageSize.get(JAVA_LONG, 0);
             }
         } catch (Throwable t) {
             // IGNORED
         }
-        return -1;
+        LOG.error("Failed to get host page size. Error code: {}", result);
+        return 4096L;
     }
 
     @Override

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerFFM.java
@@ -11,14 +11,15 @@ import oshi.ffm.unix.CupsPrinter;
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.ComputerSystem;
 import oshi.hardware.Display;
-import oshi.hardware.GraphicsCard;
 import oshi.hardware.GlobalMemory;
+import oshi.hardware.GraphicsCard;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.PowerSource;
 import oshi.hardware.Printer;
 import oshi.hardware.Sensors;
 import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.mac.MacHardwareAbstractionLayer;
 
 @ThreadSafe
 public final class MacHardwareAbstractionLayerFFM extends MacHardwareAbstractionLayer {

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
@@ -26,6 +26,7 @@ import oshi.ffm.mac.CoreFoundationFunctions;
 import oshi.ffm.mac.IOKit.IOIterator;
 import oshi.ffm.mac.IOKit.IORegistryEntry;
 import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.mac.MacUsbDevice;
 import oshi.util.platform.mac.IOKitUtilFFM;
 
 /**

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacVirtualMemoryFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacVirtualMemoryFFM.java
@@ -1,25 +1,27 @@
 /*
- * Copyright 2025 The OSHI Project Contributors
+ * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import oshi.annotation.concurrent.ThreadSafe;
-import oshi.ffm.mac.MacSystem;
-import oshi.util.ParseUtil;
-import oshi.util.platform.mac.SysctlUtilFFM;
-import oshi.util.tuples.Pair;
-
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.mac.MacSystem.VM_STATISTICS;
 import static oshi.ffm.mac.MacSystem.XSW_USAGE_TOTAL;
 import static oshi.ffm.mac.MacSystem.XSW_USAGE_USED;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.mac.MacSystem;
+import oshi.hardware.common.platform.mac.MacVirtualMemory;
+import oshi.util.ParseUtil;
+import oshi.util.platform.mac.SysctlUtilFFM;
+import oshi.util.tuples.Pair;
 
 @ThreadSafe
 final class MacVirtualMemoryFFM extends MacVirtualMemory {

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacBaseboardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacBaseboardJNA.java
@@ -1,54 +1,29 @@
 /*
- * Copyright 2016-2022 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
 
-import static oshi.util.Memoizer.memoize;
-
 import java.nio.charset.StandardCharsets;
-import java.util.function.Supplier;
 
 import com.sun.jna.Native;
 import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
 import com.sun.jna.platform.mac.IOKitUtil;
 
 import oshi.annotation.concurrent.Immutable;
-import oshi.hardware.common.AbstractBaseboard;
+import oshi.hardware.common.platform.mac.MacBaseboard;
 import oshi.util.Constants;
 import oshi.util.Util;
 import oshi.util.tuples.Quartet;
 
 /**
- * Baseboard data obtained from ioreg
+ * Baseboard data obtained from ioreg using JNA.
  */
 @Immutable
-final class MacBaseboard extends AbstractBaseboard {
-
-    private final Supplier<Quartet<String, String, String, String>> manufModelVersSerial = memoize(
-            MacBaseboard::queryPlatform);
+final class MacBaseboardJNA extends MacBaseboard {
 
     @Override
-    public String getManufacturer() {
-        return manufModelVersSerial.get().getA();
-    }
-
-    @Override
-    public String getModel() {
-        return manufModelVersSerial.get().getB();
-    }
-
-    @Override
-    public String getVersion() {
-        return manufModelVersSerial.get().getC();
-    }
-
-    @Override
-    public String getSerialNumber() {
-        return manufModelVersSerial.get().getD();
-    }
-
-    private static Quartet<String, String, String, String> queryPlatform() {
+    protected Quartet<String, String, String, String> queryPlatform() {
         String manufacturer = null;
         String model = null;
         String version = null;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacComputerSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacComputerSystemJNA.java
@@ -1,13 +1,10 @@
 /*
- * Copyright 2016-2022 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
 
-import static oshi.util.Memoizer.memoize;
-
 import java.nio.charset.StandardCharsets;
-import java.util.function.Supplier;
 
 import com.sun.jna.Native;
 import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
@@ -16,39 +13,16 @@ import com.sun.jna.platform.mac.IOKitUtil;
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Baseboard;
 import oshi.hardware.Firmware;
-import oshi.hardware.common.AbstractComputerSystem;
+import oshi.hardware.common.platform.mac.MacComputerSystem;
 import oshi.util.Constants;
 import oshi.util.Util;
 import oshi.util.tuples.Quartet;
 
 /**
- * Hardware data obtained from ioreg.
+ * Hardware data obtained from ioreg using JNA.
  */
 @Immutable
-final class MacComputerSystem extends AbstractComputerSystem {
-
-    private final Supplier<Quartet<String, String, String, String>> manufacturerModelSerialUUID = memoize(
-            MacComputerSystem::platformExpert);
-
-    @Override
-    public String getManufacturer() {
-        return manufacturerModelSerialUUID.get().getA();
-    }
-
-    @Override
-    public String getModel() {
-        return manufacturerModelSerialUUID.get().getB();
-    }
-
-    @Override
-    public String getSerialNumber() {
-        return manufacturerModelSerialUUID.get().getC();
-    }
-
-    @Override
-    public String getHardwareUUID() {
-        return manufacturerModelSerialUUID.get().getD();
-    }
+final class MacComputerSystemJNA extends MacComputerSystem {
 
     @Override
     public Firmware createFirmware() {
@@ -57,10 +31,11 @@ final class MacComputerSystem extends AbstractComputerSystem {
 
     @Override
     public Baseboard createBaseboard() {
-        return new MacBaseboard();
+        return new MacBaseboardJNA();
     }
 
-    private static Quartet<String, String, String, String> platformExpert() {
+    @Override
+    protected Quartet<String, String, String, String> platformExpert() {
         String manufacturer = null;
         String model = null;
         String serialNumber = null;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryJNA.java
@@ -1,19 +1,21 @@
 /*
- * Copyright 2025 The OSHI Project Contributors
+ * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.sun.jna.Native;
 import com.sun.jna.platform.mac.SystemB;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.VirtualMemory;
+import oshi.hardware.common.platform.mac.MacGlobalMemory;
+import oshi.jna.ByRef.CloseableIntByReference;
 import oshi.jna.ByRef.CloseableLongByReference;
 import oshi.jna.Struct.CloseableVMStatistics;
-import oshi.jna.ByRef.CloseableIntByReference;
 import oshi.util.platform.mac.SysctlUtil;
 
 @ThreadSafe
@@ -40,15 +42,17 @@ final class MacGlobalMemoryJNA extends MacGlobalMemory {
     }
 
     @Override
-    protected long host_page_size() {
+    protected long queryPageSize() {
         try (CloseableLongByReference pPageSize = new CloseableLongByReference()) {
             if (0 == SystemB.INSTANCE.host_page_size(SystemB.INSTANCE.mach_host_self(), pPageSize)) {
                 return pPageSize.getValue();
             }
         }
-        return -1;
+        LOG.error("Failed to get host page size. Error code: {}", Native.getLastError());
+        return 4096L;
     }
 
+    @Override
     protected VirtualMemory createVirtualMemory() {
         return new MacVirtualMemoryJNA(this);
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGraphicsCardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGraphicsCardJNA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
@@ -10,24 +10,24 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.GpuStats;
 import oshi.hardware.GraphicsCard;
 import oshi.hardware.common.platform.mac.MacGraphicsCard;
-import oshi.util.platform.mac.SysctlUtilFFM;
+import oshi.util.platform.mac.SysctlUtil;
 
 /**
- * Graphics card info obtained by system_profiler SPDisplaysDataType.
+ * Graphics card info obtained by system_profiler SPDisplaysDataType using JNA.
  */
 @ThreadSafe
-final class MacGraphicsCardFFM extends MacGraphicsCard {
+final class MacGraphicsCardJNA extends MacGraphicsCard {
 
-    MacGraphicsCardFFM(String name, String deviceId, String vendor, String versionInfo, long vram) {
+    MacGraphicsCardJNA(String name, String deviceId, String vendor, String versionInfo, long vram) {
         super(name, deviceId, vendor, versionInfo, vram);
     }
 
     @Override
     public GpuStats createStatsSession() {
-        return new MacGpuStatsFFM(IS_APPLE_SILICON, getName());
+        return new MacGpuStats(IS_APPLE_SILICON, getName());
     }
 
     public static List<GraphicsCard> getGraphicsCards() {
-        return parseGraphicsCards(MacGraphicsCardFFM::new, SysctlUtilFFM::sysctl);
+        return parseGraphicsCards(MacGraphicsCardJNA::new, SysctlUtil::sysctl);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerJNA.java
@@ -15,8 +15,11 @@ import oshi.hardware.GraphicsCard;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.PowerSource;
+import oshi.hardware.Printer;
 import oshi.hardware.Sensors;
 import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.mac.MacHardwareAbstractionLayer;
+import oshi.hardware.platform.unix.UnixPrinter;
 
 /**
  * MacHardwareAbstractionLayer JNA implementation.
@@ -26,7 +29,7 @@ public final class MacHardwareAbstractionLayerJNA extends MacHardwareAbstraction
 
     @Override
     public ComputerSystem createComputerSystem() {
-        return new MacComputerSystem();
+        return new MacComputerSystemJNA();
     }
 
     @Override
@@ -41,7 +44,7 @@ public final class MacHardwareAbstractionLayerJNA extends MacHardwareAbstraction
 
     @Override
     public Sensors createSensors() {
-        return new MacSensors();
+        return new MacSensorsJNA();
     }
 
     @Override
@@ -71,6 +74,11 @@ public final class MacHardwareAbstractionLayerJNA extends MacHardwareAbstraction
 
     @Override
     public List<GraphicsCard> getGraphicsCards() {
-        return MacGraphicsCard.getGraphicsCards();
+        return MacGraphicsCardJNA.getGraphicsCards();
+    }
+
+    @Override
+    public List<Printer> getPrinters() {
+        return UnixPrinter.getPrinters();
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensorsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensorsJNA.java
@@ -4,6 +4,13 @@
  */
 package oshi.hardware.platform.mac;
 
+import static oshi.util.platform.mac.SmcUtil.SMC_KEYS_CPU_TEMP_AS;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_TEMP;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_VOLTAGE;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_VOLTAGE_AS;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEY_FAN_NUM;
+import static oshi.util.platform.mac.SmcUtil.SMC_KEY_FAN_SPEED;
+
 import java.util.Locale;
 
 import com.sun.jna.platform.mac.IOKit.IOConnect;
@@ -11,18 +18,12 @@ import com.sun.jna.platform.mac.IOKit.IOConnect;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.AbstractSensors;
 import oshi.util.platform.mac.SmcUtil;
-import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_TEMP;
-import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_VOLTAGE;
-import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_VOLTAGE_AS;
-import static oshi.util.platform.mac.SmcUtil.SMC_KEY_FAN_NUM;
-import static oshi.util.platform.mac.SmcUtil.SMC_KEY_FAN_SPEED;
-import static oshi.util.platform.mac.SmcUtil.SMC_KEYS_CPU_TEMP_AS;
 
 /**
  * Sensors from SMC
  */
 @ThreadSafe
-final class MacSensors extends AbstractSensors {
+final class MacSensorsJNA extends AbstractSensors {
 
     private volatile int numFans = 0;
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceJNA.java
@@ -22,6 +22,7 @@ import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
 import com.sun.jna.platform.mac.IOKitUtil;
 
 import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.mac.MacUsbDevice;
 
 /**
  * Mac USB device helper using JNA/IOKit. Instantiates {@link MacUsbDevice} objects.

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacVirtualMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacVirtualMemoryJNA.java
@@ -1,13 +1,16 @@
 /*
- * Copyright 2025 The OSHI Project Contributors
+ * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
 
-import com.sun.jna.Native;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.sun.jna.Native;
+
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.common.platform.mac.MacVirtualMemory;
 import oshi.jna.ByRef.CloseableIntByReference;
 import oshi.jna.Struct.CloseableVMStatistics;
 import oshi.jna.Struct.CloseableXswUsage;


### PR DESCRIPTION
Continues macOS migration to `oshi-common` by moving hardware superclasses and splitting classes with JNA/FFM variants.

### Moved to `oshi.hardware.common.platform.mac` (existing superclasses)

| Class | Notes |
|-------|-------|
| `MacGlobalMemory` | Replaced `host_page_size()` + private `queryPageSize()` with single `protected abstract queryPageSize()`, removing `Native.getLastError()` JNA dependency. Fixed page size fallback from `4098L` to `4096L`. |
| `MacHardwareAbstractionLayer` | Removed `getPrinters()` (depended on `UnixPrinter` in oshi-core); moved to JNA subclass. FFM subclass already had its own override. |
| `MacUsbDevice` | Clean move |
| `MacVirtualMemory` | Clean move |
| `MacLogicalVolumeGroup` | Clean move — pure Java, no JNA dependencies |

### Split into common superclass + JNA/FFM subclasses

| Common base (oshi-common) | JNA (oshi-core) | FFM (oshi-core-java25) |
|--------------------------|-----------------|----------------------|
| `MacBaseboard` (new abstract — getters + memoized Supplier) | `MacBaseboardJNA` (renamed — JNA `queryPlatform()`) | `MacBaseboardFFM` (now extends common) |
| `MacComputerSystem` (new abstract — getters + memoized Supplier) | `MacComputerSystemJNA` (renamed — JNA `platformExpert()`, factory methods) | `MacComputerSystemFFM` (now extends common) |
| `MacGraphicsCard` (refactored — shared parsing via `parseGraphicsCards()` with factory + sysctl lambdas) | `MacGraphicsCardJNA` (renamed — thin subclass) | `MacGraphicsCardFFM` (now extends common, uses `parseGraphicsCards`) |

### JNA rename only

| Old | New | Notes |
|-----|-----|-------|
| `MacSensors` | `MacSensorsJNA` | Every method body differs between JNA/FFM (different SMC utilities) — no shared code to extract |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Improved macOS hardware detection and extensibility with clearer separation of common vs platform-specific logic.
  * More reliable memory page-size reporting with a defined 4096 fallback and improved error handling.
  * Enhanced GPU discovery and stats collection on macOS.
  * Restored printer reporting via the macOS implementation.

* **Documentation**
  * Updated CHANGELOG for upcoming 6.12.0 with macOS refactor notes.

* **Chores**
  * Adjusted style/check suppression settings for the reorg.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->