### PR TITLE
Add JMH benchmarks for CPU ticks, memory, file stores, and network interfaces

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -75,3 +75,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: linux
+      - name: JMH Benchmarks (JNA vs FFM)
+        if: contains(matrix.java, '25')
+        run: |
+          ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
+          java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -51,3 +51,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: macos
+      - name: JMH Benchmarks (JNA vs FFM)
+        if: contains(matrix.java, '25')
+        run: |
+          ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
+          java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -71,3 +71,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: ${{ matrix.coverage-flag }}
+      - name: JMH Benchmarks (JNA vs FFM)
+        if: contains(matrix.java, '25')
+        run: |
+          ./mvnw package -pl oshi-benchmark -am "-DskipTests" "-Dshade.phase=package" -q
+          java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -47,3 +47,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: windows
+      - name: JMH Benchmarks (JNA vs FFM)
+        if: contains(matrix.java, '25')
+        run: |
+          ./mvnw package -pl oshi-benchmark -am "-DskipTests" "-Dshade.phase=package" -q
+          java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/oshi-benchmark/pom.xml
+++ b/oshi-benchmark/pom.xml
@@ -86,6 +86,7 @@
                         </goals>
                         <phase>${shade.phase}</phase>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <finalName>${uberjar.name}</finalName>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/oshi-benchmark/scripts/run-benchmarks.sh
+++ b/oshi-benchmark/scripts/run-benchmarks.sh
@@ -28,7 +28,7 @@ fi
 
 if [ ! -f "${JAR}" ]; then
     echo "benchmarks.jar not found — building first..."
-    ./mvnw install -pl oshi-common,oshi-core,oshi-core-java25 -DskipTests -q
+    ./mvnw install -pl oshi-common,oshi-core,oshi-core-ffm -DskipTests -q
     ./mvnw package -pl oshi-benchmark -DskipTests -Dshade.phase=package -q
 fi
 

