### PR TITLE
Replace volatile Map with AtomicReference in WindowsCentralProcessor

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorUtilityTickCountProperty;
@@ -36,7 +37,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
             && GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_CPU_UTILITY, false);
 
     // Previous sample for utility base multiplier calculation
-    private volatile Map<ProcessorUtilityTickCountProperty, List<Long>> initialUtilityCounters;
+    private final AtomicReference<Map<ProcessorUtilityTickCountProperty, List<Long>>> initialUtilityCounters = new AtomicReference<>();
     // Lazily initialized
     private Long utilityBaseMultiplier;
 
@@ -72,7 +73,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @return the initial utility counters
      */
     protected Map<ProcessorUtilityTickCountProperty, List<Long>> getInitialUtilityCounters() {
-        return this.initialUtilityCounters;
+        return this.initialUtilityCounters.get();
     }
 
     /**
@@ -81,7 +82,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @param counters the counters to set
      */
     protected void setInitialUtilityCounters(Map<ProcessorUtilityTickCountProperty, List<Long>> counters) {
-        this.initialUtilityCounters = counters;
+        this.initialUtilityCounters.set(counters);
     }
 
     /**


### PR DESCRIPTION
Fixes SonarQube squid:S3077 on `WindowsCentralProcessor` line 39 where `volatile` is applied to a non-primitive `Map` field.

Replaces the `volatile Map<ProcessorUtilityTickCountProperty, List<Long>>` with an `AtomicReference`, which provides the same visibility guarantees without the SonarQube warning. The field follows a replace-the-whole-reference pattern (never mutated in place), so `AtomicReference` is a direct fit.

Searched the codebase for other `volatile` non-primitive fields:
- `Memoizer.value` — already suppressed with `// NOSONAR squid:S3077`
- All other `volatile` fields are primitives (`int`, `long`, `boolean`) — no issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved thread-safe management of processor utility counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->