### PR TITLE
Add FFM vs. JNA performance comparison to Performance.md

### DIFF
--- a/src/site/markdown/Performance.md
+++ b/src/site/markdown/Performance.md
@@ -1,6 +1,62 @@
 # OSHI Performance Considerations
 
 
+## FFM vs. JNA
+
+OSHI provides two native access implementations:
+
+- **JNA** (`oshi-core`): Supports JDK 8+ and all platforms OSHI targets. JNA uses reflection-based marshalling for native calls, which adds overhead per invocation.
+- **FFM** (`oshi-core-ffm`): Requires JDK 25+ and currently supports Linux, macOS, and Windows. FFM (Foreign Function & Memory API) uses compiler-optimized stubs for native calls, reducing per-call overhead.
+
+The tables below show approximate average times from JMH benchmarks (1 warmup iteration, 3 measurement iterations) run on GitHub Actions CI runners.
+
+### macOS
+
+| Benchmark  | FFM     | JNA      |
+|------------|---------|----------|
+| CpuTicks   | ~6 µs   | ~7 µs    |
+| FileStore  | ~42 µs  | ~99 µs   |
+| Memory     | ~4 µs   | ~8 µs    |
+| NetworkIF  | ~20 µs  | ~127 µs  |
+| Processes  | ~1.4 ms | ~9.6 ms  |
+
+macOS shows the largest FFM advantage because most system information requires native syscalls (`sysctl`, `proc_pidinfo`, etc.) where FFM's lower per-call overhead compounds across many invocations.
+
+### Windows
+
+| Benchmark  | FFM      | JNA       |
+|------------|----------|-----------|
+| CpuTicks   | ~0.25 ms | ~0.43 ms  |
+| FileStore  | ~35 µs   | ~136 µs   |
+| Memory     | ~77 µs   | ~113 µs   |
+| NetworkIF  | ~613 µs  | ~1238 µs  |
+| Processes  | ~49 ms   | ~11 ms    |
+
+Windows benefits from FFM for most benchmarks. The Processes benchmark is an exception where JNA is faster; this is due to JNA's use of registry-based `HKEY_PERFORMANCE_DATA` queries which bypass the per-process native calls that the FFM implementation currently uses. This is a known issue ([#3186](https://github.com/oshi/oshi/issues/3186)).
+
+### Linux
+
+| Benchmark  | FFM      | JNA      |
+|------------|----------|----------|
+| CpuTicks   | ~24 µs   | ~24 µs   |
+| FileStore  | ~4 µs    | ~31 µs   |
+| Memory     | ~81 µs   | ~81 µs   |
+| NetworkIF  | ~820 µs  | ~805 µs  |
+| Processes  | ~9.7 ms  | ~9.7 ms  |
+
+Linux shows minimal difference between FFM and JNA for most benchmarks. This is because Linux exposes most system information through the `/proc` and `/sys` pseudo-filesystems, which OSHI reads as plain files without native calls. The FileStore benchmark is the exception, where FFM's direct `statvfs` call avoids JNA marshalling overhead.
+
+### Running benchmarks locally
+
+The numbers above were collected on GitHub Actions CI runners, which may differ significantly from your hardware and workload (e.g., number of running processes, mounted file stores, or network interfaces). The `oshi-benchmark` module contains JMH benchmarks that can be built and run with JDK 25+:
+
+```sh
+./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
+java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+```
+
+Run `java -jar oshi-benchmark/target/benchmarks.jar -h` for the full list of JMH options, including listing available benchmarks (`-l`) and running specific ones by regex filter.
+
 ## CPU/memory trade-offs
 
 OSHI avoids caching large amount of information, leaving caching to the user.  Limited use of caching is employed in many classes using Memoized suppliers in instance fields, thus avoiding repeated operating system calls.


### PR DESCRIPTION
Adds a new section to `Performance.md` documenting FFM vs. JNA benchmark results across macOS, Windows, and Linux.

- Side-by-side tables for each OS from JMH benchmarks run on GitHub Actions CI (PR #3195)
- Explains why macOS sees the largest FFM advantage (heavy native syscall usage)
- Explains why Linux shows minimal difference (proc/sys filesystem reads)
- Notes the Windows Processes regression with a link to #3186
- Includes instructions for running benchmarks locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new performance comparison detailing differences between JNA- and FFM-based backends, JDK requirements, and supported platforms.
  * Published JMH benchmark results for macOS, Windows, and Linux with platform-specific notes on observed differences.
  * Added step-by-step guidance and example commands for running local performance benchmarks and viewing benchmark options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->