### PR TITLE
Extract parsing from CpuInfo and Lshal for testability

### DIFF
--- a/oshi-common/src/main/java/oshi/util/driver/linux/Lshal.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Lshal.java
@@ -4,6 +4,8 @@
  */
 package oshi.util.driver.linux;
 
+import java.util.List;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -23,9 +25,18 @@ public final class Lshal {
      * @return The serial number if available, null otherwise
      */
     public static String querySerialNumber() {
-        // if lshal command available (HAL deprecated in newer linuxes)
+        return querySerialNumber(ExecutingCommand.runNative("lshal"));
+    }
+
+    /**
+     * Parse the serial number from lshal output.
+     *
+     * @param lines output of {@code lshal}
+     * @return The serial number if available, null otherwise
+     */
+    static String querySerialNumber(List<String> lines) {
         String marker = "system.hardware.serial =";
-        for (String checkLine : ExecutingCommand.runNative("lshal")) {
+        for (String checkLine : lines) {
             if (checkLine.contains(marker)) {
                 return ParseUtil.getSingleQuoteStringValue(checkLine);
             }
@@ -39,9 +50,18 @@ public final class Lshal {
      * @return The UUID if available, null otherwise
      */
     public static String queryUUID() {
-        // if lshal command available (HAL deprecated in newer linuxes)
+        return queryUUID(ExecutingCommand.runNative("lshal"));
+    }
+
+    /**
+     * Parse the UUID from lshal output.
+     *
+     * @param lines output of {@code lshal}
+     * @return The UUID if available, null otherwise
+     */
+    static String queryUUID(List<String> lines) {
         String marker = "system.hardware.uuid =";
-        for (String checkLine : ExecutingCommand.runNative("lshal")) {
+        for (String checkLine : lines) {
             if (checkLine.contains(marker)) {
                 return ParseUtil.getSingleQuoteStringValue(checkLine);
             }

--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/CpuInfo.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/CpuInfo.java
@@ -31,7 +31,16 @@ public final class CpuInfo {
      * @return The manufacturer if known, null otherwise
      */
     public static String queryCpuManufacturer() {
-        List<String> cpuInfo = FileUtil.readFile(CPUINFO);
+        return queryCpuManufacturer(FileUtil.readFile(CPUINFO));
+    }
+
+    /**
+     * Parse the CPU manufacturer from /proc/cpuinfo lines.
+     *
+     * @param cpuInfo lines from /proc/cpuinfo
+     * @return The manufacturer if known, null otherwise
+     */
+    static String queryCpuManufacturer(List<String> cpuInfo) {
         for (String line : cpuInfo) {
             if (line.startsWith("CPU implementer")) {
                 int part = ParseUtil.parseLastInt(line, 0);
@@ -73,12 +82,21 @@ public final class CpuInfo {
      *         unknown.
      */
     public static Quartet<String, String, String, String> queryBoardInfo() {
+        return queryBoardInfo(FileUtil.readFile(CPUINFO));
+    }
+
+    /**
+     * Parse board info from /proc/cpuinfo lines.
+     *
+     * @param cpuInfo lines from /proc/cpuinfo
+     * @return A quartet of strings for manufacturer, model, version, and serial number
+     */
+    static Quartet<String, String, String, String> queryBoardInfo(List<String> cpuInfo) {
         String pcManufacturer = null;
         String pcModel = null;
         String pcVersion = null;
         String pcSerialNumber = null;
 
-        List<String> cpuInfo = FileUtil.readFile(CPUINFO);
         for (String line : cpuInfo) {
             String[] splitLine = ParseUtil.whitespacesColonWhitespace.split(line);
             if (splitLine.length < 2) {
@@ -124,7 +142,17 @@ public final class CpuInfo {
     }
 
     public static List<String> queryFeatureFlags() {
-        return FileUtil.readFile(CPUINFO).stream().filter(f -> {
+        return queryFeatureFlags(FileUtil.readFile(CPUINFO));
+    }
+
+    /**
+     * Parse feature flag lines from /proc/cpuinfo.
+     *
+     * @param cpuInfo lines from /proc/cpuinfo
+     * @return deduplicated lines starting with "flags" or "features"
+     */
+    static List<String> queryFeatureFlags(List<String> cpuInfo) {
+        return cpuInfo.stream().filter(f -> {
             String s = f.toLowerCase(Locale.ROOT);
             return s.startsWith("flags") || s.startsWith("features");
         }).distinct().collect(Collectors.toList());

--- a/oshi-common/src/test/java/oshi/util/driver/linux/LshalTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/LshalTest.java
@@ -5,8 +5,14 @@
 package oshi.util.driver.linux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,14 +20,40 @@ import oshi.TestConstants;
 
 class LshalTest {
 
+    // Fixture: lshal output with system hardware info
+    private static final List<String> LSHAL_OUTPUT = Arrays.asList("udi = '/org/freedesktop/Hal/devices/computer'",
+            "  system.hardware.vendor = 'Dell Inc.'  (string)",
+            "  system.hardware.product = 'PowerEdge R720'  (string)", "  system.hardware.serial = 'ABC1234'  (string)",
+            "  system.hardware.uuid = '4C4C4544-0044-4810-8031-B4C04F333132'  (string)",
+            "  system.firmware.vendor = 'Dell Inc.'  (string)");
+
     @Test
-    void testQueries() {
-        assertDoesNotThrow(Lshal::querySerialNumber);
+    void testQuerySerialNumber() {
+        assertThat(Lshal.querySerialNumber(LSHAL_OUTPUT), is("ABC1234"));
+    }
+
+    @Test
+    void testQuerySerialNumberNotFound() {
+        assertThat(Lshal.querySerialNumber(Collections.emptyList()), is(nullValue()));
+    }
+
+    @Test
+    void testQueryUUID() {
+        assertThat(Lshal.queryUUID(LSHAL_OUTPUT), is("4C4C4544-0044-4810-8031-B4C04F333132"));
+    }
+
+    @Test
+    void testQueryUUIDNotFound() {
+        assertThat(Lshal.queryUUID(Collections.emptyList()), is(nullValue()));
+    }
+
+    @Test
+    void testLiveQueries() {
+        assertDoesNotThrow(() -> Lshal.querySerialNumber());
 
         final String uuid = Lshal.queryUUID();
         if (uuid != null) {
             assertThat("Test Lshal queryUUID format", uuid, matchesRegex(TestConstants.UUID_REGEX));
         }
     }
-
 }

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/CpuInfoTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/CpuInfoTest.java
@@ -5,40 +5,149 @@
 package oshi.util.driver.linux.proc;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import oshi.util.Constants;
 import oshi.util.tuples.Quartet;
 
-@EnabledOnOs(OS.LINUX)
 class CpuInfoTest {
+
+    // Fixture: ARM /proc/cpuinfo (Raspberry Pi style)
+    private static final List<String> CPUINFO_ARM = Arrays.asList("processor\t: 0", "BogoMIPS\t: 108.00",
+            "Features\t: fp asimd evtstrm crc32 cpuid", "CPU implementer\t: 0x41", "CPU architecture: 8",
+            "CPU variant\t: 0x0", "CPU part\t: 0xd08", "CPU revision\t: 3", "", "Hardware\t: BCM2835",
+            "Revision\t: a020d3", "Serial\t\t: 00000000abcdef01");
+
+    // Fixture: x86 /proc/cpuinfo
+    private static final List<String> CPUINFO_X86 = Arrays.asList("processor\t: 0", "vendor_id\t: GenuineIntel",
+            "model name\t: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+            "flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic", "", "processor\t: 1", "vendor_id\t: GenuineIntel",
+            "model name\t: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+            "flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic");
+
     @Test
-    void testQueries() {
-        assertDoesNotThrow(CpuInfo::queryCpuManufacturer);
-        assertDoesNotThrow(CpuInfo::queryBoardInfo);
+    void testQueryCpuManufacturerARM() {
+        assertThat(CpuInfo.queryCpuManufacturer(CPUINFO_ARM), is("ARM"));
     }
 
     @Test
-    void testQueryBoardInfoAccessors() {
-        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo();
-        // On x86 these are typically null (ARM-specific fields), but accessors must not throw
-        assertDoesNotThrow(info::getA);
-        assertDoesNotThrow(info::getB);
-        assertDoesNotThrow(info::getC);
-        assertDoesNotThrow(info::getD);
+    void testQueryCpuManufacturerQualcomm() {
+        List<String> qualcomm = Arrays.asList("CPU implementer\t: 0x51");
+        assertThat(CpuInfo.queryCpuManufacturer(qualcomm), is("Qualcomm"));
     }
 
     @Test
-    void testQueryFeatureFlagLines() {
-        // Returns deduplicated full lines from /proc/cpuinfo starting with "flags" or "features"
-        List<String> flagLines = CpuInfo.queryFeatureFlags();
-        assertThat(flagLines, hasSize(greaterThan(0)));
+    void testQueryCpuManufacturerUnknown() {
+        List<String> unknown = Arrays.asList("CPU implementer\t: 0xff");
+        assertThat(CpuInfo.queryCpuManufacturer(unknown), is(nullValue()));
+    }
+
+    @Test
+    void testQueryCpuManufacturerX86() {
+        // x86 doesn't have "CPU implementer" line
+        assertThat(CpuInfo.queryCpuManufacturer(CPUINFO_X86), is(nullValue()));
+    }
+
+    @Test
+    void testQueryCpuManufacturerEmpty() {
+        assertThat(CpuInfo.queryCpuManufacturer(Collections.emptyList()), is(nullValue()));
+    }
+
+    @Test
+    void testQueryBoardInfoRaspberryPi() {
+        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo(CPUINFO_ARM);
+        assertThat(info.getA(), is("Sony UK")); // manufacturer from revision digit '0'
+        assertThat(info.getB(), is("BCM2835")); // model from Hardware
+        assertThat(info.getC(), is("a020d3")); // version from Revision
+        assertThat(info.getD(), is("00000000abcdef01")); // serial
+    }
+
+    @Test
+    void testQueryBoardInfoEgoman() {
+        List<String> egoman = Arrays.asList("Revision\t: a120d3");
+        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo(egoman);
+        assertThat(info.getA(), is("Egoman"));
+    }
+
+    @Test
+    void testQueryBoardInfoUnknownManufacturer() {
+        List<String> unknown = Arrays.asList("Revision\t: a920d3");
+        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo(unknown);
+        assertThat(info.getA(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testQueryBoardInfoX86() {
+        // x86 doesn't have Hardware/Revision/Serial
+        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo(CPUINFO_X86);
+        assertThat(info.getA(), is(nullValue()));
+        assertThat(info.getB(), is(nullValue()));
+        assertThat(info.getC(), is(nullValue()));
+        assertThat(info.getD(), is(nullValue()));
+    }
+
+    @Test
+    void testQueryBoardInfoEmpty() {
+        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo(Collections.emptyList());
+        assertThat(info.getA(), is(nullValue()));
+    }
+
+    @Test
+    void testQueryFeatureFlagsX86() {
+        List<String> flags = CpuInfo.queryFeatureFlags(CPUINFO_X86);
+        // Two identical flag lines should be deduplicated to one
+        assertThat(flags, hasSize(1));
+        assertThat(flags.get(0).contains("fpu"), is(true));
+    }
+
+    @Test
+    void testQueryFeatureFlagsARM() {
+        List<String> flags = CpuInfo.queryFeatureFlags(CPUINFO_ARM);
+        assertThat(flags, hasSize(1));
+        assertThat(flags.get(0).contains("asimd"), is(true));
+    }
+
+    @Test
+    void testQueryFeatureFlagsEmpty() {
+        assertThat(CpuInfo.queryFeatureFlags(Collections.emptyList()), is(empty()));
+    }
+
+    @Nested
+    @EnabledOnOs(OS.LINUX)
+    class LiveTests {
+        @Test
+        void testQueries() {
+            assertDoesNotThrow(() -> CpuInfo.queryCpuManufacturer());
+            assertDoesNotThrow(() -> CpuInfo.queryBoardInfo());
+        }
+
+        @Test
+        void testQueryBoardInfoAccessors() {
+            Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo();
+            assertDoesNotThrow(info::getA);
+            assertDoesNotThrow(info::getB);
+            assertDoesNotThrow(info::getC);
+            assertDoesNotThrow(info::getD);
+        }
+
+        @Test
+        void testQueryFeatureFlagLines() {
+            List<String> flagLines = CpuInfo.queryFeatureFlags();
+            assertThat(flagLines, hasSize(greaterThan(0)));
+        }
     }
 }


### PR DESCRIPTION
Improves test coverage by separating file reading from parsing in CpuInfo and Lshal.

**Refactored methods:**
- `CpuInfo.queryCpuManufacturer()` → new `queryCpuManufacturer(List<String>)`
- `CpuInfo.queryBoardInfo()` → new `queryBoardInfo(List<String>)`
- `CpuInfo.queryFeatureFlags()` → new `queryFeatureFlags(List<String>)`
- `Lshal.querySerialNumber()` → new `querySerialNumber(List<String>)`
- `Lshal.queryUUID()` → new `queryUUID(List<String>)`

**Tests added to CpuInfoTest:**
- ARM manufacturer lookup (ARM, Qualcomm, unknown implementer)
- Board info parsing (Raspberry Pi Hardware/Revision/Serial, manufacturer variants)
- Feature flag deduplication (x86 flags, ARM features, empty)

**Tests added to LshalTest:**
- Serial number and UUID parsing from fixture data
- Empty input handling

No public API changes. No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code structure for system information parsing utilities by delegating parsing logic to dedicated helper methods.

* **Tests**
  * Enhanced test coverage for Linux-based system information retrieval with comprehensive unit tests for hardware serial number, UUID, CPU manufacturer, board information, and feature flag parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->