### PR TITLE
Refactor FFM PDH utility and remove dead constants

### DIFF
--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -8,6 +8,8 @@ import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESS;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.TOTAL_INSTANCE;
 import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
 
@@ -26,12 +28,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.ProcessInformation.HandleCountProperty;
 import oshi.driver.windows.wmi.Win32LogicalDiskFFM;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.software.common.AbstractFileSystem;
 import oshi.software.os.OSFileStore;
 import oshi.util.ParseUtil;
-import oshi.util.platform.windows.PdhUtilFFM;
+import oshi.util.platform.windows.PerfDataUtilFFM;
 
 @ThreadSafe
 public class WindowsFileSystemFFM extends AbstractFileSystem {
@@ -303,7 +306,7 @@ public class WindowsFileSystemFFM extends AbstractFileSystem {
 
     @Override
     public long getOpenFileDescriptors() {
-        return PdhUtilFFM.getOpenFileDescriptors();
+        return PerfDataUtilFFM.queryCounter(PROCESS, TOTAL_INSTANCE, HandleCountProperty.HANDLECOUNT.getCounter());
     }
 
     @Override

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
@@ -23,41 +23,61 @@ import java.lang.foreign.MemorySegment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class PdhUtilFFM {
+/**
+ * Helper class to centralize the boilerplate portions of PDH counter setup using the FFM API.
+ */
+public final class PerfDataUtilFFM {
 
-    private PdhUtilFFM() {
+    private PerfDataUtilFFM() {
     }
 
-    private static final Logger LOG = LoggerFactory.getLogger(PdhUtilFFM.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PerfDataUtilFFM.class);
 
-    public static long getOpenFileDescriptors() {
+    /**
+     * Query a single PDH counter value.
+     *
+     * @param object   The PDH object name (e.g., "Process")
+     * @param instance The instance name (e.g., "_Total"), or null for no instance
+     * @param counter  The counter name (e.g., "Handle Count")
+     * @return The counter value, or -1 if the query failed
+     */
+    public static long queryCounter(String object, String instance, String counter) {
+        StringBuilder path = new StringBuilder();
+        path.append('\\').append(object);
+        if (instance != null) {
+            path.append('(').append(instance).append(')');
+        }
+        path.append('\\').append(counter);
+
         try (Arena arena = Arena.ofConfined()) {
-
             MemorySegment queryPtr = arena.allocate(ADDRESS);
             checkSuccess(PdhOpenQuery(MemorySegment.NULL, MemorySegment.NULL, queryPtr));
-            MemorySegment query = queryPtr.get(ADDRESS, 0);
+            MemorySegment query = null;
 
             try {
+                query = queryPtr.get(ADDRESS, 0);
                 MemorySegment counterPtr = arena.allocate(ADDRESS);
-                checkSuccess(PdhAddEnglishCounter(query, toWideString(arena, "\\Process(_Total)\\Handle Count"),
-                        MemorySegment.NULL, counterPtr));
-                MemorySegment counter = counterPtr.get(ADDRESS, 0);
+                checkSuccess(PdhAddEnglishCounter(query, toWideString(arena, path.toString()), MemorySegment.NULL,
+                        counterPtr));
+                MemorySegment counterHandle = counterPtr.get(ADDRESS, 0);
 
                 checkSuccess(PdhCollectQueryData(query));
 
                 MemorySegment value = arena.allocate(PDH_FMT_COUNTERVALUE_LAYOUT);
-                checkSuccess(PdhGetFormattedCounterValue(counter, PDH_FMT_LARGE, MemorySegment.NULL, value));
+                checkSuccess(PdhGetFormattedCounterValue(counterHandle, PDH_FMT_LARGE, MemorySegment.NULL, value));
 
                 long valueOffset = PDH_FMT_COUNTERVALUE_LAYOUT.byteOffset(groupElement("Value"),
                         groupElement("largeValue"));
                 return value.get(JAVA_LONG, valueOffset);
 
             } finally {
-                PdhCloseQuery(query);
+                if (query != null) {
+                    PdhCloseQuery(query);
+                }
             }
 
         } catch (Throwable t) {
-            LOG.debug("PDH getOpenFileDescriptors failed: {}", t.getMessage(), t);
+            LOG.debug("PDH queryCounter failed for {}: {}", path, t.getMessage(), t);
             return -1;
         }
     }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
@@ -24,7 +24,6 @@ import com.sun.jna.platform.win32.Win32Exception;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.PdhCounterProperty;
-import oshi.driver.common.windows.perfmon.PerfmonConstants;
 import oshi.util.platform.windows.PerfDataUtil.PerfCounter;
 
 /**
@@ -42,15 +41,6 @@ public final class PerfCounterQuery {
 
     // A map to cache localization strings
     private static final ConcurrentHashMap<String, String> LOCALIZE_CACHE = new ConcurrentHashMap<>();
-
-    /*
-     * Multiple classes use these constants. Delegated to PerfmonConstants for sharing with FFM.
-     */
-    public static final String TOTAL_INSTANCE = PerfmonConstants.TOTAL_INSTANCE;
-    public static final String TOTAL_OR_IDLE_INSTANCES = PerfmonConstants.TOTAL_OR_IDLE_INSTANCES;
-    public static final String TOTAL_INSTANCES = PerfmonConstants.TOTAL_INSTANCES;
-    public static final String NOT_TOTAL_INSTANCE = PerfmonConstants.NOT_TOTAL_INSTANCE;
-    public static final String NOT_TOTAL_INSTANCES = PerfmonConstants.NOT_TOTAL_INSTANCES;
 
     private PerfCounterQuery() {
     }


### PR DESCRIPTION
## Summary

Rename `PdhUtilFFM` to `PerfDataUtilFFM`, paralleling `PerfDataUtil` on the JNA side. Generalize the hardcoded handle count query into a reusable `queryCounter(object, instance, counter)` method. Update the caller in `WindowsFileSystemFFM` to use constants from `PerfmonConstants` and `HandleCountProperty` instead of hardcoded strings.

Remove unused delegated constants from `PerfCounterQuery` that were left over from the perfmon enum refactoring to oshi-common.

## Changes

- **`PdhUtilFFM` → `PerfDataUtilFFM`**: Renamed and generalized `getOpenFileDescriptors()` into `queryCounter(String object, String instance, String counter)` that builds the counter path from parameters and returns the value (or -1 on failure). Fixed resource safety: query handle is null-checked in `finally` to handle the case where `queryPtr.get()` throws after `PdhOpenQuery` succeeds.
- **`WindowsFileSystemFFM`**: Updated to call `PerfDataUtilFFM.queryCounter(PROCESS, TOTAL_INSTANCE, HandleCountProperty.HANDLECOUNT.getCounter())` using shared constants.
- **`PerfCounterQuery`**: Removed 5 dead delegated constants (`TOTAL_INSTANCE`, `TOTAL_OR_IDLE_INSTANCES`, `TOTAL_INSTANCES`, `NOT_TOTAL_INSTANCE`, `NOT_TOTAL_INSTANCES`) that just pointed to `PerfmonConstants` with no remaining callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Windows file descriptor tracking through improved performance counter query mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->