### PR TITLE
Fix misc. SonarQube and Coverity findings

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -55,7 +55,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
     private static final String LSB_RELEASE_A_LOG = "lsb_release -a: {}";
     private static final String LSB_RELEASE_LOG = "lsb-release: {}";
     private static final String RELEASE_DELIM = " release ";
-    private static final String DOUBLE_QUOTES = "(?:^\"|(?:\"$))";
+    private static final String DOUBLE_QUOTES = "(?:(?:^\")|(?:\"$))";
     private static final String FILENAME_PROPERTIES = "oshi.linux.filename.properties";
 
     private final Supplier<List<ApplicationInfo>> installedAppsSupplier = Memoizer

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -118,7 +118,12 @@ public final class MacInstalledApps {
     private static byte[] readFirstBytes(File file) throws IOException {
         byte[] buffer = new byte[8];
         try (FileInputStream fis = new FileInputStream(file)) {
-            fis.read(buffer);
+            int bytesRead = fis.read(buffer);
+            if (bytesRead < buffer.length) {
+                byte[] result = new byte[Math.max(0, bytesRead)];
+                System.arraycopy(buffer, 0, result, 0, result.length);
+                return result;
+            }
             return buffer;
         }
     }

--- a/oshi-common/src/main/java/oshi/util/PrivilegedUtil.java
+++ b/oshi-common/src/main/java/oshi/util/PrivilegedUtil.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -42,11 +43,12 @@ public final class PrivilegedUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(PrivilegedUtil.class);
 
-    private static volatile Supplier<Set<String>> commandAllowlist = memoize(PrivilegedUtil::queryCommandAllowlist,
-            defaultExpiration());
-    private static volatile Supplier<Set<String>> fileAllowlist = memoize(PrivilegedUtil::queryFileAllowlist,
-            defaultExpiration());
-    private static volatile Supplier<String> prefix = memoize(PrivilegedUtil::queryPrefix, defaultExpiration());
+    private static final AtomicReference<Supplier<Set<String>>> COMMAND_ALLOWLIST = new AtomicReference<>(
+            memoize(PrivilegedUtil::queryCommandAllowlist, defaultExpiration()));
+    private static final AtomicReference<Supplier<Set<String>>> FILE_ALLOWLIST = new AtomicReference<>(
+            memoize(PrivilegedUtil::queryFileAllowlist, defaultExpiration()));
+    private static final AtomicReference<Supplier<String>> PREFIX = new AtomicReference<>(
+            memoize(PrivilegedUtil::queryPrefix, defaultExpiration()));
 
     private PrivilegedUtil() {
     }
@@ -118,6 +120,7 @@ public final class PrivilegedUtil {
             return false;
         }
         Path path = Paths.get(filePath);
+        // Default FileSystem is a JVM singleton that must not be closed
         FileSystem fs = FileSystems.getDefault();
         for (String allowed : allowlist) {
             PathMatcher matcher = fs.getPathMatcher("glob:" + allowed);
@@ -161,7 +164,7 @@ public final class PrivilegedUtil {
      * @return The current command allowlist
      */
     public static Set<String> getCommandAllowlist() {
-        return commandAllowlist.get();
+        return COMMAND_ALLOWLIST.get().get();
     }
 
     /**
@@ -170,7 +173,7 @@ public final class PrivilegedUtil {
      * @return The current file allowlist
      */
     public static Set<String> getFileAllowlist() {
-        return fileAllowlist.get();
+        return FILE_ALLOWLIST.get().get();
     }
 
     /**
@@ -179,7 +182,7 @@ public final class PrivilegedUtil {
      * @return The prefix string, or empty string if not configured or not supported on this platform
      */
     public static String getPrefix() {
-        return prefix.get();
+        return PREFIX.get().get();
     }
 
     /**
@@ -187,9 +190,9 @@ public final class PrivilegedUtil {
      * immediately after {@link GlobalConfig#clear()}.
      */
     static void clearCaches() {
-        commandAllowlist = memoize(PrivilegedUtil::queryCommandAllowlist, defaultExpiration());
-        fileAllowlist = memoize(PrivilegedUtil::queryFileAllowlist, defaultExpiration());
-        prefix = memoize(PrivilegedUtil::queryPrefix, defaultExpiration());
+        COMMAND_ALLOWLIST.set(memoize(PrivilegedUtil::queryCommandAllowlist, defaultExpiration()));
+        FILE_ALLOWLIST.set(memoize(PrivilegedUtil::queryFileAllowlist, defaultExpiration()));
+        PREFIX.set(memoize(PrivilegedUtil::queryPrefix, defaultExpiration()));
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/SystemInfoHelper.java
+++ b/oshi-common/src/main/java/oshi/util/SystemInfoHelper.java
@@ -211,6 +211,9 @@ public final class SystemInfoHelper {
 
     public static void printProcesses(List<String> lines, OperatingSystem os, GlobalMemory memory) {
         OSProcess myProc = os.getProcess(os.getProcessId());
+        if (myProc == null) {
+            return;
+        }
         lines.add(
                 "My PID: " + myProc.getProcessID() + " with affinity " + Long.toBinaryString(myProc.getAffinityMask()));
         lines.add("My TID: " + os.getThreadId() + " with details " + os.getCurrentThread());
@@ -226,6 +229,9 @@ public final class SystemInfoHelper {
                     p.getName()));
         }
         OSProcess p = os.getProcess(os.getProcessId());
+        if (p == null) {
+            return;
+        }
         lines.add("Current process arguments: ");
         for (String s : p.getArguments()) {
             lines.add("  " + s);

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/com/GuidFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/com/GuidFFM.java
@@ -55,7 +55,7 @@ public final class GuidFFM {
         guid.set(JAVA_SHORT, 4, data2);
         guid.set(JAVA_SHORT, 6, data3);
         for (int i = 0; i < 8; i++) {
-            guid.set(JAVA_BYTE, 8 + i, data4[i]);
+            guid.set(JAVA_BYTE, 8L + i, data4[i]);
         }
         return guid;
     }

--- a/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
@@ -147,13 +147,13 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
                 for (int cpu = 0; cpu < cpuLimit; cpu++) {
                     int offset = cpu * MacSystem.CPU_STATE_MAX;
                     ticks[cpu][TickType.USER.getIndex()] = FormatUtil.getUnsignedInt(
-                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, offset + MacSystem.CPU_STATE_USER));
+                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, (long) offset + MacSystem.CPU_STATE_USER));
                     ticks[cpu][TickType.NICE.getIndex()] = FormatUtil.getUnsignedInt(
-                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, offset + MacSystem.CPU_STATE_NICE));
+                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, (long) offset + MacSystem.CPU_STATE_NICE));
                     ticks[cpu][TickType.SYSTEM.getIndex()] = FormatUtil.getUnsignedInt(
-                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, offset + MacSystem.CPU_STATE_SYSTEM));
+                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, (long) offset + MacSystem.CPU_STATE_SYSTEM));
                     ticks[cpu][TickType.IDLE.getIndex()] = FormatUtil.getUnsignedInt(
-                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, offset + MacSystem.CPU_STATE_IDLE));
+                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, (long) offset + MacSystem.CPU_STATE_IDLE));
                 }
             } finally {
                 try {

--- a/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
@@ -28,7 +28,7 @@ final class LinuxNetworkParamsFFM extends LinuxNetworkParams {
     @Override
     public String getHostName() {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1);
+            MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
             if (0 == LinuxLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
                 return buf.getString(0);
             }

--- a/oshi-core-java25/src/main/java/oshi/software/os/mac/MacNetworkParamsFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/mac/MacNetworkParamsFFM.java
@@ -88,8 +88,8 @@ final class MacNetworkParamsFFM extends AbstractNetworkParams {
     @Override
     public String getHostName() {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1);
-            if (gethostname(buf, HOST_NAME_MAX + 1) == 0) {
+            MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
+            if (gethostname(buf, HOST_NAME_MAX + 1L) == 0) {
                 return buf.getString(0);
             }
         } catch (Throwable e) {

--- a/oshi-core-java25/src/main/java/oshi/util/gpu/NvmlUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/gpu/NvmlUtilFFM.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +33,7 @@ public final class NvmlUtilFFM {
     private static final Logger LOG = LoggerFactory.getLogger(NvmlUtilFFM.class);
 
     private static volatile boolean devicesEnumerated = false;
-    private static volatile Set<String> deviceBusIds = Collections.emptySet();
+    private static final AtomicReference<Set<String>> DEVICE_BUS_IDS = new AtomicReference<>(Collections.emptySet());
 
     private NvmlUtilFFM() {
     }
@@ -59,9 +60,9 @@ public final class NvmlUtilFFM {
         }
         Set<String> ids = enumerateDeviceBusIds();
         if (ids != null) {
-            deviceBusIds = ids;
+            DEVICE_BUS_IDS.set(ids);
             devicesEnumerated = true;
-            LOG.debug("NVML (FFM) enumerated {} device(s)", deviceBusIds.size());
+            LOG.debug("NVML (FFM) enumerated {} device(s)", DEVICE_BUS_IDS.get().size());
         }
     }
 
@@ -207,7 +208,7 @@ public final class NvmlUtilFFM {
         try {
             ensureDevicesEnumerated();
             String needle = pciBusId.toLowerCase(Locale.ROOT);
-            for (String id : deviceBusIds) {
+            for (String id : DEVICE_BUS_IDS.get()) {
                 if (id.contains(needle) || needle.contains(id)) {
                     return id;
                 }

--- a/oshi-core/src/main/java/oshi/util/gpu/AdlUtil.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/AdlUtil.java
@@ -7,6 +7,7 @@ package oshi.util.gpu;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +91,8 @@ public final class AdlUtil {
 
     // Lazy adapter enumeration state — written once, read-only thereafter
     private static volatile boolean adaptersEnumerated = false;
-    private static volatile Map<Integer, Integer> busToIndex = Collections.emptyMap();
+    private static final AtomicReference<Map<Integer, Integer>> BUS_TO_INDEX = new AtomicReference<>(
+            Collections.emptyMap());
 
     // -------------------------------------------------------------------------
     // Init/uninit helpers (COM pattern)
@@ -139,9 +141,9 @@ public final class AdlUtil {
         }
         Map<Integer, Integer> result = enumerateAdapters(context);
         if (result != null) {
-            busToIndex = result;
+            BUS_TO_INDEX.set(result);
             adaptersEnumerated = true;
-            LOG.debug("ADL enumerated {} adapter(s)", busToIndex.size());
+            LOG.debug("ADL enumerated {} adapter(s)", BUS_TO_INDEX.get().size());
         } else {
             LOG.debug("ADL adapter enumeration failed; will retry on next call");
         }
@@ -212,7 +214,7 @@ public final class AdlUtil {
         }
         try {
             ensureAdaptersEnumerated(ctx);
-            return busToIndex.getOrDefault(pciBusNumber, -1);
+            return BUS_TO_INDEX.get().getOrDefault(pciBusNumber, -1);
         } finally {
             adlUninit(ctx);
         }

--- a/oshi-core/src/main/java/oshi/util/gpu/NvmlUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/NvmlUtilJNA.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +71,7 @@ public final class NvmlUtilJNA {
     // Stores PCI bus ID strings (stable identifiers) rather than Pointer handles, which are only valid
     // within a single nvmlInit/nvmlShutdown scope.
     private static volatile boolean devicesEnumerated = false;
-    private static volatile Set<String> deviceBusIds = Collections.emptySet();
+    private static final AtomicReference<Set<String>> DEVICE_BUS_IDS = new AtomicReference<>(Collections.emptySet());
 
     private NvmlUtilJNA() {
     }
@@ -116,9 +117,9 @@ public final class NvmlUtilJNA {
         }
         Set<String> ids = enumerateDeviceBusIds();
         if (ids != null) {
-            deviceBusIds = ids;
+            DEVICE_BUS_IDS.set(ids);
             devicesEnumerated = true;
-            LOG.debug("NVML enumerated {} device(s)", deviceBusIds.size());
+            LOG.debug("NVML enumerated {} device(s)", DEVICE_BUS_IDS.get().size());
         }
     }
 
@@ -286,7 +287,7 @@ public final class NvmlUtilJNA {
             // Verify a handle can be acquired (device exists), then return the canonical bus ID
             // from the enumerated set that matches — not the handle itself.
             String needle = pciBusId.toLowerCase(Locale.ROOT);
-            for (String id : deviceBusIds) {
+            for (String id : DEVICE_BUS_IDS.get()) {
                 if (id.contains(needle) || needle.contains(id)) {
                     return id;
                 }


### PR DESCRIPTION
Coverity:
- MacInstalledApps: handle return value of FileInputStream.read() to avoid potential out-of-range buffer access (CWE-252)
- SystemInfoHelper: null-check getProcess() return before dereferencing in printProcesses() (CWE-476)
- PrivilegedUtil: add comment that default FileSystem is a JVM singleton that does not need closing (CWE-404 false positive)

SonarQube:
- LinuxOperatingSystem: group regex alternatives with anchors to make precedence explicit (S5850)
- PrivilegedUtil: replace volatile Supplier fields with AtomicReference (S3077)
- NvmlUtilFFM, NvmlUtilJNA, AdlUtil: replace volatile Set/Map fields with AtomicReference (S3077)
- GuidFFM, MacCentralProcessorFFM, LinuxNetworkParamsFFM, MacNetworkParamsFFM: cast int operands to long before assignment to long parameters (S2184)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoided null-reference crashes when printing process information.
  * Corrected partial-file-read handling when detecting installed apps.
  * Fixed buffer/allocation sizing for hostname and memory reads.
  * Adjusted string parsing to handle surrounding double quotes reliably.
  * Improved thread-safety of GPU device and internal cache management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->