### PR TITLE
Add macOS disk type detection via IOKit

### DIFF
--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -258,6 +258,7 @@ class NativeComparisonTest {
             assertThat(f.getModel()).isEqualTo(j.getModel());
             assertThat(f.getSerial()).isEqualTo(j.getSerial());
             assertThat(f.getSize()).isEqualTo(j.getSize());
+            assertThat(f.getDiskType()).as("diskType(%s)", j.getName()).isEqualTo(j.getDiskType());
             // Stats are nondecreasing; FFM called second
             assertThat(f.getReads()).as("reads(%s)", j.getName()).isGreaterThanOrEqualTo(j.getReads());
             assertThat(f.getReadBytes()).as("readBytes(%s)", j.getName()).isGreaterThanOrEqualTo(j.getReadBytes());

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacHWDiskStore.java
@@ -31,6 +31,10 @@ public abstract class MacHWDiskStore extends AbstractHWDiskStore {
         super(name, model, serial, size);
     }
 
+    protected MacHWDiskStore(String name, String model, String serial, long size, String diskType) {
+        super(name, model, serial, size, diskType);
+    }
+
     @Override
     public long getReads() {
         return reads;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -50,6 +50,12 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
         updateDiskStats(session, mountPointMap, cfKeyMap);
     }
 
+    private MacHWDiskStoreFFM(String name, String model, String serial, long size, String diskType,
+            DASessionRef session, Map<String, String> mountPointMap, Map<CFKey, CFStringRef> cfKeyMap) {
+        super(name, model, serial, size, diskType);
+        updateDiskStats(session, mountPointMap, cfKeyMap);
+    }
+
     @Override
     public boolean updateAttributes() {
         try {
@@ -348,8 +354,8 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                     if (size <= 0) {
                         continue;
                     }
-                    diskList.add(new MacHWDiskStoreFFM(bsdName, model.trim(), serial.trim(), size, session,
-                            mountPointMap, cfKeyMap));
+                    diskList.add(new MacHWDiskStoreFFM(bsdName, model.trim(), serial.trim(), size,
+                            detectDiskType(bsdName), session, mountPointMap, cfKeyMap));
                 }
             } finally {
                 session.release();
@@ -376,6 +382,75 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
             keyMap.put(cfKey, CFStringRef.createCFString(cfKey.getKey()));
         }
         return keyMap;
+    }
+
+    private static String detectDiskType(String bsdName) {
+        MemorySegment matchingDict = IOKitUtilFFM.getBSDNameMatchingDict(bsdName);
+        if (matchingDict == null || matchingDict.equals(MemorySegment.NULL)) {
+            return "Unknown";
+        }
+        IOIterator iter = IOKitUtilFFM.getMatchingServices(matchingDict);
+        if (iter == null) {
+            return "Unknown";
+        }
+        try {
+            IORegistryEntry media = iter.next();
+            if (media == null) {
+                return "Unknown";
+            }
+            try {
+                // Check removable at the IOMedia level
+                Boolean removable = media.getBooleanProperty("Removable");
+                if (removable != null && removable) {
+                    return "Removable";
+                }
+                // Traverse up: IOMedia -> IOBlockStorageDriver -> IOBlockStorageDevice
+                IORegistryEntry driver = media.getParentEntry("IOService");
+                if (driver != null) {
+                    try {
+                        IORegistryEntry device = driver.getParentEntry("IOService");
+                        if (device != null) {
+                            try {
+                                MemorySegment propsSeg = device.createCFProperties();
+                                if (!propsSeg.equals(MemorySegment.NULL)) {
+                                    CFDictionaryRef props = new CFDictionaryRef(propsSeg);
+                                    try {
+                                        MemorySegment charSeg = props
+                                                .getValue(CFStringRef.createCFString("Device Characteristics"));
+                                        if (!charSeg.equals(MemorySegment.NULL)) {
+                                            CFDictionaryRef chars = new CFDictionaryRef(charSeg);
+                                            MemorySegment typeSeg = chars
+                                                    .getValue(CFStringRef.createCFString("Medium Type"));
+                                            if (!typeSeg.equals(MemorySegment.NULL)) {
+                                                String type = new CFStringRef(typeSeg).stringValue();
+                                                if (type != null) {
+                                                    if (type.contains("Solid State") || type.contains("SSD")) {
+                                                        return "SSD";
+                                                    } else if (type.contains("Rotational")) {
+                                                        return "HDD";
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    } finally {
+                                        props.release();
+                                    }
+                                }
+                            } finally {
+                                device.release();
+                            }
+                        }
+                    } finally {
+                        driver.release();
+                    }
+                }
+            } finally {
+                media.release();
+            }
+        } finally {
+            iter.release();
+        }
+        return "Unknown";
     }
 
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
@@ -51,9 +51,9 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacHWDiskStoreJNA.class);
 
-    private MacHWDiskStoreJNA(String name, String model, String serial, long size, DASessionRef session,
-            Map<String, String> mountPointMap, Map<CFKey, CFStringRef> cfKeyMap) {
-        super(name, model, serial, size);
+    private MacHWDiskStoreJNA(String name, String model, String serial, long size, String diskType,
+            DASessionRef session, Map<String, String> mountPointMap, Map<CFKey, CFStringRef> cfKeyMap) {
+        super(name, model, serial, size, diskType);
         updateDiskStats(session, mountPointMap, cfKeyMap);
     }
 
@@ -330,8 +330,8 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
                 if (size <= 0) {
                     continue;
                 }
-                HWDiskStore diskStore = new MacHWDiskStoreJNA(bsdName, model.trim(), serial.trim(), size, session,
-                        mountPointMap, cfKeyMap);
+                HWDiskStore diskStore = new MacHWDiskStoreJNA(bsdName, model.trim(), serial.trim(), size,
+                        detectDiskType(bsdName), session, mountPointMap, cfKeyMap);
                 diskList.add(diskStore);
             }
         }
@@ -354,6 +354,70 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
             keyMap.put(cfKey, CFStringRef.createCFString(cfKey.getKey()));
         }
         return keyMap;
+    }
+
+    private static String detectDiskType(String bsdName) {
+        CFMutableDictionaryRef matchingDict = IOKitUtil.getBSDNameMatchingDict(bsdName);
+        if (matchingDict == null) {
+            return "Unknown";
+        }
+        IOIterator iter = IOKitUtil.getMatchingServices(matchingDict);
+        if (iter == null) {
+            return "Unknown";
+        }
+        try {
+            IORegistryEntry media = iter.next();
+            if (media != null) {
+                try {
+                    // Check removable at the IOMedia level
+                    Boolean removable = media.getBooleanProperty("Removable");
+                    if (removable != null && removable) {
+                        return "Removable";
+                    }
+                    // Traverse up: IOMedia -> IOBlockStorageDriver -> IOBlockStorageDevice
+                    IORegistryEntry driver = media.getParentEntry("IOService");
+                    if (driver != null) {
+                        try {
+                            IORegistryEntry device = driver.getParentEntry("IOService");
+                            if (device != null) {
+                                try {
+                                    CFMutableDictionaryRef props = device.createCFProperties();
+                                    if (props != null) {
+                                        Pointer charDict = props
+                                                .getValue(CFStringRef.createCFString("Device Characteristics"));
+                                        if (charDict != null) {
+                                            CFDictionaryRef characteristics = new CFDictionaryRef(charDict);
+                                            Pointer mediumType = characteristics
+                                                    .getValue(CFStringRef.createCFString("Medium Type"));
+                                            if (mediumType != null) {
+                                                String type = CFUtil.cfPointerToString(mediumType);
+                                                if (type != null) {
+                                                    if (type.contains("Solid State") || type.contains("SSD")) {
+                                                        return "SSD";
+                                                    } else if (type.contains("Rotational")) {
+                                                        return "HDD";
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        props.release();
+                                    }
+                                } finally {
+                                    device.release();
+                                }
+                            }
+                        } finally {
+                            driver.release();
+                        }
+                    }
+                } finally {
+                    media.release();
+                }
+            }
+        } finally {
+            iter.release();
+        }
+        return "Unknown";
     }
 
 }


### PR DESCRIPTION
## Summary

Follow-up to #3230 — adds macOS disk type detection for both JNA and FFM backends.

## Implementation

Traverses the IOKit registry hierarchy:
```
IOMedia (has 'Removable' property)
  └── IOBlockStorageDriver
      └── IOBlockStorageDevice (has 'Device Characteristics' -> 'Medium Type')
```

- **Removable**: Detected from `IOMedia.Removable` boolean property
- **SSD**: `Medium Type` contains "Solid State" or "SSD"
- **HDD**: `Medium Type` contains "Rotational"
- **Unknown**: If properties are unavailable

## Changes

- `MacHWDiskStore.java`: Added 5-arg constructor with diskType
- `MacHWDiskStoreJNA.java`: Added `detectDiskType()` using JNA IOKit bindings
- `MacHWDiskStoreFFM.java`: Added `detectDiskType()` using FFM IOKit bindings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS disk detection now classifies disk types (SSD, HDD, Removable, Unknown) and includes this info in hardware reports.
* **Tests**
  * Added a test to validate disk type classification is consistent across native implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->