### PR TITLE
Extract macOS parsing logic for testability

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
@@ -196,12 +196,16 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     }
 
     private List<String> getFeatureFlagsFromSysctl() {
-        List<String> x86Features = Stream.of("features", "extfeatures", "leaf7_features").map(f -> {
+        List<String> x86Features = parseX86FeatureFlags();
+        return x86Features.isEmpty() ? ExecutingCommand.runNative("sysctl -a hw.optional") : x86Features;
+    }
+
+    List<String> parseX86FeatureFlags() {
+        return Stream.of("features", "extfeatures", "leaf7_features").map(f -> {
             String key = "machdep.cpu." + f;
             String features = sysctlStringNoWarn(key, "");
             return Util.isBlank(features) ? null : (key + ": " + features);
         }).filter(Objects::nonNull).collect(Collectors.toList());
-        return x86Features.isEmpty() ? ExecutingCommand.runNative("sysctl -a hw.optional") : x86Features;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGraphicsCard.java
@@ -28,8 +28,12 @@ public abstract class MacGraphicsCard extends AbstractGraphicsCard {
     }
 
     protected static List<GraphicsCard> parseGraphicsCards(GraphicsCardFactory factory, SysctlLong sysctl) {
-        List<GraphicsCard> cardList = new ArrayList<>();
         List<String> sp = ExecutingCommand.runNative("system_profiler SPDisplaysDataType");
+        return parseGraphicsCards(sp, factory, sysctl);
+    }
+
+    static List<GraphicsCard> parseGraphicsCards(List<String> sp, GraphicsCardFactory factory, SysctlLong sysctl) {
+        List<GraphicsCard> cardList = new ArrayList<>();
         String name = Constants.UNKNOWN;
         String deviceId = Constants.UNKNOWN;
         String vendor = Constants.UNKNOWN;

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
@@ -65,17 +65,21 @@ public abstract class MacOperatingSystem extends AbstractOperatingSystem {
         // Big Sur (11.x) may return 10.16
         if (verMajor == 10 && verMinor > 15) {
             String swVers = ExecutingCommand.getFirstAnswer("sw_vers -productVersion");
-            if (!swVers.isEmpty()) {
-                version = swVers;
-            }
+            version = resolveVersion(version, swVers);
             verMajor = ParseUtil.getFirstIntValue(version);
             verMinor = ParseUtil.getNthIntValue(version, 2);
         }
         this.osXVersion = version;
         this.major = verMajor;
         this.minor = verMinor;
-        // Set max processes
         this.maxProc = maxproc;
+    }
+
+    static String resolveVersion(String osVersion, String swVersOutput) {
+        if (!swVersOutput.isEmpty()) {
+            return swVersOutput;
+        }
+        return osVersion;
     }
 
     @Override

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -17,6 +17,8 @@
 --add-opens
   com.github.oshi.common/oshi.driver.common.mac=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.software.common.os.mac=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.util.driver.linux=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.util.driver.linux.proc=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class MacCentralProcessorTest {
+
+    @Test
+    void testParseX86FeatureFlagsWithFeatures() {
+        Map<String, String> strings = new HashMap<>();
+        strings.put("machdep.cpu.brand_string", "Test CPU");
+        strings.put("machdep.cpu.features", "FPU VME SSE SSE2 SSE3");
+        strings.put("machdep.cpu.extfeatures", "LAHF EM64T");
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(strings);
+
+        List<String> flags = cpu.parseX86FeatureFlags();
+        assertThat(flags, hasSize(2));
+        assertThat(flags.get(0), is("machdep.cpu.features: FPU VME SSE SSE2 SSE3"));
+        assertThat(flags.get(1), is("machdep.cpu.extfeatures: LAHF EM64T"));
+    }
+
+    @Test
+    void testParseX86FeatureFlagsEmpty() {
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(new HashMap<>());
+        List<String> flags = cpu.parseX86FeatureFlags();
+        assertThat(flags, is(empty()));
+    }
+
+    /**
+     * Minimal stub providing sysctl values without native calls.
+     */
+    static class StubMacCentralProcessor extends MacCentralProcessor {
+
+        private final Map<String, Integer> sysctlInts = new HashMap<>();
+        private final Map<String, Long> sysctlLongs = new HashMap<>();
+        private final Map<String, String> sysctlStrings;
+
+        StubMacCentralProcessor(Map<String, String> extraStrings) {
+            Map<String, String> defaults = new HashMap<>();
+            defaults.put("machdep.cpu.brand_string", "Test CPU");
+            defaults.putAll(extraStrings);
+            this.sysctlStrings = defaults;
+            sysctlInts.put("hw.logicalcpu", 1);
+            sysctlInts.put("hw.physicalcpu", 1);
+            sysctlInts.put("hw.packages", 1);
+            sysctlInts.put("hw.cpu64bit_capable", 1);
+        }
+
+        @Override
+        protected int sysctlInt(String name, int def) {
+            return sysctlInts == null ? def : sysctlInts.getOrDefault(name, def);
+        }
+
+        @Override
+        protected int sysctlIntNoWarn(String name, int def) {
+            return sysctlInts == null ? def : sysctlInts.getOrDefault(name, def);
+        }
+
+        @Override
+        protected long sysctlLong(String name, long def) {
+            return sysctlLongs == null ? def : sysctlLongs.getOrDefault(name, def);
+        }
+
+        @Override
+        protected String sysctlString(String name, String def) {
+            return sysctlStrings == null ? def : sysctlStrings.getOrDefault(name, def);
+        }
+
+        @Override
+        protected String sysctlStringNoWarn(String name, String def) {
+            return sysctlStrings == null ? def : sysctlStrings.getOrDefault(name, def);
+        }
+
+        @Override
+        protected String platformExpert() {
+            return "Apple";
+        }
+
+        @Override
+        protected Map<Integer, String> queryCompatibleStrings() {
+            return new HashMap<>();
+        }
+
+        @Override
+        protected void calculateNominalFrequencies() {
+        }
+
+        @Override
+        protected long[] querySystemCpuLoadTicks() {
+            return new long[8];
+        }
+
+        @Override
+        protected long[][] queryProcessorCpuLoadTicks() {
+            return new long[1][8];
+        }
+
+        @Override
+        public long queryMaxFreq() {
+            return 0L;
+        }
+
+        @Override
+        public long[] queryCurrentFreq() {
+            return new long[] { 0L };
+        }
+
+        @Override
+        public long queryContextSwitches() {
+            return 0L;
+        }
+
+        @Override
+        public long queryInterrupts() {
+            return 0L;
+        }
+
+        @Override
+        public double[] getSystemLoadAverage(int nelem) {
+            return new double[nelem];
+        }
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGraphicsCardTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.GraphicsCard;
+import oshi.hardware.common.AbstractGraphicsCard;
+import oshi.util.Constants;
+
+class MacGraphicsCardTest {
+
+    private static final MacGraphicsCard.GraphicsCardFactory FACTORY = TestGraphicsCard::new;
+    private static final MacGraphicsCard.SysctlLong SYSCTL = (name, def) -> def;
+
+    @Test
+    void testEmptyInput() {
+        List<GraphicsCard> cards = MacGraphicsCard.parseGraphicsCards(Collections.emptyList(), FACTORY, SYSCTL);
+        assertThat(cards, is(empty()));
+    }
+
+    @Test
+    void testSingleCard() {
+        // Real output from system_profiler SPDisplaysDataType on Apple M3 Pro
+        List<String> sp = Arrays.asList("Graphics/Displays:", "", "    Apple M3 Pro:", "",
+                "      Chipset Model: Apple M3 Pro", "      Type: GPU", "      Bus: Built-In",
+                "      Total Number of Cores: 18", "      Vendor: Apple (0x106b)", "      Metal Support: Metal 4",
+                "      Displays:", "        LG ULTRAWIDE:",
+                "          Resolution: 3440 x 1440 (UWQHD - Ultra-Wide Quad HD)",
+                "          UI Looks like: 3440 x 1440 @ 50.00Hz", "          Main Display: Yes",
+                "          Mirror: Off", "          Online: Yes", "          Rotation: Supported", "        Color LCD:",
+                "          Display Type: Built-in Liquid Retina XDR Display",
+                "          Resolution: 3456 x 2234 Retina", "          Mirror: Off", "          Online: Yes",
+                "          Automatically Adjust Brightness: Yes", "          Connection Type: Internal");
+        List<GraphicsCard> cards = MacGraphicsCard.parseGraphicsCards(sp, FACTORY, SYSCTL);
+        assertThat(cards, hasSize(1));
+        assertThat(cards.get(0).getName(), is("Apple M3 Pro"));
+        assertThat(cards.get(0).getVendor(), is("Apple (0x106b)"));
+        assertThat(cards.get(0).getDeviceId(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testTwoCards() {
+        // Representative output from a 2017 MacBook Pro with Intel + AMD GPUs
+        List<String> sp = Arrays.asList("Graphics/Displays:", "", "    Intel HD Graphics 630:", "",
+                "      Chipset Model: Intel HD Graphics 630", "      Device ID: 0x591b", "      Vendor: Intel (0x8086)",
+                "      VRAM (Dynamic, Max): 1536 MB", "      Revision ID: 0x0004", "", "    Radeon Pro 560:", "",
+                "      Chipset Model: Radeon Pro 560", "      Device ID: 0x67ef", "      Vendor: AMD (0x1002)",
+                "      VRAM (Total): 4096 MB", "      EFI Driver Version: 01.00.560");
+        List<GraphicsCard> cards = MacGraphicsCard.parseGraphicsCards(sp, FACTORY, SYSCTL);
+        assertThat(cards, hasSize(2));
+        assertThat(cards.get(0).getName(), is("Intel HD Graphics 630"));
+        assertThat(cards.get(0).getDeviceId(), is("0x591b"));
+        assertThat(cards.get(0).getVRam(), is(1536L * 1024 * 1024));
+        assertThat(cards.get(1).getName(), is("Radeon Pro 560"));
+        assertThat(cards.get(1).getDeviceId(), is("0x67ef"));
+        assertThat(cards.get(1).getVRam(), is(4096L * 1024 * 1024));
+    }
+
+    @Test
+    void testVersionInfo() {
+        List<String> sp = Arrays.asList("    Card:", "      Chipset Model: Test GPU", "      EFI Driver Version: 1.2.3",
+                "      Metal Revision: 42");
+        List<GraphicsCard> cards = MacGraphicsCard.parseGraphicsCards(sp, FACTORY, SYSCTL);
+        assertThat(cards, hasSize(1));
+        assertThat(cards.get(0).getVersionInfo(), is("EFI Driver Version: 1.2.3, Metal Revision: 42"));
+    }
+
+    @Test
+    void testVramFallbackHwMemsize() {
+        // Apple Silicon GPUs have no VRAM line; resolveVram falls back to hw.memsize
+        long memsize = 36L * 1024 * 1024 * 1024;
+        MacGraphicsCard.SysctlLong sysctl = (name, def) -> "hw.memsize".equals(name) ? memsize : def;
+        List<String> sp = Arrays.asList("      Chipset Model: Apple M3 Pro", "      Vendor: Apple (0x106b)");
+        List<GraphicsCard> cards = MacGraphicsCard.parseGraphicsCards(sp, FACTORY, sysctl);
+        assertThat(cards, hasSize(1));
+        assertThat(cards.get(0).getVRam(), is(memsize));
+    }
+
+    static class TestGraphicsCard extends AbstractGraphicsCard {
+        TestGraphicsCard(String name, String deviceId, String vendor, String versionInfo, long vram) {
+            super(name, deviceId, vendor, versionInfo, vram);
+        }
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/mac/MacOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/mac/MacOperatingSystemTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+class MacOperatingSystemTest {
+
+    @Test
+    void testResolveVersionUsesSwVersWhenNonEmpty() {
+        assertThat(MacOperatingSystem.resolveVersion("10.16", "11.2.3"), is("11.2.3"));
+    }
+
+    @Test
+    void testResolveVersionFallsBackWhenSwVersEmpty() {
+        assertThat(MacOperatingSystem.resolveVersion("10.16", ""), is("10.16"));
+    }
+}


### PR DESCRIPTION
Addresses the macOS items in #3189.

Separates command execution from output parsing in three macOS classes, following the established pattern (e.g., `LinuxCentralProcessor.readTopologyFromCpuinfo(List<String>)`):

- **MacGraphicsCard**: extract `system_profiler SPDisplaysDataType` parsing into a package-private `parseGraphicsCards(List<String>, ...)` overload
- **MacOperatingSystem**: extract `sw_vers` version resolution into a static `resolveVersion(String, String)`
- **MacCentralProcessor**: extract x86 feature flag sysctl parsing into `parseX86FeatureFlags()`

Tests use real fixture data captured from an M3 Pro, plus representative multi-GPU fixture data from an Intel Mac.

No public API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests covering macOS processor feature detection, graphics-card parsing, OS version resolution, and test JVM configuration adjustments for macOS.

* **Refactor**
  * Extracted and reorganized parsing logic into dedicated helpers to improve maintainability and preserve previous behaviors for processor feature flags, graphics-card parsing, and OS version selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->