### PR TITLE
Fix Apple Silicon compatibility and suppress build warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#3146](https://github.com/oshi/oshi/pull/3146),
   [#3147](https://github.com/oshi/oshi/pull/3147),
   [#3149](https://github.com/oshi/oshi/pull/3149): Move macOS HardwareAbstractionLayer tree to oshi-common - [@dbwiddis](https://github.com/dbwiddis).
+* [#3152](https://github.com/oshi/oshi/pull/3152): Fix FFM TCP stats sysctl failure on Apple Silicon; suppress missing AppleHDA.kext log noise on ARM macOS - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacSoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacSoundCard.java
@@ -54,8 +54,8 @@ public final class MacSoundCard extends AbstractSoundCard {
         boolean version = false;
         String versionMarker = "<key>com.apple.driver.AppleHDAController</key>";
 
-        for (final String checkLine : FileUtil
-                .readFile("/System/Library/Extensions/AppleHDA.kext/Contents/Info.plist")) {
+        for (final String checkLine : FileUtil.readFile("/System/Library/Extensions/AppleHDA.kext/Contents/Info.plist",
+                false)) {
             if (checkLine.contains(versionMarker)) {
                 version = true;
                 continue;

--- a/oshi-core-java25/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
@@ -309,7 +309,7 @@ public class MacInternetProtocolStatsFFM extends AbstractInternetProtocolStats {
     private static BsdTcpstat queryTcpstat() {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment buffer = arena.allocate(128);
-            if (SysctlUtilFFM.sysctl(new int[] { 1, 4, 8 }, buffer) > 0) {
+            if (SysctlUtilFFM.sysctl("net.inet.tcp.stats", buffer)) {
                 return new BsdTcpstat(buffer.get(JAVA_INT, 0), buffer.get(JAVA_INT, 4), buffer.get(JAVA_INT, 12),
                         buffer.get(JAVA_INT, 16), buffer.get(JAVA_INT, 64), buffer.get(JAVA_INT, 72),
                         buffer.get(JAVA_INT, 104), buffer.get(JAVA_INT, 112), buffer.get(JAVA_INT, 116),

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,9 @@
                         <!-- Slightly faster builds, see
                         https://issues.apache.org/jira/browse/MCOMPILER-209 -->
                         <useIncrementalCompilation>false</useIncrementalCompilation>
+                        <compilerArgs>
+                            <arg>-Xlint:-options</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
## Summary

Three small fixes:

1. **FFM TCP stats sysctl on Apple Silicon** — `MacInternetProtocolStatsFFM.queryTcpstat()` used numeric MIB `{1, 4, 8}` which fails with EISDIR (error 21) on ARM macOS because MIB numbers differ between Intel and Apple Silicon. Switched to `sysctlbyname("net.inet.tcp.stats")` which works on both architectures, matching the pattern already used by `queryUdpstat`, `queryIpstat`, and `queryIp6stat` in the same file.

2. **MacSoundCard log noise on Apple Silicon** — `/System/Library/Extensions/AppleHDA.kext/Contents/Info.plist` doesn't exist on Apple Silicon, producing a WARN log on every call. Pass `reportError=false` to `FileUtil.readFile()` to suppress it.

3. **Compiler warning suppression** — Added `-Xlint:-options` to the parent POM's `maven-compiler-plugin` configuration to suppress "source value 8 is obsolete" warnings when building with newer JDKs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FFM TCP stats sysctl failure on Apple Silicon
  * Suppressed AppleHDA.kext log noise on ARM macOS systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->