### PR TITLE
Add FFM registry drivers for HKEY_PERFORMANCE_DATA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#3167](https://github.com/oshi/oshi/pull/3167): Add PerfCounterQueryFFM for multi-counter PDH queries with WMI fallback; improve per-counter error resilience in both JNA and FFM paths - [@dbwiddis](https://github.com/dbwiddis).
 * [#3168](https://github.com/oshi/oshi/pull/3168): Add PerfCounterWildcardQueryFFM with PdhEnumObjectItems FFM binding; refactor LoadAverage into abstract base with JNA/FFM subclasses - [@dbwiddis](https://github.com/dbwiddis).
 * [#3170](https://github.com/oshi/oshi/pull/3170): Complete FFM perfmon driver migration with all wildcard and non-wildcard counters; add PDH vs WMI and JNA vs FFM comparison tests - [@dbwiddis](https://github.com/dbwiddis).
+* [#3171](https://github.com/oshi/oshi/pull/3171): Add FFM registry drivers for HKEY_PERFORMANCE_DATA process and thread data; extract PerfCounterBlock POJOs to oshi-common - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-benchmark/src/test/java/oshi/comparison/RegistryComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/RegistryComparisonTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.comparison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
+import oshi.driver.windows.registry.ProcessPerformanceDataFFM;
+import oshi.driver.windows.registry.ThreadPerformanceDataFFM;
+import oshi.util.PlatformEnum;
+
+/**
+ * Compares FFM PerfCounters (PDH) and FFM Registry (HKEY_PERFORMANCE_DATA) implementations. Both ultimately read the
+ * same kernel performance data, so results should be nearly identical — differences only arise from the time between
+ * the two calls and from dynamic fields the scheduler can change.
+ */
+@DisabledIf("isNotWindows")
+class RegistryComparisonTest {
+
+    // Absolute tolerance for the zero-value branch in assertWithinRatio: a process may transiently show 0 bytes
+    // for a memory gauge while the other read captures a small allocation.
+    private static final long ZERO_TOLERANCE_BYTES = 1024L * 1024L;
+
+    @Test
+    void testProcessData() {
+        // Registry first, then PerfCounters
+        Map<Integer, ProcessPerfCounterBlock> reg = ProcessPerformanceDataFFM.buildProcessMapFromRegistry(null);
+        Map<Integer, ProcessPerfCounterBlock> pdh = ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(null);
+        assertThat(reg).as("Registry process map").isNotNull().isNotEmpty();
+        assertThat(pdh).as("PerfCounter process map").isNotNull().isNotEmpty();
+
+        // PID sets should have high overlap — processes rarely start/stop in a few ms
+        Set<Integer> commonPids = new HashSet<>(reg.keySet());
+        commonPids.retainAll(pdh.keySet());
+        int minSize = Math.min(reg.size(), pdh.size());
+        assertThat(commonPids.size()).as("common PID overlap (reg=%d, pdh=%d)", reg.size(), pdh.size())
+                .isGreaterThanOrEqualTo((minSize * 90 + 99) / 100);
+
+        for (int pid : commonPids) {
+            ProcessPerfCounterBlock r = reg.get(pid);
+            ProcessPerfCounterBlock p = pdh.get(pid);
+
+            // Static fields — must be exact
+            assertThat(p.getName()).as("process[%d].name", pid).isEqualTo(r.getName());
+            assertThat(p.getParentProcessID()).as("process[%d].ppid", pid).isEqualTo(r.getParentProcessID());
+            assertThat(p.getPriority()).as("process[%d].priority", pid).isEqualTo(r.getPriority());
+            assertThat(p.getStartTime()).as("process[%d].startTime", pid).isEqualTo(r.getStartTime());
+
+            // Cumulative counters — PDH called second, should be >=
+            assertThat(p.getBytesRead()).as("process[%d].bytesRead", pid).isGreaterThanOrEqualTo(r.getBytesRead());
+            assertThat(p.getBytesWritten()).as("process[%d].bytesWritten", pid)
+                    .isGreaterThanOrEqualTo(r.getBytesWritten());
+            assertThat(p.getPageFaults()).as("process[%d].pageFaults", pid).isGreaterThanOrEqualTo(r.getPageFaults());
+
+            // Memory gauges — should be close, allow 25% fluctuation
+            assertWithinRatio(p.getWorkingSetSize(), r.getWorkingSetSize(), 0.25,
+                    "process[" + pid + "].workingSetSize");
+            assertWithinRatio(p.getPrivateWorkingSetSize(), r.getPrivateWorkingSetSize(), 0.25,
+                    "process[" + pid + "].privateWorkingSetSize");
+
+            // Uptime differs by the delta between the two reads
+            assertThat(Math.abs(p.getUpTime() - r.getUpTime())).as("process[%d].upTime delta", pid)
+                    .isLessThanOrEqualTo(Math.max(r.getUpTime() / 10, 1000L));
+        }
+    }
+
+    @Test
+    void testThreadData() {
+        // Registry first, then PerfCounters
+        Map<Integer, ThreadPerfCounterBlock> reg = ThreadPerformanceDataFFM.buildThreadMapFromRegistry(null);
+        Map<Integer, ThreadPerfCounterBlock> pdh = ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(null);
+        assertThat(reg).as("Registry thread map").isNotNull().isNotEmpty();
+        assertThat(pdh).as("PerfCounter thread map").isNotNull().isNotEmpty();
+
+        // TID sets should have high overlap
+        Set<Integer> commonTids = new HashSet<>(reg.keySet());
+        commonTids.retainAll(pdh.keySet());
+        int minSize = Math.min(reg.size(), pdh.size());
+        assertThat(commonTids.size()).as("common TID overlap (reg=%d, pdh=%d)", reg.size(), pdh.size())
+                .isGreaterThanOrEqualTo((minSize * 90 + 99) / 100);
+
+        for (int tid : commonTids) {
+            ThreadPerfCounterBlock r = reg.get(tid);
+            ThreadPerfCounterBlock p = pdh.get(tid);
+
+            // Static fields — must be exact
+            assertThat(p.getOwningProcessID()).as("thread[%d].pid", tid).isEqualTo(r.getOwningProcessID());
+
+            // Priority and thread state are dynamic — scheduler can change them between reads
+            assertThat(p.getPriority()).as("thread[%d].priority", tid).isGreaterThanOrEqualTo(0);
+
+            // Cumulative counters — PDH called second, should be >=
+            assertThat(p.getUserTime()).as("thread[%d].userTime", tid).isGreaterThanOrEqualTo(r.getUserTime());
+            assertThat(p.getKernelTime()).as("thread[%d].kernelTime", tid).isGreaterThanOrEqualTo(r.getKernelTime());
+            assertThat(p.getContextSwitches()).as("thread[%d].contextSwitches", tid)
+                    .isGreaterThanOrEqualTo(r.getContextSwitches());
+
+            // Start time — allow tolerance for Windows clock tick resolution (1/64s ≈ 15.625ms)
+            // and integer division rounding in the now - upTime computation
+            assertThat(Math.abs(p.getStartTime() - r.getStartTime())).as("thread[%d].startTime", tid)
+                    .isLessThanOrEqualTo(20L);
+        }
+    }
+
+    // ---- Helpers ----
+
+    private static void assertWithinRatio(double actual, double expected, double ratio, String description) {
+        if (expected == 0 && actual == 0) {
+            return;
+        }
+        if (expected == 0 || actual == 0) {
+            double nonZero = Math.max(Math.abs(expected), Math.abs(actual));
+            assertThat(nonZero).as("%s: one value is 0, other is %.0f", description, nonZero)
+                    .isLessThanOrEqualTo(ZERO_TOLERANCE_BYTES);
+            return;
+        }
+        double min = Math.min(Math.abs(actual), Math.abs(expected));
+        double max = Math.max(Math.abs(actual), Math.abs(expected));
+        assertThat(min / max).as("%s: expected=%f, actual=%f", description, expected, actual)
+                .isGreaterThanOrEqualTo(1.0 - ratio);
+    }
+
+    static boolean isNotWindows() {
+        return PlatformEnum.getCurrentPlatform() != PlatformEnum.WINDOWS;
+    }
+}

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -22,6 +22,7 @@ module com.github.oshi.common {
     exports oshi.annotation.concurrent;
     exports oshi.driver.common.mac;
     exports oshi.driver.common.windows.perfmon;
+    exports oshi.driver.common.windows.registry;
     exports oshi.hardware;
     exports oshi.hardware.common;
     exports oshi.hardware.common.platform.linux;

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/ProcessPerfCounterBlock.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/ProcessPerfCounterBlock.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.registry;
+
+import oshi.annotation.concurrent.Immutable;
+
+/**
+ * Encapsulates process performance data from the registry performance counter block.
+ */
+@Immutable
+public final class ProcessPerfCounterBlock {
+    private final String name;
+    private final int parentProcessID;
+    private final int priority;
+    private final long privateWorkingSetSize;
+    private final long workingSetSize;
+    private final long startTime;
+    private final long upTime;
+    private final long bytesRead;
+    private final long bytesWritten;
+    private final long pageFaults;
+
+    public ProcessPerfCounterBlock(String name, int parentProcessID, int priority, long privateWorkingSetSize,
+            long workingSetSize, long startTime, long upTime, long bytesRead, long bytesWritten, long pageFaults) {
+        this.name = name;
+        this.parentProcessID = parentProcessID;
+        this.priority = priority;
+        this.privateWorkingSetSize = privateWorkingSetSize;
+        this.workingSetSize = workingSetSize;
+        this.startTime = startTime;
+        this.upTime = upTime;
+        this.bytesRead = bytesRead;
+        this.bytesWritten = bytesWritten;
+        this.pageFaults = pageFaults;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the parentProcessID
+     */
+    public int getParentProcessID() {
+        return parentProcessID;
+    }
+
+    /**
+     * @return the priority
+     */
+    public int getPriority() {
+        return priority;
+    }
+
+    /**
+     * @return the Private Working Set size
+     */
+    public long getPrivateWorkingSetSize() {
+        return privateWorkingSetSize;
+    }
+
+    /**
+     * @return the Working Set size (RSS)
+     */
+    public long getWorkingSetSize() {
+        return workingSetSize;
+    }
+
+    /**
+     * @return the startTime
+     */
+    public long getStartTime() {
+        return startTime;
+    }
+
+    /**
+     * @return the upTime
+     */
+    public long getUpTime() {
+        return upTime;
+    }
+
+    /**
+     * @return the bytesRead
+     */
+    public long getBytesRead() {
+        return bytesRead;
+    }
+
+    /**
+     * @return the bytesWritten
+     */
+    public long getBytesWritten() {
+        return bytesWritten;
+    }
+
+    /**
+     * @return the pageFaults
+     */
+    public long getPageFaults() {
+        return pageFaults;
+    }
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/ThreadPerfCounterBlock.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/ThreadPerfCounterBlock.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.registry;
+
+import oshi.annotation.concurrent.Immutable;
+
+/**
+ * Encapsulates thread performance data from the registry performance counter block.
+ */
+@Immutable
+public final class ThreadPerfCounterBlock {
+    private final String name;
+    private final int threadID;
+    private final int owningProcessID;
+    private final long startTime;
+    private final long userTime;
+    private final long kernelTime;
+    private final int priority;
+    private final int threadState;
+    private final int threadWaitReason;
+    private final long startAddress;
+    private final long contextSwitches;
+
+    public ThreadPerfCounterBlock(String name, int threadID, int owningProcessID, long startTime, long userTime,
+            long kernelTime, int priority, int threadState, int threadWaitReason, long startAddress,
+            long contextSwitches) {
+        this.name = name;
+        this.threadID = threadID;
+        this.owningProcessID = owningProcessID;
+        this.startTime = startTime;
+        this.userTime = userTime;
+        this.kernelTime = kernelTime;
+        this.priority = priority;
+        this.threadState = threadState;
+        this.threadWaitReason = threadWaitReason;
+        this.startAddress = startAddress;
+        this.contextSwitches = contextSwitches;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the threadID
+     */
+    public int getThreadID() {
+        return threadID;
+    }
+
+    /**
+     * @return the owningProcessID
+     */
+    public int getOwningProcessID() {
+        return owningProcessID;
+    }
+
+    /**
+     * @return the startTime
+     */
+    public long getStartTime() {
+        return startTime;
+    }
+
+    /**
+     * @return the userTime
+     */
+    public long getUserTime() {
+        return userTime;
+    }
+
+    /**
+     * @return the kernelTime
+     */
+    public long getKernelTime() {
+        return kernelTime;
+    }
+
+    /**
+     * @return the priority
+     */
+    public int getPriority() {
+        return priority;
+    }
+
+    /**
+     * @return the threadState
+     */
+    public int getThreadState() {
+        return threadState;
+    }
+
+    /**
+     * @return the threadWaitReason
+     */
+    public int getThreadWaitReason() {
+        return threadWaitReason;
+    }
+
+    /**
+     * @return the startMemoryAddress
+     */
+    public long getStartAddress() {
+        return startAddress;
+    }
+
+    /**
+     * @return the contextSwitches
+     */
+    public long getContextSwitches() {
+        return contextSwitches;
+    }
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/package-info.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides common Windows registry performance data POJOs shared between JNA and FFM implementations.
+ */
+package oshi.driver.common.windows.registry;

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilFFM.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.registry;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.windows.Advapi32FFM.RegQueryValueEx;
+import static oshi.ffm.windows.WinErrorFFM.ERROR_MORE_DATA;
+import static oshi.ffm.windows.WinErrorFFM.ERROR_SUCCESS;
+import static oshi.ffm.windows.WinPerfFFM.PERF_COUNTER_BLOCK_ByteLength;
+import static oshi.ffm.windows.WinPerfFFM.PERF_COUNTER_DEF_ByteLength;
+import static oshi.ffm.windows.WinPerfFFM.PERF_COUNTER_DEF_CounterNameTitleIndex;
+import static oshi.ffm.windows.WinPerfFFM.PERF_COUNTER_DEF_CounterOffset;
+import static oshi.ffm.windows.WinPerfFFM.PERF_COUNTER_DEF_CounterSize;
+import static oshi.ffm.windows.WinPerfFFM.PERF_DATA_BLOCK_HeaderLength;
+import static oshi.ffm.windows.WinPerfFFM.PERF_DATA_BLOCK_NumObjectTypes;
+import static oshi.ffm.windows.WinPerfFFM.PERF_DATA_BLOCK_PerfTime100nSec;
+import static oshi.ffm.windows.WinPerfFFM.PERF_INSTANCE_DEF_ByteLength;
+import static oshi.ffm.windows.WinPerfFFM.PERF_INSTANCE_DEF_NameOffset;
+import static oshi.ffm.windows.WinPerfFFM.PERF_OBJECT_TYPE_DefinitionLength;
+import static oshi.ffm.windows.WinPerfFFM.PERF_OBJECT_TYPE_HeaderLength;
+import static oshi.ffm.windows.WinPerfFFM.PERF_OBJECT_TYPE_NumCounters;
+import static oshi.ffm.windows.WinPerfFFM.PERF_OBJECT_TYPE_NumInstances;
+import static oshi.ffm.windows.WinPerfFFM.PERF_OBJECT_TYPE_ObjectNameTitleIndex;
+import static oshi.ffm.windows.WinPerfFFM.PERF_OBJECT_TYPE_TotalByteLength;
+import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
+import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
+import oshi.ffm.windows.WinRegFFM;
+import oshi.util.ParseUtil;
+import oshi.util.platform.windows.Advapi32UtilFFM;
+import oshi.util.tuples.Pair;
+import oshi.util.tuples.Triplet;
+
+/**
+ * Utility to read HKEY_PERFORMANCE_DATA information using the FFM API.
+ */
+@ThreadSafe
+public final class HkeyPerformanceDataUtilFFM {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HkeyPerformanceDataUtilFFM.class);
+
+    /*
+     * Do a one-time lookup of the HKEY_PERFORMANCE_TEXT counter indices and store in a map for efficient lookups
+     * on-demand.
+     */
+    private static final String HKEY_PERFORMANCE_TEXT = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib\\009";
+    private static final String COUNTER = "Counter";
+    private static final Map<String, Integer> COUNTER_INDEX_MAP = mapCounterIndicesFromRegistry();
+
+    private static int maxPerfBufferSize = 16384;
+
+    private HkeyPerformanceDataUtilFFM() {
+    }
+
+    /**
+     * Reads and parses a block of performance data from the registry.
+     *
+     * @param <T>         PDH Counters use an Enum to identify the fields to query in either the counter or WMI backup,
+     *                    and use the enum values as keys to retrieve the results.
+     * @param objectName  The counter object for which to fetch data
+     * @param counterEnum Which counters to return data for
+     * @return A triplet containing the results. The first element maps the input enum to the counter values where the
+     *         first enum will contain the instance name as a {@link String}, and the remaining values will either be
+     *         {@link Long}, {@link Integer}, or {@code null} depending on whether the specified enum counter was
+     *         present and the size of the counter value. The second element is a timestamp in 100nSec increments
+     *         (Windows 1601 Epoch) while the third element is a timestamp in milliseconds since the 1970 Epoch.
+     */
+    public static <T extends Enum<T> & PdhCounterWildcardProperty> Triplet<List<Map<T, Object>>, Long, Long> readPerfDataFromRegistry(
+            String objectName, Class<T> counterEnum) {
+        // Load indices
+        // e.g., call with "Process" and ProcessPerformanceProperty.class
+        Pair<Integer, EnumMap<T, Integer>> indices = getCounterIndices(objectName, counterEnum);
+        if (indices == null) {
+            return null;
+        }
+        int objectIndex = indices.getA();
+        EnumMap<T, Integer> enumIndexMap = indices.getB();
+        // The above test checks validity of objectName as an index but it could still
+        // fail to read
+        MemorySegment pPerfData = readPerfDataBuffer(objectName);
+        if (pPerfData == null) {
+            return null;
+        }
+        // Buffer is now successfully populated.
+        // See format at
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa373105(v=vs.85).aspx
+
+        // Start with a data header (PERF_DATA_BLOCK)
+        // Then iterate one or more objects
+        // Each object contains
+        // [ ] Object Type header (PERF_OBJECT_TYPE)
+        // [ ][ ][ ] Multiple counter definitions (PERF_COUNTER_DEFINITION)
+        // Then after object(s), multiple:
+        // [ ] Instance Definition
+        // [ ] Instance name
+        // [ ] Counter Block
+        // [ ][ ][ ] Counter data for each definition above
+
+        // Store timestamp
+        long perfTime100nSec = pPerfData.get(JAVA_LONG, PERF_DATA_BLOCK_PerfTime100nSec); // 1601
+        long now = ParseUtil.filetimeToUtcMs(perfTime100nSec, false); // 1970
+
+        // Iterate object types.
+        long perfObjectOffset = pPerfData.get(JAVA_INT, PERF_DATA_BLOCK_HeaderLength);
+        int numObjectTypes = pPerfData.get(JAVA_INT, PERF_DATA_BLOCK_NumObjectTypes);
+        for (int obj = 0; obj < numObjectTypes; obj++) {
+            // Some counters will require multiple objects so we iterate until we find the
+            // right one. e.g. Process (230) is by itself but Thread (232) has Process
+            // object first
+            int objectNameTitleIndex = pPerfData.get(JAVA_INT,
+                    perfObjectOffset + PERF_OBJECT_TYPE_ObjectNameTitleIndex);
+            if (objectNameTitleIndex == objectIndex) {
+                // We found a matching object.
+
+                // Counter definitions start after the object header
+                long perfCounterOffset = perfObjectOffset
+                        + pPerfData.get(JAVA_INT, perfObjectOffset + PERF_OBJECT_TYPE_HeaderLength);
+                int numCounters = pPerfData.get(JAVA_INT, perfObjectOffset + PERF_OBJECT_TYPE_NumCounters);
+
+                // Iterate counter definitions and fill maps with counter offsets and sizes
+                Map<Integer, Integer> counterOffsetMap = new HashMap<>();
+                Map<Integer, Integer> counterSizeMap = new HashMap<>();
+                for (int counter = 0; counter < numCounters; counter++) {
+                    int counterNameTitleIndex = pPerfData.get(JAVA_INT,
+                            perfCounterOffset + PERF_COUNTER_DEF_CounterNameTitleIndex);
+                    int counterOffset = pPerfData.get(JAVA_INT, perfCounterOffset + PERF_COUNTER_DEF_CounterOffset);
+                    int counterSize = pPerfData.get(JAVA_INT, perfCounterOffset + PERF_COUNTER_DEF_CounterSize);
+                    counterOffsetMap.put(counterNameTitleIndex, counterOffset);
+                    counterSizeMap.put(counterNameTitleIndex, counterSize);
+                    // Increment for next Counter
+                    perfCounterOffset += pPerfData.get(JAVA_INT, perfCounterOffset + PERF_COUNTER_DEF_ByteLength);
+                }
+
+                // Instances start after all the object definitions. The DefinitionLength
+                // includes both the header and all the definitions.
+                long perfInstanceOffset = perfObjectOffset
+                        + pPerfData.get(JAVA_INT, perfObjectOffset + PERF_OBJECT_TYPE_DefinitionLength);
+                int numInstances = pPerfData.get(JAVA_INT, perfObjectOffset + PERF_OBJECT_TYPE_NumInstances);
+
+                // Iterate instances and fill map
+                T[] counterKeys = counterEnum.getEnumConstants();
+                List<Map<T, Object>> counterMaps = new ArrayList<>(numInstances);
+                for (int inst = 0; inst < numInstances; inst++) {
+                    int instanceByteLength = pPerfData.get(JAVA_INT, perfInstanceOffset + PERF_INSTANCE_DEF_ByteLength);
+                    int nameOffset = pPerfData.get(JAVA_INT, perfInstanceOffset + PERF_INSTANCE_DEF_NameOffset);
+                    long perfCounterBlockOffset = perfInstanceOffset + instanceByteLength;
+
+                    // Populate the enumMap
+                    Map<T, Object> counterMap = new EnumMap<>(counterEnum);
+                    // First enum index is the name, ignore the counter text which is used for other
+                    // purposes
+                    counterMap.put(counterKeys[0], readWideString(pPerfData.asSlice(perfInstanceOffset + nameOffset)));
+                    for (int i = 1; i < counterKeys.length; i++) {
+                        T key = counterKeys[i];
+                        int keyIndex = enumIndexMap.get(key);
+                        // All entries in size map have corresponding entry in offset map
+                        int size = counterSizeMap.getOrDefault(keyIndex, 0);
+                        // Currently, only DWORDs (4 bytes) and ULONGLONGs (8 bytes) are used to provide
+                        // counter values.
+                        if (size == 4) {
+                            counterMap.put(key,
+                                    pPerfData.get(JAVA_INT, perfCounterBlockOffset + counterOffsetMap.get(keyIndex)));
+                        } else if (size == 8) {
+                            counterMap.put(key,
+                                    pPerfData.get(JAVA_LONG, perfCounterBlockOffset + counterOffsetMap.get(keyIndex)));
+                        } else {
+                            // If counter defined in enum isn't in registry, fail
+                            return null;
+                        }
+                    }
+                    counterMaps.add(counterMap);
+
+                    // counters at perfCounterBlockOffset + appropriate offset per enum
+                    // use pPerfData.getInt or getLong as determined by counter size
+                    // Currently, only DWORDs (4 bytes) and ULONGLONGs (8 bytes) are used to provide
+                    // counter values.
+
+                    // Increment to next instance
+                    perfInstanceOffset = perfCounterBlockOffset
+                            + pPerfData.get(JAVA_INT, perfCounterBlockOffset + PERF_COUNTER_BLOCK_ByteLength);
+                }
+                // We've found the necessary object and are done, no need to look at any other
+                // objects (shouldn't be any). Return results
+                return new Triplet<>(counterMaps, perfTime100nSec, now);
+            }
+            // Increment for next object
+            perfObjectOffset += pPerfData.get(JAVA_INT, perfObjectOffset + PERF_OBJECT_TYPE_TotalByteLength);
+        }
+        // Failed, return null
+        return null;
+    }
+
+    /**
+     * Looks up the counter index values for the given counter object and the enum of counter names.
+     *
+     * @param <T>         An enum containing the counters, whose class is passed as {@code counterEnum}
+     * @param objectName  The counter object to look up the index for
+     * @param counterEnum The {@link Enum} containing counters to look up the indices for. The first Enum value will be
+     *                    ignored.
+     * @return A {@link Pair} containing the index of the counter object as the first element, and an {@link EnumMap}
+     *         mapping counter enum values to their index as the second element, if the lookup is successful; null
+     *         otherwise.
+     */
+    private static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<Integer, EnumMap<T, Integer>> getCounterIndices(
+            String objectName, Class<T> counterEnum) {
+        if (!COUNTER_INDEX_MAP.containsKey(objectName)) {
+            LOG.debug("Couldn't find counter index of {}.", objectName);
+            return null;
+        }
+        int counterIndex = COUNTER_INDEX_MAP.get(objectName);
+        T[] enumConstants = counterEnum.getEnumConstants();
+        EnumMap<T, Integer> indexMap = new EnumMap<>(counterEnum);
+        // Start iterating at 1 because first Enum value defines the name/instance and
+        // is not a counter name
+        for (int i = 1; i < enumConstants.length; i++) {
+            T key = enumConstants[i];
+            String counterName = key.getCounter();
+            if (!COUNTER_INDEX_MAP.containsKey(counterName)) {
+                LOG.debug("Couldn't find counter index of {}.", counterName);
+                return null;
+            }
+            indexMap.put(key, COUNTER_INDEX_MAP.get(counterName));
+        }
+        // We have all the pieces! Return them.
+        return new Pair<>(counterIndex, indexMap);
+    }
+
+    /**
+     * Read the performance data for a counter object from the registry.
+     *
+     * @param objectName The counter object for which to fetch data. It is the user's responsibility to ensure this key
+     *                   exists in {@link #COUNTER_INDEX_MAP}.
+     * @return A buffer containing the data if successful, null otherwise.
+     */
+    private static synchronized MemorySegment readPerfDataBuffer(String objectName) {
+        // Need this index as a string
+        String objectIndexStr = Integer.toString(COUNTER_INDEX_MAP.get(objectName));
+
+        // Now load the data from the registry.
+        // Use a global arena so the returned segment outlives this method
+        Arena arena = Arena.ofAuto();
+        try {
+            MemorySegment lpValueName = toWideString(arena, objectIndexStr);
+            MemorySegment lpcbData = arena.allocate(JAVA_INT);
+            lpcbData.set(JAVA_INT, 0, maxPerfBufferSize);
+            MemorySegment pPerfData = arena.allocate(maxPerfBufferSize);
+
+            int ret = RegQueryValueEx(MemorySegment.ofAddress(WinRegFFM.HKEY_PERFORMANCE_DATA), lpValueName, 0,
+                    MemorySegment.NULL, pPerfData, lpcbData);
+            if (ret != ERROR_SUCCESS && ret != ERROR_MORE_DATA) {
+                LOG.error("Error reading performance data from registry for {}.", objectName);
+                return null;
+            }
+            // Grow buffer as needed to fit the data
+            while (ret == ERROR_MORE_DATA) {
+                maxPerfBufferSize += 8192;
+                lpcbData.set(JAVA_INT, 0, maxPerfBufferSize);
+                pPerfData = arena.allocate(maxPerfBufferSize);
+                ret = RegQueryValueEx(MemorySegment.ofAddress(WinRegFFM.HKEY_PERFORMANCE_DATA), lpValueName, 0,
+                        MemorySegment.NULL, pPerfData, lpcbData);
+            }
+            if (ret != ERROR_SUCCESS) {
+                LOG.error("Error reading performance data from registry for {} (ret={}).", objectName, ret);
+                return null;
+            }
+            return pPerfData;
+        } catch (Throwable t) {
+            LOG.error("Error reading performance data from registry for {}.", objectName, t);
+            return null;
+        }
+    }
+
+    /*
+     * Registry entries subordinate to HKEY_PERFORMANCE_TEXT key reference the text strings that describe counters in US
+     * English. Not supported in Windows 2000.
+     *
+     * With the "Counter" value, the resulting array contains alternating index/name pairs "1", "1847", "2", "System",
+     * "4", "Memory", ...
+     *
+     * These pairs are translated to a map for later lookup.
+     *
+     * @return An unmodifiable map containing counter name strings as keys and indices as integer values if the key is
+     * read successfully; an empty map otherwise.
+     */
+    private static Map<String, Integer> mapCounterIndicesFromRegistry() {
+        HashMap<String, Integer> indexMap = new HashMap<>();
+        try {
+            String[] counterText = Advapi32UtilFFM.registryGetStringArray(
+                    MemorySegment.ofAddress(WinRegFFM.HKEY_LOCAL_MACHINE), HKEY_PERFORMANCE_TEXT, COUNTER);
+            if (counterText != null && counterText.length > 1) {
+                for (int i = 1; i < counterText.length; i += 2) {
+                    int idx = ParseUtil.parseIntOrDefault(counterText[i - 1], 0);
+                    if (idx > 0) {
+                        indexMap.putIfAbsent(counterText[i], idx);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error(
+                    "Unable to locate English counter names in registry Perflib 009. Counters may need to be rebuilt: ",
+                    e);
+        }
+        return Collections.unmodifiableMap(indexMap);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataFFM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2026 The OSHI Project Contributors
+ * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.registry;
@@ -9,13 +9,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.sun.jna.platform.win32.WinBase;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.ProcessPerformanceProperty;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
-import oshi.driver.windows.perfmon.ProcessInformationJNA;
+import oshi.driver.windows.perfmon.ProcessInformationFFM;
 import oshi.util.GlobalConfig;
+import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
@@ -23,12 +22,12 @@ import oshi.util.tuples.Triplet;
  * Utility to read process data from HKEY_PERFORMANCE_DATA information with backup from Performance Counters or WMI
  */
 @ThreadSafe
-public final class ProcessPerformanceData {
+public final class ProcessPerformanceDataFFM {
 
     private static final String PROCESS = "Process";
     private static final boolean PERFDATA = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_HKEYPERFDATA, true);
 
-    private ProcessPerformanceData() {
+    private ProcessPerformanceDataFFM() {
     }
 
     /**
@@ -42,7 +41,8 @@ public final class ProcessPerformanceData {
         // Grab the data from the registry.
         Triplet<List<Map<ProcessPerformanceProperty, Object>>, Long, Long> processData = null;
         if (PERFDATA) {
-            processData = HkeyPerformanceDataUtil.readPerfDataFromRegistry(PROCESS, ProcessPerformanceProperty.class);
+            processData = HkeyPerformanceDataUtilFFM.readPerfDataFromRegistry(PROCESS,
+                    ProcessPerformanceProperty.class);
         }
         if (processData == null) {
             return null;
@@ -62,7 +62,7 @@ public final class ProcessPerformanceData {
                 // if creation time value is less than current millis, it's in 1970 epoch,
                 // otherwise it's 1601 epoch and we must convert
                 if (ctime > now) {
-                    ctime = WinBase.FILETIME.filetimeToDate((int) (ctime >> 32), (int) (ctime & 0xffffffffL)).getTime();
+                    ctime = ParseUtil.filetimeToUtcMs(ctime, false);
                 }
                 long upTime = now - ctime;
                 if (upTime < 1L) {
@@ -104,7 +104,7 @@ public final class ProcessPerformanceData {
     public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids,
             String procName) {
         Map<Integer, ProcessPerfCounterBlock> processMap = new HashMap<>();
-        Pair<List<String>, Map<ProcessPerformanceProperty, List<Long>>> instanceValues = ProcessInformationJNA
+        Pair<List<String>, Map<ProcessPerformanceProperty, List<Long>>> instanceValues = ProcessInformationFFM
                 .queryProcessCounters();
         long now = System.currentTimeMillis(); // 1970 epoch
         List<String> instances = instanceValues.getA();
@@ -127,7 +127,7 @@ public final class ProcessPerformanceData {
                 // if creation time value is less than current millis, it's in 1970 epoch,
                 // otherwise it's 1601 epoch and we must convert
                 if (ctime > now) {
-                    ctime = WinBase.FILETIME.filetimeToDate((int) (ctime >> 32), (int) (ctime & 0xffffffffL)).getTime();
+                    ctime = ParseUtil.filetimeToUtcMs(ctime, false);
                 }
                 long upTime = now - ctime;
                 if (upTime < 1L) {

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataFFM.java
@@ -1,22 +1,19 @@
 /*
- * Copyright 2020-2026 The OSHI Project Contributors
+ * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.registry;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.sun.jna.platform.win32.WinBase.FILETIME;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ThreadInformation.ThreadPerformanceProperty;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
-import oshi.driver.windows.perfmon.PerfmonDisabled;
-import oshi.driver.windows.perfmon.ThreadInformationJNA;
+import oshi.driver.windows.perfmon.ThreadInformationFFM;
+import oshi.util.ParseUtil;
 import oshi.util.Util;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
@@ -25,11 +22,11 @@ import oshi.util.tuples.Triplet;
  * Utility to read thread data from HKEY_PERFORMANCE_DATA information with backup from Performance Counters or WMI
  */
 @ThreadSafe
-public final class ThreadPerformanceData {
+public final class ThreadPerformanceDataFFM {
 
     private static final String THREAD = "Thread";
 
-    private ThreadPerformanceData() {
+    private ThreadPerformanceDataFFM() {
     }
 
     /**
@@ -41,7 +38,7 @@ public final class ThreadPerformanceData {
      */
     public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
         // Grab the data from the registry.
-        Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtil
+        Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtilFFM
                 .readPerfDataFromRegistry(THREAD, ThreadPerformanceProperty.class);
         if (threadData == null) {
             return null;
@@ -107,13 +104,10 @@ public final class ThreadPerformanceData {
      */
     public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids,
             String procName, int threadNum) {
-        if (PerfmonDisabled.PERF_PROC_DISABLED) {
-            return Collections.emptyMap();
-        }
         Map<Integer, ThreadPerfCounterBlock> threadMap = new HashMap<>();
         Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> instanceValues = Util.isBlank(procName)
-                ? ThreadInformationJNA.queryThreadCounters()
-                : ThreadInformationJNA.queryThreadCounters(procName, threadNum);
+                ? ThreadInformationFFM.queryThreadCounters()
+                : ThreadInformationFFM.queryThreadCounters(procName, threadNum);
         long now = System.currentTimeMillis(); // 1970 epoch
         List<String> instances = instanceValues.getA();
         Map<ThreadPerformanceProperty, List<Long>> valueMap = instanceValues.getB();
@@ -135,9 +129,7 @@ public final class ThreadPerformanceData {
                 int tid = tidList.get(inst).intValue();
                 String name = Integer.toString(nameIndex++);
                 long startTime = startTimeList.get(inst);
-                int lowerStartTimeLimit = (int) (startTime >> 32);
-                int higherStartTimeLimit = (int) (startTime & 0xffffffffL);
-                startTime = FILETIME.filetimeToDate(lowerStartTimeLimit, higherStartTimeLimit).getTime();
+                startTime = ParseUtil.filetimeToUtcMs(startTime, false);
                 if (startTime > now) {
                     startTime = now - 1;
                 }
@@ -149,8 +141,7 @@ public final class ThreadPerformanceData {
                 long startAddr = startAddrList.get(inst).longValue();
                 long contextSwitches = contextSwitchesList.get(inst).longValue();
 
-                // if creation time value is less than current millis, it's in 1970 epoch,
-                // otherwise it's 1601 epoch and we must convert
+                // ParseUtil already converted to UTC ms; clamp future timestamps
                 threadMap.put(tid, new ThreadPerfCounterBlock(name, tid, pid, startTime, user, kernel, priority,
                         threadState, threadWaitReason, startAddr, contextSwitches));
             }

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/WinPerfFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/WinPerfFFM.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.windows;
+
+import static java.lang.foreign.MemoryLayout.structLayout;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
+
+/**
+ * FFM struct layouts for Windows Performance Counter structures read from HKEY_PERFORMANCE_DATA.
+ * <p>
+ * The registry data is organized as:
+ *
+ * <pre>
+ * [ PERF_DATA_BLOCK ]                          -- data header with timestamps
+ *   [ PERF_OBJECT_TYPE ]                       -- object type header (e.g., Process, Thread)
+ *     [ PERF_COUNTER_DEFINITION ] × NumCounters -- counter metadata (offset, size, index)
+ *   [ PERF_INSTANCE_DEFINITION ] × NumInstances -- per-instance data:
+ *     [ instance name (wide string) ]
+ *     [ PERF_COUNTER_BLOCK ]                    -- raw counter values for this instance
+ *       [ counter data bytes ]
+ * </pre>
+ *
+ * @see <a href="https://learn.microsoft.com/en-us/windows/win32/perfctrs/performance-counters-structures">Performance
+ *      Counters Structures</a>
+ */
+public interface WinPerfFFM {
+
+    // PERF_DATA_BLOCK: describes the performance data block header
+    // https://learn.microsoft.com/en-us/windows/win32/api/winperf/ns-winperf-perf_data_block
+    //
+    // Fields:
+    // WCHAR[4] Signature (8 bytes)
+    // DWORD LittleEndian (4 bytes)
+    // DWORD Version (4 bytes)
+    // DWORD Revision (4 bytes)
+    // DWORD TotalByteLength (4 bytes)
+    // DWORD HeaderLength (4 bytes)
+    // DWORD NumObjectTypes (4 bytes)
+    // LONG DefaultObject (4 bytes)
+    // SYSTEMTIME SystemTime (16 bytes: 8 × WORD)
+    // LARGE_INTEGER PerfTime (8 bytes)
+    // LARGE_INTEGER PerfFreq (8 bytes)
+    // LARGE_INTEGER PerfTime100nSec (8 bytes)
+    // DWORD SystemNameLength (4 bytes)
+    // DWORD SystemNameOffset (4 bytes)
+    StructLayout PERF_DATA_BLOCK = structLayout(JAVA_SHORT.withName("Signature0"), JAVA_SHORT.withName("Signature1"),
+            JAVA_SHORT.withName("Signature2"), JAVA_SHORT.withName("Signature3"), JAVA_INT.withName("LittleEndian"),
+            JAVA_INT.withName("Version"), JAVA_INT.withName("Revision"), JAVA_INT.withName("TotalByteLength"),
+            JAVA_INT.withName("HeaderLength"), JAVA_INT.withName("NumObjectTypes"), JAVA_INT.withName("DefaultObject"),
+            // 4 bytes padding for 8-byte alignment of LARGE_INTEGER fields
+            MemoryLayout.paddingLayout(4),
+            // SYSTEMTIME: 8 × WORD (16 bytes) — we only need the struct size, not individual fields
+            MemoryLayout.paddingLayout(16).withName("SystemTime"), JAVA_LONG.withName("PerfTime"),
+            JAVA_LONG.withName("PerfFreq"), JAVA_LONG.withName("PerfTime100nSec"),
+            JAVA_INT.withName("SystemNameLength"), JAVA_INT.withName("SystemNameOffset"));
+
+    long PERF_DATA_BLOCK_HeaderLength = PERF_DATA_BLOCK
+            .byteOffset(MemoryLayout.PathElement.groupElement("HeaderLength"));
+    long PERF_DATA_BLOCK_NumObjectTypes = PERF_DATA_BLOCK
+            .byteOffset(MemoryLayout.PathElement.groupElement("NumObjectTypes"));
+    long PERF_DATA_BLOCK_PerfTime100nSec = PERF_DATA_BLOCK
+            .byteOffset(MemoryLayout.PathElement.groupElement("PerfTime100nSec"));
+
+    // PERF_OBJECT_TYPE: describes object-specific performance information
+    // https://learn.microsoft.com/en-us/windows/win32/api/winperf/ns-winperf-perf_object_type
+    //
+    // Fields:
+    // DWORD TotalByteLength (4 bytes)
+    // DWORD DefinitionLength (4 bytes)
+    // DWORD HeaderLength (4 bytes)
+    // DWORD ObjectNameTitleIndex (4 bytes)
+    // DWORD ObjectNameTitle (4 bytes) — always 32-bit
+    // DWORD ObjectHelpTitleIndex (4 bytes)
+    // DWORD ObjectHelpTitle (4 bytes) — always 32-bit
+    // DWORD DetailLevel (4 bytes)
+    // DWORD NumCounters (4 bytes)
+    // LONG DefaultCounter (4 bytes)
+    // LONG NumInstances (4 bytes)
+    // DWORD CodePage (4 bytes)
+    // LARGE_INTEGER PerfTime (8 bytes)
+    // LARGE_INTEGER PerfFreq (8 bytes)
+    StructLayout PERF_OBJECT_TYPE = structLayout(JAVA_INT.withName("TotalByteLength"),
+            JAVA_INT.withName("DefinitionLength"), JAVA_INT.withName("HeaderLength"),
+            JAVA_INT.withName("ObjectNameTitleIndex"), JAVA_INT.withName("ObjectNameTitle"),
+            JAVA_INT.withName("ObjectHelpTitleIndex"), JAVA_INT.withName("ObjectHelpTitle"),
+            JAVA_INT.withName("DetailLevel"), JAVA_INT.withName("NumCounters"), JAVA_INT.withName("DefaultCounter"),
+            JAVA_INT.withName("NumInstances"), JAVA_INT.withName("CodePage"), JAVA_LONG.withName("PerfTime"),
+            JAVA_LONG.withName("PerfFreq"));
+
+    long PERF_OBJECT_TYPE_TotalByteLength = PERF_OBJECT_TYPE
+            .byteOffset(MemoryLayout.PathElement.groupElement("TotalByteLength"));
+    long PERF_OBJECT_TYPE_DefinitionLength = PERF_OBJECT_TYPE
+            .byteOffset(MemoryLayout.PathElement.groupElement("DefinitionLength"));
+    long PERF_OBJECT_TYPE_HeaderLength = PERF_OBJECT_TYPE
+            .byteOffset(MemoryLayout.PathElement.groupElement("HeaderLength"));
+    long PERF_OBJECT_TYPE_ObjectNameTitleIndex = PERF_OBJECT_TYPE
+            .byteOffset(MemoryLayout.PathElement.groupElement("ObjectNameTitleIndex"));
+    long PERF_OBJECT_TYPE_NumCounters = PERF_OBJECT_TYPE
+            .byteOffset(MemoryLayout.PathElement.groupElement("NumCounters"));
+    long PERF_OBJECT_TYPE_NumInstances = PERF_OBJECT_TYPE
+            .byteOffset(MemoryLayout.PathElement.groupElement("NumInstances"));
+
+    // PERF_COUNTER_DEFINITION: describes a performance counter
+    // https://learn.microsoft.com/en-us/windows/win32/api/winperf/ns-winperf-perf_counter_definition
+    //
+    // Fields:
+    // DWORD ByteLength (4 bytes)
+    // DWORD CounterNameTitleIndex (4 bytes)
+    // DWORD CounterNameTitle (4 bytes) — always 32-bit
+    // DWORD CounterHelpTitleIndex (4 bytes)
+    // DWORD CounterHelpTitle (4 bytes) — always 32-bit
+    // LONG DefaultScale (4 bytes)
+    // DWORD DetailLevel (4 bytes)
+    // DWORD CounterType (4 bytes)
+    // DWORD CounterSize (4 bytes)
+    // DWORD CounterOffset (4 bytes)
+    StructLayout PERF_COUNTER_DEFINITION = structLayout(JAVA_INT.withName("ByteLength"),
+            JAVA_INT.withName("CounterNameTitleIndex"), JAVA_INT.withName("CounterNameTitle"),
+            JAVA_INT.withName("CounterHelpTitleIndex"), JAVA_INT.withName("CounterHelpTitle"),
+            JAVA_INT.withName("DefaultScale"), JAVA_INT.withName("DetailLevel"), JAVA_INT.withName("CounterType"),
+            JAVA_INT.withName("CounterSize"), JAVA_INT.withName("CounterOffset"));
+
+    long PERF_COUNTER_DEF_ByteLength = PERF_COUNTER_DEFINITION
+            .byteOffset(MemoryLayout.PathElement.groupElement("ByteLength"));
+    long PERF_COUNTER_DEF_CounterNameTitleIndex = PERF_COUNTER_DEFINITION
+            .byteOffset(MemoryLayout.PathElement.groupElement("CounterNameTitleIndex"));
+    long PERF_COUNTER_DEF_CounterSize = PERF_COUNTER_DEFINITION
+            .byteOffset(MemoryLayout.PathElement.groupElement("CounterSize"));
+    long PERF_COUNTER_DEF_CounterOffset = PERF_COUNTER_DEFINITION
+            .byteOffset(MemoryLayout.PathElement.groupElement("CounterOffset"));
+
+    // PERF_INSTANCE_DEFINITION: describes an instance of a performance object
+    // https://learn.microsoft.com/en-us/windows/win32/api/winperf/ns-winperf-perf_instance_definition
+    //
+    // Fields:
+    // DWORD ByteLength (4 bytes)
+    // DWORD ParentObjectTitleIndex (4 bytes)
+    // DWORD ParentObjectInstance (4 bytes)
+    // LONG UniqueID (4 bytes)
+    // DWORD NameOffset (4 bytes)
+    // DWORD NameLength (4 bytes)
+    StructLayout PERF_INSTANCE_DEFINITION = structLayout(JAVA_INT.withName("ByteLength"),
+            JAVA_INT.withName("ParentObjectTitleIndex"), JAVA_INT.withName("ParentObjectInstance"),
+            JAVA_INT.withName("UniqueID"), JAVA_INT.withName("NameOffset"), JAVA_INT.withName("NameLength"));
+
+    long PERF_INSTANCE_DEF_ByteLength = PERF_INSTANCE_DEFINITION
+            .byteOffset(MemoryLayout.PathElement.groupElement("ByteLength"));
+    long PERF_INSTANCE_DEF_NameOffset = PERF_INSTANCE_DEFINITION
+            .byteOffset(MemoryLayout.PathElement.groupElement("NameOffset"));
+
+    // PERF_COUNTER_BLOCK: header for the raw counter data block following each instance
+    // https://learn.microsoft.com/en-us/windows/win32/api/winperf/ns-winperf-perf_counter_block
+    //
+    // Fields:
+    // DWORD ByteLength (4 bytes)
+    // Followed by the actual counter data bytes at offsets defined by PERF_COUNTER_DEFINITION.CounterOffset
+    StructLayout PERF_COUNTER_BLOCK = structLayout(JAVA_INT.withName("ByteLength"));
+
+    long PERF_COUNTER_BLOCK_ByteLength = 0L;
+}

--- a/oshi-core-java25/src/main/java/oshi/ffm/windows/WinRegFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/ffm/windows/WinRegFFM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The OSHI Project Contributors
+ * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.ffm.windows;
@@ -8,4 +8,5 @@ public interface WinRegFFM {
 
     long HKEY_LOCAL_MACHINE = 0x80000002L;
     long HKEY_CURRENT_USER = 0x80000001L;
+    long HKEY_PERFORMANCE_DATA = 0x80000004L;
 }

--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -38,9 +38,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.windows.registry.ProcessPerformanceData;
+import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
-import oshi.driver.windows.registry.ThreadPerformanceData;
 import oshi.ffm.windows.Advapi32FFM;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.ffm.windows.NtDllFFM;
@@ -63,9 +63,8 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
     private static final boolean IS_VISTA_OR_GREATER = VersionHelpersFFM.IsWindowsVistaOrGreater();
     private static final boolean IS_WINDOWS7_OR_GREATER = VersionHelpersFFM.IsWindows7OrGreater();
 
-    public WindowsOSProcessFFM(int pid, WindowsOperatingSystem os,
-            Map<Integer, ProcessPerformanceData.PerfCounterBlock> processMap, Map<Integer, WtsInfo> processWtsMap,
-            Map<Integer, ThreadPerformanceData.PerfCounterBlock> threadMap) {
+    public WindowsOSProcessFFM(int pid, WindowsOperatingSystem os, Map<Integer, ProcessPerfCounterBlock> processMap,
+            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
         super(pid, os, processMap, processWtsMap, threadMap);
     }
 
@@ -88,7 +87,7 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
     }
 
     @Override
-    protected boolean updateAttributes(ProcessPerformanceData.PerfCounterBlock pcb, WtsInfo wts) {
+    protected boolean updateAttributes(ProcessPerfCounterBlock pcb, WtsInfo wts) {
         if (!super.updateAttributes(pcb, wts)) {
             return false;
         }

--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -28,10 +28,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.windows.registry.ProcessPerformanceData;
+import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
+import oshi.driver.windows.registry.ProcessPerformanceDataFFM;
 import oshi.driver.windows.registry.ProcessWtsData;
 import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
-import oshi.driver.windows.registry.ThreadPerformanceData;
+import oshi.driver.windows.registry.ThreadPerformanceDataFFM;
 import oshi.ffm.windows.Advapi32FFM;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.ffm.windows.PsapiFFM;
@@ -179,13 +181,13 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     private static final boolean USE_PROCSTATE_SUSPENDED = GlobalConfig
             .get(GlobalConfig.OSHI_OS_WINDOWS_PROCSTATE_SUSPENDED, false);
 
-    private final Supplier<Map<Integer, ProcessPerformanceData.PerfCounterBlock>> processMapFromRegistry = Memoizer
+    private final Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromRegistry = Memoizer
             .memoize(WindowsOperatingSystemFFM::queryProcessMapFromRegistry, Memoizer.defaultExpiration());
-    private final Supplier<Map<Integer, ProcessPerformanceData.PerfCounterBlock>> processMapFromPerfCounters = Memoizer
+    private final Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromPerfCounters = Memoizer
             .memoize(WindowsOperatingSystemFFM::queryProcessMapFromPerfCounters, Memoizer.defaultExpiration());
-    private final Supplier<Map<Integer, ThreadPerformanceData.PerfCounterBlock>> threadMapFromRegistry = Memoizer
+    private final Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromRegistry = Memoizer
             .memoize(WindowsOperatingSystemFFM::queryThreadMapFromRegistry, Memoizer.defaultExpiration());
-    private final Supplier<Map<Integer, ThreadPerformanceData.PerfCounterBlock>> threadMapFromPerfCounters = Memoizer
+    private final Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromPerfCounters = Memoizer
             .memoize(WindowsOperatingSystemFFM::queryThreadMapFromPerfCounters, Memoizer.defaultExpiration());
 
     @Override
@@ -206,20 +208,20 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
 
     private List<OSProcess> processMapToList(Collection<Integer> pids) {
         // Get data from the registry if possible
-        Map<Integer, ProcessPerformanceData.PerfCounterBlock> processMap = processMapFromRegistry.get();
+        Map<Integer, ProcessPerfCounterBlock> processMap = processMapFromRegistry.get();
         // otherwise performance counters with WMI backup
         if (processMap == null || processMap.isEmpty()) {
             processMap = (pids == null) ? processMapFromPerfCounters.get()
-                    : ProcessPerformanceData.buildProcessMapFromPerfCounters(pids);
+                    : ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(pids);
         }
-        Map<Integer, ThreadPerformanceData.PerfCounterBlock> threadMap = null;
+        Map<Integer, ThreadPerfCounterBlock> threadMap = null;
         if (USE_PROCSTATE_SUSPENDED) {
             // Get data from the registry if possible
             threadMap = threadMapFromRegistry.get();
             // otherwise performance counters with WMI backup
             if (threadMap == null || threadMap.isEmpty()) {
                 threadMap = (pids == null) ? threadMapFromPerfCounters.get()
-                        : ThreadPerformanceData.buildThreadMapFromPerfCounters(pids);
+                        : ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids);
             }
         }
 
@@ -237,26 +239,26 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
             mapKeys.retainAll(processMap.keySet());
         }
 
-        final Map<Integer, ProcessPerformanceData.PerfCounterBlock> finalProcessMap = processMap;
-        final Map<Integer, ThreadPerformanceData.PerfCounterBlock> finalThreadMap = threadMap;
+        final Map<Integer, ProcessPerfCounterBlock> finalProcessMap = processMap;
+        final Map<Integer, ThreadPerfCounterBlock> finalThreadMap = threadMap;
         return mapKeys.stream().parallel()
                 .map(pid -> new WindowsOSProcessFFM(pid, this, finalProcessMap, processWtsMap, finalThreadMap))
                 .filter(VALID_PROCESS).collect(Collectors.toList());
     }
 
-    private static Map<Integer, ProcessPerformanceData.PerfCounterBlock> queryProcessMapFromRegistry() {
-        return ProcessPerformanceData.buildProcessMapFromRegistry(null);
+    private static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromRegistry() {
+        return ProcessPerformanceDataFFM.buildProcessMapFromRegistry(null);
     }
 
-    private static Map<Integer, ProcessPerformanceData.PerfCounterBlock> queryProcessMapFromPerfCounters() {
-        return ProcessPerformanceData.buildProcessMapFromPerfCounters(null);
+    private static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromPerfCounters() {
+        return ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(null);
     }
 
-    private static Map<Integer, ThreadPerformanceData.PerfCounterBlock> queryThreadMapFromRegistry() {
-        return ThreadPerformanceData.buildThreadMapFromRegistry(null);
+    private static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromRegistry() {
+        return ThreadPerformanceDataFFM.buildThreadMapFromRegistry(null);
     }
 
-    private static Map<Integer, ThreadPerformanceData.PerfCounterBlock> queryThreadMapFromPerfCounters() {
-        return ThreadPerformanceData.buildThreadMapFromPerfCounters(null);
+    private static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromPerfCounters() {
+        return ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(null);
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
 import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.driver.windows.registry.ProcessPerformanceData;
 import oshi.driver.windows.registry.ProcessWtsData;
 import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
@@ -56,7 +58,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     private Supplier<List<String>> args = memoize(this::queryArguments);
     private Supplier<Triplet<String, String, Map<String, String>>> cwdCmdEnv = memoize(
             this::queryCwdCommandlineEnvironment);
-    private Map<Integer, ThreadPerformanceData.PerfCounterBlock> tcb;
+    private Map<Integer, ThreadPerfCounterBlock> tcb;
 
     private String name;
     private String path = "";
@@ -77,9 +79,8 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     private int bitness;
     private long pageFaults;
 
-    protected WindowsOSProcess(int pid, WindowsOperatingSystem os,
-            Map<Integer, ProcessPerformanceData.PerfCounterBlock> processMap, Map<Integer, WtsInfo> processWtsMap,
-            Map<Integer, ThreadPerformanceData.PerfCounterBlock> threadMap) {
+    protected WindowsOSProcess(int pid, WindowsOperatingSystem os, Map<Integer, ProcessPerfCounterBlock> processMap,
+            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
         super(pid);
         this.os = os;
         this.bitness = os.getBitness();
@@ -259,7 +260,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        Map<Integer, ThreadPerformanceData.PerfCounterBlock> threads = tcb == null
+        Map<Integer, ThreadPerfCounterBlock> threads = tcb == null
                 ? queryMatchingThreads(Collections.singleton(this.getProcessID()))
                 : tcb;
         return threads.entrySet().stream().parallel()
@@ -272,8 +273,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     public boolean updateAttributes() {
         Set<Integer> pids = Collections.singleton(this.getProcessID());
         // Get data from the registry if possible
-        Map<Integer, ProcessPerformanceData.PerfCounterBlock> pcb = ProcessPerformanceData
-                .buildProcessMapFromRegistry(null);
+        Map<Integer, ProcessPerfCounterBlock> pcb = ProcessPerformanceData.buildProcessMapFromRegistry(null);
         // otherwise performance counters with WMI backup
         if (pcb == null) {
             pcb = ProcessPerformanceData.buildProcessMapFromPerfCounters(pids);
@@ -293,7 +293,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
      * @param wts WTS info for this process, or null if unavailable
      * @return true if the process is valid after the update
      */
-    protected boolean updateAttributes(ProcessPerformanceData.PerfCounterBlock pcb, WtsInfo wts) {
+    protected boolean updateAttributes(ProcessPerfCounterBlock pcb, WtsInfo wts) {
         if (pcb == null) {
             this.state = INVALID;
             return false;
@@ -320,7 +320,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
         this.state = RUNNING;
         if (this.tcb != null) {
             int pid = this.getProcessID();
-            for (ThreadPerformanceData.PerfCounterBlock tpd : this.tcb.values()) {
+            for (ThreadPerfCounterBlock tpd : this.tcb.values()) {
                 if (tpd.getOwningProcessID() == pid) {
                     if (tpd.getThreadWaitReason() == 5) {
                         this.state = SUSPENDED;
@@ -362,9 +362,8 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
         this.state = state;
     }
 
-    protected Map<Integer, ThreadPerformanceData.PerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
-        Map<Integer, ThreadPerformanceData.PerfCounterBlock> threads = ThreadPerformanceData
-                .buildThreadMapFromRegistry(pids);
+    protected Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
+        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceData.buildThreadMapFromRegistry(pids);
         if (threads == null) {
             threads = ThreadPerformanceData.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
         }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
@@ -27,9 +27,9 @@ import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.windows.registry.ProcessPerformanceData;
+import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
-import oshi.driver.windows.registry.ThreadPerformanceData;
 import oshi.jna.ByRef.CloseableHANDLEByReference;
 import oshi.jna.ByRef.CloseableIntByReference;
 import oshi.jna.ByRef.CloseableULONGptrByReference;
@@ -50,9 +50,8 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
     private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
     private static final boolean IS_WINDOWS7_OR_GREATER = VersionHelpers.IsWindows7OrGreater();
 
-    public WindowsOSProcessJNA(int pid, WindowsOperatingSystem os,
-            Map<Integer, ProcessPerformanceData.PerfCounterBlock> processMap, Map<Integer, WtsInfo> processWtsMap,
-            Map<Integer, ThreadPerformanceData.PerfCounterBlock> threadMap) {
+    public WindowsOSProcessJNA(int pid, WindowsOperatingSystem os, Map<Integer, ProcessPerfCounterBlock> processMap,
+            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
         super(pid, os, processMap, processWtsMap, threadMap);
     }
 
@@ -73,7 +72,7 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
     }
 
     @Override
-    protected boolean updateAttributes(ProcessPerformanceData.PerfCounterBlock pcb, WtsInfo wts) {
+    protected boolean updateAttributes(ProcessPerfCounterBlock pcb, WtsInfo wts) {
         if (!super.updateAttributes(pcb, wts)) {
             return false;
         }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThread.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.windows;
@@ -18,8 +18,8 @@ import java.util.Map;
 import java.util.Set;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.driver.windows.registry.ThreadPerformanceData;
-import oshi.driver.windows.registry.ThreadPerformanceData.PerfCounterBlock;
 import oshi.software.common.AbstractOSThread;
 import oshi.software.os.OSProcess.State;
 
@@ -40,7 +40,7 @@ public class WindowsOSThread extends AbstractOSThread {
     private long upTime;
     private int priority;
 
-    public WindowsOSThread(int pid, int tid, String procName, PerfCounterBlock pcb) {
+    public WindowsOSThread(int pid, int tid, String procName, ThreadPerfCounterBlock pcb) {
         super(pid);
         this.threadId = tid;
         updateAttributes(procName, pcb);
@@ -100,12 +100,12 @@ public class WindowsOSThread extends AbstractOSThread {
     public boolean updateAttributes() {
         Set<Integer> pids = Collections.singleton(getOwningProcessId());
         String procName = this.name.split("/")[0];
-        Map<Integer, ThreadPerformanceData.PerfCounterBlock> threads = ThreadPerformanceData
-                .buildThreadMapFromPerfCounters(pids, procName, getThreadId());
+        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceData.buildThreadMapFromPerfCounters(pids,
+                procName, getThreadId());
         return updateAttributes(procName, threads.get(getThreadId()));
     }
 
-    private boolean updateAttributes(String procName, PerfCounterBlock pcb) {
+    private boolean updateAttributes(String procName, ThreadPerfCounterBlock pcb) {
         if (pcb == null) {
             this.state = INVALID;
             return false;
@@ -118,26 +118,26 @@ public class WindowsOSThread extends AbstractOSThread {
             state = SUSPENDED;
         } else {
             switch (pcb.getThreadState()) {
-            case 0:
-                state = NEW;
-                break;
-            case 2:
-            case 3:
-                state = RUNNING;
-                break;
-            case 4:
-                state = STOPPED;
-                break;
-            case 5:
-                state = SLEEPING;
-                break;
-            case 1:
-            case 6:
-                state = WAITING;
-                break;
-            case 7:
-            default:
-                state = OTHER;
+                case 0:
+                    state = NEW;
+                    break;
+                case 2:
+                case 3:
+                    state = RUNNING;
+                    break;
+                case 4:
+                    state = STOPPED;
+                    break;
+                case 5:
+                    state = SLEEPING;
+                    break;
+                case 1:
+                case 6:
+                    state = WAITING;
+                    break;
+                case 7:
+                default:
+                    state = OTHER;
             }
         }
         startMemoryAddress = pcb.getStartAddress();

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -48,6 +48,8 @@ import com.sun.jna.platform.win32.WinNT.LUID;
 import com.sun.jna.platform.win32.Winsvc;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.driver.windows.EnumWindows;
 import oshi.driver.windows.registry.HkeyUserData;
 import oshi.driver.windows.registry.NetSessionData;
@@ -120,17 +122,17 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
     /*
      * Cache full process stats queries. Second query will only populate if first one returns null.
      */
-    private Supplier<Map<Integer, ProcessPerformanceData.PerfCounterBlock>> processMapFromRegistry = memoize(
+    private Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromRegistry = memoize(
             WindowsOperatingSystem::queryProcessMapFromRegistry, defaultExpiration());
-    private Supplier<Map<Integer, ProcessPerformanceData.PerfCounterBlock>> processMapFromPerfCounters = memoize(
+    private Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromPerfCounters = memoize(
             WindowsOperatingSystem::queryProcessMapFromPerfCounters, defaultExpiration());
     /*
      * Cache full thread stats queries. Second query will only populate if first one returns null. Only used if
      * USE_PROCSTATE_SUSPENDED is set true.
      */
-    private Supplier<Map<Integer, ThreadPerformanceData.PerfCounterBlock>> threadMapFromRegistry = memoize(
+    private Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromRegistry = memoize(
             WindowsOperatingSystem::queryThreadMapFromRegistry, defaultExpiration());
-    private Supplier<Map<Integer, ThreadPerformanceData.PerfCounterBlock>> threadMapFromPerfCounters = memoize(
+    private Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromPerfCounters = memoize(
             WindowsOperatingSystem::queryThreadMapFromPerfCounters, defaultExpiration());
 
     @Override
@@ -295,13 +297,13 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
 
     private List<OSProcess> processMapToList(Collection<Integer> pids) {
         // Get data from the registry if possible
-        Map<Integer, ProcessPerformanceData.PerfCounterBlock> processMap = processMapFromRegistry.get();
+        Map<Integer, ProcessPerfCounterBlock> processMap = processMapFromRegistry.get();
         // otherwise performance counters with WMI backup
         if (processMap == null || processMap.isEmpty()) {
             processMap = (pids == null) ? processMapFromPerfCounters.get()
                     : ProcessPerformanceData.buildProcessMapFromPerfCounters(pids);
         }
-        Map<Integer, ThreadPerformanceData.PerfCounterBlock> threadMap = null;
+        Map<Integer, ThreadPerfCounterBlock> threadMap = null;
         if (USE_PROCSTATE_SUSPENDED) {
             // Get data from the registry if possible
             threadMap = threadMapFromRegistry.get();
@@ -317,26 +319,26 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         Set<Integer> mapKeys = new HashSet<>(processWtsMap.keySet());
         mapKeys.retainAll(processMap.keySet());
 
-        final Map<Integer, ProcessPerformanceData.PerfCounterBlock> finalProcessMap = processMap;
-        final Map<Integer, ThreadPerformanceData.PerfCounterBlock> finalThreadMap = threadMap;
+        final Map<Integer, ProcessPerfCounterBlock> finalProcessMap = processMap;
+        final Map<Integer, ThreadPerfCounterBlock> finalThreadMap = threadMap;
         return mapKeys.stream().parallel()
                 .map(pid -> new WindowsOSProcessJNA(pid, this, finalProcessMap, processWtsMap, finalThreadMap))
                 .filter(VALID_PROCESS).collect(Collectors.toList());
     }
 
-    private static Map<Integer, ProcessPerformanceData.PerfCounterBlock> queryProcessMapFromRegistry() {
+    private static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromRegistry() {
         return ProcessPerformanceData.buildProcessMapFromRegistry(null);
     }
 
-    private static Map<Integer, ProcessPerformanceData.PerfCounterBlock> queryProcessMapFromPerfCounters() {
+    private static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromPerfCounters() {
         return ProcessPerformanceData.buildProcessMapFromPerfCounters(null);
     }
 
-    private static Map<Integer, ThreadPerformanceData.PerfCounterBlock> queryThreadMapFromRegistry() {
+    private static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromRegistry() {
         return ThreadPerformanceData.buildThreadMapFromRegistry(null);
     }
 
-    private static Map<Integer, ThreadPerformanceData.PerfCounterBlock> queryThreadMapFromPerfCounters() {
+    private static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromPerfCounters() {
         return ThreadPerformanceData.buildThreadMapFromPerfCounters(null);
     }
 

--- a/oshi-core/src/test/java/oshi/driver/windows/registry/RegistryDriversTest.java
+++ b/oshi-core/src/test/java/oshi/driver/windows/registry/RegistryDriversTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The OSHI Project Contributors
+ * Copyright 2022-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.registry;
@@ -18,21 +18,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
+
 @EnabledOnOs(OS.WINDOWS)
 class RegistryDriversTest {
 
     @Test
     void testProcessPerformanceData() {
-        Map<Integer, ProcessPerformanceData.PerfCounterBlock> processMap = ProcessPerformanceData
-                .buildProcessMapFromRegistry(null);
+        Map<Integer, ProcessPerfCounterBlock> processMap = ProcessPerformanceData.buildProcessMapFromRegistry(null);
         assertNotNull(processMap);
         assertThat("Process map should not be empty", processMap, is(not(anEmptyMap())));
     }
 
     @Test
     void testThreadPerformanceData() {
-        Map<Integer, ThreadPerformanceData.PerfCounterBlock> threadMap = ThreadPerformanceData
-                .buildThreadMapFromRegistry(null);
+        Map<Integer, ThreadPerfCounterBlock> threadMap = ThreadPerformanceData.buildThreadMapFromRegistry(null);
         assertNotNull(threadMap);
         assertThat("Thread map should not be empty", threadMap, is(not(anEmptyMap())));
     }


### PR DESCRIPTION
## Summary

Parse HKEY_PERFORMANCE_DATA binary structs via FFM for process and thread performance data, bypassing the PDH abstraction layer for faster access.

## Changes

### oshi-common
- Extract `ProcessPerfCounterBlock` and `ThreadPerfCounterBlock` POJOs from oshi-core inner classes into `oshi.driver.common.windows.registry` package, enabling FFM code to use them without depending on oshi-core (JNA)
- Add `exports oshi.driver.common.windows.registry` to module-info

### oshi-core-java25
- `WinPerfFFM`: FFM struct layouts for `PERF_DATA_BLOCK`, `PERF_OBJECT_TYPE`, `PERF_COUNTER_DEFINITION`, `PERF_INSTANCE_DEFINITION`, `PERF_COUNTER_BLOCK` with pre-computed field offset constants
- `HkeyPerformanceDataUtilFFM`: Core parser for HKEY_PERFORMANCE_DATA binary data using FFM `RegQueryValueEx`
- `ProcessPerformanceDataFFM` and `ThreadPerformanceDataFFM`: Registry-based process/thread data drivers
- `WinRegFFM`: Add `HKEY_PERFORMANCE_DATA` constant
- `WindowsOperatingSystemFFM`: Switch from JNA to FFM registry data classes

### oshi-core
- Remove inner `PerfCounterBlock` classes from `ProcessPerformanceData` and `ThreadPerformanceData`, replaced by common POJOs
- Update all consumers: `WindowsOperatingSystem`, `WindowsOSProcess`, `WindowsOSProcessJNA`, `WindowsOSThread`

### oshi-benchmark
- New `RegistryComparisonTest`: Validates JNA vs FFM registry parsing produces matching results (exact match on static fields, tolerance on dynamic/timing-sensitive fields)

## Testing
- All builds pass: `mvn clean spotless:apply install checkstyle:check`, `forbiddenapis:check`, `javadoc:aggregate`
- Windows CI validates FFM struct parsing correctness via comparison tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FFM-based registry drivers to read Windows process and thread performance counters.

* **Tests**
  * Added comparison tests validating registry reads against PerfMon data on Windows.

* **Refactor**
  * Moved shared process/thread performance data types into a common module and updated consumers.

* **Chores**
  * Updated changelog for the upcoming release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->