### PR TITLE
Use native WTSEnumerateProcessesEx in FFM ProcessWtsData

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessWtsDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessWtsDataFFM.java
@@ -4,33 +4,117 @@
  */
 package oshi.driver.windows.registry;
 
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
+import static oshi.ffm.windows.Wtsapi32FFM.PROCESS_INFO_EX_HANDLE_COUNT;
+import static oshi.ffm.windows.Wtsapi32FFM.PROCESS_INFO_EX_KERNEL_TIME;
+import static oshi.ffm.windows.Wtsapi32FFM.PROCESS_INFO_EX_NUMBER_OF_THREADS;
+import static oshi.ffm.windows.Wtsapi32FFM.PROCESS_INFO_EX_PAGEFILE_USAGE;
+import static oshi.ffm.windows.Wtsapi32FFM.PROCESS_INFO_EX_PROCESS_ID;
+import static oshi.ffm.windows.Wtsapi32FFM.PROCESS_INFO_EX_PROCESS_NAME;
+import static oshi.ffm.windows.Wtsapi32FFM.PROCESS_INFO_EX_SIZE;
+import static oshi.ffm.windows.Wtsapi32FFM.PROCESS_INFO_EX_USER_TIME;
+import static oshi.ffm.windows.Wtsapi32FFM.WTS_ANY_SESSION;
+import static oshi.ffm.windows.Wtsapi32FFM.WTS_CURRENT_SERVER_HANDLE;
+import static oshi.ffm.windows.Wtsapi32FFM.WTS_PROCESS_INFO_LEVEL_1;
+import static oshi.ffm.windows.Wtsapi32FFM.WTS_TYPE_PROCESS_INFO_LEVEL_1;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.WtsInfo;
 import oshi.driver.common.windows.wmi.Win32Process.ProcessXPProperty;
 import oshi.driver.windows.wmi.Win32ProcessFFM;
+import oshi.ffm.windows.Kernel32FFM;
+import oshi.ffm.windows.VersionHelpersFFM;
+import oshi.ffm.windows.Wtsapi32FFM;
 import oshi.util.platform.windows.WbemcliUtilFFM.WmiResult;
 import oshi.util.platform.windows.WmiUtilFFM;
 
 /**
- * Utility to read process data from WMI as a substitute for WTS native calls.
+ * Utility to read process data from WTS native calls with backup from WMI.
  */
 @ThreadSafe
 public final class ProcessWtsDataFFM {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProcessWtsDataFFM.class);
