### PR TITLE
Extract common Windows perfmon/registry driver code to oshi-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#3168](https://github.com/oshi/oshi/pull/3168): Add PerfCounterWildcardQueryFFM with PdhEnumObjectItems FFM binding; refactor LoadAverage into abstract base with JNA/FFM subclasses - [@dbwiddis](https://github.com/dbwiddis).
 * [#3170](https://github.com/oshi/oshi/pull/3170): Complete FFM perfmon driver migration with all wildcard and non-wildcard counters; add PDH vs WMI and JNA vs FFM comparison tests - [@dbwiddis](https://github.com/dbwiddis).
 * [#3171](https://github.com/oshi/oshi/pull/3171): Add FFM registry drivers for HKEY_PERFORMANCE_DATA process and thread data; extract PerfCounterBlock POJOs to oshi-common - [@dbwiddis](https://github.com/dbwiddis).
+* [#3172](https://github.com/oshi/oshi/pull/3172): Extract common Windows perfmon/registry driver code to oshi-common; reduce duplication between JNA and FFM implementations - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PerfCounter.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PerfCounter.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.perfmon;
+
+import java.util.Objects;
+
+import oshi.annotation.concurrent.Immutable;
+
+/**
+ * Encapsulates the three string components of a PDH performance counter path, plus whether it refers to the base
+ * (SecondValue) of a multi-value counter.
+ */
+@Immutable
+public final class PerfCounter {
+
+    private final String object;
+    private final String instance;
+    private final String counter;
+    private final boolean baseCounter;
+
+    /**
+     * Suffix appended to counter names in enum definitions to indicate that the SecondValue (base) should be read
+     * instead of the FirstValue.
+     */
+    public static final String BASE_SUFFIX = "_Base";
+
+    public PerfCounter(String objectName, String instanceName, String counterName) {
+        this.object = objectName;
+        this.instance = instanceName;
+        this.baseCounter = counterName.endsWith(BASE_SUFFIX);
+        this.counter = this.baseCounter ? counterName.substring(0, counterName.length() - BASE_SUFFIX.length())
+                : counterName;
+    }
+
+    /**
+     * @return Returns the object.
+     */
+    public String getObject() {
+        return object;
+    }
+
+    /**
+     * @return Returns the instance.
+     */
+    public String getInstance() {
+        return instance;
+    }
+
+    /**
+     * @return Returns the counter.
+     */
+    public String getCounter() {
+        return counter;
+    }
+
+    /**
+     * @return Returns whether the counter is a base counter
+     */
+    public boolean isBaseCounter() {
+        return baseCounter;
+    }
+
+    /**
+     * Returns the path for this counter
+     *
+     * @return A string representing the counter path
+     */
+    public String getCounterPath() {
+        StringBuilder sb = new StringBuilder();
+        sb.append('\\').append(object);
+        if (instance != null) {
+            sb.append('(').append(instance).append(')');
+        }
+        sb.append('\\').append(counter);
+        return sb.toString();
+    }
+
+    /**
+     * Strips the {@link #BASE_SUFFIX} from a counter name if present.
+     *
+     * @param counterName The counter name, possibly ending with {@code _Base}
+     * @return The counter name without the {@code _Base} suffix, or the original name if the suffix is not present
+     */
+    public static String stripBaseSuffix(String counterName) {
+        if (counterName.endsWith(BASE_SUFFIX)) {
+            return counterName.substring(0, counterName.length() - BASE_SUFFIX.length());
+        }
+        return counterName;
+    }
+
+    /**
+     * Tests whether a counter name has the {@link #BASE_SUFFIX}.
+     *
+     * @param counterName The counter name to test
+     * @return true if the counter name ends with {@code _Base}
+     */
+    public static boolean isBase(String counterName) {
+        return counterName.endsWith(BASE_SUFFIX);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PerfCounter)) {
+            return false;
+        }
+        PerfCounter other = (PerfCounter) o;
+        return baseCounter == other.baseCounter && Objects.equals(object, other.object)
+                && Objects.equals(instance, other.instance) && Objects.equals(counter, other.counter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(object, instance, counter, baseCounter);
+    }
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/HkeyPerformanceDataUtil.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/HkeyPerformanceDataUtil.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.registry;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
+
+/**
+ * Base class for HKEY_PERFORMANCE_DATA utilities. Contains the common logic for building the counter name/index map and
+ * resolving counter indices from enum definitions. Subclasses provide the platform-specific native call to read the
+ * registry string array.
+ */
+@ThreadSafe
+public abstract class HkeyPerformanceDataUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HkeyPerformanceDataUtil.class);
+
+    /**
+     * Subclass-only constructor.
+     */
+    protected HkeyPerformanceDataUtil() {
+    }
+
+    /**
+     * Registry key containing English counter name/index pairs.
+     */
+    public static final String HKEY_PERFORMANCE_TEXT = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib\\009";
+
+    /**
+     * Registry value name for the counter text.
+     */
+    public static final String COUNTER = "Counter";
+
+    /**
+     * Builds the counter index map from a string array of alternating index/name pairs.
+     * <p>
+     * The array format is pairs of {@code "<index>", "<name>"}. The first pair is a length/count entry (e.g.,
+     * {@code "1", "1847"}) followed by actual counter definitions such as {@code "2", "System", "4", "Memory", "6",
+     * "% Processor Time", ...}. Even positions (0, 2, 4, ...) hold numeric index strings and odd positions (1, 3, 5,
+     * ...) hold the corresponding counter names.
+     *
+     * @param counterText The string array from the registry, or null if the read failed
+     * @return An unmodifiable map of counter name to index
+     */
+    protected static Map<String, Integer> buildCounterIndexMap(String[] counterText) {
+        HashMap<String, Integer> indexMap = new HashMap<>();
+        if (counterText != null && counterText.length > 1) {
+            for (int i = 1; i < counterText.length; i += 2) {
+                int idx = ParseUtil.parseIntOrDefault(counterText[i - 1], 0);
+                if (idx > 0) {
+                    indexMap.putIfAbsent(counterText[i], idx);
+                }
+            }
+        }
+        return Collections.unmodifiableMap(indexMap);
+    }
+
+    /**
+     * Looks up the counter index values for the given counter object and the enum of counter names.
+     *
+     * @param <T>             An enum containing the counters, whose class is passed as {@code counterEnum}
+     * @param objectName      The counter object to look up the index for
+     * @param counterEnum     The {@link Enum} containing counters to look up the indices for. The first Enum value will
+     *                        be ignored.
+     * @param counterIndexMap The map of counter names to their indices
+     * @return A {@link Pair} containing the index of the counter object as the first element, and an {@link EnumMap}
+     *         mapping counter enum values to their index as the second element, if the lookup is successful; null
+     *         otherwise.
+     */
+    protected static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<Integer, EnumMap<T, Integer>> getCounterIndices(
+            String objectName, Class<T> counterEnum, Map<String, Integer> counterIndexMap) {
+        Integer counterIndex = counterIndexMap.get(objectName);
+        if (counterIndex == null) {
+            LOG.debug("Couldn't find counter index of {}.", objectName);
+            return null;
+        }
+        T[] enumConstants = counterEnum.getEnumConstants();
+        EnumMap<T, Integer> indexMap = new EnumMap<>(counterEnum);
+        // Start iterating at 1 because first Enum value defines the name/instance and
+        // is not a counter name
+        for (int i = 1; i < enumConstants.length; i++) {
+            T key = enumConstants[i];
+            Integer idx = counterIndexMap.get(key.getCounter());
+            if (idx == null) {
+                LOG.debug("Couldn't find counter index of {}.", key.getCounter());
+                return null;
+            }
+            indexMap.put(key, idx);
+        }
+        // We have all the pieces! Return them.
+        return new Pair<>(counterIndex, indexMap);
+    }
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/ProcessPerformanceData.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/ProcessPerformanceData.java
@@ -2,67 +2,58 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.windows.registry;
+package oshi.driver.common.windows.registry;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.sun.jna.platform.win32.WinBase;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.ProcessPerformanceProperty;
-import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
-import oshi.driver.windows.perfmon.ProcessInformationJNA;
-import oshi.util.GlobalConfig;
+import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
 /**
- * Utility to read process data from HKEY_PERFORMANCE_DATA information with backup from Performance Counters or WMI
+ * Common logic for building process performance data maps from registry or performance counter results. Callers
+ * (JNA/FFM variants) supply the platform-specific pre-fetched registry or performance-counter data.
  */
 @ThreadSafe
 public final class ProcessPerformanceData {
 
-    private static final String PROCESS = "Process";
-    private static final boolean PERFDATA = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_HKEYPERFDATA, true);
+    /**
+     * The performance object name for process counters.
+     */
+    public static final String PROCESS = "Process";
 
     private ProcessPerformanceData() {
     }
 
     /**
-     * Query the registry for process performance counters
+     * Builds a process map from registry performance data that has already been read.
      *
-     * @param pids An optional collection of process IDs to filter the list to. May be null for no filtering.
+     * @param pids        An optional collection of process IDs to filter the list to. May be null for no filtering.
+     * @param processData The raw registry data triplet (instance maps, perfTime100nSec, now in ms)
      * @return A map with Process ID as the key and a {@link ProcessPerfCounterBlock} object populated with performance
-     *         counter information if successful, or null otherwise.
+     *         counter information, or null if processData is null.
      */
-    public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids) {
-        // Grab the data from the registry.
-        Triplet<List<Map<ProcessPerformanceProperty, Object>>, Long, Long> processData = null;
-        if (PERFDATA) {
-            processData = HkeyPerformanceDataUtil.readPerfDataFromRegistry(PROCESS, ProcessPerformanceProperty.class);
-        }
+    public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids,
+            Triplet<List<Map<ProcessPerformanceProperty, Object>>, Long, Long> processData) {
         if (processData == null) {
             return null;
         }
         List<Map<ProcessPerformanceProperty, Object>> processInstanceMaps = processData.getA();
         long now = processData.getC(); // 1970 epoch
 
-        // Create a map and fill it
         Map<Integer, ProcessPerfCounterBlock> processMap = new HashMap<>();
-        // Iterate instances.
         for (Map<ProcessPerformanceProperty, Object> processInstanceMap : processInstanceMaps) {
             int pid = ((Integer) processInstanceMap.get(ProcessPerformanceProperty.IDPROCESS)).intValue();
             String name = (String) processInstanceMap.get(ProcessPerformanceProperty.NAME);
             if ((pids == null || pids.contains(pid)) && !"_Total".equals(name)) {
-                // Field name is elapsed time but the value is the process start time
                 long ctime = (Long) processInstanceMap.get(ProcessPerformanceProperty.ELAPSEDTIME);
-                // if creation time value is less than current millis, it's in 1970 epoch,
-                // otherwise it's 1601 epoch and we must convert
                 if (ctime > now) {
-                    ctime = WinBase.FILETIME.filetimeToDate((int) (ctime >> 32), (int) (ctime & 0xffffffffL)).getTime();
+                    ctime = ParseUtil.filetimeToUtcMs(ctime, false);
                 }
                 long upTime = now - ctime;
                 if (upTime < 1L) {
@@ -83,29 +74,19 @@ public final class ProcessPerformanceData {
     }
 
     /**
-     * Query PerfMon for process performance counters
+     * Builds a process map from performance counter query results.
      *
-     * @param pids An optional collection of process IDs to filter the list to. May be null for no filtering.
+     * @param pids           An optional collection of process IDs to filter the list to. May be null for no filtering.
+     * @param instanceValues The query results as a pair of (instances, valueMap)
      * @return A map with Process ID as the key and a {@link ProcessPerfCounterBlock} object populated with performance
-     *         counter information.
-     */
-    public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids) {
-        return buildProcessMapFromPerfCounters(pids, null);
-    }
-
-    /**
-     * Query PerfMon for process performance counters
-     *
-     * @param pids     An optional collection of process IDs to filter the list to. May be null for no filtering.
-     * @param procName Filter by this process name.
-     * @return A map with Process ID as the key and a {@link ProcessPerfCounterBlock} object populated with performance
-     *         counter information.
+     *         counter information, or null if instanceValues is null.
      */
     public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids,
-            String procName) {
+            Pair<List<String>, Map<ProcessPerformanceProperty, List<Long>>> instanceValues) {
+        if (instanceValues == null) {
+            return null;
+        }
         Map<Integer, ProcessPerfCounterBlock> processMap = new HashMap<>();
-        Pair<List<String>, Map<ProcessPerformanceProperty, List<Long>>> instanceValues = ProcessInformationJNA
-                .queryProcessCounters();
         long now = System.currentTimeMillis(); // 1970 epoch
         List<String> instances = instanceValues.getA();
         Map<ProcessPerformanceProperty, List<Long>> valueMap = instanceValues.getB();
@@ -122,12 +103,9 @@ public final class ProcessPerformanceData {
         for (int inst = 0; inst < instances.size(); inst++) {
             int pid = pidList.get(inst).intValue();
             if (pids == null || pids.contains(pid)) {
-                // Field name is elapsed time but the value is the process start time
                 long ctime = elapsedTimeList.get(inst);
-                // if creation time value is less than current millis, it's in 1970 epoch,
-                // otherwise it's 1601 epoch and we must convert
                 if (ctime > now) {
-                    ctime = WinBase.FILETIME.filetimeToDate((int) (ctime >> 32), (int) (ctime & 0xffffffffL)).getTime();
+                    ctime = ParseUtil.filetimeToUtcMs(ctime, false);
                 }
                 long upTime = now - ctime;
                 if (upTime < 1L) {

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/ThreadPerformanceData.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/ThreadPerformanceData.java
@@ -2,47 +2,44 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.windows.registry;
+package oshi.driver.common.windows.registry;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.sun.jna.platform.win32.WinBase.FILETIME;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ThreadInformation.ThreadPerformanceProperty;
-import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
-import oshi.driver.windows.perfmon.PerfmonDisabled;
-import oshi.driver.windows.perfmon.ThreadInformationJNA;
-import oshi.util.Util;
+import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
 /**
- * Utility to read thread data from HKEY_PERFORMANCE_DATA information with backup from Performance Counters or WMI
+ * Common logic for building thread performance data maps from registry or performance counter results. Callers (JNA/FFM
+ * variants) supply the platform-specific pre-fetched registry or performance-counter data.
  */
 @ThreadSafe
 public final class ThreadPerformanceData {
 
-    private static final String THREAD = "Thread";
+    /**
+     * The performance object name for thread counters.
+     */
+    public static final String THREAD = "Thread";
 
     private ThreadPerformanceData() {
     }
 
     /**
-     * Query the registry for thread performance counters
+     * Builds a thread map from registry performance data that has already been read.
      *
-     * @param pids An optional collection of thread IDs to filter the list to. May be null for no filtering.
+     * @param pids       An optional collection of process IDs to filter the list to. May be null for no filtering.
+     * @param threadData The raw registry data triplet (instance maps, perfTime100nSec, now in ms)
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
-     *         counter information if successful, or null otherwise.
+     *         counter information, or null if threadData is null.
      */
-    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
-        // Grab the data from the registry.
-        Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtil
-                .readPerfDataFromRegistry(THREAD, ThreadPerformanceProperty.class);
+    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids,
+            Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData) {
         if (threadData == null) {
             return null;
         }
@@ -50,9 +47,7 @@ public final class ThreadPerformanceData {
         long perfTime100nSec = threadData.getB(); // 1601
         long now = threadData.getC(); // 1970 epoch
 
-        // Create a map and fill it
         Map<Integer, ThreadPerfCounterBlock> threadMap = new HashMap<>();
-        // Iterate instances.
         for (Map<ThreadPerformanceProperty, Object> threadInstanceMap : threadInstanceMaps) {
             Integer pid = (Integer) threadInstanceMap.get(ThreadPerformanceProperty.IDPROCESS);
             if ((pids == null || pids.contains(pid)) && pid > 0) {
@@ -86,34 +81,19 @@ public final class ThreadPerformanceData {
     }
 
     /**
-     * Query PerfMon for thread performance counters
+     * Builds a thread map from performance counter query results.
      *
-     * @param pids An optional collection of process IDs to filter the list to. May be null for no filtering.
+     * @param pids           An optional collection of process IDs to filter the list to. May be null for no filtering.
+     * @param instanceValues The query results as a pair of (instances, valueMap)
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
-     *         counter information.
-     */
-    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids) {
-        return buildThreadMapFromPerfCounters(pids, null, -1);
-    }
-
-    /**
-     * Query PerfMon for thread performance counters
-     *
-     * @param pids      An optional collection of process IDs to filter the list to. May be null for no filtering.
-     * @param procName  Limit the matches to processes matching the given name.
-     * @param threadNum Limit the matches to threads matching the given thread. Use -1 to match all threads.
-     * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
-     *         counter information.
+     *         counter information, or null if instanceValues is null.
      */
     public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids,
-            String procName, int threadNum) {
-        if (PerfmonDisabled.PERF_PROC_DISABLED) {
-            return Collections.emptyMap();
+            Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> instanceValues) {
+        if (instanceValues == null) {
+            return null;
         }
         Map<Integer, ThreadPerfCounterBlock> threadMap = new HashMap<>();
-        Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> instanceValues = Util.isBlank(procName)
-                ? ThreadInformationJNA.queryThreadCounters()
-                : ThreadInformationJNA.queryThreadCounters(procName, threadNum);
         long now = System.currentTimeMillis(); // 1970 epoch
         List<String> instances = instanceValues.getA();
         Map<ThreadPerformanceProperty, List<Long>> valueMap = instanceValues.getB();
@@ -135,9 +115,7 @@ public final class ThreadPerformanceData {
                 int tid = tidList.get(inst).intValue();
                 String name = Integer.toString(nameIndex++);
                 long startTime = startTimeList.get(inst);
-                int lowerStartTimeLimit = (int) (startTime >> 32);
-                int higherStartTimeLimit = (int) (startTime & 0xffffffffL);
-                startTime = FILETIME.filetimeToDate(lowerStartTimeLimit, higherStartTimeLimit).getTime();
+                startTime = ParseUtil.filetimeToUtcMs(startTime, false);
                 if (startTime > now) {
                     startTime = now - 1;
                 }
@@ -149,8 +127,6 @@ public final class ThreadPerformanceData {
                 long startAddr = startAddrList.get(inst).longValue();
                 long contextSwitches = contextSwitchesList.get(inst).longValue();
 
-                // if creation time value is less than current millis, it's in 1970 epoch,
-                // otherwise it's 1601 epoch and we must convert
                 threadMap.put(tid, new ThreadPerfCounterBlock(name, tid, pid, startTime, user, kernel, priority,
                         threadState, threadWaitReason, startAddr, contextSwitches));
             }

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/PerfmonDisabledFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/perfmon/PerfmonDisabledFFM.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.perfmon;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Locale;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.windows.WinRegFFM;
+import oshi.util.GlobalConfig;
+import oshi.util.Util;
+import oshi.util.platform.windows.Advapi32UtilFFM;
+
+/**
+ * Tests whether performance counters are disabled
+ */
+@ThreadSafe
+public final class PerfmonDisabledFFM {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PerfmonDisabledFFM.class);
+
+    public static final boolean PERF_OS_DISABLED = isDisabled(GlobalConfig.OSHI_OS_WINDOWS_PERFOS_DISABLED, "PerfOS");
+    public static final boolean PERF_PROC_DISABLED = isDisabled(GlobalConfig.OSHI_OS_WINDOWS_PERFPROC_DISABLED,
+            "PerfProc");
+    public static final boolean PERF_DISK_DISABLED = isDisabled(GlobalConfig.OSHI_OS_WINDOWS_PERFDISK_DISABLED,
+            "PerfDisk");
+
+    private PerfmonDisabledFFM() {
+        throw new AssertionError();
+    }
+
+    private static boolean isDisabled(String config, String service) {
+        String perfDisabled = GlobalConfig.get(config);
+        // If null or empty, check registry
+        if (Util.isBlank(perfDisabled)) {
+            String key = String.format(Locale.ROOT, "SYSTEM\\CurrentControlSet\\Services\\%s\\Performance", service);
+            String value = "Disable Performance Counters";
+            MemorySegment hklm = MemorySegment.ofAddress(WinRegFFM.HKEY_LOCAL_MACHINE);
+            Object disabled = Advapi32UtilFFM.registryGetValue(hklm, key, value);
+            if (disabled instanceof Integer) {
+                if ((Integer) disabled > 0) {
+                    LOG.warn("{} counters are disabled and won't return data: {}\\{}\\{} > 0.", service,
+                            "HKEY_LOCAL_MACHINE", key, value);
+                    return true;
+                }
+            } else if (disabled != null) {
+                LOG.warn(
+                        "Invalid registry value type detected for {} counters. Should be REG_DWORD. Ignoring: {}\\{}\\{}.",
+                        service, "HKEY_LOCAL_MACHINE", key, value);
+            }
+            return false;
+        }
+        // If not null or empty, parse as boolean
+        return Boolean.parseBoolean(perfDisabled);
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilFFM.java
@@ -31,7 +31,6 @@ import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -42,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
+import oshi.driver.common.windows.registry.HkeyPerformanceDataUtil;
 import oshi.ffm.windows.WinRegFFM;
 import oshi.util.ParseUtil;
 import oshi.util.platform.windows.Advapi32UtilFFM;
@@ -52,7 +52,7 @@ import oshi.util.tuples.Triplet;
  * Utility to read HKEY_PERFORMANCE_DATA information using the FFM API.
  */
 @ThreadSafe
-public final class HkeyPerformanceDataUtilFFM {
+public final class HkeyPerformanceDataUtilFFM extends HkeyPerformanceDataUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(HkeyPerformanceDataUtilFFM.class);
 
@@ -60,13 +60,21 @@ public final class HkeyPerformanceDataUtilFFM {
      * Do a one-time lookup of the HKEY_PERFORMANCE_TEXT counter indices and store in a map for efficient lookups
      * on-demand.
      */
-    private static final String HKEY_PERFORMANCE_TEXT = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib\\009";
-    private static final String COUNTER = "Counter";
     private static final Map<String, Integer> COUNTER_INDEX_MAP = mapCounterIndicesFromRegistry();
 
     private static int maxPerfBufferSize = 16384;
 
     private HkeyPerformanceDataUtilFFM() {
+    }
+
+    /**
+     * Looks up the performance counter index for the given English counter name.
+     *
+     * @param name The English counter name
+     * @return The counter index, or 0 if not found
+     */
+    public static int getCounterIndex(String name) {
+        return COUNTER_INDEX_MAP.getOrDefault(name, 0);
     }
 
     /**
@@ -86,7 +94,7 @@ public final class HkeyPerformanceDataUtilFFM {
             String objectName, Class<T> counterEnum) {
         // Load indices
         // e.g., call with "Process" and ProcessPerformanceProperty.class
-        Pair<Integer, EnumMap<T, Integer>> indices = getCounterIndices(objectName, counterEnum);
+        Pair<Integer, EnumMap<T, Integer>> indices = getCounterIndices(objectName, counterEnum, COUNTER_INDEX_MAP);
         if (indices == null) {
             return null;
         }
@@ -208,41 +216,6 @@ public final class HkeyPerformanceDataUtilFFM {
     }
 
     /**
-     * Looks up the counter index values for the given counter object and the enum of counter names.
-     *
-     * @param <T>         An enum containing the counters, whose class is passed as {@code counterEnum}
-     * @param objectName  The counter object to look up the index for
-     * @param counterEnum The {@link Enum} containing counters to look up the indices for. The first Enum value will be
-     *                    ignored.
-     * @return A {@link Pair} containing the index of the counter object as the first element, and an {@link EnumMap}
-     *         mapping counter enum values to their index as the second element, if the lookup is successful; null
-     *         otherwise.
-     */
-    private static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<Integer, EnumMap<T, Integer>> getCounterIndices(
-            String objectName, Class<T> counterEnum) {
-        if (!COUNTER_INDEX_MAP.containsKey(objectName)) {
-            LOG.debug("Couldn't find counter index of {}.", objectName);
-            return null;
-        }
-        int counterIndex = COUNTER_INDEX_MAP.get(objectName);
-        T[] enumConstants = counterEnum.getEnumConstants();
-        EnumMap<T, Integer> indexMap = new EnumMap<>(counterEnum);
-        // Start iterating at 1 because first Enum value defines the name/instance and
-        // is not a counter name
-        for (int i = 1; i < enumConstants.length; i++) {
-            T key = enumConstants[i];
-            String counterName = key.getCounter();
-            if (!COUNTER_INDEX_MAP.containsKey(counterName)) {
-                LOG.debug("Couldn't find counter index of {}.", counterName);
-                return null;
-            }
-            indexMap.put(key, COUNTER_INDEX_MAP.get(counterName));
-        }
-        // We have all the pieces! Return them.
-        return new Pair<>(counterIndex, indexMap);
-    }
-
-    /**
      * Read the performance data for a counter object from the registry.
      *
      * @param objectName The counter object for which to fetch data. It is the user's responsibility to ensure this key
@@ -300,23 +273,15 @@ public final class HkeyPerformanceDataUtilFFM {
      * read successfully; an empty map otherwise.
      */
     private static Map<String, Integer> mapCounterIndicesFromRegistry() {
-        HashMap<String, Integer> indexMap = new HashMap<>();
         try {
             String[] counterText = Advapi32UtilFFM.registryGetStringArray(
                     MemorySegment.ofAddress(WinRegFFM.HKEY_LOCAL_MACHINE), HKEY_PERFORMANCE_TEXT, COUNTER);
-            if (counterText != null && counterText.length > 1) {
-                for (int i = 1; i < counterText.length; i += 2) {
-                    int idx = ParseUtil.parseIntOrDefault(counterText[i - 1], 0);
-                    if (idx > 0) {
-                        indexMap.putIfAbsent(counterText[i], idx);
-                    }
-                }
-            }
+            return buildCounterIndexMap(counterText);
         } catch (Exception e) {
             LOG.error(
                     "Unable to locate English counter names in registry Perflib 009. Counters may need to be rebuilt: ",
                     e);
         }
-        return Collections.unmodifiableMap(indexMap);
+        return buildCounterIndexMap(null);
     }
 }

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/Advapi32UtilFFM.java
@@ -198,6 +198,67 @@ public final class Advapi32UtilFFM {
     }
 
     /**
+     * Reads a registry value from the given root key and path.
+     *
+     * @param rootKey   The root key handle (e.g., HKEY_LOCAL_MACHINE)
+     * @param keyPath   The registry key path
+     * @param valueName The value name to read
+     * @return The value object (Integer for REG_DWORD, String for REG_SZ/REG_EXPAND_SZ), or null on failure
+     */
+    public static Object registryGetValue(MemorySegment rootKey, String keyPath, String valueName) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment phkResult = arena.allocate(ADDRESS);
+            int rc = RegOpenKeyEx(rootKey, toWideString(arena, keyPath), 0, KEY_READ, phkResult);
+            if (rc != ERROR_SUCCESS) {
+                return null;
+            }
+            MemorySegment hKey = phkResult.get(ADDRESS, 0);
+            try {
+                return registryGetValue(hKey, valueName);
+            } finally {
+                int closeRc = RegCloseKey(hKey);
+                if (closeRc != ERROR_SUCCESS) {
+                    LOG.debug("Failed to close registry key {}: error {}", keyPath, closeRc);
+                }
+            }
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    /**
+     * Checks whether a registry value exists under the given root key and path.
+     *
+     * @param rootKey   The root key handle (e.g., HKEY_LOCAL_MACHINE)
+     * @param keyPath   The registry key path
+     * @param valueName The value name to check
+     * @return true if the value exists, false otherwise
+     */
+    public static boolean registryValueExists(MemorySegment rootKey, String keyPath, String valueName) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment phkResult = arena.allocate(ADDRESS);
+            int rc = RegOpenKeyEx(rootKey, toWideString(arena, keyPath), 0, KEY_READ, phkResult);
+            if (rc != ERROR_SUCCESS) {
+                return false;
+            }
+            MemorySegment hKey = phkResult.get(ADDRESS, 0);
+            try {
+                MemorySegment lpType = arena.allocate(JAVA_INT);
+                rc = RegQueryValueEx(hKey, toWideString(arena, valueName), 0, lpType, MemorySegment.NULL,
+                        arena.allocate(JAVA_INT));
+                return rc == ERROR_SUCCESS || rc == ERROR_MORE_DATA || rc == ERROR_INSUFFICIENT_BUFFER;
+            } finally {
+                int closeRc = RegCloseKey(hKey);
+                if (closeRc != ERROR_SUCCESS) {
+                    LOG.debug("Failed to close registry key {}: error {}", keyPath, closeRc);
+                }
+            }
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    /**
      * Reads a REG_MULTI_SZ value from an open registry key.
      *
      * @param rootKey   The root key handle (e.g., HKEY_LOCAL_MACHINE)

--- a/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/util/platform/windows/PerfDataUtilFFM.java
@@ -40,8 +40,8 @@ import org.slf4j.LoggerFactory;
 
 import oshi.driver.common.windows.perfmon.PdhCounterProperty;
 import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
-import oshi.ffm.windows.WinRegFFM;
-import oshi.util.ParseUtil;
+import oshi.driver.common.windows.perfmon.PerfCounter;
+import oshi.driver.windows.registry.HkeyPerformanceDataUtilFFM;
 import oshi.util.Util;
 import oshi.util.tuples.Pair;
 
@@ -61,10 +61,6 @@ public final class PerfDataUtilFFM {
 
     // Cache for English-to-localized object name mapping
     private static final Map<String, String> LOCALIZE_CACHE = new ConcurrentHashMap<>();
-
-    // English counter index registry key
-    private static final String ENGLISH_COUNTER_KEY = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib\\009";
-    private static final String ENGLISH_COUNTER_VALUE = "Counter";
 
     /**
      * Query multiple PDH counter values in a single query, one per enum constant.
@@ -93,9 +89,9 @@ public final class PerfDataUtilFFM {
                 EnumMap<T, Boolean> baseFlags = new EnumMap<>(propertyEnum);
                 for (T prop : props) {
                     String counterName = prop.getCounter();
-                    boolean isBase = counterName.endsWith(BASE_SUFFIX);
+                    boolean isBase = PerfCounter.isBase(counterName);
                     if (isBase) {
-                        counterName = counterName.substring(0, counterName.length() - BASE_SUFFIX.length());
+                        counterName = PerfCounter.stripBaseSuffix(counterName);
                     }
                     String path = counterPath(perfObject, prop.getInstance(), counterName);
                     try {
@@ -154,8 +150,6 @@ public final class PerfDataUtilFFM {
     private static final long RAW_CSTATUS_OFFSET = PDH_RAW_COUNTER_LAYOUT.byteOffset(groupElement("CStatus"));
     private static final long RAW_FIRST_VALUE_OFFSET = PDH_RAW_COUNTER_LAYOUT.byteOffset(groupElement("FirstValue"));
     private static final long RAW_SECOND_VALUE_OFFSET = PDH_RAW_COUNTER_LAYOUT.byteOffset(groupElement("SecondValue"));
-
-    private static final String BASE_SUFFIX = "_Base";
 
     private static long readRawCounterValue(Arena arena, MemorySegment counterHandle, boolean secondValue)
             throws Throwable {
@@ -320,8 +314,8 @@ public final class PerfDataUtilFFM {
                 List<MemorySegment>[] counterHandles = new List[props.length - 1];
                 for (int p = 1; p < props.length; p++) {
                     String counterName = props[p].getCounter();
-                    if (counterName.endsWith(BASE_SUFFIX)) {
-                        counterName = counterName.substring(0, counterName.length() - BASE_SUFFIX.length());
+                    if (PerfCounter.isBase(counterName)) {
+                        counterName = PerfCounter.stripBaseSuffix(counterName);
                         isBase[p - 1] = true;
                     }
                     counterHandles[p - 1] = new ArrayList<>(instances.size());
@@ -390,18 +384,7 @@ public final class PerfDataUtilFFM {
     }
 
     private static int lookupPerfIndexByEnglishName(String name) {
-        String[] counters = Advapi32UtilFFM.registryGetStringArray(
-                MemorySegment.ofAddress(WinRegFFM.HKEY_LOCAL_MACHINE), ENGLISH_COUNTER_KEY, ENGLISH_COUNTER_VALUE);
-        // Array contains alternating index/name pairs: {"1", "1847", "2", "System", "4", "Memory", ...}
-        for (int i = 1; i < counters.length; i += 2) {
-            if (counters[i].equals(name)) {
-                int idx = ParseUtil.parseIntOrDefault(counters[i - 1], 0);
-                if (idx > 0) {
-                    return idx;
-                }
-            }
-        }
-        return 0;
+        return HkeyPerformanceDataUtilFFM.getCounterIndex(name);
     }
 
     private static String lookupPerfNameByIndex(int index) {

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilJNA.java
@@ -5,7 +5,6 @@
 package oshi.driver.windows.registry;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -18,7 +17,6 @@ import com.sun.jna.Memory;
 import com.sun.jna.platform.win32.Advapi32;
 import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.Win32Exception;
-import com.sun.jna.platform.win32.WinBase.FILETIME;
 import com.sun.jna.platform.win32.WinError;
 import com.sun.jna.platform.win32.WinPerf.PERF_COUNTER_BLOCK;
 import com.sun.jna.platform.win32.WinPerf.PERF_COUNTER_DEFINITION;
@@ -27,10 +25,11 @@ import com.sun.jna.platform.win32.WinPerf.PERF_INSTANCE_DEFINITION;
 import com.sun.jna.platform.win32.WinPerf.PERF_OBJECT_TYPE;
 import com.sun.jna.platform.win32.WinReg;
 
-import oshi.annotation.SuppressForbidden;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
+import oshi.driver.common.windows.registry.HkeyPerformanceDataUtil;
 import oshi.jna.ByRef.CloseableIntByReference;
+import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
@@ -38,21 +37,15 @@ import oshi.util.tuples.Triplet;
  * Utility to read HKEY_PERFORMANCE_DATA information.
  */
 @ThreadSafe
-public final class HkeyPerformanceDataUtil {
+public final class HkeyPerformanceDataUtilJNA extends HkeyPerformanceDataUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(HkeyPerformanceDataUtil.class);
+    private static final Logger LOG = LoggerFactory.getLogger(HkeyPerformanceDataUtilJNA.class);
 
-    /*
-     * Do a one-time lookup of the HKEY_PERFORMANCE_TEXT counter indices and store in a map for efficient lookups
-     * on-demand.
-     */
-    private static final String HKEY_PERFORMANCE_TEXT = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib\\009";
-    private static final String COUNTER = "Counter";
     private static final Map<String, Integer> COUNTER_INDEX_MAP = mapCounterIndicesFromRegistry();
 
     private static int maxPerfBufferSize = 16384;
 
-    private HkeyPerformanceDataUtil() {
+    private HkeyPerformanceDataUtilJNA() {
     }
 
     /**
@@ -71,11 +64,12 @@ public final class HkeyPerformanceDataUtil {
     public static <T extends Enum<T> & PdhCounterWildcardProperty> Triplet<List<Map<T, Object>>, Long, Long> readPerfDataFromRegistry(
             String objectName, Class<T> counterEnum) {
         // Load indices
-        // e.g., call with "Process" and ProcessPerformanceProperty.class
-        Pair<Integer, EnumMap<T, Integer>> indices = getCounterIndices(objectName, counterEnum);
+        Pair<Integer, EnumMap<T, Integer>> indices = getCounterIndices(objectName, counterEnum, COUNTER_INDEX_MAP);
         if (indices == null) {
             return null;
         }
+        int objectIndex = indices.getA();
+        EnumMap<T, Integer> enumIndexMap = indices.getB();
         // The above test checks validity of objectName as an index but it could still
         // fail to read
         try (Memory pPerfData = readPerfDataBuffer(objectName)) {
@@ -83,34 +77,17 @@ public final class HkeyPerformanceDataUtil {
                 return null;
             }
             // Buffer is now successfully populated.
-            // See format at
-            // https://msdn.microsoft.com/en-us/library/windows/desktop/aa373105(v=vs.85).aspx
-
-            // Start with a data header (PERF_DATA_BLOCK)
-            // Then iterate one or more objects
-            // Each object contains
-            // [ ] Object Type header (PERF_OBJECT_TYPE)
-            // [ ][ ][ ] Multiple counter definitions (PERF_COUNTER_DEFINITION)
-            // Then after object(s), multiple:
-            // [ ] Instance Definition
-            // [ ] Instance name
-            // [ ] Counter Block
-            // [ ][ ][ ] Counter data for each definition above
 
             // Store timestamp
             PERF_DATA_BLOCK perfData = new PERF_DATA_BLOCK(pPerfData.share(0));
             long perfTime100nSec = perfData.PerfTime100nSec.getValue(); // 1601
-            long now = FILETIME.filetimeToDate((int) (perfTime100nSec >> 32), (int) (perfTime100nSec & 0xffffffffL))
-                    .getTime(); // 1970
+            long now = ParseUtil.filetimeToUtcMs(perfTime100nSec, false); // 1970
 
             // Iterate object types.
             long perfObjectOffset = perfData.HeaderLength;
             for (int obj = 0; obj < perfData.NumObjectTypes; obj++) {
                 PERF_OBJECT_TYPE perfObject = new PERF_OBJECT_TYPE(pPerfData.share(perfObjectOffset));
-                // Some counters will require multiple objects so we iterate until we find the
-                // right one. e.g. Process (230) is by itself but Thread (232) has Process
-                // object first
-                if (perfObject.ObjectNameTitleIndex == COUNTER_INDEX_MAP.get(objectName).intValue()) {
+                if (perfObject.ObjectNameTitleIndex == objectIndex) {
                     // We found a matching object.
 
                     // Counter definitions start after the object header
@@ -127,11 +104,11 @@ public final class HkeyPerformanceDataUtil {
                         perfCounterOffset += perfCounter.ByteLength;
                     }
 
-                    // Instances start after all the object definitions. The DefinitionLength
-                    // includes both the header and all the definitions.
+                    // Instances start after all the object definitions.
                     long perfInstanceOffset = perfObjectOffset + perfObject.DefinitionLength;
 
                     // Iterate instances and fill map
+                    T[] counterKeys = counterEnum.getEnumConstants();
                     List<Map<T, Object>> counterMaps = new ArrayList<>(perfObject.NumInstances);
                     for (int inst = 0; inst < perfObject.NumInstances; inst++) {
                         PERF_INSTANCE_DEFINITION perfInstance = new PERF_INSTANCE_DEFINITION(
@@ -139,18 +116,12 @@ public final class HkeyPerformanceDataUtil {
                         long perfCounterBlockOffset = perfInstanceOffset + perfInstance.ByteLength;
                         // Populate the enumMap
                         Map<T, Object> counterMap = new EnumMap<>(counterEnum);
-                        T[] counterKeys = counterEnum.getEnumConstants();
-                        // First enum index is the name, ignore the counter text which is used for other
-                        // purposes
                         counterMap.put(counterKeys[0],
                                 pPerfData.getWideString(perfInstanceOffset + perfInstance.NameOffset));
                         for (int i = 1; i < counterKeys.length; i++) {
                             T key = counterKeys[i];
-                            int keyIndex = COUNTER_INDEX_MAP.get(key.getCounter());
-                            // All entries in size map have corresponding entry in offset map
+                            int keyIndex = enumIndexMap.get(key);
                             int size = counterSizeMap.getOrDefault(keyIndex, 0);
-                            // Currently, only DWORDs (4 bytes) and ULONGLONGs (8 bytes) are used to provide
-                            // counter values.
                             if (size == 4) {
                                 counterMap.put(key,
                                         pPerfData.getInt(perfCounterBlockOffset + counterOffsetMap.get(keyIndex)));
@@ -158,80 +129,32 @@ public final class HkeyPerformanceDataUtil {
                                 counterMap.put(key,
                                         pPerfData.getLong(perfCounterBlockOffset + counterOffsetMap.get(keyIndex)));
                             } else {
-                                // If counter defined in enum isn't in registry, fail
                                 return null;
                             }
                         }
                         counterMaps.add(counterMap);
 
-                        // counters at perfCounterBlockOffset + appropriate offset per enum
-                        // use pPerfData.getInt or getLong as determined by counter size
-                        // Currently, only DWORDs (4 bytes) and ULONGLONGs (8 bytes) are used to provide
-                        // counter values.
-
                         // Increment to next instance
                         perfInstanceOffset = perfCounterBlockOffset
                                 + new PERF_COUNTER_BLOCK(pPerfData.share(perfCounterBlockOffset)).ByteLength;
                     }
-                    // We've found the necessary object and are done, no need to look at any other
-                    // objects (shouldn't be any). Return results
                     return new Triplet<>(counterMaps, perfTime100nSec, now);
                 }
                 // Increment for next object
                 perfObjectOffset += perfObject.TotalByteLength;
             }
         }
-        // Failed, return null
         return null;
-    }
-
-    /**
-     * Looks up the counter index values for the given counter object and the enum of counter names.
-     *
-     * @param <T>         An enum containing the counters, whose class is passed as {@code counterEnum}
-     * @param objectName  The counter object to look up the index for
-     * @param counterEnum The {@link Enum} containing counters to look up the indices for. The first Enum value will be
-     *                    ignored.
-     * @return A {@link Pair} containing the index of the counter object as the first element, and an {@link EnumMap}
-     *         mapping counter enum values to their index as the second element, if the lookup is successful; null
-     *         otherwise.
-     */
-    private static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<Integer, EnumMap<T, Integer>> getCounterIndices(
-            String objectName, Class<T> counterEnum) {
-        if (!COUNTER_INDEX_MAP.containsKey(objectName)) {
-            LOG.debug("Couldn't find counter index of {}.", objectName);
-            return null;
-        }
-        int counterIndex = COUNTER_INDEX_MAP.get(objectName);
-        T[] enumConstants = counterEnum.getEnumConstants();
-        EnumMap<T, Integer> indexMap = new EnumMap<>(counterEnum);
-        // Start iterating at 1 because first Enum value defines the name/instance and
-        // is not a counter name
-        for (int i = 1; i < enumConstants.length; i++) {
-            T key = enumConstants[i];
-            String counterName = key.getCounter();
-            if (!COUNTER_INDEX_MAP.containsKey(counterName)) {
-                LOG.debug("Couldn't find counter index of {}.", counterName);
-                return null;
-            }
-            indexMap.put(key, COUNTER_INDEX_MAP.get(counterName));
-        }
-        // We have all the pieces! Return them.
-        return new Pair<>(counterIndex, indexMap);
     }
 
     /**
      * Read the performance data for a counter object from the registry.
      *
-     * @param objectName The counter object for which to fetch data. It is the user's responsibility to ensure this key
-     *                   exists in {@link #COUNTER_INDEX_MAP}.
+     * @param objectName The counter object for which to fetch data.
      * @return A buffer containing the data if successful, null otherwise.
      */
     private static synchronized Memory readPerfDataBuffer(String objectName) {
-        // Need this index as a string
         String objectIndexStr = Integer.toString(COUNTER_INDEX_MAP.get(objectName));
-
-        // Now load the data from the regsitry.
 
         try (CloseableIntByReference lpcbData = new CloseableIntByReference(maxPerfBufferSize)) {
             Memory pPerfData = new Memory(maxPerfBufferSize);
@@ -242,7 +165,6 @@ public final class HkeyPerformanceDataUtil {
                 pPerfData.close();
                 return null;
             }
-            // Grow buffer as needed to fit the data
             while (ret == WinError.ERROR_MORE_DATA) {
                 maxPerfBufferSize += 8192;
                 lpcbData.setValue(maxPerfBufferSize);
@@ -255,35 +177,16 @@ public final class HkeyPerformanceDataUtil {
         }
     }
 
-    /*
-     * Registry entries subordinate to HKEY_PERFORMANCE_TEXT key reference the text strings that describe counters in US
-     * English. Not supported in Windows 2000.
-     *
-     * With the "Counter" value, the resulting array contains alternating index/name pairs "1", "1847", "2", "System",
-     * "4", "Memory", ...
-     *
-     * These pairs are translated to a map for later lookup.
-     *
-     * @return An unmodifiable map containing counter name strings as keys and indices as integer values if the key is
-     * read successfully; an empty map otherwise.
-     */
-    @SuppressForbidden(reason = "Catching the error here")
     private static Map<String, Integer> mapCounterIndicesFromRegistry() {
-        HashMap<String, Integer> indexMap = new HashMap<>();
         try {
             String[] counterText = Advapi32Util.registryGetStringArray(WinReg.HKEY_LOCAL_MACHINE, HKEY_PERFORMANCE_TEXT,
                     COUNTER);
-            for (int i = 1; i < counterText.length; i += 2) {
-                indexMap.putIfAbsent(counterText[i], Integer.parseInt(counterText[i - 1]));
-            }
+            return buildCounterIndexMap(counterText);
         } catch (Win32Exception we) {
             LOG.error(
                     "Unable to locate English counter names in registry Perflib 009. Counters may need to be rebuilt: ",
                     we);
-        } catch (NumberFormatException nfe) {
-            // Unexpected to ever get this, but handling it anyway
-            LOG.error("Unable to parse English counter names in registry Perflib 009.");
         }
-        return Collections.unmodifiableMap(indexMap);
+        return buildCounterIndexMap(null);
     }
 }

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataJNA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.registry;
@@ -13,8 +13,8 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.ProcessPerformanceProperty;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
 import oshi.driver.common.windows.registry.ProcessPerformanceData;
-import oshi.driver.windows.perfmon.PerfmonDisabledFFM;
-import oshi.driver.windows.perfmon.ProcessInformationFFM;
+import oshi.driver.windows.perfmon.PerfmonDisabled;
+import oshi.driver.windows.perfmon.ProcessInformationJNA;
 import oshi.util.GlobalConfig;
 import oshi.util.tuples.Triplet;
 
@@ -22,11 +22,11 @@ import oshi.util.tuples.Triplet;
  * Utility to read process data from HKEY_PERFORMANCE_DATA information with backup from Performance Counters or WMI
  */
 @ThreadSafe
-public final class ProcessPerformanceDataFFM {
+public final class ProcessPerformanceDataJNA {
 
     private static final boolean PERFDATA = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_HKEYPERFDATA, true);
 
-    private ProcessPerformanceDataFFM() {
+    private ProcessPerformanceDataJNA() {
     }
 
     /**
@@ -39,7 +39,7 @@ public final class ProcessPerformanceDataFFM {
     public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids) {
         Triplet<List<Map<ProcessPerformanceProperty, Object>>, Long, Long> processData = null;
         if (PERFDATA) {
-            processData = HkeyPerformanceDataUtilFFM.readPerfDataFromRegistry(ProcessPerformanceData.PROCESS,
+            processData = HkeyPerformanceDataUtilJNA.readPerfDataFromRegistry(ProcessPerformanceData.PROCESS,
                     ProcessPerformanceProperty.class);
         }
         return ProcessPerformanceData.buildProcessMapFromRegistry(pids, processData);
@@ -53,10 +53,10 @@ public final class ProcessPerformanceDataFFM {
      *         counter information.
      */
     public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids) {
-        if (PerfmonDisabledFFM.PERF_PROC_DISABLED) {
+        if (PerfmonDisabled.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }
         return ProcessPerformanceData.buildProcessMapFromPerfCounters(pids,
-                ProcessInformationFFM.queryProcessCounters());
+                ProcessInformationJNA.queryProcessCounters());
     }
 }

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataJNA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.registry;
@@ -13,20 +13,19 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ThreadInformation.ThreadPerformanceProperty;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.driver.common.windows.registry.ThreadPerformanceData;
-import oshi.driver.windows.perfmon.PerfmonDisabledFFM;
-import oshi.driver.windows.perfmon.ThreadInformationFFM;
+import oshi.driver.windows.perfmon.PerfmonDisabled;
+import oshi.driver.windows.perfmon.ThreadInformationJNA;
 import oshi.util.Util;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
 /**
- * Utility to read thread data from HKEY_PERFORMANCE_DATA via HkeyPerformanceDataUtilFFM with backup from Performance
- * Counters via ThreadInformationFFM
+ * Utility to read thread data from HKEY_PERFORMANCE_DATA information with backup from Performance Counters or WMI
  */
 @ThreadSafe
-public final class ThreadPerformanceDataFFM {
+public final class ThreadPerformanceDataJNA {
 
-    private ThreadPerformanceDataFFM() {
+    private ThreadPerformanceDataJNA() {
     }
 
     /**
@@ -37,7 +36,7 @@ public final class ThreadPerformanceDataFFM {
      *         counter information if successful, or null otherwise.
      */
     public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
-        Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtilFFM
+        Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtilJNA
                 .readPerfDataFromRegistry(ThreadPerformanceData.THREAD, ThreadPerformanceProperty.class);
         return ThreadPerformanceData.buildThreadMapFromRegistry(pids, threadData);
     }
@@ -64,12 +63,12 @@ public final class ThreadPerformanceDataFFM {
      */
     public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids,
             String procName, int threadNum) {
-        if (PerfmonDisabledFFM.PERF_PROC_DISABLED) {
+        if (PerfmonDisabled.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }
         Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> instanceValues = Util.isBlank(procName)
-                ? ThreadInformationFFM.queryThreadCounters()
-                : ThreadInformationFFM.queryThreadCounters(procName, threadNum);
+                ? ThreadInformationJNA.queryThreadCounters()
+                : ThreadInformationJNA.queryThreadCounters(procName, threadNum);
         return ThreadPerformanceData.buildThreadMapFromPerfCounters(pids, instanceValues);
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcess.java
@@ -22,10 +22,10 @@ import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
-import oshi.driver.windows.registry.ProcessPerformanceData;
+import oshi.driver.windows.registry.ProcessPerformanceDataJNA;
 import oshi.driver.windows.registry.ProcessWtsData;
 import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
-import oshi.driver.windows.registry.ThreadPerformanceData;
+import oshi.driver.windows.registry.ThreadPerformanceDataJNA;
 import oshi.driver.windows.wmi.Win32Process;
 import oshi.driver.windows.wmi.Win32Process.CommandLineProperty;
 import oshi.driver.windows.wmi.Win32ProcessCached;
@@ -273,16 +273,17 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     public boolean updateAttributes() {
         Set<Integer> pids = Collections.singleton(this.getProcessID());
         // Get data from the registry if possible
-        Map<Integer, ProcessPerfCounterBlock> pcb = ProcessPerformanceData.buildProcessMapFromRegistry(null);
+        Map<Integer, ProcessPerfCounterBlock> pcb = ProcessPerformanceDataJNA.buildProcessMapFromRegistry(pids);
         // otherwise performance counters with WMI backup
         if (pcb == null) {
-            pcb = ProcessPerformanceData.buildProcessMapFromPerfCounters(pids);
+            pcb = ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(pids);
         }
         if (USE_PROCSTATE_SUSPENDED) {
             this.tcb = queryMatchingThreads(pids);
         }
         Map<Integer, WtsInfo> wts = ProcessWtsData.queryProcessWtsMap(pids);
-        return updateAttributes(pcb.get(this.getProcessID()), wts.get(this.getProcessID()));
+        return updateAttributes(pcb == null ? null : pcb.get(this.getProcessID()),
+                wts == null ? null : wts.get(this.getProcessID()));
     }
 
     /**
@@ -363,9 +364,9 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     }
 
     protected Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
-        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceData.buildThreadMapFromRegistry(pids);
+        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataJNA.buildThreadMapFromRegistry(pids);
         if (threads == null) {
-            threads = ThreadPerformanceData.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
+            threads = ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
         }
         return threads;
     }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThread.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThread.java
@@ -19,7 +19,7 @@ import java.util.Set;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
-import oshi.driver.windows.registry.ThreadPerformanceData;
+import oshi.driver.windows.registry.ThreadPerformanceDataJNA;
 import oshi.software.common.AbstractOSThread;
 import oshi.software.os.OSProcess.State;
 
@@ -100,9 +100,9 @@ public class WindowsOSThread extends AbstractOSThread {
     public boolean updateAttributes() {
         Set<Integer> pids = Collections.singleton(getOwningProcessId());
         String procName = this.name.split("/")[0];
-        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceData.buildThreadMapFromPerfCounters(pids,
+        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids,
                 procName, getThreadId());
-        return updateAttributes(procName, threads.get(getThreadId()));
+        return updateAttributes(procName, threads == null ? null : threads.get(getThreadId()));
     }
 
     private boolean updateAttributes(String procName, ThreadPerfCounterBlock pcb) {

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -53,11 +53,11 @@ import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.driver.windows.EnumWindows;
 import oshi.driver.windows.registry.HkeyUserData;
 import oshi.driver.windows.registry.NetSessionData;
-import oshi.driver.windows.registry.ProcessPerformanceData;
+import oshi.driver.windows.registry.ProcessPerformanceDataJNA;
 import oshi.driver.windows.registry.ProcessWtsData;
 import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
 import oshi.driver.windows.registry.SessionWtsData;
-import oshi.driver.windows.registry.ThreadPerformanceData;
+import oshi.driver.windows.registry.ThreadPerformanceDataJNA;
 import oshi.driver.windows.wmi.Win32OperatingSystem;
 import oshi.driver.windows.wmi.Win32OperatingSystem.OSVersionProperty;
 import oshi.driver.windows.wmi.Win32Processor;
@@ -301,7 +301,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         // otherwise performance counters with WMI backup
         if (processMap == null || processMap.isEmpty()) {
             processMap = (pids == null) ? processMapFromPerfCounters.get()
-                    : ProcessPerformanceData.buildProcessMapFromPerfCounters(pids);
+                    : ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(pids);
         }
         Map<Integer, ThreadPerfCounterBlock> threadMap = null;
         if (USE_PROCSTATE_SUSPENDED) {
@@ -310,7 +310,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
             // otherwise performance counters with WMI backup
             if (threadMap == null || threadMap.isEmpty()) {
                 threadMap = (pids == null) ? threadMapFromPerfCounters.get()
-                        : ThreadPerformanceData.buildThreadMapFromPerfCounters(pids);
+                        : ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids);
             }
         }
 
@@ -327,19 +327,19 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
     }
 
     private static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromRegistry() {
-        return ProcessPerformanceData.buildProcessMapFromRegistry(null);
+        return ProcessPerformanceDataJNA.buildProcessMapFromRegistry(null);
     }
 
     private static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromPerfCounters() {
-        return ProcessPerformanceData.buildProcessMapFromPerfCounters(null);
+        return ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(null);
     }
 
     private static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromRegistry() {
-        return ThreadPerformanceData.buildThreadMapFromRegistry(null);
+        return ThreadPerformanceDataJNA.buildThreadMapFromRegistry(null);
     }
 
     private static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromPerfCounters() {
-        return ThreadPerformanceData.buildThreadMapFromPerfCounters(null);
+        return ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(null);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
@@ -24,7 +24,7 @@ import com.sun.jna.platform.win32.Win32Exception;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.PdhCounterProperty;
-import oshi.util.platform.windows.PerfDataUtil.PerfCounter;
+import oshi.driver.common.windows.perfmon.PerfCounter;
 
 /**
  * Enables queries of Performance Counters using wild cards to filter instances
@@ -93,8 +93,7 @@ public final class PerfCounterQuery {
         try (PerfCounterQueryHandler pdhQueryHandler = new PerfCounterQueryHandler()) {
             // Set up the query and counter handles, skipping any that fail
             for (T prop : props) {
-                PerfCounter counter = PerfDataUtil.createCounter(perfObjectLocalized, prop.getInstance(),
-                        prop.getCounter());
+                PerfCounter counter = new PerfCounter(perfObjectLocalized, prop.getInstance(), prop.getCounter());
                 if (pdhQueryHandler.addCounterToQuery(counter)) {
                     counterMap.put(prop, counter);
                 } else {

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQueryHandler.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQueryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 The OSHI Project Contributors
+ * Copyright 2019-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.windows;
@@ -12,9 +12,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.NotThreadSafe;
+import oshi.driver.common.windows.perfmon.PerfCounter;
 import oshi.jna.ByRef.CloseableHANDLEByReference;
 import oshi.util.FormatUtil;
-import oshi.util.platform.windows.PerfDataUtil.PerfCounter;
 
 /**
  * Utility to handle Performance Counter Queries

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -26,9 +26,9 @@ import com.sun.jna.platform.win32.PdhUtil.PdhException;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
+import oshi.driver.common.windows.perfmon.PerfCounter;
 import oshi.util.GlobalConfig;
 import oshi.util.Util;
-import oshi.util.platform.windows.PerfDataUtil.PerfCounter;
 import oshi.util.tuples.Pair;
 
 /**
@@ -169,7 +169,7 @@ public final class PerfCounterWildcardQuery {
                 T prop = props[i];
                 List<PerfCounter> counterList = new ArrayList<>(instances.size());
                 for (String instance : instances) {
-                    PerfCounter counter = PerfDataUtil.createCounter(perfObject, instance,
+                    PerfCounter counter = new PerfCounter(perfObject, instance,
                             ((PdhCounterWildcardProperty) prop).getCounter());
                     if (!pdhQueryHandler.addCounterToQuery(counter)) {
                         return new Pair<>(Collections.emptyList(), Collections.emptyMap());

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 The OSHI Project Contributors
+ * Copyright 2018-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.windows;
@@ -18,7 +18,6 @@ import com.sun.jna.platform.win32.WinDef.DWORDByReference;
 import com.sun.jna.platform.win32.WinError;
 import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
 
-import oshi.annotation.concurrent.Immutable;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseableLONGLONGByReference;
 import oshi.jna.Struct.CloseablePdhRawCounter;
@@ -41,86 +40,7 @@ public final class PerfDataUtil {
 
     private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
 
-    /**
-     * Encapsulates the three string components of a performance counter
-     */
-    @Immutable
-    public static class PerfCounter {
-        private final String object;
-        private final String instance;
-        private final String counter;
-        private final boolean baseCounter;
-
-        public PerfCounter(String objectName, String instanceName, String counterName) {
-            this.object = objectName;
-            this.instance = instanceName;
-            int baseIdx = counterName.indexOf("_Base");
-            if (baseIdx > 0) {
-                this.counter = counterName.substring(0, baseIdx);
-                this.baseCounter = true;
-            } else {
-                this.counter = counterName;
-                this.baseCounter = false;
-            }
-        }
-
-        /**
-         * @return Returns the object.
-         */
-        public String getObject() {
-            return object;
-        }
-
-        /**
-         * @return Returns the instance.
-         */
-        public String getInstance() {
-            return instance;
-        }
-
-        /**
-         * @return Returns the counter.
-         */
-        public String getCounter() {
-            return counter;
-        }
-
-        /**
-         * @return Returns whether the counter is a base counter
-         */
-        public boolean isBaseCounter() {
-            return baseCounter;
-        }
-
-        /**
-         * Returns the path for this counter
-         *
-         * @return A string representing the counter path
-         */
-        public String getCounterPath() {
-            StringBuilder sb = new StringBuilder();
-            sb.append('\\').append(object);
-            if (instance != null) {
-                sb.append('(').append(instance).append(')');
-            }
-            sb.append('\\').append(counter);
-            return sb.toString();
-        }
-    }
-
     private PerfDataUtil() {
-    }
-
-    /**
-     * Create a Performance Counter
-     *
-     * @param object   The object/path for the counter
-     * @param instance The instance of the counter, or null if no instance
-     * @param counter  The counter name
-     * @return A PerfCounter object encapsulating the object, instance, and counter
-     */
-    public static PerfCounter createCounter(String object, String instance, String counter) {
-        return new PerfCounter(object, instance, counter);
     }
 
     /**

--- a/oshi-core/src/test/java/oshi/driver/windows/registry/RegistryDriversTest.java
+++ b/oshi-core/src/test/java/oshi/driver/windows/registry/RegistryDriversTest.java
@@ -26,14 +26,14 @@ class RegistryDriversTest {
 
     @Test
     void testProcessPerformanceData() {
-        Map<Integer, ProcessPerfCounterBlock> processMap = ProcessPerformanceData.buildProcessMapFromRegistry(null);
+        Map<Integer, ProcessPerfCounterBlock> processMap = ProcessPerformanceDataJNA.buildProcessMapFromRegistry(null);
         assertNotNull(processMap);
         assertThat("Process map should not be empty", processMap, is(not(anEmptyMap())));
     }
 
     @Test
     void testThreadPerformanceData() {
-        Map<Integer, ThreadPerfCounterBlock> threadMap = ThreadPerformanceData.buildThreadMapFromRegistry(null);
+        Map<Integer, ThreadPerfCounterBlock> threadMap = ThreadPerformanceDataJNA.buildThreadMapFromRegistry(null);
         assertNotNull(threadMap);
         assertThat("Thread map should not be empty", threadMap, is(not(anEmptyMap())));
     }


### PR DESCRIPTION
## Summary

Extracts shared logic from the Windows performance counter, registry (HKEY_PERFORMANCE_DATA), and process/thread data driver classes into oshi-common, reducing duplication between the JNA (oshi-core) and FFM (oshi-core-java25) implementations.

## Changes

### New in oshi-common

- **`PerfCounter`** — Extracted from `PerfDataUtil.PerfCounter` inner class. Contains `_Base` suffix handling, counter path building, `BASE_SUFFIX` constant, and `isBase()`/`stripBaseSuffix()` helper methods.
- **`HkeyPerformanceDataUtil`** — Abstract base class with `HKEY_PERFORMANCE_TEXT`/`COUNTER` constants, `buildCounterIndexMap()` (parses alternating index/name pairs from registry), and `getCounterIndices()` (resolves enum counter names to indices).
- **`ProcessPerformanceData`** — Static utility with `buildProcessMapFromRegistry()` and `buildProcessMapFromPerfCounters()` that take pre-fetched data as parameters.
- **`ThreadPerformanceData`** — Same pattern for thread data.

### Renamed/refactored in oshi-core

- `HkeyPerformanceDataUtil` → `HkeyPerformanceDataUtilJNA` (extends common class)
- `ProcessPerformanceData` → `ProcessPerformanceDataJNA` (thin wrapper delegating to common class)
- `ThreadPerformanceData` → `ThreadPerformanceDataJNA` (thin wrapper delegating to common class)
- `PerfDataUtil` — Removed inner `PerfCounter` class, now imports from oshi-common
- Unified FILETIME conversion to `ParseUtil.filetimeToUtcMs()` (removing JNA `WinBase.FILETIME.filetimeToDate` dependency)

### Updated in oshi-core-java25

- `HkeyPerformanceDataUtilFFM` — Extends common class, removed duplicate `getCounterIndices()` and map-building logic
- `ProcessPerformanceDataFFM` / `ThreadPerformanceDataFFM` — Thin wrappers delegating to common class
- `PerfDataUtilFFM` — Uses `PerfCounter.isBase()`/`stripBaseSuffix()` helpers and shared constants instead of local duplicates

## Result

Net reduction of ~76 lines while improving code sharing. The common logic for parsing performance data is now in one place, making future maintenance easier and ensuring consistency between JNA and FFM implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated Windows perfmon and registry logic into shared common modules and moved platform-specific builders to use them.
* **New Features**
  * Added a standalone perf-counter abstraction with consistent path and base-counter handling.
  * Introduced JNA and FFM adapters and runtime flags to detect disabled Windows performance counters.
  * Exposed safer registry helper overloads for robust reads.
* **Tests / Changelog**
  * Updated tests and changelog to reflect these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->