### PR TITLE
Fix getOpenFileDescriptors() to use _Total PDH counter instance

### DIFF
--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/PdhFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/PdhFFM.java
@@ -4,17 +4,17 @@
  */
 package oshi.ffm.windows;
 
+import static java.lang.foreign.MemoryLayout.structLayout;
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
 import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
-
-import static java.lang.foreign.MemoryLayout.structLayout;
-import static java.lang.foreign.ValueLayout.ADDRESS;
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 
 public class PdhFFM extends WindowsForeignFunctions {
 
@@ -51,6 +51,14 @@ public class PdhFFM extends WindowsForeignFunctions {
     public static int PdhGetFormattedCounterArray(MemorySegment counter, int format, MemorySegment bufferSize,
             MemorySegment itemCount, MemorySegment buffer) throws Throwable {
         return (int) PdhGetFormattedCounterArray.invokeExact(counter, format, bufferSize, itemCount, buffer);
+    }
+
+    private static final MethodHandle PdhGetFormattedCounterValue = downcall(Pdh, "PdhGetFormattedCounterValue",
+            JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, ADDRESS);
+
+    public static int PdhGetFormattedCounterValue(MemorySegment counter, int format, MemorySegment type,
+            MemorySegment value) throws Throwable {
+        return (int) PdhGetFormattedCounterValue.invokeExact(counter, format, type, value);
     }
 
     private static final MethodHandle PdhCloseQuery = downcall(Pdh, "PdhCloseQuery", JAVA_INT, ADDRESS);

--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -116,13 +116,13 @@ public class WindowsFileSystemFFM extends AbstractFileSystem {
         // or add new if it doesn't (expected for network drives)
         for (OSFileStore wmiVolume : getWmiVolumes(null, localOnly)) {
             if (volumeMap.containsKey(wmiVolume.getMount())) {
-                // If the volume is already in our list, preserve local values
-                // and only backfill missing fields from WMI
+                // If the volume is already in our list, update the name field
+                // using WMI's more verbose name and update label if needed
                 OSFileStore volume = volumeMap.get(wmiVolume.getMount());
                 int idx = result.indexOf(volume);
-                WindowsOSFileStoreFFM updated = new WindowsOSFileStoreFFM(volume.getName(), // preserve local name
-                        volume.getVolume(), volume.getLabel().isEmpty() ? wmiVolume.getLabel() : volume.getLabel(),
-                        volume.getMount(), volume.getOptions(), volume.getUUID(), true, "",
+                WindowsOSFileStoreFFM updated = new WindowsOSFileStoreFFM(wmiVolume.getName(), volume.getVolume(),
+                        volume.getLabel().isEmpty() ? wmiVolume.getLabel() : volume.getLabel(), volume.getMount(),
+                        volume.getOptions(), volume.getUUID(), true, "",
                         volume.getDescription().isEmpty() ? wmiVolume.getDescription() : volume.getDescription(),
                         volume.getType(), volume.getFreeSpace(), volume.getUsableSpace(), volume.getTotalSpace(), 0, 0);
                 if (idx >= 0) {

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PdhUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PdhUtilFFM.java
@@ -6,15 +6,13 @@ package oshi.util.platform.windows;
 
 import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
 import static java.lang.foreign.ValueLayout.ADDRESS;
-import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static oshi.ffm.windows.PdhFFM.PDH_FMT_COUNTERVALUE_ITEM_LAYOUT;
+import static oshi.ffm.windows.PdhFFM.PDH_FMT_COUNTERVALUE_LAYOUT;
 import static oshi.ffm.windows.PdhFFM.PDH_FMT_LARGE;
-import static oshi.ffm.windows.PdhFFM.PDH_MORE_DATA;
 import static oshi.ffm.windows.PdhFFM.PdhAddEnglishCounter;
 import static oshi.ffm.windows.PdhFFM.PdhCloseQuery;
 import static oshi.ffm.windows.PdhFFM.PdhCollectQueryData;
-import static oshi.ffm.windows.PdhFFM.PdhGetFormattedCounterArray;
+import static oshi.ffm.windows.PdhFFM.PdhGetFormattedCounterValue;
 import static oshi.ffm.windows.PdhFFM.PdhOpenQuery;
 import static oshi.ffm.windows.WindowsForeignFunctions.checkSuccess;
 import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
@@ -24,8 +22,6 @@ import java.lang.foreign.MemorySegment;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import oshi.ffm.windows.Win32Exception;
 
 public final class PdhUtilFFM {
 
@@ -49,23 +45,12 @@ public final class PdhUtilFFM {
 
                 checkSuccess(PdhCollectQueryData(query));
 
-                MemorySegment bufferSize = arena.allocate(JAVA_INT);
-                MemorySegment itemCount = arena.allocate(JAVA_INT);
+                MemorySegment value = arena.allocate(PDH_FMT_COUNTERVALUE_LAYOUT);
+                checkSuccess(PdhGetFormattedCounterValue(counter, PDH_FMT_LARGE, MemorySegment.NULL, value));
 
-                int rc = PdhGetFormattedCounterArray(counter, PDH_FMT_LARGE, bufferSize, itemCount, MemorySegment.NULL);
-
-                if (rc != PDH_MORE_DATA) {
-                    throw new Win32Exception(rc);
-                }
-
-                MemorySegment buffer = arena.allocate(bufferSize.get(JAVA_INT, 0));
-
-                checkSuccess(PdhGetFormattedCounterArray(counter, PDH_FMT_LARGE, bufferSize, itemCount, buffer));
-
-                long valueOffset = PDH_FMT_COUNTERVALUE_ITEM_LAYOUT.byteOffset(groupElement("FmtValue"),
-                        groupElement("Value"), groupElement("largeValue"));
-
-                return buffer.get(JAVA_LONG, valueOffset);
+                long valueOffset = PDH_FMT_COUNTERVALUE_LAYOUT.byteOffset(groupElement("Value"),
+                        groupElement("largeValue"));
+                return value.get(JAVA_LONG, valueOffset);
 
             } finally {
                 PdhCloseQuery(query);

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PdhUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PdhUtilFFM.java
@@ -4,27 +4,28 @@
  */
 package oshi.util.platform.windows;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import oshi.ffm.windows.Win32Exception;
+import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.windows.PdhFFM.PDH_FMT_COUNTERVALUE_ITEM_LAYOUT;
+import static oshi.ffm.windows.PdhFFM.PDH_FMT_LARGE;
+import static oshi.ffm.windows.PdhFFM.PDH_MORE_DATA;
+import static oshi.ffm.windows.PdhFFM.PdhAddEnglishCounter;
+import static oshi.ffm.windows.PdhFFM.PdhCloseQuery;
+import static oshi.ffm.windows.PdhFFM.PdhCollectQueryData;
+import static oshi.ffm.windows.PdhFFM.PdhGetFormattedCounterArray;
+import static oshi.ffm.windows.PdhFFM.PdhOpenQuery;
+import static oshi.ffm.windows.WindowsForeignFunctions.checkSuccess;
+import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
-import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static java.lang.foreign.ValueLayout.ADDRESS;
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static oshi.ffm.windows.PdhFFM.PdhCloseQuery;
-import static oshi.ffm.windows.PdhFFM.PdhOpenQuery;
-import static oshi.ffm.windows.PdhFFM.PdhAddEnglishCounter;
-import static oshi.ffm.windows.PdhFFM.PdhCollectQueryData;
-import static oshi.ffm.windows.PdhFFM.PdhGetFormattedCounterArray;
-import static oshi.ffm.windows.PdhFFM.PDH_FMT_LARGE;
-import static oshi.ffm.windows.PdhFFM.PDH_MORE_DATA;
-import static oshi.ffm.windows.PdhFFM.PDH_FMT_COUNTERVALUE_ITEM_LAYOUT;
-import static oshi.ffm.windows.WindowsForeignFunctions.checkSuccess;
-import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.ffm.windows.Win32Exception;
 
 public final class PdhUtilFFM {
 

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PdhUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PdhUtilFFM.java
@@ -24,7 +24,6 @@ import static oshi.ffm.windows.PdhFFM.PDH_FMT_LARGE;
 import static oshi.ffm.windows.PdhFFM.PDH_MORE_DATA;
 import static oshi.ffm.windows.PdhFFM.PDH_FMT_COUNTERVALUE_ITEM_LAYOUT;
 import static oshi.ffm.windows.WindowsForeignFunctions.checkSuccess;
-import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
 
 public final class PdhUtilFFM {
@@ -35,8 +34,6 @@ public final class PdhUtilFFM {
     private static final Logger LOG = LoggerFactory.getLogger(PdhUtilFFM.class);
 
     public static long getOpenFileDescriptors() {
-        long totalHandles = 0L;
-
         try (Arena arena = Arena.ofConfined()) {
 
             MemorySegment queryPtr = arena.allocate(ADDRESS);
@@ -45,7 +42,7 @@ public final class PdhUtilFFM {
 
             try {
                 MemorySegment counterPtr = arena.allocate(ADDRESS);
-                checkSuccess(PdhAddEnglishCounter(query, toWideString(arena, "\\Process(*)\\Handle Count"),
+                checkSuccess(PdhAddEnglishCounter(query, toWideString(arena, "\\Process(_Total)\\Handle Count"),
                         MemorySegment.NULL, counterPtr));
                 MemorySegment counter = counterPtr.get(ADDRESS, 0);
 
@@ -64,25 +61,10 @@ public final class PdhUtilFFM {
 
                 checkSuccess(PdhGetFormattedCounterArray(counter, PDH_FMT_LARGE, bufferSize, itemCount, buffer));
 
-                int count = itemCount.get(JAVA_INT, 0);
-                long offset = 0;
-                long itemSize = PDH_FMT_COUNTERVALUE_ITEM_LAYOUT.byteSize();
-                long szNameOffset = PDH_FMT_COUNTERVALUE_ITEM_LAYOUT.byteOffset(groupElement("szName"));
                 long valueOffset = PDH_FMT_COUNTERVALUE_ITEM_LAYOUT.byteOffset(groupElement("FmtValue"),
                         groupElement("Value"), groupElement("largeValue"));
 
-                for (int i = 0; i < count; i++) {
-                    MemorySegment item = buffer.asSlice(offset, itemSize);
-                    // Read instance name pointer and convert to string
-                    MemorySegment szNamePtr = item.get(ADDRESS, szNameOffset);
-                    String instanceName = readWideString(szNamePtr);
-                    // Skip the _Total instance (case-insensitive)
-                    if (!"_Total".equalsIgnoreCase(instanceName)) {
-                        long value = item.get(JAVA_LONG, valueOffset);
-                        totalHandles += value;
-                    }
-                    offset += itemSize;
-                }
+                return buffer.get(JAVA_LONG, valueOffset);
 
             } finally {
                 PdhCloseQuery(query);
@@ -92,8 +74,6 @@ public final class PdhUtilFFM {
             LOG.debug("PDH getOpenFileDescriptors failed: {}", t.getMessage(), t);
             return -1;
         }
-
-        return totalHandles;
     }
 
 }


### PR DESCRIPTION
Fix PdhUtilFFM.getOpenFileDescriptors() to query the pre-aggregated _Total PDH counter instance instead of wildcard.

Aligns FFM implementation with the working JNA version for better efficiency.

Removes loop iteration and directly returns the single handle count value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Windows handle-count retrieval by switching to a direct aggregate counter query, simplifying logic and reducing overhead.
  * No public API signatures changed.
  * Existing error behavior (returning an error indicator on failure) is preserved.

* **Fix**
  * When merging filesystem entries on Windows, prefer the name from system/WMI data so store names are more accurate.

* **Chore**
  * Internal native binding adjustments to support the new retrieval approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->