### PR TITLE
Add cross-platform tests for Windows and Mac utility methods

### DIFF
--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -11,6 +11,12 @@
 --add-opens
   com.github.oshi.common/oshi.hardware.common.platform.linux=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.hardware.common.platform.mac=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.hardware.common.platform.windows=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.driver.common.mac=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.util.driver.linux=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.util.driver.linux.proc=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/driver/common/mac/ThreadInfoTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/mac/ThreadInfoTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.software.os.OSProcess.State;
+
+class ThreadInfoTest {
+
+    @Test
+    void testThreadStatsStateMapping() {
+        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'S', 100L, 200L, 31).getState(), is(State.SLEEPING));
+        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'I', 100L, 200L, 31).getState(), is(State.SLEEPING));
+        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'R', 100L, 200L, 31).getState(), is(State.RUNNING));
+        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'U', 100L, 200L, 31).getState(), is(State.WAITING));
+        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'Z', 100L, 200L, 31).getState(), is(State.ZOMBIE));
+        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'T', 100L, 200L, 31).getState(), is(State.STOPPED));
+        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'X', 100L, 200L, 31).getState(), is(State.OTHER));
+    }
+
+    @Test
+    void testThreadStatsGetters() {
+        ThreadInfo.ThreadStats ts = new ThreadInfo.ThreadStats(5, 25.0, 'R', 1000L, 2000L, 20);
+        assertThat(ts.getThreadId(), is(5));
+        assertThat(ts.getSystemTime(), is(1000L));
+        assertThat(ts.getUserTime(), is(2000L));
+        assertThat(ts.getUpTime(), greaterThan(0L));
+        assertThat(ts.getPriority(), is(20));
+    }
+}

--- a/oshi-common/src/test/java/oshi/driver/common/mac/ThreadInfoTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/mac/ThreadInfoTest.java
@@ -5,7 +5,6 @@
 package oshi.driver.common.mac;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
@@ -27,11 +26,14 @@ class ThreadInfoTest {
 
     @Test
     void testThreadStatsGetters() {
+        // upTime = (long) ((uTime + sTime) / (cpu / 100d + 0.0005))
+        // = (long) ((2000 + 1000) / (25.0 / 100.0 + 0.0005))
+        // = (long) (3000 / 0.2505) = 11976
         ThreadInfo.ThreadStats ts = new ThreadInfo.ThreadStats(5, 25.0, 'R', 1000L, 2000L, 20);
         assertThat(ts.getThreadId(), is(5));
         assertThat(ts.getSystemTime(), is(1000L));
         assertThat(ts.getUserTime(), is(2000L));
-        assertThat(ts.getUpTime(), greaterThan(0L));
+        assertThat(ts.getUpTime(), is(11976L));
         assertThat(ts.getPriority(), is(20));
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsCentralProcessorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+class WindowsCentralProcessorTest {
+
+    @Test
+    void testParseIdentifier() {
+        String id = "Intel64 Family 6 Model 142 Stepping 12";
+        assertThat(WindowsCentralProcessor.parseIdentifier(id, "Family"), is("6"));
+        assertThat(WindowsCentralProcessor.parseIdentifier(id, "Model"), is("142"));
+        assertThat(WindowsCentralProcessor.parseIdentifier(id, "Stepping"), is("12"));
+    }
+
+    @Test
+    void testParseIdentifierNotFound() {
+        assertThat(WindowsCentralProcessor.parseIdentifier("Intel64 Family 6", "Model"), is(""));
+    }
+
+    @Test
+    void testParseIdentifierKeyAtEnd() {
+        // Key is the last token — no value follows
+        assertThat(WindowsCentralProcessor.parseIdentifier("Family 6 Model", "Model"), is(""));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGlobalMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGlobalMemoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+class WindowsGlobalMemoryTest {
+
+    @Test
+    void testMemoryTypeKnownValues() {
+        assertThat(WindowsGlobalMemory.memoryType(0), is("Unknown"));
+        assertThat(WindowsGlobalMemory.memoryType(1), is("Other"));
+        assertThat(WindowsGlobalMemory.memoryType(2), is("DRAM"));
+        assertThat(WindowsGlobalMemory.memoryType(17), is("SDRAM"));
+        assertThat(WindowsGlobalMemory.memoryType(20), is("DDR"));
+        assertThat(WindowsGlobalMemory.memoryType(21), is("DDR2"));
+        assertThat(WindowsGlobalMemory.memoryType(22), is("BRAM"));
+        assertThat(WindowsGlobalMemory.memoryType(23), is("DDR FB-DIMM"));
+    }
+
+    @Test
+    void testMemoryTypeFallsBackToSmBios() {
+        // Values > 23 fall through to smBiosMemoryType
+        assertThat(WindowsGlobalMemory.memoryType(0x1A), is("DDR4"));
+        assertThat(WindowsGlobalMemory.memoryType(0x22), is("DDR5"));
+    }
+
+    @Test
+    void testSmBiosMemoryTypeKnownValues() {
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x01), is("Other"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x03), is("DRAM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x12), is("DDR"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x13), is("DDR2"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x14), is("DDR2 FB-DIMM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x18), is("DDR3"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x1A), is("DDR4"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x1E), is("LPDDR4"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x22), is("DDR5"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x23), is("LPDDR5"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x24), is("HBM3"));
+    }
+
+    @Test
+    void testSmBiosMemoryTypeUnknown() {
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x02), is("Unknown"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0xFF), is("Unknown"));
+    }
+}


### PR DESCRIPTION
### Description

Tests pure lookup/mapping methods in Windows and Mac platform classes that are testable from any platform — no native calls or platform-specific APIs involved.

#### New test classes

**WindowsGlobalMemoryTest** — Tests `memoryType(int)` and `smBiosMemoryType(int)` switch statements covering WMI memory type codes (0-23) and SMBIOS type codes (DDR through HBM3, plus unknown/default). This file was at 3.3% coverage — the two methods are 58 lines of pure lookup logic.

**WindowsCentralProcessorTest** — Tests `parseIdentifier(String, String)` which extracts Family/Model/Stepping values from Windows processor identifier strings. Covers found, not-found, and key-at-end-of-string edge cases.

**ThreadInfoTest** (Mac) — Tests `ThreadStats` constructor state mapping for all 7 process states (Sleeping, Idle, Running, Waiting, Zombie, Stopped, Other) and getter methods.

Also adds `--add-opens` directives to `module-info.test` for the `oshi.hardware.common.platform.windows`, `oshi.hardware.common.platform.mac`, and `oshi.driver.common.mac` packages.

### Testing
All 455 tests pass locally on Linux (Java 25). Spotless, checkstyle, and forbiddenapis all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for thread information state mapping and properties.
  * Added test coverage for Windows processor identifier parsing.
  * Added test coverage for Windows memory type and SMBIOS classification.

* **Chores**
  * Extended test JVM launch configuration to open additional OS-specific packages for test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->