### PR TITLE
Add PerfCounterWildcardQueryFFM with PdhEnumObjectItems FFM binding; refactor LoadAverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#3161](https://github.com/oshi/oshi/pull/3161): Add Linux hardware unit tests; fix parseDecimalMemorySizeToBinary for single-char suffixes; use platform-independent path separators - [@dbwiddis](https://github.com/dbwiddis).
 * [#3164](https://github.com/oshi/oshi/pull/3164): Refactor Windows perfmon counter enums into oshi-common for sharing between JNA and FFM implementations - [@dbwiddis](https://github.com/dbwiddis).
 * [#3167](https://github.com/oshi/oshi/pull/3167): Add PerfCounterQueryFFM for multi-counter PDH queries with WMI fallback; improve per-counter error resilience in both JNA and FFM paths - [@dbwiddis](https://github.com/dbwiddis).
+* [#3168](https://github.com/oshi/oshi/pull/3168): Add PerfCounterWildcardQueryFFM with PdhEnumObjectItems FFM binding; refactor LoadAverage into abstract base with JNA/FFM subclasses - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/LoadAverage.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/LoadAverage.java
@@ -2,49 +2,56 @@
  * Copyright 2022-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.windows.perfmon;
+package oshi.driver.common.windows.perfmon;
 
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.common.windows.perfmon.ProcessInformation.IdleProcessorTimeProperty;
-import oshi.driver.common.windows.perfmon.SystemInformation.ProcessorQueueLengthProperty;
 import oshi.util.tuples.Pair;
 
 /**
  * Utility to calculate a load average equivalent metric on Windows. Starts a daemon thread to collect the necessary
- * counters and averages in 5-second intervals.
+ * counters and averages in 5-second intervals. Subclasses provide the platform-specific perfmon queries.
  */
 @ThreadSafe
-public final class LoadAverage {
+public abstract class LoadAverage {
 
     // Daemon thread for Load Average
-    private static Thread loadAvgThread = null;
+    private Thread loadAvgThread = null;
 
-    private static double[] loadAverages = new double[] { -1d, -1d, -1d };
+    private final double[] loadAverages = new double[] { -1d, -1d, -1d };
     private static final double[] EXP_WEIGHT = new double[] {
             // 1-, 5-, and 15-minute exponential smoothing weight
             Math.exp(-5d / 60d), Math.exp(-5d / 300d), Math.exp(-5d / 900d) };
 
-    private LoadAverage() {
-    }
+    /**
+     * Query the non-idle ticks from performance counters.
+     *
+     * @return A pair of (nonIdleTicks, nonIdleBase) values
+     */
+    protected abstract Pair<Long, Long> queryNonIdleTicks();
 
-    public static double[] queryLoadAverage(int nelem) {
+    /**
+     * Query the processor queue length from performance counters.
+     *
+     * @return The processor queue length
+     */
+    protected abstract long queryQueueLength();
+
+    public double[] queryLoadAverage(int nelem) {
         synchronized (loadAverages) {
             return Arrays.copyOf(loadAverages, nelem);
         }
     }
 
-    public static synchronized void stopDaemon() {
+    public synchronized void stopDaemon() {
         if (loadAvgThread != null) {
             loadAvgThread.interrupt();
             loadAvgThread = null;
         }
     }
 
-    public static synchronized void startDaemon() {
+    public synchronized void startDaemon() {
         if (loadAvgThread != null) {
             return;
         }
@@ -52,7 +59,7 @@ public final class LoadAverage {
             @Override
             public void run() {
                 // Initialize tick counters
-                Pair<Long, Long> nonIdlePair = LoadAverage.queryNonIdleTicks();
+                Pair<Long, Long> nonIdlePair = queryNonIdleTicks();
                 long nonIdleTicks0 = nonIdlePair.getA();
                 long nonIdleBase0 = nonIdlePair.getB();
                 long nonIdleTicks;
@@ -73,7 +80,7 @@ public final class LoadAverage {
                 }
                 while (!Thread.currentThread().isInterrupted()) {
                     // get non-idle ticks, proxy for average processes running
-                    nonIdlePair = LoadAverage.queryNonIdleTicks();
+                    nonIdlePair = queryNonIdleTicks();
                     nonIdleTicks = nonIdlePair.getA() - nonIdleTicks0;
                     nonIdleBase = nonIdlePair.getB() - nonIdleBase0;
                     if (nonIdleBase > 0 && nonIdleTicks > 0) {
@@ -84,8 +91,7 @@ public final class LoadAverage {
                     nonIdleTicks0 = nonIdlePair.getA();
                     nonIdleBase0 = nonIdlePair.getB();
                     // get processes waiting
-                    queueLength = SystemInformationJNA.queryProcessorQueueLength()
-                            .getOrDefault(ProcessorQueueLengthProperty.PROCESSORQUEUELENGTH, 0L);
+                    queueLength = queryQueueLength();
 
                     synchronized (loadAverages) {
                         // Init to running procs the first time
@@ -113,25 +119,5 @@ public final class LoadAverage {
         };
         loadAvgThread.setDaemon(true);
         loadAvgThread.start();
-    }
-
-    private static Pair<Long, Long> queryNonIdleTicks() {
-        Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> idleValues = ProcessInformationJNA
-                .queryIdleProcessCounters();
-        List<String> instances = idleValues.getA();
-        Map<IdleProcessorTimeProperty, List<Long>> valueMap = idleValues.getB();
-        List<Long> proctimeTicks = valueMap.get(IdleProcessorTimeProperty.PERCENTPROCESSORTIME);
-        List<Long> proctimeBase = valueMap.get(IdleProcessorTimeProperty.ELAPSEDTIME);
-        long nonIdleTicks = 0L;
-        long nonIdleBase = 0L;
-        for (int i = 0; i < instances.size(); i++) {
-            if ("_Total".equals(instances.get(i))) {
-                nonIdleTicks += proctimeTicks.get(i);
-                nonIdleBase += proctimeBase.get(i);
-            } else if ("Idle".equals(instances.get(i))) {
-                nonIdleTicks -= proctimeTicks.get(i);
-            }
-        }
-        return new Pair<>(nonIdleTicks, nonIdleBase);
     }
 }

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/LoadAverageFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/LoadAverageFFM.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.perfmon;
+
+import java.util.List;
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.LoadAverage;
+import oshi.driver.common.windows.perfmon.ProcessInformation.IdleProcessorTimeProperty;
+import oshi.driver.common.windows.perfmon.SystemInformation.ProcessorQueueLengthProperty;
+import oshi.util.tuples.Pair;
+
+/**
+ * FFM implementation of {@link LoadAverage} using FFM-based perfmon drivers.
+ */
+@ThreadSafe
+public final class LoadAverageFFM extends LoadAverage {
+
+    private static final LoadAverageFFM INSTANCE = new LoadAverageFFM();
+
+    private LoadAverageFFM() {
+    }
+
+    public static LoadAverageFFM getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    protected Pair<Long, Long> queryNonIdleTicks() {
+        Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> idleValues = ProcessInformationFFM
+                .queryIdleProcessCounters();
+        List<String> instances = idleValues.getA();
+        Map<IdleProcessorTimeProperty, List<Long>> valueMap = idleValues.getB();
+        List<Long> proctimeTicks = valueMap.get(IdleProcessorTimeProperty.PERCENTPROCESSORTIME);
+        List<Long> proctimeBase = valueMap.get(IdleProcessorTimeProperty.ELAPSEDTIME);
+        if (proctimeTicks == null || proctimeBase == null) {
+            return new Pair<>(0L, 0L);
+        }
+        long nonIdleTicks = 0L;
+        long nonIdleBase = 0L;
+        for (int i = 0; i < instances.size(); i++) {
+            if (i >= proctimeTicks.size() || i >= proctimeBase.size()) {
+                break;
+            }
+            if ("_Total".equals(instances.get(i))) {
+                nonIdleTicks += proctimeTicks.get(i);
+                nonIdleBase += proctimeBase.get(i);
+            } else if ("Idle".equals(instances.get(i))) {
+                nonIdleTicks -= proctimeTicks.get(i);
+            }
+        }
+        return new Pair<>(nonIdleTicks, nonIdleBase);
+    }
+
+    @Override
+    protected long queryQueueLength() {
+        return SystemInformationFFM.queryProcessorQueueLength()
+                .getOrDefault(ProcessorQueueLengthProperty.PROCESSORQUEUELENGTH, 0L);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/MemoryInformationFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/MemoryInformationFFM.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.perfmon;
+
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.MEMORY;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_MEMORY;
+
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.MemoryInformation.PageSwapProperty;
+import oshi.util.platform.windows.PerfCounterQueryFFM;
+
+/**
+ * Utility to query Memory performance counter using FFM.
+ */
+@ThreadSafe
+public final class MemoryInformationFFM {
+
+    private MemoryInformationFFM() {
+    }
+
+    /**
+     * Returns page swap counters.
+     *
+     * @return Page swap counters for memory.
+     */
+    public static Map<PageSwapProperty, Long> queryPageSwaps() {
+        return PerfCounterQueryFFM.queryValues(PageSwapProperty.class, MEMORY, WIN32_PERF_RAW_DATA_PERF_OS_MEMORY);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/PagingFileFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/PagingFileFFM.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.perfmon;
+
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.PAGING_FILE;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PAGING_FILE;
+
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.PagingFile.PagingPercentProperty;
+import oshi.util.platform.windows.PerfCounterQueryFFM;
+
+/**
+ * Utility to query Paging File performance counter using FFM.
+ */
+@ThreadSafe
+public final class PagingFileFFM {
+
+    private PagingFileFFM() {
+    }
+
+    /**
+     * Returns paging file counters.
+     *
+     * @return Paging file counters for memory.
+     */
+    public static Map<PagingPercentProperty, Long> querySwapUsed() {
+        return PerfCounterQueryFFM.queryValues(PagingPercentProperty.class, PAGING_FILE,
+                WIN32_PERF_RAW_DATA_PERF_OS_PAGING_FILE);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/ProcessInformationFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/ProcessInformationFFM.java
@@ -5,13 +5,18 @@
 package oshi.driver.windows.perfmon;
 
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESS;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL;
 
+import java.util.List;
 import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.HandleCountProperty;
+import oshi.driver.common.windows.perfmon.ProcessInformation.IdleProcessorTimeProperty;
 import oshi.util.platform.windows.PerfCounterQueryFFM;
+import oshi.util.platform.windows.PerfCounterWildcardQueryFFM;
+import oshi.util.tuples.Pair;
 
 /**
  * Utility to query Process Information performance counter using FFM.
@@ -30,5 +35,15 @@ public final class ProcessInformationFFM {
     public static Map<HandleCountProperty, Long> queryHandles() {
         return PerfCounterQueryFFM.queryValues(HandleCountProperty.class, PROCESS,
                 WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL);
+    }
+
+    /**
+     * Returns raw idle process performance counters.
+     *
+     * @return Raw performance counters for idle process.
+     */
+    public static Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> queryIdleProcessCounters() {
+        return PerfCounterWildcardQueryFFM.queryInstancesAndValues(IdleProcessorTimeProperty.class, PROCESS,
+                WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0);
     }
 }

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/ProcessorInformationFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/ProcessorInformationFFM.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.perfmon;
+
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESSOR;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_TOTAL;
+
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.ProcessorInformation.InterruptsProperty;
+import oshi.driver.common.windows.perfmon.ProcessorInformation.SystemTickCountProperty;
+import oshi.util.platform.windows.PerfCounterQueryFFM;
+
+/**
+ * Utility to query Processor performance counters using FFM.
+ */
+@ThreadSafe
+public final class ProcessorInformationFFM {
+
+    private ProcessorInformationFFM() {
+    }
+
+    /**
+     * Returns system performance counters.
+     *
+     * @return Performance Counters for the total of all processors.
+     */
+    public static Map<SystemTickCountProperty, Long> querySystemCounters() {
+        return PerfCounterQueryFFM.queryValues(SystemTickCountProperty.class, PROCESSOR,
+                WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_TOTAL);
+    }
+
+    /**
+     * Returns system interrupts counters.
+     *
+     * @return Interrupts counter for the total of all processors.
+     */
+    public static Map<InterruptsProperty, Long> queryInterruptCounters() {
+        return PerfCounterQueryFFM.queryValues(InterruptsProperty.class, PROCESSOR,
+                WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_TOTAL);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/SystemInformationFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/SystemInformationFFM.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.perfmon;
+
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.SYSTEM;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_SYSTEM;
+
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.SystemInformation.ContextSwitchProperty;
+import oshi.driver.common.windows.perfmon.SystemInformation.ProcessorQueueLengthProperty;
+import oshi.util.platform.windows.PerfCounterQueryFFM;
+
+/**
+ * Utility to query System performance counters using FFM.
+ */
+@ThreadSafe
+public final class SystemInformationFFM {
+
+    private SystemInformationFFM() {
+    }
+
+    /**
+     * Returns system context switch counters.
+     *
+     * @return Context switches counter for the total of all processors.
+     */
+    public static Map<ContextSwitchProperty, Long> queryContextSwitchCounters() {
+        return PerfCounterQueryFFM.queryValues(ContextSwitchProperty.class, SYSTEM, WIN32_PERF_RAW_DATA_PERF_OS_SYSTEM);
+    }
+
+    /**
+     * Returns processor queue length.
+     *
+     * @return Processor Queue Length.
+     */
+    public static Map<ProcessorQueueLengthProperty, Long> queryProcessorQueueLength() {
+        return PerfCounterQueryFFM.queryValues(ProcessorQueueLengthProperty.class, SYSTEM,
+                WIN32_PERF_RAW_DATA_PERF_OS_SYSTEM);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/PdhFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/PdhFFM.java
@@ -6,7 +6,6 @@ package oshi.ffm.windows;
 
 import static java.lang.foreign.MemoryLayout.structLayout;
 import static java.lang.foreign.ValueLayout.ADDRESS;
-import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
@@ -20,7 +19,6 @@ public class PdhFFM extends WindowsForeignFunctions {
 
     private static final SymbolLookup Pdh = lib("Pdh");
 
-    public static final int PDH_FMT_LARGE = 0x00000400;
     public static final int PDH_MORE_DATA = 0x800007D2;
 
     private static final MethodHandle PdhOpenQuery = downcall(Pdh, "PdhOpenQueryW", JAVA_INT, ADDRESS, ADDRESS,
@@ -45,20 +43,41 @@ public class PdhFFM extends WindowsForeignFunctions {
         return (int) PdhCollectQueryData.invokeExact(query);
     }
 
-    private static final MethodHandle PdhGetFormattedCounterArray = downcall(Pdh, "PdhGetFormattedCounterArrayW",
-            JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, ADDRESS, ADDRESS);
+    private static final MethodHandle PdhGetRawCounterValue = downcall(Pdh, "PdhGetRawCounterValue", JAVA_INT, ADDRESS,
+            ADDRESS, ADDRESS);
 
-    public static int PdhGetFormattedCounterArray(MemorySegment counter, int format, MemorySegment bufferSize,
-            MemorySegment itemCount, MemorySegment buffer) throws Throwable {
-        return (int) PdhGetFormattedCounterArray.invokeExact(counter, format, bufferSize, itemCount, buffer);
+    public static int PdhGetRawCounterValue(MemorySegment counter, MemorySegment type, MemorySegment value)
+            throws Throwable {
+        return (int) PdhGetRawCounterValue.invokeExact(counter, type, value);
     }
 
-    private static final MethodHandle PdhGetFormattedCounterValue = downcall(Pdh, "PdhGetFormattedCounterValue",
-            JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, ADDRESS);
+    // PDH_RAW_COUNTER: CStatus(4) + pad(4) + TimeStamp(8) + FirstValue(8) + SecondValue(8) + MultiCount(4) + pad(4)
+    // MSVC aligns LONGLONG to 8 bytes, so 4 bytes padding after FILETIME (offset 12 → 16)
+    public static final int PDH_CSTATUS_VALID_DATA = 0;
+    public static final int PDH_CSTATUS_NEW_DATA = 1;
 
-    public static int PdhGetFormattedCounterValue(MemorySegment counter, int format, MemorySegment type,
-            MemorySegment value) throws Throwable {
-        return (int) PdhGetFormattedCounterValue.invokeExact(counter, format, type, value);
+    public static final StructLayout PDH_RAW_COUNTER_LAYOUT = structLayout(JAVA_INT.withName("CStatus"),
+            MemoryLayout.paddingLayout(4), JAVA_LONG.withName("TimeStamp"), JAVA_LONG.withName("FirstValue"),
+            JAVA_LONG.withName("SecondValue"), JAVA_INT.withName("MultiCount"), MemoryLayout.paddingLayout(4));
+
+    private static final MethodHandle PdhLookupPerfNameByIndexW = downcall(Pdh, "PdhLookupPerfNameByIndexW", JAVA_INT,
+            ADDRESS, JAVA_INT, ADDRESS, ADDRESS);
+
+    public static int PdhLookupPerfNameByIndexW(MemorySegment szMachineName, int dwNameIndex,
+            MemorySegment szNameBuffer, MemorySegment pcchNameBufferSize) throws Throwable {
+        return (int) PdhLookupPerfNameByIndexW.invokeExact(szMachineName, dwNameIndex, szNameBuffer,
+                pcchNameBufferSize);
+    }
+
+    private static final MethodHandle PdhEnumObjectItemsW = downcall(Pdh, "PdhEnumObjectItemsW", JAVA_INT, ADDRESS,
+            ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS, JAVA_INT, JAVA_INT);
+
+    public static int PdhEnumObjectItemsW(MemorySegment szDataSource, MemorySegment szMachineName,
+            MemorySegment szObjectName, MemorySegment mszCounterList, MemorySegment pcchCounterListLength,
+            MemorySegment mszInstanceList, MemorySegment pcchInstanceListLength, int dwDetailLevel, int dwFlags)
+            throws Throwable {
+        return (int) PdhEnumObjectItemsW.invokeExact(szDataSource, szMachineName, szObjectName, mszCounterList,
+                pcchCounterListLength, mszInstanceList, pcchInstanceListLength, dwDetailLevel, dwFlags);
     }
 
     private static final MethodHandle PdhCloseQuery = downcall(Pdh, "PdhCloseQuery", JAVA_INT, ADDRESS);
@@ -66,16 +85,5 @@ public class PdhFFM extends WindowsForeignFunctions {
     public static int PdhCloseQuery(MemorySegment query) throws Throwable {
         return (int) PdhCloseQuery.invokeExact(query);
     }
-
-    public static final MemoryLayout PDH_FMT_COUNTERVALUE_UNION = MemoryLayout.unionLayout(
-            JAVA_INT.withName("longValue"), JAVA_DOUBLE.withName("doubleValue"), JAVA_LONG.withName("largeValue"),
-            ADDRESS.withName("AnsiStringValue"), ADDRESS.withName("WideStringValue"));
-
-    public static final StructLayout PDH_FMT_COUNTERVALUE_LAYOUT = MemoryLayout.structLayout(
-            JAVA_INT.withName("CStatus"), MemoryLayout.paddingLayout(4), // align union to 8 bytes
-            PDH_FMT_COUNTERVALUE_UNION.withName("Value"));
-
-    public static final StructLayout PDH_FMT_COUNTERVALUE_ITEM_LAYOUT = structLayout(ADDRESS.withName("szName"),
-            PDH_FMT_COUNTERVALUE_LAYOUT.withName("FmtValue"));
 
 }

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/WinErrorFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/WinErrorFFM.java
@@ -9,6 +9,7 @@ public interface WinErrorFFM {
     int ERROR_ACCESS_DENIED = 5;
     int ERROR_BUFFER_OVERFLOW = 111;
     int ERROR_INSUFFICIENT_BUFFER = 122;
+    int ERROR_MORE_DATA = 234;
     int ERROR_NO_MORE_ITEMS = 259;
     int ERROR_SUCCESS = 0;
 }

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/WinNTFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/WinNTFFM.java
@@ -24,6 +24,7 @@ public interface WinNTFFM {
     int REG_SZ = 1;
     int REG_EXPAND_SZ = 2;
     int REG_DWORD = 4;
+    int REG_MULTI_SZ = 7;
     int SE_PRIVILEGE_ENABLED = 0x00000002;
     int TOKEN_QUERY = 0x0008;
     int TOKEN_ADJUST_PRIVILEGES = 0x0020;

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/Advapi32UtilFFM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The OSHI Project Contributors
+ * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.windows;
@@ -15,10 +15,12 @@ import static oshi.ffm.windows.Advapi32FFM.RegOpenKeyEx;
 import static oshi.ffm.windows.Advapi32FFM.RegQueryInfoKey;
 import static oshi.ffm.windows.Advapi32FFM.RegQueryValueEx;
 import static oshi.ffm.windows.WinErrorFFM.ERROR_INSUFFICIENT_BUFFER;
+import static oshi.ffm.windows.WinErrorFFM.ERROR_MORE_DATA;
 import static oshi.ffm.windows.WinErrorFFM.ERROR_SUCCESS;
 import static oshi.ffm.windows.WinNTFFM.KEY_READ;
 import static oshi.ffm.windows.WinNTFFM.REG_DWORD;
 import static oshi.ffm.windows.WinNTFFM.REG_EXPAND_SZ;
+import static oshi.ffm.windows.WinNTFFM.REG_MULTI_SZ;
 import static oshi.ffm.windows.WinNTFFM.REG_SZ;
 import static oshi.ffm.windows.WindowsForeignFunctions.checkSuccess;
 import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
@@ -192,6 +194,80 @@ public final class Advapi32UtilFFM {
                     yield null;
                 }
             };
+        }
+    }
+
+    /**
+     * Reads a REG_MULTI_SZ value from an open registry key.
+     *
+     * @param rootKey   The root key handle (e.g., HKEY_LOCAL_MACHINE)
+     * @param keyPath   The registry key path
+     * @param valueName The value name to read
+     * @return An array of strings from the multi-sz value, or an empty array on failure
+     */
+    public static String[] registryGetStringArray(MemorySegment rootKey, String keyPath, String valueName) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment phkResult = arena.allocate(ADDRESS);
+            int rc = RegOpenKeyEx(rootKey, toWideString(arena, keyPath), 0, KEY_READ, phkResult);
+            if (rc != ERROR_SUCCESS) {
+                throw new Win32Exception(rc);
+            }
+            MemorySegment hKey = phkResult.get(ADDRESS, 0);
+            try {
+                MemorySegment lpType = arena.allocate(JAVA_INT);
+                MemorySegment lpcbData = arena.allocate(JAVA_INT);
+
+                rc = RegQueryValueEx(hKey, toWideString(arena, valueName), 0, lpType, MemorySegment.NULL, lpcbData);
+                if (rc != ERROR_SUCCESS && rc != ERROR_INSUFFICIENT_BUFFER && rc != ERROR_MORE_DATA) {
+                    throw new Win32Exception(rc);
+                }
+                if (lpType.get(JAVA_INT, 0) != REG_MULTI_SZ) {
+                    throw new IllegalStateException(
+                            "Unexpected registry type " + lpType.get(JAVA_INT, 0) + ", expected REG_MULTI_SZ");
+                }
+
+                int size = lpcbData.get(JAVA_INT, 0);
+                MemorySegment data;
+                rc = ERROR_MORE_DATA;
+                for (int attempt = 0; attempt < 3 && rc != ERROR_SUCCESS; attempt++) {
+                    // Allocate extra for double-null terminator
+                    data = arena.allocate(size + 4);
+                    data.fill((byte) 0);
+                    lpcbData.set(JAVA_INT, 0, size + 4);
+
+                    rc = RegQueryValueEx(hKey, toWideString(arena, valueName), 0, lpType, data, lpcbData);
+                    if (rc == ERROR_MORE_DATA || rc == ERROR_INSUFFICIENT_BUFFER) {
+                        size = lpcbData.get(JAVA_INT, 0);
+                        continue;
+                    }
+                    if (rc != ERROR_SUCCESS) {
+                        throw new Win32Exception(rc);
+                    }
+
+                    // Parse multi-sz: null-delimited wide strings, double-null terminated
+                    int bytesWritten = lpcbData.get(JAVA_INT, 0);
+                    List<String> result = new ArrayList<>();
+                    long offset = 0;
+                    while (offset < bytesWritten) {
+                        String s = readWideString(data.asSlice(offset, bytesWritten - offset));
+                        if (s.isEmpty()) {
+                            break;
+                        }
+                        result.add(s);
+                        offset += ((long) s.length() + 1) * 2; // chars + null, 2 bytes each
+                    }
+                    return result.toArray(new String[0]);
+                }
+                throw new Win32Exception(rc);
+            } finally {
+                int closeRc = RegCloseKey(hKey);
+                if (closeRc != ERROR_SUCCESS) {
+                    LOG.debug("Failed to close registry key {}\\{}: error {}", keyPath, valueName, closeRc);
+                }
+            }
+        } catch (Throwable t) {
+            LOG.warn("Failed to read registry string array {}\\{}: {}", keyPath, valueName, t.getMessage());
+            return new String[0];
         }
     }
 

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQueryFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQueryFFM.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.platform.windows;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
+import oshi.ffm.windows.com.IWbemClassObjectFFM;
+import oshi.util.tuples.Pair;
+
+/**
+ * Enables queries of Performance Counters using wild cards to filter instances. FFM-based equivalent of
+ * {@code PerfCounterWildcardQuery}.
+ */
+@ThreadSafe
+public final class PerfCounterWildcardQueryFFM {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PerfCounterWildcardQueryFFM.class);
+
+    // Use a thread safe set to cache failed pdh queries
+    private static final Set<String> FAILED_QUERY_CACHE = ConcurrentHashMap.newKeySet();
+
+    private PerfCounterWildcardQueryFFM() {
+    }
+
+    /**
+     * Query Performance Counters using PDH, with WMI backup on failure, for values corresponding to the property enum.
+     *
+     * @param <T>          The enum type of {@code propertyEnum}
+     * @param propertyEnum An enum which implements {@link PdhCounterWildcardProperty} and contains the WMI field (Enum
+     *                     value) and PDH Counter string (instance and counter)
+     * @param perfObject   The PDH object for this counter; all counters on this object will be refreshed at the same
+     *                     time
+     * @param perfWmiClass The WMI PerfData_RawData_* class corresponding to the PDH object, optionally including a
+     *                     WHERE clause
+     * @return A pair containing a list of instances and an {@link EnumMap} of the corresponding values indexed by
+     *         {@code propertyEnum} on success, or an empty list and empty map if both PDH and WMI queries failed.
+     */
+    public static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
+            Class<T> propertyEnum, String perfObject, String perfWmiClass) {
+        if (!FAILED_QUERY_CACHE.contains(perfObject)) {
+            Pair<List<String>, Map<T, List<Long>>> result = queryInstancesAndValuesFromPDH(propertyEnum, perfObject);
+            if (!result.getA().isEmpty()) {
+                return result;
+            }
+            LOG.info("Disabling further attempts to query {}.", perfObject);
+            FAILED_QUERY_CACHE.add(perfObject);
+        }
+        return queryInstancesAndValuesFromWMI(propertyEnum, perfWmiClass);
+    }
+
+    /**
+     * Query Performance Counters using PDH for values corresponding to the property enum.
+     *
+     * @param <T>          The enum type of {@code propertyEnum}
+     * @param propertyEnum An enum which implements {@link PdhCounterWildcardProperty} and contains the WMI field (Enum
+     *                     value) and PDH Counter string (instance and counter)
+     * @param perfObject   The PDH object for this counter; all counters on this object will be refreshed at the same
+     *                     time
+     * @return A pair containing a list of instances and an {@link EnumMap} of the corresponding values indexed by
+     *         {@code propertyEnum} on success, or an empty list and empty map if the PDH query failed.
+     */
+    public static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromPDH(
+            Class<T> propertyEnum, String perfObject) {
+        return PerfDataUtilFFM.queryWildcardCounters(propertyEnum, perfObject);
+    }
+
+    /**
+     * Query Performance Counters using WMI for values corresponding to the property enum.
+     *
+     * @param <T>          The enum type of {@code propertyEnum}
+     * @param propertyEnum An enum which implements {@link PdhCounterWildcardProperty} and contains the WMI field (Enum
+     *                     value) and PDH Counter string (instance and counter)
+     * @param perfWmiClass The WMI PerfData_RawData_* class corresponding to the PDH object, optionally including a
+     *                     WHERE clause
+     * @return A pair containing a list of instances and an {@link EnumMap} of the corresponding values indexed by
+     *         {@code propertyEnum} on success, or an empty list and empty map if the WMI query failed.
+     */
+    public static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromWMI(
+            Class<T> propertyEnum, String perfWmiClass) {
+        T[] props = propertyEnum.getEnumConstants();
+        List<String> instances = new ArrayList<>();
+        EnumMap<T, List<Long>> valuesMap = new EnumMap<>(propertyEnum);
+
+        List<Map<T, Object>> rows = WmiQueryHandlerFFM.createInstance().queryWMI(perfWmiClass, null,
+                () -> new EnumMap<T, Object>(propertyEnum), (pObject, arena, row) -> {
+                    for (T prop : props) {
+                        if (prop.ordinal() == 0) {
+                            row.put(prop, IWbemClassObjectFFM.getString(pObject, prop.name(), arena));
+                        } else {
+                            row.put(prop, IWbemClassObjectFFM.getLong(pObject, prop.name(), arena));
+                        }
+                    }
+                });
+
+        for (Map<T, Object> row : rows) {
+            instances.add((String) row.get(props[0]));
+            for (int i = 1; i < props.length; i++) {
+                valuesMap.computeIfAbsent(props[i], k -> new ArrayList<>()).add((Long) row.get(props[i]));
+            }
+        }
+        return new Pair<>(instances, valuesMap);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
@@ -6,26 +6,44 @@ package oshi.util.platform.windows;
 
 import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
 import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_CHAR;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static oshi.ffm.windows.PdhFFM.PDH_FMT_COUNTERVALUE_LAYOUT;
-import static oshi.ffm.windows.PdhFFM.PDH_FMT_LARGE;
+import static oshi.ffm.windows.PdhFFM.PDH_CSTATUS_NEW_DATA;
+import static oshi.ffm.windows.PdhFFM.PDH_CSTATUS_VALID_DATA;
+import static oshi.ffm.windows.PdhFFM.PDH_MORE_DATA;
+import static oshi.ffm.windows.PdhFFM.PDH_RAW_COUNTER_LAYOUT;
 import static oshi.ffm.windows.PdhFFM.PdhAddEnglishCounter;
 import static oshi.ffm.windows.PdhFFM.PdhCloseQuery;
 import static oshi.ffm.windows.PdhFFM.PdhCollectQueryData;
-import static oshi.ffm.windows.PdhFFM.PdhGetFormattedCounterValue;
+import static oshi.ffm.windows.PdhFFM.PdhEnumObjectItemsW;
+import static oshi.ffm.windows.PdhFFM.PdhGetRawCounterValue;
+import static oshi.ffm.windows.PdhFFM.PdhLookupPerfNameByIndexW;
 import static oshi.ffm.windows.PdhFFM.PdhOpenQuery;
+import static oshi.ffm.windows.WinErrorFFM.ERROR_SUCCESS;
 import static oshi.ffm.windows.WindowsForeignFunctions.checkSuccess;
+import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.driver.common.windows.perfmon.PdhCounterProperty;
+import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
+import oshi.ffm.windows.WinRegFFM;
+import oshi.util.ParseUtil;
+import oshi.util.Util;
+import oshi.util.tuples.Pair;
 
 /**
  * Helper class to centralize the boilerplate portions of PDH counter setup using the FFM API.
@@ -41,8 +59,12 @@ public final class PerfDataUtilFFM {
 
     private static final Logger LOG = LoggerFactory.getLogger(PerfDataUtilFFM.class);
 
-    private static final long VALUE_OFFSET = PDH_FMT_COUNTERVALUE_LAYOUT.byteOffset(groupElement("Value"),
-            groupElement("largeValue"));
+    // Cache for English-to-localized object name mapping
+    private static final Map<String, String> LOCALIZE_CACHE = new ConcurrentHashMap<>();
+
+    // English counter index registry key
+    private static final String ENGLISH_COUNTER_KEY = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib\\009";
+    private static final String ENGLISH_COUNTER_VALUE = "Counter";
 
     /**
      * Query multiple PDH counter values in a single query, one per enum constant.
@@ -86,7 +108,7 @@ public final class PerfDataUtilFFM {
                 // Read all values, skipping any that fail
                 for (var entry : counterHandles.entrySet()) {
                     try {
-                        valueMap.put(entry.getKey(), readCounterValue(arena, entry.getValue()));
+                        valueMap.put(entry.getKey(), readRawCounterValue(arena, entry.getValue()));
                     } catch (Throwable t) {
                         LOG.debug("Failed to read counter for {}: {}", entry.getKey(), t.getMessage());
                     }
@@ -121,10 +143,251 @@ public final class PerfDataUtilFFM {
         return counterPtr.get(ADDRESS, 0);
     }
 
-    private static long readCounterValue(Arena arena, MemorySegment counterHandle) throws Throwable {
-        MemorySegment value = arena.allocate(PDH_FMT_COUNTERVALUE_LAYOUT);
-        checkSuccess(PdhGetFormattedCounterValue(counterHandle, PDH_FMT_LARGE, MemorySegment.NULL, value));
-        return value.get(JAVA_LONG, VALUE_OFFSET);
+    private static final long RAW_CSTATUS_OFFSET = PDH_RAW_COUNTER_LAYOUT.byteOffset(groupElement("CStatus"));
+    private static final long RAW_FIRST_VALUE_OFFSET = PDH_RAW_COUNTER_LAYOUT.byteOffset(groupElement("FirstValue"));
+
+    private static long readRawCounterValue(Arena arena, MemorySegment counterHandle) throws Throwable {
+        MemorySegment value = arena.allocate(PDH_RAW_COUNTER_LAYOUT);
+        checkSuccess(PdhGetRawCounterValue(counterHandle, MemorySegment.NULL, value));
+        int cStatus = value.get(JAVA_INT, RAW_CSTATUS_OFFSET);
+        if (cStatus != PDH_CSTATUS_VALID_DATA && cStatus != PDH_CSTATUS_NEW_DATA) {
+            throw new IllegalStateException(
+                    String.format(Locale.ROOT, "PDH raw counter CStatus invalid: 0x%08X", cStatus));
+        }
+        return value.get(JAVA_LONG, RAW_FIRST_VALUE_OFFSET);
     }
 
+    /**
+     * Enumerate instances of a PDH performance object, filtering by the wildcard pattern from the first enum constant.
+     *
+     * @param perfObject     The PDH object name (e.g., "Process")
+     * @param instanceFilter The wildcard filter pattern (lowercase)
+     * @return A list of matching instance names, or an empty list on failure
+     */
+    static List<String> enumInstances(String perfObject, String instanceFilter) {
+        // PdhEnumObjectItemsW requires the localized object name
+        String localizedObject = localizeObjectName(perfObject);
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment objectName = toWideString(arena, localizedObject);
+            MemorySegment counterLen = arena.allocate(JAVA_INT);
+            MemorySegment instanceLen = arena.allocate(JAVA_INT);
+
+            // First call: get required buffer sizes
+            counterLen.set(JAVA_INT, 0, 0);
+            instanceLen.set(JAVA_INT, 0, 0);
+            int result = PdhEnumObjectItemsW(MemorySegment.NULL, MemorySegment.NULL, objectName, MemorySegment.NULL,
+                    counterLen, MemorySegment.NULL, instanceLen, 100, 0);
+            if (result != ERROR_SUCCESS && result != PDH_MORE_DATA) {
+                LOG.warn("Failed to enumerate instances for {}: 0x{}", perfObject, Integer.toHexString(result));
+                return Collections.emptyList();
+            }
+
+            // Retry loop for race conditions (e.g., process/thread list changes)
+            MemorySegment counterBuf;
+            MemorySegment instanceBuf;
+            int retries = 0;
+            do {
+                int cLen = counterLen.get(JAVA_INT, 0);
+                int iLen = instanceLen.get(JAVA_INT, 0);
+                counterBuf = cLen > 0 ? arena.allocate((long) cLen * 2) : MemorySegment.NULL;
+                instanceBuf = iLen > 0 ? arena.allocate((long) iLen * 2) : MemorySegment.NULL;
+
+                result = PdhEnumObjectItemsW(MemorySegment.NULL, MemorySegment.NULL, objectName, counterBuf, counterLen,
+                        instanceBuf, instanceLen, 100, 0);
+                // On PDH_MORE_DATA, counterLen/instanceLen are updated with required sizes;
+                // add headroom for race conditions where instances change between calls
+                if (result == PDH_MORE_DATA) {
+                    counterLen.set(JAVA_INT, 0, counterLen.get(JAVA_INT, 0) + 1024);
+                    instanceLen.set(JAVA_INT, 0, instanceLen.get(JAVA_INT, 0) + 1024);
+                }
+            } while (result == PDH_MORE_DATA && ++retries < 5);
+
+            if (result != ERROR_SUCCESS) {
+                LOG.warn("Failed to enumerate instances for {}: 0x{}", localizedObject, Integer.toHexString(result));
+                return Collections.emptyList();
+            }
+
+            // Parse multi-sz instance list and filter
+            List<String> instances = parseMultiSz(instanceBuf);
+            instances.removeIf(i -> !Util.wildcardMatch(i.toLowerCase(Locale.ROOT), instanceFilter));
+            return instances;
+        } catch (Throwable t) {
+            LOG.warn("Failed to enumerate instances for {}: {}", localizedObject, t.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Parse a null-terminated double-null-terminated wide string list (multi-sz) into a list of strings.
+     *
+     * @param buf the memory segment containing the multi-sz wide string data
+     * @return a list of parsed strings
+     */
+    private static List<String> parseMultiSz(MemorySegment buf) {
+        List<String> result = new ArrayList<>();
+        if (buf == null || buf.equals(MemorySegment.NULL)) {
+            return result;
+        }
+        long offset = 0;
+        long size = buf.byteSize();
+        while (offset < size) {
+            StringBuilder sb = new StringBuilder();
+            while (offset < size) {
+                char c = buf.get(JAVA_CHAR, offset);
+                offset += 2;
+                if (c == '\0') {
+                    break;
+                }
+                sb.append(c);
+            }
+            if (sb.isEmpty()) {
+                break; // double null = end of list
+            }
+            result.add(sb.toString());
+        }
+        return result;
+    }
+
+    /**
+     * Query wildcard PDH counter values for all instances matching the filter defined by the first enum constant.
+     *
+     * @param <T>          An enum implementing {@link PdhCounterWildcardProperty}
+     * @param propertyEnum The enum class whose constants define the counters to query. The first constant defines the
+     *                     instance filter; remaining constants define counter names.
+     * @param perfObject   The PDH object name (e.g., "Process")
+     * @return A pair of (instances, valueMap) where valueMap is indexed by enum constant (excluding the first). Returns
+     *         empty list and empty map on failure.
+     */
+    public static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryWildcardCounters(
+            Class<T> propertyEnum, String perfObject) {
+
+        T[] props = propertyEnum.getEnumConstants();
+        if (props.length < 2) {
+            throw new IllegalArgumentException("Enum " + propertyEnum.getName()
+                    + " must have at least two elements, an instance filter and a counter.");
+        }
+        String instanceFilter = props[0].getCounter().toLowerCase(Locale.ROOT);
+
+        List<String> instances = enumInstances(perfObject, instanceFilter);
+        EnumMap<T, List<Long>> valuesMap = new EnumMap<>(propertyEnum);
+        if (instances.isEmpty()) {
+            return new Pair<>(Collections.emptyList(), valuesMap);
+        }
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment queryPtr = arena.allocate(ADDRESS);
+            checkSuccess(PdhOpenQuery(MemorySegment.NULL, MemorySegment.NULL, queryPtr));
+            MemorySegment query = null;
+
+            try {
+                query = queryPtr.get(ADDRESS, 0);
+
+                // Add counters for each instance × property (skip first which is the filter)
+                // counterHandles[propIndex - 1][instanceIndex]
+                @SuppressWarnings("unchecked")
+                List<MemorySegment>[] counterHandles = new List[props.length - 1];
+                for (int p = 1; p < props.length; p++) {
+                    counterHandles[p - 1] = new ArrayList<>(instances.size());
+                    for (String instance : instances) {
+                        String path = counterPath(perfObject, instance, props[p].getCounter());
+                        try {
+                            counterHandles[p - 1].add(addEnglishCounter(arena, query, path));
+                        } catch (Throwable t) {
+                            LOG.debug("Failed to add counter {}: {}", path, t.getMessage());
+                            return new Pair<>(Collections.emptyList(), new EnumMap<>(propertyEnum));
+                        }
+                    }
+                }
+
+                // Collect once
+                checkSuccess(PdhCollectQueryData(query));
+
+                // Read values
+                for (int p = 1; p < props.length; p++) {
+                    List<Long> values = new ArrayList<>(instances.size());
+                    for (MemorySegment handle : counterHandles[p - 1]) {
+                        try {
+                            values.add(readRawCounterValue(arena, handle));
+                        } catch (Throwable t) {
+                            LOG.debug("Failed to read counter for {}: {}", props[p], t.getMessage());
+                            values.add(0L);
+                        }
+                    }
+                    valuesMap.put(props[p], values);
+                }
+            } finally {
+                if (query != null) {
+                    PdhCloseQuery(query);
+                }
+            }
+        } catch (Throwable t) {
+            LOG.debug("PDH queryWildcardCounters failed for {}: {}", perfObject, t.getMessage(), t);
+            return new Pair<>(Collections.emptyList(), new EnumMap<>(propertyEnum));
+        }
+        return new Pair<>(instances, valuesMap);
+    }
+
+    /**
+     * Localize a PDH object name. {@code PdhEnumObjectItemsW} requires the localized name unlike
+     * {@code PdhAddEnglishCounterW} which handles English names natively.
+     *
+     * @param perfObject The English object name
+     * @return The localized name, or the original if localization fails
+     */
+    private static String localizeObjectName(String perfObject) {
+        return LOCALIZE_CACHE.computeIfAbsent(perfObject, PerfDataUtilFFM::localizeUsingPerfIndex);
+    }
+
+    private static String localizeUsingPerfIndex(String perfObject) {
+        int index = lookupPerfIndexByEnglishName(perfObject);
+        if (index == 0) {
+            LOG.debug("Unable to find English counter index for {}", perfObject);
+            return perfObject;
+        }
+        String localized = lookupPerfNameByIndex(index);
+        if (localized.isEmpty()) {
+            return perfObject;
+        }
+        LOG.debug("Localized {} to {}", perfObject, localized);
+        return localized;
+    }
+
+    private static int lookupPerfIndexByEnglishName(String name) {
+        String[] counters = Advapi32UtilFFM.registryGetStringArray(
+                MemorySegment.ofAddress(WinRegFFM.HKEY_LOCAL_MACHINE), ENGLISH_COUNTER_KEY, ENGLISH_COUNTER_VALUE);
+        // Array contains alternating index/name pairs: {"1", "1847", "2", "System", "4", "Memory", ...}
+        for (int i = 1; i < counters.length; i += 2) {
+            if (counters[i].equals(name)) {
+                int idx = ParseUtil.parseIntOrDefault(counters[i - 1], 0);
+                if (idx > 0) {
+                    return idx;
+                }
+            }
+        }
+        return 0;
+    }
+
+    private static String lookupPerfNameByIndex(int index) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment bufSize = arena.allocate(JAVA_INT);
+            bufSize.set(JAVA_INT, 0, 0);
+            int result = PdhLookupPerfNameByIndexW(MemorySegment.NULL, index, MemorySegment.NULL, bufSize);
+            if (result != PDH_MORE_DATA && result != ERROR_SUCCESS) {
+                return "";
+            }
+            int size = bufSize.get(JAVA_INT, 0);
+            if (size <= 0) {
+                return "";
+            }
+            MemorySegment nameBuf = arena.allocate((long) size * 2);
+            result = PdhLookupPerfNameByIndexW(MemorySegment.NULL, index, nameBuf, bufSize);
+            if (result != ERROR_SUCCESS) {
+                return "";
+            }
+            return readWideString(nameBuf);
+        } catch (Throwable t) {
+            LOG.debug("Failed to lookup perf name by index {}: {}", index, t.getMessage());
+            return "";
+        }
+    }
 }

--- a/oshi-core-java25/src/test/java/module-info.test
+++ b/oshi-core-java25/src/test/java/module-info.test
@@ -10,6 +10,8 @@
   com.github.oshi/oshi.ffm.mac=org.junit.platform.commons
 --add-opens
   com.github.oshi/oshi.ffm.windows.com=org.junit.platform.commons
+--add-opens
+  com.github.oshi/oshi.driver.windows.perfmon=org.junit.platform.commons
 
 --enable-native-access
   com.github.oshi

--- a/oshi-core-java25/src/test/java/oshi/driver/windows/perfmon/LoadAverageFFMTest.java
+++ b/oshi-core-java25/src/test/java/oshi/driver/windows/perfmon/LoadAverageFFMTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2026 The OSHI Project Contributors
+ * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.perfmon;
@@ -15,11 +15,11 @@ import org.junit.jupiter.api.condition.OS;
 import oshi.util.Util;
 
 @EnabledOnOs(OS.WINDOWS)
-class LoadAverageTest {
+class LoadAverageFFMTest {
 
     @Test
     void testQueryLoadAverage() {
-        LoadAverageJNA loadAvg = LoadAverageJNA.getInstance();
+        LoadAverageFFM loadAvg = LoadAverageFFM.getInstance();
         double[] loadAverage = loadAvg.queryLoadAverage(3);
         assertThat("1m load average should be negative", loadAverage[0], lessThan(0d));
         assertThat("5m load average should be negative", loadAverage[1], lessThan(0d));

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/LoadAverageJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/LoadAverageJNA.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.perfmon;
+
+import java.util.List;
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.LoadAverage;
+import oshi.driver.common.windows.perfmon.ProcessInformation.IdleProcessorTimeProperty;
+import oshi.driver.common.windows.perfmon.SystemInformation.ProcessorQueueLengthProperty;
+import oshi.util.tuples.Pair;
+
+/**
+ * JNA implementation of {@link LoadAverage} using JNA-based perfmon drivers.
+ */
+@ThreadSafe
+public final class LoadAverageJNA extends LoadAverage {
+
+    private static final LoadAverageJNA INSTANCE = new LoadAverageJNA();
+
+    private LoadAverageJNA() {
+    }
+
+    public static LoadAverageJNA getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    protected Pair<Long, Long> queryNonIdleTicks() {
+        Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> idleValues = ProcessInformationJNA
+                .queryIdleProcessCounters();
+        List<String> instances = idleValues.getA();
+        Map<IdleProcessorTimeProperty, List<Long>> valueMap = idleValues.getB();
+        List<Long> proctimeTicks = valueMap.get(IdleProcessorTimeProperty.PERCENTPROCESSORTIME);
+        List<Long> proctimeBase = valueMap.get(IdleProcessorTimeProperty.ELAPSEDTIME);
+        if (proctimeTicks == null || proctimeBase == null) {
+            return new Pair<>(0L, 0L);
+        }
+        long nonIdleTicks = 0L;
+        long nonIdleBase = 0L;
+        for (int i = 0; i < instances.size(); i++) {
+            if (i >= proctimeTicks.size() || i >= proctimeBase.size()) {
+                break;
+            }
+            if ("_Total".equals(instances.get(i))) {
+                nonIdleTicks += proctimeTicks.get(i);
+                nonIdleBase += proctimeBase.get(i);
+            } else if ("Idle".equals(instances.get(i))) {
+                nonIdleTicks -= proctimeTicks.get(i);
+            }
+        }
+        return new Pair<>(nonIdleTicks, nonIdleBase);
+    }
+
+    @Override
+    protected long queryQueueLength() {
+        return SystemInformationJNA.queryProcessorQueueLength()
+                .getOrDefault(ProcessorQueueLengthProperty.PROCESSORQUEUELENGTH, 0L);
+    }
+}

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessInformationJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessInformationJNA.java
@@ -57,9 +57,9 @@ public final class ProcessInformationJNA {
     }
 
     /**
-     * Returns cooked idle process performance counters.
+     * Returns raw idle process performance counters.
      *
-     * @return Cooked performance counters for idle process.
+     * @return Raw performance counters for idle process.
      */
     public static Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> queryIdleProcessCounters() {
         if (PerfmonDisabled.PERF_OS_DISABLED) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessor.java
@@ -35,7 +35,7 @@ import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorUtilityT
 import oshi.driver.common.windows.perfmon.ProcessorInformation.SystemTickCountProperty;
 import oshi.driver.common.windows.perfmon.SystemInformation.ContextSwitchProperty;
 import oshi.driver.windows.LogicalProcessorInformation;
-import oshi.driver.windows.perfmon.LoadAverage;
+import oshi.driver.windows.perfmon.LoadAverageJNA;
 import oshi.driver.windows.perfmon.ProcessorInformationJNA;
 import oshi.driver.windows.perfmon.SystemInformationJNA;
 import oshi.driver.windows.wmi.Win32Processor;
@@ -72,7 +72,7 @@ final class WindowsCentralProcessor extends AbstractCentralProcessor {
     private static final boolean USE_LOAD_AVERAGE = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_LOADAVERAGE, false);
     static {
         if (USE_LOAD_AVERAGE) {
-            LoadAverage.startDaemon();
+            LoadAverageJNA.getInstance().startDaemon();
         }
     }
 
@@ -318,7 +318,7 @@ final class WindowsCentralProcessor extends AbstractCentralProcessor {
         if (nelem < 1 || nelem > 3) {
             throw new IllegalArgumentException("Must include from one to three elements.");
         }
-        return LoadAverage.queryLoadAverage(nelem);
+        return LoadAverageJNA.getInstance().queryLoadAverage(nelem);
     }
 
     @Override


### PR DESCRIPTION
### Wildcard Query Infrastructure

Adds FFM-based wildcard PDH counter query support, enabling enumeration of performance counter instances and querying per-instance values:

- **PdhFFM**: Add `PdhEnumObjectItemsW`, `PdhLookupPerfNameByIndexW`, and `PdhGetRawCounterValue` FFM bindings; remove unused formatted counter bindings (`PdhGetFormattedCounterValue`, `PdhGetFormattedCounterArray`, `PDH_FMT_COUNTERVALUE_*` layouts)
- **PerfDataUtilFFM**: Add `enumInstances` (two-call pattern with `PDH_MORE_DATA` retry), `queryWildcardCounters`, object name localization (required by `PdhEnumObjectItemsW`), and `parseMultiSz` for REG_MULTI_SZ parsing. Both wildcard and non-wildcard paths now use raw counters exclusively, matching JNA behavior
- **Advapi32UtilFFM**: Add `registryGetStringArray` for REG_MULTI_SZ registry values (used for English→index counter name lookup)
- **WinNTFFM**: Add `REG_MULTI_SZ` constant
- **PerfCounterWildcardQueryFFM**: New class with PDH-first/WMI-fallback pattern and failed query caching, mirroring JNA's `PerfCounterWildcardQuery`

### LoadAverage Refactoring

- Extract abstract `LoadAverage` to `oshi-common` with daemon thread logic, exponential smoothing, `startDaemon`/`stopDaemon`/`queryLoadAverage`, and two abstract methods: `queryNonIdleTicks()` and `queryQueueLength()`
- Create `LoadAverageJNA` singleton in `oshi-core` using JNA perfmon drivers
- Create `LoadAverageFFM` singleton in `oshi-core-java25` using FFM perfmon drivers
- Add `LoadAverageFFMTest` mirroring existing JNA test structure

### FFM Perfmon Drivers

- `ProcessInformationFFM`: Add `queryIdleProcessCounters()` (wildcard query)
- New non-wildcard drivers: `MemoryInformationFFM`, `PagingFileFFM`, `ProcessorInformationFFM`, `SystemInformationFFM`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * More reliable Windows perf-counter reads via raw-counter PDH path with PDH→WMI fallback and improved load-average reporting using platform-specific backends.

* **New Features**
  * Wildcard enumeration for perf-counter instances.
  * New utilities for paging/memory and processor/system counters.
  * Support for reading multi-string (REG_MULTI_SZ) registry values.

* **Tests**
  * Added Windows-only tests validating load-average behavior.

* **Chores**
  * Updated CHANGELOG entry for 6.12.0 (in progress).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->