### PR TITLE
Add PerfCounterQueryFFM for multi-counter PDH queries with WMI fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#3160](https://github.com/oshi/oshi/pull/3160): Fix LinuxSensors fan and voltage discovery passing wrong path to getSensorFilesFromPath - [@dbwiddis](https://github.com/dbwiddis).
 * [#3161](https://github.com/oshi/oshi/pull/3161): Add Linux hardware unit tests; fix parseDecimalMemorySizeToBinary for single-char suffixes; use platform-independent path separators - [@dbwiddis](https://github.com/dbwiddis).
 * [#3164](https://github.com/oshi/oshi/pull/3164): Refactor Windows perfmon counter enums into oshi-common for sharing between JNA and FFM implementations - [@dbwiddis](https://github.com/dbwiddis).
+* [#3167](https://github.com/oshi/oshi/pull/3167): Add PerfCounterQueryFFM for multi-counter PDH queries with WMI fallback; improve per-counter error resilience in both JNA and FFM paths - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/ProcessInformationFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/ProcessInformationFFM.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.perfmon;
+
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESS;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL;
+
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.ProcessInformation.HandleCountProperty;
+import oshi.util.platform.windows.PerfCounterQueryFFM;
+
+/**
+ * Utility to query Process Information performance counter using FFM.
+ */
+@ThreadSafe
+public final class ProcessInformationFFM {
+
+    private ProcessInformationFFM() {
+    }
+
+    /**
+     * Returns handle counters.
+     *
+     * @return Handle count for the _Total instance.
+     */
+    public static Map<HandleCountProperty, Long> queryHandles() {
+        return PerfCounterQueryFFM.queryValues(HandleCountProperty.class, PROCESS,
+                WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -8,8 +8,6 @@ import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESS;
-import static oshi.driver.common.windows.perfmon.PerfmonConstants.TOTAL_INSTANCE;
 import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
 
@@ -29,12 +27,12 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.HandleCountProperty;
+import oshi.driver.windows.perfmon.ProcessInformationFFM;
 import oshi.driver.windows.wmi.Win32LogicalDiskFFM;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.software.common.AbstractFileSystem;
 import oshi.software.os.OSFileStore;
 import oshi.util.ParseUtil;
-import oshi.util.platform.windows.PerfDataUtilFFM;
 
 @ThreadSafe
 public class WindowsFileSystemFFM extends AbstractFileSystem {
@@ -306,7 +304,7 @@ public class WindowsFileSystemFFM extends AbstractFileSystem {
 
     @Override
     public long getOpenFileDescriptors() {
-        return PerfDataUtilFFM.queryCounter(PROCESS, TOTAL_INSTANCE, HandleCountProperty.HANDLECOUNT.getCounter());
+        return ProcessInformationFFM.queryHandles().getOrDefault(HandleCountProperty.HANDLECOUNT, 0L);
     }
 
     @Override

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfCounterQueryFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfCounterQueryFFM.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.platform.windows;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.PdhCounterProperty;
+import oshi.ffm.windows.com.IWbemClassObjectFFM;
+
+/**
+ * Enables queries of Performance Counters using PDH with WMI backup, for enums implementing {@link PdhCounterProperty}.
+ * FFM-based equivalent of {@code PerfCounterQuery}.
+ */
+@ThreadSafe
+public final class PerfCounterQueryFFM {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PerfCounterQueryFFM.class);
+
+    // Use a thread safe set to cache failed pdh queries
+    private static final Set<String> FAILED_QUERY_CACHE = ConcurrentHashMap.newKeySet();
+
+    private PerfCounterQueryFFM() {
+    }
+
+    /**
+     * Query Performance Counters using PDH, with WMI backup on failure, for values corresponding to the property enum.
+     *
+     * @param <T>          The enum type of {@code propertyEnum}
+     * @param propertyEnum An enum which implements {@link PdhCounterProperty} and contains the WMI field (Enum value)
+     *                     and PDH Counter string (instance and counter)
+     * @param perfObject   The PDH object for this counter; all counters on this object will be refreshed at the same
+     *                     time
+     * @param perfWmiClass The WMI PerfData_RawData_* class corresponding to the PDH object, optionally including a
+     *                     WHERE clause
+     * @return An {@link EnumMap} of the values indexed by {@code propertyEnum} on success, or an empty map if both PDH
+     *         and WMI queries failed.
+     */
+    public static <T extends Enum<T> & PdhCounterProperty> Map<T, Long> queryValues(Class<T> propertyEnum,
+            String perfObject, String perfWmiClass) {
+        if (!FAILED_QUERY_CACHE.contains(perfObject)) {
+            Map<T, Long> valueMap = queryValuesFromPDH(propertyEnum, perfObject);
+            if (!valueMap.isEmpty()) {
+                return valueMap;
+            }
+            LOG.info("Disabling further attempts to query {}.", perfObject);
+            FAILED_QUERY_CACHE.add(perfObject);
+        }
+        return queryValuesFromWMI(propertyEnum, perfWmiClass);
+    }
+
+    /**
+     * Query Performance Counters using PDH for values corresponding to the property enum.
+     *
+     * @param <T>          The enum type of {@code propertyEnum}
+     * @param propertyEnum An enum which implements {@link PdhCounterProperty} and contains the WMI field (Enum value)
+     *                     and PDH Counter string (instance and counter)
+     * @param perfObject   The PDH object for this counter; all counters on this object will be refreshed at the same
+     *                     time
+     * @return An {@link EnumMap} of the values indexed by {@code propertyEnum} on success, or an empty map if the PDH
+     *         query failed.
+     */
+    public static <T extends Enum<T> & PdhCounterProperty> Map<T, Long> queryValuesFromPDH(Class<T> propertyEnum,
+            String perfObject) {
+        return PerfDataUtilFFM.queryCounters(propertyEnum, perfObject);
+    }
+
+    /**
+     * Query Performance Counters using WMI for values corresponding to the property enum.
+     *
+     * @param <T>          The enum type of {@code propertyEnum}
+     * @param propertyEnum An enum which implements {@link PdhCounterProperty} and contains the WMI field (Enum value)
+     *                     and PDH Counter string (instance and counter)
+     * @param perfWmiClass The WMI PerfData_RawData_* class corresponding to the PDH object, optionally including a
+     *                     WHERE clause
+     * @return An {@link EnumMap} of the values indexed by {@code propertyEnum} if successful, an empty map if the WMI
+     *         query failed.
+     */
+    public static <T extends Enum<T> & PdhCounterProperty> Map<T, Long> queryValuesFromWMI(Class<T> propertyEnum,
+            String perfWmiClass) {
+        T[] props = propertyEnum.getEnumConstants();
+        EnumMap<T, Long> valueMap = new EnumMap<>(propertyEnum);
+
+        List<Map<T, Long>> rows = WmiQueryHandlerFFM.createInstance().queryWMI(perfWmiClass, null,
+                () -> new EnumMap<T, Long>(propertyEnum), (pObject, arena, row) -> {
+                    for (T prop : props) {
+                        row.put(prop, IWbemClassObjectFFM.getLong(pObject, prop.name(), arena));
+                    }
+                });
+
+        if (!rows.isEmpty()) {
+            valueMap.putAll(rows.getFirst());
+        }
+        return valueMap;
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
@@ -29,6 +29,10 @@ import oshi.driver.common.windows.perfmon.PdhCounterProperty;
 
 /**
  * Helper class to centralize the boilerplate portions of PDH counter setup using the FFM API.
+ * <p>
+ * This utility collects counter data with a single call to {@code PdhCollectQueryData}, which yields valid results for
+ * raw counters. OSHI queries raw counter values and computes rates in Java rather than using PDH formatted rate
+ * counters, which would require two samples separated by an interval.
  */
 public final class PerfDataUtilFFM {
 
@@ -46,7 +50,8 @@ public final class PerfDataUtilFFM {
      * @param <T>          An enum implementing {@link PdhCounterProperty}
      * @param propertyEnum The enum class whose constants define the counters to query
      * @param perfObject   The PDH object name (e.g., "Process")
-     * @return An {@link EnumMap} of values indexed by enum constant, or an empty map on failure
+     * @return An {@link EnumMap} of values indexed by enum constant. May contain a subset of constants if individual
+     *         counters fail to add or read. Returns an empty map if the query itself fails to open or collect.
      */
     public static <T extends Enum<T> & PdhCounterProperty> Map<T, Long> queryCounters(Class<T> propertyEnum,
             String perfObject) {
@@ -61,19 +66,30 @@ public final class PerfDataUtilFFM {
             try {
                 query = queryPtr.get(ADDRESS, 0);
 
-                // Add all counters to the single query
+                // Add all counters to the single query, skipping any that fail
                 EnumMap<T, MemorySegment> counterHandles = new EnumMap<>(propertyEnum);
                 for (T prop : props) {
                     String path = counterPath(perfObject, prop.getInstance(), prop.getCounter());
-                    counterHandles.put(prop, addEnglishCounter(arena, query, path));
+                    try {
+                        counterHandles.put(prop, addEnglishCounter(arena, query, path));
+                    } catch (Throwable t) {
+                        LOG.debug("Failed to add counter {}: {}", path, t.getMessage());
+                    }
+                }
+                if (counterHandles.isEmpty()) {
+                    return valueMap;
                 }
 
                 // Collect once
                 checkSuccess(PdhCollectQueryData(query));
 
-                // Read all values
-                for (T prop : props) {
-                    valueMap.put(prop, readCounterValue(arena, counterHandles.get(prop)));
+                // Read all values, skipping any that fail
+                for (var entry : counterHandles.entrySet()) {
+                    try {
+                        valueMap.put(entry.getKey(), readCounterValue(arena, entry.getValue()));
+                    } catch (Throwable t) {
+                        LOG.debug("Failed to read counter for {}: {}", entry.getKey(), t.getMessage());
+                    }
                 }
 
             } finally {

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
@@ -41,41 +41,6 @@ public final class PerfDataUtilFFM {
             groupElement("largeValue"));
 
     /**
-     * Query a single PDH counter value.
-     *
-     * @param object   The PDH object name (e.g., "Process")
-     * @param instance The instance name (e.g., "_Total"), or null for no instance
-     * @param counter  The counter name (e.g., "Handle Count")
-     * @return The counter value, or -1 if the query failed
-     */
-    public static long queryCounter(String object, String instance, String counter) {
-        String path = counterPath(object, instance, counter);
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment queryPtr = arena.allocate(ADDRESS);
-            checkSuccess(PdhOpenQuery(MemorySegment.NULL, MemorySegment.NULL, queryPtr));
-            MemorySegment query = null;
-
-            try {
-                query = queryPtr.get(ADDRESS, 0);
-                MemorySegment counterHandle = addEnglishCounter(arena, query, path);
-
-                checkSuccess(PdhCollectQueryData(query));
-
-                return readCounterValue(arena, counterHandle);
-
-            } finally {
-                if (query != null) {
-                    PdhCloseQuery(query);
-                }
-            }
-
-        } catch (Throwable t) {
-            LOG.debug("PDH queryCounter failed for {}: {}", path, t.getMessage(), t);
-            return -1;
-        }
-    }
-
-    /**
      * Query multiple PDH counter values in a single query, one per enum constant.
      *
      * @param <T>          An enum implementing {@link PdhCounterProperty}

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
@@ -19,9 +19,13 @@ import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.EnumMap;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import oshi.driver.common.windows.perfmon.PdhCounterProperty;
 
 /**
  * Helper class to centralize the boilerplate portions of PDH counter setup using the FFM API.
@@ -33,6 +37,9 @@ public final class PerfDataUtilFFM {
 
     private static final Logger LOG = LoggerFactory.getLogger(PerfDataUtilFFM.class);
 
+    private static final long VALUE_OFFSET = PDH_FMT_COUNTERVALUE_LAYOUT.byteOffset(groupElement("Value"),
+            groupElement("largeValue"));
+
     /**
      * Query a single PDH counter value.
      *
@@ -42,13 +49,7 @@ public final class PerfDataUtilFFM {
      * @return The counter value, or -1 if the query failed
      */
     public static long queryCounter(String object, String instance, String counter) {
-        StringBuilder path = new StringBuilder();
-        path.append('\\').append(object);
-        if (instance != null) {
-            path.append('(').append(instance).append(')');
-        }
-        path.append('\\').append(counter);
-
+        String path = counterPath(object, instance, counter);
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment queryPtr = arena.allocate(ADDRESS);
             checkSuccess(PdhOpenQuery(MemorySegment.NULL, MemorySegment.NULL, queryPtr));
@@ -56,19 +57,11 @@ public final class PerfDataUtilFFM {
 
             try {
                 query = queryPtr.get(ADDRESS, 0);
-                MemorySegment counterPtr = arena.allocate(ADDRESS);
-                checkSuccess(PdhAddEnglishCounter(query, toWideString(arena, path.toString()), MemorySegment.NULL,
-                        counterPtr));
-                MemorySegment counterHandle = counterPtr.get(ADDRESS, 0);
+                MemorySegment counterHandle = addEnglishCounter(arena, query, path);
 
                 checkSuccess(PdhCollectQueryData(query));
 
-                MemorySegment value = arena.allocate(PDH_FMT_COUNTERVALUE_LAYOUT);
-                checkSuccess(PdhGetFormattedCounterValue(counterHandle, PDH_FMT_LARGE, MemorySegment.NULL, value));
-
-                long valueOffset = PDH_FMT_COUNTERVALUE_LAYOUT.byteOffset(groupElement("Value"),
-                        groupElement("largeValue"));
-                return value.get(JAVA_LONG, valueOffset);
+                return readCounterValue(arena, counterHandle);
 
             } finally {
                 if (query != null) {
@@ -80,6 +73,77 @@ public final class PerfDataUtilFFM {
             LOG.debug("PDH queryCounter failed for {}: {}", path, t.getMessage(), t);
             return -1;
         }
+    }
+
+    /**
+     * Query multiple PDH counter values in a single query, one per enum constant.
+     *
+     * @param <T>          An enum implementing {@link PdhCounterProperty}
+     * @param propertyEnum The enum class whose constants define the counters to query
+     * @param perfObject   The PDH object name (e.g., "Process")
+     * @return An {@link EnumMap} of values indexed by enum constant, or an empty map on failure
+     */
+    public static <T extends Enum<T> & PdhCounterProperty> Map<T, Long> queryCounters(Class<T> propertyEnum,
+            String perfObject) {
+        T[] props = propertyEnum.getEnumConstants();
+        EnumMap<T, Long> valueMap = new EnumMap<>(propertyEnum);
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment queryPtr = arena.allocate(ADDRESS);
+            checkSuccess(PdhOpenQuery(MemorySegment.NULL, MemorySegment.NULL, queryPtr));
+            MemorySegment query = null;
+
+            try {
+                query = queryPtr.get(ADDRESS, 0);
+
+                // Add all counters to the single query
+                EnumMap<T, MemorySegment> counterHandles = new EnumMap<>(propertyEnum);
+                for (T prop : props) {
+                    String path = counterPath(perfObject, prop.getInstance(), prop.getCounter());
+                    counterHandles.put(prop, addEnglishCounter(arena, query, path));
+                }
+
+                // Collect once
+                checkSuccess(PdhCollectQueryData(query));
+
+                // Read all values
+                for (T prop : props) {
+                    valueMap.put(prop, readCounterValue(arena, counterHandles.get(prop)));
+                }
+
+            } finally {
+                if (query != null) {
+                    PdhCloseQuery(query);
+                }
+            }
+
+        } catch (Throwable t) {
+            LOG.debug("PDH queryCounters failed for {}: {}", perfObject, t.getMessage(), t);
+            return new EnumMap<>(propertyEnum);
+        }
+        return valueMap;
+    }
+
+    private static String counterPath(String object, String instance, String counter) {
+        StringBuilder path = new StringBuilder();
+        path.append('\\').append(object);
+        if (instance != null) {
+            path.append('(').append(instance).append(')');
+        }
+        path.append('\\').append(counter);
+        return path.toString();
+    }
+
+    private static MemorySegment addEnglishCounter(Arena arena, MemorySegment query, String path) throws Throwable {
+        MemorySegment counterPtr = arena.allocate(ADDRESS);
+        checkSuccess(PdhAddEnglishCounter(query, toWideString(arena, path), MemorySegment.NULL, counterPtr));
+        return counterPtr.get(ADDRESS, 0);
+    }
+
+    private static long readCounterValue(Arena arena, MemorySegment counterHandle) throws Throwable {
+        MemorySegment value = arena.allocate(PDH_FMT_COUNTERVALUE_LAYOUT);
+        checkSuccess(PdhGetFormattedCounterValue(counterHandle, PDH_FMT_LARGE, MemorySegment.NULL, value));
+        return value.get(JAVA_LONG, VALUE_OFFSET);
     }
 
 }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
@@ -91,19 +91,20 @@ public final class PerfCounterQuery {
         EnumMap<T, PerfCounter> counterMap = new EnumMap<>(propertyEnum);
         EnumMap<T, Long> valueMap = new EnumMap<>(propertyEnum);
         try (PerfCounterQueryHandler pdhQueryHandler = new PerfCounterQueryHandler()) {
-            // Set up the query and counter handles
+            // Set up the query and counter handles, skipping any that fail
             for (T prop : props) {
                 PerfCounter counter = PerfDataUtil.createCounter(perfObjectLocalized, prop.getInstance(),
                         prop.getCounter());
-                counterMap.put(prop, counter);
-                if (!pdhQueryHandler.addCounterToQuery(counter)) {
-                    return valueMap;
+                if (pdhQueryHandler.addCounterToQuery(counter)) {
+                    counterMap.put(prop, counter);
+                } else {
+                    LOG.debug("Failed to add counter for {}", prop);
                 }
             }
             // And then query. Zero timestamp means update failed
-            if (0 < pdhQueryHandler.updateQuery()) {
-                for (T prop : props) {
-                    valueMap.put(prop, pdhQueryHandler.queryCounter(counterMap.get(prop)));
+            if (!counterMap.isEmpty() && 0 < pdhQueryHandler.updateQuery()) {
+                for (Map.Entry<T, PerfCounter> entry : counterMap.entrySet()) {
+                    valueMap.put(entry.getKey(), pdhQueryHandler.queryCounter(entry.getValue()));
                 }
             }
         }


### PR DESCRIPTION
Adds FFM-based infrastructure for querying PDH performance counters, paralleling the JNA `PerfCounterQuery`.

### Changes

**`PerfDataUtilFFM`**
- Add `queryCounters(Class<T>, String)` method that opens a single PDH query, adds all counters from `PdhCounterProperty` enum constants, collects once, and returns an `EnumMap<T, Long>`
- Remove single-counter `queryCounter()` method (now dead code)
- Extract `VALUE_OFFSET` constant and shared helpers (`counterPath`, `addEnglishCounter`, `readCounterValue`)

**`PerfCounterQueryFFM`** (new)
- `queryValues` — PDH first with failure caching, WMI fallback
- `queryValuesFromPDH` — delegates to `PerfDataUtilFFM.queryCounters`
- `queryValuesFromWMI` — uses `WmiQueryHandlerFFM` with `IWbemClassObjectFFM.getLong` to read enum property values

**`ProcessInformationFFM`** (new)
- FFM equivalent of `ProcessInformationJNA`, routes handle count query through `PerfCounterQueryFFM`

**`WindowsFileSystemFFM`**
- Updated to use `ProcessInformationFFM.queryHandles()` instead of direct `PerfDataUtilFFM.queryCounter()`, exercising the full PDH/WMI fallback path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-counter Windows performance querying with automatic WMI fallback and an aggregated handle-count metric for total processes.

* **Refactor**
  * Per-counter failures are isolated and logged so partial results are returned instead of aborting entire queries.

* **Bug Fixes**
  * File-descriptor handling now defaults to 0 when handle metrics are unavailable, avoiding erroneous negative values.

* **Chores**
  * Updated changelog for the release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->