### PR TITLE
Support environment variables (OSHI_*) for configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 7.1.0 (in progress)
 
 * [#3225](https://github.com/oshi/oshi/pull/3225): Add CgroupInfo API with Linux cgroup v1/v2 support - [@rohan-coder02](https://github.com/rohan-coder02).
+* [#3229](https://github.com/oshi/oshi/pull/3229): Support environment variables (`OSHI_*`) for configuration - [@dbwiddis](https://github.com/dbwiddis).
 * [#3223](https://github.com/oshi/oshi/issues/3223): Add `oshi-metrics` module with Micrometer integration for system metrics following OpenTelemetry semantic conventions - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 7.1.0 (in progress)
 
 * [#3225](https://github.com/oshi/oshi/pull/3225): Add CgroupInfo API with Linux cgroup v1/v2 support - [@rohan-coder02](https://github.com/rohan-coder02).
+* [#3222](https://github.com/oshi/oshi/issues/3222): Support environment variables (`OSHI_*`) for configuration - [@dbwiddis](https://github.com/dbwiddis).
 * [#3223](https://github.com/oshi/oshi/issues/3223): Add `oshi-metrics` module with Micrometer integration for system metrics following OpenTelemetry semantic conventions - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # 7.1.0 (in progress)
 
 * [#3225](https://github.com/oshi/oshi/pull/3225): Add CgroupInfo API with Linux cgroup v1/v2 support - [@rohan-coder02](https://github.com/rohan-coder02).
-* [#3222](https://github.com/oshi/oshi/issues/3222): Support environment variables (`OSHI_*`) for configuration - [@dbwiddis](https://github.com/dbwiddis).
 * [#3223](https://github.com/oshi/oshi/issues/3223): Add `oshi-metrics` module with Micrometer integration for system metrics following OpenTelemetry semantic conventions - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -11,6 +11,7 @@
   * [How do I resolve `Pdh call failed with error code 0xC0000BB8` issues?](#how-do-i-resolve-pdh-call-failed-with-error-code-0xc0000bb8-issues)
   * [How do I resolve JNA `NoClassDefFoundError` or `NoSuchMethodError` issues?](#how-do-i-resolve-jna-noclassdeffounderror-or-nosuchmethoderror-issues)
   * [Does OSHI work in containers (Docker, Kubernetes)?](#does-oshi-work-in-containers-docker-kubernetes)
+  * [How do I configure OSHI?](#how-do-i-configure-oshi)
   * [How does OSHI support the Principle of Least Privilege?](#how-does-oshi-support-the-principle-of-least-privilege)
   * [How do I get CPU usage?](#how-do-i-get-cpu-usage)
   * [Why does OSHI's System and Processor CPU usage differ from the Windows Task Manager?](#why-does-oshi-s-system-and-processor-cpu-usage-differ-from-the-windows-task-manager)
@@ -68,7 +69,7 @@ each class. The following classes are not thread-safe:
  However, these methods are intended to be used by a single thread at startup in lieu of reading a configuration file.
  OSHI gives no guarantees on re-reading changed configurations.
  - On non-Windows platforms, the `getSessions()` method on the `OperatingSystem` interface uses native code which is not thread safe. While OSHI's methods employ synchronization to coordinate access from its own threads, users are cautioned that other operating system code may access the same underlying data structures and produce unexpected results, particularly on servers with frequent new logins.
-The `oshi.os.unix.whoCommand` property may be set to parse the Posix-standard `who` command in preference to the native implementation,
+The `oshi.os.unix.whocommand` property may be set to parse the Posix-standard `who` command in preference to the native implementation,
 which may use reentrant code on some platforms.
  - The `PerfCounterQueryHandler` class is not thread-safe but is only internally used in single-thread contexts,
 and is not intended for user use.
@@ -174,6 +175,126 @@ long cpuPeriod = FileUtil.getLongFromFile("/sys/fs/cgroup/cpu/cpu.cfs_period_us"
 
 // Memory limit (bytes)
 long memLimit = FileUtil.getLongFromFile("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+```
+
+## How do I configure OSHI?
+
+OSHI supports multiple configuration mechanisms with a clear precedence order. Higher-priority sources override lower ones:
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 (highest) | `GlobalConfig.set()` in Java code | `GlobalConfig.set("oshi.os.linux.privileged.prefix", "sudo -n");` |
+| 2 | Java system properties | `java -Doshi.os.linux.privileged.prefix="sudo -n" -jar app.jar` |
+| 3 | Environment variables (`OSHI_*`) | `export OSHI_OS_LINUX_PRIVILEGED_PREFIX="sudo -n"` |
+| 4 | External properties file | `java -Doshi.properties.file=/etc/oshi.conf -jar app.jar` |
+| 5 (lowest) | `oshi.properties` on classpath | Place in `src/main/resources/oshi.properties` |
+
+### Environment variables
+
+Environment variables use the convention: uppercase the property name and replace dots with underscores.
+
+| Property key | Environment variable |
+|---|---|
+| `oshi.os.linux.privileged.prefix` | `OSHI_OS_LINUX_PRIVILEGED_PREFIX` |
+| `oshi.util.memoizer.expiration` | `OSHI_UTIL_MEMOIZER_EXPIRATION` |
+| `oshi.util.proc.path` | `OSHI_UTIL_PROC_PATH` |
+
+This is the recommended approach for containers, Kubernetes, and 12-factor apps:
+
+```sh
+# Docker
+docker run -e OSHI_OS_LINUX_PRIVILEGED_PREFIX="sudo -n" myapp
+
+# Kubernetes (in pod spec)
+env:
+  - name: OSHI_OS_LINUX_PRIVILEGED_PREFIX
+    value: "sudo -n"
+```
+
+### External properties file
+
+Point OSHI at a properties file on disk using the `oshi.properties.file` system property:
+
+```sh
+java -Doshi.properties.file=/etc/oshi.conf -jar app.jar
+```
+
+This is useful for server deployments where config lives in `/etc/` or Docker containers mounting config files as volumes.
+
+### Java system properties
+
+Pass properties on the command line with `-D`:
+
+```sh
+java -Doshi.os.linux.privileged.prefix="sudo -n" -Doshi.util.memoizer.expiration=500 -jar app.jar
+```
+
+### Programmatic configuration
+
+Set values in Java code at startup, before creating any OSHI objects:
+
+```java
+GlobalConfig.set(GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_PREFIX, "sudo -n");
+GlobalConfig.set(GlobalConfig.OSHI_UTIL_MEMOIZER_EXPIRATION, 500);
+```
+
+### Properties file
+
+Place an `oshi.properties` file in `src/main/resources/` to override defaults. See the [default oshi.properties](https://github.com/oshi/oshi/blob/master/oshi-common/src/main/resources/oshi.properties) for all available keys and their defaults.
+
+### Spring Boot integration
+
+Spring Boot does not automatically propagate its `application.yml` properties to Java system properties. Use one of these approaches:
+
+**Option A** — Set environment variables (works with the new `OSHI_*` support):
+```yaml
+# In your deployment config or docker-compose.yml
+environment:
+  OSHI_OS_LINUX_PRIVILEGED_PREFIX: "sudo -n"
+```
+
+**Option B** — Bridge all `oshi.*` properties from `application.yml` (recommended for Spring Boot):
+
+```yaml
+# application.yml
+oshi:
+  os:
+    linux:
+      privileged:
+        prefix: "sudo -n"
+  util:
+    memoizer:
+      expiration: 500
+```
+
+```java
+@Configuration
+public class OshiConfig {
+    @Autowired
+    private Environment env;
+
+    @PostConstruct
+    void init() {
+        // Bridge any oshi.* properties from Spring Environment to OSHI GlobalConfig
+        for (String key : new String[] {
+                GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_PREFIX,
+                GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_ALLOWLIST,
+                GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_FILE_ALLOWLIST,
+                GlobalConfig.OSHI_UTIL_MEMOIZER_EXPIRATION
+                // Add other keys as needed
+        }) {
+            String value = env.getProperty(key);
+            if (value != null) {
+                GlobalConfig.set(key, value);
+            }
+        }
+    }
+}
+```
+
+**Option C** — Use `-D` flags in your startup script:
+```sh
+java -Doshi.os.linux.privileged.prefix="sudo -n" -jar myapp.jar
 ```
 
 ## How does OSHI support the Principle of Least Privilege?

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.oshi/oshi-core.svg?label=Maven%20Central)](https://central.sonatype.com/search?namespace=com.github.oshi&sort=name)
 [![first-timers-only](https://img.shields.io/badge/first--timers--only-friendly-blue.svg?style=flat-square)](https://www.firsttimersonly.com/)
-[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/oshi/oshi)](https://app.coderabbit.ai/dashboard/summary)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/oshi/oshi?utm_source=oss&utm_medium=github&utm_campaign=oshi%2Foshi&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://app.coderabbit.ai/dashboard/summary)
 [![GitHub contributors](https://img.shields.io/github/contributors/oshi/oshi)](https://github.com/oshi/oshi/graphs/contributors)
 
 OSHI is a free native (JNA or FFM) Operating System and Hardware Information library for Java.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,17 @@
 # Guide to upgrading from OSHI 6.x to 7.x
 
+## Configuration property key changes (7.1.0)
+
+Three property keys have been renamed to use consistent all-lowercase naming, enabling environment variable configuration:
+
+| Old key | New key |
+|---------|---------|
+| `oshi.os.unix.whoCommand` | `oshi.os.unix.whocommand` |
+| `oshi.os.solaris.allowKstat2` | `oshi.os.solaris.allowkstat2` |
+| `oshi.os.linux.sensors.cpuTemperature.types` | `oshi.os.linux.sensors.cputemperature.types` |
+
+If you reference these keys in your `oshi.properties` file, update them to the new lowercase names. Old camelCase keys (`whoCommand`, `allowKstat2`, `cpuTemperature.types`) will be silently ignored if present. The Java constant names (`OSHI_OS_UNIX_WHOCOMMAND`, `OSHI_OS_SOLARIS_ALLOWKSTAT2`) are unchanged.
+
 ## Deprecated method and class removal
 
 ### Process memory: `getResidentSetSize()` replaced by two methods

--- a/oshi-common/src/main/java/oshi/hardware/Sensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/Sensors.java
@@ -38,7 +38,7 @@ public interface Sensors {
      *         <p>
      *         On Linux, values are read from hwmon sensors or thermal zones. The sensor names and priority can be
      *         configured via {@code oshi.os.linux.sensors.hwmon.names} and
-     *         {@code oshi.os.linux.sensors.cpuTemperature.types} in the configuration.
+     *         {@code oshi.os.linux.sensors.cputemperature.types} in the configuration.
      */
     double getCpuTemperature();
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSensors.java
@@ -43,7 +43,7 @@ class LinuxSensors extends AbstractSensors {
      * </ul>
      */
     public static final String OSHI_HWMON_NAME_PRIORITY = "oshi.os.linux.sensors.hwmon.names";
-    public static final String OSHI_THERMAL_ZONE_TYPE_PRIORITY = "oshi.os.linux.sensors.cpuTemperature.types";
+    public static final String OSHI_THERMAL_ZONE_TYPE_PRIORITY = "oshi.os.linux.sensors.cputemperature.types";
 
     private static final List<String> HWMON_NAME_PRIORITY = Stream.of(GlobalConfig
             .get(OSHI_HWMON_NAME_PRIORITY, "coretemp,k10temp,zenpower,k8temp,via-cputemp,acpitz").split(","))

--- a/oshi-common/src/main/java/oshi/software/os/OperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/os/OperatingSystem.java
@@ -351,7 +351,7 @@ public interface OperatingSystem {
      * <p>
      * The {@code Who#queryWho()} method produces similar output parsing the output of the Posix-standard {@code who}
      * command, and may internally employ reentrant code on some platforms. Users may opt to use this command-line
-     * variant by default using the {@code oshi.os.unix.whoCommand} configuration property.
+     * variant by default using the {@code oshi.os.unix.whocommand} configuration property.
      *
      * @return A list of {@link oshi.software.os.OSSession} objects representing logged-in users
      */

--- a/oshi-common/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-common/src/main/java/oshi/util/GlobalConfig.java
@@ -4,7 +4,15 @@
  */
 package oshi.util;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
 import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.NotThreadSafe;
 import oshi.hardware.CentralProcessor;
@@ -12,12 +20,17 @@ import oshi.hardware.CentralProcessor;
 /**
  * The global configuration utility. See {@code src/main/resources/oshi.properties} for default values.
  * <p>
- * Configuration values set as Java System Properties using {@link System#setProperty(String, String)} will override
- * values from the {@code oshi.properties} file, but may then be later altered using {@link #set(String, Object)} or
- * {@link #remove(String)}.
+ * Configuration is resolved in the following precedence order (highest wins):
+ * <ol>
+ * <li>{@link #set(String, Object)} — programmatic, at runtime</li>
+ * <li>Java system properties ({@code -Doshi.*})</li>
+ * <li>Environment variables ({@code OSHI_*}) — mapped by uppercasing and replacing dots with underscores</li>
+ * <li>External properties file ({@code -Doshi.properties.file=/path/to/file})</li>
+ * <li>{@code oshi.properties} on the classpath (defaults)</li>
+ * </ol>
  * <p>
  * This class is not thread safe if methods manipulating the configuration are used. These methods are intended for use
- * by a single thread at startup, before instantiation of any other OSHI classes. OSHI does not guarantee re- reading of
+ * by a single thread at startup, before instantiation of any other OSHI classes. OSHI does not guarantee re-reading of
  * any configuration changes.
  */
 @NotThreadSafe
@@ -25,14 +38,54 @@ public final class GlobalConfig {
 
     private static final String OSHI_PROPERTIES = "oshi.properties";
 
+    private static final Logger LOG = LoggerFactory.getLogger(GlobalConfig.class);
+
     private static final Properties CONFIG = FileUtil.readPropertiesFromFilename(OSHI_PROPERTIES);
     static {
-        System.getProperties().forEach((k, v) -> {
-            String key = k.toString();
-            if (key.startsWith("oshi.")) {
-                set(key, v);
+        loadExternalConfig(CONFIG);
+    }
+
+    // package-private for testing
+    static void loadExternalConfig(Properties config) {
+        // External properties file: system property takes precedence, env var as fallback
+        String externalFile = System.getProperty("oshi.properties.file");
+        if (externalFile == null || externalFile.isEmpty()) {
+            externalFile = System.getenv("OSHI_PROPERTIES_FILE");
+        }
+        if (externalFile != null && !externalFile.isEmpty()) {
+            try (InputStream is = new FileInputStream(externalFile)) {
+                config.load(is);
+            } catch (FileNotFoundException e) {
+                LOG.debug("External properties file '{}' not found, continuing", externalFile);
+            } catch (IOException e) {
+                LOG.debug("Failed to load external properties file '{}'", externalFile, e);
+            }
+        }
+        // Environment variables (OSHI_*) override external file and classpath defaults
+        System.getenv().forEach((k, v) -> {
+            if (k.startsWith("OSHI_") && !"OSHI_PROPERTIES_FILE".equals(k)) {
+                config.setProperty(envKeyToProperty(k), v);
             }
         });
+        // System properties (-Doshi.*) override everything else
+        System.getProperties().forEach((k, v) -> {
+            String key = k.toString();
+            if (key.startsWith("oshi.") && !"oshi.properties.file".equals(key)) {
+                config.setProperty(key, v.toString());
+            }
+        });
+    }
+
+    /**
+     * Converts an environment variable name to a property key. For example, {@code OSHI_OS_LINUX_PRIVILEGED_PREFIX}
+     * becomes {@code oshi.os.linux.privileged.prefix}.
+     *
+     * @param envKey the environment variable name (e.g., {@code OSHI_UTIL_MEMOIZER_EXPIRATION})
+     * @return the corresponding property key
+     */
+    // package-private for testing
+    static String envKeyToProperty(String envKey) {
+        return envKey.toLowerCase(Locale.ROOT).replace('_', '.');
     }
 
     /**
@@ -184,13 +237,13 @@ public final class GlobalConfig {
      * access the same data structures. The command-line variant may use reentrant code on some platforms. Default is
      * {@code false}.
      */
-    public static final String OSHI_OS_UNIX_WHOCOMMAND = "oshi.os.unix.whoCommand";
+    public static final String OSHI_OS_UNIX_WHOCOMMAND = "oshi.os.unix.whocommand";
     /**
      * Whether to allow use of the kstat2 API on Solaris 11.4+. The new API offers additional features but may have a
      * file descriptor leak when parallel GC is in use. Set to {@code false} to always use the original kstat API.
      * Default is {@code true}.
      */
-    public static final String OSHI_OS_SOLARIS_ALLOWKSTAT2 = "oshi.os.solaris.allowKstat2";
+    public static final String OSHI_OS_SOLARIS_ALLOWKSTAT2 = "oshi.os.solaris.allowkstat2";
 
     /**
      * The command prefix to prepend for privileged command execution on Linux (e.g., {@code "sudo -n"} for
@@ -216,15 +269,11 @@ public final class GlobalConfig {
      * normal file read fails due to permissions. Supports Java glob patterns ({@code *}, {@code ?}, {@code [abc]}).
      * <p>
      * <b>Security warning:</b> Take care when adding paths. Allowing privileged reads of sensitive files such as
-     * {@code /proc/*
-     /
-    environ} can expose credentials to unprivileged users. Default is the empty
-     *
-     * string (no files allowed).
+     * process environ files can expose credentials to unprivileged users. Default is the empty string (no files
+     * allowed).
      *
      * @see #OSHI_OS_LINUX_PRIVILEGED_PREFIX
      */
-
     public static final String OSHI_OS_LINUX_PRIVILEGED_FILE_ALLOWLIST = "oshi.os.linux.privileged.file.allowlist";
 
     private GlobalConfig() {

--- a/oshi-common/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-common/src/main/java/oshi/util/GlobalConfig.java
@@ -12,16 +12,12 @@ import oshi.hardware.CentralProcessor;
 /**
  * The global configuration utility. See {@code src/main/resources/oshi.properties} for default values.
  * <p>
- * Configuration is resolved in the following precedence order (highest wins):
- * <ol>
- * <li>{@link #set(String, Object)} — programmatic, at runtime</li>
- * <li>Java system properties ({@code -Doshi.*})</li>
- * <li>Environment variables ({@code OSHI_*}) — mapped by uppercasing and replacing dots with underscores</li>
- * <li>{@code oshi.properties} on the classpath (defaults)</li>
- * </ol>
+ * Configuration values set as Java System Properties using {@link System#setProperty(String, String)} will override
+ * values from the {@code oshi.properties} file, but may then be later altered using {@link #set(String, Object)} or
+ * {@link #remove(String)}.
  * <p>
  * This class is not thread safe if methods manipulating the configuration are used. These methods are intended for use
- * by a single thread at startup, before instantiation of any other OSHI classes. OSHI does not guarantee re-reading of
+ * by a single thread at startup, before instantiation of any other OSHI classes. OSHI does not guarantee re- reading of
  * any configuration changes.
  */
 @NotThreadSafe
@@ -31,14 +27,6 @@ public final class GlobalConfig {
 
     private static final Properties CONFIG = FileUtil.readPropertiesFromFilename(OSHI_PROPERTIES);
     static {
-        // Environment variables (OSHI_*) override properties file defaults
-        System.getenv().forEach((k, v) -> {
-            if (k.startsWith("OSHI_")) {
-                String propKey = k.toLowerCase(java.util.Locale.ROOT).replace('_', '.');
-                CONFIG.putIfAbsent(propKey, v);
-            }
-        });
-        // System properties (-Doshi.*) override environment variables
         System.getProperties().forEach((k, v) -> {
             String key = k.toString();
             if (key.startsWith("oshi.")) {

--- a/oshi-common/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-common/src/main/java/oshi/util/GlobalConfig.java
@@ -12,12 +12,16 @@ import oshi.hardware.CentralProcessor;
 /**
  * The global configuration utility. See {@code src/main/resources/oshi.properties} for default values.
  * <p>
- * Configuration values set as Java System Properties using {@link System#setProperty(String, String)} will override
- * values from the {@code oshi.properties} file, but may then be later altered using {@link #set(String, Object)} or
- * {@link #remove(String)}.
+ * Configuration is resolved in the following precedence order (highest wins):
+ * <ol>
+ * <li>{@link #set(String, Object)} — programmatic, at runtime</li>
+ * <li>Java system properties ({@code -Doshi.*})</li>
+ * <li>Environment variables ({@code OSHI_*}) — mapped by uppercasing and replacing dots with underscores</li>
+ * <li>{@code oshi.properties} on the classpath (defaults)</li>
+ * </ol>
  * <p>
  * This class is not thread safe if methods manipulating the configuration are used. These methods are intended for use
- * by a single thread at startup, before instantiation of any other OSHI classes. OSHI does not guarantee re- reading of
+ * by a single thread at startup, before instantiation of any other OSHI classes. OSHI does not guarantee re-reading of
  * any configuration changes.
  */
 @NotThreadSafe
@@ -27,6 +31,14 @@ public final class GlobalConfig {
 
     private static final Properties CONFIG = FileUtil.readPropertiesFromFilename(OSHI_PROPERTIES);
     static {
+        // Environment variables (OSHI_*) override properties file defaults
+        System.getenv().forEach((k, v) -> {
+            if (k.startsWith("OSHI_")) {
+                String propKey = k.toLowerCase(java.util.Locale.ROOT).replace('_', '.');
+                CONFIG.putIfAbsent(propKey, v);
+            }
+        });
+        // System properties (-Doshi.*) override environment variables
         System.getProperties().forEach((k, v) -> {
             String key = k.toString();
             if (key.startsWith("oshi.")) {

--- a/oshi-common/src/main/resources/oshi.properties
+++ b/oshi-common/src/main/resources/oshi.properties
@@ -162,14 +162,14 @@ oshi.os.mac.sysctl.logwarning=false
 # the output of the Posix-standard "who" command, and may internally employ
 # reentrant code on some platforms. Setting this configuration to true will
 # use the command-line variant.  Defaults to false.
-oshi.os.unix.whoCommand=false
+oshi.os.unix.whocommand=false
 
 # Solaris 11.4 deprecated the previous kstat API and introduced kstat2, with
 # additional features. OSHI uses the new API if it is available. However,
 # there may be a file descriptor leak when parallel GC is in use. Setting
 # this configuration to false will always use the original kstat API even if
 # Kstat2 is available.
-oshi.os.solaris.allowKstat2=true
+oshi.os.solaris.allowkstat2=true
 
 # The name of the System event log containing bootup event IDs 12 and 6005.
 #
@@ -287,7 +287,7 @@ oshi.os.linux.sensors.hwmon.names=coretemp,k10temp,zenpower,k8temp,via-cputemp
 
 # List of types inside /sys/class/thermal/thermal_zone*/type to detect as CPU temperature.
 # The order of entries in the list does represent the priority, the first match will be used.
-oshi.os.linux.sensors.cpuTemperature.types=cpu-thermal,x86_pkg_temp
+oshi.os.linux.sensors.cputemperature.types=cpu-thermal,x86_pkg_temp
 
 # ==============================================================================
 # Privilege Escalation Configuration (Linux/Unix)

--- a/oshi-common/src/test/java/oshi/util/GlobalConfigTest.java
+++ b/oshi-common/src/test/java/oshi/util/GlobalConfigTest.java
@@ -16,11 +16,15 @@ import static oshi.util.GlobalConfig.remove;
 import static oshi.util.GlobalConfig.set;
 import static oshi.util.GlobalConfigTest.GlobalConfigAsserter.asserter;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 
 import oshi.util.GlobalConfig.PropertyException;
@@ -121,6 +125,56 @@ class GlobalConfigTest {
                 "/proc/*/io,/sys/devices/virtual/dmi/id/product_serial");
         assertThat(get(GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_FILE_ALLOWLIST, ""),
                 is("/proc/*/io,/sys/devices/virtual/dmi/id/product_serial"));
+    }
+
+    @Test
+    void testLoadExternalConfig(@TempDir Path tempDir) throws Exception {
+        // Write a temp properties file
+        Path propsFile = tempDir.resolve("test-oshi.properties");
+        Files.write(propsFile, "oshi.test.external=fromfile\n".getBytes(StandardCharsets.UTF_8));
+
+        // Set system property to point to it
+        System.setProperty("oshi.properties.file", propsFile.toString());
+        try {
+            Properties config = new Properties();
+            GlobalConfig.loadExternalConfig(config);
+            // External file value should be loaded
+            assertThat(config.getProperty("oshi.test.external"), is("fromfile"));
+            // System property override should win
+            System.setProperty("oshi.test.external", "fromsysprop");
+            config = new Properties();
+            GlobalConfig.loadExternalConfig(config);
+            assertThat(config.getProperty("oshi.test.external"), is("fromsysprop"));
+        } finally {
+            System.clearProperty("oshi.properties.file");
+            System.clearProperty("oshi.test.external");
+        }
+    }
+
+    @Test
+    void testLoadExternalConfigMissingFile() {
+        // Non-existent file should not throw or mutate config
+        System.setProperty("oshi.properties.file", "/nonexistent/path/oshi.properties");
+        try {
+            Properties config = new Properties();
+            GlobalConfig.loadExternalConfig(config);
+            assertThat("Config should not contain the meta-property", config.getProperty("oshi.properties.file"),
+                    is((String) null));
+        } finally {
+            System.clearProperty("oshi.properties.file");
+        }
+    }
+
+    @Test
+    void testEnvKeyToProperty() {
+        assertThat(GlobalConfig.envKeyToProperty("OSHI_OS_LINUX_PRIVILEGED_PREFIX"),
+                is("oshi.os.linux.privileged.prefix"));
+        assertThat(GlobalConfig.envKeyToProperty("OSHI_UTIL_MEMOIZER_EXPIRATION"), is("oshi.util.memoizer.expiration"));
+        assertThat(GlobalConfig.envKeyToProperty("OSHI_UTIL_PROC_PATH"), is("oshi.util.proc.path"));
+        // Verify renamed constants match their env var mapping
+        assertThat(GlobalConfig.envKeyToProperty("OSHI_OS_UNIX_WHOCOMMAND"), is(GlobalConfig.OSHI_OS_UNIX_WHOCOMMAND));
+        assertThat(GlobalConfig.envKeyToProperty("OSHI_OS_SOLARIS_ALLOWKSTAT2"),
+                is(GlobalConfig.OSHI_OS_SOLARIS_ALLOWKSTAT2));
     }
 
     private Properties propertiesWith(String value) {

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -3,7 +3,7 @@
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.oshi/oshi-core.svg?label=Maven%20Central)](https://central.sonatype.com/search?namespace=com.github.oshi&amp;sort=name)
 [![first-timers-only](https://img.shields.io/badge/first--timers--only-friendly-blue.svg?style=flat-square)](https://www.firsttimersonly.com/)
-[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/oshi/oshi)](https://app.coderabbit.ai/dashboard/summary)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/oshi/oshi?utm_source=oss&amp;utm_medium=github&amp;utm_campaign=oshi%2Foshi&amp;labelColor=171717&amp;color=FF570A&amp;link=https%3A%2F%2Fcoderabbit.ai&amp;label=CodeRabbit+Reviews)](https://app.coderabbit.ai/dashboard/summary)
 [![GitHub contributors](https://img.shields.io/github/contributors/oshi/oshi)](https://github.com/oshi/oshi/graphs/contributors)
 
 OSHI is a free native (JNA or FFM) Operating System and Hardware Information library for Java.


### PR DESCRIPTION
## Summary

Resolves #3222

Makes OSHI configuration accessible to containerized and framework-managed environments without requiring Java code or classpath manipulation.

## Configuration precedence (highest wins)

| Priority | Source | Example |
|----------|--------|---------|
| 1 | `GlobalConfig.set()` | `GlobalConfig.set("oshi.os.linux.privileged.prefix", "sudo -n");` |
| 2 | System properties | `java -Doshi.os.linux.privileged.prefix="sudo -n" -jar app.jar` |
| 3 | Environment variables | `export OSHI_OS_LINUX_PRIVILEGED_PREFIX="sudo -n"` |
| 4 | External properties file | `java -Doshi.properties.file=/etc/oshi.conf -jar app.jar` |
| 5 | Classpath `oshi.properties` | Defaults shipped in the JAR |

## Environment variable mapping

Variables with the `OSHI_` prefix are mapped by lowercasing and replacing underscores with dots:

`OSHI_OS_LINUX_PRIVILEGED_PREFIX` → `oshi.os.linux.privileged.prefix`

## Changes

- **`GlobalConfig.java`**:
  - Added `loadExternalConfig()` method handling external file + env vars + system properties
  - Added `envKeyToProperty()` helper (package-private, tested)
  - SLF4J logging for missing/unreadable external files
  - Excludes `oshi.properties.file` meta-property from config copy
  - Fixed broken javadoc on `OSHI_OS_LINUX_PRIVILEGED_FILE_ALLOWLIST`
- **`oshi.properties`**: Renamed camelCase keys to lowercase (`whoCommand` → `whocommand`, `allowKstat2` → `allowkstat2`)
- **`OperatingSystem.java`**: Updated javadoc reference to new key name
- **`FAQ.md`**: New comprehensive "How do I configure OSHI?" section with precedence table, env var examples (Docker, Kubernetes), external file, Spring Boot integration patterns
- **`UPGRADING.md`**: Documented property key renames
- **`CHANGELOG.md`**: Entry for this PR
- **`GlobalConfigTest.java`**: Tests for `loadExternalConfig()`, missing file handling, and `envKeyToProperty()` mapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for OSHI_* environment variables and an external properties file for configuration with defined precedence (external file → env vars → system properties → defaults).

* **Documentation**
  * Added FAQ and UPGRADING guidance describing configuration methods, precedence, examples, and migration notes.

* **Breaking Changes**
  * Configuration property keys standardized to lowercase (e.g., oshi.os.unix.whocommand, oshi.os.solaris.allowkstat2, oshi.os.linux.sensors.cputemperature.types).

* **Tests**
  * Added tests for external configuration loading and missing-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->