### PR TITLE
Log return codes instead of errno for Mach kernel functions

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessor.java
@@ -203,8 +203,9 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
         int machPort = SystemB.INSTANCE.mach_host_self();
         try (CloseableHostCpuLoadInfo cpuLoadInfo = new CloseableHostCpuLoadInfo();
                 CloseableIntByReference size = new CloseableIntByReference(cpuLoadInfo.size())) {
-            if (0 != SystemB.INSTANCE.host_statistics(machPort, SystemB.HOST_CPU_LOAD_INFO, cpuLoadInfo, size)) {
-                LOG.error("Failed to get System CPU ticks. Error code: {} ", Native.getLastError());
+            int ret = SystemB.INSTANCE.host_statistics(machPort, SystemB.HOST_CPU_LOAD_INFO, cpuLoadInfo, size);
+            if (0 != ret) {
+                LOG.error("Failed to get System CPU ticks. Error code: {} ", ret);
                 return ticks;
             }
 
@@ -258,9 +259,10 @@ final class MacCentralProcessor extends AbstractCentralProcessor {
         try (CloseableIntByReference procCount = new CloseableIntByReference();
                 CloseablePointerByReference procCpuLoadInfo = new CloseablePointerByReference();
                 CloseableIntByReference procInfoCount = new CloseableIntByReference()) {
-            if (0 != SystemB.INSTANCE.host_processor_info(machPort, SystemB.PROCESSOR_CPU_LOAD_INFO, procCount,
-                    procCpuLoadInfo, procInfoCount)) {
-                LOG.error("Failed to update CPU Load. Error code: {}", Native.getLastError());
+            int ret = SystemB.INSTANCE.host_processor_info(machPort, SystemB.PROCESSOR_CPU_LOAD_INFO, procCount,
+                    procCpuLoadInfo, procInfoCount);
+            if (0 != ret) {
+                LOG.error("Failed to update CPU Load. Error code: {}", ret);
                 return ticks;
             }
             try {

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryJNA.java
@@ -7,7 +7,6 @@ package oshi.hardware.platform.mac;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.Native;
 import com.sun.jna.platform.mac.SystemB;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -27,9 +26,10 @@ final class MacGlobalMemoryJNA extends MacGlobalMemory {
     protected long queryVmStats() {
         try (CloseableVMStatistics vmStats = new CloseableVMStatistics();
                 CloseableIntByReference size = new CloseableIntByReference(vmStats.size() / SystemB.INT_SIZE)) {
-            if (0 != SystemB.INSTANCE.host_statistics(SystemB.INSTANCE.mach_host_self(), SystemB.HOST_VM_INFO, vmStats,
-                    size)) {
-                LOG.error("Failed to get host VM info. Error code: {}", Native.getLastError());
+            int ret = SystemB.INSTANCE.host_statistics(SystemB.INSTANCE.mach_host_self(), SystemB.HOST_VM_INFO, vmStats,
+                    size);
+            if (0 != ret) {
+                LOG.error("Failed to get host VM info. Error code: {}", ret);
                 return 0L;
             }
             return (vmStats.free_count + vmStats.inactive_count) * getPageSize();
@@ -43,12 +43,14 @@ final class MacGlobalMemoryJNA extends MacGlobalMemory {
 
     @Override
     protected long queryPageSize() {
+        int ret = -1;
         try (CloseableLongByReference pPageSize = new CloseableLongByReference()) {
-            if (0 == SystemB.INSTANCE.host_page_size(SystemB.INSTANCE.mach_host_self(), pPageSize)) {
+            ret = SystemB.INSTANCE.host_page_size(SystemB.INSTANCE.mach_host_self(), pPageSize);
+            if (0 == ret) {
                 return pPageSize.getValue();
             }
         }
-        LOG.error("Failed to get host page size. Error code: {}", Native.getLastError());
+        LOG.error("Failed to get host page size. Error code: {}", ret);
         return 4096L;
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacVirtualMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacVirtualMemoryJNA.java
@@ -7,8 +7,6 @@ package oshi.hardware.platform.mac;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.Native;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.platform.mac.MacVirtualMemory;
 import oshi.jna.ByRef.CloseableIntByReference;
@@ -46,12 +44,13 @@ final class MacVirtualMemoryJNA extends MacVirtualMemory {
         long swapPagesOut = 0L;
         try (CloseableVMStatistics vmStats = new CloseableVMStatistics();
                 CloseableIntByReference size = new CloseableIntByReference(vmStats.size() / SystemB.INT_SIZE)) {
-            if (0 == SystemB.INSTANCE.host_statistics(SystemB.INSTANCE.mach_host_self(), SystemB.HOST_VM_INFO, vmStats,
-                    size)) {
+            int ret = SystemB.INSTANCE.host_statistics(SystemB.INSTANCE.mach_host_self(), SystemB.HOST_VM_INFO, vmStats,
+                    size);
+            if (0 == ret) {
                 swapPagesIn = ParseUtil.unsignedIntToLong(vmStats.pageins);
                 swapPagesOut = ParseUtil.unsignedIntToLong(vmStats.pageouts);
             } else {
-                LOG.error("Failed to get host VM info. Error code: {}", Native.getLastError());
+                LOG.error("Failed to get host VM info. Error code: {}", ret);
             }
         }
         return new Pair<>(swapPagesIn, swapPagesOut);


### PR DESCRIPTION
Mach kernel functions (`host_statistics`, `host_page_size`, `host_processor_info`) return `kern_return_t` error codes directly, unlike POSIX/C functions which return -1 and set `errno`. The existing code incorrectly logged `Native.getLastError()` (which reads `errno`) instead of the actual return value.

This fixes 5 call sites across 3 files:

| File | Function | 
|---|---|
| `MacGlobalMemoryJNA` | `host_statistics` |
| `MacGlobalMemoryJNA` | `host_page_size` |
| `MacVirtualMemoryJNA` | `host_statistics` |
| `MacCentralProcessor` | `host_statistics` |
| `MacCentralProcessor` | `host_processor_info` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for macOS CPU load and memory information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->