### PR TITLE
Split JMH benchmarks into separate CI job

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -75,8 +75,20 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: linux
-      - name: JMH Benchmarks (JNA vs FFM)
-        if: contains(matrix.java, '25')
-        run: |
-          ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
-          java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+
+  # JMH performance benchmarks — separate job to avoid slowing down test+coverage
+  benchmarks:
+    runs-on: ubuntu-latest
+    name: JMH Benchmarks
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: 25
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Build benchmark jar
+        run: ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
+      - name: Run JMH Benchmarks (JNA vs FFM)
+        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -51,8 +51,20 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: macos
-      - name: JMH Benchmarks (JNA vs FFM)
-        if: contains(matrix.java, '25')
-        run: |
-          ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
-          java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+
+  # JMH performance benchmarks — separate job to avoid slowing down test+coverage
+  benchmarks:
+    runs-on: macos-15
+    name: JMH Benchmarks
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: 25
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Build benchmark jar
+        run: ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
+      - name: Run JMH Benchmarks (JNA vs FFM)
+        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -71,8 +71,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: ${{ matrix.coverage-flag }}
-      - name: JMH Benchmarks (JNA vs FFM)
-        if: contains(matrix.java, '25')
-        run: |
-          ./mvnw package -pl oshi-benchmark -am "-DskipTests" "-Dshade.phase=package" -q
-          java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+
+  # JMH performance benchmarks — separate job to avoid slowing down test+coverage
+  benchmarks:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    name: JMH Benchmarks, ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: 25
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Build benchmark jar
+        run: ./mvnw package -pl oshi-benchmark -am "-DskipTests" "-Dshade.phase=package" -q
+      - name: Run JMH Benchmarks (JNA vs FFM)
+        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -47,8 +47,20 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: windows
-      - name: JMH Benchmarks (JNA vs FFM)
-        if: contains(matrix.java, '25')
-        run: |
-          ./mvnw package -pl oshi-benchmark -am "-DskipTests" "-Dshade.phase=package" -q
-          java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+
+  # JMH performance benchmarks — separate job to avoid slowing down test+coverage
+  benchmarks:
+    runs-on: windows-2022
+    name: JMH Benchmarks
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: 25
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Build benchmark jar
+        run: ./mvnw package -pl oshi-benchmark -am "-DskipTests" "-Dshade.phase=package" -q
+      - name: Run JMH Benchmarks (JNA vs FFM)
+        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1


### PR DESCRIPTION
Move JMH performance benchmarks out of the test matrix into a standalone parallel job in all four workflows (linux, macos, windows, pr).

**Before:** JDK 25 test jobs ran unit tests + comparison tests + JMH benchmarks sequentially, making them the slowest jobs in the matrix.

**After:** JDK 25 test jobs run unit tests + comparison tests only (with coverage upload). JMH benchmarks run in a separate parallel job with no coverage overhead.

Coverage uploads are unaffected — JMH benchmarks never contributed to coverage (they're in `src/main`, not `src/test`).

Benchmark jobs run on one runner per platform:
- Linux: `ubuntu-latest`
- macOS: `macos-15`
- Windows: `windows-2022`
- PR: `ubuntu-latest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved JMH performance benchmarks into dedicated benchmark jobs (Linux, macOS, Windows, and PR workflows), decoupling them from test jobs and test matrices; benchmarks now run independently with a consistent JDK 25 setup and unified execution settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->