### PR TITLE
Add japicmp for @PublicApi binary compatibility checks

### DIFF
--- a/oshi-common/pom.xml
+++ b/oshi-common/pom.xml
@@ -54,6 +54,18 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>cmp</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>de.thetaphi</groupId>
                 <artifactId>forbiddenapis</artifactId>
                 <configuration>

--- a/oshi-core-ffm/pom.xml
+++ b/oshi-core-ffm/pom.xml
@@ -78,6 +78,18 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>cmp</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
                 <configuration>

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -135,6 +135,18 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>cmp</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
         <!-- Misc. -->
         <sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
         <dependency-check-maven.version>12.2.1</dependency-check-maven.version>
+        <japicmp-maven-plugin.version>0.25.6</japicmp-maven-plugin.version>
         <puppycrawl.checkstyle.version>13.4.1</puppycrawl.checkstyle.version>
         <m2e.lifecycle-mapping.version>1.0.0</m2e.lifecycle-mapping.version>
     </properties>
@@ -607,6 +608,20 @@
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${dependency-check-maven.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.siom79.japicmp</groupId>
+                    <artifactId>japicmp-maven-plugin</artifactId>
+                    <version>${japicmp-maven-plugin.version}</version>
+                    <configuration>
+                        <parameter>
+                            <includes>
+                                <include>@oshi.annotation.PublicApi</include>
+                            </includes>
+                            <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+                            <onlyModified>true</onlyModified>
+                        </parameter>
+                    </configuration>
                 </plugin>
 
             </plugins>


### PR DESCRIPTION
## Summary

Adds [japicmp](https://siom79.github.io/japicmp/) to enforce semantic versioning on `@PublicApi`-annotated classes.

**How it works:**
- Runs in the `verify` phase (already covered by the `lint` CI job's `install` step)
- Auto-resolves the latest released version from Maven Central as the baseline
- Only inspects classes annotated with `@PublicApi`
- Breaks the build if the version bump doesn't match the change level:
  - Patch (7.0.x): no API changes allowed
  - Minor (7.x.0): additions OK, removals/incompatible changes fail
  - Major (x.0.0): anything goes

**Zero maintenance** — no baseline version to update after releases.

**Modules covered:** oshi-common, oshi-core, oshi-core-ffm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated API compatibility verification into the build process to automatically detect and prevent unintended breaking changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->