### PR TITLE
Extract parsing logic from lspci/lshw commands

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
@@ -158,9 +158,23 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
 
     // Faster, use as primary
     private static List<GraphicsCard> getGraphicsCardsFromLspci(Function<Attrs, GraphicsCard> factory) {
+        return getGraphicsCardsFromLspci(ExecutingCommand.runNative("lspci -vnnm"), factory,
+                slot -> queryLspciMemorySize(ExecutingCommand.runNative("lspci -v -s " + slot)),
+                LinuxGraphicsCard::findDrmInfo);
+    }
+
+    /**
+     * Parse graphics card information from lspci machine-readable output.
+     *
+     * @param lspci      output of {@code lspci -vnnm}
+     * @param factory    function that creates a concrete {@link GraphicsCard} from parsed attributes
+     * @param vramLookup function to look up VRAM for a PCI slot address
+     * @param drmLookup  function to look up DRM info for a PCI slot address
+     * @return list of graphics cards
+     */
+    static List<GraphicsCard> getGraphicsCardsFromLspci(List<String> lspci, Function<Attrs, GraphicsCard> factory,
+            Function<String, Long> vramLookup, Function<String, Triplet<String, String, String>> drmLookup) {
         List<GraphicsCard> cardList = new ArrayList<>();
-        // Machine readable version
-        List<String> lspci = ExecutingCommand.runNative("lspci -vnnm");
         String name = Constants.UNKNOWN;
         String deviceId = Constants.UNKNOWN;
         String vendor = Constants.UNKNOWN;
@@ -185,11 +199,11 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
             if (found) {
                 if (split.length < 2) {
                     // Save previous card
-                    Triplet<String, String, String> drmInfo = findDrmInfo(lookupDevice);
+                    Triplet<String, String, String> drmInfo = drmLookup.apply(lookupDevice);
                     cardList.add(factory.apply(new Attrs(name, deviceId, vendor,
                             versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList),
-                            lookupDevice != null ? queryLspciMemorySize(lookupDevice) : 0L, drmInfo.getA(),
-                            drmInfo.getB(), drmInfo.getC())));
+                            lookupDevice != null ? vramLookup.apply(lookupDevice) : 0L, drmInfo.getA(), drmInfo.getB(),
+                            drmInfo.getC())));
                     versionInfoList.clear();
                     found = false;
                 } else {
@@ -214,20 +228,27 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
         }
         // If we haven't yet written the last card do so now
         if (found) {
-            Triplet<String, String, String> drmInfo = findDrmInfo(lookupDevice);
+            Triplet<String, String, String> drmInfo = drmLookup.apply(lookupDevice);
             cardList.add(factory.apply(new Attrs(name, deviceId, vendor,
                     versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList),
-                    lookupDevice != null ? queryLspciMemorySize(lookupDevice) : 0L, drmInfo.getA(), drmInfo.getB(),
+                    lookupDevice != null ? vramLookup.apply(lookupDevice) : 0L, drmInfo.getA(), drmInfo.getB(),
                     drmInfo.getC())));
         }
         return cardList;
     }
 
     private static long queryLspciMemorySize(String lookupDevice) {
+        return queryLspciMemorySize(ExecutingCommand.runNative("lspci -v -s " + lookupDevice));
+    }
+
+    /**
+     * Parse prefetchable memory size from lspci verbose output.
+     *
+     * @param lspciMem output of {@code lspci -v -s <device>}
+     * @return total prefetchable memory size in bytes
+     */
+    static long queryLspciMemorySize(List<String> lspciMem) {
         long vram = 0L;
-        // Lookup memory
-        // Human readable version, includes memory
-        List<String> lspciMem = ExecutingCommand.runNative("lspci -v -s " + lookupDevice);
         for (String mem : lspciMem) {
             if (mem.contains(" prefetchable")) {
                 vram += ParseUtil.parseLspciMemorySize(mem);

--- a/oshi-common/src/main/java/oshi/util/driver/linux/Lshw.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Lshw.java
@@ -4,9 +4,12 @@
  */
 package oshi.util.driver.linux;
 
+import java.util.List;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Triplet;
 
 /**
  * Utility to read info from {@code lshw}
@@ -21,6 +24,19 @@ public final class Lshw {
     private static final String SERIAL;
     private static final String UUID;
     static {
+        Triplet<String, String, String> info = parseSystemInfo(ExecutingCommand.runPrivilegedNative("lshw -C system"));
+        MODEL = info.getA();
+        SERIAL = info.getB();
+        UUID = info.getC();
+    }
+
+    /**
+     * Parse model, serial number, and UUID from lshw system output.
+     *
+     * @param lines output of {@code lshw -C system}
+     * @return triplet of (model, serial, uuid), with null for missing values
+     */
+    static Triplet<String, String, String> parseSystemInfo(List<String> lines) {
         String model = null;
         String serial = null;
         String uuid = null;
@@ -29,7 +45,7 @@ public final class Lshw {
         String serialMarker = "serial:";
         String uuidMarker = "uuid:";
 
-        for (String checkLine : ExecutingCommand.runPrivilegedNative("lshw -C system")) {
+        for (String checkLine : lines) {
             if (checkLine.contains(modelMarker)) {
                 model = checkLine.split(modelMarker)[1].trim();
             } else if (checkLine.contains(serialMarker)) {
@@ -38,9 +54,7 @@ public final class Lshw {
                 uuid = checkLine.split(uuidMarker)[1].trim();
             }
         }
-        MODEL = model;
-        SERIAL = serial;
-        UUID = uuid;
+        return new Triplet<>(model, serial, uuid);
     }
 
     /**
@@ -76,8 +90,18 @@ public final class Lshw {
      * @return The CPU capacity (max frequency) if available, -1 otherwise
      */
     public static long queryCpuCapacity() {
+        return queryCpuCapacity(ExecutingCommand.runPrivilegedNative("lshw -class processor"));
+    }
+
+    /**
+     * Parse the CPU capacity (max frequency) from lshw processor output.
+     *
+     * @param lines output of {@code lshw -class processor}
+     * @return The CPU capacity (max frequency) if available, -1 otherwise
+     */
+    static long queryCpuCapacity(List<String> lines) {
         String capacityMarker = "capacity:";
-        for (String checkLine : ExecutingCommand.runPrivilegedNative("lshw -class processor")) {
+        for (String checkLine : lines) {
             if (checkLine.contains(capacityMarker)) {
                 return ParseUtil.parseHertz(checkLine.split(capacityMarker)[1].trim());
             }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
@@ -5,16 +5,22 @@
 package oshi.hardware.common.platform.linux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import oshi.hardware.GraphicsCard;
 import oshi.util.tuples.Triplet;
 
 class LinuxGraphicsCardTest {
@@ -174,5 +180,91 @@ class LinuxGraphicsCardTest {
         Files.createSymbolicLink(deviceDir.resolve("driver"), driverTarget);
         // Write uevent with PCI_SLOT_NAME
         Files.write(deviceDir.resolve("uevent"), ("PCI_SLOT_NAME=" + slotName + "\n").getBytes(StandardCharsets.UTF_8));
+    }
+
+    // -------------------------------------------------------------------------
+    // getGraphicsCardsFromLspci parsing
+    // -------------------------------------------------------------------------
+
+    // Fixture: lspci -vnnm output with one VGA card
+    private static final List<String> LSPCI_VNNM = Arrays.asList("Slot:\t01:00.0",
+            "Class:\tVGA compatible controller [0300]", "Vendor:\tNVIDIA Corporation [10de]",
+            "Device:\tGA102 [GeForce RTX 3090] [2204]", "SVendor:\tASUS [1043]",
+            "SDevice:\tGA102 [GeForce RTX 3090] [8687]", "Rev:\ta1", "");
+
+    private static final Function<LinuxGraphicsCard.Attrs, GraphicsCard> STUB_FACTORY = attrs -> new StubGraphicsCard(
+            attrs.getName(), attrs.getDeviceId(), attrs.getVendor(), attrs.getVersionInfo(), attrs.getVram(),
+            attrs.getDrmDevicePath(), attrs.getDriverName(), attrs.getPciBusId());
+
+    // No-op lookups for pure parsing tests
+    private static final Function<String, Long> NO_VRAM = slot -> 0L;
+    private static final Function<String, Triplet<String, String, String>> NO_DRM = slot -> new Triplet<>("", "", "");
+
+    @Test
+    void testGetGraphicsCardsFromLspciSingleCard() {
+        List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(LSPCI_VNNM, STUB_FACTORY, NO_VRAM,
+                NO_DRM);
+        assertThat(cards.size(), is(1));
+        GraphicsCard card = cards.get(0);
+        assertThat(card.getName(), is("GA102 [GeForce RTX 3090]"));
+        assertThat(card.getDeviceId(), is("0x2204"));
+        assertThat(card.getVendor(), is("NVIDIA Corporation (0x10de)"));
+        assertThat(card.getVersionInfo(), is("Rev:\ta1"));
+    }
+
+    @Test
+    void testGetGraphicsCardsFromLspciEmpty() {
+        List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(Collections.emptyList(), STUB_FACTORY,
+                NO_VRAM, NO_DRM);
+        assertThat(cards, is(empty()));
+    }
+
+    @Test
+    void testGetGraphicsCardsFromLspciTwoCards() {
+        List<String> twoCards = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
+                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1", "",
+                "Slot:\t00:02.0", "Class:\tVGA compatible controller [0300]", "Vendor:\tIntel Corporation [8086]",
+                "Device:\tUHD Graphics 630 [3E92]", "Rev:\t00", "");
+        List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(twoCards, STUB_FACTORY, NO_VRAM, NO_DRM);
+        assertThat(cards.size(), is(2));
+        assertThat(cards.get(0).getName(), is("GA102 [GeForce RTX 3090]"));
+        assertThat(cards.get(1).getName(), is("UHD Graphics 630"));
+        assertThat(cards.get(1).getDeviceId(), is("0x3E92"));
+    }
+
+    @Test
+    void testGetGraphicsCardsFromLspci3DController() {
+        List<String> threeD = Arrays.asList("Slot:\t01:00.0", "Class:\t3D controller [0302]",
+                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tTesla V100 [1db4]", "");
+        List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(threeD, STUB_FACTORY, NO_VRAM, NO_DRM);
+        assertThat(cards.size(), is(1));
+        assertThat(cards.get(0).getName(), is("Tesla V100"));
+    }
+
+    // -------------------------------------------------------------------------
+    // queryLspciMemorySize parsing
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testQueryLspciMemorySize() {
+        List<String> lspciV = Arrays.asList("01:00.0 VGA compatible controller: NVIDIA Corporation",
+                "\tMemory at f6000000 (32-bit, non-prefetchable) [size=16M]",
+                "\tMemory at e0000000 (64-bit, prefetchable) [size=256M]",
+                "\tMemory at f0000000 (64-bit, prefetchable) [size=32M]", "\tI/O ports at e000 [size=128]");
+        long vram = LinuxGraphicsCard.queryLspciMemorySize(lspciV);
+        // 256M + 32M = 288M
+        assertThat(vram, is(256L * 1024 * 1024 + 32L * 1024 * 1024));
+    }
+
+    @Test
+    void testQueryLspciMemorySizeNoPrefetchable() {
+        List<String> noPrefetch = Arrays.asList("01:00.0 VGA compatible controller: Intel",
+                "\tMemory at f6000000 (32-bit, non-prefetchable) [size=16M]");
+        assertThat(LinuxGraphicsCard.queryLspciMemorySize(noPrefetch), is(0L));
+    }
+
+    @Test
+    void testQueryLspciMemorySizeEmpty() {
+        assertThat(LinuxGraphicsCard.queryLspciMemorySize(Collections.emptyList()), is(0L));
     }
 }

--- a/oshi-common/src/test/java/oshi/util/driver/linux/LshwTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/LshwTest.java
@@ -8,26 +8,88 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import oshi.TestConstants;
+import oshi.util.tuples.Triplet;
 
-@EnabledOnOs(OS.LINUX)
 class LshwTest {
 
+    // Fixture: lshw -C system output
+    private static final List<String> SYSTEM_OUTPUT = Arrays.asList("  *-system", "       description: Computer",
+            "       product: PowerEdge R720", "       vendor: Dell Inc.", "       serial: ABC1234",
+            "       width: 64 bits", "       uuid: 4C4C4544-0044-4810-8031-B4C04F333132");
+
+    // Fixture: lshw -class processor output
+    private static final List<String> PROCESSOR_OUTPUT = Arrays.asList("  *-cpu",
+            "       product: Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz", "       vendor: Intel Corp.",
+            "       capacity: 3300MHz", "       width: 64 bits");
+
     @Test
-    void testQueries() {
-        assertDoesNotThrow(Lshw::queryModel);
-        assertDoesNotThrow(Lshw::querySerialNumber);
-        String uuid = Lshw.queryUUID();
-        if (uuid != null) {
-            assertThat("Test Lshw queryUUID", uuid, matchesRegex(TestConstants.UUID_REGEX));
+    void testParseSystemInfo() {
+        Triplet<String, String, String> result = Lshw.parseSystemInfo(SYSTEM_OUTPUT);
+        assertThat(result.getA(), is("PowerEdge R720"));
+        assertThat(result.getB(), is("ABC1234"));
+        assertThat(result.getC(), is("4C4C4544-0044-4810-8031-B4C04F333132"));
+    }
+
+    @Test
+    void testParseSystemInfoEmpty() {
+        Triplet<String, String, String> result = Lshw.parseSystemInfo(Collections.emptyList());
+        assertThat(result.getA(), is(nullValue()));
+        assertThat(result.getB(), is(nullValue()));
+        assertThat(result.getC(), is(nullValue()));
+    }
+
+    @Test
+    void testParseSystemInfoPartial() {
+        List<String> partial = Arrays.asList("       product: MyServer");
+        Triplet<String, String, String> result = Lshw.parseSystemInfo(partial);
+        assertThat(result.getA(), is("MyServer"));
+        assertThat(result.getB(), is(nullValue()));
+        assertThat(result.getC(), is(nullValue()));
+    }
+
+    @Test
+    void testQueryCpuCapacityParsing() {
+        assertThat(Lshw.queryCpuCapacity(PROCESSOR_OUTPUT), is(3_300_000_000L));
+    }
+
+    @Test
+    void testQueryCpuCapacityEmpty() {
+        assertThat(Lshw.queryCpuCapacity(Collections.emptyList()), is(-1L));
+    }
+
+    @Test
+    void testQueryCpuCapacityNoCapacityLine() {
+        List<String> noCapacity = Arrays.asList("  *-cpu", "       product: ARM Cortex-A72");
+        assertThat(Lshw.queryCpuCapacity(noCapacity), is(-1L));
+    }
+
+    @Nested
+    @EnabledOnOs(OS.LINUX)
+    class LiveTests {
+        @Test
+        void testQueries() {
+            assertDoesNotThrow(Lshw::queryModel);
+            assertDoesNotThrow(Lshw::querySerialNumber);
+            String uuid = Lshw.queryUUID();
+            if (uuid != null) {
+                assertThat("Test Lshw queryUUID", uuid, matchesRegex(TestConstants.UUID_REGEX));
+            }
+            assertThat("Test Lshw queryCpuCapacity", Lshw.queryCpuCapacity(), anyOf(greaterThan(0L), equalTo(-1L)));
         }
-        assertThat("Test Lshw queryCpuCapacity", Lshw.queryCpuCapacity(), anyOf(greaterThan(0L), equalTo(-1L)));
     }
 }


### PR DESCRIPTION
Resolves part of #3189.

Separates command execution from output parsing in 4 methods across 2 classes:

**Refactored methods:**
- `LinuxGraphicsCard.getGraphicsCardsFromLspci()` — `lspci -vnnm`
- `LinuxGraphicsCard.queryLspciMemorySize()` — `lspci -v -s`
- `Lshw` static initializer → new `parseSystemInfo(List<String>)` — `lshw -C system`
- `Lshw.queryCpuCapacity()` — `lshw -class processor`

**Tests added to LinuxGraphicsCardTest:**
- Single VGA card, two cards, 3D controller parsing from lspci -vnnm
- Prefetchable memory size parsing, no-prefetchable, empty input

**Tests added to LshwTest:**
- System info parsing (model, serial, UUID), partial/empty input
- CPU capacity parsing, missing capacity line, empty input

No public API changes. No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured graphics card detection processing to improve code modularity and testability
  * Enhanced system information extraction with input-driven parsing mechanisms

* **Tests**
  * Added comprehensive test coverage for graphics card detection and parsing scenarios
  * Introduced unit tests for system information parsing with edge cases and various input conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->