### PR TITLE
Extract parsing from NetStat and Xrandr commands

### DIFF
--- a/oshi-common/src/main/java/oshi/util/driver/unix/NetStat.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/NetStat.java
@@ -33,10 +33,19 @@ public final class NetStat {
      * @return A pair with number of established IPv4 and IPv6 connections
      */
     public static Pair<Long, Long> queryTcpnetstat() {
+        return queryTcpnetstat(ExecutingCommand.runNative("netstat -n -p tcp"));
+    }
+
+    /**
+     * Parse netstat output to count established TCP connections.
+     *
+     * @param lines output of {@code netstat -n -p tcp}
+     * @return A pair with number of established IPv4 and IPv6 connections
+     */
+    static Pair<Long, Long> queryTcpnetstat(List<String> lines) {
         long tcp4 = 0L;
         long tcp6 = 0L;
-        List<String> activeConns = ExecutingCommand.runNative("netstat -n -p tcp");
-        for (String s : activeConns) {
+        for (String s : lines) {
             if (s.endsWith("ESTABLISHED")) {
                 if (s.startsWith("tcp4")) {
                     tcp4++;
@@ -54,9 +63,18 @@ public final class NetStat {
      * @return A list of TCP and UDP connections
      */
     public static List<IPConnection> queryNetstat() {
+        return queryNetstat(ExecutingCommand.runNative("netstat -n"));
+    }
+
+    /**
+     * Parse netstat output for TCP and UDP connections.
+     *
+     * @param lines output of {@code netstat -n}
+     * @return A list of TCP and UDP connections
+     */
+    static List<IPConnection> queryNetstat(List<String> lines) {
         List<IPConnection> connections = new ArrayList<>();
-        List<String> activeConns = ExecutingCommand.runNative("netstat -n");
-        for (String s : activeConns) {
+        for (String s : lines) {
             String[] split = null;
             if (s.startsWith("tcp") || s.startsWith("udp")) {
                 split = ParseUtil.whitespaces.split(s);
@@ -115,6 +133,16 @@ public final class NetStat {
      * @return The statistics
      */
     public static TcpStats queryTcpStats(String netstatStr) {
+        return queryTcpStats(ExecutingCommand.runNative(netstatStr));
+    }
+
+    /**
+     * Parse TCP statistics from netstat -s output.
+     *
+     * @param netstat output lines from {@code netstat -s} (TCP section)
+     * @return The statistics
+     */
+    static TcpStats queryTcpStats(List<String> netstat) {
         long connectionsEstablished = 0;
         long connectionsActive = 0;
         long connectionsPassive = 0;
@@ -125,7 +153,6 @@ public final class NetStat {
         long segmentsRetransmitted = 0;
         long inErrors = 0;
         long outResets = 0;
-        List<String> netstat = ExecutingCommand.runNative(netstatStr);
         for (String s : netstat) {
             String[] split = s.trim().split(" ", 2);
             if (split.length == 2) {
@@ -196,11 +223,20 @@ public final class NetStat {
      * @return The statistics
      */
     public static UdpStats queryUdpStats(String netstatStr) {
+        return queryUdpStats(ExecutingCommand.runNative(netstatStr));
+    }
+
+    /**
+     * Parse UDP statistics from netstat -s output.
+     *
+     * @param netstat output lines from {@code netstat -s} (UDP section)
+     * @return The statistics
+     */
+    static UdpStats queryUdpStats(List<String> netstat) {
         long datagramsSent = 0;
         long datagramsReceived = 0;
         long datagramsNoPort = 0;
         long datagramsReceivedErrors = 0;
-        List<String> netstat = ExecutingCommand.runNative(netstatStr);
         for (String s : netstat) {
             String[] split = s.trim().split(" ", 2);
             if (split.length == 2) {

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
@@ -25,7 +25,16 @@ public final class Xrandr {
 
     public static List<byte[]> getEdidArrays() {
         // Special handling for X commands, don't use LC_ALL
-        List<String> xrandr = ExecutingCommand.runNative(XRANDR_VERBOSE, null);
+        return getEdidArrays(ExecutingCommand.runNative(XRANDR_VERBOSE, null));
+    }
+
+    /**
+     * Parse EDID arrays from xrandr verbose output.
+     *
+     * @param xrandr output of {@code xrandr --verbose}
+     * @return a list of EDID byte arrays (at least 128 bytes each)
+     */
+    static List<byte[]> getEdidArrays(List<String> xrandr) {
         // xrandr reports edid in multiple lines. After seeing a line containing
         // EDID, read subsequent lines of hex until 256 characters are reached
         if (xrandr.isEmpty()) {

--- a/oshi-common/src/test/java/oshi/util/driver/unix/NetStatTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/NetStatTest.java
@@ -6,57 +6,168 @@ package oshi.util.driver.unix;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import oshi.software.os.InternetProtocolStats.IPConnection;
+import oshi.software.os.InternetProtocolStats.TcpState;
 import oshi.software.os.InternetProtocolStats.TcpStats;
 import oshi.software.os.InternetProtocolStats.UdpStats;
 import oshi.util.tuples.Pair;
 
-@DisabledOnOs(OS.WINDOWS)
 class NetStatTest {
 
-    @DisabledOnOs({ OS.WINDOWS, OS.MAC, OS.LINUX })
+    // Fixture: netstat -n -p tcp output (macOS style)
+    private static final List<String> TCP_NETSTAT = Arrays.asList("Active Internet connections",
+            "Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)",
+            "tcp4       0      0  192.168.1.5.55362      93.184.216.34.443      ESTABLISHED",
+            "tcp4       0      0  192.168.1.5.55363      93.184.216.34.443      ESTABLISHED",
+            "tcp6       0      0  ::1.55364              ::1.8080               ESTABLISHED",
+            "tcp4       0      0  192.168.1.5.55365      10.0.0.1.80            TIME_WAIT");
+
+    // Fixture: netstat -n output
+    private static final List<String> NETSTAT_N = Arrays.asList("Active Internet connections",
+            "Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)",
+            "tcp4       0      0  192.168.1.5.55362      93.184.216.34.443      ESTABLISHED",
+            "udp4       0      0  192.168.1.5.5353       *.* ");
+
+    // Fixture: netstat -st4 output (Linux TCP stats)
+    private static final List<String> TCP_STATS_LINUX = Arrays.asList("Tcp:", "    1234 active connection openings",
+            "    5678 passive connection openings", "    12 failed connection attempts",
+            "    34 connection resets received", "    56 connections established", "    789012 segments received",
+            "    345678 segments sent out", "    901 segments retransmitted", "    0 bad segments received",
+            "    45 resets sent");
+
+    // Fixture: netstat -su4 output (Linux UDP stats)
+    private static final List<String> UDP_STATS_LINUX = Arrays.asList("Udp:", "    12345 packets received",
+            "    67 packets to unknown port received", "    0 packet receive errors", "    8901 packets sent");
+
+    @Test
+    void testQueryTcpnetstat() {
+        Pair<Long, Long> result = NetStat.queryTcpnetstat(TCP_NETSTAT);
+        assertThat(result.getA(), is(2L));
+        assertThat(result.getB(), is(1L));
+    }
+
+    @Test
+    void testQueryTcpnetstatEmpty() {
+        Pair<Long, Long> result = NetStat.queryTcpnetstat(Collections.emptyList());
+        assertThat(result.getA(), is(0L));
+        assertThat(result.getB(), is(0L));
+    }
+
     @Test
     void testQueryNetstat() {
-        for (IPConnection conn : NetStat.queryNetstat()) {
-            assertThat("Connection is tcp or udp", conn.getType(), anyOf(startsWith("tcp"), startsWith("udp")));
+        List<IPConnection> connections = NetStat.queryNetstat(NETSTAT_N);
+        assertThat(connections, hasSize(2));
+        assertThat(connections.get(0).getType(), is("tcp4"));
+        assertThat(connections.get(0).getState(), is(TcpState.ESTABLISHED));
+        assertThat(connections.get(0).getLocalPort(), is(55362));
+        assertThat(connections.get(0).getForeignPort(), is(443));
+        assertThat(connections.get(1).getType(), is("udp4"));
+        assertThat(connections.get(1).getState(), is(TcpState.NONE));
+        assertThat(connections.get(1).getLocalPort(), is(5353));
+    }
+
+    @Test
+    void testQueryNetstatEmpty() {
+        assertThat(NetStat.queryNetstat(Collections.emptyList()), is(empty()));
+    }
+
+    @Test
+    void testQueryTcpStatsLinux() {
+        TcpStats stats = NetStat.queryTcpStats(TCP_STATS_LINUX);
+        assertThat(stats.getConnectionsEstablished(), is(56L));
+        assertThat(stats.getConnectionsActive(), is(1234L));
+        assertThat(stats.getConnectionsPassive(), is(5678L));
+        assertThat(stats.getConnectionFailures(), is(12L));
+        assertThat(stats.getConnectionsReset(), is(34L));
+        assertThat(stats.getSegmentsSent(), is(345678L));
+        assertThat(stats.getSegmentsReceived(), is(789012L));
+        assertThat(stats.getSegmentsRetransmitted(), is(901L));
+        assertThat(stats.getOutResets(), is(45L));
+        assertThat(stats.getInErrors(), is(0L));
+    }
+
+    @Test
+    void testQueryTcpStatsEmpty() {
+        TcpStats stats = NetStat.queryTcpStats(Collections.emptyList());
+        assertThat(stats.getConnectionsEstablished(), is(0L));
+        assertThat(stats.getConnectionsActive(), is(0L));
+        assertThat(stats.getSegmentsReceived(), is(0L));
+        assertThat(stats.getInErrors(), is(0L));
+    }
+
+    @Test
+    void testQueryUdpStatsLinux() {
+        UdpStats stats = NetStat.queryUdpStats(UDP_STATS_LINUX);
+        assertThat(stats.getDatagramsSent(), is(8901L));
+        assertThat(stats.getDatagramsReceived(), is(12345L));
+        assertThat(stats.getDatagramsNoPort(), is(67L));
+        assertThat(stats.getDatagramsReceivedErrors(), is(0L));
+    }
+
+    @Test
+    void testQueryUdpStatsEmpty() {
+        UdpStats stats = NetStat.queryUdpStats(Collections.emptyList());
+        assertThat(stats.getDatagramsSent(), is(0L));
+        assertThat(stats.getDatagramsReceived(), is(0L));
+        assertThat(stats.getDatagramsNoPort(), is(0L));
+        assertThat(stats.getDatagramsReceivedErrors(), is(0L));
+    }
+
+    @Nested
+    @DisabledOnOs(OS.WINDOWS)
+    class LiveTests {
+        // netstat -n output format varies across platforms; live parsing only verified on FreeBSD/OpenBSD
+        @DisabledOnOs({ OS.WINDOWS, OS.MAC, OS.LINUX })
+        @Test
+        void testQueryNetstat() {
+            for (IPConnection conn : NetStat.queryNetstat()) {
+                assertThat("Connection is tcp or udp", conn.getType(), anyOf(startsWith("tcp"), startsWith("udp")));
+            }
         }
-    }
 
-    @EnabledOnOs({ OS.MAC, OS.FREEBSD })
-    @Test
-    void testQueryTcpNetstat() {
-        Pair<Long, Long> tcpConns = NetStat.queryTcpnetstat();
-        assertThat("ipv4 connections must be nonnegative", tcpConns.getA().intValue(), greaterThanOrEqualTo(0));
-        assertThat("ipv6 connections must be nonnegative", tcpConns.getB().intValue(), greaterThanOrEqualTo(0));
-    }
+        @EnabledOnOs({ OS.MAC, OS.FREEBSD })
+        @Test
+        void testQueryTcpNetstat() {
+            Pair<Long, Long> tcpConns = NetStat.queryTcpnetstat();
+            assertThat("ipv4 connections must be nonnegative", tcpConns.getA().intValue(), greaterThanOrEqualTo(0));
+            assertThat("ipv6 connections must be nonnegative", tcpConns.getB().intValue(), greaterThanOrEqualTo(0));
+        }
 
-    @EnabledOnOs(OS.LINUX)
-    @Test
-    void testQueryStatsLinux() {
-        TcpStats tcpStats = NetStat.queryTcpStats("netstat -st4");
-        assertThat("tcp connections must be nonnegative", tcpStats.getConnectionsEstablished(),
-                greaterThanOrEqualTo(0L));
-        UdpStats udp4Stats = NetStat.queryUdpStats("netstat -su4");
-        assertThat("udp4 datagrams sent must be nonnegative", udp4Stats.getDatagramsSent(), greaterThanOrEqualTo(0L));
-        UdpStats udp6Stats = NetStat.queryUdpStats("netstat -su6");
-        assertThat("udp4 datagrams sent must be nonnegative", udp6Stats.getDatagramsSent(), greaterThanOrEqualTo(0L));
-    }
+        @EnabledOnOs(OS.LINUX)
+        @Test
+        void testQueryStatsLinux() {
+            TcpStats tcpStats = NetStat.queryTcpStats("netstat -st4");
+            assertThat("tcp connections must be nonnegative", tcpStats.getConnectionsEstablished(),
+                    greaterThanOrEqualTo(0L));
+            UdpStats udp4Stats = NetStat.queryUdpStats("netstat -su4");
+            assertThat("udp4 datagrams sent must be nonnegative", udp4Stats.getDatagramsSent(),
+                    greaterThanOrEqualTo(0L));
+        }
 
-    @EnabledOnOs(OS.OPENBSD)
-    @Test
-    void testQueryStatsOpenBSD() {
-        TcpStats tcpStats = NetStat.queryTcpStats("netstat -s -p tcp");
-        assertThat("tcp connections must be nonnegative", tcpStats.getConnectionsEstablished(),
-                greaterThanOrEqualTo(0L));
-        UdpStats udpStats = NetStat.queryUdpStats("netstat -s -p udp");
-        assertThat("udp  datagrams sent must be nonnegative", udpStats.getDatagramsSent(), greaterThanOrEqualTo(0L));
+        @EnabledOnOs(OS.OPENBSD)
+        @Test
+        void testQueryStatsOpenBSD() {
+            TcpStats tcpStats = NetStat.queryTcpStats("netstat -s -p tcp");
+            assertThat("tcp connections must be nonnegative", tcpStats.getConnectionsEstablished(),
+                    greaterThanOrEqualTo(0L));
+            UdpStats udpStats = NetStat.queryUdpStats("netstat -s -p udp");
+            assertThat("udp datagrams sent must be nonnegative", udpStats.getDatagramsSent(), greaterThanOrEqualTo(0L));
+        }
     }
 }

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
@@ -5,18 +5,78 @@
 package oshi.util.driver.unix;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-@DisabledOnOs({ OS.WINDOWS, OS.MAC })
 class XrandrTest {
+
+    // Fixture: xrandr --verbose output with one EDID block (128 bytes = 256 hex chars)
+    private static List<String> createXrandrWithEdid() {
+        List<String> lines = new ArrayList<>();
+        lines.add("Screen 0: minimum 8 x 8, current 1920 x 1080, maximum 32767 x 32767");
+        lines.add("HDMI-1 connected primary 1920x1080+0+0");
+        lines.add("\tEDID:");
+        // 8 lines x 32 hex chars = 256 hex chars = 128 bytes (standard EDID block)
+        lines.add("\t\t00ffffffffffff001e6d085b0b0b0b0b");
+        lines.add("\t\t0c1c0104b53c2278fb2eb5ae4f46a527");
+        lines.add("\t\t0d5054254b80714f81809500a9c0b300");
+        lines.add("\t\td1c001010101565e00a0a0a029503020");
+        lines.add("\t\t35000f282100001a000000fd00384b1e");
+        lines.add("\t\t5a1900000a202020202020000000fc00");
+        lines.add("\t\t4c4720554c545241474541520000ff00");
+        lines.add("\t\t3630344e54505a4832313337370a0100");
+        lines.add("  1920x1080 (0x48) 148.500MHz +HSync +VSync *current +preferred");
+        return lines;
+    }
+
     @Test
-    void testGetEdidArrays() {
-        for (byte[] edid : Xrandr.getEdidArrays()) {
-            assertThat("Edid length must be at least 128", edid.length, greaterThanOrEqualTo(128));
+    void testGetEdidArraysSingleDisplay() {
+        List<byte[]> edids = Xrandr.getEdidArrays(createXrandrWithEdid());
+        assertThat(edids, hasSize(1));
+        byte[] edid = edids.get(0);
+        assertThat(edid.length, is(128));
+        // Verify EDID magic header: 00 FF FF FF FF FF FF 00
+        assertThat(edid[0], is((byte) 0x00));
+        assertThat(edid[1], is((byte) 0xFF));
+        assertThat(edid[2], is((byte) 0xFF));
+        assertThat(edid[7], is((byte) 0x00));
+    }
+
+    @Test
+    void testGetEdidArraysEmpty() {
+        assertThat(Xrandr.getEdidArrays(Collections.emptyList()), is(empty()));
+    }
+
+    @Test
+    void testGetEdidArraysNoEdidBlock() {
+        List<String> noEdid = new ArrayList<>();
+        noEdid.add("Screen 0: minimum 8 x 8, current 1920 x 1080");
+        noEdid.add("HDMI-1 connected primary 1920x1080+0+0");
+        assertThat(Xrandr.getEdidArrays(noEdid), is(empty()));
+    }
+
+    @Nested
+    @DisabledOnOs({ OS.WINDOWS, OS.MAC })
+    class LiveTests {
+        @Test
+        void testGetEdidArrays() {
+            List<byte[]> edids = Xrandr.getEdidArrays();
+            assumeFalse(edids.isEmpty(), "No displays found (headless system); skipping");
+            for (byte[] edid : edids) {
+                assertThat("Edid length must be at least 128", edid.length, greaterThanOrEqualTo(128));
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves part of #3189.

Separates command execution from output parsing in 5 methods:

**Refactored methods:**
- `NetStat.queryTcpnetstat()` → new `queryTcpnetstat(List<String>)` — `netstat -n -p tcp`
- `NetStat.queryNetstat()` → new `queryNetstat(List<String>)` — `netstat -n`
- `NetStat.queryTcpStats(String)` → new `queryTcpStats(List<String>)` — `netstat -s` TCP section
- `NetStat.queryUdpStats(String)` → new `queryUdpStats(List<String>)` — `netstat -s` UDP section
- `Xrandr.getEdidArrays()` → new `getEdidArrays(List<String>)` — `xrandr --verbose`

**Tests added:**
- NetStatTest: TCP connection counting, connection parsing with state, TCP/UDP stats (Linux format), empty input
- XrandrTest: EDID block parsing, no EDID block, empty input

No public API changes. No new dependencies.

Note: `Xwininfo` is not included — its parsing is tightly coupled to multiple sequential X11 commands (stacking order, window tree, per-window PID lookup), making a clean extraction impractical without a larger refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Separated native command execution from output parsing for network and display; parsing now operates on pre-collected output and handles empty/truncated inputs more robustly.

* **Tests**
  * Added deterministic, fixture-driven unit tests for network stats and EDID parsing, including explicit empty-input cases.
  * Moved environment-dependent checks into nested live test suites to keep CI stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->