### PR TITLE
Migrate Windows software OS classes to common/JNA/FFM pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [#3174](https://github.com/oshi/oshi/pull/3174): Migrate all remaining WMI drivers to common/JNA/FFM three-tier pattern - [@dbwiddis](https://github.com/dbwiddis).
 * [#3175](https://github.com/oshi/oshi/pull/3175): Migrate simple WMI-only Windows hardware classes (Baseboard, Firmware, ComputerSystem, Printer) to FFM - [@dbwiddis](https://github.com/dbwiddis).
 * [#3176](https://github.com/oshi/oshi/pull/3176): Migrate all remaining Windows hardware classes to FFM three-tier pattern (Sensors, GpuStats, GlobalMemory, VirtualMemory, LogicalVolumeGroup, SoundCard, NetworkIF, GraphicsCard, Display, UsbDevice, HWDiskStore, CentralProcessor) - [@dbwiddis](https://github.com/dbwiddis).
+* [#3177](https://github.com/oshi/oshi/pull/3177): Migrate Windows software OS classes (OSProcess, OSThread, FileSystem, InstalledApps, InternetProtocolStats, NetworkParams) to FFM three-tier pattern - [@dbwiddis](https://github.com/dbwiddis).
 
 # 6.11.0 (2026-04-04), 6.11.1 (2026-04-07)
 

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/WtsInfo.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/WtsInfo.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.registry;
+
+/**
+ * Data holder for Windows Terminal Services (WTS) process information.
+ */
+public final class WtsInfo {
+
+    private final String name;
+    private final String path;
+    private final int threadCount;
+    private final long virtualSize;
+    private final long kernelTime;
+    private final long userTime;
+    private final long openFiles;
+
+    public WtsInfo(String name, String path, int threadCount, long virtualSize, long kernelTime, long userTime,
+            long openFiles) {
+        this.name = name;
+        this.path = path;
+        this.threadCount = threadCount;
+        this.virtualSize = virtualSize;
+        this.kernelTime = kernelTime;
+        this.userTime = userTime;
+        this.openFiles = openFiles;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the path
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * @return the threadCount
+     */
+    public int getThreadCount() {
+        return threadCount;
+    }
+
+    /**
+     * @return the virtualSize
+     */
+    public long getVirtualSize() {
+        return virtualSize;
+    }
+
+    /**
+     * @return the kernelTime
+     */
+    public long getKernelTime() {
+        return kernelTime;
+    }
+
+    /**
+     * @return the userTime
+     */
+    public long getUserTime() {
+        return userTime;
+    }
+
+    /**
+     * @return the openFiles
+     */
+    public long getOpenFiles() {
+        return openFiles;
+    }
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.windows;
+package oshi.software.common.os.windows;
 
 import static oshi.software.os.OSProcess.State.INVALID;
 import static oshi.software.os.OSProcess.State.RUNNING;
@@ -17,23 +17,15 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
-import oshi.driver.common.windows.wmi.Win32Process.CommandLineProperty;
-import oshi.driver.windows.registry.ProcessPerformanceDataJNA;
-import oshi.driver.windows.registry.ProcessWtsData;
-import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
-import oshi.driver.windows.registry.ThreadPerformanceDataJNA;
-import oshi.driver.windows.wmi.Win32ProcessCachedJNA;
-import oshi.driver.windows.wmi.Win32ProcessJNA;
+import oshi.driver.common.windows.registry.WtsInfo;
 import oshi.software.common.AbstractOSProcess;
 import oshi.software.os.OSThread;
+import oshi.software.os.OperatingSystem;
 import oshi.util.Constants;
 import oshi.util.GlobalConfig;
-import oshi.util.platform.windows.WmiUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
@@ -43,13 +35,23 @@ import oshi.util.tuples.Triplet;
 @ThreadSafe
 public abstract class WindowsOSProcess extends AbstractOSProcess {
 
+    // See https://blogs.technet.microsoft.com/markrussinovich/2009/09/29/pushing-the-limits-of-windows-handles/
+    protected static final long MAX_WINDOWS_HANDLES;
+    static {
+        if (System.getenv("ProgramFiles(x86)") == null) {
+            MAX_WINDOWS_HANDLES = 16_777_216L - 32_768L;
+        } else {
+            MAX_WINDOWS_HANDLES = 16_777_216L - 65_536L;
+        }
+    }
+
     protected static final boolean USE_BATCH_COMMANDLINE = GlobalConfig
             .get(GlobalConfig.OSHI_OS_WINDOWS_COMMANDLINE_BATCH, false);
 
     protected static final boolean USE_PROCSTATE_SUSPENDED = GlobalConfig
             .get(GlobalConfig.OSHI_OS_WINDOWS_PROCSTATE_SUSPENDED, false);
 
-    private final WindowsOperatingSystem os;
+    private final OperatingSystem os;
 
     private Supplier<Pair<String, String>> userInfo = memoize(this::queryUserInfo);
     private Supplier<Pair<String, String>> groupInfo = memoize(this::queryGroupInfo);
@@ -79,7 +81,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     private int bitness;
     private long pageFaults;
 
-    protected WindowsOSProcess(int pid, WindowsOperatingSystem os, Map<Integer, ProcessPerfCounterBlock> processMap,
+    protected WindowsOSProcess(int pid, OperatingSystem os, Map<Integer, ProcessPerfCounterBlock> processMap,
             Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
         super(pid);
         this.os = os;
@@ -89,11 +91,11 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     }
 
     /**
-     * Returns the {@link WindowsOperatingSystem} instance associated with this process.
+     * Returns the {@link OperatingSystem} instance associated with this process.
      *
      * @return the operating system instance
      */
-    protected WindowsOperatingSystem getOs() {
+    protected OperatingSystem getOs() {
         return this.os;
     }
 
@@ -240,12 +242,12 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
 
     @Override
     public long getSoftOpenFileLimit() {
-        return WindowsFileSystem.MAX_WINDOWS_HANDLES;
+        return MAX_WINDOWS_HANDLES;
     }
 
     @Override
     public long getHardOpenFileLimit() {
-        return WindowsFileSystem.MAX_WINDOWS_HANDLES;
+        return MAX_WINDOWS_HANDLES;
     }
 
     @Override
@@ -263,28 +265,25 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
         Map<Integer, ThreadPerfCounterBlock> threads = tcb == null
                 ? queryMatchingThreads(Collections.singleton(this.getProcessID()))
                 : tcb;
+        if (threads == null) {
+            threads = Collections.emptyMap();
+        }
         return threads.entrySet().stream().parallel()
                 .filter(entry -> entry.getValue().getOwningProcessID() == this.getProcessID())
-                .map(entry -> new WindowsOSThread(getProcessID(), entry.getKey(), this.name, entry.getValue()))
+                .map(entry -> createOSThread(getProcessID(), entry.getKey(), this.name, entry.getValue()))
                 .collect(Collectors.toList());
     }
 
-    @Override
-    public boolean updateAttributes() {
-        Set<Integer> pids = Collections.singleton(this.getProcessID());
-        // Get data from the registry if possible
-        Map<Integer, ProcessPerfCounterBlock> pcb = ProcessPerformanceDataJNA.buildProcessMapFromRegistry(pids);
-        // otherwise performance counters with WMI backup
-        if (pcb == null) {
-            pcb = ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(pids);
-        }
-        if (USE_PROCSTATE_SUSPENDED) {
-            this.tcb = queryMatchingThreads(pids);
-        }
-        Map<Integer, WtsInfo> wts = ProcessWtsData.queryProcessWtsMap(pids);
-        return updateAttributes(pcb == null ? null : pcb.get(this.getProcessID()),
-                wts == null ? null : wts.get(this.getProcessID()));
-    }
+    /**
+     * Creates a platform-specific OS thread instance.
+     *
+     * @param pid      the owning process ID
+     * @param tid      the thread ID
+     * @param procName the process name
+     * @param pcb      the thread performance counter block
+     * @return a new OSThread instance
+     */
+    protected abstract OSThread createOSThread(int pid, int tid, String procName, ThreadPerfCounterBlock pcb);
 
     /**
      * Updates process attributes from performance counter and WTS data, then performs native-specific updates.
@@ -337,6 +336,15 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     }
 
     /**
+     * Sets the process name. Used by subclasses to ensure the name is current before querying threads.
+     *
+     * @param name the process name to set
+     */
+    protected void setName(String name) {
+        this.name = name;
+    }
+
+    /**
      * Sets the process bitness. Used by subclasses to update after WOW64 check.
      *
      * @param bitness the bitness to set
@@ -363,28 +371,29 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
         this.state = state;
     }
 
-    protected Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
-        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataJNA.buildThreadMapFromRegistry(pids);
-        if (threads == null) {
-            threads = ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
-        }
-        return threads;
+    /**
+     * Sets the thread counter block map. Used by subclasses during attribute updates.
+     *
+     * @param tcb the thread performance counter block map
+     */
+    protected void setTcb(Map<Integer, ThreadPerfCounterBlock> tcb) {
+        this.tcb = tcb;
     }
 
-    private String queryCommandLine() {
-        if (!cwdCmdEnv.get().getB().isEmpty()) {
-            return cwdCmdEnv.get().getB();
-        }
-        if (USE_BATCH_COMMANDLINE) {
-            return Win32ProcessCachedJNA.getInstance().getCommandLine(getProcessID(), getStartTime());
-        }
-        WmiResult<CommandLineProperty> commandLineProcs = Win32ProcessJNA
-                .queryCommandLines(Collections.singleton(getProcessID()));
-        if (commandLineProcs.getResultCount() > 0) {
-            return WmiUtil.getString(commandLineProcs, CommandLineProperty.COMMANDLINE, 0);
-        }
-        return "";
-    }
+    /**
+     * Queries thread performance data matching the given process IDs.
+     *
+     * @param pids the set of process IDs to match
+     * @return a map of thread ID to thread performance counter block
+     */
+    protected abstract Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids);
+
+    /**
+     * Queries the command line for this process.
+     *
+     * @return the command line string
+     */
+    protected abstract String queryCommandLine();
 
     /**
      * Queries the argument list for this process.

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSThread.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.windows;
+package oshi.software.common.os.windows;
 
 import static oshi.software.os.OSProcess.State.INVALID;
 import static oshi.software.os.OSProcess.State.NEW;
@@ -13,21 +13,16 @@ import static oshi.software.os.OSProcess.State.STOPPED;
 import static oshi.software.os.OSProcess.State.SUSPENDED;
 import static oshi.software.os.OSProcess.State.WAITING;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
-import oshi.driver.windows.registry.ThreadPerformanceDataJNA;
 import oshi.software.common.AbstractOSThread;
 import oshi.software.os.OSProcess.State;
 
 /**
- * OSThread implementation
+ * Common base class for Windows OS thread implementations.
  */
 @ThreadSafe
-public class WindowsOSThread extends AbstractOSThread {
+public abstract class WindowsOSThread extends AbstractOSThread {
 
     private final int threadId;
     private String name;
@@ -40,7 +35,7 @@ public class WindowsOSThread extends AbstractOSThread {
     private long upTime;
     private int priority;
 
-    public WindowsOSThread(int pid, int tid, String procName, ThreadPerfCounterBlock pcb) {
+    protected WindowsOSThread(int pid, int tid, String procName, ThreadPerfCounterBlock pcb) {
         super(pid);
         this.threadId = tid;
         updateAttributes(procName, pcb);
@@ -96,21 +91,28 @@ public class WindowsOSThread extends AbstractOSThread {
         return this.priority;
     }
 
-    @Override
-    public boolean updateAttributes() {
-        Set<Integer> pids = Collections.singleton(getOwningProcessId());
-        String procName = this.name.split("/")[0];
-        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids,
-                procName, getThreadId());
-        return updateAttributes(procName, threads == null ? null : threads.get(getThreadId()));
+    /**
+     * Returns the process name prefix used for thread name construction.
+     *
+     * @return the process name (portion before "/" in the thread name)
+     */
+    protected String getProcName() {
+        return this.name == null ? "" : this.name.split("/")[0];
     }
 
-    private boolean updateAttributes(String procName, ThreadPerfCounterBlock pcb) {
+    /**
+     * Updates thread attributes from a performance counter block.
+     *
+     * @param procName the owning process name
+     * @param pcb      the thread performance counter block, or null if unavailable
+     * @return true if the thread is valid after the update
+     */
+    protected boolean updateAttributes(String procName, ThreadPerfCounterBlock pcb) {
         if (pcb == null) {
             this.state = INVALID;
             return false;
-        } else if (pcb.getName().contains("/") || procName.isEmpty()) {
-            name = pcb.getName();
+        } else if (pcb.getName().contains("/") || procName == null || procName.isEmpty()) {
+            this.name = pcb.getName();
         } else {
             this.name = procName + "/" + pcb.getName();
         }

--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,15 +41,24 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
-import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
+import oshi.driver.common.windows.registry.WtsInfo;
+import oshi.driver.common.windows.wmi.Win32Process.CommandLineProperty;
+import oshi.driver.windows.registry.ProcessPerformanceDataFFM;
+import oshi.driver.windows.registry.ProcessWtsData;
+import oshi.driver.windows.registry.ThreadPerformanceDataFFM;
+import oshi.driver.windows.wmi.Win32ProcessCachedFFM;
+import oshi.driver.windows.wmi.Win32ProcessFFM;
 import oshi.ffm.windows.Advapi32FFM;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.ffm.windows.NtDllFFM;
 import oshi.ffm.windows.Shell32FFM;
 import oshi.ffm.windows.VersionHelpersFFM;
 import oshi.ffm.windows.WinErrorFFM;
+import oshi.software.common.os.windows.WindowsOSProcess;
+import oshi.software.os.OSThread;
 import oshi.util.Constants;
 import oshi.util.ParseUtil;
+import oshi.util.platform.windows.WmiUtilFFM;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
@@ -87,13 +97,32 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
     }
 
     @Override
+    public boolean updateAttributes() {
+        Set<Integer> pids = Collections.singleton(this.getProcessID());
+        // Get data from the registry if possible
+        Map<Integer, ProcessPerfCounterBlock> pcbMap = ProcessPerformanceDataFFM.buildProcessMapFromRegistry(pids);
+        // otherwise performance counters with WMI backup
+        if (pcbMap == null || pcbMap.isEmpty()) {
+            pcbMap = ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(pids);
+        }
+        ProcessPerfCounterBlock pcb = pcbMap == null ? null : pcbMap.get(this.getProcessID());
+        if (USE_PROCSTATE_SUSPENDED) {
+            // Populate name from pcb before querying threads, since the fallback path uses getName()
+            if (pcb != null) {
+                setName(pcb.getName());
+            }
+            setTcb(queryMatchingThreads(pids));
+        }
+        Map<Integer, WtsInfo> wts = ProcessWtsData.queryProcessWtsMap(pids);
+        return updateAttributes(pcb, wts == null ? null : wts.get(this.getProcessID()));
+    }
+
+    @Override
     protected boolean updateAttributes(ProcessPerfCounterBlock pcb, WtsInfo wts) {
         if (!super.updateAttributes(pcb, wts)) {
             return false;
         }
 
-        // Get a handle to the process for various extended info. Only gets
-        // current user unless running as administrator
         Optional<MemorySegment> pHandleOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION, false, getProcessID());
         if (pHandleOpt.isPresent()) {
             MemorySegment pHandle = pHandleOpt.get();
@@ -111,7 +140,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                     if (pathOpt.isPresent()) {
                         setPath(pathOpt.get());
                     }
-                    // Don't set INVALID on path failure - process is still valid
                 }
             } finally {
                 Kernel32FFM.CloseHandle(pHandle);
@@ -119,6 +147,36 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
         }
 
         return !getState().equals(State.INVALID);
+    }
+
+    @Override
+    protected OSThread createOSThread(int pid, int tid, String procName, ThreadPerfCounterBlock pcb) {
+        return new WindowsOSThreadFFM(pid, tid, procName, pcb);
+    }
+
+    @Override
+    protected Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
+        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataFFM.buildThreadMapFromRegistry(pids);
+        if (threads == null || threads.isEmpty()) {
+            threads = ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
+        }
+        return threads;
+    }
+
+    @Override
+    protected String queryCommandLine() {
+        String cwdCmdEnvB = getCwdCmdEnv().getB();
+        if (!cwdCmdEnvB.isEmpty()) {
+            return cwdCmdEnvB;
+        }
+        if (USE_BATCH_COMMANDLINE) {
+            return Win32ProcessCachedFFM.getInstance().getCommandLine(getProcessID(), getStartTime());
+        }
+        var commandLineProcs = Win32ProcessFFM.queryCommandLines(Collections.singleton(getProcessID()));
+        if (commandLineProcs.getResultCount() > 0) {
+            return WmiUtilFFM.getString(commandLineProcs, CommandLineProperty.COMMANDLINE, 0);
+        }
+        return "";
     }
 
     @Override
@@ -144,7 +202,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                     pair = getTokenAccountInfo(hToken, TokenUser, arena);
                 } else {
                     int error = Kernel32FFM.GetLastError().orElse(0);
-                    // Access denied errors are common. Fail silently.
                     if (error != WinErrorFFM.ERROR_ACCESS_DENIED) {
                         LOG.error("Failed to get process token for process {}: {}", getProcessID(), error);
                     }
@@ -176,7 +233,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                     pair = getTokenAccountInfo(hToken, TokenPrimaryGroup, arena);
                 } else {
                     int error = Kernel32FFM.GetLastError().orElse(0);
-                    // Access denied errors are common. Fail silently.
                     if (error != WinErrorFFM.ERROR_ACCESS_DENIED) {
                         LOG.error("Failed to get process token for process {}: {}", getProcessID(), error);
                     }
@@ -196,7 +252,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
 
     private Pair<String, String> getTokenAccountInfo(MemorySegment hToken, int tokenInfoClass, Arena arena)
             throws Throwable {
-        // First call to get required size
         MemorySegment returnLength = arena.allocate(JAVA_INT);
         Advapi32FFM.GetTokenInformation(hToken, tokenInfoClass, MemorySegment.NULL, 0, returnLength);
 
@@ -210,14 +265,11 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
             return null;
         }
 
-        // TOKEN_USER and TOKEN_PRIMARY_GROUP both start with a SID_AND_ATTRIBUTES structure
-        // which contains a pointer to the SID at offset 0
         MemorySegment sidPtr = tokenInfo.get(ADDRESS, 0);
         if (sidPtr.address() == 0) {
             return null;
         }
 
-        // Get account name
         int maxNameLen = 256;
         MemorySegment nameBuffer = arena.allocate(JAVA_CHAR, maxNameLen);
         MemorySegment nameLen = arena.allocate(JAVA_INT);
@@ -235,14 +287,12 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
             accountName = readWideString(nameBuffer);
         }
 
-        // Get SID string
         String sidString = Constants.UNKNOWN;
         MemorySegment sidStringPtr = arena.allocate(ADDRESS);
         if (Advapi32FFM.ConvertSidToStringSid(sidPtr, sidStringPtr)) {
             MemorySegment strPtr = sidStringPtr.get(ADDRESS, 0);
             if (strPtr.address() != 0) {
                 sidString = readWideString(strPtr.reinterpret(512));
-                // Free the buffer allocated by ConvertSidToStringSid
                 Kernel32FFM.LocalFree(strPtr);
             }
         }
@@ -257,9 +307,7 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
         if (hOpt.isPresent()) {
             MemorySegment h = hOpt.get();
             try (Arena arena = Arena.ofConfined()) {
-                // Can't check 32-bit procs from a 64-bit one
                 if (WindowsOperatingSystem.isX86() == isWow(h, arena)) {
-                    // Start by getting the address of the PEB
                     MemorySegment pbi = arena.allocate(PROCESS_BASIC_INFORMATION_STRUCT);
                     MemorySegment nRead = arena.allocate(JAVA_INT);
 
@@ -274,7 +322,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                         return defaultCwdCommandlineEnvironment();
                     }
 
-                    // Now fetch the PEB
                     MemorySegment peb = arena.allocate(PEB);
                     MemorySegment bytesRead = arena.allocate(JAVA_LONG);
                     if (!Kernel32FFM.ReadProcessMemory(h, pebAddress, peb, PEB.byteSize(), bytesRead)) {
@@ -289,7 +336,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                         return defaultCwdCommandlineEnvironment();
                     }
 
-                    // Now fetch the Process Parameters structure containing our data
                     MemorySegment upp = arena.allocate(RTL_USER_PROCESS_PARAMETERS);
                     if (!Kernel32FFM.ReadProcessMemory(h, processParamsAddress, upp,
                             RTL_USER_PROCESS_PARAMETERS.byteSize(), bytesRead)) {
@@ -299,7 +345,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                         return defaultCwdCommandlineEnvironment();
                     }
 
-                    // Get CWD and Command Line strings here
                     MemorySegment cwdUnicodeString = upp.asSlice(UPP_CURRENT_DIRECTORY_OFFSET,
                             UNICODE_STRING.byteSize());
                     String cwd = readUnicodeString(h, cwdUnicodeString, arena);
@@ -308,7 +353,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                             UNICODE_STRING.byteSize());
                     String cl = readUnicodeString(h, cmdLineUnicodeString, arena);
 
-                    // Fetch the Environment Strings
                     long envSize = upp.get(JAVA_LONG, UPP_ENVIRONMENT_SIZE_OFFSET);
                     if (envSize > 0 && envSize < Integer.MAX_VALUE) {
                         MemorySegment envAddress = upp.get(ADDRESS, UPP_ENVIRONMENT_OFFSET);
@@ -321,7 +365,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                                         env[i] = envBuffer.get(JAVA_CHAR, (long) i * 2);
                                     }
                                     Map<String, String> envMap = ParseUtil.parseCharArrayToStringMap(env);
-                                    // First entry in Environment is "=::=::\"
                                     envMap.remove("");
                                     return new Triplet<>(cwd, cl, Collections.unmodifiableMap(envMap));
                                 }

--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOSThreadFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOSThreadFFM.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.windows;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
+import oshi.driver.windows.registry.ThreadPerformanceDataFFM;
+
+/**
+ * FFM-based Windows OS thread implementation.
+ */
+@ThreadSafe
+public class WindowsOSThreadFFM extends oshi.software.common.os.windows.WindowsOSThread {
+
+    public WindowsOSThreadFFM(int pid, int tid, String procName, ThreadPerfCounterBlock pcb) {
+        super(pid, tid, procName, pcb);
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        Set<Integer> pids = Collections.singleton(getOwningProcessId());
+        String procName = getProcName();
+        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids,
+                procName, getThreadId());
+        return updateAttributes(procName, threads == null ? null : threads.get(getThreadId()));
+    }
+}

--- a/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-java25/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -30,9 +30,9 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
+import oshi.driver.common.windows.registry.WtsInfo;
 import oshi.driver.windows.registry.ProcessPerformanceDataFFM;
 import oshi.driver.windows.registry.ProcessWtsData;
-import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
 import oshi.driver.windows.registry.ThreadPerformanceDataFFM;
 import oshi.ffm.windows.Advapi32FFM;
 import oshi.ffm.windows.Kernel32FFM;
@@ -43,6 +43,7 @@ import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
+import oshi.software.os.OSThread;
 import oshi.util.GlobalConfig;
 import oshi.util.Memoizer;
 import oshi.util.platform.windows.Advapi32UtilFFM;
@@ -176,6 +177,17 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     @Override
     public int getThreadId() {
         return Kernel32FFM.GetCurrentThreadId().orElse(-1);
+    }
+
+    @Override
+    public OSThread getCurrentThread() {
+        final int tid = getThreadId();
+        OSProcess proc = getCurrentProcess();
+        if (proc == null) {
+            return new WindowsOSThreadFFM(0, tid, null, null);
+        }
+        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
+                .orElseGet(() -> new WindowsOSThreadFFM(proc.getProcessID(), tid, null, null));
     }
 
     private static final boolean USE_PROCSTATE_SUSPENDED = GlobalConfig

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessWtsData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessWtsData.java
@@ -18,8 +18,8 @@ import com.sun.jna.platform.win32.VersionHelpers;
 import com.sun.jna.platform.win32.Wtsapi32;
 import com.sun.jna.platform.win32.Wtsapi32.WTS_PROCESS_INFO_EX;
 
-import oshi.annotation.concurrent.Immutable;
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.registry.WtsInfo;
 import oshi.driver.common.windows.wmi.Win32Process.ProcessXPProperty;
 import oshi.driver.windows.wmi.Win32ProcessJNA;
 import oshi.jna.ByRef.CloseableIntByReference;
@@ -103,77 +103,4 @@ public final class ProcessWtsData {
         return wtsMap;
     }
 
-    /**
-     * Class to encapsulate data from WTS Process Info
-     */
-    @Immutable
-    public static class WtsInfo {
-        private final String name;
-        private final String path;
-        private final int threadCount;
-        private final long virtualSize;
-        private final long kernelTime;
-        private final long userTime;
-        private final long openFiles;
-
-        public WtsInfo(String name, String path, int threadCount, long virtualSize, long kernelTime, long userTime,
-                long openFiles) {
-            this.name = name;
-            this.path = path;
-            this.threadCount = threadCount;
-            this.virtualSize = virtualSize;
-            this.kernelTime = kernelTime;
-            this.userTime = userTime;
-            this.openFiles = openFiles;
-        }
-
-        /**
-         * @return the name
-         */
-        public String getName() {
-            return name;
-        }
-
-        /**
-         * @return the path
-         */
-        public String getPath() {
-            return path;
-        }
-
-        /**
-         * @return the threadCount
-         */
-        public int getThreadCount() {
-            return threadCount;
-        }
-
-        /**
-         * @return the virtualSize
-         */
-        public long getVirtualSize() {
-            return virtualSize;
-        }
-
-        /**
-         * @return the kernelTime
-         */
-        public long getKernelTime() {
-            return kernelTime;
-        }
-
-        /**
-         * @return the userTime
-         */
-        public long getUserTime() {
-            return userTime;
-        }
-
-        /**
-         * @return the openFiles
-         */
-        public long getOpenFiles() {
-            return openFiles;
-        }
-    }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
@@ -34,7 +34,7 @@ import oshi.util.platform.windows.WmiUtil;
  * represented by a drive letter, e.g., "A:\" and "C:\"
  */
 @ThreadSafe
-public class WindowsFileSystem extends AbstractFileSystem {
+public class WindowsFileSystemJNA extends AbstractFileSystem {
 
     private static final int BUFSIZE = 255;
 
@@ -91,12 +91,11 @@ public class WindowsFileSystem extends AbstractFileSystem {
     }
 
     /**
-     * <p>
-     * Constructor for WindowsFileSystem.
-     * </p>
+     * Constructor for WindowsFileSystemJNA. Sets the Windows error mode via
+     * {@code Kernel32.INSTANCE.SetErrorMode(SEM_FAILCRITICALERRORS)} to suppress system prompts for floppy/CD-ROM
+     * drives that have no media.
      */
-    public WindowsFileSystem() {
-        // Set error mode to fail rather than prompt for FLoppy/CD-Rom
+    public WindowsFileSystemJNA() {
         Kernel32.INSTANCE.SetErrorMode(SEM_FAILCRITICALERRORS);
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInstalledAppsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInstalledAppsJNA.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2025 The OSHI Project Contributors
+ * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.windows;
 
+import java.util.List;
+
 import oshi.driver.windows.registry.InstalledAppsData;
 import oshi.software.os.ApplicationInfo;
 
-import java.util.List;
+public final class WindowsInstalledAppsJNA {
 
-public final class WindowsInstalledApps {
-
-    private WindowsInstalledApps() {
+    private WindowsInstalledAppsJNA() {
     }
 
     public static List<ApplicationInfo> queryInstalledApps() {

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsJNA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.windows;
@@ -49,7 +49,7 @@ import oshi.util.ParseUtil;
  * Internet Protocol Stats implementation
  */
 @ThreadSafe
-public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats {
+public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolStats {
 
     private static final IPHlpAPI IPHLP = IPHlpAPI.INSTANCE;
 
@@ -218,31 +218,31 @@ public class WindowsInternetProtocolStats extends AbstractInternetProtocolStats 
 
     private static TcpState stateLookup(int state) {
         switch (state) {
-        case 1:
-        case 12:
-            return CLOSED;
-        case 2:
-            return LISTEN;
-        case 3:
-            return SYN_SENT;
-        case 4:
-            return SYN_RECV;
-        case 5:
-            return ESTABLISHED;
-        case 6:
-            return FIN_WAIT_1;
-        case 7:
-            return FIN_WAIT_2;
-        case 8:
-            return CLOSE_WAIT;
-        case 9:
-            return CLOSING;
-        case 10:
-            return LAST_ACK;
-        case 11:
-            return TIME_WAIT;
-        default:
-            return UNKNOWN;
+            case 1:
+            case 12:
+                return CLOSED;
+            case 2:
+                return LISTEN;
+            case 3:
+                return SYN_SENT;
+            case 4:
+                return SYN_RECV;
+            case 5:
+                return ESTABLISHED;
+            case 6:
+                return FIN_WAIT_1;
+            case 7:
+                return FIN_WAIT_2;
+            case 8:
+                return CLOSE_WAIT;
+            case 9:
+                return CLOSING;
+            case 10:
+                return LAST_ACK;
+            case 11:
+                return TIME_WAIT;
+            default:
+                return UNKNOWN;
         }
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParamsJNA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 The OSHI Project Contributors
+ * Copyright 2017-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.software.os.windows;
@@ -28,12 +28,12 @@ import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 /**
- * WindowsNetworkParams class.
+ * WindowsNetworkParamsJNA class.
  */
 @ThreadSafe
-final class WindowsNetworkParams extends AbstractNetworkParams {
+final class WindowsNetworkParamsJNA extends AbstractNetworkParams {
 
-    private static final Logger LOG = LoggerFactory.getLogger(WindowsNetworkParams.class);
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsNetworkParamsJNA.class);
 
     private static final int COMPUTER_NAME_DNS_DOMAIN_FULLY_QUALIFIED = 3;
 

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSFileStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSFileStoreJNA.java
@@ -28,11 +28,11 @@ public class WindowsOSFileStoreJNA extends WindowsOSFileStore {
         // Check if we have the volume locally
         List<OSFileStore> volumes;
         if (isLocal()) {
-            volumes = WindowsFileSystem.getLocalVolumes(getVolume());
+            volumes = WindowsFileSystemJNA.getLocalVolumes(getVolume());
         } else {
             // Not locally, search WMI
             String nameToMatch = getMount().length() < 2 ? null : getMount().substring(0, 2);
-            volumes = WindowsFileSystem.getWmiVolumes(nameToMatch, false);
+            volumes = WindowsFileSystemJNA.getWmiVolumes(nameToMatch, false);
         }
         for (OSFileStore fileStore : volumes) {
             if (getVolume().equals(fileStore.getVolume()) && getMount().equals(fileStore.getMount())) {

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +18,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.Advapi32;
 import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.Advapi32Util.Account;
+import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.Kernel32Util;
 import com.sun.jna.platform.win32.Shell32Util;
@@ -29,13 +31,22 @@ import com.sun.jna.platform.win32.WinNT.HANDLE;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
-import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
+import oshi.driver.common.windows.registry.WtsInfo;
+import oshi.driver.common.windows.wmi.Win32Process.CommandLineProperty;
+import oshi.driver.windows.registry.ProcessPerformanceDataJNA;
+import oshi.driver.windows.registry.ProcessWtsData;
+import oshi.driver.windows.registry.ThreadPerformanceDataJNA;
+import oshi.driver.windows.wmi.Win32ProcessCachedJNA;
+import oshi.driver.windows.wmi.Win32ProcessJNA;
 import oshi.jna.ByRef.CloseableHANDLEByReference;
 import oshi.jna.ByRef.CloseableIntByReference;
 import oshi.jna.ByRef.CloseableULONGptrByReference;
 import oshi.jna.platform.windows.NtDll;
 import oshi.jna.platform.windows.NtDll.UNICODE_STRING;
+import oshi.software.common.os.windows.WindowsOSProcess;
+import oshi.software.os.OSThread;
 import oshi.util.ParseUtil;
+import oshi.util.platform.windows.WmiUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
@@ -72,6 +83,27 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
     }
 
     @Override
+    public boolean updateAttributes() {
+        Set<Integer> pids = Collections.singleton(this.getProcessID());
+        // Get data from the registry if possible
+        Map<Integer, ProcessPerfCounterBlock> pcbMap = ProcessPerformanceDataJNA.buildProcessMapFromRegistry(pids);
+        // otherwise performance counters with WMI backup
+        if (pcbMap == null || pcbMap.isEmpty()) {
+            pcbMap = ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(pids);
+        }
+        ProcessPerfCounterBlock pcb = pcbMap == null ? null : pcbMap.get(this.getProcessID());
+        if (USE_PROCSTATE_SUSPENDED) {
+            // Populate name from pcb before querying threads, since the fallback path uses getName()
+            if (pcb != null) {
+                setName(pcb.getName());
+            }
+            setTcb(queryMatchingThreads(pids));
+        }
+        Map<Integer, WtsInfo> wts = ProcessWtsData.queryProcessWtsMap(pids);
+        return updateAttributes(pcb, wts == null ? null : wts.get(this.getProcessID()));
+    }
+
+    @Override
     protected boolean updateAttributes(ProcessPerfCounterBlock pcb, WtsInfo wts) {
         if (!super.updateAttributes(pcb, wts)) {
             return false;
@@ -101,6 +133,37 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
         }
 
         return !getState().equals(State.INVALID);
+    }
+
+    @Override
+    protected OSThread createOSThread(int pid, int tid, String procName, ThreadPerfCounterBlock pcb) {
+        return new WindowsOSThreadJNA(pid, tid, procName, pcb);
+    }
+
+    @Override
+    protected Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
+        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataJNA.buildThreadMapFromRegistry(pids);
+        if (threads == null || threads.isEmpty()) {
+            threads = ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
+        }
+        return threads;
+    }
+
+    @Override
+    protected String queryCommandLine() {
+        String cwdCmd = getCwdCmdEnv().getB();
+        if (!cwdCmd.isEmpty()) {
+            return cwdCmd;
+        }
+        if (USE_BATCH_COMMANDLINE) {
+            return Win32ProcessCachedJNA.getInstance().getCommandLine(getProcessID(), getStartTime());
+        }
+        WmiResult<CommandLineProperty> commandLineProcs = Win32ProcessJNA
+                .queryCommandLines(Collections.singleton(getProcessID()));
+        if (commandLineProcs.getResultCount() > 0) {
+            return WmiUtil.getString(commandLineProcs, CommandLineProperty.COMMANDLINE, 0);
+        }
+        return "";
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThreadJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThreadJNA.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.windows;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
+import oshi.driver.windows.registry.ThreadPerformanceDataJNA;
+
+/**
+ * JNA-based Windows OS thread implementation.
+ */
+@ThreadSafe
+public class WindowsOSThreadJNA extends oshi.software.common.os.windows.WindowsOSThread {
+
+    public WindowsOSThreadJNA(int pid, int tid, String procName, ThreadPerfCounterBlock pcb) {
+        super(pid, tid, procName, pcb);
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        Set<Integer> pids = Collections.singleton(getOwningProcessId());
+        String procName = getProcName();
+        Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids,
+                procName, getThreadId());
+        return updateAttributes(procName, threads == null ? null : threads.get(getThreadId()));
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -50,6 +50,7 @@ import com.sun.jna.platform.win32.Winsvc;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
+import oshi.driver.common.windows.registry.WtsInfo;
 import oshi.driver.common.windows.wmi.Win32OperatingSystem.OSVersionProperty;
 import oshi.driver.common.windows.wmi.Win32Processor.BitnessProperty;
 import oshi.driver.windows.EnumWindows;
@@ -57,7 +58,6 @@ import oshi.driver.windows.registry.HkeyUserData;
 import oshi.driver.windows.registry.NetSessionData;
 import oshi.driver.windows.registry.ProcessPerformanceDataJNA;
 import oshi.driver.windows.registry.ProcessWtsData;
-import oshi.driver.windows.registry.ProcessWtsData.WtsInfo;
 import oshi.driver.windows.registry.SessionWtsData;
 import oshi.driver.windows.registry.ThreadPerformanceDataJNA;
 import oshi.driver.windows.wmi.Win32OperatingSystemJNA;
@@ -117,7 +117,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
     private static final boolean WOW = isCurrentWow();
 
     private final Supplier<List<ApplicationInfo>> installedAppsSupplier = Memoizer
-            .memoize(WindowsInstalledApps::queryInstalledApps, installedAppsExpiration());
+            .memoize(WindowsInstalledAppsJNA::queryInstalledApps, installedAppsExpiration());
 
     /*
      * Cache full process stats queries. Second query will only populate if first one returns null.
@@ -233,12 +233,12 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public FileSystem getFileSystem() {
-        return new WindowsFileSystem();
+        return new WindowsFileSystemJNA();
     }
 
     @Override
     public InternetProtocolStats getInternetProtocolStats() {
-        return new WindowsInternetProtocolStats();
+        return new WindowsInternetProtocolStatsJNA();
     }
 
     @Override
@@ -368,7 +368,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
         OSProcess proc = getCurrentProcess();
         final int tid = getThreadId();
         return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
-                .orElse(new WindowsOSThread(proc.getProcessID(), tid, null, null));
+                .orElse(new WindowsOSThreadJNA(proc.getProcessID(), tid, null, null));
     }
 
     @Override
@@ -443,7 +443,7 @@ public class WindowsOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public NetworkParams getNetworkParams() {
-        return new WindowsNetworkParams();
+        return new WindowsNetworkParamsJNA();
     }
 
     /**


### PR DESCRIPTION
## Summary

Migrates the remaining Windows software OS classes (OSThread, OSProcess, and supporting classes) to the three-tier common/JNA/FFM architecture pattern.

## Changes

### oshi-common (new/modified)
- **WindowsOSThread** (new): Abstract superclass with shared fields, getters, and state mapping logic
- **WindowsOSProcess** (new): Abstract superclass with shared process fields/getters and update logic; native-dependent methods are abstract
- **WtsInfo** (new): Standalone data holder extracted from ProcessWtsData inner class

### oshi-core (new/modified)
- **WindowsOSThreadJNA** (new): JNA implementation extending common WindowsOSThread
- **WindowsOSProcessJNA** (rewritten): Now extends common WindowsOSProcess, implements all abstract methods
- **WindowsFileSystem → WindowsFileSystemJNA** (renamed)
- **WindowsInstalledApps → WindowsInstalledAppsJNA** (renamed)
- **WindowsInternetProtocolStats → WindowsInternetProtocolStatsJNA** (renamed)
- **WindowsNetworkParams → WindowsNetworkParamsJNA** (renamed)
- Updated WindowsOperatingSystem and ProcessWtsData imports

### oshi-core-java25 (new/modified)
- **WindowsOSThreadFFM** (new): FFM implementation extending common WindowsOSThread
- **WindowsOSProcessFFM** (rewritten): Now extends common WindowsOSProcess, implements all abstract methods
- Added `getCurrentThread()` override to WindowsOperatingSystemFFM

## Smoke Test

Removing the `build-helper-maven-plugin` source copy from oshi-core-java25 now leaves only 5 remaining dependencies on oshi-core:
1. `WindowsOperatingSystem` — FFM extends it (needs common superclass extraction)
2. `ProcessWtsData` — JNA-dependent registry reader
3. `PlatformEnum` (deprecated) — can switch to `oshi.util.PlatformEnum`
4. `oshi.driver.mac.disk.Fsstat` — JNA-based
5. `oshi.driver.mac.net.NetStat` — JNA-based

## Testing
- All existing tests pass on macOS
- CI will validate Windows/Linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated Windows OS abstractions, unified JNA/FFM naming, and moved process/thread responsibilities into common base classes to support multiple native backends.
  * Renamed several Windows system utilities to JNA-specific variants for consistent behavior.

* **New Features**
  * Added a shared Windows Terminal Services (WTS) process info data holder.
  * Introduced JNA/FFM-specific process and thread implementations with improved current-thread handling and enhanced command-line/attribute retrieval using registry → WMI → perf-counter fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->