+
+    private static final boolean IS_WINDOWS7_OR_GREATER = VersionHelpersFFM.IsWindows7OrGreater();
 
     private ProcessWtsDataFFM() {
     }
 
     /**
-     * Query WMI for process performance counters.
+     * Query process information using native WTS calls (Win7+) or WMI as fallback.
      *
      * @param pids An optional collection of process IDs to filter the list to. May be null for no filtering.
      * @return A map with Process ID as the key and a {@link WtsInfo} object populated with data.
      */
     public static Map<Integer, WtsInfo> queryProcessWtsMap(Collection<Integer> pids) {
+        if (IS_WINDOWS7_OR_GREATER) {
+            return queryProcessWtsMapFromWTS(pids);
+        }
+        return queryProcessWtsMapFromWMI(pids);
+    }
+
+    private static Map<Integer, WtsInfo> queryProcessWtsMapFromWTS(Collection<Integer> pids) {
+        Set<Integer> pidSet = pids != null ? new HashSet<>(pids) : null;
+        Map<Integer, WtsInfo> wtsMap = new HashMap<>();
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment pLevel = arena.allocate(JAVA_INT);
+            pLevel.set(JAVA_INT, 0, WTS_PROCESS_INFO_LEVEL_1);
+            MemorySegment ppProcessInfo = arena.allocate(ADDRESS);
+            MemorySegment pCount = arena.allocate(JAVA_INT);
+
+            if (!Wtsapi32FFM.WTSEnumerateProcessesEx(WTS_CURRENT_SERVER_HANDLE, pLevel, WTS_ANY_SESSION, ppProcessInfo,
+                    pCount)) {
+                LOG.error("Failed to enumerate Processes. Error code: {}", Kernel32FFM.GetLastError().orElse(-1));
+                return wtsMap;
+            }
+
+            int count = pCount.get(JAVA_INT, 0);
+            MemorySegment pProcessInfo = ppProcessInfo.get(ADDRESS, 0).reinterpret(PROCESS_INFO_EX_SIZE * count);
+            try {
+                for (int i = 0; i < count; i++) {
+                    long base = i * PROCESS_INFO_EX_SIZE;
+                    int pid = pProcessInfo.get(JAVA_INT, base + PROCESS_INFO_EX_PROCESS_ID);
+                    if (pidSet != null && !pidSet.contains(pid)) {
+                        continue;
+                    }
+                    MemorySegment pName = pProcessInfo.get(ADDRESS, base + PROCESS_INFO_EX_PROCESS_NAME);
+                    String name = pName.equals(MemorySegment.NULL) ? "" : readWideString(pName.reinterpret(512));
+                    int threads = pProcessInfo.get(JAVA_INT, base + PROCESS_INFO_EX_NUMBER_OF_THREADS);
+                    long pagefileUsage = pProcessInfo.get(JAVA_INT, base + PROCESS_INFO_EX_PAGEFILE_USAGE)
+                            & 0xffff_ffffL;
+                    long kernelTime = pProcessInfo.get(JAVA_LONG, base + PROCESS_INFO_EX_KERNEL_TIME) / 10_000L;
+                    long userTime = pProcessInfo.get(JAVA_LONG, base + PROCESS_INFO_EX_USER_TIME) / 10_000L;
+                    int handles = pProcessInfo.get(JAVA_INT, base + PROCESS_INFO_EX_HANDLE_COUNT);
+                    wtsMap.put(pid, new WtsInfo(name, "", threads, pagefileUsage, kernelTime, userTime, handles));
+                }
+            } finally {
+                if (!Wtsapi32FFM.WTSFreeMemoryEx(WTS_TYPE_PROCESS_INFO_LEVEL_1, pProcessInfo, count)) {
+                    LOG.warn("Failed to Free Memory for Processes. Error code: {}",
+                            Kernel32FFM.GetLastError().orElse(-1));
+                }
+            }
+        } catch (Throwable t) {
+            LOG.error("Failed to enumerate Processes via WTS", t);
+        }
+        return wtsMap;
+    }
+
+    private static Map<Integer, WtsInfo> queryProcessWtsMapFromWMI(Collection<Integer> pids) {
         Map<Integer, WtsInfo> wtsMap = new HashMap<>();
         WmiResult<ProcessXPProperty> processWmiResult = Win32ProcessFFM.queryProcesses(pids);
         for (int i = 0; i < processWmiResult.getResultCount(); i++) {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/Wtsapi32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/Wtsapi32FFM.java
@@ -17,12 +17,42 @@ public final class Wtsapi32FFM extends WindowsForeignFunctions {
 
     public static final MemorySegment WTS_CURRENT_SERVER_HANDLE = MemorySegment.NULL;
 
+    /** Pass to WTSEnumerateProcessesEx to enumerate all sessions. */
+    public static final int WTS_ANY_SESSION = -2;
+
+    /** Request WTS_PROCESS_INFO_EX structures from WTSEnumerateProcessesEx. */
+    public static final int WTS_PROCESS_INFO_LEVEL_1 = 1;
+
+    /** WTS_TYPE_CLASS value for WTSTypeProcessInfoLevel1, used with WTSFreeMemoryEx. */
+    public static final int WTS_TYPE_PROCESS_INFO_LEVEL_1 = 1;
+
+    // WTS_PROCESS_INFO_EXW struct layout (64-bit):
+    // SessionId(4) ProcessId(4) pProcessName(ptr) pUserSid(ptr)
+    // NumberOfThreads(4) HandleCount(4) PagefileUsage(4) PeakPagefileUsage(4)
+    // WorkingSetSize(4) PeakWorkingSetSize(4) UserTime(8) KernelTime(8) = 64 bytes
+    public static final long PROCESS_INFO_EX_SIZE = 64;
+    public static final long PROCESS_INFO_EX_PROCESS_ID = 4;
+    public static final long PROCESS_INFO_EX_PROCESS_NAME = 8;
+    public static final long PROCESS_INFO_EX_NUMBER_OF_THREADS = 24;
+    public static final long PROCESS_INFO_EX_HANDLE_COUNT = 28;
+    public static final long PROCESS_INFO_EX_PAGEFILE_USAGE = 32;
+    public static final long PROCESS_INFO_EX_USER_TIME = 48;
+    public static final long PROCESS_INFO_EX_KERNEL_TIME = 56;
+
     private static final MethodHandle WTSEnumerateSessionsW = downcall(WTS, "WTSEnumerateSessionsW", JAVA_INT, ADDRESS,
             JAVA_INT, JAVA_INT, ADDRESS, ADDRESS);
 
     public static boolean WTSEnumerateSessions(MemorySegment hServer, int reserved, int version,
             MemorySegment ppSessionInfo, MemorySegment pCount) throws Throwable {
         return isSuccess((int) WTSEnumerateSessionsW.invokeExact(hServer, reserved, version, ppSessionInfo, pCount));
+    }
+
+    private static final MethodHandle WTSEnumerateProcessesExW = downcall(WTS, "WTSEnumerateProcessesExW", JAVA_INT,
+            ADDRESS, ADDRESS, JAVA_INT, ADDRESS, ADDRESS);
+
+    public static boolean WTSEnumerateProcessesEx(MemorySegment hServer, MemorySegment pLevel, int sessionId,
+            MemorySegment ppProcessInfo, MemorySegment pCount) throws Throwable {
+        return isSuccess((int) WTSEnumerateProcessesExW.invokeExact(hServer, pLevel, sessionId, ppProcessInfo, pCount));
     }
 
     private static final MethodHandle WTSQuerySessionInformationW = downcall(WTS, "WTSQuerySessionInformationW",
@@ -38,5 +68,13 @@ public final class Wtsapi32FFM extends WindowsForeignFunctions {
 
     public static void WTSFreeMemory(MemorySegment pMemory) throws Throwable {
         WTSFreeMemory.invokeExact(pMemory);
+    }
+
+    private static final MethodHandle WTSFreeMemoryExW = downcall(WTS, "WTSFreeMemoryExW", JAVA_INT, JAVA_INT, ADDRESS,
+            JAVA_INT);
+
+    public static boolean WTSFreeMemoryEx(int wtsTypeClass, MemorySegment pMemory, int numberOfEntries)
+            throws Throwable {
+        return isSuccess((int) WTSFreeMemoryExW.invokeExact(wtsTypeClass, pMemory, numberOfEntries));
     }
 }

--- a/src/site/markdown/Performance.md
+++ b/src/site/markdown/Performance.md
@@ -30,9 +30,9 @@ macOS shows the largest FFM advantage because most system information requires n
 | FileStore  | ~35 µs   | ~136 µs   |
 | Memory     | ~77 µs   | ~113 µs   |
 | NetworkIF  | ~613 µs  | ~1238 µs  |
-| Processes  | ~49 ms   | ~11 ms    |
+| Processes  | ~2.9 ms  | ~9.9 ms   |
 
-Windows benefits from FFM for most benchmarks. The Processes benchmark is an exception where JNA is faster; this is due to JNA's use of registry-based `HKEY_PERFORMANCE_DATA` queries which bypass the per-process native calls that the FFM implementation currently uses. This is a known issue ([#3186](https://github.com/oshi/oshi/issues/3186)).
+Windows benefits from FFM across all benchmarks.
 
 ### Linux
 


### PR DESCRIPTION
## Summary

Replace WMI-based process enumeration in `ProcessWtsDataFFM` with native `WTSEnumerateProcessesEx` calls on Windows 7+, matching the JNA implementation's fast path. Keep WMI as a fallback for pre-Win7.

## Changes

**`Wtsapi32FFM.java`**
- Add `WTSEnumerateProcessesEx` and `WTSFreeMemoryEx` downcall bindings
- Add `WTS_PROCESS_INFO_EX` struct offset constants
- Add `WTS_ANY_SESSION`, `WTS_PROCESS_INFO_LEVEL_1`, `WTS_TYPE_PROCESS_INFO_LEVEL_1` constants

**`ProcessWtsDataFFM.java`**
- Add native WTS fast path using `WTSEnumerateProcessesEx` (Win7+)
- Retain WMI fallback for pre-Win7 systems
- Add logging for error cases matching JNA implementation

## Motivation

The FFM process benchmark was ~4x slower than JNA because it always used WMI (`Win32_Process`) instead of the native kernel call. This should bring FFM process enumeration performance in line with JNA.

Fixes #3186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native process enumeration on Windows 7+ with fallback for older versions.

* **Performance Improvements**
  * Much faster process data retrieval on supported Windows platforms (benchmarks updated).

* **Reliability**
  * Improved error handling, memory management, and logging for enumeration failures.

* **Documentation**
  * Updated Windows performance benchmarks and simplified explanatory text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->