### PR TITLE
Improve javadoc for @PublicApi interfaces

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/Baseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/Baseboard.java
@@ -9,6 +9,13 @@ import oshi.annotation.concurrent.Immutable;
 
 /**
  * The Baseboard represents the system board, also called motherboard, logic board, etc.
+ * <p>
+ * Obtained from {@link ComputerSystem#getBaseboard()}.
+ * <p>
+ * <b>Platform notes:</b> On Linux, reading the serial number requires root access because
+ * {@code /sys/class/dmi/id/board_serial} is root-owned and read-only (mode 0400) by default.
+ *
+ * @see ComputerSystem
  */
 @PublicApi
 @Immutable

--- a/oshi-common/src/main/java/oshi/hardware/ComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/ComputerSystem.java
@@ -10,6 +10,18 @@ import oshi.annotation.concurrent.Immutable;
 /**
  * The ComputerSystem represents the physical hardware, of a computer system/product and includes BIOS/firmware and a
  * motherboard, logic board, etc.
+ * <p>
+ * <b>Docker/container note:</b> OSHI reports the <em>host</em> operating system and hardware information, not the
+ * container's. Serial numbers and UUIDs may return "unknown" inside containers.
+ * <p>
+ * <b>Unique machine identifier:</b> The {@link #getHardwareUUID()} value can be combined with other fields (such as
+ * processor ID and serial number) to construct a machine fingerprint. Note that the UUID value
+ * {@code 03000200-0400-0500-0006-000700080009} is a known placeholder that is not unique. See the {@code ComputerID}
+ * class in the {@code oshi-demo} module for an example approach.
+ * <p>
+ * <b>VM detection:</b> Virtual machine environments can often be identified by examining the
+ * {@link #getManufacturer()}, {@link #getModel()}, and {@link Firmware} values. See the {@code DetectVM} class in the
+ * {@code oshi-demo} module for an example.
  */
 @PublicApi
 @Immutable

--- a/oshi-common/src/main/java/oshi/hardware/Display.java
+++ b/oshi-common/src/main/java/oshi/hardware/Display.java
@@ -9,6 +9,26 @@ import oshi.annotation.concurrent.Immutable;
 
 /**
  * Display refers to the information regarding a video source and monitor identified by the EDID standard.
+ * <p>
+ * The {@link #getEdid()} method returns the raw EDID (Extended Display Identification Data) byte array, a 128-byte (or
+ * longer) structure that monitors transmit to describe their capabilities. Use the {@link oshi.util.EdidUtil} class to
+ * parse this byte array into human-readable fields such as manufacturer ID, product ID, serial number, display
+ * dimensions, and supported resolutions.
+ * <p>
+ * Example: extracting monitor manufacturer and dimensions:
+ *
+ * <pre>{@code
+ * for (Display display : hal.getDisplays()) {
+ *     byte[] edid = display.getEdid();
+ *     System.out.println("Manufacturer: " + EdidUtil.getManufacturerID(edid));
+ *     System.out.println("Product ID:   " + EdidUtil.getProductID(edid));
+ *     int hCm = EdidUtil.getHcm(edid);
+ *     int vCm = EdidUtil.getVcm(edid);
+ *     System.out.printf("Size: %d cm x %d cm%n", hCm, vCm);
+ * }
+ * }</pre>
+ *
+ * @see oshi.util.EdidUtil
  */
 @PublicApi
 @Immutable

--- a/oshi-common/src/main/java/oshi/hardware/Firmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/Firmware.java
@@ -9,6 +9,13 @@ import oshi.annotation.concurrent.Immutable;
 
 /**
  * The Firmware represents the low level BIOS or equivalent.
+ * <p>
+ * Obtained from {@link ComputerSystem#getFirmware()}.
+ * <p>
+ * <b>Platform notes:</b> On Raspberry Pi, {@code vcgencmd} is used as a fallback to retrieve firmware version
+ * information when standard SMBIOS data is not available.
+ *
+ * @see ComputerSystem
  */
 @PublicApi
 @Immutable

