### PR TITLE
Add Linux hardware unit tests and fix parseDecimalMemorySizeToBinary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#3153](https://github.com/oshi/oshi/pull/3153): Fix FFM network stats to use two-call sysctl pattern matching JNA approach - [@dbwiddis](https://github.com/dbwiddis).
 * [#3154](https://github.com/oshi/oshi/pull/3154): Improve API documentation: usage examples, platform notes, cross-references, JEP 472 guidance, and virtual memory model differences - [@dbwiddis](https://github.com/dbwiddis).
 * [#3160](https://github.com/oshi/oshi/pull/3160): Fix LinuxSensors fan and voltage discovery passing wrong path to getSensorFilesFromPath - [@dbwiddis](https://github.com/dbwiddis).
+* [#3161](https://github.com/oshi/oshi/pull/3161): Add Linux hardware unit tests; fix parseDecimalMemorySizeToBinary for single-char suffixes; use platform-independent path separators - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
@@ -205,12 +205,17 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     protected abstract Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyWithUdev();
 
     protected static Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyFromSysfs() {
+        return readTopologyFromSysfs(SysPath.CPU);
+    }
+
+    static Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyFromSysfs(
+            String cpuPath) {
         List<LogicalProcessor> logProcs = new ArrayList<>();
         Set<ProcessorCache> caches = new HashSet<>();
         Map<Integer, Integer> coreEfficiencyMap = new HashMap<>();
         Map<Integer, String> modAliasMap = new HashMap<>();
         try {
-            try (Stream<Path> cpuFiles = Files.find(Paths.get(SysPath.CPU), Integer.MAX_VALUE,
+            try (Stream<Path> cpuFiles = Files.find(Paths.get(cpuPath), Integer.MAX_VALUE,
                     (path, basicFileAttributes) -> path.toFile().getName().matches("cpu\\d+"))) {
                 cpuFiles.forEach(cpu -> {
                     String syspath = cpu.toString(); // /sys/devices/system/cpu/cpuX
@@ -223,7 +228,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
             }
         } catch (IOException e) {
             // No udev and no cpu info in sysfs? Bad.
-            LOG.warn("Unable to find CPU information in sysfs at path {}", SysPath.CPU);
+            LOG.warn("Unable to find CPU information in sysfs at path {}", cpuPath);
         }
         return new Quartet<>(logProcs, orderedProcCaches(caches), coreEfficiencyMap, modAliasMap);
     }
@@ -240,7 +245,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
             modAliasMap.put(pkgCoreKey, modAlias);
         }
         int nodeId = 0;
-        final String nodePrefix = syspath + "/node";
+        final String nodePrefix = Paths.get(syspath, "node").toString();
         try (Stream<Path> path = Files.list(Paths.get(syspath))) {
             Optional<Path> first = path.filter(p -> p.toString().startsWith(nodePrefix)).findFirst();
             if (first.isPresent()) {
@@ -249,8 +254,8 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
         } catch (IOException e) {
             // ignore
         }
-        final String cachePath = syspath + "/cache";
-        final String indexPrefix = cachePath + "/index";
+        final String cachePath = Paths.get(syspath, "cache").toString();
+        final String indexPrefix = Paths.get(cachePath, "index").toString();
         try (Stream<Path> path = Files.list(Paths.get(cachePath))) {
             path.filter(p -> p.toString().startsWith(indexPrefix)).forEach(c -> {
                 int level = FileUtil.getIntFromFile(c + "/level"); // 1
@@ -275,12 +280,16 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     private static Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyFromCpuinfo() {
+        return readTopologyFromCpuinfo(FileUtil.readFile(CPUINFO));
+    }
+
+    static Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyFromCpuinfo(
+            List<String> procCpu) {
         List<LogicalProcessor> logProcs = new ArrayList<>();
         Set<ProcessorCache> caches = mapCachesFromLscpu();
         Map<Integer, Integer> numaNodeMap = mapNumaNodesFromLscpu();
         Map<Integer, Integer> coreEfficiencyMap = new HashMap<>();
 
-        List<String> procCpu = FileUtil.readFile(CPUINFO);
         int currentProcessor = 0;
         int currentCore = 0;
         int currentPackage = 0;
@@ -482,7 +491,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     protected static long queryMaxFreqFromCpuFreqPath(String cpuFreqPath) {
-        String policyPrefix = cpuFreqPath + "/policy";
+        String policyPrefix = Paths.get(cpuFreqPath, "policy").toString();
         try (Stream<Path> path = Files.list(Paths.get(cpuFreqPath))) {
             Optional<Long> maxPolicy = path.filter(p -> p.toString().startsWith(policyPrefix)).map(p -> {
                 long freq = FileUtil.getLongFromFile(p.toString() + "/scaling_max_freq");
@@ -502,11 +511,15 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
 
     @Override
     public double[] getSystemLoadAverage(int nelem) {
+        return getSystemLoadAverage(nelem, FileUtil.getStringFromFile(LOADAVG));
+    }
+
+    static double[] getSystemLoadAverage(int nelem, String loadavgContent) {
         if (nelem < 1 || nelem > 3) {
             throw new IllegalArgumentException("Must include from one to three elements.");
         }
         double[] average = new double[nelem];
-        String[] parts = ParseUtil.whitespaces.split(FileUtil.getStringFromFile(LOADAVG).trim());
+        String[] parts = ParseUtil.whitespaces.split(loadavgContent.trim());
         for (int i = 0; i < nelem; i++) {
             average[i] = i < parts.length ? ParseUtil.parseDoubleOrDefault(parts[i], -1d) : -1d;
         }
@@ -596,7 +609,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
      * @param family   the architecture
      * @return A 32-bit hex string for the MIDR
      */
-    private static String createMIDR(String vendor, String stepping, String model, String family) {
+    static String createMIDR(String vendor, String stepping, String model, String family) {
         int midrBytes = 0;
         // Build 32-bit MIDR
         if (stepping.startsWith("r") && stepping.contains("p")) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
@@ -47,7 +47,11 @@ public abstract class LinuxNetworkIF extends AbstractNetworkIF {
      * @return vendor + model string, or the interface name if not found
      */
     protected static String queryIfModelFromSysfs(String name) {
-        Map<String, String> uevent = FileUtil.getKeyValueMapFromFile(SysPath.NET + name + "/uevent", "=");
+        return queryIfModelFromSysfs(name, SysPath.NET);
+    }
+
+    static String queryIfModelFromSysfs(String name, String netPath) {
+        Map<String, String> uevent = FileUtil.getKeyValueMapFromFile(netPath + name + "/uevent", "=");
         String devVendor = uevent.get("ID_VENDOR_FROM_DATABASE");
         String devModel = uevent.get("ID_MODEL_FROM_DATABASE");
         if (!Util.isBlank(devModel)) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSoundCard.java
@@ -22,7 +22,7 @@ import oshi.util.linux.ProcPath;
  * Sound card data obtained via /proc/asound directory
  */
 @Immutable
-final class LinuxSoundCard extends AbstractSoundCard {
+class LinuxSoundCard extends AbstractSoundCard {
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxSoundCard.class);
 
@@ -45,10 +45,11 @@ final class LinuxSoundCard extends AbstractSoundCard {
      * Method to find all the card folders contained in the <b>asound</b> folder denoting the cards currently contained
      * in our machine.
      *
+     * @param asoundPath The path to the asound directory
      * @return : A list of files starting with 'card'
      */
-    private static List<File> getCardFolders() {
-        File cardsDirectory = new File(ProcPath.ASOUND);
+    static List<File> getCardFolders(String asoundPath) {
+        File cardsDirectory = new File(asoundPath);
         List<File> cardFolders = new ArrayList<>();
         File[] allContents = cardsDirectory.listFiles();
         if (allContents != null) {
@@ -67,10 +68,11 @@ final class LinuxSoundCard extends AbstractSoundCard {
      * Reads the 'version' file in the asound folder that contains the complete name of the ALSA driver. Reads all the
      * lines of the file and retrieves the first line.
      *
+     * @param asoundPath The path to the asound directory
      * @return The complete name of the ALSA driver currently residing in our machine
      */
-    private static String getSoundCardVersion() {
-        String driverVersion = FileUtil.getStringFromFile(ProcPath.ASOUND + "version");
+    static String getSoundCardVersion(String asoundPath) {
+        String driverVersion = FileUtil.getStringFromFile(new File(asoundPath, "version").getPath());
         return driverVersion.isEmpty() ? "not available" : driverVersion;
     }
 
@@ -84,7 +86,7 @@ final class LinuxSoundCard extends AbstractSoundCard {
      * @param cardDir The sound card directory
      * @return The name of the codec
      */
-    private static String getCardCodec(File cardDir) {
+    static String getCardCodec(File cardDir) {
         String cardCodec = "";
         File[] cardFiles = cardDir.listFiles();
         if (cardFiles != null) {
@@ -120,13 +122,15 @@ final class LinuxSoundCard extends AbstractSoundCard {
      * <li>If the id and the card name matches , then it assigns that name to {@literal cardName}</li>
      * </ol>
      *
-     * @param file The sound card File.
+     * @param file       The sound card File.
+     * @param asoundPath The path to the asound directory
      * @return The name of the sound card.
      */
-    private static String getCardName(File file) {
+    static String getCardName(File file, String asoundPath) {
         String cardName = "Not Found..";
-        Map<String, String> cardNamePairs = FileUtil.getKeyValueMapFromFile(ProcPath.ASOUND + "/" + CARDS_FILE, ":");
-        String cardId = FileUtil.getStringFromFile(file.getPath() + "/" + ID_FILE);
+        Map<String, String> cardNamePairs = FileUtil.getKeyValueMapFromFile(new File(asoundPath, CARDS_FILE).getPath(),
+                ":");
+        String cardId = FileUtil.getStringFromFile(new File(file, ID_FILE).getPath());
         for (Map.Entry<String, String> entry : cardNamePairs.entrySet()) {
             if (entry.getKey().contains(cardId)) {
                 cardName = entry.getValue();
@@ -142,9 +146,14 @@ final class LinuxSoundCard extends AbstractSoundCard {
      * @return List of {@link LinuxSoundCard} objects.
      */
     public static List<SoundCard> getSoundCards() {
+        return getSoundCards(ProcPath.ASOUND);
+    }
+
+    static List<SoundCard> getSoundCards(String asoundPath) {
         List<SoundCard> soundCards = new ArrayList<>();
-        for (File cardFile : getCardFolders()) {
-            soundCards.add(new LinuxSoundCard(getSoundCardVersion(), getCardName(cardFile), getCardCodec(cardFile)));
+        String version = getSoundCardVersion(asoundPath);
+        for (File cardFile : getCardFolders(asoundPath)) {
+            soundCards.add(new LinuxSoundCard(version, getCardName(cardFile, asoundPath), getCardCodec(cardFile)));
         }
         return soundCards;
     }

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -995,7 +995,7 @@ public final class ParseUtil {
             }
         }
         long capacity = ParseUtil.parseLongOrDefault(mem[0], 0L);
-        if (mem.length == 2 && mem[1].length() > 1) {
+        if (mem.length == 2 && mem[1].length() > 0) {
             switch (mem[1].charAt(0)) {
                 case 'T':
                     capacity <<= 40;

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static oshi.hardware.common.platform.linux.TestFileUtil.writeFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import oshi.hardware.CentralProcessor.LogicalProcessor;
+import oshi.hardware.CentralProcessor.ProcessorCache;
+import oshi.util.tuples.Quartet;
+
+class LinuxCentralProcessorTest {
+
+    private static final double EPS = 1e-6;
+
+    // -------------------------------------------------------------------------
+    // createMIDR
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testCreateMIDRBasic() {
+        // vendor=0x41 (ARM), stepping=r1p3, model=0xd07, family=8
+        String midr = LinuxCentralProcessor.createMIDR("0x41", "r1p3", "0xd07", "8");
+        // Implementer 0x41 << 24 = 0x41000000
+        // Variant 1 << 20 = 0x00100000
+        // Architecture 8 << 16 = 0x00080000
+        // PartNum 0xd07 << 4 = 0x0000D070
+        // Revision 3 = 0x00000003
+        // Total = 0x41180073... let me compute:
+        // 0x41 << 24 = 0x41000000
+        // 1 << 20 = 0x00100000
+        // 8 << 16 = 0x00080000
+        // 0xd07 << 4 = 0x0000D070
+        // 3 = 0x00000003
+        // Sum = 0x4118D073
+        assertThat(midr, is("4118D073"));
+    }
+
+    @Test
+    void testCreateMIDRNoStepping() {
+        // No rnpn stepping format
+        String midr = LinuxCentralProcessor.createMIDR("0x41", "", "0xd03", "8");
+        // 0x41 << 24 + 8 << 16 + 0xd03 << 4 = 0x4108D030
+        assertThat(midr, is("4108D030"));
+    }
+
+    @Test
+    void testCreateMIDRZeroValues() {
+        String midr = LinuxCentralProcessor.createMIDR("0x0", "r0p0", "0x0", "0");
+        assertThat(midr, is("00000000"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getSystemLoadAverage
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testGetSystemLoadAverageThreeElements() {
+        double[] avg = LinuxCentralProcessor.getSystemLoadAverage(3, "1.25 0.75 0.50 1/234 5678");
+        assertThat(avg.length, is(3));
+        assertThat(avg[0], closeTo(1.25, EPS));
+        assertThat(avg[1], closeTo(0.75, EPS));
+        assertThat(avg[2], closeTo(0.50, EPS));
+    }
+
+    @Test
+    void testGetSystemLoadAverageOneElement() {
+        double[] avg = LinuxCentralProcessor.getSystemLoadAverage(1, "2.00 1.00 0.50 1/100 999");
+        assertThat(avg.length, is(1));
+        assertThat(avg[0], closeTo(2.0, EPS));
+    }
+
+    @Test
+    void testGetSystemLoadAverageEmptyContent() {
+        double[] avg = LinuxCentralProcessor.getSystemLoadAverage(3, "");
+        assertThat(avg.length, is(3));
+        assertThat(avg[0], closeTo(-1d, EPS));
+        assertThat(avg[1], closeTo(-1d, EPS));
+        assertThat(avg[2], closeTo(-1d, EPS));
+    }
+
+    @Test
+    void testGetSystemLoadAverageInvalidNelem() {
+        assertThrows(IllegalArgumentException.class, () -> LinuxCentralProcessor.getSystemLoadAverage(0, "1 2 3"));
+        assertThrows(IllegalArgumentException.class, () -> LinuxCentralProcessor.getSystemLoadAverage(4, "1 2 3"));
+    }
+
+    // -------------------------------------------------------------------------
+    // queryMaxFreqFromCpuFreqPath
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testQueryMaxFreqFromCpuFreqPathWithPolicies(@TempDir Path tempDir) throws IOException {
+        Path cpuFreq = tempDir.resolve("cpufreq");
+        Path policy0 = cpuFreq.resolve("policy0");
+        Path policy1 = cpuFreq.resolve("policy1");
+        Files.createDirectories(policy0);
+        Files.createDirectories(policy1);
+        writeFile(policy0.resolve("scaling_max_freq"), "3600000");
+        writeFile(policy1.resolve("scaling_max_freq"), "4200000");
+
+        long maxFreq = LinuxCentralProcessor.queryMaxFreqFromCpuFreqPath(cpuFreq.toString());
+        // 4200000 kHz * 1000 = 4200000000 Hz
+        assertThat(maxFreq, is(4200000000L));
+    }
+
+    @Test
+    void testQueryMaxFreqFallbackToCpuinfoMaxFreq(@TempDir Path tempDir) throws IOException {
+        Path cpuFreq = tempDir.resolve("cpufreq");
+        Path policy0 = cpuFreq.resolve("policy0");
+        Files.createDirectories(policy0);
+        // scaling_max_freq is 0, fall back to cpuinfo_max_freq
+        writeFile(policy0.resolve("scaling_max_freq"), "0");
+        writeFile(policy0.resolve("cpuinfo_max_freq"), "2500000");
+
+        long maxFreq = LinuxCentralProcessor.queryMaxFreqFromCpuFreqPath(cpuFreq.toString());
+        assertThat(maxFreq, is(2500000000L));
+    }
+
+    @Test
+    void testQueryMaxFreqNonexistentPath(@TempDir Path tempDir) {
+        long maxFreq = LinuxCentralProcessor.queryMaxFreqFromCpuFreqPath(tempDir.resolve("missing").toString());
+        assertThat(maxFreq, is(-1L));
+    }
+
+    @Test
+    void testQueryMaxFreqNoPolicies(@TempDir Path tempDir) throws IOException {
+        Path cpuFreq = tempDir.resolve("cpufreq");
+        Files.createDirectories(cpuFreq);
+        // Directory exists but no policy subdirectories
+
+        long maxFreq = LinuxCentralProcessor.queryMaxFreqFromCpuFreqPath(cpuFreq.toString());
+        assertThat(maxFreq, is(-1L));
+    }
+
+    // -------------------------------------------------------------------------
+    // readTopologyFromSysfs
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testReadTopologyFromSysfsNonexistentPath(@TempDir Path tempDir) {
+        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
+                .readTopologyFromSysfs(tempDir.resolve("missing").toString());
+        assertThat(result.getA(), is(empty()));
+        assertThat(result.getB(), is(empty()));
+        assertThat(result.getC().isEmpty(), is(true));
+        assertThat(result.getD().isEmpty(), is(true));
+    }
+
+    @Test
+    void testReadTopologyFromSysfsSingleCpu(@TempDir Path tempDir) throws IOException {
+        Path cpu0 = tempDir.resolve("cpu0");
+        Files.createDirectories(cpu0.resolve("topology"));
+        writeFile(cpu0.resolve("topology/core_id"), "0");
+        writeFile(cpu0.resolve("topology/physical_package_id"), "0");
+        writeFile(cpu0.resolve("cpu_capacity"), "1024");
+
+        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
+                .readTopologyFromSysfs(tempDir.toString());
+        assertThat(result.getA(), hasSize(1));
+        LogicalProcessor lp = result.getA().get(0);
+        assertThat(lp.getPhysicalProcessorNumber(), is(0));
+        assertThat(lp.getPhysicalPackageNumber(), is(0));
+        // cpu_capacity value stored in coreEfficiencyMap keyed by (pkg<<16)+core = 0
+        assertThat(result.getC().containsKey(0), is(true));
+        assertThat(result.getC().get(0), is(1024));
+    }
+
+    @Test
+    void testReadTopologyFromSysfsMultiCpu(@TempDir Path tempDir) throws IOException {
+        for (int i = 0; i < 4; i++) {
+            Path cpu = tempDir.resolve("cpu" + i);
+            Files.createDirectories(cpu.resolve("topology"));
+            writeFile(cpu.resolve("topology/core_id"), String.valueOf(i % 2));
+            writeFile(cpu.resolve("topology/physical_package_id"), "0");
+        }
+
+        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
+                .readTopologyFromSysfs(tempDir.toString());
+        assertThat(result.getA(), hasSize(4));
+    }
+
+    @Test
+    void testReadTopologyFromSysfsWithCache(@TempDir Path tempDir) throws IOException {
+        Path cpu0 = tempDir.resolve("cpu0");
+        Files.createDirectories(cpu0.resolve("topology"));
+        writeFile(cpu0.resolve("topology/core_id"), "0");
+        writeFile(cpu0.resolve("topology/physical_package_id"), "0");
+
+        Path index0 = cpu0.resolve("cache/index0");
+        Files.createDirectories(index0);
+        writeFile(index0.resolve("level"), "1");
+        writeFile(index0.resolve("type"), "Data");
+        writeFile(index0.resolve("ways_of_associativity"), "8");
+        writeFile(index0.resolve("coherency_line_size"), "64");
+        writeFile(index0.resolve("size"), "32K");
+
+        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
+                .readTopologyFromSysfs(tempDir.toString());
+        assertThat(result.getB(), hasSize(1));
+        ProcessorCache cache = result.getB().get(0);
+        assertThat(cache.getLevel(), is((byte) 1));
+        assertThat(cache.getType(), is(ProcessorCache.Type.DATA));
+        assertThat(cache.getAssociativity(), is((byte) 8));
+        assertThat(cache.getLineSize(), is((short) 64));
+        assertThat(cache.getCacheSize(), is(32768));
+    }
+
+    @Test
+    void testReadTopologyFromSysfsWithModAlias(@TempDir Path tempDir) throws IOException {
+        Path cpu0 = tempDir.resolve("cpu0");
+        Files.createDirectories(cpu0.resolve("topology"));
+        writeFile(cpu0.resolve("topology/core_id"), "0");
+        writeFile(cpu0.resolve("topology/physical_package_id"), "0");
+        writeFile(cpu0.resolve("uevent"), "MODALIAS=cpu:type:aarch64:feature:0001");
+
+        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
+                .readTopologyFromSysfs(tempDir.toString());
+        assertThat(result.getD().get(0), is("cpu:type:aarch64:feature:0001"));
+    }
+
+    // -------------------------------------------------------------------------
+    // readTopologyFromCpuinfo
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testReadTopologyFromCpuinfoSingleProcessor() {
+        List<String> lines = Arrays.asList("processor\t: 0", "core id\t\t: 0", "physical id\t: 0");
+        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
+                .readTopologyFromCpuinfo(lines);
+        assertThat(result.getA(), hasSize(1));
+        LogicalProcessor lp = result.getA().get(0);
+        assertThat(lp.getProcessorNumber(), is(0));
+        assertThat(lp.getPhysicalProcessorNumber(), is(0));
+        assertThat(lp.getPhysicalPackageNumber(), is(0));
+    }
+
+    @Test
+    void testReadTopologyFromCpuinfoMultiProcessor() {
+        List<String> lines = Arrays.asList("processor\t: 0", "core id\t\t: 0", "physical id\t: 0", "", "processor\t: 1",
+                "core id\t\t: 1", "physical id\t: 0", "", "processor\t: 2", "core id\t\t: 0", "physical id\t: 1");
+        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
+                .readTopologyFromCpuinfo(lines);
+        assertThat(result.getA(), hasSize(3));
+        // Verify second processor
+        LogicalProcessor lp1 = result.getA().get(1);
+        assertThat(lp1.getProcessorNumber(), is(1));
+        assertThat(lp1.getPhysicalProcessorNumber(), is(1));
+        // Verify third processor on different package
+        LogicalProcessor lp2 = result.getA().get(2);
+        assertThat(lp2.getPhysicalPackageNumber(), is(1));
+    }
+
+    @Test
+    void testReadTopologyFromCpuinfoCpuNumber() {
+        // Some architectures use "cpu number" instead of "core id"
+        List<String> lines = Arrays.asList("processor\t: 0", "cpu number\t: 5", "physical id\t: 0");
+        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
+                .readTopologyFromCpuinfo(lines);
+        assertThat(result.getA().get(0).getPhysicalProcessorNumber(), is(5));
+    }
+
+    @Test
+    void testReadTopologyFromCpuinfoEmptyInput() {
+        // Even with empty input, the method adds one default processor
+        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
+                .readTopologyFromCpuinfo(Collections.emptyList());
+        assertThat(result.getA(), hasSize(1));
+        assertThat(result.getA().get(0).getProcessorNumber(), is(0));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGpuStatsTest.java
@@ -8,9 +8,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static oshi.hardware.common.platform.linux.TestFileUtil.writeFile;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -151,11 +151,6 @@ class LinuxGpuStatsTest {
         protected double nvmlGetFanSpeedPercent(String deviceId) {
             return 45.0;
         }
-    }
-
-    private static void writeFile(Path path, String content) throws IOException {
-        Files.createDirectories(path.getParent());
-        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
     }
 
     // -------------------------------------------------------------------------

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxNetworkIFTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxNetworkIFTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static oshi.hardware.common.platform.linux.TestFileUtil.writeFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import oshi.hardware.NetworkIF.IfOperStatus;
+
+class LinuxNetworkIFTest {
+
+    // -------------------------------------------------------------------------
+    // queryIfModelFromSysfs
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testQueryIfModelVendorAndModel(@TempDir Path tempDir) throws IOException {
+        Path eth0 = tempDir.resolve("eth0");
+        Files.createDirectories(eth0);
+        writeFile(eth0.resolve("uevent"),
+                "ID_VENDOR_FROM_DATABASE=Intel Corporation\nID_MODEL_FROM_DATABASE=Ethernet Controller I225-V");
+
+        String model = LinuxNetworkIF.queryIfModelFromSysfs("eth0", tempDir.toString() + "/");
+        assertThat(model, is("Intel Corporation Ethernet Controller I225-V"));
+    }
+
+    @Test
+    void testQueryIfModelOnlyModel(@TempDir Path tempDir) throws IOException {
+        Path eth0 = tempDir.resolve("eth0");
+        Files.createDirectories(eth0);
+        writeFile(eth0.resolve("uevent"), "ID_MODEL_FROM_DATABASE=RTL8111/8168/8411");
+
+        String model = LinuxNetworkIF.queryIfModelFromSysfs("eth0", tempDir.toString() + "/");
+        assertThat(model, is("RTL8111/8168/8411"));
+    }
+
+    @Test
+    void testQueryIfModelNoUevent(@TempDir Path tempDir) {
+        // No uevent file — should return the interface name
+        String model = LinuxNetworkIF.queryIfModelFromSysfs("eth0", tempDir.toString() + "/");
+        assertThat(model, is("eth0"));
+    }
+
+    @Test
+    void testQueryIfModelEmptyUevent(@TempDir Path tempDir) throws IOException {
+        Path eth0 = tempDir.resolve("eth0");
+        Files.createDirectories(eth0);
+        writeFile(eth0.resolve("uevent"), "DRIVER=e1000e");
+
+        String model = LinuxNetworkIF.queryIfModelFromSysfs("eth0", tempDir.toString() + "/");
+        assertThat(model, is("eth0"));
+    }
+
+    // -------------------------------------------------------------------------
+    // parseIfOperStatus — all cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testParseIfOperStatusUp() {
+        assertThat(LinuxNetworkIF.parseIfOperStatus("up"), is(IfOperStatus.UP));
+    }
+
+    @Test
+    void testParseIfOperStatusDown() {
+        assertThat(LinuxNetworkIF.parseIfOperStatus("down"), is(IfOperStatus.DOWN));
+    }
+
+    @Test
+    void testParseIfOperStatusTesting() {
+        assertThat(LinuxNetworkIF.parseIfOperStatus("testing"), is(IfOperStatus.TESTING));
+    }
+
+    @Test
+    void testParseIfOperStatusDormant() {
+        assertThat(LinuxNetworkIF.parseIfOperStatus("dormant"), is(IfOperStatus.DORMANT));
+    }
+
+    @Test
+    void testParseIfOperStatusNotPresent() {
+        assertThat(LinuxNetworkIF.parseIfOperStatus("notpresent"), is(IfOperStatus.NOT_PRESENT));
+    }
+
+    @Test
+    void testParseIfOperStatusLowerLayerDown() {
+        assertThat(LinuxNetworkIF.parseIfOperStatus("lowerlayerdown"), is(IfOperStatus.LOWER_LAYER_DOWN));
+    }
+
+    @Test
+    void testParseIfOperStatusUnknown() {
+        assertThat(LinuxNetworkIF.parseIfOperStatus("unknown"), is(IfOperStatus.UNKNOWN));
+    }
+
+    @Test
+    void testParseIfOperStatusUnrecognized() {
+        assertThat(LinuxNetworkIF.parseIfOperStatus("somethingelse"), is(IfOperStatus.UNKNOWN));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSensorsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSensorsTest.java
@@ -7,9 +7,9 @@ package oshi.hardware.common.platform.linux;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
+import static oshi.hardware.common.platform.linux.TestFileUtil.writeFile;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -180,14 +180,4 @@ class LinuxSensorsTest {
         return hwmon;
     }
 
-    /**
-     * Writes a string to a file.
-     *
-     * @param path    the file path
-     * @param content the content to write
-     * @throws IOException if writing fails
-     */
-    private static void writeFile(Path path, String content) throws IOException {
-        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
-    }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSoundCardTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static oshi.hardware.common.platform.linux.TestFileUtil.writeFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import oshi.hardware.SoundCard;
+
+class LinuxSoundCardTest {
+
+    // -------------------------------------------------------------------------
+    // getCardFolders
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testGetCardFoldersNonexistentPath(@TempDir Path tempDir) {
+        List<File> folders = LinuxSoundCard.getCardFolders(tempDir.resolve("missing").toString());
+        assertThat(folders, is(empty()));
+    }
+
+    @Test
+    void testGetCardFoldersEmptyDir(@TempDir Path tempDir) throws IOException {
+        Path asound = tempDir.resolve("asound");
+        Files.createDirectories(asound);
+        List<File> folders = LinuxSoundCard.getCardFolders(asound.toString());
+        assertThat(folders, is(empty()));
+    }
+
+    @Test
+    void testGetCardFoldersFiltersCorrectly(@TempDir Path tempDir) throws IOException {
+        Path asound = tempDir.resolve("asound");
+        Files.createDirectories(asound.resolve("card0"));
+        Files.createDirectories(asound.resolve("card1"));
+        // Not a card directory — should be excluded
+        Files.createDirectories(asound.resolve("timers"));
+        // File starting with "card" but not a directory
+        writeFile(asound.resolve("cards"), "content");
+
+        List<File> folders = LinuxSoundCard.getCardFolders(asound.toString());
+        assertThat(folders, hasSize(2));
+        List<String> names = new ArrayList<>();
+        for (File f : folders) {
+            names.add(f.getName());
+        }
+        assertThat(names, containsInAnyOrder("card0", "card1"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getSoundCardVersion
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testGetSoundCardVersionPresent(@TempDir Path tempDir) throws IOException {
+        Path asound = tempDir.resolve("asound/");
+        Files.createDirectories(asound);
+        writeFile(asound.resolve("version"), "Advanced Linux Sound Architecture Driver Version k5.15.0.");
+
+        String version = LinuxSoundCard.getSoundCardVersion(asound.toString());
+        assertThat(version, is("Advanced Linux Sound Architecture Driver Version k5.15.0."));
+    }
+
+    @Test
+    void testGetSoundCardVersionMissing(@TempDir Path tempDir) {
+        String version = LinuxSoundCard.getSoundCardVersion(tempDir.resolve("asound").toString());
+        assertThat(version, is("not available"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getCardCodec
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testGetCardCodecFromFile(@TempDir Path tempDir) throws IOException {
+        Path card0 = tempDir.resolve("card0");
+        Files.createDirectories(card0);
+        writeFile(card0.resolve("codec#0"), "Codec: Realtek ALC892\nAddress: 0\nVendor Id: 0x10ec0892");
+
+        String codec = LinuxSoundCard.getCardCodec(card0.toFile());
+        assertThat(codec, is("Realtek ALC892"));
+    }
+
+    @Test
+    void testGetCardCodecFromSubdirectory(@TempDir Path tempDir) throws IOException {
+        // CentOS-style: codec is a directory containing files like "codec#0-0"
+        Path card0 = tempDir.resolve("card0");
+        Path codecDir = card0.resolve("codec");
+        Files.createDirectories(codecDir);
+        writeFile(codecDir.resolve("ac97#0-0"), "dummy");
+
+        String codec = LinuxSoundCard.getCardCodec(card0.toFile());
+        assertThat(codec, is("ac97"));
+    }
+
+    @Test
+    void testGetCardCodecNoCodecFile(@TempDir Path tempDir) throws IOException {
+        Path card0 = tempDir.resolve("card0");
+        Files.createDirectories(card0);
+        writeFile(card0.resolve("pcm0p"), "dummy");
+
+        String codec = LinuxSoundCard.getCardCodec(card0.toFile());
+        assertThat(codec, is(""));
+    }
+
+    @Test
+    void testGetCardCodecEmptyDir(@TempDir Path tempDir) throws IOException {
+        Path card0 = tempDir.resolve("card0");
+        Files.createDirectories(card0);
+
+        String codec = LinuxSoundCard.getCardCodec(card0.toFile());
+        assertThat(codec, is(""));
+    }
+
+    // -------------------------------------------------------------------------
+    // getCardName
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testGetCardNameMatches(@TempDir Path tempDir) throws IOException {
+        Path asound = tempDir.resolve("asound");
+        Path card0 = asound.resolve("card0");
+        Files.createDirectories(card0);
+        writeFile(card0.resolve("id"), "PCH");
+        // cards file: key contains the card id, value is the name
+        writeFile(asound.resolve("cards"), " 0 [PCH            ]: HDA-Intel - HDA Intel PCH");
+
+        String name = LinuxSoundCard.getCardName(card0.toFile(), asound.toString());
+        assertThat(name, is("HDA-Intel - HDA Intel PCH"));
+    }
+
+    @Test
+    void testGetCardNameNoMatch(@TempDir Path tempDir) throws IOException {
+        Path asound = tempDir.resolve("asound");
+        Path card0 = asound.resolve("card0");
+        Files.createDirectories(card0);
+        writeFile(card0.resolve("id"), "HDMI");
+        writeFile(asound.resolve("cards"), " 0 [PCH            ]: HDA-Intel - HDA Intel PCH");
+
+        String name = LinuxSoundCard.getCardName(card0.toFile(), asound.toString());
+        assertThat(name, is("Not Found.."));
+    }
+
+    // -------------------------------------------------------------------------
+    // getSoundCards (integration)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testGetSoundCardsIntegration(@TempDir Path tempDir) throws IOException {
+        Path asound = tempDir.resolve("asound/");
+        Files.createDirectories(asound);
+        writeFile(asound.resolve("version"), "ALSA v1.2.6");
+
+        Path card0 = asound.resolve("card0");
+        Files.createDirectories(card0);
+        writeFile(card0.resolve("id"), "PCH");
+        writeFile(card0.resolve("codec#0"), "Codec: ALC892\nAddress: 0");
+        writeFile(asound.resolve("cards"), " 0 [PCH            ]: HDA-Intel - HDA Intel PCH");
+
+        List<SoundCard> cards = LinuxSoundCard.getSoundCards(asound.toString());
+        assertThat(cards, hasSize(1));
+        SoundCard sc = cards.get(0);
+        assertThat(sc.getDriverVersion(), is("ALSA v1.2.6"));
+        assertThat(sc.getName(), is("HDA-Intel - HDA Intel PCH"));
+        assertThat(sc.getCodec(), is("ALC892"));
+    }
+
+    @Test
+    void testGetSoundCardsEmptyDir(@TempDir Path tempDir) throws IOException {
+        Path asound = tempDir.resolve("asound");
+        Files.createDirectories(asound);
+
+        List<SoundCard> cards = LinuxSoundCard.getSoundCards(asound.toString());
+        assertThat(cards, is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxUsbDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxUsbDeviceTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.UsbDevice;
+
+class LinuxUsbDeviceTest {
+
+    // -------------------------------------------------------------------------
+    // getDeviceAndChildren — leaf device
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testLeafDevice() {
+        Map<String, String> nameMap = new HashMap<>();
+        nameMap.put("usb1/1-1", "USB Mouse");
+        Map<String, String> vendorMap = new HashMap<>();
+        vendorMap.put("usb1/1-1", "Logitech");
+        Map<String, String> vendorIdMap = new HashMap<>();
+        vendorIdMap.put("usb1/1-1", "046d");
+        Map<String, String> productIdMap = new HashMap<>();
+        productIdMap.put("usb1/1-1", "c077");
+        Map<String, String> serialMap = new HashMap<>();
+        serialMap.put("usb1/1-1", "SN123");
+        Map<String, List<String>> hubMap = Collections.emptyMap();
+
+        LinuxUsbDevice device = LinuxUsbDevice.getDeviceAndChildren("usb1/1-1", "0000", "0000", nameMap, vendorMap,
+                vendorIdMap, productIdMap, serialMap, hubMap);
+
+        assertThat(device.getName(), is("USB Mouse"));
+        assertThat(device.getVendor(), is("Logitech"));
+        assertThat(device.getVendorId(), is("046d"));
+        assertThat(device.getProductId(), is("c077"));
+        assertThat(device.getSerialNumber(), is("SN123"));
+        assertThat(device.getUniqueDeviceId(), is("usb1/1-1"));
+        assertThat(device.getConnectedDevices(), is(empty()));
+    }
+
+    // -------------------------------------------------------------------------
+    // getDeviceAndChildren — fallback to parent vid/pid
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testFallbackToParentVidPid() {
+        // Device not in vendorIdMap/productIdMap — should inherit parent vid/pid
+        LinuxUsbDevice device = LinuxUsbDevice.getDeviceAndChildren("usb1/1-2", "abcd", "1234", Collections.emptyMap(),
+                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+                Collections.emptyMap());
+
+        assertThat(device.getVendorId(), is("abcd"));
+        assertThat(device.getProductId(), is("1234"));
+        // Name falls back to "vid:pid"
+        assertThat(device.getName(), is("abcd:1234"));
+        assertThat(device.getVendor(), is(""));
+        assertThat(device.getSerialNumber(), is(""));
+    }
+
+    // -------------------------------------------------------------------------
+    // getDeviceAndChildren — hub with children, sorted
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testHubWithSortedChildren() {
+        Map<String, String> nameMap = new HashMap<>();
+        nameMap.put("usb1", "Root Hub");
+        nameMap.put("usb1/1-1", "Zebra Device");
+        nameMap.put("usb1/1-2", "Alpha Device");
+        Map<String, String> vendorMap = Collections.emptyMap();
+        Map<String, String> vendorIdMap = new HashMap<>();
+        vendorIdMap.put("usb1", "1d6b");
+        vendorIdMap.put("usb1/1-1", "aaaa");
+        vendorIdMap.put("usb1/1-2", "bbbb");
+        Map<String, String> productIdMap = new HashMap<>();
+        productIdMap.put("usb1", "0002");
+        productIdMap.put("usb1/1-1", "0001");
+        productIdMap.put("usb1/1-2", "0002");
+        Map<String, String> serialMap = Collections.emptyMap();
+        Map<String, List<String>> hubMap = new HashMap<>();
+        hubMap.put("usb1", Arrays.asList("usb1/1-1", "usb1/1-2"));
+
+        LinuxUsbDevice hub = LinuxUsbDevice.getDeviceAndChildren("usb1", "0000", "0000", nameMap, vendorMap,
+                vendorIdMap, productIdMap, serialMap, hubMap);
+
+        assertThat(hub.getName(), is("Root Hub"));
+        List<UsbDevice> children = hub.getConnectedDevices();
+        assertThat(children, hasSize(2));
+        // Children sorted by name: "Alpha Device" before "Zebra Device"
+        assertThat(children.get(0).getName(), is("Alpha Device"));
+        assertThat(children.get(1).getName(), is("Zebra Device"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getDeviceAndChildren — nested hierarchy
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testNestedHierarchy() {
+        Map<String, String> nameMap = new HashMap<>();
+        nameMap.put("usb1", "Root Hub");
+        nameMap.put("usb1/1-1", "Hub");
+        nameMap.put("usb1/1-1/1-1.1", "Keyboard");
+        Map<String, String> vendorIdMap = new HashMap<>();
+        vendorIdMap.put("usb1", "1d6b");
+        vendorIdMap.put("usb1/1-1", "0424");
+        vendorIdMap.put("usb1/1-1/1-1.1", "04f2");
+        Map<String, String> productIdMap = new HashMap<>();
+        productIdMap.put("usb1", "0002");
+        productIdMap.put("usb1/1-1", "2514");
+        productIdMap.put("usb1/1-1/1-1.1", "0112");
+        Map<String, List<String>> hubMap = new HashMap<>();
+        hubMap.put("usb1", Collections.singletonList("usb1/1-1"));
+        hubMap.put("usb1/1-1", Collections.singletonList("usb1/1-1/1-1.1"));
+
+        LinuxUsbDevice root = LinuxUsbDevice.getDeviceAndChildren("usb1", "0000", "0000", nameMap,
+                Collections.emptyMap(), vendorIdMap, productIdMap, Collections.emptyMap(), hubMap);
+
+        assertThat(root.getConnectedDevices(), hasSize(1));
+        UsbDevice hub = root.getConnectedDevices().get(0);
+        assertThat(hub.getName(), is("Hub"));
+        assertThat(hub.getConnectedDevices(), hasSize(1));
+        assertThat(hub.getConnectedDevices().get(0).getName(), is("Keyboard"));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/TestFileUtil.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/TestFileUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Shared test utility for writing files in synthetic sysfs trees.
+ */
+final class TestFileUtil {
+
+    private TestFileUtil() {
+    }
+
+    /**
+     * Writes a string to a file, creating parent directories as needed.
+     *
+     * @param path    the file path
+     * @param content the content to write
+     * @throws IOException if writing fails
+     */
+    static void writeFile(Path path, String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
@@ -520,6 +520,13 @@ class ParseUtilTest {
         assertThat(ParseUtil.parseDecimalMemorySizeToBinary("1MB"), is(1_048_576L));
         assertThat(ParseUtil.parseDecimalMemorySizeToBinary("1 GB"), is(1_073_741_824L));
         assertThat(ParseUtil.parseDecimalMemorySizeToBinary("1 TB"), is(1_099_511_627_776L));
+        // Single-char suffixes (sysfs cache format)
+        assertThat(ParseUtil.parseDecimalMemorySizeToBinary("32K"), is(32_768L));
+        assertThat(ParseUtil.parseDecimalMemorySizeToBinary("1M"), is(1_048_576L));
+        assertThat(ParseUtil.parseDecimalMemorySizeToBinary("2G"), is(2_147_483_648L));
+        assertThat(ParseUtil.parseDecimalMemorySizeToBinary("1T"), is(1_099_511_627_776L));
+        // Bare "B" suffix should not multiply
+        assertThat(ParseUtil.parseDecimalMemorySizeToBinary("32B"), is(32L));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Add unit tests for Linux hardware classes in `oshi-common` and fix a latent bug in `ParseUtil.parseDecimalMemorySizeToBinary`.

## Bug Fix

`ParseUtil.parseDecimalMemorySizeToBinary` failed to apply the multiplier for single-character suffixes like `"K"`, `"M"`, `"G"`, `"T"`. The guard `mem[1].length() > 1` skipped these, so sysfs cache sizes like `"32K"` parsed to `32` instead of `32768`. Changed to `mem[1].length() > 0`. Bare `"B"` correctly falls through to the `default` switch case with no shift.

## New Tests

Four new test files using `@TempDir` to build synthetic sysfs directory trees, runnable on any platform:

- **LinuxCentralProcessorTest** — ``createMIDR``, ``getSystemLoadAverage``, ``queryMaxFreqFromCpuFreqPath``, ``readTopologyFromSysfs`` (including cache parsing), ``readTopologyFromCpuinfo``
- **LinuxSoundCardTest** — ``getCardFolders``, ``getSoundCardVersion``, ``getCardCodec``, ``getCardName``, ``getSoundCards`` integration
- **LinuxNetworkIFTest** — ``queryIfModelFromSysfs``, ``parseIfOperStatus`` (all 8 cases)
- **LinuxUsbDeviceTest** — ``getDeviceAndChildren`` (leaf, fallback vid/pid, hub with sorted children, nested hierarchy)

## Source Changes

Extracted testable package-private overloads with path parameters (original methods delegate to them):

- **LinuxCentralProcessor**: ``readTopologyFromSysfs(String)``, ``readTopologyFromCpuinfo(List<String>)``, ``getSystemLoadAverage(int, String)``; ``createMIDR`` narrowed from `private` to package-private
- **LinuxSoundCard**: Removed `final`; ``getSoundCards(String)``, ``getCardFolders(String)``, ``getSoundCardVersion(String)``, ``getCardCodec(File)``, ``getCardName(File, String)`` made package-private with path params
- **LinuxNetworkIF**: ``queryIfModelFromSysfs(String, String)`` overload

## ParseUtilTest Additions

Added assertions for single-char suffixes (`"32K"`, `"1M"`, `"2G"`, `"1T"`) and bare `"B"` suffix (`"32B"` → 32).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory-size parsing to correctly handle single-character unit suffixes (e.g., "32K", "1M").

* **Improvements**
  * More robust Linux hardware and load-average parsing with improved path handling and fallback behavior.
  * Enhanced network interface model and sound-card discovery reliability and flexibility.

* **Tests**
  * Added extensive Linux unit tests for CPU, networking, sound, USB, parsing, and shared test utilities.

* **Documentation**
  * Added changelog entry for Linux-related updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->