### PR TITLE
Improve oshi-common test coverage for release parsing and memory types

### DIFF
--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -65,6 +65,9 @@ class NativeComparisonTest {
     static void setup() {
         // Disable memoization so each call gets fresh data for accurate comparison
         GlobalConfig.set(GlobalConfig.OSHI_UTIL_MEMOIZER_EXPIRATION, 0);
+        // Enable CPU utility counters (Windows 8+) to exercise that branch;
+        // normal CI tests use the default (false) so both paths get coverage
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_CPU_UTILITY, true);
 
         oshi.SystemInfo jnaSi = new oshi.SystemInfo();
         jnaHal = jnaSi.getHardware();
@@ -125,9 +128,10 @@ class NativeComparisonTest {
         long[] jnaTicks = jna.getSystemCpuLoadTicks();
         long[] ffmTicks = ffm.getSystemCpuLoadTicks();
         assertThat(ffmTicks).hasSameSizeAs(jnaTicks);
-        // Ticks are monotonically increasing counters; FFM (called second) should be >= JNA
+        // With USE_CPU_UTILITY enabled, ticks are derived from utility counters
+        // and may not be strictly monotonic between JNA and FFM calls
         for (int i = 0; i < jnaTicks.length; i++) {
-            assertThat(ffmTicks[i]).as("systemCpuLoadTick[%d]", i).isGreaterThanOrEqualTo(jnaTicks[i]);
+            assertWithinRatio(ffmTicks[i], jnaTicks[i], 0.05, "systemCpuLoadTick[" + i + "]");
         }
         long[][] jnaProc = jna.getProcessorCpuLoadTicks();
         long[][] ffmProc = ffm.getProcessorCpuLoadTicks();

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -370,11 +370,21 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      *         DISTRIB_DESCRIPTION, null otherwise
      */
     private static Triplet<String, String, String> readLsbRelease() {
+        return readLsbRelease(FileUtil.readFile("/etc/lsb-release"));
+    }
+
+    /**
+     * Parse /etc/lsb-release content.
+     *
+     * @param lines lines from /etc/lsb-release
+     * @return a triplet with the parsed family, versionID and codeName if DISTRIB_ID or DISTRIB_DESCRIPTION found, null
+     *         otherwise
+     */
+    static Triplet<String, String, String> readLsbRelease(List<String> lines) {
         String family = null;
         String versionId = Constants.UNKNOWN;
         String codeName = Constants.UNKNOWN;
-        List<String> osRelease = FileUtil.readFile("/etc/lsb-release");
-        for (String line : osRelease) {
+        for (String line : lines) {
             if (line.startsWith("DISTRIB_DESCRIPTION=")) {
                 LOG.debug(LSB_RELEASE_LOG, line);
                 line = line.replace("DISTRIB_DESCRIPTION=", "").replaceAll(DOUBLE_QUOTES, "").trim();
@@ -411,14 +421,24 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      */
     private static Triplet<String, String, String> readDistribRelease(String filename) {
         if (new File(filename).exists()) {
-            List<String> osRelease = FileUtil.readFile(filename);
-            for (String line : osRelease) {
-                LOG.debug("{}: {}", filename, line);
-                if (line.contains(RELEASE_DELIM)) {
-                    return parseRelease(line, RELEASE_DELIM);
-                } else if (line.contains(" VERSION ")) {
-                    return parseRelease(line, " VERSION ");
-                }
+            return readDistribRelease(FileUtil.readFile(filename));
+        }
+        return null;
+    }
+
+    /**
+     * Parse distrib-release file content.
+     *
+     * @param lines lines from a distrib-release file
+     * @return a triplet with the parsed family, versionID and codeName if " release " or " VERSION " found, null
+     *         otherwise
+     */
+    static Triplet<String, String, String> readDistribRelease(List<String> lines) {
+        for (String line : lines) {
+            if (line.contains(RELEASE_DELIM)) {
+                return parseRelease(line, RELEASE_DELIM);
+            } else if (line.contains(" VERSION ")) {
+                return parseRelease(line, " VERSION ");
             }
         }
         return null;
@@ -431,7 +451,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @param splitLine A regex to split on, e.g. " release "
      * @return a triplet with the parsed family, versionID and codeName
      */
-    private static Triplet<String, String, String> parseRelease(String line, String splitLine) {
+    static Triplet<String, String, String> parseRelease(String line, String splitLine) {
         String[] split = line.split(splitLine);
         String family = split[0].trim();
         String versionId = Constants.UNKNOWN;
@@ -480,7 +500,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @param name Stripped version of filename after removing /etc and -release
      * @return Mixed case family
      */
-    private static String filenameToFamily(String name) {
+    static String filenameToFamily(String name) {
         if (name.isEmpty()) {
             return "Solaris";
         } else if ("issue".equalsIgnoreCase(name)) {

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxFirmwareTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import oshi.hardware.common.platform.linux.LinuxFirmware.VcGenCmdStrings;
+import oshi.util.Constants;
 
 class LinuxFirmwareTest {
 
@@ -71,7 +72,7 @@ class LinuxFirmwareTest {
     void testQueryVcGenCmdInvalidDate() {
         List<String> badDate = Arrays.asList("not a date", "Copyright (c) 2012 Broadcom", "version abc123");
         VcGenCmdStrings result = LinuxFirmware.queryVcGenCmd(badDate);
-        assertThat(result.getReleaseDate(), is("unknown"));
+        assertThat(result.getReleaseDate(), is(Constants.UNKNOWN));
         assertThat(result.getManufacturer(), is("Broadcom"));
         assertThat(result.getVersion(), is("abc123"));
     }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGlobalMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGlobalMemoryTest.java
@@ -12,34 +12,52 @@ import org.junit.jupiter.api.Test;
 class WindowsGlobalMemoryTest {
 
     @Test
-    void testMemoryTypeKnownValues() {
-        assertThat(WindowsGlobalMemory.memoryType(0), is("Unknown"));
-        assertThat(WindowsGlobalMemory.memoryType(1), is("Other"));
-        assertThat(WindowsGlobalMemory.memoryType(2), is("DRAM"));
-        assertThat(WindowsGlobalMemory.memoryType(17), is("SDRAM"));
-        assertThat(WindowsGlobalMemory.memoryType(20), is("DDR"));
-        assertThat(WindowsGlobalMemory.memoryType(21), is("DDR2"));
-        assertThat(WindowsGlobalMemory.memoryType(22), is("BRAM"));
-        assertThat(WindowsGlobalMemory.memoryType(23), is("DDR FB-DIMM"));
+    void testMemoryTypeAllCases() {
+        String[] expected = { "Unknown", "Other", "DRAM", "Synchronous DRAM", "Cache DRAM", "EDO", "EDRAM", "VRAM",
+                "SRAM", "RAM", "ROM", "Flash", "EEPROM", "FEPROM", "EPROM", "CDRAM", "3DRAM", "SDRAM", "SGRAM", "RDRAM",
+                "DDR", "DDR2", "BRAM", "DDR FB-DIMM" };
+        for (int i = 0; i < expected.length; i++) {
+            assertThat("memoryType(" + i + ")", WindowsGlobalMemory.memoryType(i), is(expected[i]));
+        }
     }
 
     @Test
     void testMemoryTypeFallsBackToSmBios() {
-        // Values > 23 fall through to smBiosMemoryType
         assertThat(WindowsGlobalMemory.memoryType(0x1A), is("DDR4"));
         assertThat(WindowsGlobalMemory.memoryType(0x22), is("DDR5"));
     }
 
     @Test
-    void testSmBiosMemoryTypeKnownValues() {
+    void testSmBiosMemoryTypeAllCases() {
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x01), is("Other"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x03), is("DRAM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x04), is("EDRAM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x05), is("VRAM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x06), is("SRAM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x07), is("RAM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x08), is("ROM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x09), is("FLASH"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x0A), is("EEPROM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x0B), is("FEPROM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x0C), is("EPROM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x0D), is("CDRAM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x0E), is("3DRAM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x0F), is("SDRAM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x10), is("SGRAM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x11), is("RDRAM"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x12), is("DDR"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x13), is("DDR2"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x14), is("DDR2 FB-DIMM"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x18), is("DDR3"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x19), is("FBD2"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x1A), is("DDR4"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x1B), is("LPDDR"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x1C), is("LPDDR2"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x1D), is("LPDDR3"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x1E), is("LPDDR4"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x1F), is("Logical non-volatile device"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x20), is("HBM"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x21), is("HBM2"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x22), is("DDR5"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x23), is("LPDDR5"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x24), is("HBM3"));
@@ -49,5 +67,9 @@ class WindowsGlobalMemoryTest {
     void testSmBiosMemoryTypeUnknown() {
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0x02), is("Unknown"));
         assertThat(WindowsGlobalMemory.smBiosMemoryType(0xFF), is("Unknown"));
+        // Gap values between defined ranges
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x15), is("Unknown"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x16), is("Unknown"));
+        assertThat(WindowsGlobalMemory.smBiosMemoryType(0x17), is("Unknown"));
     }
 }

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import oshi.util.Constants;
 import oshi.util.tuples.Triplet;
 
 @EnabledOnOs(OS.LINUX)
@@ -114,5 +115,109 @@ class LinuxOperatingSystemTest {
         String stat = "42 (Web Content (pid 42)) S 100 42 42 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 0 0 0 "
                 + "18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0";
         assertThat(LinuxOperatingSystem.getParentPidFromStat(stat), is(100));
+    }
+
+    // -------------------------------------------------------------------------
+    // readLsbRelease — parses /etc/lsb-release
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testReadLsbRelease() {
+        List<String> lines = Arrays.asList("DISTRIB_ID=Ubuntu", "DISTRIB_RELEASE=20.04", "DISTRIB_CODENAME=focal",
+                "DISTRIB_DESCRIPTION=\"Ubuntu 20.04.6 LTS\"");
+        Triplet<String, String, String> result = LinuxOperatingSystem.readLsbRelease(lines);
+        assertThat(result.getA(), is("Ubuntu"));
+        assertThat(result.getB(), is("20.04"));
+        assertThat(result.getC(), is("focal"));
+    }
+
+    @Test
+    void testReadLsbReleaseDescriptionWithRelease() {
+        List<String> lines = Arrays.asList("DISTRIB_DESCRIPTION=\"Fedora release 38 (Thirty Eight)\"");
+        Triplet<String, String, String> result = LinuxOperatingSystem.readLsbRelease(lines);
+        assertThat(result.getA(), is("Fedora"));
+        assertThat(result.getB(), is("38"));
+        assertThat(result.getC(), is("Thirty Eight"));
+    }
+
+    @Test
+    void testReadLsbReleaseEmpty() {
+        assertThat(LinuxOperatingSystem.readLsbRelease(Collections.emptyList()), is(nullValue()));
+    }
+
+    // -------------------------------------------------------------------------
+    // readDistribRelease — parses distrib-release files
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testReadDistribRelease() {
+        List<String> lines = Arrays.asList("CentOS release 6.10 (Final)");
+        Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertThat(result.getA(), is("CentOS"));
+        assertThat(result.getB(), is("6.10"));
+        assertThat(result.getC(), is("Final"));
+    }
+
+    @Test
+    void testReadDistribReleaseVersion() {
+        List<String> lines = Arrays.asList("SUSE Linux Enterprise Server VERSION 15");
+        Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertThat(result.getA(), is("SUSE Linux Enterprise Server"));
+        assertThat(result.getB(), is("15"));
+        assertThat(result.getC(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testReadDistribReleaseEmpty() {
+        assertThat(LinuxOperatingSystem.readDistribRelease(Collections.emptyList()), is(nullValue()));
+    }
+
+    // -------------------------------------------------------------------------
+    // parseRelease — pure parsing logic
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testParseRelease() {
+        Triplet<String, String, String> result = LinuxOperatingSystem
+                .parseRelease("Red Hat Enterprise Linux release 8.5 (Ootpa)", " release ");
+        assertThat(result.getA(), is("Red Hat Enterprise Linux"));
+        assertThat(result.getB(), is("8.5"));
+        assertThat(result.getC(), is("Ootpa"));
+    }
+
+    @Test
+    void testParseReleaseNoCodename() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.parseRelease("Debian release 11", " release ");
+        assertThat(result.getA(), is("Debian"));
+        assertThat(result.getB(), is("11"));
+        assertThat(result.getC(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testParseReleaseNoVersion() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.parseRelease("MyLinux", " release ");
+        assertThat(result.getA(), is("MyLinux"));
+        assertThat(result.getB(), is(Constants.UNKNOWN));
+        assertThat(result.getC(), is(Constants.UNKNOWN));
+    }
+
+    // -------------------------------------------------------------------------
+    // filenameToFamily — maps release filename to distro family
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testFilenameToFamilyEmpty() {
+        assertThat(LinuxOperatingSystem.filenameToFamily(""), is("Solaris"));
+    }
+
+    @Test
+    void testFilenameToFamilyIssue() {
+        assertThat(LinuxOperatingSystem.filenameToFamily("issue"), is("Unknown"));
+    }
+
+    @Test
+    void testFilenameToFamilyUnknown() {
+        // Unknown name gets capitalized
+        assertThat(LinuxOperatingSystem.filenameToFamily("mylinux"), is("Mylinux"));
     }
 }


### PR DESCRIPTION
Improves test coverage across oshi-common and comparison tests.

**LinuxOperatingSystem — extracted parsing methods:**
- `readLsbRelease(List<String>)` — parses `/etc/lsb-release` content
- `readDistribRelease(List<String>)` — parses distrib-release file content
- `parseRelease()` — made package-private (was private), pure parsing logic
- `filenameToFamily()` — made package-private (was private), filename-to-distro mapping

**Tests added to LinuxOperatingSystemTest:**
- lsb-release: Ubuntu with all fields, Fedora description-only, empty
- distrib-release: CentOS ` release ` format, SUSE ` VERSION ` format, empty
- parseRelease: full format, no codename, no version
- filenameToFamily: empty (Solaris), issue (Unknown), unknown name (capitalized)

**WindowsGlobalMemoryTest — expanded to full coverage:**
- `memoryType()`: all 24 cases (0-23) verified
- `smBiosMemoryType()`: all 32 defined cases plus gap/unknown values
- Replaces previous partial test that only covered ~8 cases each

**NativeComparisonTest — enable USE_CPU_UTILITY:**
- Sets `oshi.os.windows.cpu.utility=true` before SystemInfo creation
- Normal CI tests use default (false), so both code paths get coverage across CI

**Misc fixes:**
- LinuxFirmwareTest: replaced hardcoded `"unknown"` with `Constants.UNKNOWN`
- Added missing `Constants.UNKNOWN` codename assertions in release parsing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Linux distro parsing tests to cover many input formats, edge cases, and fallback behaviors.
  * Converted Windows memory-type tests to fully data-driven coverage with broader SMBIOS mappings and explicit unknown-code checks.
  * Enabled Windows CPU utility path in benchmark comparisons and relaxed tick comparison to a ratio-based check.
  * Aligned firmware date test to use the shared unknown constant.

* **Refactor**
  * Simplified Linux release-file parsing by separating file reading from content parsing for clearer, more maintainable logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->