### PR TITLE
Extract /proc/[pid]/stat parsing and add LinuxFileSystem tests

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -181,12 +181,19 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
     }
 
     private static int getParentPidFromProcFile(int pid) {
-        String stat = FileUtil.getStringFromFile(String.format(Locale.ROOT, "/proc/%d/stat", pid));
-        // A race condition may leave us with an empty string
+        return getParentPidFromStat(FileUtil.getStringFromFile(String.format(Locale.ROOT, ProcPath.PID_STAT, pid)));
+    }
+
+    /**
+     * Parse the parent PID from a /proc/[pid]/stat line.
+     *
+     * @param stat contents of /proc/[pid]/stat
+     * @return the parent PID, or 0 if unparseable
+     */
+    static int getParentPidFromStat(String stat) {
         if (stat.isEmpty()) {
             return 0;
         }
-        // Grab PPID
         long[] statArray = ParseUtil.parseStringToLongArray(stat, PPID_INDEX, ProcessStat.PROC_PID_STAT_LENGTH, ' ');
         return (int) statArray[0];
     }

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxFileSystemTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.software.os.OSFileStore;
+
+@EnabledOnOs(OS.LINUX)
+class LinuxFileSystemTest {
+
+    /** Concrete subclass that falls back to File methods for space queries. */
+    private static final class StubLinuxFileSystem extends LinuxFileSystem {
+        @Override
+        protected long[] queryStatvfs(String path) {
+            return null;
+        }
+    }
+
+    @Test
+    void testGetFileStoresReturnsRootMount() {
+        StubLinuxFileSystem fs = new StubLinuxFileSystem();
+        List<OSFileStore> stores = fs.getFileStoreMatching(null, Collections.emptyMap(), false);
+        // Every Linux system has at least a root filesystem
+        assertThat(stores, hasSize(greaterThan(0)));
+
+        // Find root mount
+        OSFileStore root = null;
+        for (OSFileStore store : stores) {
+            if ("/".equals(store.getMount())) {
+                root = store;
+                break;
+            }
+        }
+        assertThat("Root mount should be present", root != null, is(true));
+        assertThat(root.getMount(), is("/"));
+        assertThat(root.getType(), is(not(emptyString())));
+        assertThat(root.getTotalSpace(), is(greaterThan(0L)));
+    }
+
+    @Test
+    void testGetFileStoresLocalOnly() {
+        StubLinuxFileSystem fs = new StubLinuxFileSystem();
+        List<OSFileStore> all = fs.getFileStoreMatching(null, Collections.emptyMap(), false);
+        List<OSFileStore> local = fs.getFileStoreMatching(null, Collections.emptyMap(), true);
+        // Local should be a subset of all
+        assertThat(local.size(), is(not(greaterThan(all.size()))));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
@@ -82,4 +82,37 @@ class LinuxOperatingSystemTest {
         assertThat(result.getB(), is("38"));
         assertThat(result.getC(), is("Thirty Eight"));
     }
+
+    // -------------------------------------------------------------------------
+    // getParentPidFromStat — parses /proc/[pid]/stat
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testGetParentPidFromStat() {
+        // Real /proc/[pid]/stat line: pid (comm) state ppid ...
+        String stat = "1234 (bash) S 567 1234 1234 0 -1 4194304 1234 0 0 0 0 0 0 0 20 0 1 0 12345 67890 0 "
+                + "18446744073709551615 0 0 0 0 0 0 0 0 65536 0 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0";
+        assertThat(LinuxOperatingSystem.getParentPidFromStat(stat), is(567));
+    }
+
+    @Test
+    void testGetParentPidFromStatInit() {
+        // PID 1 (init/systemd) has PPID 0
+        String stat = "1 (systemd) S 0 1 1 0 -1 4194560 12345 0 0 0 0 0 0 0 20 0 1 0 1 67890 0 "
+                + "18446744073709551615 0 0 0 0 0 0 0 0 65536 0 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0";
+        assertThat(LinuxOperatingSystem.getParentPidFromStat(stat), is(0));
+    }
+
+    @Test
+    void testGetParentPidFromStatEmpty() {
+        assertThat(LinuxOperatingSystem.getParentPidFromStat(""), is(0));
+    }
+
+    @Test
+    void testGetParentPidFromStatCommWithSpaces() {
+        // Process name can contain spaces and parentheses
+        String stat = "42 (Web Content (pid 42)) S 100 42 42 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 0 0 0 "
+                + "18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0";
+        assertThat(LinuxOperatingSystem.getParentPidFromStat(stat), is(100));
+    }
 }


### PR DESCRIPTION
Resolves the remaining items in #3189.

**Refactored methods:**
- `LinuxOperatingSystem.getParentPidFromProcFile()` → new `getParentPidFromStat(String)` — parses `/proc/[pid]/stat` content
  - Also fixed to use `ProcPath.PID_STAT` instead of hardcoded `/proc` path

**Tests added to LinuxOperatingSystemTest:**
- Standard stat line (PPID extraction)
- Init process (PPID = 0)
- Empty stat line
- Process name with spaces/parentheses

**New LinuxFileSystemTest (Linux-only):**
- Verifies mount parsing returns root filesystem with expected properties
- Verifies local-only filtering is a subset of all mounts

No public API changes. No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved process identification logic structure for enhanced code reusability and maintainability.

* **Tests**
  * Added comprehensive test coverage for file system operations and process management, including edge cases and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->