### PR TITLE
Add fast path to OSFileStore.updateAttributes() for all platforms

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSFileStore.java
@@ -82,19 +82,49 @@ public class LinuxOSFileStore extends AbstractOSFileStore {
 
     @Override
     public boolean updateAttributes() {
+        // Fast path: query space/inode stats directly on the known mount point
+        long[] vfs = fs.queryStatvfs(getMount());
+        if (vfs != null) {
+            long ts = vfs[2];
+            long us = vfs[3];
+            long frs = vfs[4];
+            // If native methods failed use JVM methods
+            if (ts == 0L) {
+                java.io.File f = new java.io.File(getMount());
+                ts = f.getTotalSpace();
+                us = f.getUsableSpace();
+                frs = f.getFreeSpace();
+            }
+            updateSpaceAndInodes(frs, us, ts, vfs[1], vfs[0]);
+            return true;
+        }
+        // Fall back to full enumeration if the direct call failed
         for (OSFileStore fileStore : fs.getFileStoreMatching(getName(), LinuxFileSystem.buildUuidMap(), isLocal())) {
             if (getVolume().equals(fileStore.getVolume()) && getMount().equals(fileStore.getMount())) {
-                this.logicalVolume = fileStore.getLogicalVolume();
-                this.description = fileStore.getDescription();
-                this.fsType = fileStore.getType();
-                this.freeSpace = fileStore.getFreeSpace();
-                this.usableSpace = fileStore.getUsableSpace();
-                this.totalSpace = fileStore.getTotalSpace();
-                this.freeInodes = fileStore.getFreeInodes();
-                this.totalInodes = fileStore.getTotalInodes();
+                updateFrom(fileStore);
                 return true;
             }
         }
         return false;
+    }
+
+    private void updateSpaceAndInodes(long freeSpace, long usableSpace, long totalSpace, long freeInodes,
+            long totalInodes) {
+        this.freeSpace = freeSpace;
+        this.usableSpace = usableSpace;
+        this.totalSpace = totalSpace;
+        this.freeInodes = freeInodes;
+        this.totalInodes = totalInodes;
+    }
+
+    private void updateFrom(OSFileStore fileStore) {
+        this.logicalVolume = fileStore.getLogicalVolume();
+        this.description = fileStore.getDescription();
+        this.fsType = fileStore.getType();
+        this.freeSpace = fileStore.getFreeSpace();
+        this.usableSpace = fileStore.getUsableSpace();
+        this.totalSpace = fileStore.getTotalSpace();
+        this.freeInodes = fileStore.getFreeInodes();
+        this.totalInodes = fileStore.getTotalInodes();
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSFileStore.java
@@ -93,4 +93,22 @@ public abstract class MacOSFileStore extends AbstractOSFileStore {
         this.freeInodes = fileStore.getFreeInodes();
         this.totalInodes = fileStore.getTotalInodes();
     }
+
+    /**
+     * Updates only the space and inode fields, bypassing full enumeration.
+     *
+     * @param freeSpace   free space in bytes
+     * @param usableSpace usable space in bytes
+     * @param totalSpace  total space in bytes
+     * @param freeInodes  free inodes
+     * @param totalInodes total inodes
+     */
+    protected void updateSpaceAndInodes(long freeSpace, long usableSpace, long totalSpace, long freeInodes,
+            long totalInodes) {
+        this.freeSpace = freeSpace;
+        this.usableSpace = usableSpace;
+        this.totalSpace = totalSpace;
+        this.freeInodes = freeInodes;
+        this.totalInodes = totalInodes;
+    }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSFileStore.java
@@ -93,4 +93,17 @@ public abstract class WindowsOSFileStore extends AbstractOSFileStore {
         this.freeInodes = fileStore.getFreeInodes();
         this.totalInodes = fileStore.getTotalInodes();
     }
+
+    /**
+     * Updates only the space fields, bypassing full volume enumeration.
+     *
+     * @param freeSpace   free space in bytes
+     * @param usableSpace usable space in bytes
+     * @param totalSpace  total space in bytes
+     */
+    protected void updateSpace(long freeSpace, long usableSpace, long totalSpace) {
+        this.freeSpace = freeSpace;
+        this.usableSpace = usableSpace;
+        this.totalSpace = totalSpace;
+    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/mac/MacSystem.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/mac/MacSystem.java
@@ -256,6 +256,10 @@ public interface MacSystem {
             sequenceLayout(MAXPATHLEN, JAVA_BYTE).withName("f_mntfromname"), // mounted filesystem
             paddingLayout(8 * 4).withName("f_reserved") // For future use
     );
+    PathElement F_BSIZE = groupElement("f_bsize");
+    PathElement F_BLOCKS = groupElement("f_blocks");
+    PathElement F_BFREE = groupElement("f_bfree");
+    PathElement F_BAVAIL = groupElement("f_bavail");
     PathElement F_FILES = groupElement("f_files");
     PathElement F_FFREE = groupElement("f_ffree");
     PathElement F_FSTYPENAME = groupElement("f_fstypename");

--- a/oshi-core-ffm/src/main/java/oshi/ffm/mac/MacSystemFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/mac/MacSystemFunctions.java
@@ -153,6 +153,15 @@ public final class MacSystemFunctions extends MacForeignFunctions {
         return (int) getfsstat64.invokeExact(buffer, bufsize, flags);
     }
 
+    // int statfs64(const char *path, struct statfs *buf);
+
+    private static final MethodHandle statfs64 = LINKER.downcallHandle(SYSTEM_LIBRARY.findOrThrow("statfs64"),
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+
+    public static int statfs64(MemorySegment path, MemorySegment buf) throws Throwable {
+        return (int) statfs64.invokeExact(path, buf);
+    }
+
     // void setutxent(void);
 
     private static final MethodHandle setutxent = LINKER.downcallHandle(SYSTEM_LIBRARY.findOrThrow("setutxent"),

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSFileStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSFileStoreFFM.java
@@ -4,7 +4,20 @@
  */
 package oshi.software.os.mac;
 
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.mac.MacSystem.F_FFREE;
+import static oshi.ffm.mac.MacSystem.F_FILES;
+import static oshi.ffm.mac.MacSystem.STATFS;
+
+import java.io.File;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.mac.MacSystemFunctions;
 import oshi.software.common.os.mac.MacOSFileStore;
 import oshi.software.os.OSFileStore;
 
@@ -13,6 +26,8 @@ import oshi.software.os.OSFileStore;
  */
 @ThreadSafe
 public class MacOSFileStoreFFM extends MacOSFileStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MacOSFileStoreFFM.class);
 
     public MacOSFileStoreFFM(String name, String volume, String label, String mount, String options, String uuid,
             boolean local, String logicalVolume, String description, String fsType, long freeSpace, long usableSpace,
@@ -23,6 +38,21 @@ public class MacOSFileStoreFFM extends MacOSFileStore {
 
     @Override
     public boolean updateAttributes() {
+        // Fast path: call statfs64 directly on the known mount point
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment buf = arena.allocate(STATFS);
+            MemorySegment pathSeg = arena.allocateFrom(getMount());
+            if (MacSystemFunctions.statfs64(pathSeg, buf) == 0) {
+                long ffree = buf.get(JAVA_LONG, STATFS.byteOffset(F_FFREE));
+                long files = buf.get(JAVA_LONG, STATFS.byteOffset(F_FILES));
+                File f = new File(getMount());
+                updateSpaceAndInodes(f.getFreeSpace(), f.getUsableSpace(), f.getTotalSpace(), ffree, files);
+                return true;
+            }
+        } catch (Throwable e) {
+            LOG.debug("statfs64 fast path failed for {}: {}", getMount(), e.getMessage());
+        }
+        // Fall back to full enumeration
         for (OSFileStore fileStore : MacFileSystemFFM.getFileStoreMatching(getName(), isLocal())) {
             if (getVolume().equals(fileStore.getVolume()) && getMount().equals(fileStore.getMount())) {
                 updateFrom(fileStore);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSFileStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSFileStoreFFM.java
@@ -4,9 +4,16 @@
  */
 package oshi.software.os.windows;
 
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.util.List;
+import java.util.OptionalInt;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.windows.Kernel32FFM;
 import oshi.software.common.os.windows.WindowsOSFileStore;
 import oshi.software.os.OSFileStore;
 
@@ -25,12 +32,24 @@ public class WindowsOSFileStoreFFM extends WindowsOSFileStore {
 
     @Override
     public boolean updateAttributes() {
-        // Check if we have the volume locally
+        // Fast path: call GetDiskFreeSpaceEx directly on the known volume
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment userFreeBytesBuf = arena.allocate(JAVA_LONG);
+            MemorySegment totalBytesBuf = arena.allocate(JAVA_LONG);
+            MemorySegment systemFreeBytesBuf = arena.allocate(JAVA_LONG);
+            OptionalInt result = Kernel32FFM.GetDiskFreeSpaceEx(toWideString(arena, getVolume()), userFreeBytesBuf,
+                    totalBytesBuf, systemFreeBytesBuf);
+            if (result.isPresent() && result.getAsInt() != 0) {
+                updateSpace(systemFreeBytesBuf.get(JAVA_LONG, 0), userFreeBytesBuf.get(JAVA_LONG, 0),
+                        totalBytesBuf.get(JAVA_LONG, 0));
+                return true;
+            }
+        }
+        // Fall back to full enumeration
         List<OSFileStore> volumes;
         if (isLocal()) {
             volumes = WindowsFileSystemFFM.getLocalVolumes(getVolume());
         } else {
-            // Not locally, search WMI
             String nameToMatch = getMount().length() < 2 ? null : getMount().substring(0, 2);
             volumes = WindowsFileSystemFFM.getWmiVolumes(nameToMatch, false);
         }

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
@@ -172,6 +172,18 @@ public interface SystemB extends com.sun.jna.platform.mac.SystemB, CLibrary {
 
     int proc_pidfdinfo(int pid, int fd, int flavor, Structure buffer, int buffersize);
 
+    /**
+     * The statfs64() routine returns information about a mounted file system. The {@code path} argument is the path
+     * name of any file or directory within the mounted file system. The {@code buf} argument is a pointer to a
+     * {@code statfs} structure.
+     *
+     * @param path the path to any file within the mounted filesystem
+     * @param buf  a {@link com.sun.jna.platform.mac.SystemB.Statfs} structure
+     * @return Upon successful completion, a value of 0 is returned. Otherwise, -1 is returned and the global variable
+     *         {@code errno} is set to indicate the error.
+     */
+    int statfs64(String path, Statfs buf);
+
     // kern_return_t vm_deallocate(vm_map_t target_task, vm_address_t address, vm_size_t size);
     int vm_deallocate(int targetTask, long address, long size);
 }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSFileStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSFileStoreJNA.java
@@ -4,7 +4,15 @@
  */
 package oshi.software.os.mac;
 
+import java.io.File;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.jna.platform.mac.SystemB.Statfs;
+
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.jna.platform.mac.SystemB;
 import oshi.software.common.os.mac.MacOSFileStore;
 import oshi.software.os.OSFileStore;
 
@@ -13,6 +21,8 @@ import oshi.software.os.OSFileStore;
  */
 @ThreadSafe
 public class MacOSFileStoreJNA extends MacOSFileStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MacOSFileStoreJNA.class);
 
     public MacOSFileStoreJNA(String name, String volume, String label, String mount, String options, String uuid,
             boolean local, String logicalVolume, String description, String fsType, long freeSpace, long usableSpace,
@@ -23,6 +33,19 @@ public class MacOSFileStoreJNA extends MacOSFileStore {
 
     @Override
     public boolean updateAttributes() {
+        // Fast path: call statfs64 directly on the known mount point
+        try {
+            Statfs stat = new Statfs();
+            if (SystemB.INSTANCE.statfs64(getMount(), stat) == 0) {
+                File f = new File(getMount());
+                updateSpaceAndInodes(f.getFreeSpace(), f.getUsableSpace(), f.getTotalSpace(), stat.f_ffree,
+                        stat.f_files);
+                return true;
+            }
+        } catch (Throwable e) {
+            LOG.debug("statfs64 fast path failed for {}: {}", getMount(), e.getMessage());
+        }
+        // Fall back to full enumeration
         for (OSFileStore fileStore : MacFileSystemJNA.getFileStoreMatching(getName(), isLocal())) {
             if (getVolume().equals(fileStore.getVolume()) && getMount().equals(fileStore.getMount())) {
                 updateFrom(fileStore);

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSFileStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSFileStoreJNA.java
@@ -6,6 +6,9 @@ package oshi.software.os.windows;
 
 import java.util.List;
 
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.WinNT;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.os.windows.WindowsOSFileStore;
 import oshi.software.os.OSFileStore;
@@ -25,12 +28,19 @@ public class WindowsOSFileStoreJNA extends WindowsOSFileStore {
 
     @Override
     public boolean updateAttributes() {
-        // Check if we have the volume locally
+        // Fast path: call GetDiskFreeSpaceEx directly on the known volume
+        WinNT.LARGE_INTEGER userFreeBytes = new WinNT.LARGE_INTEGER(0L);
+        WinNT.LARGE_INTEGER totalBytes = new WinNT.LARGE_INTEGER(0L);
+        WinNT.LARGE_INTEGER systemFreeBytes = new WinNT.LARGE_INTEGER(0L);
+        if (Kernel32.INSTANCE.GetDiskFreeSpaceEx(getVolume(), userFreeBytes, totalBytes, systemFreeBytes)) {
+            updateSpace(systemFreeBytes.getValue(), userFreeBytes.getValue(), totalBytes.getValue());
+            return true;
+        }
+        // Fall back to full enumeration
         List<OSFileStore> volumes;
         if (isLocal()) {
             volumes = WindowsFileSystemJNA.getLocalVolumes(getVolume());
         } else {
-            // Not locally, search WMI
             String nameToMatch = getMount().length() < 2 ? null : getMount().substring(0, 2);
             volumes = WindowsFileSystemJNA.getWmiVolumes(nameToMatch, false);
         }


### PR DESCRIPTION
## Summary

`OSFileStore.updateAttributes()` re-enumerates every mounted filesystem just to update space/inode numbers for a single known mount point. When called in a monitoring loop for N file stores, this results in O(N²) work.

This PR adds platform-specific fast paths that call stat syscalls directly on the known mount point instead of re-enumerating all filesystems:

### Linux
- Calls the existing `queryStatvfs()` directly on the mount path
- Works for both JNA and FFM since `LinuxOSFileStore` is in `oshi-common` and `queryStatvfs()` is resolved polymorphically
- Falls back to `java.io.File` methods if native call returns zero total space

### macOS
- Adds new `statfs64()` per-path binding in both JNA (`SystemB`) and FFM (`MacSystemFunctions`)
- Extracts inode counts (`f_files`, `f_ffree`) from the struct; uses `java.io.File` for space values (matching existing pattern in `getFileStoreMatching`)
- Adds `updateSpaceAndInodes()` helper to `MacOSFileStore` base class

### Windows
- Calls `GetDiskFreeSpaceEx` directly on the known volume path (bindings already exist in both JNA and FFM)
- Adds `updateSpace()` helper to `WindowsOSFileStore` base class (Windows inode fields are always -1)

All platforms fall back to the existing full-enumeration path if the direct syscall fails (e.g., mount was removed), ensuring backward compatibility.

### Complexity reduction
- `updateAttributes()`: O(N) enumeration → O(1) per store
- Monitoring loop over N stores: O(N²) → O(N)

### Verification
- `spotless:apply` — no formatting changes needed
- `checkstyle:check` — 0 violations
- `forbiddenapis:check` — 0 errors
- `javadoc:javadoc` — builds successfully

Closes #3185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster filesystem info retrieval on Linux, macOS, and Windows via new native fast-paths that directly read space and inode metrics for known mounts/volumes.

* **Bug Fixes / Reliability**
  * Safer fallbacks preserve accurate storage and inode metrics when fast-path calls fail or return incomplete data.

* **Compatibility**
  * Expanded native bindings on macOS and Windows for more reliable metric collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->