--- a/oshi-common/src/main/java/oshi/hardware/NetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/NetworkIF.java
@@ -13,6 +13,14 @@ import oshi.annotation.concurrent.ThreadSafe;
 /**
  * A network interface in the machine, including statistics.
  * <p>
+ * <b>Filtering interfaces:</b> {@link HardwareAbstractionLayer#getNetworkIFs(boolean)} with {@code false} excludes
+ * loopback and no-hardware-address interfaces. To further filter to physical interfaces, check
+ * {@link #queryNetworkInterface()} properties or use {@link #isKnownVmMacAddr()} to exclude virtual adapters.
+ * <p>
+ * <b>Polling guidance:</b> The {@link #updateAttributes()} method makes system calls and should not be called more
+ * frequently than approximately once per second. For monitoring multiple interfaces, it is more efficient to re-query
+ * the full list from {@link HardwareAbstractionLayer#getNetworkIFs()} than to update each interface individually.
+ * <p>
  * Thread safe for the designed use of retrieving the most recent data. Users should be aware that the
  * {@link #updateAttributes()} method may update attributes, including the time stamp, and should externally synchronize
  * such usage to ensure consistent calculations.

--- a/oshi-common/src/main/java/oshi/hardware/PowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/PowerSource.java
@@ -10,7 +10,34 @@ import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
- * The Power Source is one or more batteries with some capacity, and some state of charge/discharge
+ * A Power Source represents a battery or UPS device with some capacity and charge/discharge state.
+ * <p>
+ * To monitor battery charge over time, call {@link #updateAttributes()} periodically to refresh the statistics on this
+ * object:
+ *
+ * <pre>{@code
+ * List<PowerSource> powerSources = hal.getPowerSources();
+ * if (powerSources.isEmpty()) {
+ *     System.out.println("No battery found");
+ *     return;
+ * }
+ * PowerSource battery = powerSources.get(0);
+ * System.out.printf("Charge: %.0f%%%n", battery.getRemainingCapacityPercent() * 100);
+ * Thread.sleep(5000);
+ * battery.updateAttributes();
+ * System.out.printf("Charge: %.0f%%%n", battery.getRemainingCapacityPercent() * 100);
+ * }</pre>
+ *
+ * <b>Capacity units:</b> The {@link CapacityUnits} enum indicates whether capacity values from
+ * {@link #getCurrentCapacity()}, {@link #getMaxCapacity()}, and {@link #getDesignCapacity()} are reported in
+ * milliWatt-hours (mWh), milliAmp-hours (mAh), or relative units. Use {@link #getCapacityUnits()} to determine which
+ * unit applies.
+ * <p>
+ * <b>Sentinel values:</b> Several methods return sentinel values when information is unavailable. For example,
+ * {@link #getVoltage()} and {@link #getCycleCount()} return {@code -1} when unknown, and
+ * {@link #getTimeRemainingEstimated()} returns {@code -1.0} (calculating) or {@code -2.0} (unlimited).
+ * <p>
+ * <b>Platform notes:</b> On Android and some embedded systems, the power source list may be empty.
  */
 @PublicApi
 @ThreadSafe

--- a/oshi-common/src/main/java/oshi/hardware/Printer.java
+++ b/oshi-common/src/main/java/oshi/hardware/Printer.java
@@ -8,7 +8,11 @@ import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
- * Printer interface representing a printer device.
+ * Represents a printer device available to the operating system, including its name, driver, status, and connection
+ * type (local or network).
+ * <p>
+ * <b>Platform notes:</b> On Windows, printer information is retrieved via WMI. On Linux, CUPS is used. On macOS,
+ * printer information is retrieved from the CUPS/IPP subsystem.
  */
 @PublicApi
 @Immutable

--- a/oshi-common/src/main/java/oshi/hardware/SoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/SoundCard.java
@@ -8,7 +8,8 @@ import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
- * SoundCard interface.
+ * Represents a sound card (audio adapter) installed in the system, providing the card name, driver version, and codec
+ * information.
  */
 @PublicApi
 @Immutable

--- a/oshi-common/src/main/java/oshi/hardware/UsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/UsbDevice.java
@@ -12,6 +12,23 @@ import oshi.annotation.concurrent.Immutable;
 /**
  * A USB device is a device connected via a USB port, possibly internally/permanently. Hubs may contain ports to which
  * other devices connect in a recursive fashion.
+ * <p>
+ * USB devices form a tree structure rooted at one or more host controllers. Each device may be a hub with child devices
+ * accessible via {@link #getConnectedDevices()}. To traverse the full USB tree:
+ *
+ * <pre>{@code
+ * for (UsbDevice device : hal.getUsbDevices(true)) {
+ *     printDevice(device, 0);
+ * }
+ *
+ * void printDevice(UsbDevice device, int indent) {
+ *     String prefix = " ".repeat(indent);
+ *     System.out.printf("%s%s (vendor=%s)%n", prefix, device.getName(), device.getVendor());
+ *     for (UsbDevice child : device.getConnectedDevices()) {
+ *         printDevice(child, indent + 2);
+ *     }
+ * }
+ * }</pre>
  */
 @PublicApi
 @Immutable

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorUtilityTickCountProperty;
@@ -36,7 +37,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
             && GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_CPU_UTILITY, false);
 
     // Previous sample for utility base multiplier calculation
-    private volatile Map<ProcessorUtilityTickCountProperty, List<Long>> initialUtilityCounters;
+    private final AtomicReference<Map<ProcessorUtilityTickCountProperty, List<Long>>> initialUtilityCounters = new AtomicReference<>();
     // Lazily initialized
     private Long utilityBaseMultiplier;
 
