### PR TITLE
Expand JaCoCo coverage scope and extract DxgiUtilJNA

### DIFF
--- a/oshi-core/src/main/java/oshi/driver/windows/DxgiAdapterInfo.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/DxgiAdapterInfo.java
@@ -10,7 +10,7 @@ import java.util.Locale;
  * Immutable snapshot of a DXGI adapter's identity and dedicated video memory.
  *
  * <p>
- * Populated by {@link oshi.jna.platform.windows.WindowsDxgi#queryAdapters()} and used by
+ * Populated by {@link oshi.jna.platform.windows.Dxgi#queryAdapters()} and used by
  * {@code oshi.hardware.platform.windows.WindowsGraphicsCard} to supply accurate VRAM values.
  * {@code DedicatedVideoMemory} from {@code DXGI_ADAPTER_DESC} is the authoritative Windows API source for dedicated GPU
  * memory; it is not subject to the 2 GiB cap that affects the 32-bit registry value

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGpuStats.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGpuStats.java
@@ -22,7 +22,7 @@ import oshi.driver.windows.wmi.LhmSensor;
 import oshi.driver.windows.wmi.LhmSensor.LhmSensorProperty;
 import oshi.hardware.GpuStats;
 import oshi.hardware.GpuTicks;
-import oshi.util.gpu.AdlUtil;
+import oshi.util.gpu.AdlUtilJNA;
 import oshi.util.gpu.NvmlUtilJNA;
 import oshi.util.platform.windows.WmiUtil;
 import oshi.util.tuples.Pair;
@@ -202,7 +202,7 @@ final class WindowsGpuStats implements GpuStats {
         }
         int adlIndex = findAdlIndex();
         if (adlIndex >= 0) {
-            double val = AdlUtil.getTemperature(adlIndex);
+            double val = AdlUtilJNA.getTemperature(adlIndex);
             if (val >= 0) {
                 return val;
             }
@@ -222,7 +222,7 @@ final class WindowsGpuStats implements GpuStats {
         }
         int adlIndex = findAdlIndex();
         if (adlIndex >= 0) {
-            double val = AdlUtil.getPowerDraw(adlIndex);
+            double val = AdlUtilJNA.getPowerDraw(adlIndex);
             if (val >= 0) {
                 return val;
             }
@@ -246,7 +246,7 @@ final class WindowsGpuStats implements GpuStats {
         }
         int adlIndex = findAdlIndex();
         if (adlIndex >= 0) {
-            long val = AdlUtil.getCoreClockMhz(adlIndex);
+            long val = AdlUtilJNA.getCoreClockMhz(adlIndex);
             if (val >= 0) {
                 return val;
             }
@@ -267,7 +267,7 @@ final class WindowsGpuStats implements GpuStats {
         }
         int adlIndex = findAdlIndex();
         if (adlIndex >= 0) {
-            long val = AdlUtil.getMemoryClockMhz(adlIndex);
+            long val = AdlUtilJNA.getMemoryClockMhz(adlIndex);
             if (val >= 0) {
                 return val;
             }
@@ -288,7 +288,7 @@ final class WindowsGpuStats implements GpuStats {
         }
         int adlIndex = findAdlIndex();
         if (adlIndex >= 0) {
-            double val = AdlUtil.getFanSpeedPercent(adlIndex);
+            double val = AdlUtilJNA.getFanSpeedPercent(adlIndex);
             if (val >= 0) {
                 return val;
             }
@@ -350,11 +350,11 @@ final class WindowsGpuStats implements GpuStats {
         if (cachedAdlIndex != Integer.MIN_VALUE) {
             return cachedAdlIndex;
         }
-        if (!AdlUtil.isAvailable() || pciBusNumber < 0) {
+        if (!AdlUtilJNA.isAvailable() || pciBusNumber < 0) {
             cachedAdlIndex = -1;
             return -1;
         }
-        cachedAdlIndex = AdlUtil.findAdapterIndex(pciBusNumber);
+        cachedAdlIndex = AdlUtilJNA.findAdapterIndex(pciBusNumber);
         return cachedAdlIndex;
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCard.java
@@ -29,13 +29,13 @@ import oshi.driver.windows.wmi.LhmSensor;
 import oshi.driver.windows.wmi.LhmSensor.LhmHardwareProperty;
 import oshi.driver.windows.wmi.Win32VideoController;
 import oshi.driver.windows.wmi.Win32VideoController.VideoControllerProperty;
-import oshi.hardware.GraphicsCard;
 import oshi.hardware.GpuStats;
+import oshi.hardware.GraphicsCard;
 import oshi.hardware.common.AbstractGraphicsCard;
-import oshi.jna.platform.windows.WindowsDxgi;
 import oshi.util.Constants;
 import oshi.util.ParseUtil;
 import oshi.util.Util;
+import oshi.util.gpu.DxgiUtilJNA;
 import oshi.util.platform.windows.RegistryUtil;
 import oshi.util.platform.windows.WmiUtil;
 import oshi.util.tuples.Pair;
@@ -137,7 +137,7 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
      */
     public static List<GraphicsCard> getGraphicsCards() {
         // Query DXGI once. Fails gracefully to empty list if unavailable.
-        List<DxgiAdapterInfo> dxgiAdapters = WindowsDxgi.queryAdapters();
+        List<DxgiAdapterInfo> dxgiAdapters = DxgiUtilJNA.queryAdapters();
         boolean dxgiAvailable = !dxgiAdapters.isEmpty();
         // Mutable copy for match-and-consume (prevents same adapter matching two registry entries).
         List<DxgiAdapterInfo> remainingDxgi = new ArrayList<>(dxgiAdapters);
@@ -188,7 +188,7 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                 String pciBusId = "";
                 String locationInfo = RegistryUtil.getStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey,
                         LOCATION_INFORMATION);
-                DxgiAdapterInfo dxgiMatch = WindowsDxgi.findMatch(remainingDxgi, pciVendorId, pciDeviceId, name);
+                DxgiAdapterInfo dxgiMatch = DxgiUtilJNA.findMatch(remainingDxgi, pciVendorId, pciDeviceId, name);
                 if (dxgiMatch != null) {
                     vram = dxgiMatch.getDedicatedVideoMemory();
                     dxgiIndex = dxgiAdapters.indexOf(dxgiMatch);
@@ -215,7 +215,7 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                 // HardwareInformation.MemorySize (32-bit) is intentionally omitted: Windows caps
                 // it at 0x7FFFF000 (~2 GiB) for GPUs with more VRAM, making it unreliable.
 
-                String lhmParent = lhmParentMap.getOrDefault(WindowsDxgi.normalizeName(Util.isBlank(name) ? "" : name),
+                String lhmParent = lhmParentMap.getOrDefault(DxgiUtilJNA.normalizeName(Util.isBlank(name) ? "" : name),
                         "");
 
                 GraphicsCard card = new WindowsGraphicsCard(Util.isBlank(name) ? Constants.UNKNOWN : name,
@@ -261,7 +261,7 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
      * @return the VRAM size in bytes, or 0 if the value type is unrecognised
      */
     static long registryValueToVram(Object value) {
-        return WindowsDxgi.registryValueToVram(value);
+        return DxgiUtilJNA.registryValueToVram(value);
     }
 
     // fall back if something went wrong
@@ -308,7 +308,7 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                         WmiUtil.getString(cards, VideoControllerProperty.PNPDEVICEID, index));
                 int pciVendorId = pciIds == null ? 0 : pciIds.getA();
                 int pciDeviceId = pciIds == null ? 0 : pciIds.getB();
-                DxgiAdapterInfo dxgiMatch = WindowsDxgi.findMatch(remainingDxgi, pciVendorId, pciDeviceId, name);
+                DxgiAdapterInfo dxgiMatch = DxgiUtilJNA.findMatch(remainingDxgi, pciVendorId, pciDeviceId, name);
                 long vram;
                 int dxgiIndex = -1;
                 String luidPrefix = "";
@@ -323,7 +323,7 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                 } else {
                     vram = WmiUtil.getUint32asLong(cards, VideoControllerProperty.ADAPTERRAM, index);
                 }
-                String lhmParent = lhmParentMap.getOrDefault(WindowsDxgi.normalizeName(Util.isBlank(name) ? "" : name),
+                String lhmParent = lhmParentMap.getOrDefault(DxgiUtilJNA.normalizeName(Util.isBlank(name) ? "" : name),
                         "");
                 GraphicsCard card = new WindowsGraphicsCard(Util.isBlank(name) ? Constants.UNKNOWN : name, deviceId,
                         Util.isBlank(vendor) ? Constants.UNKNOWN : vendor, versionInfo, vram, luidPrefix, lhmParent,
@@ -362,7 +362,7 @@ final class WindowsGraphicsCard extends AbstractGraphicsCard {
                 String identifier = WmiUtil.getString(hw, LhmHardwareProperty.IDENTIFIER, i);
                 String hwName = WmiUtil.getString(hw, LhmHardwareProperty.NAME, i);
                 if (!identifier.isEmpty() && !hwName.isEmpty()) {
-                    String norm = WindowsDxgi.normalizeName(hwName);
+                    String norm = DxgiUtilJNA.normalizeName(hwName);
                     if (map.containsKey(norm)) {
                         // Two adapters with the same normalized name: mark ambiguous so neither
                         // is used (empty string is the "skip LHM" sentinel for callers).

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/Dxgi.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/Dxgi.java
@@ -46,9 +46,9 @@ import oshi.driver.windows.DxgiAdapterInfo;
  * <p>
  * This class should be considered non-API as it may be removed if/when its code is incorporated into the JNA project.
  */
-public final class WindowsDxgi {
+public final class Dxgi {
 
-    private static final Logger LOG = LoggerFactory.getLogger(WindowsDxgi.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Dxgi.class);
 
     // IID for IDXGIFactory {7B7166EC-21C7-44AE-B21A-C9AE321AE369}
     private static final com.sun.jna.platform.win32.Guid.IID IID_IDXGI_FACTORY = new com.sun.jna.platform.win32.Guid.IID(
@@ -57,7 +57,7 @@ public final class WindowsDxgi {
     // DXGI_ERROR_NOT_FOUND: returned by EnumAdapters when index is out of range
     private static final int DXGI_ERROR_NOT_FOUND = 0x887A0002;
 
-    private WindowsDxgi() {
+    private Dxgi() {
     }
 
     // -------------------------------------------------------------------------
@@ -275,89 +275,5 @@ public final class WindowsDxgi {
             factory.Release();
         }
         return Collections.unmodifiableList(result);
-    }
-
-    /**
-     * Finds the best-matching DXGI adapter for a given vendor ID, device ID, and adapter name.
-     *
-     * <p>
-     * Matching priority:
-     * <ol>
-     * <li>Vendor ID + Device ID (exact, both non-zero)</li>
-     * <li>Normalized name match (case-insensitive, ignoring {@code (R)}, {@code (TM)}, extra spaces)</li>
-     * </ol>
-     *
-     * <p>
-     * If multiple adapters share the same vendor+device ID (e.g. multi-GPU), the first one is returned. If no confident
-     * match is found, returns {@code null}.
-     *
-     * @param adapters    list from {@link #queryAdapters()}
-     * @param vendorId    PCI vendor ID parsed from the registry key (0 if unknown)
-     * @param deviceId    PCI device ID parsed from the registry key (0 if unknown)
-     * @param adapterName adapter name from the registry {@code DriverDesc} value
-     * @return best-matching adapter, or {@code null}
-     */
-    public static DxgiAdapterInfo findMatch(List<DxgiAdapterInfo> adapters, int vendorId, int deviceId,
-            String adapterName) {
-        // Priority 1: vendor + device ID
-        if (vendorId != 0 && deviceId != 0) {
-            for (DxgiAdapterInfo a : adapters) {
-                if (a.getVendorId() == vendorId && a.getDeviceId() == deviceId) {
-                    return a;
-                }
-            }
-        }
-        // Priority 2: normalized name
-        if (adapterName != null && !adapterName.isEmpty()) {
-            String norm = normalizeName(adapterName);
-            for (DxgiAdapterInfo a : adapters) {
-                if (normalizeName(a.getDescription()).equals(norm)) {
-                    return a;
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Converts a registry value (REG_QWORD as Long, REG_DWORD as Integer, or REG_BINARY as byte[]) to a VRAM size in
-     * bytes. REG_BINARY is interpreted as little-endian.
-     *
-     * <p>
-     * Exposed as public for testing.
-     *
-     * @param value the registry value object
-     * @return the VRAM size in bytes, or 0 if the value type is unrecognised
-     */
-    public static long registryValueToVram(Object value) {
-        if (value instanceof Long) {
-            return (long) value;
-        } else if (value instanceof Integer) {
-            return Integer.toUnsignedLong((int) value);
-        } else if (value instanceof byte[]) {
-            byte[] bytes = (byte[]) value;
-            // Import is not available here; inline the little-endian conversion
-            long total = 0L;
-            int size = Math.min(bytes.length, 8);
-            for (int i = 0; i < size; i++) {
-                total = total << 8 | bytes[size - i - 1] & 0xff;
-            }
-            return total;
-        }
-        return 0L;
-    }
-
-    /**
-     * Normalizes an adapter name for fuzzy matching: lower-case, strips {@code (R)}/{@code (TM)}, collapses whitespace.
-     *
-     * @param name the raw adapter name, may be {@code null}
-     * @return normalized name, never {@code null}
-     */
-    public static String normalizeName(String name) {
-        if (name == null) {
-            return "";
-        }
-        return name.toLowerCase(java.util.Locale.ROOT).replace("(r)", "").replace("(tm)", "").replaceAll("\\s+", " ")
-                .trim();
     }
 }

--- a/oshi-core/src/main/java/oshi/util/gpu/AdlUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/AdlUtilJNA.java
@@ -41,9 +41,9 @@ import oshi.jna.platform.windows.Adl.AdlMallocCallback;
  * Adapter bus-number-to-index mappings are enumerated once on first successful init and cached thereafter.
  */
 @ThreadSafe
-public final class AdlUtil {
+public final class AdlUtilJNA {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AdlUtil.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AdlUtilJNA.class);
 
     // -------------------------------------------------------------------------
     // Library loading (holder pattern — loads the .dll once)
@@ -86,7 +86,7 @@ public final class AdlUtil {
         }
     }
 
-    private AdlUtil() {
+    private AdlUtilJNA() {
     }
 
     // Lazy adapter enumeration state — written once, read-only thereafter

--- a/oshi-core/src/main/java/oshi/util/gpu/DxgiUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/DxgiUtilJNA.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.gpu;
+
+import java.util.List;
+import java.util.Locale;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.windows.DxgiAdapterInfo;
+import oshi.jna.platform.windows.Dxgi;
+
+/**
+ * Utility methods for DXGI adapter enumeration and matching on Windows.
+ */
+@ThreadSafe
+public final class DxgiUtilJNA {
+
+    private DxgiUtilJNA() {
+    }
+
+    /**
+     * Enumerates all DXGI display adapters and returns their identity and dedicated video memory. Delegates to
+     * {@link Dxgi#queryAdapters()}.
+     *
+     * @return list of {@link DxgiAdapterInfo}, one per adapter; empty if DXGI is unavailable
+     */
+    public static List<DxgiAdapterInfo> queryAdapters() {
+        return Dxgi.queryAdapters();
+    }
+
+    /**
+     * Finds the best-matching DXGI adapter for a given vendor ID, device ID, and adapter name.
+     *
+     * <p>
+     * Matching priority:
+     * <ol>
+     * <li>Vendor ID + Device ID (exact, both non-zero)</li>
+     * <li>Normalized name match (case-insensitive, ignoring {@code (R)}, {@code (TM)}, extra spaces)</li>
+     * </ol>
+     *
+     * <p>
+     * If multiple adapters share the same vendor+device ID (e.g. multi-GPU), the first one is returned. If no confident
+     * match is found, returns {@code null}.
+     *
+     * @param adapters    list from {@link #queryAdapters()}
+     * @param vendorId    PCI vendor ID parsed from the registry key (0 if unknown)
+     * @param deviceId    PCI device ID parsed from the registry key (0 if unknown)
+     * @param adapterName adapter name from the registry {@code DriverDesc} value
+     * @return best-matching adapter, or {@code null}
+     */
+    public static DxgiAdapterInfo findMatch(List<DxgiAdapterInfo> adapters, int vendorId, int deviceId,
+            String adapterName) {
+        // Priority 1: vendor + device ID
+        if (vendorId != 0 && deviceId != 0) {
+            for (DxgiAdapterInfo a : adapters) {
+                if (a.getVendorId() == vendorId && a.getDeviceId() == deviceId) {
+                    return a;
+                }
+            }
+        }
+        // Priority 2: normalized name
+        if (adapterName != null && !adapterName.isEmpty()) {
+            String norm = normalizeName(adapterName);
+            for (DxgiAdapterInfo a : adapters) {
+                if (normalizeName(a.getDescription()).equals(norm)) {
+                    return a;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Converts a registry value (REG_QWORD as Long, REG_DWORD as Integer, or REG_BINARY as byte[]) to a VRAM size in
+     * bytes. REG_BINARY is interpreted as little-endian.
+     *
+     * @param value the registry value object
+     * @return the VRAM size in bytes, or 0 if the value type is unrecognised
+     */
+    public static long registryValueToVram(Object value) {
+        if (value instanceof Long) {
+            return (long) value;
+        } else if (value instanceof Integer) {
+            return Integer.toUnsignedLong((int) value);
+        } else if (value instanceof byte[]) {
+            byte[] bytes = (byte[]) value;
+            long total = 0L;
+            int size = Math.min(bytes.length, 8);
+            for (int i = 0; i < size; i++) {
+                total = total << 8 | bytes[size - i - 1] & 0xff;
+            }
+            return total;
+        }
+        return 0L;
+    }
+
+    /**
+     * Normalizes an adapter name for fuzzy matching: lower-case, strips {@code (R)}/{@code (TM)}, collapses whitespace.
+     *
+     * @param name the raw adapter name, may be {@code null}
+     * @return normalized name, never {@code null}
+     */
+    public static String normalizeName(String name) {
+        if (name == null) {
+            return "";
+        }
+        return name.toLowerCase(Locale.ROOT).replace("(r)", "").replace("(tm)", "").replaceAll("\\s+", " ").trim();
+    }
+}

--- a/oshi-core/src/test/java/oshi/util/gpu/DxgiUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/gpu/DxgiUtilTest.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.windows;
+package oshi.util.gpu;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -18,9 +18,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import oshi.jna.platform.windows.WindowsDxgi;
+import oshi.driver.windows.DxgiAdapterInfo;
 
-class WindowsDxgiTest {
+class DxgiUtilTest {
 
     // -------------------------------------------------------------------------
     // Unit tests for findMatch — platform-independent
@@ -34,7 +34,7 @@ class WindowsDxgiTest {
                 0);
         List<DxgiAdapterInfo> adapters = Arrays.asList(arc, igpu);
 
-        DxgiAdapterInfo match = WindowsDxgi.findMatch(adapters, 0x8086, 0x56A0, "Intel Arc A770");
+        DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0x8086, 0x56A0, "Intel Arc A770");
         assertThat("Should match Arc A770 by vendor+device ID", match, is(notNullValue()));
         assertThat(match.getDedicatedVideoMemory(), is(16L * 1024 * 1024 * 1024));
     }
@@ -48,7 +48,7 @@ class WindowsDxgiTest {
                 24L * 1024 * 1024 * 1024, 0, 0);
         List<DxgiAdapterInfo> adapters = Arrays.asList(first, second);
 
-        DxgiAdapterInfo match = WindowsDxgi.findMatch(adapters, 0x10DE, 0x2684, "NVIDIA GeForce RTX 4090");
+        DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0x10DE, 0x2684, "NVIDIA GeForce RTX 4090");
         assertThat(match, is(first));
     }
 
@@ -61,7 +61,7 @@ class WindowsDxgiTest {
                 16L * 1024 * 1024 * 1024, 0, 0);
         List<DxgiAdapterInfo> adapters = Collections.singletonList(adapter);
 
-        DxgiAdapterInfo match = WindowsDxgi.findMatch(adapters, 0, 0, "Intel Arc A770 Graphics");
+        DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0, 0, "Intel Arc A770 Graphics");
         assertThat("Should match by normalized name after stripping (R)/(TM)", match, is(notNullValue()));
         assertThat(match.getDedicatedVideoMemory(), is(16L * 1024 * 1024 * 1024));
     }
@@ -72,13 +72,13 @@ class WindowsDxgiTest {
                 24L * 1024 * 1024 * 1024, 0, 0);
         List<DxgiAdapterInfo> adapters = Collections.singletonList(adapter);
 
-        DxgiAdapterInfo match = WindowsDxgi.findMatch(adapters, 0x8086, 0x56A0, "Intel Arc A770");
+        DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0x8086, 0x56A0, "Intel Arc A770");
         assertThat("Different vendor+device should not match", match, is(nullValue()));
     }
 
     @Test
     void testFindMatchEmptyListReturnsNull() {
-        DxgiAdapterInfo match = WindowsDxgi.findMatch(Collections.emptyList(), 0x8086, 0x56A0, "Intel Arc A770");
+        DxgiAdapterInfo match = DxgiUtilJNA.findMatch(Collections.emptyList(), 0x8086, 0x56A0, "Intel Arc A770");
         assertThat(match, is(nullValue()));
     }
 
@@ -89,7 +89,7 @@ class WindowsDxgiTest {
         List<DxgiAdapterInfo> adapters = Collections.singletonList(adapter);
 
         // vendorId=0 and deviceId=0 should skip ID matching and try name
-        DxgiAdapterInfo match = WindowsDxgi.findMatch(adapters, 0, 0, "AMD Radeon RX 7900 XTX");
+        DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0, 0, "AMD Radeon RX 7900 XTX");
         assertThat("Should fall through to name match when IDs are zero", match, is(notNullValue()));
     }
 
@@ -99,17 +99,17 @@ class WindowsDxgiTest {
 
     @Test
     void testNormalizeNameStripsTrademarks() {
-        assertThat(WindowsDxgi.normalizeName("Intel(R) Arc(TM) A770 Graphics"), is("intel arc a770 graphics"));
+        assertThat(DxgiUtilJNA.normalizeName("Intel(R) Arc(TM) A770 Graphics"), is("intel arc a770 graphics"));
     }
 
     @Test
     void testNormalizeNameCollapsesWhitespace() {
-        assertThat(WindowsDxgi.normalizeName("NVIDIA  GeForce   RTX  4090"), is("nvidia geforce rtx 4090"));
+        assertThat(DxgiUtilJNA.normalizeName("NVIDIA  GeForce   RTX  4090"), is("nvidia geforce rtx 4090"));
     }
 
     @Test
     void testNormalizeNameNull() {
-        assertThat(WindowsDxgi.normalizeName(null), is(""));
+        assertThat(DxgiUtilJNA.normalizeName(null), is(""));
     }
 
     // -------------------------------------------------------------------------
@@ -119,25 +119,25 @@ class WindowsDxgiTest {
     @Test
     void testRegistryValueToVramLong() {
         long expected = 16L * 1024 * 1024 * 1024;
-        assertThat(WindowsDxgi.registryValueToVram(expected), is(expected));
+        assertThat(DxgiUtilJNA.registryValueToVram(expected), is(expected));
     }
 
     @Test
     void testRegistryValueToVramInteger() {
         // 0x80000000 would overflow signed int; test unsigned widening
-        assertThat(WindowsDxgi.registryValueToVram(0x80000000), is(0x80000000L));
+        assertThat(DxgiUtilJNA.registryValueToVram(0x80000000), is(0x80000000L));
     }
 
     @Test
     void testRegistryValueToVramByteArrayLittleEndian() {
         // 16 GB = 0x0000000400000000 in little-endian bytes
         byte[] bytes = { 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00 };
-        assertThat(WindowsDxgi.registryValueToVram(bytes), is(0x0000000400000000L));
+        assertThat(DxgiUtilJNA.registryValueToVram(bytes), is(0x0000000400000000L));
     }
 
     @Test
     void testRegistryValueToVramNull() {
-        assertThat(WindowsDxgi.registryValueToVram(null), is(0L));
+        assertThat(DxgiUtilJNA.registryValueToVram(null), is(0L));
     }
 
     // -------------------------------------------------------------------------
@@ -147,7 +147,7 @@ class WindowsDxgiTest {
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void testQueryAdaptersOnWindows() {
-        List<DxgiAdapterInfo> adapters = WindowsDxgi.queryAdapters();
+        List<DxgiAdapterInfo> adapters = DxgiUtilJNA.queryAdapters();
         // An empty list is acceptable in headless or virtual environments where DXGI
         // is unavailable; only assert per-adapter invariants when adapters are present.
         for (DxgiAdapterInfo a : adapters) {

--- a/pom.xml
+++ b/pom.xml
@@ -799,13 +799,20 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <configuration>
                     <excludes>
-                        <exclude>**/driver/**</exclude>
-                        <exclude>**/common/**</exclude>
-                        <exclude>**/Abstract*</exclude>
                         <exclude>**/annotation/**</exclude>
-                        <exclude>**/jna/**</exclude>
-                        <exclude>**/unix/**</exclude>
+                        <exclude>**/benchmark/**</exclude>
                         <exclude>**/demo/**</exclude>
+                        <exclude>**/jna/**</exclude>
+                        <exclude>**/unix/aix/**</exclude>
+                        <exclude>**/unix/freebsd/**</exclude>
+                        <exclude>**/unix/openbsd/**</exclude>
+                        <exclude>**/unix/solaris/**</exclude>
+                        <exclude>**/unix/*Aix*</exclude>
+                        <exclude>**/unix/*Bsd*</exclude>
+                        <exclude>**/unix/*FreeBsd*</exclude>
+                        <exclude>**/unix/*OpenBsd*</exclude>
+                        <exclude>**/unix/*Solaris*</exclude>
+                        <exclude>**/unix/UnixBaseboard*</exclude>
                     </excludes>
                 </configuration>
                 <executions>


### PR DESCRIPTION
## JaCoCo exclude changes

Remove excludes that were hiding tested code from coverage reports:
- ``**/common/**`` - oshi-common classes now have direct tests
- ``**/driver/**`` - driver classes are exercised by platform tests
- ``**/Abstract*`` - abstract base classes are tested via subclasses

Add new exclude:
- ``**/benchmark/**`` - benchmark harness code, not production logic

Replace blanket ``**/unix/**`` exclude with granular excludes for platforms with limited CI coverage:
- ``**/unix/aix/**``, ``**/unix/freebsd/**``, ``**/unix/openbsd/**``, ``**/unix/solaris/**``
- ``**/unix/*Aix*``, ``**/unix/*Bsd*``, ``**/unix/*FreeBsd*``, ``**/unix/*OpenBsd*``, ``**/unix/*Solaris*``
- ``**/unix/UnixBaseboard*``

This preserves coverage for shared unix classes used on macOS (e.g. UnixPrinter, Cups).

## DxgiUtilJNA extraction

Extract four static helper methods from the JNA mapping class ``Dxgi`` (formerly ``WindowsDxgi``) to new ``DxgiUtilJNA`` in ``oshi.util.gpu`` so they are visible to JaCoCo (``**/jna/**`` is excluded):
- ``queryAdapters()`` (delegates to ``Dxgi``)
- ``findMatch()``
- ``registryValueToVram()``
- ``normalizeName()``

Rename ``AdlUtil`` to ``AdlUtilJNA`` for consistency with ``NvmlUtilJNA`` and ``DxgiUtilJNA``.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized GPU utility code with improved separation of concerns for AMD and NVIDIA GPU metric backends.
  * Consolidated adapter query and utility operations into dedicated utility classes.

* **Tests**
  * Relocated and updated GPU-related tests to align with utility code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->