### PR TITLE
Extract parsing from Who, LinuxOSProcess, LinuxOperatingSystem

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -335,11 +335,23 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
     public long getAffinityMask() {
         // Would prefer to use native sched_getaffinity call but variable sizing is
         // kernel-dependent and requires C macros, so we use command line instead.
-        String mask = ExecutingCommand.getFirstAnswer("taskset -p " + getProcessID());
+        return parseAffinityMask(ExecutingCommand.getFirstAnswer("taskset -p " + getProcessID()));
+    }
+
+    /**
+     * Parse the affinity mask from taskset output.
+     *
+     * @param tasksetOutput output of {@code taskset -p <pid>}
+     * @return the affinity mask as a long, or 0 if unparseable
+     */
+    static long parseAffinityMask(String tasksetOutput) {
         // Output:
         // pid 3283's current affinity mask: 3
         // pid 9726's current affinity mask: f
-        String[] split = ParseUtil.whitespaces.split(mask);
+        String[] split = ParseUtil.whitespaces.split(tasksetOutput);
+        if (split.length == 0) {
+            return 0;
+        }
         try {
             return new BigInteger(split[split.length - 1], 16).longValue();
         } catch (NumberFormatException e) {

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -268,10 +268,19 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      *         otherwise
      */
     private static Triplet<String, String, String> readOsRelease() {
+        return readOsRelease(FileUtil.readFile("/etc/os-release"));
+    }
+
+    /**
+     * Parse /etc/os-release content.
+     *
+     * @param osRelease lines from /etc/os-release
+     * @return a triplet with the parsed family, versionID and codeName if NAME= found, null otherwise
+     */
+    static Triplet<String, String, String> readOsRelease(List<String> osRelease) {
         String family = null;
         String versionId = Constants.UNKNOWN;
         String codeName = Constants.UNKNOWN;
-        List<String> osRelease = FileUtil.readFile("/etc/os-release");
         // Search for NAME=
         for (String line : osRelease) {
             if (line.startsWith("VERSION=")) {
@@ -305,10 +314,21 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      *         Distributor ID: or Description: found, null otherwise
      */
     private static Triplet<String, String, String> execLsbRelease() {
+        return execLsbRelease(ExecutingCommand.runNative("lsb_release -a"));
+    }
+
+    /**
+     * Parse lsb_release -a output.
+     *
+     * @param lines output of {@code lsb_release -a}
+     * @return a triplet with the parsed family, versionID and codeName if Distributor ID: or Description: found, null
+     *         otherwise
+     */
+    static Triplet<String, String, String> execLsbRelease(List<String> lines) {
         String family = null;
         String versionId = Constants.UNKNOWN;
         String codeName = Constants.UNKNOWN;
-        for (String line : ExecutingCommand.runNative("lsb_release -a")) {
+        for (String line : lines) {
             if (line.startsWith("Description:")) {
                 LOG.debug(LSB_RELEASE_A_LOG, line);
                 line = line.replace("Description:", "").trim();

--- a/oshi-common/src/main/java/oshi/util/driver/linux/Who.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Who.java
@@ -57,7 +57,7 @@ public final class Who {
      * @param s       the string to match
      * @return true if successful, false otherwise
      */
-    private static boolean matchLinux(List<OSSession> whoList, String s) {
+    static boolean matchLinux(List<OSSession> whoList, String s) {
         Matcher m = WHO_FORMAT_LINUX.matcher(s);
         if (m.matches()) {
             try {

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -19,6 +19,8 @@
 --add-opens
   com.github.oshi.common/oshi.software.common.os.mac=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.software.common.os.linux=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.util.driver.linux=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.util.driver.linux.proc=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOSProcessTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOSProcessTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+class LinuxOSProcessTest {
+
+    @Test
+    void testParseAffinityMaskHex() {
+        assertThat(LinuxOSProcess.parseAffinityMask("pid 3283's current affinity mask: 3"), is(3L));
+    }
+
+    @Test
+    void testParseAffinityMaskFullHex() {
+        assertThat(LinuxOSProcess.parseAffinityMask("pid 9726's current affinity mask: f"), is(15L));
+    }
+
+    @Test
+    void testParseAffinityMaskMultiCore() {
+        assertThat(LinuxOSProcess.parseAffinityMask("pid 1234's current affinity mask: ff"), is(255L));
+    }
+
+    @Test
+    void testParseAffinityMaskEmpty() {
+        assertThat(LinuxOSProcess.parseAffinityMask(""), is(0L));
+    }
+
+    @Test
+    void testParseAffinityMaskInvalid() {
+        assertThat(LinuxOSProcess.parseAffinityMask("no mask here"), is(0L));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.util.tuples.Triplet;
+
+@EnabledOnOs(OS.LINUX)
+class LinuxOperatingSystemTest {
+
+    // Fixture: /etc/os-release from Ubuntu 22.04
+    private static final List<String> OS_RELEASE_UBUNTU = Arrays.asList("NAME=\"Ubuntu\"",
+            "VERSION=\"22.04.3 LTS (Jammy Jellyfish)\"", "ID=ubuntu", "VERSION_ID=\"22.04\"",
+            "PRETTY_NAME=\"Ubuntu 22.04.3 LTS\"");
+
+    // Fixture: /etc/os-release from CentOS Stream (no codename in VERSION)
+    private static final List<String> OS_RELEASE_CENTOS = Arrays.asList("NAME=\"CentOS Stream\"", "VERSION=\"9\"",
+            "ID=\"centos\"", "VERSION_ID=\"9\"");
+
+    // Fixture: lsb_release -a output
+    private static final List<String> LSB_RELEASE = Arrays.asList(
+            "LSB Version:\tcore-11.1.0ubuntu4-noarch:security-11.1.0ubuntu4-noarch", "Distributor ID:\tUbuntu",
+            "Description:\tUbuntu 22.04.3 LTS", "Release:\t22.04", "Codename:\tjammy");
+
+    @Test
+    void testReadOsReleaseUbuntu() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_UBUNTU);
+        assertThat(result.getA(), is("Ubuntu"));
+        assertThat(result.getB(), is("22.04.3 LTS"));
+        assertThat(result.getC(), is("Jammy Jellyfish"));
+    }
+
+    @Test
+    void testReadOsReleaseCentOS() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_CENTOS);
+        assertThat(result.getA(), is("CentOS Stream"));
+        assertThat(result.getB(), is("9"));
+    }
+
+    @Test
+    void testReadOsReleaseEmpty() {
+        assertThat(LinuxOperatingSystem.readOsRelease(Collections.emptyList()), is(nullValue()));
+    }
+
+    @Test
+    void testReadOsReleaseNoName() {
+        List<String> noName = Arrays.asList("VERSION=\"1.0\"", "VERSION_ID=\"1\"");
+        assertThat(LinuxOperatingSystem.readOsRelease(noName), is(nullValue()));
+    }
+
+    @Test
+    void testExecLsbRelease() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(LSB_RELEASE);
+        assertThat(result.getA(), is("Ubuntu"));
+        assertThat(result.getB(), is("22.04"));
+        assertThat(result.getC(), is("jammy"));
+    }
+
+    @Test
+    void testExecLsbReleaseEmpty() {
+        assertThat(LinuxOperatingSystem.execLsbRelease(Collections.emptyList()), is(nullValue()));
+    }
+
+    @Test
+    void testExecLsbReleaseDescriptionOnly() {
+        List<String> descOnly = Arrays.asList("Description:\tFedora release 38 (Thirty Eight)");
+        Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(descOnly);
+        assertThat(result.getA(), is("Fedora"));
+        assertThat(result.getB(), is("38"));
+        assertThat(result.getC(), is("Thirty Eight"));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/driver/linux/WhoTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/WhoTest.java
@@ -5,27 +5,65 @@
 package oshi.util.driver.linux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import oshi.software.os.OSSession;
+import oshi.util.Constants;
 
-@EnabledOnOs(OS.LINUX)
 class WhoTest {
 
     @Test
-    void testQueryWho() {
-        List<OSSession> sessions = Who.queryWho();
-        assertThat(sessions, is(notNullValue()));
-        for (OSSession session : sessions) {
-            assertThat(session.getUserName(), is(notNullValue()));
-            assertThat(session.getTerminalDevice(), is(notNullValue()));
+    void testMatchLinuxStandardFormat() {
+        List<OSSession> sessions = new ArrayList<>();
+        boolean matched = Who.matchLinux(sessions, "oshi pts/0        2020-05-14 21:23 (192.168.1.23)");
+        assertThat(matched, is(true));
+        assertThat(sessions.size(), is(1));
+        assertThat(sessions.get(0).getUserName(), is("oshi"));
+        assertThat(sessions.get(0).getTerminalDevice(), is("pts/0"));
+        assertThat(sessions.get(0).getLoginTime(), is(greaterThan(0L)));
+        assertThat(sessions.get(0).getHost(), is("192.168.1.23"));
+    }
+
+    @Test
+    void testMatchLinuxNoHost() {
+        List<OSSession> sessions = new ArrayList<>();
+        boolean matched = Who.matchLinux(sessions, "root     tty1         2023-01-15 08:30");
+        assertThat(matched, is(true));
+        assertThat(sessions.size(), is(1));
+        assertThat(sessions.get(0).getUserName(), is("root"));
+        assertThat(sessions.get(0).getTerminalDevice(), is("tty1"));
+        assertThat(sessions.get(0).getHost(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testMatchLinuxNoMatch() {
+        List<OSSession> sessions = new ArrayList<>();
+        boolean matched = Who.matchLinux(sessions, "not a valid who line");
+        assertThat(matched, is(false));
+        assertThat(sessions.size(), is(0));
+    }
+
+    @Nested
+    @EnabledOnOs(OS.LINUX)
+    class LiveTests {
+        @Test
+        void testQueryWho() {
+            List<OSSession> sessions = Who.queryWho();
+            assertThat(sessions, is(notNullValue()));
+            for (OSSession session : sessions) {
+                assertThat(session.getUserName(), is(notNullValue()));
+                assertThat(session.getTerminalDevice(), is(notNullValue()));
+            }
         }
     }
 }

--- a/oshi-common/src/test/java/oshi/util/driver/unix/WhoTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/WhoTest.java
@@ -11,22 +11,71 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import oshi.software.os.OSSession;
 
-@DisabledOnOs(OS.WINDOWS)
 class WhoTest {
+
     @Test
-    void testQueryWho() {
-        for (OSSession session : Who.queryWho()) {
-            assertThat("Session login time should be greater than 0", session.getLoginTime(), is(greaterThan(0L)));
-            assertThat("Session login time should be less than current time", session.getLoginTime(),
-                    is(lessThan(System.currentTimeMillis())));
-            assertThat("User should be non-empty", session.getUserName(), is(not(emptyOrNullString())));
-            assertThat("Devices should be non-empty", session.getTerminalDevice(), is(not(emptyOrNullString())));
+    void testMatchUnixStandardFormat() {
+        List<OSSession> sessions = new ArrayList<>();
+        boolean matched = Who.matchUnix(sessions, "oshi ttys000 May  4 23:50 (192.168.1.23)");
+        assertThat(matched, is(true));
+        assertThat(sessions.size(), is(1));
+        assertThat(sessions.get(0).getUserName(), is("oshi"));
+        assertThat(sessions.get(0).getTerminalDevice(), is("ttys000"));
+        assertThat(sessions.get(0).getLoginTime(), is(greaterThan(0L)));
+    }
+
+    @Test
+    void testMatchUnixNoHost() {
+        List<OSSession> sessions = new ArrayList<>();
+        boolean matched = Who.matchUnix(sessions, "root     console  Jan 15 08:30");
+        assertThat(matched, is(true));
+        assertThat(sessions.size(), is(1));
+        assertThat(sessions.get(0).getUserName(), is("root"));
+        assertThat(sessions.get(0).getTerminalDevice(), is("console"));
+        assertThat(sessions.get(0).getHost(), is(""));
+    }
+
+    @Test
+    void testMatchUnixSingleDigitDay() {
+        List<OSSession> sessions = new ArrayList<>();
+        boolean matched = Who.matchUnix(sessions, "user1 pts/0 Dec  3 14:22 (10.0.0.1)");
+        assertThat(matched, is(true));
+        assertThat(sessions.size(), is(1));
+        assertThat(sessions.get(0).getUserName(), is("user1"));
+        assertThat(sessions.get(0).getTerminalDevice(), is("pts/0"));
+        assertThat(sessions.get(0).getHost(), is("10.0.0.1"));
+    }
+
+    @Test
+    void testMatchUnixNoMatch() {
+        List<OSSession> sessions = new ArrayList<>();
+        boolean matched = Who.matchUnix(sessions, "not a valid who line");
+        assertThat(matched, is(false));
+        assertThat(sessions.size(), is(0));
+    }
+
+    @Nested
+    @DisabledOnOs(OS.WINDOWS)
+    class LiveTests {
+        @Test
+        void testQueryWho() {
+            for (OSSession session : Who.queryWho()) {
+                assertThat("Session login time should be greater than 0", session.getLoginTime(), is(greaterThan(0L)));
+                assertThat("Session login time should be less than current time", session.getLoginTime(),
+                        is(lessThan(System.currentTimeMillis())));
+                assertThat("User should be non-empty", session.getUserName(), is(not(emptyOrNullString())));
+                assertThat("Devices should be non-empty", session.getTerminalDevice(), is(not(emptyOrNullString())));
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves part of #3189.

Separates command execution from output parsing in 5 methods:

**Refactored methods:**
- `Who.matchLinux()` — made package-private (was private) for direct testing with fixture data
- `Who.matchUnix()` — already public, added fixture tests for various `who` date formats
- `LinuxOSProcess.getAffinityMask()` → new `parseAffinityMask(String)` — `taskset -p` output
- `LinuxOperatingSystem.readOsRelease()` → new `readOsRelease(List<String>)` — `/etc/os-release`
- `LinuxOperatingSystem.execLsbRelease()` → new `execLsbRelease(List<String>)` — `lsb_release -a`

**Tests added:**
- Linux WhoTest: standard format, no host, no match
- Unix WhoTest: standard format, no host, single-digit day, no match
- LinuxOSProcessTest: hex affinity masks, empty/invalid input
- LinuxOperatingSystemTest: Ubuntu/CentOS os-release, lsb_release, empty/partial input

No public API changes. No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Linux OS identification and process-affinity parsing internals for more reliable detection and resilience to malformed inputs.

* **Tests**
  * Added deterministic unit tests covering OS release parsing, process affinity extraction, and user/session parsing to increase confidence and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->