@@ -72,7 +73,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @return the initial utility counters
      */
     protected Map<ProcessorUtilityTickCountProperty, List<Long>> getInitialUtilityCounters() {
-        return this.initialUtilityCounters;
+        return this.initialUtilityCounters.get();
     }
 
     /**
@@ -81,7 +82,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @param counters the counters to set
      */
     protected void setInitialUtilityCounters(Map<ProcessorUtilityTickCountProperty, List<Long>> counters) {
-        this.initialUtilityCounters = counters;
+        this.initialUtilityCounters.set(counters);
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/os/FileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/os/FileSystem.java
@@ -12,6 +12,12 @@ import oshi.annotation.concurrent.ThreadSafe;
 /**
  * The File System is a logical arrangement, usually in a hierarchial tree, where files are placed for storage and
  * retrieval. It may consist of one or more file stores.
+ * <p>
+ * To correlate file stores with their underlying hardware, match {@link OSFileStore#getMount()} with
+ * {@link oshi.hardware.HWPartition#getMountPoint()}.
+ *
+ * @see OSFileStore
+ * @see oshi.hardware.HWDiskStore
  */
 @PublicApi
 @ThreadSafe

--- a/oshi-common/src/main/java/oshi/software/os/InternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/os/InternetProtocolStats.java
@@ -14,7 +14,44 @@ import oshi.annotation.concurrent.Immutable;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
- * Includes key statistics of TCP and UDP protocols
+ * Provides key statistics for TCP and UDP network protocols, including aggregate counters and per-connection details.
+ * <p>
+ * Use {@link #getTCPv4Stats()} and {@link #getTCPv6Stats()} for aggregate TCP counters (connections established,
+ * active, passive, failures, resets, and segment counts). Use {@link #getUDPv4Stats()} and {@link #getUDPv6Stats()} for
+ * aggregate UDP counters (datagrams sent, received, and errors).
+ * <p>
+ * Use {@link #getConnections()} to list individual active TCP and UDP connections, each represented as an
+ * {@link IPConnection} with local/remote addresses, ports, state, and owning process ID.
+ * <p>
+ * Example: listing active TCP connections:
+ *
+ * <pre>{@code
+ * InternetProtocolStats ipStats = os.getInternetProtocolStats();
+ * for (IPConnection conn : ipStats.getConnections()) {
+ *     if (conn.getType().startsWith("tcp")) {
+ *         String local = addrToString(conn.getLocalAddress());
+ *         String foreign = addrToString(conn.getForeignAddress());
+ *         System.out.printf("%s:%d -> %s:%d (%s)%n", local, conn.getLocalPort(), foreign, conn.getForeignPort(),
+ *                 conn.getState());
+ *     }
+ * }
+ *
+ * // Helper to safely convert address bytes to a string
+ * static String addrToString(byte[] addr) {
+ *     try {
+ *         return addr.length > 0 ? InetAddress.getByAddress(addr).getHostAddress() : "*";
+ *     } catch (UnknownHostException e) {
+ *         return "?";
+ *     }
+ * }
+ * }</pre>
+ *
+ * <b>Platform notes:</b> On macOS, connection information requires elevated permissions. Without elevated permissions,
+ * TCP segment data is estimated.
+ *
+ * @see TcpStats
+ * @see UdpStats
+ * @see IPConnection
  */
 @PublicApi
 @ThreadSafe
@@ -23,7 +60,7 @@ public interface InternetProtocolStats {
     /**
      * Get the TCP stats for IPv4 connections.
      * <p>
-     * On macOS connection information requires elevated permissions. Without elevatd permissions, segment data is
+     * On macOS connection information requires elevated permissions. Without elevated permissions, segment data is
      * estimated.
      *
      * @return a {@link TcpStats} object encapsulating the stats.

--- a/oshi-common/src/main/java/oshi/software/os/NetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/os/NetworkParams.java
@@ -8,7 +8,13 @@ import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
- * NetworkParams presents network parameters of running OS, such as DNS, host name etc.
+ * Provides network parameters of the running operating system, including the hostname, domain name, DNS server
+ * addresses, and default gateways for IPv4 and IPv6.
+ * <p>
+ * The hostname ({@link #getHostName()}) is the local machine name. The domain name ({@link #getDomainName()}) is the
+ * DNS domain suffix. DNS servers ({@link #getDnsServers()}) are the configured name resolution servers. The default
+ * gateways ({@link #getIpv4DefaultGateway()}, {@link #getIpv6DefaultGateway()}) are the routing destinations for
+ * {@code 0.0.0.0/0} and {@code ::/0} respectively, and return an empty string if not defined.
  */
 @PublicApi
 @ThreadSafe

--- a/oshi-common/src/main/java/oshi/software/os/OSDesktopWindow.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSDesktopWindow.java
@@ -10,7 +10,14 @@ import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
 /**
- * This class encapsulates information about a window on the operating system's GUI desktop
+ * This class encapsulates information about a window on the operating system's GUI desktop.
+ * <p>
+ * Desktop windows are obtained from {@link OperatingSystem#getDesktopWindows(boolean)}.
+ * <p>
+ * <b>Platform notes:</b> This feature requires a GUI session. On Unix-like systems, only X11 windows are reported,
+ * which may be limited to the current display. On headless or non-GUI environments, the list will be empty.
+ *
+ * @see OperatingSystem#getDesktopWindows(boolean)
  */
 @PublicApi
 @Immutable

--- a/oshi-common/src/main/java/oshi/software/os/OSSession.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSSession.java
@@ -15,6 +15,11 @@ import oshi.annotation.concurrent.Immutable;
 
 /**
  * This class encapsulates information about users who are currently logged in to an operating system.
+ * <p>
+ * Sessions are obtained from {@link OperatingSystem#getSessions()}. See that method's documentation for important
+ * thread-safety notes on macOS, Linux, and Unix systems.
+ *
+ * @see OperatingSystem#getSessions()
  */
 @PublicApi
 @Immutable

--- a/oshi-common/src/main/java/oshi/software/os/OSThread.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSThread.java
@@ -11,6 +11,11 @@ import oshi.software.os.OSProcess.State;
 
 /**
  * Represents a Thread/Task on the operating system.
+ * <p>
+ * Threads are obtained from {@link oshi.software.os.OSProcess#getThreadDetails()}. Each thread belongs to a parent
+ * process identified by {@link #getOwningProcessId()}.
+ *
+ * @see oshi.software.os.OSProcess#getThreadDetails()
  */
 @PublicApi
 public interface OSThread {

--- a/oshi-common/src/main/java/oshi/software/os/OperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/os/OperatingSystem.java
@@ -24,6 +24,9 @@ import oshi.util.Util;
  * An operating system (OS) is the software on a computer that manages the way different programs use its hardware, and
  * regulates the ways that a user controls the computer.
  * <p>
+ * <b>Docker/container note:</b> OSHI reports the <em>host</em> operating system information, not the container's. In
+ * containerized environments, values such as the OS version and process list reflect the host system.
+ * <p>
  * Considered thread safe, but see remarks for the {@link #getSessions()} method.
  */
 @PublicApi


### PR DESCRIPTION
## Summary

Addresses the "Interfaces needing richer class-level documentation" and "Usage examples to add" sections of #3190 by improving javadoc on 16 `@PublicApi` interfaces and classes.

### Interfaces with richer class-level docs
- **PowerSource** — `updateAttributes()` monitoring pattern, `CapacityUnits` explanation, sentinel values (`-1`, `-2.0`), platform note
- **InternetProtocolStats** — `TcpStats`/`UdpStats`/`IPConnection` overview with usage example, macOS permissions note
- **Display** — EDID byte array explanation, `EdidUtil` parsing example (manufacturer, dimensions)
- **UsbDevice** — tree structure explanation, recursive traversal example
- **Baseboard** — `ComputerSystem` cross-reference, Linux serial number permissions note
- **Firmware** — `ComputerSystem` cross-reference, Raspberry Pi `vcgencmd` fallback note
- **SoundCard** — meaningful description replacing bare "SoundCard interface"
- **Printer** — description with platform notes (WMI, CUPS, IPP)
- **NetworkParams** — field descriptions for hostname, DNS, gateways
- **OSThread** — cross-reference to `OSProcess.getThreadDetails()`
- **OSDesktopWindow** — platform availability, GUI session requirement
- **OSSession** — cross-reference to `OperatingSystem.getSessions()` thread-safety notes

### Cross-references and usage guidance
- **ComputerSystem** — Docker/container note, unique machine ID guidance (known non-unique UUID), VM detection cross-ref to demo
- **OperatingSystem** — Docker/container note
- **NetworkIF** — interface filtering guidance, polling interval recommendation
- **FileSystem** — disk-to-filesystem correlation cross-reference

### What's not included
Items from #3190 that require site/FAQ documentation changes, or that need human judgment about specific user-reported behaviors, are left for follow-up PRs.

### Testing
- `mvn -pl oshi-common compile` — clean
- `mvn -pl oshi-common javadoc:javadoc` — no new errors
- `mvn -pl oshi-common spotless:apply` — applied
- `mvn -pl oshi-common checkstyle:check` — clean

Closes partially #3190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded API documentation across hardware and software interfaces with detailed Javadoc, platform-specific notes (including container/host behavior), usage guidance, code examples, and cross-references for parsing and correlating data.
* **Chores**
  * Internal concurrency/storage improvement for utility counter management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->