### PR TITLE
Add @PublicApi annotation to semver-guaranteed API types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [Upgrading](src/site/markdown/Upgrading.md) for breaking changes and migrati
 * [#3181](https://github.com/oshi/oshi/pull/3181): Merge `oshi-core-java11` into `oshi-core`; `oshi-core` now includes a module descriptor (`com.github.oshi`). A redirection pom is provided for the old `oshi-core-java11` artifact ID - [@dbwiddis](https://github.com/dbwiddis).
 * [#3182](https://github.com/oshi/oshi/pull/3182): Remove deprecated `OSProcess.getResidentSetSize()` (use `getResidentMemory()` or `getPrivateResidentMemory()`), `oshi.PlatformEnum` and `oshi.PlatformEnumFFM` (use `oshi.util.PlatformEnum`), `SystemInfo.getCurrentPlatform()` and `SystemInfoFFM` (use `oshi.util.PlatformEnum.getCurrentPlatform()` and `oshi.ffm.SystemInfo`), and misspelled `GlobalConfig` constants - [@dbwiddis](https://github.com/dbwiddis).
 
+##### New Features
+
+* [#3183](https://github.com/oshi/oshi/pull/3183): Add `@PublicApi` annotation to all SemVer-guaranteed API types in `oshi.hardware`, `oshi.software.os`, both `SystemInfo` entry points, and `PlatformEnum` - [@dbwiddis](https://github.com/dbwiddis).
+
 # 6.12.0 (2026-04-20)
 
 ##### New Features

--- a/oshi-common/src/main/java/oshi/annotation/PublicApi.java
+++ b/oshi-common/src/main/java/oshi/annotation/PublicApi.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated type is part of the OSHI public API. Public API types follow
+ * <a href="https://semver.org/">Semantic Versioning</a>: they are guaranteed to remain binary-compatible within the
+ * same major version.
+ * <p>
+ * Types <em>not</em> annotated with {@code @PublicApi} (such as platform-specific implementations, drivers, and utility
+ * classes) may change between minor releases.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface PublicApi {
+}

--- a/oshi-common/src/main/java/oshi/hardware/Baseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/Baseboard.java
@@ -4,11 +4,13 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
  * The Baseboard represents the system board, also called motherboard, logic board, etc.
  */
+@PublicApi
 @Immutable
 public interface Baseboard {
     /**

--- a/oshi-common/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/CentralProcessor.java
@@ -14,6 +14,7 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.os.OSProcess;
@@ -56,6 +57,7 @@ import oshi.util.Util;
  * of logical processors. A polling interval of at least one second is recommended.</li>
  * </ul>
  */
+@PublicApi
 @ThreadSafe
 public interface CentralProcessor {
 
@@ -402,6 +404,7 @@ public interface CentralProcessor {
      * Index of CPU tick counters in the {@link #getSystemCpuLoadTicks()} and {@link #getProcessorCpuLoadTicks()}
      * arrays.
      */
+    @PublicApi
     enum TickType {
         /**
          * CPU utilization that occurred while executing at the user level (application).
@@ -455,6 +458,7 @@ public interface CentralProcessor {
      * A class representing a Logical Processor and its replationship to physical processors, physical packages, and
      * logical groupings such as NUMA Nodes and Processor groups, useful for identifying processor topology.
      */
+    @PublicApi
     @Immutable
     class LogicalProcessor {
         private final int processorNumber;
@@ -561,6 +565,7 @@ public interface CentralProcessor {
      * A class representing a Physical Processor (a core) providing per-core statistics that may vary, particularly in
      * hybrid/modular processors.
      */
+    @PublicApi
     @Immutable
     class PhysicalProcessor {
         private final int physicalPackageNumber;
@@ -655,12 +660,14 @@ public interface CentralProcessor {
     /**
      * A class representing CPU Cache Memory.
      */
+    @PublicApi
     @Immutable
     class ProcessorCache {
 
         /**
          * The type of cache.
          */
+        @PublicApi
         public enum Type {
             UNIFIED, INSTRUCTION, DATA, TRACE;
 
@@ -763,6 +770,7 @@ public interface CentralProcessor {
      * A class encapsulating ghe CPU's identifier strings ,including name, vendor, stepping, model, and family
      * information (also called the signature of a CPU)
      */
+    @PublicApi
     @Immutable
     final class ProcessorIdentifier {
         private static final String OSHI_ARCHITECTURE_PROPERTIES = "oshi.architecture.properties";

--- a/oshi-common/src/main/java/oshi/hardware/ComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/ComputerSystem.java
@@ -4,12 +4,14 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
  * The ComputerSystem represents the physical hardware, of a computer system/product and includes BIOS/firmware and a
  * motherboard, logic board, etc.
  */
+@PublicApi
 @Immutable
 public interface ComputerSystem {
     /**

--- a/oshi-common/src/main/java/oshi/hardware/Display.java
+++ b/oshi-common/src/main/java/oshi/hardware/Display.java
@@ -4,11 +4,13 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
  * Display refers to the information regarding a video source and monitor identified by the EDID standard.
  */
+@PublicApi
 @Immutable
 public interface Display {
     /**

--- a/oshi-common/src/main/java/oshi/hardware/Firmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/Firmware.java
@@ -4,11 +4,13 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
  * The Firmware represents the low level BIOS or equivalent.
  */
+@PublicApi
 @Immutable
 public interface Firmware {
 

--- a/oshi-common/src/main/java/oshi/hardware/GlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/GlobalMemory.java
@@ -6,6 +6,7 @@ package oshi.hardware;
 
 import java.util.List;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -25,6 +26,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  *
  * For swap/virtual memory information, see {@link #getVirtualMemory()}.
  */
+@PublicApi
 @ThreadSafe
 public interface GlobalMemory {
     /**

--- a/oshi-common/src/main/java/oshi/hardware/GpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/GpuStats.java
@@ -4,6 +4,7 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -76,6 +77,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  * <p>
  * All methods are safe for concurrent use from multiple threads.
  */
+@PublicApi
 @ThreadSafe
 public interface GpuStats extends AutoCloseable {
 

--- a/oshi-common/src/main/java/oshi/hardware/GpuTicks.java
+++ b/oshi-common/src/main/java/oshi/hardware/GpuTicks.java
@@ -4,6 +4,7 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
@@ -25,6 +26,7 @@ import oshi.annotation.concurrent.Immutable;
  * natural starting value of a real counter, callers cannot distinguish "not available" from "counter just started" —
  * but the {@code dTotal > 0} guard in the utilization formula handles both cases correctly.
  */
+@PublicApi
 @Immutable
 public final class GpuTicks {
 

--- a/oshi-common/src/main/java/oshi/hardware/GraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/GraphicsCard.java
@@ -4,6 +4,7 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
@@ -28,6 +29,7 @@ import oshi.annotation.concurrent.Immutable;
  * For repeated polling, hold the session open across iterations to preserve internal delta state. See {@link GpuStats}
  * for a full polling example and details on which metrics require priming.
  */
+@PublicApi
 @Immutable
 public interface GraphicsCard {
 

--- a/oshi-common/src/main/java/oshi/hardware/HWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/HWDiskStore.java
@@ -6,6 +6,7 @@ package oshi.hardware;
 
 import java.util.List;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.os.OSFileStore;
 
@@ -39,6 +40,7 @@ import oshi.software.os.OSFileStore;
  * @see HWPartition
  * @see OSFileStore
  */
+@PublicApi
 @ThreadSafe
 public interface HWDiskStore {
 

--- a/oshi-common/src/main/java/oshi/hardware/HWPartition.java
+++ b/oshi-common/src/main/java/oshi/hardware/HWPartition.java
@@ -6,6 +6,7 @@ package oshi.hardware;
 
 import static oshi.util.Util.isBlank;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 import oshi.util.FormatUtil;
 
@@ -14,6 +15,7 @@ import oshi.util.FormatUtil;
  * separately. A partition appears in the operating system as a distinct "logical" disk that uses part of the actual
  * disk.
  */
+@PublicApi
 @Immutable
 public class HWPartition {
 

--- a/oshi-common/src/main/java/oshi/hardware/HardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/HardwareAbstractionLayer.java
@@ -7,11 +7,13 @@ package oshi.hardware;
 import java.util.Collections;
 import java.util.List;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
  * A hardware abstraction layer. Provides access to hardware items such as processors, memory, battery, and disks.
  */
+@PublicApi
 @ThreadSafe
 public interface HardwareAbstractionLayer {
 

--- a/oshi-common/src/main/java/oshi/hardware/LogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/LogicalVolumeGroup.java
@@ -7,6 +7,7 @@ package oshi.hardware;
 import java.util.Map;
 import java.util.Set;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
@@ -14,6 +15,7 @@ import oshi.annotation.concurrent.Immutable;
  * devices such as disks or partitions (physical volumes) into a storage pool, and subsequently allocating that space to
  * virtual partitions (logical volumes) as block devices accessible to the file system.
  */
+@PublicApi
 @Immutable
 public interface LogicalVolumeGroup {
     /**

--- a/oshi-common/src/main/java/oshi/hardware/NetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/NetworkIF.java
@@ -7,6 +7,7 @@ package oshi.hardware;
 import java.net.NetworkInterface;
 import java.util.Arrays;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -16,6 +17,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  * {@link #updateAttributes()} method may update attributes, including the time stamp, and should externally synchronize
  * such usage to ensure consistent calculations.
  */
+@PublicApi
 @ThreadSafe
 public interface NetworkIF {
 
@@ -311,6 +313,7 @@ public interface NetworkIF {
      * <p>
      * As described in RFC 2863.
      */
+    @PublicApi
     enum IfOperStatus {
         /**
          * Up and operational. Ready to pass packets.

--- a/oshi-common/src/main/java/oshi/hardware/PhysicalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/PhysicalMemory.java
@@ -4,6 +4,7 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 import oshi.util.FormatUtil;
 
@@ -11,6 +12,7 @@ import oshi.util.FormatUtil;
  * The PhysicalMemory class represents a physical memory device located on a computer system and available to the
  * operating system.
  */
+@PublicApi
 @Immutable
 public class PhysicalMemory {
 

--- a/oshi-common/src/main/java/oshi/hardware/PowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/PowerSource.java
@@ -6,16 +6,19 @@ package oshi.hardware;
 
 import java.time.LocalDate;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
  * The Power Source is one or more batteries with some capacity, and some state of charge/discharge
  */
+@PublicApi
 @ThreadSafe
 public interface PowerSource {
     /**
      * Units of Battery Capacity
      */
+    @PublicApi
     enum CapacityUnits {
         /**
          * MilliWattHours (mWh).

--- a/oshi-common/src/main/java/oshi/hardware/Printer.java
+++ b/oshi-common/src/main/java/oshi/hardware/Printer.java
@@ -4,11 +4,13 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
  * Printer interface representing a printer device.
  */
+@PublicApi
 @Immutable
 public interface Printer {
 
@@ -71,6 +73,7 @@ public interface Printer {
     /**
      * Printer status enumeration.
      */
+    @PublicApi
     enum PrinterStatus {
         IDLE, PRINTING, ERROR, OFFLINE, UNKNOWN
     }

--- a/oshi-common/src/main/java/oshi/hardware/Sensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/Sensors.java
@@ -4,6 +4,7 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -22,6 +23,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  * if it is running. Otherwise, OSHI retrieves via the Microsoft API, which may require elevated permissions and still
  * may provide no results or unchanging results depending on the motherboard manufacturer.
  */
+@PublicApi
 @ThreadSafe
 public interface Sensors {
     /**

--- a/oshi-common/src/main/java/oshi/hardware/SoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/SoundCard.java
@@ -4,11 +4,13 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
  * SoundCard interface.
  */
+@PublicApi
 @Immutable
 public interface SoundCard {
 

--- a/oshi-common/src/main/java/oshi/hardware/UsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/UsbDevice.java
@@ -6,12 +6,14 @@ package oshi.hardware;
 
 import java.util.List;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
  * A USB device is a device connected via a USB port, possibly internally/permanently. Hubs may contain ports to which
  * other devices connect in a recursive fashion.
  */
+@PublicApi
 @Immutable
 public interface UsbDevice extends Comparable<UsbDevice> {
     /**

--- a/oshi-common/src/main/java/oshi/hardware/VirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/VirtualMemory.java
@@ -4,6 +4,7 @@
  */
 package oshi.hardware;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -28,6 +29,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  * These differences affect how to interpret the values returned by this interface, particularly
  * {@link #getVirtualMax()} and {@link #getVirtualInUse()}.
  */
+@PublicApi
 @ThreadSafe
 public interface VirtualMemory {
 

--- a/oshi-common/src/main/java/oshi/software/os/ApplicationInfo.java
+++ b/oshi-common/src/main/java/oshi/software/os/ApplicationInfo.java
@@ -9,11 +9,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import oshi.annotation.PublicApi;
+
 /**
  * Represents common information about an installed application across different operating systems. This class provides
  * standardized access to essential application details while allowing flexibility for OS-specific fields via an
  * additional information map.
  */
+@PublicApi
 public class ApplicationInfo {
 
     /** The name of the application. */

--- a/oshi-common/src/main/java/oshi/software/os/FileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/os/FileSystem.java
@@ -6,12 +6,14 @@ package oshi.software.os;
 
 import java.util.List;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
  * The File System is a logical arrangement, usually in a hierarchial tree, where files are placed for storage and
  * retrieval. It may consist of one or more file stores.
  */
+@PublicApi
 @ThreadSafe
 public interface FileSystem {
 

--- a/oshi-common/src/main/java/oshi/software/os/InternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/os/InternetProtocolStats.java
@@ -9,12 +9,14 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
  * Includes key statistics of TCP and UDP protocols
  */
+@PublicApi
 @ThreadSafe
 public interface InternetProtocolStats {
 
@@ -61,6 +63,7 @@ public interface InternetProtocolStats {
     /**
      * Encapsulates statistics associated with a TCP connection.
      */
+    @PublicApi
     @Immutable
     final class TcpStats {
         private final long connectionsEstablished;
@@ -203,6 +206,7 @@ public interface InternetProtocolStats {
     /**
      * Encapsulates statistics associated with a UDP connection.
      */
+    @PublicApi
     @Immutable
     final class UdpStats {
         private final long datagramsSent;
@@ -267,6 +271,7 @@ public interface InternetProtocolStats {
     /**
      * The TCP connection state as described in RFC 793.
      */
+    @PublicApi
     enum TcpState {
         UNKNOWN, CLOSED, LISTEN, SYN_SENT, SYN_RECV, ESTABLISHED, FIN_WAIT_1, FIN_WAIT_2, CLOSE_WAIT, CLOSING, LAST_ACK,
         TIME_WAIT, NONE;
@@ -275,6 +280,7 @@ public interface InternetProtocolStats {
     /**
      * Encapsulates information associated with an IP connection.
      */
+    @PublicApi
     @Immutable
     final class IPConnection {
         private final String type;

--- a/oshi-common/src/main/java/oshi/software/os/NetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/os/NetworkParams.java
@@ -4,11 +4,13 @@
  */
 package oshi.software.os;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
  * NetworkParams presents network parameters of running OS, such as DNS, host name etc.
  */
+@PublicApi
 @ThreadSafe
 public interface NetworkParams {
 

--- a/oshi-common/src/main/java/oshi/software/os/OSDesktopWindow.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSDesktopWindow.java
@@ -6,11 +6,13 @@ package oshi.software.os;
 
 import java.awt.Rectangle;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
  * This class encapsulates information about a window on the operating system's GUI desktop
  */
+@PublicApi
 @Immutable
 public class OSDesktopWindow {
     private final long windowId;

--- a/oshi-common/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSFileStore.java
@@ -4,6 +4,7 @@
  */
 package oshi.software.os;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
@@ -20,6 +21,7 @@ import oshi.hardware.HWPartition;
  * @see HWDiskStore
  * @see HWPartition
  */
+@PublicApi
 @ThreadSafe
 public interface OSFileStore {
 

--- a/oshi-common/src/main/java/oshi/software/os/OSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSProcess.java
@@ -7,6 +7,7 @@ package oshi.software.os;
 import java.util.List;
 import java.util.Map;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -32,6 +33,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  * processes (consistent with {@code top} on Unix). To match the Windows Task Manager, which scales to the system,
  * divide by {@link oshi.hardware.CentralProcessor#getLogicalProcessorCount()}.
  */
+@PublicApi
 @ThreadSafe
 public interface OSProcess {
 
@@ -432,6 +434,7 @@ public interface OSProcess {
     /**
      * Process and Thread Execution States
      */
+    @PublicApi
     enum State {
         /**
          * Intermediate state in process creation

--- a/oshi-common/src/main/java/oshi/software/os/OSService.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSService.java
@@ -4,6 +4,7 @@
  */
 package oshi.software.os;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
@@ -13,6 +14,7 @@ import oshi.annotation.concurrent.Immutable;
  * This class is provided for information purposes only. Interpretation of the meaning of services is
  * platform-dependent.
  */
+@PublicApi
 @Immutable
 public class OSService {
 
@@ -23,6 +25,7 @@ public class OSService {
     /**
      * Service Execution States
      */
+    @PublicApi
     public enum State {
         RUNNING, STOPPED, OTHER
     }

--- a/oshi-common/src/main/java/oshi/software/os/OSSession.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSSession.java
@@ -10,11 +10,13 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
  * This class encapsulates information about users who are currently logged in to an operating system.
  */
+@PublicApi
 @Immutable
 public class OSSession {
     private static final DateTimeFormatter LOGIN_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm", Locale.ROOT);

--- a/oshi-common/src/main/java/oshi/software/os/OSThread.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSThread.java
@@ -6,16 +6,19 @@ package oshi.software.os;
 
 import java.util.function.Predicate;
 
+import oshi.annotation.PublicApi;
 import oshi.software.os.OSProcess.State;
 
 /**
  * Represents a Thread/Task on the operating system.
  */
+@PublicApi
 public interface OSThread {
 
     /**
      * Constants which may be used to filter Thread lists
      */
+    @PublicApi
     final class ThreadFiltering {
         private ThreadFiltering() {
         }

--- a/oshi-common/src/main/java/oshi/software/os/OperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/os/OperatingSystem.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.os.OSProcess.State;
@@ -25,6 +26,7 @@ import oshi.util.Util;
  * <p>
  * Considered thread safe, but see remarks for the {@link #getSessions()} method.
  */
+@PublicApi
 @ThreadSafe
 public interface OperatingSystem {
 
@@ -33,6 +35,7 @@ public interface OperatingSystem {
      * {@link #getChildProcesses(int, Predicate, Comparator, int)}, and
      * {@link #getDescendantProcesses(int, Predicate, Comparator, int)}.
      */
+    @PublicApi
     final class ProcessFiltering {
         private ProcessFiltering() {
         }
@@ -64,6 +67,7 @@ public interface OperatingSystem {
      * {@link #getChildProcesses(int, Predicate, Comparator, int)}, and
      * {@link #getDescendantProcesses(int, Predicate, Comparator, int)}.
      */
+    @PublicApi
     final class ProcessSorting {
         private ProcessSorting() {
         }
@@ -385,6 +389,7 @@ public interface OperatingSystem {
     /**
      * A class representing the Operating System version details.
      */
+    @PublicApi
     @Immutable
     class OSVersionInfo {
         private final String version;

--- a/oshi-common/src/main/java/oshi/util/PlatformEnum.java
+++ b/oshi-common/src/main/java/oshi/util/PlatformEnum.java
@@ -6,10 +6,13 @@ package oshi.util;
 
 import java.util.Locale;
 
+import oshi.annotation.PublicApi;
+
 /**
  * An enumeration of supported operating systems. The order of declaration matches the osType constants in the JNA
  * Platform class.
  */
+@PublicApi
 public enum PlatformEnum {
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
@@ -8,6 +8,7 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.function.Supplier;
 
+import oshi.annotation.PublicApi;
 import oshi.hardware.HardwareAbstractionLayer;
 import oshi.hardware.platform.linux.LinuxHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.mac.MacHardwareAbstractionLayerFFM;
@@ -57,6 +58,7 @@ import oshi.util.PlatformEnum;
  * All other imports ({@code oshi.hardware.*}, {@code oshi.software.os.*}) remain the same regardless of which entry
  * point is used. The API is identical; only the underlying native access mechanism differs.
  */
+@PublicApi
 public class SystemInfo {
 
     private static final String NOT_SUPPORTED = "Unsupported platform: " + PlatformEnum.getCurrentPlatform().getName();

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -8,6 +8,7 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.function.Supplier;
 
+import oshi.annotation.PublicApi;
 import oshi.hardware.HardwareAbstractionLayer;
 import oshi.hardware.platform.linux.LinuxHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.mac.MacHardwareAbstractionLayerJNA;
@@ -63,6 +64,7 @@ import oshi.util.PlatformEnum;
  * module alone and implement the OSHI interfaces without native calls. See the {@link oshi oshi package documentation}
  * for details.
  */
+@PublicApi
 public class SystemInfo {
 
     private static final String NOT_SUPPORTED = "Operating system not supported: ";


### PR DESCRIPTION
New `@PublicApi` annotation marks types whose API is guaranteed stable within a major version per [SemVer](https://semver.org/).

Applied to:
- All interfaces and classes in `oshi.hardware`
- All interfaces and classes in `oshi.software.os`
- Both `SystemInfo` entry points (JNA and FFM)
- `PlatformEnum`

Types *not* annotated (platform implementations, drivers, utilities) may change between minor releases.

This prepares for `japicmp-maven-plugin` enforcement post-7.0.0 release to automatically detect binary-incompatible changes to the public API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked numerous public types across hardware, OS, and system-info areas with a new Public API marker to indicate they are stable and covered by semantic versioning guarantees.
  * Clarifies which APIs are intended for public use and signals long-term binary/compatibility expectations for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->