### PR TITLE
Move more macOS hardware superclasses to oshi-common

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacNetworkIF.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import java.net.NetworkInterface;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.common.AbstractNetworkIF;
+
+/**
+ * Base class for macOS NetworkIF implementations. Subclasses provide platform-specific display name resolution and
+ * network statistics updates.
+ */
+@ThreadSafe
+public abstract class MacNetworkIF extends AbstractNetworkIF {
+
+    private int ifType;
+    private long bytesRecv;
+    private long bytesSent;
+    private long packetsRecv;
+    private long packetsSent;
+    private long inErrors;
+    private long outErrors;
+    private long inDrops;
+    private long collisions;
+    private long speed;
+    private long timeStamp;
+
+    protected MacNetworkIF(NetworkInterface netint, String displayName) throws InstantiationException {
+        super(netint, displayName);
+    }
+
+    @Override
+    public int getIfType() {
+        return this.ifType;
+    }
+
+    @Override
+    public long getBytesRecv() {
+        return this.bytesRecv;
+    }
+
+    @Override
+    public long getBytesSent() {
+        return this.bytesSent;
+    }
+
+    @Override
+    public long getPacketsRecv() {
+        return this.packetsRecv;
+    }
+
+    @Override
+    public long getPacketsSent() {
+        return this.packetsSent;
+    }
+
+    @Override
+    public long getInErrors() {
+        return this.inErrors;
+    }
+
+    @Override
+    public long getOutErrors() {
+        return this.outErrors;
+    }
+
+    @Override
+    public long getInDrops() {
+        return this.inDrops;
+    }
+
+    @Override
+    public long getCollisions() {
+        return this.collisions;
+    }
+
+    @Override
+    public long getSpeed() {
+        return this.speed;
+    }
+
+    @Override
+    public long getTimeStamp() {
+        return this.timeStamp;
+    }
+
+    protected void setIfType(int ifType) {
+        this.ifType = ifType;
+    }
+
+    protected void setBytesRecv(long bytesRecv) {
+        this.bytesRecv = bytesRecv;
+    }
+
+    protected void setBytesSent(long bytesSent) {
+        this.bytesSent = bytesSent;
+    }
+
+    protected void setPacketsRecv(long packetsRecv) {
+        this.packetsRecv = packetsRecv;
+    }
+
+    protected void setPacketsSent(long packetsSent) {
+        this.packetsSent = packetsSent;
+    }
+
+    protected void setInErrors(long inErrors) {
+        this.inErrors = inErrors;
+    }
+
+    protected void setOutErrors(long outErrors) {
+        this.outErrors = outErrors;
+    }
+
+    protected void setInDrops(long inDrops) {
+        this.inDrops = inDrops;
+    }
+
+    protected void setCollisions(long collisions) {
+        this.collisions = collisions;
+    }
+
+    protected void setSpeed(long speed) {
+        this.speed = speed;
+    }
+
+    protected void setTimeStamp(long timeStamp) {
+        this.timeStamp = timeStamp;
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacPowerSource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import java.time.LocalDate;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.common.AbstractPowerSource;
+
+/**
+ * A Power Source
+ */
+@ThreadSafe
+public abstract class MacPowerSource extends AbstractPowerSource {
+
+    public MacPowerSource(String psName, String psDeviceName, double psRemainingCapacityPercent,
+            double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
+            double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
+            CapacityUnits psCapacityUnits, int psCurrentCapacity, int psMaxCapacity, int psDesignCapacity,
+            int psCycleCount, String psChemistry, LocalDate psManufactureDate, String psManufacturer,
+            String psSerialNumber, double psTemperature) {
+        super(psName, psDeviceName, psRemainingCapacityPercent, psTimeRemainingEstimated, psTimeRemainingInstant,
+                psPowerUsageRate, psVoltage, psAmperage, psPowerOnLine, psCharging, psDischarging, psCapacityUnits,
+                psCurrentCapacity, psMaxCapacity, psDesignCapacity, psCycleCount, psChemistry, psManufactureDate,
+                psManufacturer, psSerialNumber, psTemperature);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacNetworkIFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacNetworkIFFM.java
@@ -23,27 +23,15 @@ import oshi.driver.mac.net.NetStat.IFdata;
 import oshi.ffm.mac.CoreFoundation.CFArrayRef;
 import oshi.ffm.mac.CoreFoundation.CFStringRef;
 import oshi.hardware.NetworkIF;
-import oshi.hardware.common.AbstractNetworkIF;
+import oshi.hardware.common.platform.mac.MacNetworkIF;
 
 /**
  * MacNetworks FFM implementation.
  */
 @ThreadSafe
-public final class MacNetworkIFFM extends AbstractNetworkIF {
+public final class MacNetworkIFFM extends MacNetworkIF {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacNetworkIFFM.class);
-
-    private int ifType;
-    private long bytesRecv;
-    private long bytesSent;
-    private long packetsRecv;
-    private long packetsSent;
-    private long inErrors;
-    private long outErrors;
-    private long inDrops;
-    private long collisions;
-    private long speed;
-    private long timeStamp;
 
     public MacNetworkIFFM(NetworkInterface netint, Map<Integer, IFdata> data) throws InstantiationException {
         super(netint, queryIfDisplayName(netint));
@@ -96,61 +84,6 @@ public final class MacNetworkIFFM extends AbstractNetworkIF {
     }
 
     @Override
-    public int getIfType() {
-        return this.ifType;
-    }
-
-    @Override
-    public long getBytesRecv() {
-        return this.bytesRecv;
-    }
-
-    @Override
-    public long getBytesSent() {
-        return this.bytesSent;
-    }
-
-    @Override
-    public long getPacketsRecv() {
-        return this.packetsRecv;
-    }
-
-    @Override
-    public long getPacketsSent() {
-        return this.packetsSent;
-    }
-
-    @Override
-    public long getInErrors() {
-        return this.inErrors;
-    }
-
-    @Override
-    public long getOutErrors() {
-        return this.outErrors;
-    }
-
-    @Override
-    public long getInDrops() {
-        return this.inDrops;
-    }
-
-    @Override
-    public long getCollisions() {
-        return this.collisions;
-    }
-
-    @Override
-    public long getSpeed() {
-        return this.speed;
-    }
-
-    @Override
-    public long getTimeStamp() {
-        return this.timeStamp;
-    }
-
-    @Override
     public boolean updateAttributes() {
         int index = queryNetworkInterface().getIndex();
         return updateNetworkStats(NetStat.queryIFdata(index));
@@ -160,17 +93,17 @@ public final class MacNetworkIFFM extends AbstractNetworkIF {
         int index = queryNetworkInterface().getIndex();
         if (data.containsKey(index)) {
             IFdata ifData = data.get(index);
-            this.ifType = ifData.getIfType();
-            this.bytesSent = ifData.getOBytes();
-            this.bytesRecv = ifData.getIBytes();
-            this.packetsSent = ifData.getOPackets();
-            this.packetsRecv = ifData.getIPackets();
-            this.outErrors = ifData.getOErrors();
-            this.inErrors = ifData.getIErrors();
-            this.collisions = ifData.getCollisions();
-            this.inDrops = ifData.getIDrops();
-            this.speed = ifData.getSpeed();
-            this.timeStamp = ifData.getTimeStamp();
+            setIfType(ifData.getIfType());
+            setBytesSent(ifData.getOBytes());
+            setBytesRecv(ifData.getIBytes());
+            setPacketsSent(ifData.getOPackets());
+            setPacketsRecv(ifData.getIPackets());
+            setOutErrors(ifData.getOErrors());
+            setInErrors(ifData.getIErrors());
+            setCollisions(ifData.getCollisions());
+            setInDrops(ifData.getIDrops());
+            setSpeed(ifData.getSpeed());
+            setTimeStamp(ifData.getTimeStamp());
             return true;
         }
         return false;

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
@@ -24,7 +24,7 @@ import oshi.ffm.mac.CoreFoundation.CFStringRef;
 import oshi.ffm.mac.CoreFoundationFunctions;
 import oshi.ffm.mac.IOKit.IOService;
 import oshi.hardware.PowerSource;
-import oshi.hardware.common.AbstractPowerSource;
+import oshi.hardware.common.platform.mac.MacPowerSource;
 import oshi.util.Constants;
 import oshi.util.platform.mac.CFUtilFFM;
 import oshi.util.platform.mac.IOKitUtilFFM;
@@ -33,7 +33,7 @@ import oshi.util.platform.mac.IOKitUtilFFM;
  * A Power Source
  */
 @ThreadSafe
-public final class MacPowerSourceFFM extends AbstractPowerSource {
+public final class MacPowerSourceFFM extends MacPowerSource {
 
     public MacPowerSourceFFM(String psName, String psDeviceName, double psRemainingCapacityPercent,
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
@@ -26,18 +26,18 @@ import oshi.hardware.common.AbstractDisplay;
  * A Display
  */
 @Immutable
-final class MacDisplay extends AbstractDisplay {
+final class MacDisplayJNA extends AbstractDisplay {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MacDisplay.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MacDisplayJNA.class);
 
     /**
-     * Constructor for MacDisplay.
+     * Constructor for MacDisplayJNA.
      *
      * @param edid a byte array representing a display EDID
      */
-    MacDisplay(byte[] edid) {
+    MacDisplayJNA(byte[] edid) {
         super(edid);
-        LOG.debug("Initialized MacDisplay");
+        LOG.debug("Initialized MacDisplayJNA");
     }
 
     /**
@@ -84,7 +84,7 @@ final class MacDisplay extends AbstractDisplay {
                                 // EDID is a byte array of 128 bytes (or more)
                                 int length = edid.getLength();
                                 Pointer p = edid.getBytePtr();
-                                displays.add(new MacDisplay(p.getByteArray(0, length)));
+                                displays.add(new MacDisplayJNA(p.getByteArray(0, length)));
                             } finally {
                                 edid.release();
                             }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
@@ -8,6 +8,9 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.mac.CoreFoundation;
 import com.sun.jna.platform.mac.CoreFoundation.CFMutableDictionaryRef;
@@ -17,9 +20,6 @@ import com.sun.jna.platform.mac.IOKit.IOConnect;
 import com.sun.jna.platform.mac.IOKit.IOIterator;
 import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
 import com.sun.jna.platform.mac.IOKitUtil;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.mac.IOReportClient;
@@ -42,9 +42,9 @@ import oshi.util.platform.mac.SmcUtil;
  * Clock speeds, fan speed, and shared memory are not available on any macOS path and always return -1.
  */
 @ThreadSafe
-final class MacGpuStats implements GpuStats {
+final class MacGpuStatsJNA implements GpuStats {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MacGpuStats.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MacGpuStatsJNA.class);
     private static final CoreFoundation CF = CoreFoundation.INSTANCE;
 
     private static final String PERF_STATS_KEY = "PerformanceStatistics";
@@ -63,7 +63,7 @@ final class MacGpuStats implements GpuStats {
 
     private boolean closed;
 
-    MacGpuStats(boolean isAppleSilicon, String cardName) {
+    MacGpuStatsJNA(boolean isAppleSilicon, String cardName) {
         this.isAppleSilicon = isAppleSilicon;
         this.cardName = cardName;
         this.ioReportClient = isAppleSilicon ? IOReportClient.create() : null;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGraphicsCardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGraphicsCardJNA.java
@@ -24,7 +24,7 @@ final class MacGraphicsCardJNA extends MacGraphicsCard {
 
     @Override
     public GpuStats createStatsSession() {
-        return new MacGpuStats(IS_APPLE_SILICON, getName());
+        return new MacGpuStatsJNA(IS_APPLE_SILICON, getName());
     }
 
     public static List<GraphicsCard> getGraphicsCards() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerJNA.java
@@ -49,7 +49,7 @@ public final class MacHardwareAbstractionLayerJNA extends MacHardwareAbstraction
 
     @Override
     public List<PowerSource> getPowerSources() {
-        return MacPowerSource.getPowerSources();
+        return MacPowerSourceJNA.getPowerSources();
     }
 
     @Override
@@ -59,12 +59,12 @@ public final class MacHardwareAbstractionLayerJNA extends MacHardwareAbstraction
 
     @Override
     public List<Display> getDisplays() {
-        return MacDisplay.getDisplays();
+        return MacDisplayJNA.getDisplays();
     }
 
     @Override
     public List<NetworkIF> getNetworkIFs(boolean includeLocalInterfaces) {
-        return MacNetworkIF.getNetworks(includeLocalInterfaces);
+        return MacNetworkIFJNA.getNetworks(includeLocalInterfaces);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIFJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIFJNA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
@@ -20,31 +20,19 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.mac.net.NetStat;
 import oshi.driver.mac.net.NetStat.IFdata;
 import oshi.hardware.NetworkIF;
-import oshi.hardware.common.AbstractNetworkIF;
+import oshi.hardware.common.platform.mac.MacNetworkIF;
 import oshi.jna.platform.mac.SystemConfiguration;
 import oshi.jna.platform.mac.SystemConfiguration.SCNetworkInterfaceRef;
 
 /**
- * MacNetworks class.
+ * MacNetworks JNA implementation.
  */
 @ThreadSafe
-public final class MacNetworkIF extends AbstractNetworkIF {
+public final class MacNetworkIFJNA extends MacNetworkIF {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MacNetworkIF.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MacNetworkIFJNA.class);
 
-    private int ifType;
-    private long bytesRecv;
-    private long bytesSent;
-    private long packetsRecv;
-    private long packetsSent;
-    private long inErrors;
-    private long outErrors;
-    private long inDrops;
-    private long collisions;
-    private long speed;
-    private long timeStamp;
-
-    public MacNetworkIF(NetworkInterface netint, Map<Integer, IFdata> data) throws InstantiationException {
+    public MacNetworkIFJNA(NetworkInterface netint, Map<Integer, IFdata> data) throws InstantiationException {
         super(netint, queryIfDisplayName(netint));
         updateNetworkStats(data);
     }
@@ -79,12 +67,11 @@ public final class MacNetworkIF extends AbstractNetworkIF {
      * @return A list of {@link NetworkIF} objects representing the interfaces
      */
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
-        // One time fetch of stats
         final Map<Integer, IFdata> data = NetStat.queryIFdata(-1);
         List<NetworkIF> ifList = new ArrayList<>();
         for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
             try {
-                ifList.add(new MacNetworkIF(ni, data));
+                ifList.add(new MacNetworkIFJNA(ni, data));
             } catch (InstantiationException e) {
                 LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
             }
@@ -93,92 +80,28 @@ public final class MacNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
-    public int getIfType() {
-        return this.ifType;
-    }
-
-    @Override
-    public long getBytesRecv() {
-        return this.bytesRecv;
-    }
-
-    @Override
-    public long getBytesSent() {
-        return this.bytesSent;
-    }
-
-    @Override
-    public long getPacketsRecv() {
-        return this.packetsRecv;
-    }
-
-    @Override
-    public long getPacketsSent() {
-        return this.packetsSent;
-    }
-
-    @Override
-    public long getInErrors() {
-        return this.inErrors;
-    }
-
-    @Override
-    public long getOutErrors() {
-        return this.outErrors;
-    }
-
-    @Override
-    public long getInDrops() {
-        return this.inDrops;
-    }
-
-    @Override
-    public long getCollisions() {
-        return this.collisions;
-    }
-
-    @Override
-    public long getSpeed() {
-        return this.speed;
-    }
-
-    @Override
-    public long getTimeStamp() {
-        return this.timeStamp;
-    }
-
-    @Override
     public boolean updateAttributes() {
         int index = queryNetworkInterface().getIndex();
         return updateNetworkStats(NetStat.queryIFdata(index));
     }
 
-    /**
-     * Updates interface network statistics on the given interface. Statistics include packets and bytes sent and
-     * received, and interface speed.
-     *
-     * @param data A map of network interface statistics with the index as the key
-     * @return {@code true} if the update was successful, {@code false} otherwise.
-     */
     private boolean updateNetworkStats(Map<Integer, IFdata> data) {
         int index = queryNetworkInterface().getIndex();
         if (data.containsKey(index)) {
             IFdata ifData = data.get(index);
-            // Update data
-            this.ifType = ifData.getIfType();
-            this.bytesSent = ifData.getOBytes();
-            this.bytesRecv = ifData.getIBytes();
-            this.packetsSent = ifData.getOPackets();
-            this.packetsRecv = ifData.getIPackets();
-            this.outErrors = ifData.getOErrors();
-            this.inErrors = ifData.getIErrors();
-            this.collisions = ifData.getCollisions();
-            this.inDrops = ifData.getIDrops();
-            this.speed = ifData.getSpeed();
-            this.timeStamp = ifData.getTimeStamp();
+            setIfType(ifData.getIfType());
+            setBytesSent(ifData.getOBytes());
+            setBytesRecv(ifData.getIBytes());
+            setPacketsSent(ifData.getOPackets());
+            setPacketsRecv(ifData.getIPackets());
+            setOutErrors(ifData.getOErrors());
+            setInErrors(ifData.getIErrors());
+            setCollisions(ifData.getCollisions());
+            setInDrops(ifData.getIDrops());
+            setSpeed(ifData.getSpeed());
+            setTimeStamp(ifData.getTimeStamp());
             return true;
         }
         return false;
     }
-
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacPowerSourceJNA.java
@@ -22,7 +22,7 @@ import com.sun.jna.platform.mac.IOKitUtil;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.PowerSource;
-import oshi.hardware.common.AbstractPowerSource;
+import oshi.hardware.common.platform.mac.MacPowerSource;
 import oshi.util.Constants;
 import oshi.util.platform.mac.CFUtil;
 
@@ -30,12 +30,12 @@ import oshi.util.platform.mac.CFUtil;
  * A Power Source
  */
 @ThreadSafe
-public final class MacPowerSource extends AbstractPowerSource {
+public final class MacPowerSourceJNA extends MacPowerSource {
 
     private static final CoreFoundation CF = CoreFoundation.INSTANCE;
     private static final IOKit IO = IOKit.INSTANCE;
 
-    public MacPowerSource(String psName, String psDeviceName, double psRemainingCapacityPercent,
+    public MacPowerSourceJNA(String psName, String psDeviceName, double psRemainingCapacityPercent,
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
             CapacityUnits psCapacityUnits, int psCurrentCapacity, int psMaxCapacity, int psDesignCapacity,
@@ -211,7 +211,7 @@ public final class MacPowerSource extends AbstractPowerSource {
                     double psRemainingCapacityPercent = maxCapacity <= 0 ? 0d
                             : Math.min(1d, currentCapacity / maxCapacity);
                     // Add to list
-                    psList.add(new MacPowerSource(psName, psDeviceName, psRemainingCapacityPercent,
+                    psList.add(new MacPowerSourceJNA(psName, psDeviceName, psRemainingCapacityPercent,
                             psTimeRemainingEstimated, psTimeRemainingInstant, psPowerUsageRate, psVoltage, psAmperage,
                             psPowerOnLine, psCharging, psDischarging, psCapacityUnits, psCurrentCapacity, psMaxCapacity,
                             psDesignCapacity, psCycleCount, psChemistry, psManufactureDate, psManufacturer,


### PR DESCRIPTION
Continues the macOS hardware migration to oshi-common

### Split into superclass (oshi-common) + JNA/FFM subclasses

| oshi-common base | JNA subclass | FFM subclass |
|---|---|---|
| `MacNetworkIF` | `MacNetworkIFJNA` | `MacNetworkIFFM` |
| `MacPowerSource` | `MacPowerSourceJNA` | `MacPowerSourceFFM` |

`MacNetworkIF` base class holds 11 fields, 11 getters, and 11 protected setters. Subclasses provide `queryIfDisplayName` (native SystemConfiguration calls), `getNetworks`, `updateAttributes`, and `updateNetworkStats` (which depend on `NetStat` in oshi-core).

`MacPowerSource` base class is a thin constructor pass-through to `AbstractPowerSource`, following the same pattern as `LinuxPowerSource` and `WindowsPowerSource`.

### JNA renames (no split — too little shared code)

| Before | After |
|---|---|
| `MacDisplay` | `MacDisplayJNA` |
| `MacGpuStats` | `MacGpuStatsJNA` |

### Other changes

- `MacHardwareAbstractionLayerJNA`: Updated references to renamed classes
- `MacGraphicsCardJNA`: Updated `MacGpuStats` → `MacGpuStatsJNA`
- `MacPowerSourceFFM`: Now extends common `MacPowerSource` instead of `AbstractPowerSource`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized macOS hardware component implementations for improved code structure and maintainability.
  * Enhanced internal architecture for network interface and power source handling.
  * Clarified platform-specific implementation separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->