### PR TITLE
Filter WMI handle count query to _Total instance

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PerfmonConstants.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PerfmonConstants.java
@@ -37,6 +37,8 @@ public final class PerfmonConstants {
     public static final String WIN32_PERFPROC_PROCESS = "Win32_PerfRawData_PerfProc_Process";
     public static final String WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL = WIN32_PERFPROC_PROCESS
             + " WHERE NOT Name LIKE \"%_Total\"";
+    public static final String WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL = WIN32_PERFPROC_PROCESS
+            + " WHERE Name=\"_Total\"";
     public static final String WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0 = "Win32_PerfRawData_PerfProc_Process WHERE IDProcess=0";
 
     public static final String THREAD = "Thread";

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/ProcessInformation.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/ProcessInformation.java
@@ -48,16 +48,20 @@ public final class ProcessInformation {
     /**
      * Handle performance counters
      */
-    public enum HandleCountProperty implements PdhCounterWildcardProperty {
-        // First element defines WMI instance name field and PDH instance filter
-        NAME(TOTAL_INSTANCE),
-        // Remaining elements define counters
-        HANDLECOUNT("Handle Count");
+    public enum HandleCountProperty implements PdhCounterProperty {
+        HANDLECOUNT(TOTAL_INSTANCE, "Handle Count");
 
+        private final String instance;
         private final String counter;
 
-        HandleCountProperty(String counter) {
+        HandleCountProperty(String instance, String counter) {
+            this.instance = instance;
             this.counter = counter;
+        }
+
+        @Override
+        public String getInstance() {
+            return instance;
         }
 
         @Override

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessInformationJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessInformationJNA.java
@@ -5,8 +5,8 @@
 package oshi.driver.windows.perfmon;
 
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESS;
-import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL;
 
 import java.util.Collections;
@@ -17,6 +17,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.HandleCountProperty;
 import oshi.driver.common.windows.perfmon.ProcessInformation.IdleProcessorTimeProperty;
 import oshi.driver.common.windows.perfmon.ProcessInformation.ProcessPerformanceProperty;
+import oshi.util.platform.windows.PerfCounterQuery;
 import oshi.util.platform.windows.PerfCounterWildcardQuery;
 import oshi.util.tuples.Pair;
 
@@ -45,14 +46,14 @@ public final class ProcessInformationJNA {
     /**
      * Returns handle counters
      *
-     * @return Process handle counters for each process.
+     * @return Handle count for the _Total instance.
      */
-    public static Pair<List<String>, Map<HandleCountProperty, List<Long>>> queryHandles() {
+    public static Map<HandleCountProperty, Long> queryHandles() {
         if (PerfmonDisabled.PERF_PROC_DISABLED) {
-            return new Pair<>(Collections.emptyList(), Collections.emptyMap());
+            return Collections.emptyMap();
         }
-        return PerfCounterWildcardQuery.queryInstancesAndValues(HandleCountProperty.class, PROCESS,
-                WIN32_PERFPROC_PROCESS);
+        return PerfCounterQuery.queryValues(HandleCountProperty.class, PROCESS,
+                WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL);
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystem.java
@@ -270,15 +270,7 @@ public class WindowsFileSystem extends AbstractFileSystem {
 
     @Override
     public long getOpenFileDescriptors() {
-        Map<HandleCountProperty, List<Long>> valueListMap = ProcessInformationJNA.queryHandles().getB();
-        List<Long> valueList = valueListMap.get(HandleCountProperty.HANDLECOUNT);
-        long descriptors = 0L;
-        if (valueList != null) {
-            for (Long value : valueList) {
-                descriptors += value;
-            }
-        }
-        return descriptors;
+        return ProcessInformationJNA.queryHandles().getOrDefault(HandleCountProperty.HANDLECOUNT, 0L);
     }
 
     @Override

--- a/oshi-core/src/test/java/oshi/driver/windows/perfmon/PerfmonDriversTest.java
+++ b/oshi-core/src/test/java/oshi/driver/windows/perfmon/PerfmonDriversTest.java
@@ -15,8 +15,8 @@ import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESSOR;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESSOR_INFORMATION;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.SYSTEM;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.THREAD;
-import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_DISK_PHYSICAL_DISK_WHERE_NAME_NOT_TOTAL;
@@ -94,10 +94,11 @@ class PerfmonDriversTest {
 
     @Test
     void testQueryHandles() {
-        testWildcardCounters("PDH Handles",
-                PerfCounterWildcardQuery.queryInstancesAndValuesFromPDH(HandleCountProperty.class, PROCESS));
-        testWildcardCounters("WMI Handles", PerfCounterWildcardQuery
-                .queryInstancesAndValuesFromWMI(HandleCountProperty.class, WIN32_PERFPROC_PROCESS));
+        assertThat("Failed PDH queryHandles", PerfCounterQuery.queryValuesFromPDH(HandleCountProperty.class, PROCESS),
+                is(aMapWithSize(HandleCountProperty.values().length)));
+        assertThat("Failed WMI queryHandles",
+                PerfCounterQuery.queryValuesFromWMI(HandleCountProperty.class, WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL),
+                is(aMapWithSize(HandleCountProperty.values().length)));
     }
 
     @Test


### PR DESCRIPTION
The `queryHandles()` WMI fallback was querying all processes from `Win32_PerfRawData_PerfProc_Process` without a WHERE clause, returning every process row when only the `_Total` instance is needed. This adds a `WHERE Name="_Total"` filter to match the PDH instance filter already defined in `HandleCountProperty`.

## Changes

- **`PerfmonConstants`**: Added `WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL` constant.
- **`ProcessInformationJNA.queryHandles()`**: Use filtered WMI class instead of unfiltered `WIN32_PERFPROC_PROCESS`.
- **`PerfmonDriversTest.testQueryHandles()`**: Updated WMI test to use the filtered class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows handle-count reporting so the system now returns a single, accurate aggregate total for open handles.
* **Tests**
  * Updated Windows performance-counter tests to validate the consolidated handle-count results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->