### PR TITLE
Add disk type information (SSD, HDD, Removable, Virtual)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#3225](https://github.com/oshi/oshi/pull/3225): Add CgroupInfo API with Linux cgroup v1/v2 support - [@rohan-coder02](https://github.com/rohan-coder02).
 * [#3229](https://github.com/oshi/oshi/pull/3229): Support environment variables (`OSHI_*`) for configuration - [@dbwiddis](https://github.com/dbwiddis).
+* [#2857](https://github.com/oshi/oshi/issues/2857): Add disk type information (SSD, HDD, Removable, Virtual) - [@dbwiddis](https://github.com/dbwiddis).
 * [#3223](https://github.com/oshi/oshi/issues/3223): Add `oshi-metrics` module with Micrometer integration for system metrics following OpenTelemetry semantic conventions - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32DiskDrive.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32DiskDrive.java
@@ -21,7 +21,7 @@ public class Win32DiskDrive {
      * Disk drive properties.
      */
     public enum DiskDriveProperty {
-        INDEX, MANUFACTURER, MODEL, NAME, SERIALNUMBER, SIZE;
+        INDEX, MANUFACTURER, MEDIATYPE, MODEL, NAME, SERIALNUMBER, SIZE;
     }
 
     protected Win32DiskDrive() {

--- a/oshi-common/src/main/java/oshi/hardware/HWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/HWDiskStore.java
@@ -52,6 +52,15 @@ public interface HWDiskStore {
     String getName();
 
     /**
+     * The type of the disk, such as SSD, HDD, Removable, Virtual, or Unknown.
+     *
+     * @return the disk type string
+     */
+    default String getDiskType() {
+        return "Unknown";
+    }
+
+    /**
      * The disk model
      *
      * @return the model

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractHWDiskStore.java
@@ -18,12 +18,18 @@ public abstract class AbstractHWDiskStore implements HWDiskStore {
     private final String model;
     private final String serial;
     private final long size;
+    private final String diskType;
 
     protected AbstractHWDiskStore(String name, String model, String serial, long size) {
+        this(name, model, serial, size, "Unknown");
+    }
+
+    protected AbstractHWDiskStore(String name, String model, String serial, long size, String diskType) {
         this.name = name;
         this.model = model;
         this.serial = serial;
         this.size = size;
+        this.diskType = diskType;
     }
 
     @Override
@@ -47,12 +53,18 @@ public abstract class AbstractHWDiskStore implements HWDiskStore {
     }
 
     @Override
+    public String getDiskType() {
+        return this.diskType;
+    }
+
+    @Override
     public String toString() {
         boolean readwrite = getReads() > 0 || getWrites() > 0;
         StringBuilder sb = new StringBuilder();
         sb.append(getName()).append(": ");
         sb.append("(model: ").append(getModel());
-        sb.append(" - S/N: ").append(getSerial()).append(") ");
+        sb.append(" - S/N: ").append(getSerial());
+        sb.append(" - type: ").append(getDiskType()).append(") ");
         sb.append("size: ").append(getSize() > 0 ? FormatUtil.formatBytesDecimal(getSize()) : "?").append(", ");
         sb.append("reads: ").append(readwrite ? getReads() : "?");
         sb.append(" (").append(readwrite ? FormatUtil.formatBytes(getReadBytes()) : "?").append("), ");

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
@@ -83,6 +83,10 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
         super(name, model, serial, size);
     }
 
+    protected LinuxHWDiskStore(String name, String model, String serial, long size, String diskType) {
+        super(name, model, serial, size, diskType);
+    }
+
     @Override
     public long getReads() {
         return reads;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsHWDiskStore.java
@@ -50,6 +50,10 @@ public abstract class WindowsHWDiskStore extends AbstractHWDiskStore {
         super(name, model, serial, size);
     }
 
+    protected WindowsHWDiskStore(String name, String model, String serial, long size, String diskType) {
+        super(name, model, serial, size, diskType);
+    }
+
     @Override
     public long getReads() {
         return reads;
@@ -322,5 +326,26 @@ public abstract class WindowsHWDiskStore extends AbstractHWDiskStore {
         public Map<String, List<HWPartition>> getPartitionMap() {
             return partitionMap;
         }
+    }
+
+    /**
+     * Parses the WMI MediaType string into a disk type.
+     *
+     * @param mediaType the WMI MediaType value from Win32_DiskDrive
+     * @return the disk type string
+     */
+    protected static String parseWindowsMediaType(String mediaType) {
+        if (mediaType == null || mediaType.isEmpty()) {
+            return "Unknown";
+        }
+        String lower = mediaType.toLowerCase(java.util.Locale.ROOT);
+        if (lower.contains("removable")) {
+            return "Removable";
+        } else if (lower.contains("fixed") || lower.contains("external")) {
+            // WMI Win32_DiskDrive MediaType doesn't distinguish SSD from HDD;
+            // "Fixed hard disk media" could be either. Return HDD as default for fixed.
+            return "HDD";
+        }
+        return "Unknown";
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
@@ -37,6 +37,10 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
         super(name, model, serial, size);
     }
 
+    LinuxHWDiskStoreFFM(String name, String model, String serial, long size, String diskType) {
+        super(name, model, serial, size, diskType);
+    }
+
     /**
      * Gets the disks on this machine
      *
@@ -97,7 +101,7 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
                                         devModel = LOGICAL_VOLUME_GROUP;
                                         devSerial = UdevFunctions.getPropertyValue(device, DM_UUID, arena);
                                         store = new LinuxHWDiskStoreFFM(devnode, devModel,
-                                                devSerial == null ? Constants.UNKNOWN : devSerial, devSize);
+                                                devSerial == null ? Constants.UNKNOWN : devSerial, devSize, "Virtual");
                                         if (devSerial != null && devSerial.startsWith("LVM-")) {
                                             String vgName = UdevFunctions.getPropertyValue(device, DM_VG_NAME, arena);
                                             String lvName = UdevFunctions.getPropertyValue(device, DM_LV_NAME, arena);
@@ -122,7 +126,8 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
                                     } else {
                                         store = new LinuxHWDiskStoreFFM(devnode,
                                                 devModel == null ? Constants.UNKNOWN : devModel,
-                                                devSerial == null ? Constants.UNKNOWN : devSerial, devSize);
+                                                devSerial == null ? Constants.UNKNOWN : devSerial, devSize,
+                                                detectDiskType(device, arena));
                                     }
                                     if (storeToUpdate == null) {
                                         computeDiskStats(store, UdevFunctions.getSysattrValue(device, STAT, arena));
@@ -190,5 +195,23 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
     @Override
     public boolean updateAttributes() {
         return !getDisks(this).isEmpty();
+    }
+
+    private static String detectDiskType(MemorySegment device, Arena arena) {
+        try {
+            String removable = UdevFunctions.getSysattrValue(device, "removable", arena);
+            if ("1".equals(removable)) {
+                return "Removable";
+            }
+            String rotational = UdevFunctions.getSysattrValue(device, "queue/rotational", arena);
+            if ("0".equals(rotational)) {
+                return "SSD";
+            } else if ("1".equals(rotational)) {
+                return "HDD";
+            }
+        } catch (Throwable t) { // NOSONAR
+            LOG.debug("Unable to read disk type sysattr", t);
+        }
+        return "Unknown";
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreFFM.java
@@ -52,6 +52,10 @@ public final class WindowsHWDiskStoreFFM extends WindowsHWDiskStore {
         super(name, model, serial, size);
     }
 
+    private WindowsHWDiskStoreFFM(String name, String model, String serial, long size, String diskType) {
+        super(name, model, serial, size, diskType);
+    }
+
     @Override
     protected DiskStats queryReadWriteStats(String index) {
         return populateDiskStats(index, PhysicalDiskFFM.queryDiskCounters());
@@ -78,7 +82,8 @@ public final class WindowsHWDiskStoreFFM extends WindowsHWDiskStore {
                         String.format(Locale.ROOT, "%s %s", WmiUtilFFM.getString(vals, DiskDriveProperty.MODEL, i),
                                 WmiUtilFFM.getString(vals, DiskDriveProperty.MANUFACTURER, i)).trim(),
                         ParseUtil.hexStringToString(WmiUtilFFM.getString(vals, DiskDriveProperty.SERIALNUMBER, i)),
-                        WmiUtilFFM.getUint64(vals, DiskDriveProperty.SIZE, i));
+                        WmiUtilFFM.getUint64(vals, DiskDriveProperty.SIZE, i),
+                        parseWindowsMediaType(WmiUtilFFM.getString(vals, DiskDriveProperty.MEDIATYPE, i)));
 
                 String index = Integer.toString(WmiUtilFFM.getUint32(vals, DiskDriveProperty.INDEX, i));
                 ds.setDiskStats(stats, index);

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
@@ -40,6 +40,10 @@ public final class LinuxHWDiskStoreJNA extends LinuxHWDiskStore {
         super(name, model, serial, size);
     }
 
+    LinuxHWDiskStoreJNA(String name, String model, String serial, long size, String diskType) {
+        super(name, model, serial, size, diskType);
+    }
+
     /**
      * Gets the disks on this machine
      *
@@ -84,7 +88,7 @@ public final class LinuxHWDiskStoreJNA extends LinuxHWDiskStore {
                                         devModel = LOGICAL_VOLUME_GROUP;
                                         devSerial = device.getPropertyValue(DM_UUID);
                                         store = new LinuxHWDiskStoreJNA(devnode, devModel,
-                                                devSerial == null ? Constants.UNKNOWN : devSerial, devSize);
+                                                devSerial == null ? Constants.UNKNOWN : devSerial, devSize, "Virtual");
                                         String vgName = device.getPropertyValue(DM_VG_NAME);
                                         String lvName = device.getPropertyValue(DM_LV_NAME);
                                         if (vgName != null && lvName != null && devSerial != null
@@ -106,7 +110,8 @@ public final class LinuxHWDiskStoreJNA extends LinuxHWDiskStore {
                                     } else {
                                         store = new LinuxHWDiskStoreJNA(devnode,
                                                 devModel == null ? Constants.UNKNOWN : devModel,
-                                                devSerial == null ? Constants.UNKNOWN : devSerial, devSize);
+                                                devSerial == null ? Constants.UNKNOWN : devSerial, devSize,
+                                                detectDiskType(device));
                                     }
                                     if (storeToUpdate == null) {
                                         computeDiskStats(store, device.getSysattrValue(STAT));
@@ -158,5 +163,19 @@ public final class LinuxHWDiskStoreJNA extends LinuxHWDiskStore {
     @Override
     public boolean updateAttributes() {
         return !getDisks(this).isEmpty();
+    }
+
+    private static String detectDiskType(UdevDevice device) {
+        String removable = device.getSysattrValue("removable");
+        if ("1".equals(removable)) {
+            return "Removable";
+        }
+        String rotational = device.getSysattrValue("queue/rotational");
+        if ("0".equals(rotational)) {
+            return "SSD";
+        } else if ("1".equals(rotational)) {
+            return "HDD";
+        }
+        return "Unknown";
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreJNA.java
@@ -47,6 +47,10 @@ public final class WindowsHWDiskStoreJNA extends WindowsHWDiskStore {
         super(name, model, serial, size);
     }
 
+    private WindowsHWDiskStoreJNA(String name, String model, String serial, long size, String diskType) {
+        super(name, model, serial, size, diskType);
+    }
+
     @Override
     protected DiskStats queryReadWriteStats(String index) {
         return populateDiskStats(index, PhysicalDiskJNA.queryDiskCounters());
@@ -72,7 +76,8 @@ public final class WindowsHWDiskStoreJNA extends WindowsHWDiskStore {
                         String.format(Locale.ROOT, "%s %s", WmiUtil.getString(vals, DiskDriveProperty.MODEL, i),
                                 WmiUtil.getString(vals, DiskDriveProperty.MANUFACTURER, i)).trim(),
                         ParseUtil.hexStringToString(WmiUtil.getString(vals, DiskDriveProperty.SERIALNUMBER, i)),
-                        WmiUtil.getUint64(vals, DiskDriveProperty.SIZE, i));
+                        WmiUtil.getUint64(vals, DiskDriveProperty.SIZE, i),
+                        parseWindowsMediaType(WmiUtil.getString(vals, DiskDriveProperty.MEDIATYPE, i)));
 
                 String index = Integer.toString(WmiUtil.getUint32(vals, DiskDriveProperty.INDEX, i));
                 ds.setDiskStats(stats, index);


### PR DESCRIPTION
## Summary

Resolves #2857

Adds a `getDiskType()` method to the `HWDiskStore` interface that reports the physical media type of a disk drive.

## Returned values

| Value | Meaning |
|-------|---------|
| `SSD` | Solid-state drive (rotational=0) |
| `HDD` | Hard disk drive (rotational=1) |
| `Removable` | Removable media (USB drives, SD cards, etc.) |
| `Virtual` | Device-mapper / logical volume |
| `Unknown` | Type could not be determined |

## Implementation

### Linux (JNA + FFM)
Reads sysfs attributes via udev:
- `/sys/block/<name>/removable` — 1 indicates removable media
- `/sys/block/<name>/queue/rotational` — 0 = SSD, 1 = HDD
- Device-mapper devices (`/dev/dm-*`) are reported as `Virtual`

### Other platforms
Returns `Unknown` via the interface default method. Windows (WMI MediaType) and macOS (IOKit) support can be added in follow-up PRs.

## API

```java
for (HWDiskStore disk : hal.getDiskStores()) {
    System.out.printf("%s: %s (%s)%n", disk.getName(), disk.getModel(), disk.getDiskType());
}
// /dev/sda: Samsung SSD 970 EVO (SSD)
// /dev/sdb: WDC WD40EFRX (HDD)
// /dev/sdc: Kingston DataTraveler (Removable)
```

## Changes

- `HWDiskStore.java`: Added `default String getDiskType()` returning `"Unknown"`
- `AbstractHWDiskStore.java`: Added `diskType` field, 5-arg constructor, `getDiskType()` override, updated `toString()`
- `LinuxHWDiskStore.java`: Added 5-arg constructor
- `LinuxHWDiskStoreJNA.java`: Added `detectDiskType()` using udev sysattr reads
- `LinuxHWDiskStoreFFM.java`: Same detection logic using FFM udev functions
- `CHANGELOG.md`: Entry for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disk type detection added: storage devices are now categorized as SSD, HDD, Removable, or Virtual, improving hardware reporting across platforms.

* **Documentation**
  * Changelog updated with a 7.1.0 entry noting the new disk type information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->