--- a/oshi-benchmark/src/main/java/oshi/benchmark/CpuTicksBenchmark.java
+++ b/oshi-benchmark/src/main/java/oshi/benchmark/CpuTicksBenchmark.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.benchmark;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import oshi.hardware.CentralProcessor;
+import oshi.util.GlobalConfig;
+
+/**
+ * Side-by-side benchmarks of JNA vs FFM implementations of {@link CentralProcessor#getProcessorCpuLoadTicks()}.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(value = 1, jvmArgsPrepend = "--enable-native-access=ALL-UNNAMED")
+public class CpuTicksBenchmark {
+
+    private CentralProcessor jnaCpu;
+    private CentralProcessor ffmCpu;
+
+    @Setup
+    public void setup() {
+        GlobalConfig.set(GlobalConfig.OSHI_UTIL_MEMOIZER_EXPIRATION, 0);
+        jnaCpu = new oshi.SystemInfo().getHardware().getProcessor();
+        ffmCpu = new oshi.ffm.SystemInfo().getHardware().getProcessor();
+    }
+
+    @Benchmark
+    public long[][] jna() {
+        return jnaCpu.getProcessorCpuLoadTicks();
+    }
+
+    @Benchmark
+    public long[][] ffm() {
+        return ffmCpu.getProcessorCpuLoadTicks();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(CpuTicksBenchmark.class.getSimpleName()).build();
+        new Runner(opt).run();
+    }
+}

--- a/oshi-benchmark/src/main/java/oshi/benchmark/FileStoreBenchmark.java
+++ b/oshi-benchmark/src/main/java/oshi/benchmark/FileStoreBenchmark.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.benchmark;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import oshi.software.os.OSFileStore;
+import oshi.software.os.OperatingSystem;
+import oshi.util.GlobalConfig;
+
+/**
+ * Side-by-side benchmarks of JNA vs FFM implementations of {@link OSFileStore#updateAttributes()}.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(value = 1, jvmArgsPrepend = "--enable-native-access=ALL-UNNAMED")
+public class FileStoreBenchmark {
+
+    private List<OSFileStore> jnaStores;
+    private List<OSFileStore> ffmStores;
+
+    @Setup
+    public void setup() {
+        GlobalConfig.set(GlobalConfig.OSHI_UTIL_MEMOIZER_EXPIRATION, 0);
+        OperatingSystem jnaOs = new oshi.SystemInfo().getOperatingSystem();
+        OperatingSystem ffmOs = new oshi.ffm.SystemInfo().getOperatingSystem();
+        jnaStores = jnaOs.getFileSystem().getFileStores();
+        ffmStores = ffmOs.getFileSystem().getFileStores();
+    }
+
+    @Benchmark
+    public void jna(Blackhole bh) {
+        for (OSFileStore store : jnaStores) {
+            bh.consume(store.updateAttributes());
+        }
+    }
+
+    @Benchmark
+    public void ffm(Blackhole bh) {
+        for (OSFileStore store : ffmStores) {
+            bh.consume(store.updateAttributes());
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(FileStoreBenchmark.class.getSimpleName()).build();
+        new Runner(opt).run();
+    }
+}

--- a/oshi-benchmark/src/main/java/oshi/benchmark/MemoryBenchmark.java
+++ b/oshi-benchmark/src/main/java/oshi/benchmark/MemoryBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.benchmark;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.VirtualMemory;
+import oshi.util.GlobalConfig;
+
+/**
+ * Side-by-side benchmarks of JNA vs FFM implementations of {@link GlobalMemory} and {@link VirtualMemory} queries.
+ * <p>
+ * Only benchmarks methods that make native calls on each invocation: {@link GlobalMemory#getAvailable()},
+ * {@link VirtualMemory#getSwapUsed()}, and {@link VirtualMemory#getSwapTotal()}. Static values like
+ * {@link GlobalMemory#getTotal()} and {@link GlobalMemory#getPageSize()} are permanently cached and excluded.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(value = 1, jvmArgsPrepend = "--enable-native-access=ALL-UNNAMED")
+public class MemoryBenchmark {
+
+    private GlobalMemory jnaMem;
+    private GlobalMemory ffmMem;
+    private VirtualMemory jnaVm;
+    private VirtualMemory ffmVm;
+
+    @Setup
+    public void setup() {
+        GlobalConfig.set(GlobalConfig.OSHI_UTIL_MEMOIZER_EXPIRATION, 0);
+        jnaMem = new oshi.SystemInfo().getHardware().getMemory();
+        ffmMem = new oshi.ffm.SystemInfo().getHardware().getMemory();
+        jnaVm = jnaMem.getVirtualMemory();
+        ffmVm = ffmMem.getVirtualMemory();
+    }
+
+    @Benchmark
+    public void jna(Blackhole bh) {
+        bh.consume(jnaMem.getAvailable());
+        bh.consume(jnaVm.getSwapTotal());
+        bh.consume(jnaVm.getSwapUsed());
+    }
+
+    @Benchmark
+    public void ffm(Blackhole bh) {
+        bh.consume(ffmMem.getAvailable());
+        bh.consume(ffmVm.getSwapTotal());
+        bh.consume(ffmVm.getSwapUsed());
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(MemoryBenchmark.class.getSimpleName()).build();
+        new Runner(opt).run();
+    }
+}

--- a/oshi-benchmark/src/main/java/oshi/benchmark/NetworkIFBenchmark.java
+++ b/oshi-benchmark/src/main/java/oshi/benchmark/NetworkIFBenchmark.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.benchmark;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.NetworkIF;
+import oshi.util.GlobalConfig;
+
+/**
+ * Side-by-side benchmarks of JNA vs FFM implementations of {@link NetworkIF#updateAttributes()}.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(value = 1, jvmArgsPrepend = "--enable-native-access=ALL-UNNAMED")
+public class NetworkIFBenchmark {
+
+    private List<NetworkIF> jnaIfs;
+    private List<NetworkIF> ffmIfs;
+
+    @Setup
+    public void setup() {
+        GlobalConfig.set(GlobalConfig.OSHI_UTIL_MEMOIZER_EXPIRATION, 0);
+        HardwareAbstractionLayer jnaHal = new oshi.SystemInfo().getHardware();
+        HardwareAbstractionLayer ffmHal = new oshi.ffm.SystemInfo().getHardware();
+        jnaIfs = jnaHal.getNetworkIFs();
+        ffmIfs = ffmHal.getNetworkIFs();
+    }
+
+    @Benchmark
+    public void jna(Blackhole bh) {
+        for (NetworkIF nif : jnaIfs) {
+            bh.consume(nif.updateAttributes());
+        }
+    }
+
+    @Benchmark
+    public void ffm(Blackhole bh) {
+        for (NetworkIF nif : ffmIfs) {
+            bh.consume(nif.updateAttributes());
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(NetworkIFBenchmark.class.getSimpleName()).build();
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
Adds four new JMH benchmark classes comparing JNA vs FFM implementations:

- **CpuTicksBenchmark** — `getProcessorCpuLoadTicks()` (2D array)
- **MemoryBenchmark** — `getAvailable()`, `getSwapTotal()`, `getSwapUsed()`
- **FileStoreBenchmark** — `OSFileStore.updateAttributes()` per store
- **NetworkIFBenchmark** — `NetworkIF.updateAttributes()` per interface

All benchmarks disable memoization (`oshi.util.memoizer.expiration=0`) so they measure actual native call overhead rather than cache hits.

Benchmarks run on JDK 25 at the end of CI on all platforms with abbreviated iterations (`-wi 1 -i 3 -f 1`).

Also:
- Fix stale `oshi-core-java25` reference in `run-benchmarks.sh`
- Suppress shade plugin's `dependency-reduced-pom.xml` generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added performance benchmarks to compare implementations for CPU ticks, file stores, memory, and network interfaces.

* **Chores**
  * CI workflows updated to run benchmarks on JDK 25.
  * Benchmark packaging behavior adjusted to ensure a runnable shaded artifact.
  * Benchmark bootstrap improved to build required modules when the artifact is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->