### PR TITLE
Add Linux hardware tests; fix sensors fan/voltage discovery bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#3152](https://github.com/oshi/oshi/pull/3152): Fix FFM TCP stats sysctl failure on Apple Silicon; suppress missing AppleHDA.kext log noise on ARM macOS - [@dbwiddis](https://github.com/dbwiddis).
 * [#3153](https://github.com/oshi/oshi/pull/3153): Fix FFM network stats to use two-call sysctl pattern matching JNA approach - [@dbwiddis](https://github.com/dbwiddis).
 * [#3154](https://github.com/oshi/oshi/pull/3154): Improve API documentation: usage examples, platform notes, cross-references, JEP 472 guidance, and virtual memory model differences - [@dbwiddis](https://github.com/dbwiddis).
+* [#3160](https://github.com/oshi/oshi/pull/3160): Fix LinuxSensors fan and voltage discovery passing wrong path to getSensorFilesFromPath - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
@@ -305,7 +305,18 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
      * @return triplet of (drmDevicePath, driverName, pciBusId), all empty strings if not found
      */
     private static Triplet<String, String, String> findDrmInfo(String pciSlot) {
-        File drmDir = new File(DRM_PATH);
+        return findDrmInfo(pciSlot, DRM_PATH);
+    }
+
+    /**
+     * Finds the sysfs DRM device path, driver name, and PCI bus ID for a GPU.
+     *
+     * @param pciSlot the PCI slot address, or {@code null} to use first-match
+     * @param drmPath the base DRM sysfs directory path
+     * @return triplet of (drmDevicePath, driverName, pciBusId), all empty strings if not found
+     */
+    static Triplet<String, String, String> findDrmInfo(String pciSlot, String drmPath) {
+        File drmDir = new File(drmPath);
         File[] cards = drmDir.listFiles(f -> f.getName().matches("card\\d+"));
         if (cards == null) {
             return new Triplet<>("", "", "");
@@ -337,7 +348,7 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
      * @param key        the key to look up (e.g. {@code "PCI_SLOT_NAME"})
      * @return the value string, or empty string if not found
      */
-    private static String readUeventValue(String ueventPath, String key) {
+    static String readUeventValue(String ueventPath, String key) {
         List<String> lines = FileUtil.readFile(ueventPath);
         String prefix = key + "=";
         for (String line : lines) {
@@ -348,7 +359,7 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
         return "";
     }
 
-    private static String readDriverName(String driverSymlink) {
+    static String readDriverName(String driverSymlink) {
         String target = FileUtil.readSymlinkTarget(new File(driverSymlink));
         if (target == null || target.isEmpty()) {
             return "";

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxPowerSource.java
@@ -83,8 +83,18 @@ public class LinuxPowerSource extends AbstractPowerSource {
      * @return An array of PowerSource objects representing batteries, etc.
      */
     public static List<PowerSource> getPowerSources() {
+        return getPowerSources(SysPath.POWER_SUPPLY);
+    }
+
+    /**
+     * Gets Battery Information from the specified power supply path.
+     *
+     * @param powerSupplyPath The path to the power supply directory.
+     * @return An array of PowerSource objects representing batteries, etc.
+     */
+    static List<PowerSource> getPowerSources(String powerSupplyPath) {
         List<PowerSource> psList = new ArrayList<>();
-        File psDir = new File(SysPath.POWER_SUPPLY);
+        File psDir = new File(powerSupplyPath);
         File[] psArr = psDir.listFiles();
         if (psArr == null) {
             return Collections.emptyList();
@@ -92,7 +102,7 @@ public class LinuxPowerSource extends AbstractPowerSource {
         for (File ps : psArr) {
             String name = ps.getName();
             if (!name.startsWith("ADP") && !name.startsWith("AC") && !name.contains("USBC")) {
-                List<String> psInfo = FileUtil.readFile(SysPath.POWER_SUPPLY + "/" + name + "/uevent", false);
+                List<String> psInfo = FileUtil.readFile(powerSupplyPath + "/" + name + "/uevent", false);
                 Map<Prop, String> props = new EnumMap<>(Prop.class);
                 for (String line : psInfo) {
                     String[] split = line.split("=", 2);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSensors.java
@@ -30,7 +30,7 @@ import oshi.util.linux.SysPath;
  * Sensors from WMI or Open Hardware Monitor
  */
 @ThreadSafe
-final class LinuxSensors extends AbstractSensors {
+class LinuxSensors extends AbstractSensors {
 
     /**
      * Configuration property for prioritizing hwmon temperature sensors by name. Common sensor names include:
@@ -62,15 +62,14 @@ final class LinuxSensors extends AbstractSensors {
     private static final String INPUT_SUFFIX = "_input";
     private static final Pattern TEMP_INPUT_PATTERN = Pattern.compile("^" + TEMP + "\\d+" + INPUT_SUFFIX + "$");
 
-    // Base HWMON path, adds 0, 1, etc. to end for various sensors
+    // Base path constants
     private static final String HWMON = "hwmon";
-    private static final String HWMON_PATH = SysPath.HWMON + HWMON;
-    // Base THERMAL_ZONE path, adds 0, 1, etc. to end for temperature sensors
     private static final String THERMAL_ZONE = "thermal_zone";
-    private static final String THERMAL_ZONE_PATH = SysPath.THERMAL + THERMAL_ZONE;
 
-    // Initial test to see if we are running on a Pi
-    private static final boolean IS_PI = queryCpuTemperatureFromVcGenCmd() > 0;
+    // Instance fields set by constructor
+    private final String hwmonPath;
+    private final String thermalZonePath;
+    private final boolean isPi;
 
     // Map from sensor to path. Built by constructor, so thread safe
     private final Map<String, String> sensorsMap = new HashMap<>();
@@ -81,7 +80,21 @@ final class LinuxSensors extends AbstractSensors {
      * </p>
      */
     LinuxSensors() {
-        if (!IS_PI) {
+        this(SysPath.HWMON + HWMON, SysPath.THERMAL + THERMAL_ZONE, queryCpuTemperatureFromVcGenCmd() > 0);
+    }
+
+    /**
+     * Constructor accepting explicit paths for testability.
+     *
+     * @param hwmonBasePath       base path for hwmon directories (e.g. "/sys/class/hwmon/hwmon")
+     * @param thermalZoneBasePath base path for thermal zone directories (e.g. "/sys/class/thermal/thermal_zone")
+     * @param isPi                whether this is a Raspberry Pi (uses vcgencmd)
+     */
+    LinuxSensors(String hwmonBasePath, String thermalZoneBasePath, boolean isPi) {
+        this.hwmonPath = hwmonBasePath;
+        this.thermalZonePath = thermalZoneBasePath;
+        this.isPi = isPi;
+        if (!isPi) {
             populateSensorsMapFromHwmon();
             // if no temperature sensor is found in hwmon, try thermal_zone
             if (!this.sensorsMap.containsKey(TEMP)) {
@@ -98,8 +111,8 @@ final class LinuxSensors extends AbstractSensors {
         int selectedPriority = Integer.MAX_VALUE;
 
         int i = 0;
-        while (Paths.get(HWMON_PATH + i).toFile().isDirectory()) {
-            String path = HWMON_PATH + i;
+        while (Paths.get(hwmonPath + i).toFile().isDirectory()) {
+            String path = hwmonPath + i;
 
             // Read the name file
             String sensorName = FileUtil.getStringFromFile(path + NAME).trim();
@@ -123,25 +136,24 @@ final class LinuxSensors extends AbstractSensors {
                 }
             }
 
-            // Handle other sensor types (fan, voltage)
-            for (String sensor : new String[] { FAN, VOLTAGE }) {
-                final String sensorPrefix = sensor;
-                // Final to pass to anonymous class
-                getSensorFilesFromPath(path, sensor, f -> {
-                    try {
-                        return f.getName().startsWith(sensorPrefix) && f.getName().endsWith(INPUT_SUFFIX)
-                                && FileUtil.getIntFromFile(f.getCanonicalPath()) > 0;
-                    } catch (IOException e) {
-                        return false;
-                    }
-                });
-            }
-
             i++;
         }
 
         if (selectedTempPath != null) {
             this.sensorsMap.put(TEMP, selectedTempPath + "/temp");
+        }
+
+        // Scan all hwmon directories for fan and voltage sensors
+        for (String sensor : new String[] { FAN, VOLTAGE }) {
+            final String sensorPrefix = sensor;
+            getSensorFilesFromPath(hwmonPath, sensor, f -> {
+                try {
+                    return f.getName().startsWith(sensorPrefix) && f.getName().endsWith(INPUT_SUFFIX)
+                            && FileUtil.getIntFromFile(f.getCanonicalPath()) > 0;
+                } catch (IOException e) {
+                    return false;
+                }
+            });
         }
     }
 
@@ -149,7 +161,7 @@ final class LinuxSensors extends AbstractSensors {
      * Iterate over all thermal_zone* directories and look for sensor files, e.g., /sys/class/thermal/thermal_zone0/temp
      */
     private void populateSensorsMapFromThermalZone() {
-        getSensorFilesFromPath(THERMAL_ZONE_PATH, TEMP, f -> f.getName().equals(TYPE) || f.getName().equals(TEMP),
+        getSensorFilesFromPath(thermalZonePath, TEMP, f -> f.getName().equals(TYPE) || f.getName().equals(TEMP),
                 files -> Stream.of(files).filter(f -> TYPE.equals(f.getName())).findFirst().map(File::getPath)
                         .map(FileUtil::getStringFromFile).map(THERMAL_ZONE_TYPE_PRIORITY::indexOf)
                         .filter((index) -> index >= 0).orElse(THERMAL_ZONE_TYPE_PRIORITY.size()));
@@ -203,7 +215,7 @@ final class LinuxSensors extends AbstractSensors {
 
     @Override
     public double queryCpuTemperature() {
-        if (IS_PI) {
+        if (isPi) {
             return queryCpuTemperatureFromVcGenCmd();
         }
         String tempStr = this.sensorsMap.get(TEMP);
@@ -259,7 +271,7 @@ final class LinuxSensors extends AbstractSensors {
 
     @Override
     public int[] queryFanSpeeds() {
-        if (!IS_PI) {
+        if (!isPi) {
             String fanStr = this.sensorsMap.get(FAN);
             if (fanStr != null) {
                 List<Integer> speeds = new ArrayList<>();
@@ -287,7 +299,7 @@ final class LinuxSensors extends AbstractSensors {
 
     @Override
     public double queryCpuVoltage() {
-        if (IS_PI) {
+        if (isPi) {
             return queryCpuVoltageFromVcGenCmd();
         }
         String voltageStr = this.sensorsMap.get(VOLTAGE);

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGpuStatsTest.java
@@ -1,0 +1,602 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests {@link LinuxGpuStats} sysfs parsing logic using temp directory fixtures. A concrete subclass stubs all NVML
+ * methods to unavailable, isolating the sysfs code paths.
+ */
+class LinuxGpuStatsTest {
+
+    private static final double EPS = 1e-6;
+
+    /** Concrete subclass with NVML always unavailable. Tracks findDevice call count. */
+    private static final class StubLinuxGpuStats extends LinuxGpuStats {
+        private int findDeviceCallCount;
+
+        StubLinuxGpuStats(String drmDevicePath, String driverName, String pciBusId, String cardName) {
+            super(drmDevicePath, driverName, pciBusId, cardName);
+        }
+
+        /**
+         * Returns the number of times nvmlFindDevice was called.
+         *
+         * @return call count
+         */
+        int getFindDeviceCallCount() {
+            return findDeviceCallCount;
+        }
+
+        @Override
+        protected boolean nvmlIsAvailable() {
+            return false;
+        }
+
+        @Override
+        protected String nvmlFindDevice(String busId) {
+            findDeviceCallCount++;
+            return null;
+        }
+
+        @Override
+        protected String nvmlFindDeviceByName(String name) {
+            return null;
+        }
+
+        @Override
+        protected long nvmlGetVramUsed(String deviceId) {
+            return -1L;
+        }
+
+        @Override
+        protected double nvmlGetTemperature(String deviceId) {
+            return -1d;
+        }
+
+        @Override
+        protected double nvmlGetPowerDraw(String deviceId) {
+            return -1d;
+        }
+
+        @Override
+        protected long nvmlGetCoreClockMhz(String deviceId) {
+            return -1L;
+        }
+
+        @Override
+        protected long nvmlGetMemoryClockMhz(String deviceId) {
+            return -1L;
+        }
+
+        @Override
+        protected double nvmlGetFanSpeedPercent(String deviceId) {
+            return -1d;
+        }
+    }
+
+    /** Concrete subclass simulating a working NVML device found by bus ID. Tracks findDevice call count. */
+    private static final class NvmlLinuxGpuStats extends LinuxGpuStats {
+        private int findDeviceCallCount;
+
+        NvmlLinuxGpuStats(String drmDevicePath, String driverName, String pciBusId, String cardName) {
+            super(drmDevicePath, driverName, pciBusId, cardName);
+        }
+
+        /**
+         * Returns the number of times nvmlFindDevice was called.
+         *
+         * @return call count
+         */
+        int getFindDeviceCallCount() {
+            return findDeviceCallCount;
+        }
+
+        @Override
+        protected boolean nvmlIsAvailable() {
+            return true;
+        }
+
+        @Override
+        protected String nvmlFindDevice(String busId) {
+            findDeviceCallCount++;
+            return "nvml-device-0";
+        }
+
+        @Override
+        protected String nvmlFindDeviceByName(String name) {
+            return "nvml-device-0";
+        }
+
+        @Override
+        protected long nvmlGetVramUsed(String deviceId) {
+            return 2147483648L;
+        }
+
+        @Override
+        protected double nvmlGetTemperature(String deviceId) {
+            return 65.0;
+        }
+
+        @Override
+        protected double nvmlGetPowerDraw(String deviceId) {
+            return 120.0;
+        }
+
+        @Override
+        protected long nvmlGetCoreClockMhz(String deviceId) {
+            return 1800L;
+        }
+
+        @Override
+        protected long nvmlGetMemoryClockMhz(String deviceId) {
+            return 7000L;
+        }
+
+        @Override
+        protected double nvmlGetFanSpeedPercent(String deviceId) {
+            return 45.0;
+        }
+    }
+
+    private static void writeFile(Path path, String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // -------------------------------------------------------------------------
+    // Empty / missing path — all metrics return sentinel
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testEmptyPathReturnsSentinels() {
+        try (LinuxGpuStats stats = new StubLinuxGpuStats("", "", "", "TestGPU")) {
+            assertThat(stats.getGpuUtilization(), is(-1d));
+            assertThat(stats.getVramUsed(), is(-1L));
+            assertThat(stats.getTemperature(), is(-1d));
+            assertThat(stats.getPowerDraw(), is(-1d));
+            assertThat(stats.getCoreClockMhz(), is(-1L));
+            assertThat(stats.getMemoryClockMhz(), is(-1L));
+            assertThat(stats.getFanSpeedPercent(), is(-1d));
+            assertThat(stats.getSharedMemoryUsed(), is(-1L));
+            assertThat(stats.getGpuTicks().getActiveTicks(), is(0L));
+            assertThat(stats.getGpuTicks().getIdleTicks(), is(0L));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Session lifecycle
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testCloseAndThrow() {
+        LinuxGpuStats stats = new StubLinuxGpuStats("", "", "", "TestGPU");
+        assertThat(stats.isClosed(), is(false));
+        stats.close();
+        assertThat(stats.isClosed(), is(true));
+        assertThrows(IllegalStateException.class, stats::getGpuUtilization);
+        assertThrows(IllegalStateException.class, stats::getVramUsed);
+        assertThrows(IllegalStateException.class, stats::getTemperature);
+        assertThrows(IllegalStateException.class, stats::getPowerDraw);
+        assertThrows(IllegalStateException.class, stats::getCoreClockMhz);
+        assertThrows(IllegalStateException.class, stats::getMemoryClockMhz);
+        assertThrows(IllegalStateException.class, stats::getFanSpeedPercent);
+        assertThrows(IllegalStateException.class, stats::getSharedMemoryUsed);
+        assertThrows(IllegalStateException.class, stats::getGpuTicks);
+    }
+
+    // -------------------------------------------------------------------------
+    // amdgpu driver
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testAmdgpuUtilization(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Files.createDirectories(device);
+        writeFile(device.resolve("gpu_busy_percent"), "42\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getGpuUtilization(), closeTo(42.0, EPS));
+        }
+    }
+
+    @Test
+    void testAmdgpuVramUsed(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Files.createDirectories(device);
+        writeFile(device.resolve("mem_info_vram_used"), "1073741824\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getVramUsed(), is(1073741824L));
+        }
+    }
+
+    @Test
+    void testAmdgpuTemperatureFromHwmon(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Path hwmon = device.resolve("hwmon/hwmon0");
+        Files.createDirectories(hwmon);
+        writeFile(hwmon.resolve("temp1_input"), "72000\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getTemperature(), closeTo(72.0, EPS));
+        }
+    }
+
+    @Test
+    void testAmdgpuPowerFromHwmon(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Path hwmon = device.resolve("hwmon/hwmon0");
+        Files.createDirectories(hwmon);
+        writeFile(hwmon.resolve("power1_average"), "150000000\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getPowerDraw(), closeTo(150.0, EPS));
+        }
+    }
+
+    @Test
+    void testAmdgpuCoreClockFromHwmonFreq(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Path hwmon = device.resolve("hwmon/hwmon0");
+        Files.createDirectories(hwmon);
+        writeFile(hwmon.resolve("freq1_input"), "1800000000\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getCoreClockMhz(), is(1800L));
+        }
+    }
+
+    @Test
+    void testAmdgpuCoreClockFallbackToDpm(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Files.createDirectories(device);
+        // No hwmon freq1_input, fall back to pp_dpm_sclk
+        writeFile(device.resolve("pp_dpm_sclk"), "0: 500Mhz\n1: 1200Mhz *\n2: 1800Mhz\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getCoreClockMhz(), is(1200L));
+        }
+    }
+
+    @Test
+    void testAmdgpuMemoryClockFromHwmonFreq(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Path hwmon = device.resolve("hwmon/hwmon0");
+        Files.createDirectories(hwmon);
+        writeFile(hwmon.resolve("freq2_input"), "1000000000\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getMemoryClockMhz(), is(1000L));
+        }
+    }
+
+    @Test
+    void testAmdgpuMemoryClockFallbackToDpm(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Files.createDirectories(device);
+        writeFile(device.resolve("pp_dpm_mclk"), "0: 400Mhz\n1: 800Mhz\n2: 1000Mhz *\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getMemoryClockMhz(), is(1000L));
+        }
+    }
+
+    @Test
+    void testAmdgpuFanSpeedFromRpm(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Path hwmon = device.resolve("hwmon/hwmon0");
+        Files.createDirectories(hwmon);
+        writeFile(hwmon.resolve("fan1_input"), "1500\n");
+        writeFile(hwmon.resolve("fan1_max"), "3000\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getFanSpeedPercent(), closeTo(50.0, EPS));
+        }
+    }
+
+    @Test
+    void testAmdgpuFanSpeedFallbackToPwm(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Path hwmon = device.resolve("hwmon/hwmon0");
+        Files.createDirectories(hwmon);
+        // No fan1_input/fan1_max, fall back to pwm1
+        // pwm1 range is 0-255; 128 ≈ 50.2%
+        writeFile(hwmon.resolve("pwm1"), "128\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getFanSpeedPercent(), closeTo(128.0 / 255.0 * 100.0, EPS));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // i915 driver
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a temp directory layout matching real sysfs: {@code card0/device} and {@code card0/gt/gt0}. The
+     * constructor computes gt0Path as {@code drmDevicePath + "/../gt/gt0"}, so the "device" dir must be a real
+     * subdirectory so that ".." resolves to the card directory.
+     *
+     * @param tmp the JUnit {@code @TempDir} root
+     * @return the {@code device} subdirectory path to pass as {@code drmDevicePath}
+     * @throws IOException if directory creation fails
+     */
+    private static Path createCardWithGt(Path tmp) throws IOException {
+        Path card = tmp.resolve("card0");
+        Path device = card.resolve("device");
+        Path gt0 = card.resolve("gt/gt0");
+        Files.createDirectories(device);
+        Files.createDirectories(gt0);
+        return device;
+    }
+
+    @Test
+    void testI915Utilization(@TempDir Path tmp) throws IOException {
+        Path device = createCardWithGt(tmp);
+        Path gt0 = device.getParent().resolve("gt/gt0");
+        writeFile(gt0.resolve("rps_act_freq_mhz"), "1200\n");
+        writeFile(gt0.resolve("rps_max_freq_mhz"), "1500\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "i915", "", "Intel GPU")) {
+            // 1200/1500 * 100 = 80%
+            assertThat(stats.getGpuUtilization(), closeTo(80.0, EPS));
+        }
+    }
+
+    @Test
+    void testI915UtilizationZeroActual(@TempDir Path tmp) throws IOException {
+        Path device = createCardWithGt(tmp);
+        Path gt0 = device.getParent().resolve("gt/gt0");
+        writeFile(gt0.resolve("rps_act_freq_mhz"), "0\n");
+        writeFile(gt0.resolve("rps_max_freq_mhz"), "1500\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "i915", "", "Intel GPU")) {
+            assertThat(stats.getGpuUtilization(), closeTo(0.0, EPS));
+        }
+    }
+
+    @Test
+    void testI915CoreClock(@TempDir Path tmp) throws IOException {
+        Path device = createCardWithGt(tmp);
+        Path gt0 = device.getParent().resolve("gt/gt0");
+        writeFile(gt0.resolve("rps_cur_freq_mhz"), "1350\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "i915", "", "Intel GPU")) {
+            assertThat(stats.getCoreClockMhz(), is(1350L));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // xe driver (same paths as i915)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testXeUtilization(@TempDir Path tmp) throws IOException {
+        Path device = createCardWithGt(tmp);
+        Path gt0 = device.getParent().resolve("gt/gt0");
+        writeFile(gt0.resolve("rps_act_freq_mhz"), "900\n");
+        writeFile(gt0.resolve("rps_max_freq_mhz"), "1800\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "xe", "", "Intel GPU")) {
+            assertThat(stats.getGpuUtilization(), closeTo(50.0, EPS));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Unknown driver — utilization/clock/memclock return sentinel
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testUnknownDriverReturnsSentinels(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Files.createDirectories(device);
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "nouveau", "", "GPU")) {
+            assertThat(stats.getGpuUtilization(), is(-1d));
+            assertThat(stats.getCoreClockMhz(), is(-1L));
+            assertThat(stats.getMemoryClockMhz(), is(-1L));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // NVML device resolution caching
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testNvmlUnavailableCachesResult() {
+        StubLinuxGpuStats stats = new StubLinuxGpuStats("", "", "0000:01:00.0", "GPU");
+        // First call resolves and caches
+        assertThat(stats.findNvmlDevice() == null, is(true));
+        assertThat(stats.getFindDeviceCallCount(), is(0)); // nvmlIsAvailable() is false, never calls findDevice
+        // Second call uses cache — still no findDevice calls
+        assertThat(stats.findNvmlDevice() == null, is(true));
+        assertThat(stats.getFindDeviceCallCount(), is(0));
+        stats.close();
+    }
+
+    // -------------------------------------------------------------------------
+    // Hwmon not present — temperature/power/fan return sentinel
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testNoHwmonReturnsSentinels(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Files.createDirectories(device);
+        // No hwmon subdirectory
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getTemperature(), is(-1d));
+            assertThat(stats.getPowerDraw(), is(-1d));
+            assertThat(stats.getFanSpeedPercent(), is(-1d));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // pp_dpm_sclk with no active entry (no asterisk)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testDpmNoActiveEntry(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Files.createDirectories(device);
+        writeFile(device.resolve("pp_dpm_sclk"), "0: 500Mhz\n1: 1200Mhz\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
+            assertThat(stats.getCoreClockMhz(), is(-1L));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-amdgpu driver — VRAM returns sentinel
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testNonAmdgpuVramReturnsSentinel(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Files.createDirectories(device);
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "i915", "", "Intel GPU")) {
+            assertThat(stats.getVramUsed(), is(-1L));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-amdgpu driver — memory clock returns sentinel
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testNonAmdgpuMemoryClockReturnsSentinel(@TempDir Path tmp) throws IOException {
+        Path device = tmp.resolve("device");
+        Files.createDirectories(device);
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "i915", "", "Intel GPU")) {
+            assertThat(stats.getMemoryClockMhz(), is(-1L));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // i915 utilization with capped value (actual > max)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testI915UtilizationCappedAt100(@TempDir Path tmp) throws IOException {
+        Path device = createCardWithGt(tmp);
+        Path gt0 = device.getParent().resolve("gt/gt0");
+        writeFile(gt0.resolve("rps_act_freq_mhz"), "2000\n");
+        writeFile(gt0.resolve("rps_max_freq_mhz"), "1500\n");
+
+        try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "i915", "", "Intel GPU")) {
+            assertThat(stats.getGpuUtilization(), closeTo(100.0, EPS));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // NVML available — all metrics sourced from NVML
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testNvmlMetrics() {
+        try (NvmlLinuxGpuStats stats = new NvmlLinuxGpuStats("", "nvidia", "0000:01:00.0", "NVIDIA GPU")) {
+            assertThat(stats.getVramUsed(), is(2147483648L));
+            assertThat(stats.getTemperature(), closeTo(65.0, EPS));
+            assertThat(stats.getPowerDraw(), closeTo(120.0, EPS));
+            assertThat(stats.getCoreClockMhz(), is(1800L));
+            assertThat(stats.getMemoryClockMhz(), is(7000L));
+            assertThat(stats.getFanSpeedPercent(), closeTo(45.0, EPS));
+        }
+    }
+
+    @Test
+    void testNvmlDeviceResolutionCaching() {
+        NvmlLinuxGpuStats stats = new NvmlLinuxGpuStats("", "nvidia", "0000:01:00.0", "NVIDIA GPU");
+        // First call resolves via bus ID
+        assertThat(stats.findNvmlDevice(), is("nvml-device-0"));
+        assertThat(stats.getFindDeviceCallCount(), is(1));
+        // Second call uses cache — findDevice not called again
+        assertThat(stats.findNvmlDevice(), is("nvml-device-0"));
+        assertThat(stats.getFindDeviceCallCount(), is(1));
+        stats.close();
+    }
+
+    @Test
+    void testNvmlFallbackToNameLookup() {
+        // Bus ID is non-empty so findDevice(busId) is called first, returns null;
+        // then falls back to findDeviceByName
+        LinuxGpuStats stats = new LinuxGpuStats("", "nvidia", "0000:01:00.0", "NVIDIA GPU") {
+            @Override
+            protected boolean nvmlIsAvailable() {
+                return true;
+            }
+
+            @Override
+            protected String nvmlFindDevice(String busId) {
+                return null;
+            }
+
+            @Override
+            protected String nvmlFindDeviceByName(String name) {
+                return "nvml-by-name";
+            }
+
+            @Override
+            protected long nvmlGetVramUsed(String deviceId) {
+                return 1024L;
+            }
+
+            @Override
+            protected double nvmlGetTemperature(String deviceId) {
+                return -1d;
+            }
+
+            @Override
+            protected double nvmlGetPowerDraw(String deviceId) {
+                return -1d;
+            }
+
+            @Override
+            protected long nvmlGetCoreClockMhz(String deviceId) {
+                return -1L;
+            }
+
+            @Override
+            protected long nvmlGetMemoryClockMhz(String deviceId) {
+                return -1L;
+            }
+
+            @Override
+            protected double nvmlGetFanSpeedPercent(String deviceId) {
+                return -1d;
+            }
+        };
+        assertThat(stats.findNvmlDevice(), is("nvml-by-name"));
+        assertThat(stats.getVramUsed(), is(1024L));
+        stats.close();
+    }
+
+    // -------------------------------------------------------------------------
+    // Protected getters
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testProtectedGetters() {
+        StubLinuxGpuStats stats = new StubLinuxGpuStats("/dev/path", "amdgpu", "0000:03:00.0", "RX 7900");
+        assertThat(stats.getPciBusId(), is("0000:03:00.0"));
+        assertThat(stats.getCardName(), is("RX 7900"));
+        stats.close();
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import oshi.util.tuples.Triplet;
+
+class LinuxGraphicsCardTest {
+
+    /**
+     * Minimal concrete subclass for testing the abstract LinuxGraphicsCard.
+     */
+    private static class StubGraphicsCard extends LinuxGraphicsCard {
+        StubGraphicsCard(String name, String deviceId, String vendor, String versionInfo, long vram,
+                String drmDevicePath, String driverName, String pciBusId) {
+            super(name, deviceId, vendor, versionInfo, vram, drmDevicePath, driverName, pciBusId);
+        }
+    }
+
+    @Test
+    void testConstructorAndGetters() {
+        StubGraphicsCard card = new StubGraphicsCard("RTX 4090", "0x2684", "NVIDIA", "Rev: 01", 24576L,
+                "/sys/class/drm/card0/device", "nvidia", "0000:01:00.0");
+        assertThat(card.getName(), is("RTX 4090"));
+        assertThat(card.getDeviceId(), is("0x2684"));
+        assertThat(card.getVendor(), is("NVIDIA"));
+        assertThat(card.getVersionInfo(), is("Rev: 01"));
+        assertThat(card.getVRam(), is(24576L));
+        assertThat(card.getDrmDevicePath(), is("/sys/class/drm/card0/device"));
+        assertThat(card.getDriverName(), is("nvidia"));
+        assertThat(card.getPciBusId(), is("0000:01:00.0"));
+    }
+
+    @Test
+    void testAttrsConstructorAndGetters() {
+        LinuxGraphicsCard.Attrs attrs = new LinuxGraphicsCard.Attrs("RX 7900", "0x744c", "AMD", "Rev: c1", 20480L,
+                "/sys/class/drm/card1/device", "amdgpu", "0000:03:00.0");
+        assertThat(attrs.getName(), is("RX 7900"));
+        assertThat(attrs.getDeviceId(), is("0x744c"));
+        assertThat(attrs.getVendor(), is("AMD"));
+        assertThat(attrs.getVersionInfo(), is("Rev: c1"));
+        assertThat(attrs.getVram(), is(20480L));
+        assertThat(attrs.getDrmDevicePath(), is("/sys/class/drm/card1/device"));
+        assertThat(attrs.getDriverName(), is("amdgpu"));
+        assertThat(attrs.getPciBusId(), is("0000:03:00.0"));
+    }
+
+    @Test
+    void testFindDrmInfoNonexistentPath(@TempDir Path tempDir) {
+        Triplet<String, String, String> result = LinuxGraphicsCard.findDrmInfo("01:00.0",
+                tempDir.resolve("does-not-exist").toString());
+        assertThat(result.getA(), is(""));
+        assertThat(result.getB(), is(""));
+        assertThat(result.getC(), is(""));
+    }
+
+    @Test
+    void testFindDrmInfoEmptyDir(@TempDir Path tempDir) {
+        Triplet<String, String, String> result = LinuxGraphicsCard.findDrmInfo("01:00.0", tempDir.toString());
+        assertThat(result.getA(), is(""));
+        assertThat(result.getB(), is(""));
+        assertThat(result.getC(), is(""));
+    }
+
+    @Test
+    void testFindDrmInfoNoDriverSymlink(@TempDir Path tempDir) throws IOException {
+        // card0/device exists but no driver symlink
+        Files.createDirectories(tempDir.resolve("card0/device"));
+        Triplet<String, String, String> result = LinuxGraphicsCard.findDrmInfo("01:00.0", tempDir.toString());
+        assertThat(result.getA(), is(""));
+        assertThat(result.getB(), is(""));
+        assertThat(result.getC(), is(""));
+    }
+
+    @Test
+    void testFindDrmInfoMatchesPciSlot(@TempDir Path tempDir) throws IOException {
+        createCardWithDriver(tempDir, "card0", "amdgpu", "0000:01:00.0");
+        createCardWithDriver(tempDir, "card1", "i915", "0000:00:02.0");
+
+        Triplet<String, String, String> result = LinuxGraphicsCard.findDrmInfo("00:02.0", tempDir.toString());
+        assertThat(result.getB(), is("i915"));
+        assertThat(result.getC(), is("0000:00:02.0"));
+    }
+
+    @Test
+    void testFindDrmInfoFallsBackToFirstDriver(@TempDir Path tempDir) throws IOException {
+        createCardWithDriver(tempDir, "card0", "amdgpu", "0000:01:00.0");
+
+        // No slot match — should fall back to first card with a driver
+        Triplet<String, String, String> result = LinuxGraphicsCard.findDrmInfo("99:00.0", tempDir.toString());
+        assertThat(result.getB(), is("amdgpu"));
+        assertThat(result.getC(), is("0000:01:00.0"));
+    }
+
+    @Test
+    void testFindDrmInfoNullPciSlotFallback(@TempDir Path tempDir) throws IOException {
+        createCardWithDriver(tempDir, "card0", "xe", "0000:00:02.0");
+
+        Triplet<String, String, String> result = LinuxGraphicsCard.findDrmInfo(null, tempDir.toString());
+        assertThat(result.getB(), is("xe"));
+        assertThat(result.getC(), is("0000:00:02.0"));
+    }
+
+    @Test
+    void testFindDrmInfoIgnoresNonCardDirs(@TempDir Path tempDir) throws IOException {
+        // "renderD128" should not match the card\d+ pattern
+        Files.createDirectories(tempDir.resolve("renderD128/device"));
+        createCardWithDriver(tempDir, "card0", "nvidia", "0000:01:00.0");
+
+        Triplet<String, String, String> result = LinuxGraphicsCard.findDrmInfo(null, tempDir.toString());
+        assertThat(result.getB(), is("nvidia"));
+    }
+
+    @Test
+    void testReadUeventValue(@TempDir Path tempDir) throws IOException {
+        Path uevent = tempDir.resolve("uevent");
+        String content = "DRIVER=amdgpu\nPCI_SLOT_NAME=0000:01:00.0\nPCI_ID=1002:744C\n";
+        Files.write(uevent, content.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(LinuxGraphicsCard.readUeventValue(uevent.toString(), "PCI_SLOT_NAME"), is("0000:01:00.0"));
+        assertThat(LinuxGraphicsCard.readUeventValue(uevent.toString(), "DRIVER"), is("amdgpu"));
+        assertThat(LinuxGraphicsCard.readUeventValue(uevent.toString(), "MISSING_KEY"), is(""));
+    }
+
+    @Test
+    void testReadUeventValueMissingFile(@TempDir Path tempDir) {
+        assertThat(LinuxGraphicsCard.readUeventValue(tempDir.resolve("no-uevent").toString(), "KEY"), is(""));
+    }
+
+    @Test
+    void testReadDriverNameSymlink(@TempDir Path tempDir) throws IOException {
+        // Create a fake driver directory and symlink to it
+        Path driverDir = tempDir.resolve("bus/pci/drivers/amdgpu");
+        Files.createDirectories(driverDir);
+        Path symlink = tempDir.resolve("driver");
+        Files.createSymbolicLink(symlink, driverDir);
+
+        assertThat(LinuxGraphicsCard.readDriverName(symlink.toString()), is("amdgpu"));
+    }
+
+    @Test
+    void testReadDriverNameNoSymlink(@TempDir Path tempDir) {
+        assertThat(LinuxGraphicsCard.readDriverName(tempDir.resolve("no-driver").toString()), is(""));
+    }
+
+    /**
+     * Creates a card directory with a driver symlink and uevent file.
+     *
+     * @param drmDir     the base DRM directory
+     * @param cardName   e.g. "card0"
+     * @param driverName e.g. "amdgpu"
+     * @param slotName   e.g. "0000:01:00.0"
+     * @throws IOException if file creation fails
+     */
+    private static void createCardWithDriver(Path drmDir, String cardName, String driverName, String slotName)
+            throws IOException {
+        Path deviceDir = drmDir.resolve(cardName + "/device");
+        Files.createDirectories(deviceDir);
+        // Create a fake driver target and symlink
+        Path driverTarget = drmDir.resolve("drivers/" + driverName);
+        Files.createDirectories(driverTarget);
+        Files.createSymbolicLink(deviceDir.resolve("driver"), driverTarget);
+        // Write uevent with PCI_SLOT_NAME
+        Files.write(deviceDir.resolve("uevent"), ("PCI_SLOT_NAME=" + slotName + "\n").getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxPowerSourceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxPowerSourceTest.java
@@ -6,20 +6,25 @@ package oshi.hardware.common.platform.linux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 
+import oshi.hardware.PowerSource;
 import oshi.hardware.PowerSource.CapacityUnits;
 
-@EnabledOnOs(OS.LINUX)
 class LinuxPowerSourceTest {
 
     // Tolerance for floating-point comparisons
@@ -207,5 +212,101 @@ class LinuxPowerSourceTest {
         LinuxPowerSource ps = LinuxPowerSource.buildPowerSource("BAT0", props);
 
         assertThat(ps.getName(), is("BAT0"));
+    }
+
+    @Test
+    void testCopyConstructor() {
+        LinuxPowerSource original = LinuxPowerSource.buildPowerSource("BAT0", sampleProps());
+        LinuxPowerSource copy = new LinuxPowerSource(original);
+
+        assertThat(copy.getName(), is(original.getName()));
+        assertThat(copy.getDeviceName(), is(original.getDeviceName()));
+        assertThat(copy.getRemainingCapacityPercent(), closeTo(original.getRemainingCapacityPercent(), EPS));
+        assertThat(copy.getPowerUsageRate(), closeTo(original.getPowerUsageRate(), EPS));
+        assertThat(copy.getVoltage(), closeTo(original.getVoltage(), EPS));
+        assertThat(copy.getAmperage(), closeTo(original.getAmperage(), EPS));
+        assertThat(copy.isCharging(), is(original.isCharging()));
+        assertThat(copy.isDischarging(), is(original.isDischarging()));
+        assertThat(copy.getCapacityUnits(), is(original.getCapacityUnits()));
+        assertThat(copy.getCurrentCapacity(), is(original.getCurrentCapacity()));
+        assertThat(copy.getMaxCapacity(), is(original.getMaxCapacity()));
+        assertThat(copy.getDesignCapacity(), is(original.getDesignCapacity()));
+        assertThat(copy.getCycleCount(), is(original.getCycleCount()));
+        assertThat(copy.getChemistry(), is(original.getChemistry()));
+        assertThat(copy.getManufacturer(), is(original.getManufacturer()));
+        assertThat(copy.getSerialNumber(), is(original.getSerialNumber()));
+    }
+
+    @Test
+    void testGetPowerSourcesNonexistentPath(@TempDir Path tempDir) {
+        List<PowerSource> result = LinuxPowerSource.getPowerSources(tempDir.resolve("power_supply_missing").toString());
+        assertThat(result, hasSize(0));
+    }
+
+    @Test
+    void testGetPowerSourcesEmptyDir(@TempDir Path tempDir) {
+        List<PowerSource> result = LinuxPowerSource.getPowerSources(tempDir.toString());
+        assertThat(result, hasSize(0));
+    }
+
+    @Test
+    void testGetPowerSourcesFiltersAdapters(@TempDir Path tempDir) throws IOException {
+        for (String name : new String[] { "ADP1", "AC0", "USBC-charger" }) {
+            Files.createDirectories(tempDir.resolve(name));
+        }
+        List<PowerSource> result = LinuxPowerSource.getPowerSources(tempDir.toString());
+        assertThat(result, hasSize(0));
+    }
+
+    @Test
+    void testGetPowerSourcesUeventParsing(@TempDir Path tempDir) throws IOException {
+        Path bat = tempDir.resolve("BAT0");
+        Files.createDirectories(bat);
+        String uevent = "POWER_SUPPLY_NAME=BAT0\n" + "POWER_SUPPLY_STATUS=Discharging\n" + "POWER_SUPPLY_PRESENT=1\n"
+                + "POWER_SUPPLY_TECHNOLOGY=Li-ion\n" + "POWER_SUPPLY_VOLTAGE_NOW=7400000\n"
+                + "POWER_SUPPLY_ENERGY_NOW=20712000\n" + "POWER_SUPPLY_ENERGY_FULL=40877000\n"
+                + "POWER_SUPPLY_ENERGY_FULL_DESIGN=48248000\n" + "POWER_SUPPLY_POWER_NOW=9361000\n"
+                + "POWER_SUPPLY_CAPACITY=50\n" + "IGNORED_KEY=should_be_skipped\n" + "MALFORMED_LINE\n";
+        Files.write(bat.resolve("uevent"), uevent.getBytes(StandardCharsets.UTF_8));
+
+        List<PowerSource> result = LinuxPowerSource.getPowerSources(tempDir.toString());
+
+        assertThat(result, hasSize(1));
+        PowerSource ps = result.get(0);
+        assertThat(ps.getName(), is("BAT0"));
+        assertThat(ps.isDischarging(), is(true));
+        assertThat(ps.getChemistry(), is("Li-ion"));
+        assertThat(ps.getCurrentCapacity(), is(20712));
+        assertThat(ps.getMaxCapacity(), is(40877));
+    }
+
+    @Test
+    void testGetPowerSourcesSkipsPresentZero(@TempDir Path tempDir) throws IOException {
+        Path bat = tempDir.resolve("BAT0");
+        Files.createDirectories(bat);
+        Files.write(bat.resolve("uevent"),
+                "POWER_SUPPLY_NAME=BAT0\nPOWER_SUPPLY_PRESENT=0\n".getBytes(StandardCharsets.UTF_8));
+
+        List<PowerSource> result = LinuxPowerSource.getPowerSources(tempDir.toString());
+        assertThat(result, hasSize(0));
+    }
+
+    @Test
+    void testGetPowerSourcesCopyRoundTrip(@TempDir Path tempDir) throws IOException {
+        Path bat = tempDir.resolve("BAT0");
+        Files.createDirectories(bat);
+        String uevent = "POWER_SUPPLY_NAME=BAT0\nPOWER_SUPPLY_STATUS=Charging\n"
+                + "POWER_SUPPLY_ENERGY_NOW=20000000\nPOWER_SUPPLY_ENERGY_FULL=40000000\n";
+        Files.write(bat.resolve("uevent"), uevent.getBytes(StandardCharsets.UTF_8));
+
+        List<PowerSource> sources = LinuxPowerSource.getPowerSources(tempDir.toString());
+        assertThat(sources, hasSize(1));
+        LinuxPowerSource ps = (LinuxPowerSource) sources.get(0);
+
+        // queryPowerSources() delegates to getPowerSources(SysPath.POWER_SUPPLY) on real
+        // systems; here we verify the copy constructor round-trip used by that path
+        LinuxPowerSource copy = new LinuxPowerSource(ps);
+        assertThat(copy.getName(), is(ps.getName()));
+        assertThat(copy.isCharging(), is(true));
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSensorsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSensorsTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LinuxSensorsTest {
+
+    private static final double EPS = 1e-6;
+
+    @Test
+    void testNoSensorsFound(@TempDir Path tempDir) {
+        // No hwmon or thermal_zone directories exist
+        LinuxSensors sensors = new LinuxSensors(tempDir.resolve("hwmon").toString(),
+                tempDir.resolve("thermal_zone").toString(), false);
+        assertThat(sensors.queryCpuTemperature(), closeTo(0d, EPS));
+        assertThat(sensors.queryFanSpeeds().length, is(0));
+        assertThat(sensors.queryCpuVoltage(), closeTo(0d, EPS));
+    }
+
+    @Test
+    void testIsPiReturnsDefaults() {
+        // isPi=true but vcgencmd won't work on test machine, so returns 0/empty
+        LinuxSensors sensors = new LinuxSensors("/nonexistent/hwmon", "/nonexistent/thermal_zone", true);
+        assertThat(sensors.queryCpuTemperature(), closeTo(0d, EPS));
+        assertThat(sensors.queryFanSpeeds().length, is(0));
+        assertThat(sensors.queryCpuVoltage(), closeTo(0d, EPS));
+    }
+
+    @Test
+    void testHwmonTemperatureTemp1(@TempDir Path tempDir) throws IOException {
+        Path hwmon0 = createHwmonDir(tempDir, 0, "coretemp");
+        writeFile(hwmon0.resolve("temp1_input"), "52000");
+
+        LinuxSensors sensors = new LinuxSensors(tempDir.resolve("hwmon").toString(),
+                tempDir.resolve("thermal_zone").toString(), false);
+        // 52000 millidegrees = 52.0 C
+        assertThat(sensors.queryCpuTemperature(), closeTo(52.0, EPS));
+    }
+
+    @Test
+    void testHwmonTemperatureAveraging(@TempDir Path tempDir) throws IOException {
+        Path hwmon0 = createHwmonDir(tempDir, 0, "coretemp");
+        // temp1_input is 0 so it falls through to averaging temp2..temp6
+        writeFile(hwmon0.resolve("temp1_input"), "0");
+        writeFile(hwmon0.resolve("temp2_input"), "50000");
+        writeFile(hwmon0.resolve("temp3_input"), "60000");
+
+        LinuxSensors sensors = new LinuxSensors(tempDir.resolve("hwmon").toString(),
+                tempDir.resolve("thermal_zone").toString(), false);
+        // Average of 50000 and 60000 = 55000 millidegrees = 55.0 C
+        assertThat(sensors.queryCpuTemperature(), closeTo(55.0, EPS));
+    }
+
+    @Test
+    void testHwmonPrioritySelection(@TempDir Path tempDir) throws IOException {
+        // hwmon0 has k10temp (priority 1), hwmon1 has coretemp (priority 0)
+        Path hwmon0 = createHwmonDir(tempDir, 0, "k10temp");
+        writeFile(hwmon0.resolve("temp1_input"), "70000");
+        Path hwmon1 = createHwmonDir(tempDir, 1, "coretemp");
+        writeFile(hwmon1.resolve("temp1_input"), "55000");
+
+        LinuxSensors sensors = new LinuxSensors(tempDir.resolve("hwmon").toString(),
+                tempDir.resolve("thermal_zone").toString(), false);
+        // coretemp has higher priority (lower index), so 55.0 C
+        assertThat(sensors.queryCpuTemperature(), closeTo(55.0, EPS));
+    }
+
+    @Test
+    void testHwmonUnknownNameSkipped(@TempDir Path tempDir) throws IOException {
+        // hwmon0 has an unknown sensor name — not in priority list, should be skipped for temp
+        Path hwmon0 = createHwmonDir(tempDir, 0, "unknown_sensor");
+        writeFile(hwmon0.resolve("temp1_input"), "60000");
+
+        LinuxSensors sensors = new LinuxSensors(tempDir.resolve("hwmon").toString(),
+                tempDir.resolve("thermal_zone").toString(), false);
+        // No recognized temp sensor, falls through to thermal_zone (also absent) → 0
+        assertThat(sensors.queryCpuTemperature(), closeTo(0d, EPS));
+    }
+
+    @Test
+    void testHwmonTempPreventsThermalZoneFallback(@TempDir Path tempDir) throws IOException {
+        // Both hwmon and thermal_zone have temp sensors; hwmon should win
+        Path hwmon0 = createHwmonDir(tempDir, 0, "coretemp");
+        writeFile(hwmon0.resolve("temp1_input"), "52000");
+        Path tz0 = tempDir.resolve("thermal_zone0");
+        Files.createDirectories(tz0);
+        writeFile(tz0.resolve("type"), "x86_pkg_temp");
+        writeFile(tz0.resolve("temp"), "99000");
+
+        LinuxSensors sensors = new LinuxSensors(tempDir.resolve("hwmon").toString(),
+                tempDir.resolve("thermal_zone").toString(), false);
+        // hwmon coretemp found → thermal_zone never consulted → 52.0 C, not 99.0
+        assertThat(sensors.queryCpuTemperature(), closeTo(52.0, EPS));
+    }
+
+    @Test
+    void testThermalZoneFallback(@TempDir Path tempDir) throws IOException {
+        // No hwmon temp sensor, so should fall back to thermal_zone
+        Path tz0 = tempDir.resolve("thermal_zone0");
+        Files.createDirectories(tz0);
+        writeFile(tz0.resolve("type"), "x86_pkg_temp");
+        writeFile(tz0.resolve("temp"), "48000");
+
+        LinuxSensors sensors = new LinuxSensors(tempDir.resolve("hwmon").toString(),
+                tempDir.resolve("thermal_zone").toString(), false);
+        // 48000 millidegrees = 48.0 C
+        assertThat(sensors.queryCpuTemperature(), closeTo(48.0, EPS));
+    }
+
+    @Test
+    void testThermalZonePriority(@TempDir Path tempDir) throws IOException {
+        // thermal_zone0 has x86_pkg_temp (priority 1), thermal_zone1 has cpu-thermal (priority 0)
+        Path tz0 = tempDir.resolve("thermal_zone0");
+        Files.createDirectories(tz0);
+        writeFile(tz0.resolve("type"), "x86_pkg_temp");
+        writeFile(tz0.resolve("temp"), "48000");
+
+        Path tz1 = tempDir.resolve("thermal_zone1");
+        Files.createDirectories(tz1);
+        writeFile(tz1.resolve("type"), "cpu-thermal");
+        writeFile(tz1.resolve("temp"), "45000");
+
+        LinuxSensors sensors = new LinuxSensors(tempDir.resolve("hwmon").toString(),
+                tempDir.resolve("thermal_zone").toString(), false);
+        // cpu-thermal has higher priority → 45.0 C
+        assertThat(sensors.queryCpuTemperature(), closeTo(45.0, EPS));
+    }
+
+    @Test
+    void testFanSpeeds(@TempDir Path tempDir) throws IOException {
+        Path hwmon0 = createHwmonDir(tempDir, 0, "nct6775");
+        writeFile(hwmon0.resolve("fan1_input"), "1200");
+        writeFile(hwmon0.resolve("fan2_input"), "800");
+
+        LinuxSensors sensors = new LinuxSensors(tempDir.resolve("hwmon").toString(),
+                tempDir.resolve("thermal_zone").toString(), false);
+        int[] fans = sensors.queryFanSpeeds();
+        assertThat(fans.length, is(2));
+        assertThat(fans[0], is(1200));
+        assertThat(fans[1], is(800));
+    }
+
+    @Test
+    void testVoltage(@TempDir Path tempDir) throws IOException {
+        Path hwmon0 = createHwmonDir(tempDir, 0, "nct6775");
+        writeFile(hwmon0.resolve("in1_input"), "1200");
+
+        LinuxSensors sensors = new LinuxSensors(tempDir.resolve("hwmon").toString(),
+                tempDir.resolve("thermal_zone").toString(), false);
+        // 1200 millivolts = 1.2 V
+        assertThat(sensors.queryCpuVoltage(), closeTo(1.2, EPS));
+    }
+
+    /**
+     * Creates an hwmon directory with a name file.
+     *
+     * @param base  the base temp directory
+     * @param index the hwmon index (0, 1, ...)
+     * @param name  the sensor name to write to the name file
+     * @return the created hwmon directory path
+     * @throws IOException if file creation fails
+     */
+    private static Path createHwmonDir(Path base, int index, String name) throws IOException {
+        Path hwmon = base.resolve("hwmon" + index);
+        Files.createDirectories(hwmon);
+        writeFile(hwmon.resolve("name"), name);
+        return hwmon;
+    }
+
+    /**
+     * Writes a string to a file.
+     *
+     * @param path    the file path
+     * @param content the content to write
+     * @throws IOException if writing fails
+     */
+    private static void writeFile(Path path, String content) throws IOException {
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
Adds tests for Linux hardware classes using `@TempDir` sysfs fixtures, and fixes a latent bug discovered during test development.

## New Tests

- **LinuxGpuStatsTest** — Comprehensive coverage of amdgpu, i915, xe drivers, NVML paths, session lifecycle, and edge cases using stub subclasses and temp directories. Coverage: 0% → ~99% instruction, ~80% branch.
- **LinuxGraphicsCardTest** — Tests for `Attrs`, constructor/getters, `findDrmInfo` (PCI slot matching, fallback, no driver), `readUeventValue`, and `readDriverName` using temp directories with symlinks.
- **LinuxPowerSourceTest** — Removed `@EnabledOnOs(OS.LINUX)` (``buildPowerSource`` is pure logic). Added copy-constructor test and ``getPowerSources(path)`` tests covering uevent parsing, `PropByName.MAP`, adapter filtering (ADP/AC/USBC), `PRESENT=0` skip, and nonexistent/empty directories.
- **LinuxSensorsTest** — Tests for hwmon temperature discovery (priority selection, temp1 direct read, temp2-6 averaging), thermal_zone fallback and priority, fan speed reading, voltage reading, isPi path, and no-sensors-found.

## Production Code Changes

- **LinuxPowerSource**: Extract ``getPowerSources(String powerSupplyPath)`` package-private overload; public no-arg method delegates with ``SysPath.POWER_SUPPLY``.
- **LinuxGraphicsCard**: Extract ``findDrmInfo(String pciSlot, String drmPath)`` package-private overload; make ``readUeventValue`` and ``readDriverName`` package-private.
- **LinuxSensors**: Replace static final path constants and `IS_PI` with instance fields set via a new package-private constructor accepting ``hwmonBasePath``, ``thermalZoneBasePath``, and ``isPi``. No-arg constructor delegates with real values.

## Bug Fix

**LinuxSensors fan/voltage discovery was broken.** Inside ``populateSensorsMapFromHwmon()``, the fan and voltage scan called ``getSensorFilesFromPath(path, ...)`` where ``path`` was the resolved directory (e.g. ``hwmon0``). Since ``getSensorFilesFromPath`` appends ``0``, ``1``, etc. to iterate, it looked for ``hwmon00``, ``hwmon01`` — which never exist. Moved the fan/voltage scan outside the while loop and passed the base ``hwmonPath`` instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Linux sensor fan and voltage discovery logic to correctly locate sensor files.

* **Improvements**
  * Made Linux graphics and power-source discovery more configurable to improve detection across environments.

* **Tests**
  * Added extensive tests for Linux graphics, GPU stats, power sources, and sensor discovery to increase reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->