### PR TITLE
Add oshi-metrics module with Micrometer integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 7.1.0 (in progress)
 
 * [#3225](https://github.com/oshi/oshi/pull/3225): Add CgroupInfo API with Linux cgroup v1/v2 support - [@rohan-coder02](https://github.com/rohan-coder02).
+* [#3223](https://github.com/oshi/oshi/issues/3223): Add `oshi-metrics` module with Micrometer integration for system metrics following OpenTelemetry semantic conventions - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 
 # 7.0.0 (2026-04-30), 7.0.1 (2026-05-02)

--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -47,4 +47,14 @@
     <allow pkg="java.time" />
     <allow pkg="java.util" />
 
+    <!-- Micrometer imports for metrics module tests -->
+    <subpackage name="metrics">
+        <allow pkg="io.micrometer.core.instrument" />
+        <allow pkg="io.micrometer.core.instrument.binder" />
+        <allow pkg="io.micrometer.core.instrument.simple" />
+        <allow pkg="io.micrometer.prometheusmetrics" />
+        <allow pkg="com.sun.net.httpserver" />
+        <allow pkg="java.net" />
+    </subpackage>
+
 </import-control>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -108,4 +108,10 @@
         </subpackage>
     </subpackage>
 
+    <!-- Micrometer imports for metrics module -->
+    <subpackage name="metrics">
+        <allow pkg="io.micrometer.core.instrument" />
+        <allow pkg="io.micrometer.core.instrument.binder" />
+    </subpackage>
+
 </import-control>

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -77,3 +77,13 @@ This metric is **not implemented** because OSHI does not expose system-level maj
 | `system.filesystem.usage` | Gauge | `By` | `system.device`, `system.filesystem.mountpoint`, `system.filesystem.type`, `system.filesystem.mode`, `system.filesystem.state` | Filesystem space usage (used, free) |
 | `system.filesystem.utilization` | Gauge | `1` | (same as above) | Fraction of filesystem space in use (0.0–1.0) |
 | `system.filesystem.limit` | Gauge | `By` | `system.device`, `system.filesystem.mountpoint`, `system.filesystem.type`, `system.filesystem.mode` | Total capacity of the filesystem |
+
+### [Network metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#network-metrics)
+
+| Metric | Instrument Type | Unit | Attributes | Description |
+|--------|----------------|------|------------|-------------|
+| `system.network.io` | FunctionCounter | `By` | `system.device`, `network.io.direction` | Network bytes transferred (receive, transmit) |
+| `system.network.packet.count` | FunctionCounter | `{packet}` | `system.device`, `network.io.direction` | Network packets (receive, transmit) |
+| `system.network.packet.dropped` | FunctionCounter | `{packet}` | `system.device`, `network.io.direction` | Dropped packets (receive only) |
+| `system.network.errors` | FunctionCounter | `{error}` | `system.device`, `network.io.direction` | Network errors (receive, transmit) |
+| `system.network.connection.count` | Gauge | `{connection}` | `network.transport`, `network.connection.state` | Connection count by protocol and state |

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -55,3 +55,25 @@ Users can implement this themselves using `CentralProcessor.getSystemCpuLoadBetw
 #### `system.paging.faults`
 
 This metric is **not implemented** because OSHI does not expose system-level major/minor page fault counters.
+
+### [Disk controller metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#disk-controller-metrics)
+
+| Metric | Instrument Type | Unit | Attributes | Description |
+|--------|----------------|------|------------|-------------|
+| `system.disk.io` | FunctionCounter | `By` | `system.device`, `disk.io.direction` | Disk bytes transferred (read, write) |
+| `system.disk.operations` | FunctionCounter | `{operation}` | `system.device`, `disk.io.direction` | Disk operations count (read, write) |
+| `system.disk.io_time` | FunctionCounter | `s` | `system.device` | Time disk spent activated |
+| `system.disk.limit` | Gauge | `By` | `system.device` | Total storage capacity of the disk |
+
+#### Not implemented
+
+- `system.disk.operation_time` — OSHI does not expose per-direction operation time
+- `system.disk.merged` — OSHI does not expose merged operation counts
+
+### [Filesystem metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#filesystem-metrics)
+
+| Metric | Instrument Type | Unit | Attributes | Description |
+|--------|----------------|------|------------|-------------|
+| `system.filesystem.usage` | Gauge | `By` | `system.device`, `system.filesystem.mountpoint`, `system.filesystem.type`, `system.filesystem.mode`, `system.filesystem.state` | Filesystem space usage (used, free) |
+| `system.filesystem.utilization` | Gauge | `1` | (same as above) | Fraction of filesystem space in use (0.0–1.0) |
+| `system.filesystem.limit` | Gauge | `By` | `system.device`, `system.filesystem.mountpoint`, `system.filesystem.type`, `system.filesystem.mode` | Total capacity of the filesystem |

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -87,3 +87,13 @@ This metric is **not implemented** because OSHI does not expose system-level maj
 | `system.network.packet.dropped` | FunctionCounter | `{packet}` | `system.device`, `network.io.direction` | Dropped packets (receive only) |
 | `system.network.errors` | FunctionCounter | `{error}` | `system.device`, `network.io.direction` | Network errors (receive, transmit) |
 | `system.network.connection.count` | Gauge | `{connection}` | `network.transport`, `network.connection.state` | Connection count by protocol and state |
+
+### [Aggregate system process metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#aggregate-system-process-metrics)
+
+| Metric | Instrument Type | Unit | Attributes | Description |
+|--------|----------------|------|------------|-------------|
+| `system.process.count` | Gauge | `{process}` | — | Total number of processes on the system |
+
+#### Not implemented
+
+- `system.process.created` — OSHI does not expose total processes created over uptime

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -1,0 +1,44 @@
+# OSHI Metrics Module
+
+Provides [Micrometer](https://micrometer.io/) meter bindings for OSHI system metrics, following the
+[OpenTelemetry Semantic Conventions for System Metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/).
+
+## Usage
+
+```java
+SystemInfo si = new SystemInfo();
+OshiMetrics.bindTo(registry, si.getHardware(), si.getOperatingSystem());
+```
+
+## Implemented Metrics
+
+### [General metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#general-metrics)
+
+| Metric | Instrument Type | Unit | Description |
+|--------|----------------|------|-------------|
+| `system.uptime` | Gauge | `s` | The time the system has been running |
+
+### [Processor metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#processor-metrics)
+
+| Metric | Instrument Type | Unit | Attributes | Description |
+|--------|----------------|------|------------|-------------|
+| `system.cpu.physical.count` | Gauge | `{cpu}` | — | Reports the number of actual physical processor cores on the hardware |
+| `system.cpu.logical.count` | Gauge | `{cpu}` | — | Reports the number of logical (virtual) processor cores |
+| `system.cpu.time` | FunctionCounter | `s` | `cpu.mode` | Seconds each logical CPU spent on each mode |
+| `system.cpu.frequency` | Gauge | `Hz` | `cpu.logical_number` | Operating frequency of the logical CPU in Hertz |
+
+#### `system.cpu.utilization`
+
+This metric is **not implemented** because it requires computing the rate of change of `system.cpu.time` over a
+measurement interval. OSHI does not own a polling loop — the application or observability agent should control the
+sampling interval.
+
+Users can implement this themselves using `CentralProcessor.getSystemCpuLoadBetweenTicks(long[] prevTicks)` with a
+`ScheduledExecutorService` and register the results as a Gauge with `cpu.mode` attributes.
+
+### [Memory metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#memory-metrics)
+
+| Metric | Instrument Type | Unit | Attributes | Description |
+|--------|----------------|------|------------|-------------|
+| `system.memory.usage` | Gauge | `By` | `system.memory.state` | Reports memory in use by state (used, free) |
+| `system.memory.utilization` | Gauge | `1` | `system.memory.state` | Fraction of memory in use by state (0.0–1.0) |

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -3,11 +3,77 @@
 Provides [Micrometer](https://micrometer.io/) meter bindings for OSHI system metrics, following the
 [OpenTelemetry Semantic Conventions for System Metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/).
 
+## Setup
+
+Add `oshi-metrics` alongside your OSHI implementation and a Micrometer registry:
+
+```xml
+<!-- OSHI metrics (requires JDK 17+) -->
+<dependency>
+    <groupId>com.github.oshi</groupId>
+    <artifactId>oshi-metrics</artifactId>
+    <version>${oshi.version}</version>
+</dependency>
+
+<!-- Pick ONE OSHI implementation -->
+<dependency>
+    <groupId>com.github.oshi</groupId>
+    <artifactId>oshi-core</artifactId>        <!-- JNA, JDK 8+ -->
+    <version>${oshi.version}</version>
+</dependency>
+<!-- OR -->
+<dependency>
+    <groupId>com.github.oshi</groupId>
+    <artifactId>oshi-core-ffm</artifactId>    <!-- FFM, JDK 25+ -->
+    <version>${oshi.version}</version>
+</dependency>
+
+<!-- Your Micrometer registry (e.g., Prometheus) -->
+<dependency>
+    <groupId>io.micrometer</groupId>
+    <artifactId>micrometer-registry-prometheus</artifactId>
+    <version>${micrometer.version}</version>
+</dependency>
+```
+
 ## Usage
+
+### Register all metrics
+
+```java
+SystemInfo si = new SystemInfo();  // or new oshi.ffm.SystemInfo()
+OshiMetrics.bindTo(registry, si.getHardware(), si.getOperatingSystem());
+```
+
+### Selective registration (Builder API)
 
 ```java
 SystemInfo si = new SystemInfo();
-OshiMetrics.bindTo(registry, si.getHardware(), si.getOperatingSystem());
+OshiMetrics.builder(si.getHardware(), si.getOperatingSystem())
+    .enableGeneral(true)
+    .enableCpu(true)
+    .enableMemory(true)
+    .enablePaging(false)
+    .enableDisk(true)
+    .enableFileSystem(true)
+    .enableNetwork(false)
+    .enableProcess(true)
+    .build()
+    .bindTo(registry);
+```
+
+All categories are enabled by default.
+
+### Spring Boot
+
+`OshiMetrics` implements `MeterBinder`, so Spring Boot auto-discovers it if you expose it as a bean:
+
+```java
+@Bean
+public OshiMetrics oshiMetrics() {
+    SystemInfo si = new SystemInfo();
+    return new OshiMetrics(si.getHardware(), si.getOperatingSystem());
+}
 ```
 
 ## Implemented Metrics
@@ -24,17 +90,14 @@ OshiMetrics.bindTo(registry, si.getHardware(), si.getOperatingSystem());
 |--------|----------------|------|------------|-------------|
 | `system.cpu.physical.count` | Gauge | `{cpu}` | — | Reports the number of actual physical processor cores on the hardware |
 | `system.cpu.logical.count` | Gauge | `{cpu}` | — | Reports the number of logical (virtual) processor cores |
-| `system.cpu.time` | FunctionCounter | `s` | `cpu.mode` | Seconds each logical CPU spent on each mode |
+| `system.cpu.time` | FunctionCounter | `s` | `cpu.mode` | Seconds spent in each CPU mode |
 | `system.cpu.frequency` | Gauge | `Hz` | `cpu.logical_number` | Operating frequency of the logical CPU in Hertz |
 
 #### `system.cpu.utilization`
 
 This metric is **not implemented** because it requires computing the rate of change of `system.cpu.time` over a
-measurement interval. OSHI does not own a polling loop — the application or observability agent should control the
-sampling interval.
-
-Users can implement this themselves using `CentralProcessor.getSystemCpuLoadBetweenTicks(long[] prevTicks)` with a
-`ScheduledExecutorService` and register the results as a Gauge with `cpu.mode` attributes.
+measurement interval. Users can implement this using `CentralProcessor.getSystemCpuLoadBetweenTicks(long[] prevTicks)`
+with a `ScheduledExecutorService`.
 
 ### [Memory metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#memory-metrics)
 
@@ -48,13 +111,13 @@ Users can implement this themselves using `CentralProcessor.getSystemCpuLoadBetw
 
 | Metric | Instrument Type | Unit | Attributes | Description |
 |--------|----------------|------|------------|-------------|
-| `system.paging.usage` | Gauge | `By` | `system.paging.state` | Unix swap or windows pagefile usage (used, free) |
+| `system.paging.usage` | Gauge | `By` | `system.paging.state` | Unix swap or Windows pagefile usage (used, free) |
 | `system.paging.utilization` | Gauge | `1` | `system.paging.state` | Fraction of swap/pagefile in use (0.0–1.0) |
 | `system.paging.operations` | FunctionCounter | `{operation}` | `system.paging.direction` | Cumulative paging operations (in, out) |
 
 #### `system.paging.faults`
 
-This metric is **not implemented** because OSHI does not expose system-level major/minor page fault counters.
+Not implemented — OSHI does not expose system-level major/minor page fault counters.
 
 ### [Disk controller metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#disk-controller-metrics)
 
@@ -97,3 +160,21 @@ This metric is **not implemented** because OSHI does not expose system-level maj
 #### Not implemented
 
 - `system.process.created` — OSHI does not expose total processes created over uptime
+
+### [Process metrics](https://opentelemetry.io/docs/specs/semconv/system/process-metrics/) (current JVM process)
+
+| Metric | Instrument Type | Unit | Attributes | Description |
+|--------|----------------|------|------------|-------------|
+| `process.cpu.time` | FunctionCounter | `s` | `cpu.mode` (user, system) | CPU seconds by mode |
+| `process.memory.usage` | Gauge | `By` | — | Physical memory (RSS) |
+| `process.memory.virtual` | Gauge | `By` | — | Committed virtual memory |
+| `process.disk.io` | FunctionCounter | `By` | `disk.io.direction` (read, write) | Disk bytes transferred |
+| `process.thread.count` | Gauge | `{thread}` | — | Thread count |
+| `process.open_file_descriptor.count` | Gauge | `{file_descriptor}` | — | Open file descriptors |
+| `process.paging.faults` | FunctionCounter | `{fault}` | `system.paging.fault.type` (major, minor) | Page faults |
+| `process.context_switches` | FunctionCounter | `{context_switch}` | `process.context_switch.type` (total) | Context switches |
+| `process.uptime` | Gauge | `s` | — | Process uptime |
+
+#### Not implemented
+
+- `process.network.io` — OSHI does not expose per-process network I/O

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -58,11 +58,12 @@ OshiMetrics.builder(si.getHardware(), si.getOperatingSystem())
     .enableFileSystem(true)
     .enableNetwork(false)
     .enableProcess(true)
+    .enableContainer(true)
     .build()
     .bindTo(registry);
 ```
 
-All categories are enabled by default.
+All categories are enabled by default. Categories: `general`, `cpu`, `memory`, `paging`, `disk`, `fileSystem`, `network`, `process`, `container`.
 
 ### Spring Boot
 
@@ -178,3 +179,19 @@ Not implemented — OSHI does not expose system-level major/minor page fault cou
 #### Not implemented
 
 - `process.network.io` — OSHI does not expose per-process network I/O
+
+### [Container metrics](https://opentelemetry.io/docs/specs/semconv/system/container-metrics/) (when containerized)
+
+| Metric | Instrument Type | Unit | Description |
+|--------|----------------|------|-------------|
+| `container.uptime` | Gauge | `s` | Time the container has been running (from PID 1 start time) |
+| `container.cpu.time` | FunctionCounter | `s` | Total CPU time consumed by the container |
+| `container.memory.usage` | Gauge | `By` | Container memory usage |
+| `container.memory.available` | Gauge | `By` | Container memory available (limit - usage, only when limit is set) |
+
+#### Not implemented
+
+- `container.cpu.usage` — requires polling interval
+- `container.disk.io`, `container.network.io` — OSHI does not expose per-cgroup I/O
+- `container.memory.rss`, `container.memory.working_set`, `container.memory.paging.faults` — not available via CgroupInfo
+- `container.filesystem.*` — not available via CgroupInfo

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -41,4 +41,17 @@ Users can implement this themselves using `CentralProcessor.getSystemCpuLoadBetw
 | Metric | Instrument Type | Unit | Attributes | Description |
 |--------|----------------|------|------------|-------------|
 | `system.memory.usage` | Gauge | `By` | `system.memory.state` | Reports memory in use by state (used, free) |
+| `system.memory.limit` | Gauge | `By` | — | Total memory available in the system |
 | `system.memory.utilization` | Gauge | `1` | `system.memory.state` | Fraction of memory in use by state (0.0–1.0) |
+
+### [Paging/Swap metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#pagingswap-metrics)
+
+| Metric | Instrument Type | Unit | Attributes | Description |
+|--------|----------------|------|------------|-------------|
+| `system.paging.usage` | Gauge | `By` | `system.paging.state` | Unix swap or windows pagefile usage (used, free) |
+| `system.paging.utilization` | Gauge | `1` | `system.paging.state` | Fraction of swap/pagefile in use (0.0–1.0) |
+| `system.paging.operations` | FunctionCounter | `{operation}` | `system.paging.direction` | Cumulative paging operations (in, out) |
+
+#### `system.paging.faults`
+
+This metric is **not implemented** because OSHI does not expose system-level major/minor page fault counters.

--- a/oshi-metrics/pom.xml
+++ b/oshi-metrics/pom.xml
@@ -47,12 +47,6 @@
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-test</artifactId>
-            <version>${micrometer.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
             <version>${micrometer.version}</version>
             <scope>test</scope>
@@ -85,6 +79,17 @@
                     <suppressAnnotations>
                         <suppressAnnotation>oshi.annotation.SuppressForbidden</suppressAnnotation>
                     </suppressAnnotations>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.github.oshi.metrics</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>

--- a/oshi-metrics/pom.xml
+++ b/oshi-metrics/pom.xml
@@ -71,7 +71,20 @@
                 <groupId>de.thetaphi</groupId>
                 <artifactId>forbiddenapis</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                    <bundledSignatures>
+                        <bundledSignature>jdk-unsafe</bundledSignature>
+                        <bundledSignature>jdk-deprecated</bundledSignature>
+                        <bundledSignature>jdk-non-portable</bundledSignature>
+                        <bundledSignature>jdk-reflection</bundledSignature>
+                        <bundledSignature>jdk-system-out</bundledSignature>
+                    </bundledSignatures>
+                    <signaturesFiles>
+                        <signaturesFile>${main.basedir}/config/forbidden-apis.txt</signaturesFile>
+                    </signaturesFiles>
+                    <suppressAnnotations>
+                        <suppressAnnotation>oshi.annotation.SuppressForbidden</suppressAnnotation>
+                    </suppressAnnotations>
                 </configuration>
             </plugin>
             <plugin>

--- a/oshi-metrics/pom.xml
+++ b/oshi-metrics/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.oshi</groupId>
+        <artifactId>oshi-parent</artifactId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oshi-metrics</artifactId>
+    <packaging>jar</packaging>
+
+    <name>oshi-metrics</name>
+    <description>Micrometer metrics binders for OSHI system metrics, following OpenTelemetry semantic conventions.</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
+        <micrometer.version>1.14.11</micrometer.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oshi-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${micrometer.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oshi-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-test</artifactId>
+            <version>${micrometer.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${micrometer.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/oshi-metrics/src/main/java/oshi/metrics/ContainerMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/ContainerMetrics.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import oshi.software.os.CgroupInfo;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OperatingSystem;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * {@link MeterBinder} for container metrics following
+ * <a href="https://opentelemetry.io/docs/specs/semconv/system/container-metrics/">OpenTelemetry semantic
+ * conventions</a>.
+ *
+ * <p>
+ * Only registers metrics when {@link CgroupInfo#isContainerized()} returns {@code true}.
+ *
+ * <p>
+ * Registers:
+ * <ul>
+ * <li>{@code container.uptime} — time the container has been running, in seconds</li>
+ * <li>{@code container.cpu.time} — total CPU time consumed, in seconds</li>
+ * <li>{@code container.memory.usage} — memory usage in bytes</li>
+ * <li>{@code container.memory.available} — memory available (limit - usage) in bytes</li>
+ * </ul>
+ *
+ * <p>
+ * Not implemented:
+ * <ul>
+ * <li>{@code container.cpu.usage} — requires polling interval</li>
+ * <li>{@code container.disk.io}, {@code container.network.io} — OSHI does not expose per-cgroup I/O</li>
+ * <li>{@code container.memory.rss}, {@code container.memory.working_set} — not available via CgroupInfo</li>
+ * <li>{@code container.memory.paging.faults} — not available via CgroupInfo</li>
+ * <li>{@code container.filesystem.*} — not available via CgroupInfo</li>
+ * </ul>
+ */
+public class ContainerMetrics implements MeterBinder {
+
+    private static final String CONTAINER_UPTIME = "container.uptime";
+    private static final String CONTAINER_CPU_TIME = "container.cpu.time";
+    private static final String CONTAINER_MEMORY_USAGE = "container.memory.usage";
+    private static final String CONTAINER_MEMORY_AVAILABLE = "container.memory.available";
+    private static final double NS_PER_SECOND = 1_000_000_000.0;
+
+    private final OperatingSystem os;
+    private final CgroupInfo cgroup;
+
+    /**
+     * Creates a new {@code ContainerMetrics} binder.
+     *
+     * @param os     the {@link OperatingSystem} instance
+     * @param cgroup the {@link CgroupInfo} instance
+     */
+    public ContainerMetrics(OperatingSystem os, CgroupInfo cgroup) {
+        this.os = os;
+        this.cgroup = cgroup;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        if (!cgroup.isContainerized()) {
+            return;
+        }
+
+        // container.uptime — Gauge, unit "s" (time since PID 1 started)
+        OSProcess init = os.getProcess(1);
+        final long initStartTime = (init != null && init.getStartTime() > 0) ? init.getStartTime() : -1L;
+        Gauge.builder(CONTAINER_UPTIME, os,
+                o -> initStartTime > 0 ? (System.currentTimeMillis() - initStartTime) / 1000.0
+                        : (double) o.getSystemUptime())
+                .description("The time the container has been running").baseUnit("s").strongReference(true)
+                .register(registry);
+
+        // container.cpu.time — Counter, unit "s" (cgroup reports nanoseconds)
+        FunctionCounter.builder(CONTAINER_CPU_TIME, cgroup, c -> c.getCpuUsage() / NS_PER_SECOND)
+                .description("Total CPU time consumed").baseUnit("s").register(registry);
+
+        // container.memory.usage — Gauge, unit "By"
+        Gauge.builder(CONTAINER_MEMORY_USAGE, cgroup, CgroupInfo::getMemoryUsage)
+                .description("Memory usage of the container").baseUnit("By").strongReference(true).register(registry);
+
+        // container.memory.available — UpDownCounter (Gauge), unit "By"
+        // Only meaningful when a memory limit is set
+        if (cgroup.getMemoryLimit() != CgroupInfo.UNLIMITED_MEMORY) {
+            Gauge.builder(CONTAINER_MEMORY_AVAILABLE, cgroup,
+                    c -> Math.max(0L, c.getMemoryLimit() - c.getMemoryUsage()))
+                    .description("Container memory available").baseUnit("By").strongReference(true).register(registry);
+        }
+    }
+}

--- a/oshi-metrics/src/main/java/oshi/metrics/CpuMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/CpuMetrics.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.CentralProcessor.TickType;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * {@link MeterBinder} for system CPU metrics following
+ * <a href="https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#processor-metrics">OpenTelemetry semantic
+ * conventions</a>.
+ *
+ * <p>
+ * Registers:
+ * <ul>
+ * <li>{@code system.cpu.time} — cumulative CPU time per mode (user, system, nice, idle, iowait, interrupt, softirq,
+ * steal), in seconds. Backends compute utilization via {@code rate(system.cpu.time[interval])}.</li>
+ * </ul>
+ */
+public class CpuMetrics implements MeterBinder {
+
+    private static final String CPU_TIME = "system.cpu.time";
+    private static final String CPU_MODE_KEY = "cpu.mode";
+    private static final double MS_PER_SECOND = 1000.0;
+
+    private static final Map<TickType, String> TICK_TO_MODE = new EnumMap<>(TickType.class);
+
+    static {
+        TICK_TO_MODE.put(TickType.USER, "user");
+        TICK_TO_MODE.put(TickType.NICE, "nice");
+        TICK_TO_MODE.put(TickType.SYSTEM, "system");
+        TICK_TO_MODE.put(TickType.IDLE, "idle");
+        TICK_TO_MODE.put(TickType.IOWAIT, "iowait");
+        TICK_TO_MODE.put(TickType.IRQ, "interrupt");
+        TICK_TO_MODE.put(TickType.SOFTIRQ, "softirq");
+        TICK_TO_MODE.put(TickType.STEAL, "steal");
+    }
+
+    private final CentralProcessor processor;
+
+    /**
+     * Creates a new {@code CpuMetrics} binder.
+     *
+     * @param processor the {@link CentralProcessor} instance to read from
+     */
+    public CpuMetrics(CentralProcessor processor) {
+        this.processor = processor;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (TickType type : TickType.values()) {
+            int index = type.getIndex();
+            String mode = TICK_TO_MODE.getOrDefault(type, type.name().toLowerCase(java.util.Locale.ROOT));
+            FunctionCounter.builder(CPU_TIME, processor, p -> p.getSystemCpuLoadTicks()[index] / MS_PER_SECOND)
+                    .tag(CPU_MODE_KEY, mode).description("System CPU time spent in " + mode + " mode").baseUnit("s")
+                    .register(registry);
+        }
+    }
+}

--- a/oshi-metrics/src/main/java/oshi/metrics/CpuMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/CpuMetrics.java
@@ -11,6 +11,7 @@ import oshi.hardware.CentralProcessor;
 import oshi.hardware.CentralProcessor.TickType;
 
 import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
@@ -24,12 +25,19 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * <ul>
  * <li>{@code system.cpu.time} — cumulative CPU time per mode (user, system, nice, idle, iowait, interrupt, softirq,
  * steal), in seconds. Backends compute utilization via {@code rate(system.cpu.time[interval])}.</li>
+ * <li>{@code system.cpu.physical.count} — number of physical processor cores</li>
+ * <li>{@code system.cpu.logical.count} — number of logical processor cores</li>
+ * <li>{@code system.cpu.frequency} — operating frequency of each logical CPU in Hertz</li>
  * </ul>
  */
 public class CpuMetrics implements MeterBinder {
 
     private static final String CPU_TIME = "system.cpu.time";
+    private static final String CPU_PHYSICAL_COUNT = "system.cpu.physical.count";
+    private static final String CPU_LOGICAL_COUNT = "system.cpu.logical.count";
+    private static final String CPU_FREQUENCY = "system.cpu.frequency";
     private static final String CPU_MODE_KEY = "cpu.mode";
+    private static final String CPU_LOGICAL_NUMBER_KEY = "cpu.logical_number";
     private static final double MS_PER_SECOND = 1000.0;
 
     private static final Map<TickType, String> TICK_TO_MODE = new EnumMap<>(TickType.class);
@@ -58,12 +66,34 @@ public class CpuMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
+        // system.cpu.time — Counter, unit "s", attr cpu.mode
         for (TickType type : TickType.values()) {
             int index = type.getIndex();
             String mode = TICK_TO_MODE.getOrDefault(type, type.name().toLowerCase(java.util.Locale.ROOT));
             FunctionCounter.builder(CPU_TIME, processor, p -> p.getSystemCpuLoadTicks()[index] / MS_PER_SECOND)
-                    .tag(CPU_MODE_KEY, mode).description("System CPU time spent in " + mode + " mode").baseUnit("s")
+                    .tag(CPU_MODE_KEY, mode).description("Seconds spent in each CPU mode").baseUnit("s")
                     .register(registry);
+        }
+
+        // system.cpu.physical.count — UpDownCounter (Gauge), unit "{cpu}"
+        Gauge.builder(CPU_PHYSICAL_COUNT, processor, CentralProcessor::getPhysicalProcessorCount)
+                .description("Reports the number of actual physical processor cores on the hardware").baseUnit("{cpu}")
+                .register(registry);
+
+        // system.cpu.logical.count — UpDownCounter (Gauge), unit "{cpu}"
+        Gauge.builder(CPU_LOGICAL_COUNT, processor, CentralProcessor::getLogicalProcessorCount).description(
+                "Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking")
+                .baseUnit("{cpu}").register(registry);
+
+        // system.cpu.frequency — Gauge, unit "Hz", attr cpu.logical_number
+        int logicalCount = processor.getLogicalProcessorCount();
+        for (int i = 0; i < logicalCount; i++) {
+            final int cpuIndex = i;
+            Gauge.builder(CPU_FREQUENCY, processor, p -> {
+                long[] freqs = p.getCurrentFreq();
+                return cpuIndex < freqs.length ? (double) freqs[cpuIndex] : 0d;
+            }).tag(CPU_LOGICAL_NUMBER_KEY, String.valueOf(i))
+                    .description("Operating frequency of the logical CPU in Hertz").baseUnit("Hz").register(registry);
         }
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/DiskMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/DiskMetrics.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import oshi.hardware.HWDiskStore;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * {@link MeterBinder} for system disk controller metrics following
+ * <a href="https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#disk-controller-metrics">OpenTelemetry
+ * semantic conventions</a>.
+ *
+ * <p>
+ * Registers per device:
+ * <ul>
+ * <li>{@code system.disk.io} — disk bytes transferred by direction (read, write)</li>
+ * <li>{@code system.disk.operations} — disk operations count by direction (read, write)</li>
+ * <li>{@code system.disk.io_time} — time disk spent activated, in seconds</li>
+ * <li>{@code system.disk.limit} — total storage capacity of the disk, in bytes</li>
+ * </ul>
+ *
+ * <p>
+ * Not implemented:
+ * <ul>
+ * <li>{@code system.disk.operation_time} — OSHI does not expose per-direction operation time</li>
+ * <li>{@code system.disk.merged} — OSHI does not expose merged operation counts</li>
+ * </ul>
+ */
+public class DiskMetrics implements MeterBinder {
+
+    private static final String DISK_IO = "system.disk.io";
+    private static final String DISK_OPERATIONS = "system.disk.operations";
+    private static final String DISK_IO_TIME = "system.disk.io_time";
+    private static final String DISK_LIMIT = "system.disk.limit";
+    private static final String DEVICE_KEY = "system.device";
+    private static final String DIRECTION_KEY = "disk.io.direction";
+    private static final double MS_PER_SECOND = 1000.0;
+
+    private final Supplier<List<HWDiskStore>> diskStoreSupplier;
+
+    /**
+     * Creates a new {@code DiskMetrics} binder.
+     *
+     * @param diskStoreSupplier supplier that returns the current list of {@link HWDiskStore} instances
+     */
+    public DiskMetrics(Supplier<List<HWDiskStore>> diskStoreSupplier) {
+        this.diskStoreSupplier = diskStoreSupplier;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (HWDiskStore disk : diskStoreSupplier.get()) {
+            String device = disk.getName();
+
+            // system.disk.io — Counter, unit "By", attrs: disk.io.direction, system.device
+            FunctionCounter.builder(DISK_IO, disk, HWDiskStore::getReadBytes).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "read").description("Disk bytes transferred").baseUnit("By").register(registry);
+            FunctionCounter.builder(DISK_IO, disk, HWDiskStore::getWriteBytes).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "write").description("Disk bytes transferred").baseUnit("By")
+                    .register(registry);
+
+            // system.disk.operations — Counter, unit "{operation}", attrs: disk.io.direction, system.device
+            FunctionCounter.builder(DISK_OPERATIONS, disk, HWDiskStore::getReads).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "read").description("Disk operations count").baseUnit("{operation}")
+                    .register(registry);
+            FunctionCounter.builder(DISK_OPERATIONS, disk, HWDiskStore::getWrites).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "write").description("Disk operations count").baseUnit("{operation}")
+                    .register(registry);
+
+            // system.disk.io_time — Counter, unit "s", attr: system.device
+            FunctionCounter.builder(DISK_IO_TIME, disk, d -> d.getTransferTime() / MS_PER_SECOND)
+                    .tag(DEVICE_KEY, device).description("Time disk spent activated").baseUnit("s").register(registry);
+
+            // system.disk.limit — UpDownCounter (Gauge), unit "By", attr: system.device
+            Gauge.builder(DISK_LIMIT, disk, HWDiskStore::getSize).tag(DEVICE_KEY, device)
+                    .description("The total storage capacity of the disk").baseUnit("By").strongReference(true)
+                    .register(registry);
+        }
+    }
+}

--- a/oshi-metrics/src/main/java/oshi/metrics/DiskMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/DiskMetrics.java
@@ -46,6 +46,7 @@ public class DiskMetrics implements MeterBinder {
     private static final double MS_PER_SECOND = 1000.0;
 
     private final Supplier<List<HWDiskStore>> diskStoreSupplier;
+    private List<HWDiskStore> diskStores;
 
     /**
      * Creates a new {@code DiskMetrics} binder.
@@ -58,27 +59,42 @@ public class DiskMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        for (HWDiskStore disk : diskStoreSupplier.get()) {
+        List<HWDiskStore> disks = diskStoreSupplier.get();
+        // Hold strong references to prevent GC (FunctionCounter uses WeakReference)
+        this.diskStores = disks;
+
+        for (HWDiskStore disk : disks) {
             String device = disk.getName();
 
             // system.disk.io — Counter, unit "By", attrs: disk.io.direction, system.device
-            FunctionCounter.builder(DISK_IO, disk, HWDiskStore::getReadBytes).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "read").description("Disk bytes transferred").baseUnit("By").register(registry);
-            FunctionCounter.builder(DISK_IO, disk, HWDiskStore::getWriteBytes).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "write").description("Disk bytes transferred").baseUnit("By")
+            FunctionCounter.builder(DISK_IO, disk, d -> {
+                d.updateAttributes();
+                return d.getReadBytes();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "read").description("Disk bytes transferred").baseUnit("By")
+                    .register(registry);
+            FunctionCounter.builder(DISK_IO, disk, d -> {
+                d.updateAttributes();
+                return d.getWriteBytes();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "write").description("Disk bytes transferred").baseUnit("By")
                     .register(registry);
 
             // system.disk.operations — Counter, unit "{operation}", attrs: disk.io.direction, system.device
-            FunctionCounter.builder(DISK_OPERATIONS, disk, HWDiskStore::getReads).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "read").description("Disk operations count").baseUnit("{operation}")
-                    .register(registry);
-            FunctionCounter.builder(DISK_OPERATIONS, disk, HWDiskStore::getWrites).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "write").description("Disk operations count").baseUnit("{operation}")
-                    .register(registry);
+            FunctionCounter.builder(DISK_OPERATIONS, disk, d -> {
+                d.updateAttributes();
+                return d.getReads();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "read").description("Disk operations count")
+                    .baseUnit("{operation}").register(registry);
+            FunctionCounter.builder(DISK_OPERATIONS, disk, d -> {
+                d.updateAttributes();
+                return d.getWrites();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "write").description("Disk operations count")
+                    .baseUnit("{operation}").register(registry);
 
             // system.disk.io_time — Counter, unit "s", attr: system.device
-            FunctionCounter.builder(DISK_IO_TIME, disk, d -> d.getTransferTime() / MS_PER_SECOND)
-                    .tag(DEVICE_KEY, device).description("Time disk spent activated").baseUnit("s").register(registry);
+            FunctionCounter.builder(DISK_IO_TIME, disk, d -> {
+                d.updateAttributes();
+                return d.getTransferTime() / MS_PER_SECOND;
+            }).tag(DEVICE_KEY, device).description("Time disk spent activated").baseUnit("s").register(registry);
 
             // system.disk.limit — UpDownCounter (Gauge), unit "By", attr: system.device
             Gauge.builder(DISK_LIMIT, disk, HWDiskStore::getSize).tag(DEVICE_KEY, device)

--- a/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
@@ -42,6 +42,11 @@ public class FileSystemMetrics implements MeterBinder {
     /**
      * Creates a new {@code FileSystemMetrics} binder.
      *
+     * <p>
+     * Note: {@link #bindTo(MeterRegistry)} calls the supplier once to capture a snapshot of filesystems. Filesystems
+     * mounted after binding will not be tracked; unmounted filesystems may leave stale meters. To refresh, create and
+     * bind a new instance.
+     *
      * @param fileStoreSupplier supplier that returns the current list of {@link OSFileStore} instances
      */
     public FileSystemMetrics(Supplier<List<OSFileStore>> fileStoreSupplier) {

--- a/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
@@ -59,32 +59,43 @@ public class FileSystemMetrics implements MeterBinder {
             String device = fs.getVolume();
             String mount = fs.getMount();
             String type = fs.getType();
-            String mode = fs.getOptions().contains("rw") ? "rw" : "ro";
+            String opts = fs.getOptions();
+            String mode = opts != null && java.util.Arrays.asList(opts.split(",")).contains("rw") ? "rw" : "ro";
 
             // system.filesystem.usage — UpDownCounter (Gauge), unit "By", attr: state, device, mount, type, mode
-            Gauge.builder(FS_USAGE, fs, f -> Math.max(0L, f.getTotalSpace() - f.getUsableSpace()))
-                    .tag(STATE_KEY, "used").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
+            Gauge.builder(FS_USAGE, fs, f -> {
+                f.updateAttributes();
+                return Math.max(0L, f.getTotalSpace() - f.getUsableSpace());
+            }).tag(STATE_KEY, "used").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
                     .tag(MODE_KEY, mode).description("Filesystem space usage").baseUnit("By").strongReference(true)
                     .register(registry);
-            Gauge.builder(FS_USAGE, fs, OSFileStore::getUsableSpace).tag(STATE_KEY, "free").tag(DEVICE_KEY, device)
-                    .tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type).tag(MODE_KEY, mode)
-                    .description("Filesystem space usage").baseUnit("By").strongReference(true).register(registry);
+            Gauge.builder(FS_USAGE, fs, f -> {
+                f.updateAttributes();
+                return (double) f.getUsableSpace();
+            }).tag(STATE_KEY, "free").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
+                    .tag(MODE_KEY, mode).description("Filesystem space usage").baseUnit("By").strongReference(true)
+                    .register(registry);
 
             // system.filesystem.utilization — Gauge, unit "1", attr: state, device, mount, type, mode
-            Gauge.builder(FS_UTILIZATION, fs,
-                    f -> f.getTotalSpace() == 0 ? 0d
-                            : Math.max(0d, (double) (f.getTotalSpace() - f.getUsableSpace()) / f.getTotalSpace()))
-                    .tag(STATE_KEY, "used").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
+            Gauge.builder(FS_UTILIZATION, fs, f -> {
+                f.updateAttributes();
+                return f.getTotalSpace() == 0 ? 0d
+                        : Math.max(0d, (double) (f.getTotalSpace() - f.getUsableSpace()) / f.getTotalSpace());
+            }).tag(STATE_KEY, "used").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
                     .tag(MODE_KEY, mode).description("Filesystem utilization").strongReference(true).register(registry);
-            Gauge.builder(FS_UTILIZATION, fs,
-                    f -> f.getTotalSpace() == 0 ? 0d : (double) f.getUsableSpace() / f.getTotalSpace())
-                    .tag(STATE_KEY, "free").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
+            Gauge.builder(FS_UTILIZATION, fs, f -> {
+                f.updateAttributes();
+                return f.getTotalSpace() == 0 ? 0d : (double) f.getUsableSpace() / f.getTotalSpace();
+            }).tag(STATE_KEY, "free").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
                     .tag(MODE_KEY, mode).description("Filesystem utilization").strongReference(true).register(registry);
 
             // system.filesystem.limit — UpDownCounter (Gauge), unit "By", attr: device, mount, type, mode
-            Gauge.builder(FS_LIMIT, fs, OSFileStore::getTotalSpace).tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount)
-                    .tag(TYPE_KEY, type).tag(MODE_KEY, mode).description("Total capacity of the filesystem")
-                    .baseUnit("By").strongReference(true).register(registry);
+            Gauge.builder(FS_LIMIT, fs, f -> {
+                f.updateAttributes();
+                return (double) f.getTotalSpace();
+            }).tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type).tag(MODE_KEY, mode)
+                    .description("Total capacity of the filesystem").baseUnit("By").strongReference(true)
+                    .register(registry);
         }
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import oshi.software.os.OSFileStore;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * {@link MeterBinder} for system filesystem metrics following
+ * <a href="https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#filesystem-metrics">OpenTelemetry
+ * semantic conventions</a>.
+ *
+ * <p>
+ * Registers per filesystem:
+ * <ul>
+ * <li>{@code system.filesystem.usage} — filesystem space usage by state ({@code used}, {@code free}), in bytes</li>
+ * <li>{@code system.filesystem.utilization} — fraction of filesystem space in use by state (0.0–1.0)</li>
+ * <li>{@code system.filesystem.limit} — total capacity of the filesystem, in bytes</li>
+ * </ul>
+ */
+public class FileSystemMetrics implements MeterBinder {
+
+    private static final String FS_USAGE = "system.filesystem.usage";
+    private static final String FS_UTILIZATION = "system.filesystem.utilization";
+    private static final String FS_LIMIT = "system.filesystem.limit";
+    private static final String DEVICE_KEY = "system.device";
+    private static final String MOUNTPOINT_KEY = "system.filesystem.mountpoint";
+    private static final String TYPE_KEY = "system.filesystem.type";
+    private static final String MODE_KEY = "system.filesystem.mode";
+    private static final String STATE_KEY = "system.filesystem.state";
+
+    private final Supplier<List<OSFileStore>> fileStoreSupplier;
+
+    /**
+     * Creates a new {@code FileSystemMetrics} binder.
+     *
+     * @param fileStoreSupplier supplier that returns the current list of {@link OSFileStore} instances
+     */
+    public FileSystemMetrics(Supplier<List<OSFileStore>> fileStoreSupplier) {
+        this.fileStoreSupplier = fileStoreSupplier;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (OSFileStore fs : fileStoreSupplier.get()) {
+            String device = fs.getVolume();
+            String mount = fs.getMount();
+            String type = fs.getType();
+            String mode = fs.getOptions().contains("rw") ? "rw" : "ro";
+
+            // system.filesystem.usage — UpDownCounter (Gauge), unit "By", attr: state, device, mount, type, mode
+            Gauge.builder(FS_USAGE, fs, f -> Math.max(0L, f.getTotalSpace() - f.getUsableSpace()))
+                    .tag(STATE_KEY, "used").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
+                    .tag(MODE_KEY, mode).description("Filesystem space usage").baseUnit("By").strongReference(true)
+                    .register(registry);
+            Gauge.builder(FS_USAGE, fs, OSFileStore::getUsableSpace).tag(STATE_KEY, "free").tag(DEVICE_KEY, device)
+                    .tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type).tag(MODE_KEY, mode)
+                    .description("Filesystem space usage").baseUnit("By").strongReference(true).register(registry);
+
+            // system.filesystem.utilization — Gauge, unit "1", attr: state, device, mount, type, mode
+            Gauge.builder(FS_UTILIZATION, fs,
+                    f -> f.getTotalSpace() == 0 ? 0d
+                            : Math.max(0d, (double) (f.getTotalSpace() - f.getUsableSpace()) / f.getTotalSpace()))
+                    .tag(STATE_KEY, "used").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
+                    .tag(MODE_KEY, mode).description("Filesystem utilization").strongReference(true).register(registry);
+            Gauge.builder(FS_UTILIZATION, fs,
+                    f -> f.getTotalSpace() == 0 ? 0d : (double) f.getUsableSpace() / f.getTotalSpace())
+                    .tag(STATE_KEY, "free").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
+                    .tag(MODE_KEY, mode).description("Filesystem utilization").strongReference(true).register(registry);
+
+            // system.filesystem.limit — UpDownCounter (Gauge), unit "By", attr: device, mount, type, mode
+            Gauge.builder(FS_LIMIT, fs, OSFileStore::getTotalSpace).tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount)
+                    .tag(TYPE_KEY, type).tag(MODE_KEY, mode).description("Total capacity of the filesystem")
+                    .baseUnit("By").strongReference(true).register(registry);
+        }
+    }
+}

--- a/oshi-metrics/src/main/java/oshi/metrics/GeneralMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/GeneralMetrics.java
@@ -43,6 +43,6 @@ public class GeneralMetrics implements MeterBinder {
         Gauge.builder(SYSTEM_UPTIME, os, o -> (double) o.getSystemUptime())
                 .description("The time the system has been running").baseUnit("s").register(registry);
         Gauge.builder(PROCESS_COUNT, os, OperatingSystem::getProcessCount)
-                .description("Total number of processes in each state").baseUnit("{process}").register(registry);
+                .description("Total number of processes on the system").baseUnit("{process}").register(registry);
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/GeneralMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/GeneralMetrics.java
@@ -19,11 +19,13 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * Registers:
  * <ul>
  * <li>{@code system.uptime} — the time the system has been running, in seconds</li>
+ * <li>{@code system.process.count} — total number of processes on the system</li>
  * </ul>
  */
 public class GeneralMetrics implements MeterBinder {
 
     private static final String SYSTEM_UPTIME = "system.uptime";
+    private static final String PROCESS_COUNT = "system.process.count";
 
     private final OperatingSystem os;
 
@@ -40,5 +42,7 @@ public class GeneralMetrics implements MeterBinder {
     public void bindTo(MeterRegistry registry) {
         Gauge.builder(SYSTEM_UPTIME, os, o -> (double) o.getSystemUptime())
                 .description("The time the system has been running").baseUnit("s").register(registry);
+        Gauge.builder(PROCESS_COUNT, os, OperatingSystem::getProcessCount)
+                .description("Total number of processes in each state").baseUnit("{process}").register(registry);
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/GeneralMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/GeneralMetrics.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import oshi.software.os.OperatingSystem;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * {@link MeterBinder} for general system metrics following
+ * <a href="https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#general-metrics">OpenTelemetry semantic
+ * conventions</a>.
+ *
+ * <p>
+ * Registers:
+ * <ul>
+ * <li>{@code system.uptime} — the time the system has been running, in seconds</li>
+ * </ul>
+ */
+public class GeneralMetrics implements MeterBinder {
+
+    private static final String SYSTEM_UPTIME = "system.uptime";
+
+    private final OperatingSystem os;
+
+    /**
+     * Creates a new {@code GeneralMetrics} binder.
+     *
+     * @param os the {@link OperatingSystem} instance to read from
+     */
+    public GeneralMetrics(OperatingSystem os) {
+        this.os = os;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Gauge.builder(SYSTEM_UPTIME, os, o -> (double) o.getSystemUptime())
+                .description("The time the system has been running").baseUnit("s").register(registry);
+    }
+}

--- a/oshi-metrics/src/main/java/oshi/metrics/MemoryMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/MemoryMetrics.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import oshi.hardware.GlobalMemory;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * {@link MeterBinder} for system memory metrics following
+ * <a href="https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#memory-metrics">OpenTelemetry semantic
+ * conventions</a>.
+ *
+ * <p>
+ * Registers:
+ * <ul>
+ * <li>{@code system.memory.usage} — memory in use by state ({@code used}, {@code free}), in bytes</li>
+ * <li>{@code system.memory.utilization} — fraction of memory in use by state (0.0–1.0)</li>
+ * </ul>
+ */
+public class MemoryMetrics implements MeterBinder {
+
+    private static final String MEMORY_USAGE = "system.memory.usage";
+    private static final String MEMORY_UTILIZATION = "system.memory.utilization";
+    private static final Tag STATE_USED = Tag.of("system.memory.state", "used");
+    private static final Tag STATE_FREE = Tag.of("system.memory.state", "free");
+
+    private final GlobalMemory memory;
+
+    /**
+     * Creates a new {@code MemoryMetrics} binder.
+     *
+     * @param memory the {@link GlobalMemory} instance to read from
+     */
+    public MemoryMetrics(GlobalMemory memory) {
+        this.memory = memory;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Gauge.builder(MEMORY_USAGE, memory, mem -> mem.getTotal() - mem.getAvailable()).tags(Tags.of(STATE_USED))
+                .description("Memory used in bytes").baseUnit("By").register(registry);
+        Gauge.builder(MEMORY_USAGE, memory, GlobalMemory::getAvailable).tags(Tags.of(STATE_FREE))
+                .description("Memory available in bytes").baseUnit("By").register(registry);
+        Gauge.builder(MEMORY_UTILIZATION, memory,
+                mem -> mem.getTotal() == 0 ? 0d : (double) (mem.getTotal() - mem.getAvailable()) / mem.getTotal())
+                .tags(Tags.of(STATE_USED)).description("Fraction of memory used").register(registry);
+        Gauge.builder(MEMORY_UTILIZATION, memory,
+                mem -> mem.getTotal() == 0 ? 0d : (double) mem.getAvailable() / mem.getTotal())
+                .tags(Tags.of(STATE_FREE)).description("Fraction of memory free").register(registry);
+    }
+}

--- a/oshi-metrics/src/main/java/oshi/metrics/MemoryMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/MemoryMetrics.java
@@ -21,12 +21,14 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * Registers:
  * <ul>
  * <li>{@code system.memory.usage} — memory in use by state ({@code used}, {@code free}), in bytes</li>
+ * <li>{@code system.memory.limit} — total memory available in the system, in bytes</li>
  * <li>{@code system.memory.utilization} — fraction of memory in use by state (0.0–1.0)</li>
  * </ul>
  */
 public class MemoryMetrics implements MeterBinder {
 
     private static final String MEMORY_USAGE = "system.memory.usage";
+    private static final String MEMORY_LIMIT = "system.memory.limit";
     private static final String MEMORY_UTILIZATION = "system.memory.utilization";
     private static final Tag STATE_USED = Tag.of("system.memory.state", "used");
     private static final Tag STATE_FREE = Tag.of("system.memory.state", "free");
@@ -48,6 +50,8 @@ public class MemoryMetrics implements MeterBinder {
                 .description("Memory used in bytes").baseUnit("By").register(registry);
         Gauge.builder(MEMORY_USAGE, memory, GlobalMemory::getAvailable).tags(Tags.of(STATE_FREE))
                 .description("Memory available in bytes").baseUnit("By").register(registry);
+        Gauge.builder(MEMORY_LIMIT, memory, GlobalMemory::getTotal).description("Total memory available in the system")
+                .baseUnit("By").register(registry);
         Gauge.builder(MEMORY_UTILIZATION, memory,
                 mem -> mem.getTotal() == 0 ? 0d : (double) (mem.getTotal() - mem.getAvailable()) / mem.getTotal())
                 .tags(Tags.of(STATE_USED)).description("Fraction of memory used").register(registry);

--- a/oshi-metrics/src/main/java/oshi/metrics/MemoryMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/MemoryMetrics.java
@@ -47,16 +47,18 @@ public class MemoryMetrics implements MeterBinder {
     @Override
     public void bindTo(MeterRegistry registry) {
         Gauge.builder(MEMORY_USAGE, memory, mem -> mem.getTotal() - mem.getAvailable()).tags(Tags.of(STATE_USED))
-                .description("Memory used in bytes").baseUnit("By").register(registry);
+                .description("Memory used in bytes").baseUnit("By").strongReference(true).register(registry);
         Gauge.builder(MEMORY_USAGE, memory, GlobalMemory::getAvailable).tags(Tags.of(STATE_FREE))
-                .description("Memory available in bytes").baseUnit("By").register(registry);
+                .description("Memory available in bytes").baseUnit("By").strongReference(true).register(registry);
         Gauge.builder(MEMORY_LIMIT, memory, GlobalMemory::getTotal).description("Total memory available in the system")
-                .baseUnit("By").register(registry);
+                .baseUnit("By").strongReference(true).register(registry);
         Gauge.builder(MEMORY_UTILIZATION, memory,
                 mem -> mem.getTotal() == 0 ? 0d : (double) (mem.getTotal() - mem.getAvailable()) / mem.getTotal())
-                .tags(Tags.of(STATE_USED)).description("Fraction of memory used").register(registry);
+                .tags(Tags.of(STATE_USED)).description("Fraction of memory used").strongReference(true)
+                .register(registry);
         Gauge.builder(MEMORY_UTILIZATION, memory,
                 mem -> mem.getTotal() == 0 ? 0d : (double) mem.getAvailable() / mem.getTotal())
-                .tags(Tags.of(STATE_FREE)).description("Fraction of memory free").register(registry);
+                .tags(Tags.of(STATE_FREE)).description("Fraction of memory free").strongReference(true)
+                .register(registry);
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/NetworkMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/NetworkMetrics.java
@@ -83,31 +83,46 @@ public class NetworkMetrics implements MeterBinder {
             String device = net.getName();
 
             // system.network.io — Counter, unit "By", attrs: network.io.direction, system.device
-            FunctionCounter.builder(NET_IO, net, NetworkIF::getBytesRecv).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "receive").description("Network bytes transferred").baseUnit("By")
-                    .register(registry);
-            FunctionCounter.builder(NET_IO, net, NetworkIF::getBytesSent).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "transmit").description("Network bytes transferred").baseUnit("By")
-                    .register(registry);
+            FunctionCounter.builder(NET_IO, net, n -> {
+                n.updateAttributes();
+                return n.getBytesRecv();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "receive").description("Network bytes transferred")
+                    .baseUnit("By").register(registry);
+            FunctionCounter.builder(NET_IO, net, n -> {
+                n.updateAttributes();
+                return n.getBytesSent();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "transmit").description("Network bytes transferred")
+                    .baseUnit("By").register(registry);
 
             // system.network.packet.count — Counter, unit "{packet}", attrs: network.io.direction, system.device
-            FunctionCounter.builder(NET_PACKETS, net, NetworkIF::getPacketsRecv).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "receive").description("Network packets transferred").baseUnit("{packet}")
-                    .register(registry);
-            FunctionCounter.builder(NET_PACKETS, net, NetworkIF::getPacketsSent).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "transmit").description("Network packets transferred").baseUnit("{packet}")
-                    .register(registry);
+            FunctionCounter.builder(NET_PACKETS, net, n -> {
+                n.updateAttributes();
+                return n.getPacketsRecv();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "receive").description("Network packets transferred")
+                    .baseUnit("{packet}").register(registry);
+            FunctionCounter.builder(NET_PACKETS, net, n -> {
+                n.updateAttributes();
+                return n.getPacketsSent();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "transmit").description("Network packets transferred")
+                    .baseUnit("{packet}").register(registry);
 
             // system.network.packet.dropped — Counter, unit "{packet}", attrs: network.io.direction, system.device
-            FunctionCounter.builder(NET_DROPPED, net, NetworkIF::getInDrops).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "receive").description("Count of packets dropped").baseUnit("{packet}")
-                    .register(registry);
+            FunctionCounter.builder(NET_DROPPED, net, n -> {
+                n.updateAttributes();
+                return n.getInDrops();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "receive").description("Count of packets dropped")
+                    .baseUnit("{packet}").register(registry);
 
             // system.network.errors — Counter, unit "{error}", attrs: network.io.direction, system.device
-            FunctionCounter.builder(NET_ERRORS, net, NetworkIF::getInErrors).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "receive").description("Network errors").baseUnit("{error}").register(registry);
-            FunctionCounter.builder(NET_ERRORS, net, NetworkIF::getOutErrors).tag(DEVICE_KEY, device)
-                    .tag(DIRECTION_KEY, "transmit").description("Network errors").baseUnit("{error}")
+            FunctionCounter.builder(NET_ERRORS, net, n -> {
+                n.updateAttributes();
+                return n.getInErrors();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "receive").description("Network errors").baseUnit("{error}")
+                    .register(registry);
+            FunctionCounter.builder(NET_ERRORS, net, n -> {
+                n.updateAttributes();
+                return n.getOutErrors();
+            }).tag(DEVICE_KEY, device).tag(DIRECTION_KEY, "transmit").description("Network errors").baseUnit("{error}")
                     .register(registry);
         }
 
@@ -131,22 +146,26 @@ public class NetworkMetrics implements MeterBinder {
                 .register(registry);
     }
 
-    private synchronized void refreshCache() {
-        long now = System.currentTimeMillis();
-        if (now - cacheTimestamp > CACHE_TTL_MS) {
-            List<IPConnection> connections = ipStats.getConnections();
-            Map<TcpState, Long> tcp = new EnumMap<>(TcpState.class);
-            long udp = 0;
-            for (IPConnection conn : connections) {
-                if (conn.getType().startsWith("tcp")) {
-                    tcp.merge(conn.getState(), 1L, Long::sum);
-                } else if (conn.getType().startsWith("udp")) {
-                    udp++;
+    private void refreshCache() {
+        if (System.currentTimeMillis() - cacheTimestamp > CACHE_TTL_MS) {
+            synchronized (this) {
+                long now = System.currentTimeMillis();
+                if (now - cacheTimestamp > CACHE_TTL_MS) {
+                    List<IPConnection> connections = ipStats.getConnections();
+                    Map<TcpState, Long> tcp = new EnumMap<>(TcpState.class);
+                    long udp = 0;
+                    for (IPConnection conn : connections) {
+                        if (conn.getType().startsWith("tcp")) {
+                            tcp.merge(conn.getState(), 1L, Long::sum);
+                        } else if (conn.getType().startsWith("udp")) {
+                            udp++;
+                        }
+                    }
+                    this.tcpCounts = tcp;
+                    this.udpCount = udp;
+                    this.cacheTimestamp = now;
                 }
             }
-            this.tcpCounts = tcp;
-            this.udpCount = udp;
-            this.cacheTimestamp = now;
         }
     }
 

--- a/oshi-metrics/src/main/java/oshi/metrics/NetworkMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/NetworkMetrics.java
@@ -131,7 +131,7 @@ public class NetworkMetrics implements MeterBinder {
                 .register(registry);
     }
 
-    private void refreshCache() {
+    private synchronized void refreshCache() {
         long now = System.currentTimeMillis();
         if (now - cacheTimestamp > CACHE_TTL_MS) {
             List<IPConnection> connections = ipStats.getConnections();

--- a/oshi-metrics/src/main/java/oshi/metrics/NetworkMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/NetworkMetrics.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Supplier;
+
+import oshi.hardware.NetworkIF;
+import oshi.software.os.InternetProtocolStats;
+import oshi.software.os.InternetProtocolStats.IPConnection;
+import oshi.software.os.InternetProtocolStats.TcpState;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * {@link MeterBinder} for system network metrics following
+ * <a href="https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#network-metrics">OpenTelemetry semantic
+ * conventions</a>.
+ *
+ * <p>
+ * Registers per network interface:
+ * <ul>
+ * <li>{@code system.network.io} — network bytes transferred by direction (transmit, receive)</li>
+ * <li>{@code system.network.packet.count} — network packets by direction (transmit, receive)</li>
+ * <li>{@code system.network.packet.dropped} — dropped packets (receive only; OSHI does not expose transmit drops)</li>
+ * <li>{@code system.network.errors} — network errors by direction (transmit, receive)</li>
+ * </ul>
+ *
+ * <p>
+ * Registers aggregate:
+ * <ul>
+ * <li>{@code system.network.connection.count} — connection count by protocol and state</li>
+ * </ul>
+ */
+public class NetworkMetrics implements MeterBinder {
+
+    private static final String NET_IO = "system.network.io";
+    private static final String NET_PACKETS = "system.network.packet.count";
+    private static final String NET_DROPPED = "system.network.packet.dropped";
+    private static final String NET_ERRORS = "system.network.errors";
+    private static final String NET_CONNECTIONS = "system.network.connection.count";
+    private static final String DEVICE_KEY = "system.device";
+    private static final String DIRECTION_KEY = "network.io.direction";
+    private static final String TRANSPORT_KEY = "network.transport";
+    private static final String STATE_KEY = "network.connection.state";
+
+    private final Supplier<List<NetworkIF>> networkIFSupplier;
+    private final InternetProtocolStats ipStats;
+
+    /**
+     * Creates a new {@code NetworkMetrics} binder.
+     *
+     * @param networkIFSupplier supplier that returns the current list of {@link NetworkIF} instances
+     * @param ipStats           the {@link InternetProtocolStats} instance for connection counting
+     */
+    public NetworkMetrics(Supplier<List<NetworkIF>> networkIFSupplier, InternetProtocolStats ipStats) {
+        this.networkIFSupplier = networkIFSupplier;
+        this.ipStats = ipStats;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        for (NetworkIF net : networkIFSupplier.get()) {
+            String device = net.getName();
+
+            // system.network.io — Counter, unit "By", attrs: network.io.direction, system.device
+            FunctionCounter.builder(NET_IO, net, NetworkIF::getBytesRecv).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "receive").description("Network bytes transferred").baseUnit("By")
+                    .register(registry);
+            FunctionCounter.builder(NET_IO, net, NetworkIF::getBytesSent).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "transmit").description("Network bytes transferred").baseUnit("By")
+                    .register(registry);
+
+            // system.network.packet.count — Counter, unit "{packet}", attrs: network.io.direction, system.device
+            FunctionCounter.builder(NET_PACKETS, net, NetworkIF::getPacketsRecv).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "receive").description("Network packets transferred").baseUnit("{packet}")
+                    .register(registry);
+            FunctionCounter.builder(NET_PACKETS, net, NetworkIF::getPacketsSent).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "transmit").description("Network packets transferred").baseUnit("{packet}")
+                    .register(registry);
+
+            // system.network.packet.dropped — Counter, unit "{packet}", attrs: network.io.direction, system.device
+            FunctionCounter.builder(NET_DROPPED, net, NetworkIF::getInDrops).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "receive").description("Count of packets dropped").baseUnit("{packet}")
+                    .register(registry);
+
+            // system.network.errors — Counter, unit "{error}", attrs: network.io.direction, system.device
+            FunctionCounter.builder(NET_ERRORS, net, NetworkIF::getInErrors).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "receive").description("Network errors").baseUnit("{error}").register(registry);
+            FunctionCounter.builder(NET_ERRORS, net, NetworkIF::getOutErrors).tag(DEVICE_KEY, device)
+                    .tag(DIRECTION_KEY, "transmit").description("Network errors").baseUnit("{error}")
+                    .register(registry);
+        }
+
+        // system.network.connection.count — UpDownCounter (Gauge), unit "{connection}",
+        // attrs: network.transport, network.connection.state
+        registerConnectionCountGauges(registry);
+    }
+
+    private void registerConnectionCountGauges(MeterRegistry registry) {
+        // Register gauges for tcp and udp with all known states
+        for (TcpState state : TcpState.values()) {
+            if (state == TcpState.NONE) {
+                continue;
+            }
+            String stateValue = state.name().toLowerCase(Locale.ROOT);
+            Gauge.builder(NET_CONNECTIONS, ipStats, ip -> countConnections(ip, "tcp", state)).tag(TRANSPORT_KEY, "tcp")
+                    .tag(STATE_KEY, stateValue).description("Total number of connections in each state")
+                    .baseUnit("{connection}").strongReference(true).register(registry);
+        }
+        // UDP has no state; register without state attribute using NONE
+        Gauge.builder(NET_CONNECTIONS, ipStats, ip -> countConnections(ip, "udp", TcpState.NONE))
+                .tag(TRANSPORT_KEY, "udp").description("Total number of UDP connections").baseUnit("{connection}")
+                .strongReference(true).register(registry);
+    }
+
+    private static double countConnections(InternetProtocolStats ip, String transport, TcpState state) {
+        List<IPConnection> connections = ip.getConnections();
+        return connections.stream().filter(c -> c.getType().startsWith(transport))
+                .filter(c -> state == TcpState.NONE || c.getState() == state).count();
+    }
+}

--- a/oshi-metrics/src/main/java/oshi/metrics/NetworkMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/NetworkMetrics.java
@@ -4,8 +4,10 @@
  */
 package oshi.metrics;
 
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import oshi.hardware.NetworkIF;
@@ -49,9 +51,18 @@ public class NetworkMetrics implements MeterBinder {
     private static final String DIRECTION_KEY = "network.io.direction";
     private static final String TRANSPORT_KEY = "network.transport";
     private static final String STATE_KEY = "network.connection.state";
+    private static final long CACHE_TTL_MS = 1000L;
 
     private final Supplier<List<NetworkIF>> networkIFSupplier;
     private final InternetProtocolStats ipStats;
+
+    // Strong reference to prevent GC of NetworkIF objects used by FunctionCounter
+    private List<NetworkIF> networkIFs;
+
+    // Connection count cache to avoid repeated getConnections() calls per scrape
+    private volatile long cacheTimestamp;
+    private volatile Map<TcpState, Long> tcpCounts = new EnumMap<>(TcpState.class);
+    private volatile long udpCount;
 
     /**
      * Creates a new {@code NetworkMetrics} binder.
@@ -66,7 +77,9 @@ public class NetworkMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        for (NetworkIF net : networkIFSupplier.get()) {
+        this.networkIFs = networkIFSupplier.get();
+
+        for (NetworkIF net : networkIFs) {
             String device = net.getName();
 
             // system.network.io — Counter, unit "By", attrs: network.io.direction, system.device
@@ -104,25 +117,46 @@ public class NetworkMetrics implements MeterBinder {
     }
 
     private void registerConnectionCountGauges(MeterRegistry registry) {
-        // Register gauges for tcp and udp with all known states
         for (TcpState state : TcpState.values()) {
             if (state == TcpState.NONE) {
                 continue;
             }
             String stateValue = state.name().toLowerCase(Locale.ROOT);
-            Gauge.builder(NET_CONNECTIONS, ipStats, ip -> countConnections(ip, "tcp", state)).tag(TRANSPORT_KEY, "tcp")
+            Gauge.builder(NET_CONNECTIONS, this, self -> self.getCachedTcpCount(state)).tag(TRANSPORT_KEY, "tcp")
                     .tag(STATE_KEY, stateValue).description("Total number of connections in each state")
                     .baseUnit("{connection}").strongReference(true).register(registry);
         }
-        // UDP has no state; register without state attribute using NONE
-        Gauge.builder(NET_CONNECTIONS, ipStats, ip -> countConnections(ip, "udp", TcpState.NONE))
-                .tag(TRANSPORT_KEY, "udp").description("Total number of UDP connections").baseUnit("{connection}")
-                .strongReference(true).register(registry);
+        Gauge.builder(NET_CONNECTIONS, this, self -> self.getCachedUdpCount()).tag(TRANSPORT_KEY, "udp")
+                .description("Total number of UDP connections").baseUnit("{connection}").strongReference(true)
+                .register(registry);
     }
 
-    private static double countConnections(InternetProtocolStats ip, String transport, TcpState state) {
-        List<IPConnection> connections = ip.getConnections();
-        return connections.stream().filter(c -> c.getType().startsWith(transport))
-                .filter(c -> state == TcpState.NONE || c.getState() == state).count();
+    private void refreshCache() {
+        long now = System.currentTimeMillis();
+        if (now - cacheTimestamp > CACHE_TTL_MS) {
+            List<IPConnection> connections = ipStats.getConnections();
+            Map<TcpState, Long> tcp = new EnumMap<>(TcpState.class);
+            long udp = 0;
+            for (IPConnection conn : connections) {
+                if (conn.getType().startsWith("tcp")) {
+                    tcp.merge(conn.getState(), 1L, Long::sum);
+                } else if (conn.getType().startsWith("udp")) {
+                    udp++;
+                }
+            }
+            this.tcpCounts = tcp;
+            this.udpCount = udp;
+            this.cacheTimestamp = now;
+        }
+    }
+
+    private double getCachedTcpCount(TcpState state) {
+        refreshCache();
+        return tcpCounts.getOrDefault(state, 0L);
+    }
+
+    private double getCachedUdpCount() {
+        refreshCache();
+        return udpCount;
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -50,6 +50,7 @@ public final class OshiMetrics implements MeterBinder {
     private final boolean fileSystem;
     private final boolean network;
     private final boolean process;
+    private final boolean container;
 
     private OshiMetrics(Builder builder) {
         this.hal = builder.hal;
@@ -62,6 +63,7 @@ public final class OshiMetrics implements MeterBinder {
         this.fileSystem = builder.fileSystem;
         this.network = builder.network;
         this.process = builder.process;
+        this.container = builder.container;
     }
 
     /**
@@ -81,6 +83,7 @@ public final class OshiMetrics implements MeterBinder {
         this.fileSystem = true;
         this.network = true;
         this.process = true;
+        this.container = true;
     }
 
     /**
@@ -120,6 +123,9 @@ public final class OshiMetrics implements MeterBinder {
         if (process) {
             new ProcessMetrics(os::getCurrentProcess).bindTo(registry);
         }
+        if (container) {
+            new ContainerMetrics(os, os.getCgroupInfo()).bindTo(registry);
+        }
     }
 
     /**
@@ -151,6 +157,7 @@ public final class OshiMetrics implements MeterBinder {
         private boolean fileSystem = true;
         private boolean network = true;
         private boolean process = true;
+        private boolean container = true;
 
         private Builder(HardwareAbstractionLayer hal, OperatingSystem os) {
             this.hal = java.util.Objects.requireNonNull(hal, "hal must not be null");
@@ -242,6 +249,17 @@ public final class OshiMetrics implements MeterBinder {
          */
         public Builder enableProcess(boolean enabled) {
             this.process = enabled;
+            return this;
+        }
+
+        /**
+         * Enable or disable container metrics (cpu time, memory usage/available).
+         *
+         * @param enabled whether to register container metrics
+         * @return this builder
+         */
+        public Builder enableContainer(boolean enabled) {
+            this.container = enabled;
             return this;
         }
 

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -11,18 +11,26 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
 /**
- * Entry point for OSHI system metrics. Registers all available metric binders with a {@link MeterRegistry}.
+ * Entry point for OSHI system metrics. Registers metric binders with a {@link MeterRegistry}.
  *
  * <p>
  * Metric names and attributes follow
  * <a href="https://opentelemetry.io/docs/specs/semconv/system/system-metrics/">OpenTelemetry semantic conventions</a>.
  *
  * <p>
- * Usage:
+ * Usage (all metrics):
  *
  * <pre>{@code
  * SystemInfo si = new SystemInfo();
  * OshiMetrics.bindTo(registry, si.getHardware(), si.getOperatingSystem());
+ * }</pre>
+ *
+ * <p>
+ * Usage (selective):
+ *
+ * <pre>{@code
+ * OshiMetrics.builder(si.getHardware(), si.getOperatingSystem()).enableCpu(true).enableMemory(true).enableDisk(false)
+ *         .build().bindTo(registry);
  * }</pre>
  *
  * <p>
@@ -33,11 +41,29 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 public final class OshiMetrics implements MeterBinder {
 
     private final HardwareAbstractionLayer hal;
-    // Reserved for future OS-level metrics (e.g., process, cgroup)
     private final OperatingSystem os;
+    private final boolean general;
+    private final boolean cpu;
+    private final boolean memory;
+    private final boolean paging;
+    private final boolean disk;
+    private final boolean fileSystem;
+    private final boolean network;
+
+    private OshiMetrics(Builder builder) {
+        this.hal = builder.hal;
+        this.os = builder.os;
+        this.general = builder.general;
+        this.cpu = builder.cpu;
+        this.memory = builder.memory;
+        this.paging = builder.paging;
+        this.disk = builder.disk;
+        this.fileSystem = builder.fileSystem;
+        this.network = builder.network;
+    }
 
     /**
-     * Creates a new {@code OshiMetrics} instance.
+     * Creates a new {@code OshiMetrics} instance that registers all metrics.
      *
      * @param hal the hardware abstraction layer
      * @param os  the operating system
@@ -45,6 +71,13 @@ public final class OshiMetrics implements MeterBinder {
     public OshiMetrics(HardwareAbstractionLayer hal, OperatingSystem os) {
         this.hal = hal;
         this.os = os;
+        this.general = true;
+        this.cpu = true;
+        this.memory = true;
+        this.paging = true;
+        this.disk = true;
+        this.fileSystem = true;
+        this.network = true;
     }
 
     /**
@@ -60,12 +93,147 @@ public final class OshiMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        new GeneralMetrics(os).bindTo(registry);
-        new MemoryMetrics(hal.getMemory()).bindTo(registry);
-        new PagingMetrics(hal.getMemory().getVirtualMemory()).bindTo(registry);
-        new CpuMetrics(hal.getProcessor()).bindTo(registry);
-        new DiskMetrics(hal::getDiskStores).bindTo(registry);
-        new FileSystemMetrics(os.getFileSystem()::getFileStores).bindTo(registry);
-        new NetworkMetrics(hal::getNetworkIFs, os.getInternetProtocolStats()).bindTo(registry);
+        if (general) {
+            new GeneralMetrics(os).bindTo(registry);
+        }
+        if (memory) {
+            new MemoryMetrics(hal.getMemory()).bindTo(registry);
+        }
+        if (paging) {
+            new PagingMetrics(hal.getMemory().getVirtualMemory()).bindTo(registry);
+        }
+        if (cpu) {
+            new CpuMetrics(hal.getProcessor()).bindTo(registry);
+        }
+        if (disk) {
+            new DiskMetrics(hal::getDiskStores).bindTo(registry);
+        }
+        if (fileSystem) {
+            new FileSystemMetrics(os.getFileSystem()::getFileStores).bindTo(registry);
+        }
+        if (network) {
+            new NetworkMetrics(hal::getNetworkIFs, os.getInternetProtocolStats()).bindTo(registry);
+        }
+    }
+
+    /**
+     * Creates a new builder for selective metric registration.
+     *
+     * @param hal the hardware abstraction layer
+     * @param os  the operating system
+     * @return a new {@link Builder}
+     */
+    public static Builder builder(HardwareAbstractionLayer hal, OperatingSystem os) {
+        return new Builder(hal, os);
+    }
+
+    /**
+     * Builder for selective metric registration.
+     *
+     * <p>
+     * By default all metric categories are enabled. Use the {@code enable*} methods to disable specific categories.
+     */
+    public static final class Builder {
+
+        private final HardwareAbstractionLayer hal;
+        private final OperatingSystem os;
+        private boolean general = true;
+        private boolean cpu = true;
+        private boolean memory = true;
+        private boolean paging = true;
+        private boolean disk = true;
+        private boolean fileSystem = true;
+        private boolean network = true;
+
+        private Builder(HardwareAbstractionLayer hal, OperatingSystem os) {
+            this.hal = hal;
+            this.os = os;
+        }
+
+        /**
+         * Enable or disable general metrics (uptime, process count).
+         *
+         * @param enabled whether to register general metrics
+         * @return this builder
+         */
+        public Builder enableGeneral(boolean enabled) {
+            this.general = enabled;
+            return this;
+        }
+
+        /**
+         * Enable or disable CPU metrics (time, frequency, counts).
+         *
+         * @param enabled whether to register CPU metrics
+         * @return this builder
+         */
+        public Builder enableCpu(boolean enabled) {
+            this.cpu = enabled;
+            return this;
+        }
+
+        /**
+         * Enable or disable memory metrics (usage, limit, utilization).
+         *
+         * @param enabled whether to register memory metrics
+         * @return this builder
+         */
+        public Builder enableMemory(boolean enabled) {
+            this.memory = enabled;
+            return this;
+        }
+
+        /**
+         * Enable or disable paging/swap metrics (usage, utilization, operations).
+         *
+         * @param enabled whether to register paging metrics
+         * @return this builder
+         */
+        public Builder enablePaging(boolean enabled) {
+            this.paging = enabled;
+            return this;
+        }
+
+        /**
+         * Enable or disable disk metrics (io, operations, io_time, limit).
+         *
+         * @param enabled whether to register disk metrics
+         * @return this builder
+         */
+        public Builder enableDisk(boolean enabled) {
+            this.disk = enabled;
+            return this;
+        }
+
+        /**
+         * Enable or disable filesystem metrics (usage, utilization, limit).
+         *
+         * @param enabled whether to register filesystem metrics
+         * @return this builder
+         */
+        public Builder enableFileSystem(boolean enabled) {
+            this.fileSystem = enabled;
+            return this;
+        }
+
+        /**
+         * Enable or disable network metrics (io, packets, errors, connections).
+         *
+         * @param enabled whether to register network metrics
+         * @return this builder
+         */
+        public Builder enableNetwork(boolean enabled) {
+            this.network = enabled;
+            return this;
+        }
+
+        /**
+         * Builds the {@link OshiMetrics} instance with the configured settings.
+         *
+         * @return a new {@link OshiMetrics}
+         */
+        public OshiMetrics build() {
+            return new OshiMetrics(this);
+        }
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -49,6 +49,7 @@ public final class OshiMetrics implements MeterBinder {
     private final boolean disk;
     private final boolean fileSystem;
     private final boolean network;
+    private final boolean process;
 
     private OshiMetrics(Builder builder) {
         this.hal = builder.hal;
@@ -60,6 +61,7 @@ public final class OshiMetrics implements MeterBinder {
         this.disk = builder.disk;
         this.fileSystem = builder.fileSystem;
         this.network = builder.network;
+        this.process = builder.process;
     }
 
     /**
@@ -78,6 +80,7 @@ public final class OshiMetrics implements MeterBinder {
         this.disk = true;
         this.fileSystem = true;
         this.network = true;
+        this.process = true;
     }
 
     /**
@@ -114,6 +117,9 @@ public final class OshiMetrics implements MeterBinder {
         if (network) {
             new NetworkMetrics(hal::getNetworkIFs, os.getInternetProtocolStats()).bindTo(registry);
         }
+        if (process) {
+            new ProcessMetrics(os::getCurrentProcess).bindTo(registry);
+        }
     }
 
     /**
@@ -144,6 +150,7 @@ public final class OshiMetrics implements MeterBinder {
         private boolean disk = true;
         private boolean fileSystem = true;
         private boolean network = true;
+        private boolean process = true;
 
         private Builder(HardwareAbstractionLayer hal, OperatingSystem os) {
             this.hal = hal;
@@ -224,6 +231,17 @@ public final class OshiMetrics implements MeterBinder {
          */
         public Builder enableNetwork(boolean enabled) {
             this.network = enabled;
+            return this;
+        }
+
+        /**
+         * Enable or disable current process metrics (cpu, memory, disk, threads, faults, uptime).
+         *
+         * @param enabled whether to register process metrics
+         * @return this builder
+         */
+        public Builder enableProcess(boolean enabled) {
+            this.process = enabled;
             return this;
         }
 

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -71,8 +71,8 @@ public final class OshiMetrics implements MeterBinder {
      * @param os  the operating system
      */
     public OshiMetrics(HardwareAbstractionLayer hal, OperatingSystem os) {
-        this.hal = hal;
-        this.os = os;
+        this.hal = java.util.Objects.requireNonNull(hal, "hal must not be null");
+        this.os = java.util.Objects.requireNonNull(os, "os must not be null");
         this.general = true;
         this.cpu = true;
         this.memory = true;
@@ -153,8 +153,8 @@ public final class OshiMetrics implements MeterBinder {
         private boolean process = true;
 
         private Builder(HardwareAbstractionLayer hal, OperatingSystem os) {
-            this.hal = hal;
-            this.os = os;
+            this.hal = java.util.Objects.requireNonNull(hal, "hal must not be null");
+            this.os = java.util.Objects.requireNonNull(os, "os must not be null");
         }
 
         /**

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -64,5 +64,7 @@ public final class OshiMetrics implements MeterBinder {
         new MemoryMetrics(hal.getMemory()).bindTo(registry);
         new PagingMetrics(hal.getMemory().getVirtualMemory()).bindTo(registry);
         new CpuMetrics(hal.getProcessor()).bindTo(registry);
+        new DiskMetrics(hal::getDiskStores).bindTo(registry);
+        new FileSystemMetrics(os.getFileSystem()::getFileStores).bindTo(registry);
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -62,6 +62,7 @@ public final class OshiMetrics implements MeterBinder {
     public void bindTo(MeterRegistry registry) {
         new GeneralMetrics(os).bindTo(registry);
         new MemoryMetrics(hal.getMemory()).bindTo(registry);
+        new PagingMetrics(hal.getMemory().getVirtualMemory()).bindTo(registry);
         new CpuMetrics(hal.getProcessor()).bindTo(registry);
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.software.os.OperatingSystem;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * Entry point for OSHI system metrics. Registers all available metric binders with a {@link MeterRegistry}.
+ *
+ * <p>
+ * Metric names and attributes follow
+ * <a href="https://opentelemetry.io/docs/specs/semconv/system/system-metrics/">OpenTelemetry semantic conventions</a>.
+ *
+ * <p>
+ * Usage:
+ *
+ * <pre>{@code
+ * SystemInfo si = new SystemInfo();
+ * OshiMetrics.bindTo(registry, si.getHardware(), si.getOperatingSystem());
+ * }</pre>
+ *
+ * <p>
+ * Since this class accepts {@link HardwareAbstractionLayer} and {@link OperatingSystem} interfaces from
+ * {@code oshi-common}, it works identically with both the JNA ({@code oshi-core}) and FFM ({@code oshi-core-ffm})
+ * implementations.
+ */
+public final class OshiMetrics implements MeterBinder {
+
+    private final HardwareAbstractionLayer hal;
+    // Reserved for future OS-level metrics (e.g., process, cgroup)
+    private final OperatingSystem os;
+
+    /**
+     * Creates a new {@code OshiMetrics} instance.
+     *
+     * @param hal the hardware abstraction layer
+     * @param os  the operating system
+     */
+    public OshiMetrics(HardwareAbstractionLayer hal, OperatingSystem os) {
+        this.hal = hal;
+        this.os = os;
+    }
+
+    /**
+     * Convenience method to create and bind all OSHI metrics in one call.
+     *
+     * @param registry the meter registry
+     * @param hal      the hardware abstraction layer
+     * @param os       the operating system
+     */
+    public static void bindTo(MeterRegistry registry, HardwareAbstractionLayer hal, OperatingSystem os) {
+        new OshiMetrics(hal, os).bindTo(registry);
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        new MemoryMetrics(hal.getMemory()).bindTo(registry);
+        new CpuMetrics(hal.getProcessor()).bindTo(registry);
+    }
+}

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -66,5 +66,6 @@ public final class OshiMetrics implements MeterBinder {
         new CpuMetrics(hal.getProcessor()).bindTo(registry);
         new DiskMetrics(hal::getDiskStores).bindTo(registry);
         new FileSystemMetrics(os.getFileSystem()::getFileStores).bindTo(registry);
+        new NetworkMetrics(hal::getNetworkIFs, os.getInternetProtocolStats()).bindTo(registry);
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -60,6 +60,7 @@ public final class OshiMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
+        new GeneralMetrics(os).bindTo(registry);
         new MemoryMetrics(hal.getMemory()).bindTo(registry);
         new CpuMetrics(hal.getProcessor()).bindTo(registry);
     }

--- a/oshi-metrics/src/main/java/oshi/metrics/PagingMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/PagingMetrics.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import oshi.hardware.VirtualMemory;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * {@link MeterBinder} for system paging/swap metrics following
+ * <a href="https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#pagingswap-metrics">OpenTelemetry
+ * semantic conventions</a>.
+ *
+ * <p>
+ * Registers:
+ * <ul>
+ * <li>{@code system.paging.usage} — swap/pagefile usage by state ({@code used}, {@code free}), in bytes</li>
+ * <li>{@code system.paging.utilization} — fraction of swap/pagefile in use by state (0.0–1.0)</li>
+ * <li>{@code system.paging.operations} — cumulative paging operations by direction ({@code in}, {@code out})</li>
+ * </ul>
+ *
+ * <p>
+ * Note: {@code system.paging.faults} is not implemented because OSHI does not expose system-level major/minor page
+ * fault counters.
+ */
+public class PagingMetrics implements MeterBinder {
+
+    private static final String PAGING_USAGE = "system.paging.usage";
+    private static final String PAGING_UTILIZATION = "system.paging.utilization";
+    private static final String PAGING_OPERATIONS = "system.paging.operations";
+    private static final Tag STATE_USED = Tag.of("system.paging.state", "used");
+    private static final Tag STATE_FREE = Tag.of("system.paging.state", "free");
+    private static final String DIRECTION_KEY = "system.paging.direction";
+
+    private final VirtualMemory vm;
+
+    /**
+     * Creates a new {@code PagingMetrics} binder.
+     *
+     * @param vm the {@link VirtualMemory} instance to read from
+     */
+    public PagingMetrics(VirtualMemory vm) {
+        this.vm = vm;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        // system.paging.usage — UpDownCounter (Gauge), unit "By", attr system.paging.state
+        Gauge.builder(PAGING_USAGE, vm, VirtualMemory::getSwapUsed).tags(Tags.of(STATE_USED))
+                .description("Unix swap or Windows pagefile usage").baseUnit("By").register(registry);
+        Gauge.builder(PAGING_USAGE, vm, v -> v.getSwapTotal() - v.getSwapUsed()).tags(Tags.of(STATE_FREE))
+                .description("Unix swap or Windows pagefile usage").baseUnit("By").register(registry);
+
+        // system.paging.utilization — Gauge, unit "1", attr system.paging.state
+        Gauge.builder(PAGING_UTILIZATION, vm,
+                v -> v.getSwapTotal() == 0 ? 0d : (double) v.getSwapUsed() / v.getSwapTotal()).tags(Tags.of(STATE_USED))
+                .description("Fraction of swap/pagefile used").register(registry);
+        Gauge.builder(PAGING_UTILIZATION, vm,
+                v -> v.getSwapTotal() == 0 ? 0d : (double) (v.getSwapTotal() - v.getSwapUsed()) / v.getSwapTotal())
+                .tags(Tags.of(STATE_FREE)).description("Fraction of swap/pagefile free").register(registry);
+
+        // system.paging.operations — Counter, unit "{operation}", attr system.paging.direction
+        FunctionCounter.builder(PAGING_OPERATIONS, vm, VirtualMemory::getSwapPagesIn).tag(DIRECTION_KEY, "in")
+                .description("Paging operations").baseUnit("{operation}").register(registry);
+        FunctionCounter.builder(PAGING_OPERATIONS, vm, VirtualMemory::getSwapPagesOut).tag(DIRECTION_KEY, "out")
+                .description("Paging operations").baseUnit("{operation}").register(registry);
+    }
+}

--- a/oshi-metrics/src/main/java/oshi/metrics/ProcessMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/ProcessMetrics.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import java.util.function.Supplier;
+
+import oshi.software.os.OSProcess;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * {@link MeterBinder} for process-level metrics following
+ * <a href="https://opentelemetry.io/docs/specs/semconv/system/process-metrics/">OpenTelemetry semantic conventions</a>.
+ *
+ * <p>
+ * Typically used to monitor the current JVM process via {@code os.getCurrentProcess()}.
+ *
+ * <p>
+ * Registers:
+ * <ul>
+ * <li>{@code process.cpu.time} — CPU seconds by mode (user, system)</li>
+ * <li>{@code process.memory.usage} — physical memory (RSS) in bytes</li>
+ * <li>{@code process.memory.virtual} — virtual memory in bytes</li>
+ * <li>{@code process.disk.io} — disk bytes by direction (read, write)</li>
+ * <li>{@code process.thread.count} — thread count</li>
+ * <li>{@code process.open_file_descriptor.count} — open file descriptors</li>
+ * <li>{@code process.paging.faults} — page faults by type (major, minor)</li>
+ * <li>{@code process.context_switches} — context switches (total; voluntary/involuntary split unavailable)</li>
+ * <li>{@code process.uptime} — process uptime in seconds</li>
+ * </ul>
+ *
+ * <p>
+ * Not implemented:
+ * <ul>
+ * <li>{@code process.network.io} — OSHI does not expose per-process network I/O</li>
+ * </ul>
+ */
+public class ProcessMetrics implements MeterBinder {
+
+    private static final String CPU_TIME = "process.cpu.time";
+    private static final String MEMORY_USAGE = "process.memory.usage";
+    private static final String MEMORY_VIRTUAL = "process.memory.virtual";
+    private static final String DISK_IO = "process.disk.io";
+    private static final String THREAD_COUNT = "process.thread.count";
+    private static final String OPEN_FD = "process.open_file_descriptor.count";
+    private static final String PAGING_FAULTS = "process.paging.faults";
+    private static final String CONTEXT_SWITCHES = "process.context_switches";
+    private static final String UPTIME = "process.uptime";
+    private static final double MS_PER_SECOND = 1000.0;
+
+    private final Supplier<OSProcess> processSupplier;
+
+    /**
+     * Creates a new {@code ProcessMetrics} binder.
+     *
+     * @param processSupplier supplier that returns a fresh {@link OSProcess} snapshot (e.g.,
+     *                        {@code os::getCurrentProcess})
+     */
+    public ProcessMetrics(Supplier<OSProcess> processSupplier) {
+        this.processSupplier = processSupplier;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        // process.cpu.time — Counter, unit "s", attr cpu.mode (Required)
+        FunctionCounter.builder(CPU_TIME, processSupplier, s -> s.get().getUserTime() / MS_PER_SECOND)
+                .tag("cpu.mode", "user").description("Total CPU seconds broken down by different CPU modes")
+                .baseUnit("s").register(registry);
+        FunctionCounter.builder(CPU_TIME, processSupplier, s -> s.get().getKernelTime() / MS_PER_SECOND)
+                .tag("cpu.mode", "system").description("Total CPU seconds broken down by different CPU modes")
+                .baseUnit("s").register(registry);
+
+        // process.memory.usage — UpDownCounter (Gauge), unit "By"
+        Gauge.builder(MEMORY_USAGE, processSupplier, s -> s.get().getResidentMemory())
+                .description("The amount of physical memory in use").baseUnit("By").register(registry);
+
+        // process.memory.virtual — UpDownCounter (Gauge), unit "By"
+        Gauge.builder(MEMORY_VIRTUAL, processSupplier, s -> s.get().getVirtualSize())
+                .description("The amount of committed virtual memory").baseUnit("By").register(registry);
+
+        // process.disk.io — Counter, unit "By", attr disk.io.direction (Required)
+        FunctionCounter.builder(DISK_IO, processSupplier, s -> s.get().getBytesRead()).tag("disk.io.direction", "read")
+                .description("Disk bytes transferred").baseUnit("By").register(registry);
+        FunctionCounter.builder(DISK_IO, processSupplier, s -> s.get().getBytesWritten())
+                .tag("disk.io.direction", "write").description("Disk bytes transferred").baseUnit("By")
+                .register(registry);
+
+        // process.thread.count — UpDownCounter (Gauge), unit "{thread}"
+        Gauge.builder(THREAD_COUNT, processSupplier, s -> s.get().getThreadCount()).description("Process threads count")
+                .baseUnit("{thread}").register(registry);
+
+        // process.open_file_descriptor.count — UpDownCounter (Gauge), unit "{file_descriptor}"
+        Gauge.builder(OPEN_FD, processSupplier, s -> s.get().getOpenFiles())
+                .description("Number of file descriptors in use by the process").baseUnit("{file_descriptor}")
+                .register(registry);
+
+        // process.paging.faults — Counter, unit "{fault}", attr system.paging.fault.type (Recommended)
+        FunctionCounter.builder(PAGING_FAULTS, processSupplier, s -> s.get().getMinorFaults())
+                .tag("system.paging.fault.type", "minor").description("Number of page faults the process has made")
+                .baseUnit("{fault}").register(registry);
+        FunctionCounter.builder(PAGING_FAULTS, processSupplier, s -> s.get().getMajorFaults())
+                .tag("system.paging.fault.type", "major").description("Number of page faults the process has made")
+                .baseUnit("{fault}").register(registry);
+
+        // process.context_switches — Counter, unit "{context_switch}", attr process.context_switch.type (Required)
+        FunctionCounter.builder(CONTEXT_SWITCHES, processSupplier, s -> s.get().getContextSwitches())
+                .tag("process.context_switch.type", "total")
+                .description("Number of times the process has been context switched").baseUnit("{context_switch}")
+                .register(registry);
+
+        // process.uptime — Gauge, unit "s"
+        Gauge.builder(UPTIME, processSupplier, s -> s.get().getUpTime() / MS_PER_SECOND)
+                .description("The time the process has been running").baseUnit("s").register(registry);
+    }
+}

--- a/oshi-metrics/src/main/java/oshi/metrics/ProcessMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/ProcessMetrics.java
@@ -77,11 +77,13 @@ public class ProcessMetrics implements MeterBinder {
 
         // process.memory.usage — UpDownCounter (Gauge), unit "By"
         Gauge.builder(MEMORY_USAGE, processSupplier, s -> s.get().getResidentMemory())
-                .description("The amount of physical memory in use").baseUnit("By").register(registry);
+                .description("The amount of physical memory in use").baseUnit("By").strongReference(true)
+                .register(registry);
 
         // process.memory.virtual — UpDownCounter (Gauge), unit "By"
         Gauge.builder(MEMORY_VIRTUAL, processSupplier, s -> s.get().getVirtualSize())
-                .description("The amount of committed virtual memory").baseUnit("By").register(registry);
+                .description("The amount of committed virtual memory").baseUnit("By").strongReference(true)
+                .register(registry);
 
         // process.disk.io — Counter, unit "By", attr disk.io.direction (Required)
         FunctionCounter.builder(DISK_IO, processSupplier, s -> s.get().getBytesRead()).tag("disk.io.direction", "read")
@@ -92,12 +94,12 @@ public class ProcessMetrics implements MeterBinder {
 
         // process.thread.count — UpDownCounter (Gauge), unit "{thread}"
         Gauge.builder(THREAD_COUNT, processSupplier, s -> s.get().getThreadCount()).description("Process threads count")
-                .baseUnit("{thread}").register(registry);
+                .baseUnit("{thread}").strongReference(true).register(registry);
 
         // process.open_file_descriptor.count — UpDownCounter (Gauge), unit "{file_descriptor}"
         Gauge.builder(OPEN_FD, processSupplier, s -> s.get().getOpenFiles())
                 .description("Number of file descriptors in use by the process").baseUnit("{file_descriptor}")
-                .register(registry);
+                .strongReference(true).register(registry);
 
         // process.paging.faults — Counter, unit "{fault}", attr system.paging.fault.type (Recommended)
         FunctionCounter.builder(PAGING_FAULTS, processSupplier, s -> s.get().getMinorFaults())
@@ -115,6 +117,7 @@ public class ProcessMetrics implements MeterBinder {
 
         // process.uptime — Gauge, unit "s"
         Gauge.builder(UPTIME, processSupplier, s -> s.get().getUpTime() / MS_PER_SECOND)
-                .description("The time the process has been running").baseUnit("s").register(registry);
+                .description("The time the process has been running").baseUnit("s").strongReference(true)
+                .register(registry);
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/package-info.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Micrometer metric binders for OSHI system metrics, following OpenTelemetry semantic conventions.
+ */
+package oshi.metrics;

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -241,12 +241,46 @@ class OshiMetricsTest {
     void builderSelectiveRegistration() {
         MeterRegistry selective = new SimpleMeterRegistry();
         OshiMetrics.builder(hal, os).enableCpu(true).enableMemory(false).enablePaging(false).enableDisk(false)
-                .enableFileSystem(false).enableNetwork(false).enableGeneral(false).build().bindTo(selective);
+                .enableFileSystem(false).enableNetwork(false).enableGeneral(false).enableProcess(false).build()
+                .bindTo(selective);
         // CPU should be registered
         assertNotNull(selective.find("system.cpu.time").functionCounter(), "CPU metrics should be registered");
         // Memory should NOT be registered
         assertNull(selective.find("system.memory.usage").gauge(), "Memory metrics should not be registered");
         // Network should NOT be registered
         assertNull(selective.find("system.network.io").functionCounter(), "Network metrics should not be registered");
+    }
+
+    @Test
+    void processCpuTimeRegistered() {
+        FunctionCounter user = registry.find("process.cpu.time").tag("cpu.mode", "user").functionCounter();
+        FunctionCounter system = registry.find("process.cpu.time").tag("cpu.mode", "system").functionCounter();
+        assertNotNull(user, "process.cpu.time{cpu.mode=user} should be registered");
+        assertNotNull(system, "process.cpu.time{cpu.mode=system} should be registered");
+        assertTrue(user.count() >= 0, "Process user CPU time should be non-negative");
+    }
+
+    @Test
+    void processMemoryRegistered() {
+        Gauge rss = registry.find("process.memory.usage").gauge();
+        Gauge virt = registry.find("process.memory.virtual").gauge();
+        assertNotNull(rss, "process.memory.usage should be registered");
+        assertNotNull(virt, "process.memory.virtual should be registered");
+        assertTrue(rss.value() > 0, "Process RSS should be positive");
+        assertTrue(virt.value() > 0, "Process virtual memory should be positive");
+    }
+
+    @Test
+    void processThreadCountRegistered() {
+        Gauge threads = registry.find("process.thread.count").gauge();
+        assertNotNull(threads, "process.thread.count should be registered");
+        assertTrue(threads.value() >= 1, "Process thread count should be at least 1");
+    }
+
+    @Test
+    void processUptimeRegistered() {
+        Gauge uptime = registry.find("process.uptime").gauge();
+        assertNotNull(uptime, "process.uptime should be registered");
+        assertTrue(uptime.value() > 0, "Process uptime should be positive");
     }
 }

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -140,4 +140,55 @@ class OshiMetricsTest {
         assertTrue(in.count() >= 0, "Pages in should be non-negative");
         assertTrue(out.count() >= 0, "Pages out should be non-negative");
     }
+
+    @Test
+    void diskIoRegistered() {
+        // At least one disk should exist with read direction
+        FunctionCounter read = registry.find("system.disk.io").tag("disk.io.direction", "read").functionCounter();
+        FunctionCounter write = registry.find("system.disk.io").tag("disk.io.direction", "write").functionCounter();
+        assertNotNull(read, "system.disk.io{direction=read} should be registered");
+        assertNotNull(write, "system.disk.io{direction=write} should be registered");
+        assertTrue(read.count() >= 0, "Disk read bytes should be non-negative");
+    }
+
+    @Test
+    void diskOperationsRegistered() {
+        FunctionCounter read = registry.find("system.disk.operations").tag("disk.io.direction", "read")
+                .functionCounter();
+        assertNotNull(read, "system.disk.operations{direction=read} should be registered");
+        assertTrue(read.count() >= 0, "Disk read operations should be non-negative");
+    }
+
+    @Test
+    void diskIoTimeRegistered() {
+        FunctionCounter ioTime = registry.find("system.disk.io_time").functionCounter();
+        assertNotNull(ioTime, "system.disk.io_time should be registered");
+        assertTrue(ioTime.count() >= 0, "Disk io_time should be non-negative");
+    }
+
+    @Test
+    void diskLimitRegistered() {
+        Gauge limit = registry.find("system.disk.limit").gauge();
+        assertNotNull(limit, "system.disk.limit should be registered");
+        // Some disks (loop devices) may have size 0, just verify registration
+        assertTrue(limit.value() >= 0, "Disk limit should be non-negative");
+    }
+
+    @Test
+    void filesystemUsageRegistered() {
+        Gauge used = registry.find("system.filesystem.usage").tag("system.filesystem.state", "used").gauge();
+        Gauge free = registry.find("system.filesystem.usage").tag("system.filesystem.state", "free").gauge();
+        assertNotNull(used, "system.filesystem.usage{state=used} should be registered");
+        assertNotNull(free, "system.filesystem.usage{state=free} should be registered");
+        // Some filesystems (e.g., tmpfs) may report 0; just verify non-negative
+        assertTrue(used.value() >= 0, "Filesystem used should be non-negative");
+        assertTrue(free.value() >= 0, "Filesystem free should be non-negative");
+    }
+
+    @Test
+    void filesystemLimitRegistered() {
+        Gauge limit = registry.find("system.filesystem.limit").gauge();
+        assertNotNull(limit, "system.filesystem.limit should be registered");
+        assertTrue(limit.value() >= 0, "Filesystem limit should be non-negative");
+    }
 }

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -5,6 +5,7 @@
 package oshi.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -234,5 +235,18 @@ class OshiMetricsTest {
         assertNotNull(udp, "system.network.connection.count{transport=udp} should be registered");
         assertTrue(tcp.value() >= 0, "TCP connection count should be non-negative");
         assertTrue(udp.value() >= 0, "UDP connection count should be non-negative");
+    }
+
+    @Test
+    void builderSelectiveRegistration() {
+        MeterRegistry selective = new SimpleMeterRegistry();
+        OshiMetrics.builder(hal, os).enableCpu(true).enableMemory(false).enablePaging(false).enableDisk(false)
+                .enableFileSystem(false).enableNetwork(false).enableGeneral(false).build().bindTo(selective);
+        // CPU should be registered
+        assertNotNull(selective.find("system.cpu.time").functionCounter(), "CPU metrics should be registered");
+        // Memory should NOT be registered
+        assertNull(selective.find("system.memory.usage").gauge(), "Memory metrics should not be registered");
+        // Network should NOT be registered
+        assertNull(selective.find("system.network.io").functionCounter(), "Network metrics should not be registered");
     }
 }

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -52,6 +52,13 @@ class OshiMetricsTest {
     }
 
     @Test
+    void memoryLimitRegistered() {
+        Gauge limit = registry.find("system.memory.limit").gauge();
+        assertNotNull(limit, "system.memory.limit should be registered");
+        assertTrue(limit.value() > 0, "Memory limit should be positive");
+    }
+
+    @Test
     void memoryUtilizationRegistered() {
         Gauge used = registry.find("system.memory.utilization").tag("system.memory.state", "used").gauge();
         Gauge free = registry.find("system.memory.utilization").tag("system.memory.state", "free").gauge();
@@ -59,8 +66,8 @@ class OshiMetricsTest {
         assertNotNull(free, "system.memory.utilization{state=free} should be registered");
         double usedVal = used.value();
         double freeVal = free.value();
-        assertTrue(usedVal > 0 && usedVal < 1, "Used utilization should be between 0 and 1");
-        assertTrue(freeVal > 0 && freeVal < 1, "Free utilization should be between 0 and 1");
+        assertTrue(usedVal >= 0 && usedVal <= 1, "Used utilization should be between 0 and 1");
+        assertTrue(freeVal >= 0 && freeVal <= 1, "Free utilization should be between 0 and 1");
     }
 
     @Test
@@ -99,5 +106,38 @@ class OshiMetricsTest {
         assertNotNull(freq, "system.cpu.frequency{cpu.logical_number=0} should be registered");
         // Frequency may be 0 on some platforms (e.g., VMs), so just check non-negative
         assertTrue(freq.value() >= 0, "CPU frequency should be non-negative");
+    }
+
+    @Test
+    void pagingUsageRegistered() {
+        Gauge used = registry.find("system.paging.usage").tag("system.paging.state", "used").gauge();
+        Gauge free = registry.find("system.paging.usage").tag("system.paging.state", "free").gauge();
+        assertNotNull(used, "system.paging.usage{state=used} should be registered");
+        assertNotNull(free, "system.paging.usage{state=free} should be registered");
+        // Swap used may be 0, but free + used should equal total
+        assertTrue(used.value() >= 0, "Paging used should be non-negative");
+        assertTrue(free.value() >= 0, "Paging free should be non-negative");
+    }
+
+    @Test
+    void pagingUtilizationRegistered() {
+        Gauge used = registry.find("system.paging.utilization").tag("system.paging.state", "used").gauge();
+        Gauge free = registry.find("system.paging.utilization").tag("system.paging.state", "free").gauge();
+        assertNotNull(used, "system.paging.utilization{state=used} should be registered");
+        assertNotNull(free, "system.paging.utilization{state=free} should be registered");
+        assertTrue(used.value() >= 0 && used.value() <= 1, "Paging utilization used should be 0-1");
+        assertTrue(free.value() >= 0 && free.value() <= 1, "Paging utilization free should be 0-1");
+    }
+
+    @Test
+    void pagingOperationsRegistered() {
+        FunctionCounter in = registry.find("system.paging.operations").tag("system.paging.direction", "in")
+                .functionCounter();
+        FunctionCounter out = registry.find("system.paging.operations").tag("system.paging.direction", "out")
+                .functionCounter();
+        assertNotNull(in, "system.paging.operations{direction=in} should be registered");
+        assertNotNull(out, "system.paging.operations{direction=out} should be registered");
+        assertTrue(in.count() >= 0, "Pages in should be non-negative");
+        assertTrue(out.count() >= 0, "Pages out should be non-negative");
     }
 }

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import oshi.SystemInfo;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.software.os.OperatingSystem;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class OshiMetricsTest {
+
+    private static MeterRegistry registry;
+    private static HardwareAbstractionLayer hal;
+    private static OperatingSystem os;
+
+    @BeforeAll
+    static void setUp() {
+        registry = new SimpleMeterRegistry();
+        SystemInfo si = new SystemInfo();
+        hal = si.getHardware();
+        os = si.getOperatingSystem();
+        OshiMetrics.bindTo(registry, hal, os);
+    }
+
+    @Test
+    void memoryUsageRegistered() {
+        Gauge used = registry.find("system.memory.usage").tag("system.memory.state", "used").gauge();
+        Gauge free = registry.find("system.memory.usage").tag("system.memory.state", "free").gauge();
+        assertNotNull(used, "system.memory.usage{state=used} should be registered");
+        assertNotNull(free, "system.memory.usage{state=free} should be registered");
+        assertTrue(used.value() > 0, "Used memory should be positive");
+        assertTrue(free.value() > 0, "Free memory should be positive");
+    }
+
+    @Test
+    void memoryUtilizationRegistered() {
+        Gauge used = registry.find("system.memory.utilization").tag("system.memory.state", "used").gauge();
+        Gauge free = registry.find("system.memory.utilization").tag("system.memory.state", "free").gauge();
+        assertNotNull(used, "system.memory.utilization{state=used} should be registered");
+        assertNotNull(free, "system.memory.utilization{state=free} should be registered");
+        double usedVal = used.value();
+        double freeVal = free.value();
+        assertTrue(usedVal > 0 && usedVal < 1, "Used utilization should be between 0 and 1");
+        assertTrue(freeVal > 0 && freeVal < 1, "Free utilization should be between 0 and 1");
+    }
+
+    @Test
+    void cpuTimeRegistered() {
+        // Should have one counter per cpu.mode
+        String[] modes = { "user", "nice", "system", "idle", "iowait", "interrupt", "softirq", "steal" };
+        for (String mode : modes) {
+            assertNotNull(registry.find("system.cpu.time").tag("cpu.mode", mode).functionCounter(),
+                    "system.cpu.time{cpu.mode=" + mode + "} should be registered");
+        }
+        // idle should be nonzero on any running system
+        FunctionCounter idleCounter = registry.find("system.cpu.time").tag("cpu.mode", "idle").functionCounter();
+        assertNotNull(idleCounter, "idle counter should exist");
+        assertTrue(idleCounter.count() > 0, "Idle CPU time should be positive, got " + idleCounter.count());
+    }
+}

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -104,6 +104,7 @@ class OshiMetricsTest {
         assertTrue(count.value() >= 1, "Logical CPU count should be at least 1");
         // logical >= physical
         Gauge physical = registry.find("system.cpu.physical.count").gauge();
+        assertNotNull(physical, "system.cpu.physical.count should be registered");
         assertTrue(count.value() >= physical.value(), "Logical count should be >= physical count");
     }
 
@@ -198,6 +199,16 @@ class OshiMetricsTest {
         Gauge limit = registry.find("system.filesystem.limit").gauge();
         assertNotNull(limit, "system.filesystem.limit should be registered");
         assertTrue(limit.value() >= 0, "Filesystem limit should be non-negative");
+    }
+
+    @Test
+    void filesystemUtilizationRegistered() {
+        Gauge used = registry.find("system.filesystem.utilization").tag("system.filesystem.state", "used").gauge();
+        Gauge free = registry.find("system.filesystem.utilization").tag("system.filesystem.state", "free").gauge();
+        assertNotNull(used, "system.filesystem.utilization{state=used} should be registered");
+        assertNotNull(free, "system.filesystem.utilization{state=free} should be registered");
+        assertTrue(used.value() >= 0, "Filesystem utilization used should be non-negative");
+        assertTrue(free.value() >= 0, "Filesystem utilization free should be non-negative");
     }
 
     @Test

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -42,6 +42,13 @@ class OshiMetricsTest {
     }
 
     @Test
+    void processCountRegistered() {
+        Gauge count = registry.find("system.process.count").gauge();
+        assertNotNull(count, "system.process.count should be registered");
+        assertTrue(count.value() >= 1, "Process count should be at least 1");
+    }
+
+    @Test
     void memoryUsageRegistered() {
         Gauge used = registry.find("system.memory.usage").tag("system.memory.state", "used").gauge();
         Gauge free = registry.find("system.memory.usage").tag("system.memory.state", "free").gauge();

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -35,6 +35,13 @@ class OshiMetricsTest {
     }
 
     @Test
+    void systemUptimeRegistered() {
+        Gauge uptime = registry.find("system.uptime").gauge();
+        assertNotNull(uptime, "system.uptime should be registered");
+        assertTrue(uptime.value() > 0, "System uptime should be positive");
+    }
+
+    @Test
     void memoryUsageRegistered() {
         Gauge used = registry.find("system.memory.usage").tag("system.memory.state", "used").gauge();
         Gauge free = registry.find("system.memory.usage").tag("system.memory.state", "free").gauge();
@@ -58,15 +65,39 @@ class OshiMetricsTest {
 
     @Test
     void cpuTimeRegistered() {
-        // Should have one counter per cpu.mode
         String[] modes = { "user", "nice", "system", "idle", "iowait", "interrupt", "softirq", "steal" };
         for (String mode : modes) {
             assertNotNull(registry.find("system.cpu.time").tag("cpu.mode", mode).functionCounter(),
                     "system.cpu.time{cpu.mode=" + mode + "} should be registered");
         }
-        // idle should be nonzero on any running system
         FunctionCounter idleCounter = registry.find("system.cpu.time").tag("cpu.mode", "idle").functionCounter();
         assertNotNull(idleCounter, "idle counter should exist");
         assertTrue(idleCounter.count() > 0, "Idle CPU time should be positive, got " + idleCounter.count());
+    }
+
+    @Test
+    void cpuPhysicalCountRegistered() {
+        Gauge count = registry.find("system.cpu.physical.count").gauge();
+        assertNotNull(count, "system.cpu.physical.count should be registered");
+        assertTrue(count.value() >= 1, "Physical CPU count should be at least 1");
+    }
+
+    @Test
+    void cpuLogicalCountRegistered() {
+        Gauge count = registry.find("system.cpu.logical.count").gauge();
+        assertNotNull(count, "system.cpu.logical.count should be registered");
+        assertTrue(count.value() >= 1, "Logical CPU count should be at least 1");
+        // logical >= physical
+        Gauge physical = registry.find("system.cpu.physical.count").gauge();
+        assertTrue(count.value() >= physical.value(), "Logical count should be >= physical count");
+    }
+
+    @Test
+    void cpuFrequencyRegistered() {
+        // At least cpu.logical_number=0 should exist
+        Gauge freq = registry.find("system.cpu.frequency").tag("cpu.logical_number", "0").gauge();
+        assertNotNull(freq, "system.cpu.frequency{cpu.logical_number=0} should be registered");
+        // Frequency may be 0 on some platforms (e.g., VMs), so just check non-negative
+        assertTrue(freq.value() >= 0, "CPU frequency should be non-negative");
     }
 }

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -191,4 +191,41 @@ class OshiMetricsTest {
         assertNotNull(limit, "system.filesystem.limit should be registered");
         assertTrue(limit.value() >= 0, "Filesystem limit should be non-negative");
     }
+
+    @Test
+    void networkIoRegistered() {
+        FunctionCounter recv = registry.find("system.network.io").tag("network.io.direction", "receive")
+                .functionCounter();
+        FunctionCounter xmit = registry.find("system.network.io").tag("network.io.direction", "transmit")
+                .functionCounter();
+        assertNotNull(recv, "system.network.io{direction=receive} should be registered");
+        assertNotNull(xmit, "system.network.io{direction=transmit} should be registered");
+        assertTrue(recv.count() >= 0, "Network bytes received should be non-negative");
+    }
+
+    @Test
+    void networkPacketCountRegistered() {
+        FunctionCounter recv = registry.find("system.network.packet.count").tag("network.io.direction", "receive")
+                .functionCounter();
+        assertNotNull(recv, "system.network.packet.count{direction=receive} should be registered");
+        assertTrue(recv.count() >= 0, "Network packets received should be non-negative");
+    }
+
+    @Test
+    void networkErrorsRegistered() {
+        FunctionCounter recv = registry.find("system.network.errors").tag("network.io.direction", "receive")
+                .functionCounter();
+        assertNotNull(recv, "system.network.errors{direction=receive} should be registered");
+        assertTrue(recv.count() >= 0, "Network errors should be non-negative");
+    }
+
+    @Test
+    void networkConnectionCountRegistered() {
+        Gauge tcp = registry.find("system.network.connection.count").tag("network.transport", "tcp").gauge();
+        Gauge udp = registry.find("system.network.connection.count").tag("network.transport", "udp").gauge();
+        assertNotNull(tcp, "system.network.connection.count{transport=tcp} should be registered");
+        assertNotNull(udp, "system.network.connection.count{transport=udp} should be registered");
+        assertTrue(tcp.value() >= 0, "TCP connection count should be non-negative");
+        assertTrue(udp.value() >= 0, "UDP connection count should be non-negative");
+    }
 }

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -207,8 +207,8 @@ class OshiMetricsTest {
         Gauge free = registry.find("system.filesystem.utilization").tag("system.filesystem.state", "free").gauge();
         assertNotNull(used, "system.filesystem.utilization{state=used} should be registered");
         assertNotNull(free, "system.filesystem.utilization{state=free} should be registered");
-        assertTrue(used.value() >= 0, "Filesystem utilization used should be non-negative");
-        assertTrue(free.value() >= 0, "Filesystem utilization free should be non-negative");
+        assertTrue(used.value() >= 0 && used.value() <= 1, "Filesystem utilization used should be in [0,1]");
+        assertTrue(free.value() >= 0 && free.value() <= 1, "Filesystem utilization free should be in [0,1]");
     }
 
     @Test
@@ -252,8 +252,8 @@ class OshiMetricsTest {
     void builderSelectiveRegistration() {
         MeterRegistry selective = new SimpleMeterRegistry();
         OshiMetrics.builder(hal, os).enableCpu(true).enableMemory(false).enablePaging(false).enableDisk(false)
-                .enableFileSystem(false).enableNetwork(false).enableGeneral(false).enableProcess(false).build()
-                .bindTo(selective);
+                .enableFileSystem(false).enableNetwork(false).enableGeneral(false).enableProcess(false)
+                .enableContainer(false).build().bindTo(selective);
         // CPU should be registered
         assertNotNull(selective.find("system.cpu.time").functionCounter(), "CPU metrics should be registered");
         // Memory should NOT be registered

--- a/oshi-metrics/src/test/java/oshi/metrics/PrometheusDemoTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/PrometheusDemoTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import com.sun.net.httpserver.HttpServer;
+
+import oshi.SystemInfo;
+
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+
+/**
+ * Demo: exposes OSHI metrics as a Prometheus scrape endpoint.
+ *
+ * <p>
+ * Run this class, then open <a href="http://localhost:8080/metrics">http://localhost:8080/metrics</a> in your browser
+ * (or {@code curl localhost:8080/metrics}) to see live Prometheus-formatted system metrics.
+ *
+ * <p>
+ * This mirrors the production pattern: create {@link OshiMetrics} once and hold it as a field for the lifetime of the
+ * application.
+ */
+public class PrometheusDemoTest {
+
+    // Hold references for the lifetime of the application, as you would in production
+    // (e.g., as a Spring @Bean or an application-scoped field)
+    private final PrometheusMeterRegistry registry;
+    private final OshiMetrics oshiMetrics;
+
+    PrometheusDemoTest() {
+        this.registry = new PrometheusMeterRegistry(new PrometheusConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public Duration step() {
+                return Duration.ofSeconds(5);
+            }
+        });
+        SystemInfo si = new SystemInfo();
+        this.oshiMetrics = new OshiMetrics(si.getHardware(), si.getOperatingSystem());
+        this.oshiMetrics.bindTo(registry);
+    }
+
+    void start() throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+        server.createContext("/metrics", exchange -> {
+            byte[] bytes = registry.scrape().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        });
+        server.start();
+        System.out.println("OSHI Prometheus metrics at http://localhost:8080/metrics");
+        System.out.println("Press Ctrl+C to stop.");
+    }
+
+    public static void main(String[] args) throws IOException {
+        new PrometheusDemoTest().start();
+    }
+}

--- a/oshi-metrics/src/test/java/oshi/metrics/PrometheusDemoTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/PrometheusDemoTest.java
@@ -13,21 +13,12 @@ import java.time.Duration;
 import com.sun.net.httpserver.HttpServer;
 
 import oshi.SystemInfo;
+import oshi.annotation.SuppressForbidden;
 
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
-/**
- * Demo: exposes OSHI metrics as a Prometheus scrape endpoint.
- *
- * <p>
- * Run this class, then open <a href="http://localhost:8080/metrics">http://localhost:8080/metrics</a> in your browser
- * (or {@code curl localhost:8080/metrics}) to see live Prometheus-formatted system metrics.
- *
- * <p>
- * This mirrors the production pattern: create {@link OshiMetrics} once and hold it as a field for the lifetime of the
- * application.
- */
+@SuppressForbidden(reason = "Demo test uses com.sun.net.httpserver and System.out for demonstration purposes")
 public class PrometheusDemoTest {
 
     // Hold references for the lifetime of the application, as you would in production

--- a/pom.xml
+++ b/pom.xml
@@ -744,6 +744,7 @@
                                         <exclusion>oshi.demo.**</exclusion>
                                         <exclusion>oshi.benchmark.**</exclusion>
                                         <exclusion>oshi.comparison.**</exclusion>
+                                        <exclusion>oshi.metrics.**</exclusion>
                                     </exclusions>
                                 </RestrictImports>
                             </rules>
@@ -1019,6 +1020,16 @@
             <properties>
                 <enable.native.access>--enable-native-access=${native.access.modules}</enable.native.access>
             </properties>
+        </profile>
+        <!-- Java 17+ profile -->
+        <profile>
+            <id>java17</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <modules>
+                <module>oshi-metrics</module>
+            </modules>
         </profile>
         <!-- Java 25+ profile -->
         <profile>


### PR DESCRIPTION
## Summary

Add the `oshi-metrics` module — first-party Micrometer metrics for OSHI system information, following OpenTelemetry semantic conventions. This PR establishes the module structure, build configuration, and initial metrics.

Fun fact: I came to OSHI in 2015 as my first start in Open Source contributions to optimize my bang-for-the-buck usage of cloud servers and was interested in using all the CPU and memory I was paying for. So of course these are the metrics I would want. Kind of fun to go full circle a decade later back to these basics....

Metric names and attributes strictly follow [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/) per feedback from @jaydeluca in #3223.

Also bumps version to 7.1.0-SNAPSHOT (new public API).

## Metrics implemented

### [General metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#general-metrics)

| Metric | Type | Unit | Attributes |
|---|---|---|---|
| `system.uptime` | Gauge | `s` | — |

### [Processor metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#processor-metrics)

| Metric | Type | Unit | Attributes |
|---|---|---|---|
| `system.cpu.physical.count` | Gauge | `{cpu}` | — |
| `system.cpu.logical.count` | Gauge | `{cpu}` | — |
| `system.cpu.time` | Counter | `s` | `cpu.mode` (user, nice, system, idle, iowait, interrupt, softirq, steal) |
| `system.cpu.frequency` | Gauge | `Hz` | `cpu.logical_number` |

### [Memory metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#memory-metrics)

| Metric | Type | Unit | Attributes |
|---|---|---|---|
| `system.memory.usage` | Gauge | `By` | `system.memory.state` (used, free) |
| `system.memory.limit` | Gauge | `By` | — |
| `system.memory.utilization` | Gauge | `1` | `system.memory.state` (used, free) |

### [Paging/Swap metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#pagingswap-metrics)

| Metric | Type | Unit | Attributes |
|---|---|---|---|
| `system.paging.usage` | Gauge | `By` | `system.paging.state` (used, free) |
| `system.paging.utilization` | Gauge | `1` | `system.paging.state` (used, free) |
| `system.paging.operations` | Counter | `{operation}` | `system.paging.direction` (in, out) |

### [Disk controller metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#disk-controller-metrics)

| Metric | Type | Unit | Attributes |
|---|---|---|---|
| `system.disk.io` | Counter | `By` | `system.device`, `disk.io.direction` (read, write) |
| `system.disk.operations` | Counter | `{operation}` | `system.device`, `disk.io.direction` (read, write) |
| `system.disk.io_time` | Counter | `s` | `system.device` |
| `system.disk.limit` | Gauge | `By` | `system.device` |

### [Filesystem metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#filesystem-metrics)

| Metric | Type | Unit | Attributes |
|---|---|---|---|
| `system.filesystem.usage` | Gauge | `By` | `system.device`, `system.filesystem.mountpoint`, `system.filesystem.type`, `system.filesystem.mode`, `system.filesystem.state` (used, free) |
| `system.filesystem.utilization` | Gauge | `1` | (same as above) |
| `system.filesystem.limit` | Gauge | `By` | `system.device`, `system.filesystem.mountpoint`, `system.filesystem.type`, `system.filesystem.mode` |

### [Network metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#network-metrics)

| Metric | Type | Unit | Attributes |
|---|---|---|---|
| `system.network.io` | Counter | `By` | `system.device`, `network.io.direction` (receive, transmit) |
| `system.network.packet.count` | Counter | `{packet}` | `system.device`, `network.io.direction` (receive, transmit) |
| `system.network.packet.dropped` | Counter | `{packet}` | `system.device`, `network.io.direction` (receive) |
| `system.network.errors` | Counter | `{error}` | `system.device`, `network.io.direction` (receive, transmit) |
| `system.network.connection.count` | Gauge | `{connection}` | `network.transport`, `network.connection.state` |

### [Aggregate system process metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#aggregate-system-process-metrics)

| Metric | Type | Unit | Attributes |
|---|---|---|---|
| `system.process.count` | Gauge | `{process}` | — |

### [Container metrics](https://opentelemetry.io/docs/specs/semconv/system/container-metrics/) (when containerized)

| Metric | Type | Unit | Description |
|---|---|---|---|
| `container.uptime` | Gauge | `s` | Time since PID 1 started |
| `container.cpu.time` | Counter | `s` | Total CPU time consumed |
| `container.memory.usage` | Gauge | `By` | Container memory usage |
| `container.memory.available` | Gauge | `By` | Memory limit - usage (when limit set) |

## Selective registration (Builder API)

```java
OshiMetrics.builder(hal, os)
    .enableCpu(true)
    .enableMemory(true)
    .enableDisk(false)
    .enableNetwork(false)
    .build()
    .bindTo(registry);
```

All categories enabled by default. Categories: `general`, `cpu`, `memory`, `paging`, `disk`, `fileSystem`, `network`.

## Module design

- **JDK 17** target (aligns with Spring Boot 3.x / Micrometer 1.13+)
- **Micrometer 1.14.x** as `provided` scope — user brings their own version
- Depends on **oshi-common interfaces only** — works identically with both JNA (`oshi-core`) and FFM (`oshi-core-ffm`)
- `OshiMetrics` entry point accepts `HardwareAbstractionLayer` + `OperatingSystem` directly (no reflection)
- Implements `MeterBinder` for Spring Boot auto-discovery
- Gated behind JDK 17+ Maven profile (like oshi-core-ffm on JDK 25+)

## Demo

```sh
./mvnw clean install -DskipTests
./mvnw exec:java -pl oshi-metrics \
  -Dexec.mainClass="oshi.metrics.PrometheusDemoTest" \
  -Dexec.classpathScope="test"
```
Then open http://localhost:8080/metrics or `curl localhost:8080/metrics`.

Resolves #3223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added oshi-metrics module with Micrometer binders exposing CPU, memory, disk, filesystem, network, paging, process, container and general system metrics; per-item tagging, units, Builder API and convenience bind method (OpenTelemetry conventions)

* **Tests**
  * Comprehensive JUnit 5 suite and a Prometheus demo validating metric registration and basic values

* **Documentation**
  * Module README, package javadoc, and CHANGELOG entry

* **Chores**
  * Java 17 profile, POM and import-control updates to enable the new module
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

