### PR TITLE
Add voluntary/involuntary context switch methods to OSProcess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#3225](https://github.com/oshi/oshi/pull/3225): Add CgroupInfo API with Linux cgroup v1/v2 support - [@rohan-coder02](https://github.com/rohan-coder02).
 * [#3229](https://github.com/oshi/oshi/pull/3229): Support environment variables (`OSHI_*`) for configuration - [@dbwiddis](https://github.com/dbwiddis).
 * [#2857](https://github.com/oshi/oshi/issues/2857): Add disk type information (SSD, HDD, Removable, Virtual) - [@dbwiddis](https://github.com/dbwiddis).
+* [#2904](https://github.com/oshi/oshi/issues/2904): Add voluntary/involuntary context switch methods to OSProcess - [@dbwiddis](https://github.com/dbwiddis).
 * [#3223](https://github.com/oshi/oshi/issues/3223): Add `oshi-metrics` module with Micrometer integration for system metrics following OpenTelemetry semantic conventions - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -391,6 +391,12 @@ class NativeComparisonTest {
                 .isLessThanOrEqualTo(Math.max(jna.getUpTime() / 10, 300L));
         assertThat(ffm.getStartTime()).isEqualTo(jna.getStartTime());
         assertThat(ffm.getCommandLine()).isEqualTo(jna.getCommandLine());
+        // Context switches: both use getrusage, snapshots taken at different times
+        assertWithinRatio(ffm.getContextSwitches(), jna.getContextSwitches(), 0.1, "process.contextSwitches");
+        assertWithinRatio(ffm.getVoluntaryContextSwitches(), jna.getVoluntaryContextSwitches(), 0.1,
+                "process.voluntaryContextSwitches");
+        assertWithinRatio(ffm.getInvoluntaryContextSwitches(), jna.getInvoluntaryContextSwitches(), 0.1,
+                "process.involuntaryContextSwitches");
     }
 
     @Test

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -101,7 +101,8 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
     private long bytesWritten;
     private long minorFaults;
     private long majorFaults;
-    private long contextSwitches;
+    private long voluntaryContextSwitches;
+    private long involuntaryContextSwitches;
 
     public LinuxOSProcess(int pid, LinuxOperatingSystem os) {
         super(pid);
@@ -275,8 +276,13 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
+    public long getVoluntaryContextSwitches() {
+        return this.voluntaryContextSwitches;
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        return this.involuntaryContextSwitches;
     }
 
     @Override
@@ -431,7 +437,8 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         this.majorFaults = statArray[ProcPidStat.MAJOR_FAULTS.ordinal()];
         long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(status.get("nonvoluntary_ctxt_switches"), 0L);
         long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(status.get("voluntary_ctxt_switches"), 0L);
-        this.contextSwitches = voluntaryContextSwitches + nonVoluntaryContextSwitches;
+        this.voluntaryContextSwitches = voluntaryContextSwitches;
+        this.involuntaryContextSwitches = nonVoluntaryContextSwitches;
 
         this.upTime = now - startTime;
 

--- a/oshi-common/src/main/java/oshi/software/os/OSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSProcess.java
@@ -417,17 +417,49 @@ public interface OSProcess {
     }
 
     /**
-     * A snapshot of the context switches the process has done. Since the context switches could be voluntary and
-     * non-voluntary, this gives the sum of both.
+     * A snapshot of the context switches the process has done, equal to the sum of
+     * {@link #getVoluntaryContextSwitches()} and {@link #getInvoluntaryContextSwitches()} on platforms that provide the
+     * split. On Windows, this returns the total from performance counters but the split is unavailable (returns 0). On
+     * macOS for non-current processes, this returns the combined total from the kernel but the split is unavailable.
      * <p>
-     * Not available on Windows. An approximation may be made by summing associated values from
-     * {@link OSThread#getContextSwitches()}.
+     * For the current process on supported POSIX platforms, this aggregates across all threads via
+     * {@code getrusage(RUSAGE_SELF)}. For other processes, platform-specific sources are used.
      * <p>
-     * Not available on AIX.
+     * Not available on AIX (returns 0).
      *
      * @return sum of both voluntary and involuntary context switches if available, 0 otherwise.
      */
     default long getContextSwitches() {
+        return getVoluntaryContextSwitches() + getInvoluntaryContextSwitches();
+    }
+
+    /**
+     * The number of voluntary context switches the process has made. A voluntary context switch occurs when a process
+     * gives up the CPU before its time slice expires (e.g., waiting for I/O).
+     * <p>
+     * For the current process, {@code getrusage(RUSAGE_SELF)} is used on supported POSIX platforms, which aggregates
+     * across all threads. For other processes, platform-specific sources are used ({@code /proc/[pid]/status} on Linux,
+     * {@code ps} on FreeBSD/OpenBSD, {@code /proc/[pid]/usage} on Solaris). On macOS, the split is only available for
+     * the current process; for other processes this returns 0.
+     *
+     * @return voluntary context switches if available, 0 otherwise.
+     */
+    default long getVoluntaryContextSwitches() {
+        return 0L;
+    }
+
+    /**
+     * The number of involuntary context switches the process has made. An involuntary context switch occurs when the
+     * scheduler preempts the process (e.g., time slice expired).
+     * <p>
+     * For the current process, {@code getrusage(RUSAGE_SELF)} is used on supported POSIX platforms, which aggregates
+     * across all threads. For other processes, platform-specific sources are used ({@code /proc/[pid]/status} on Linux,
+     * {@code ps} on FreeBSD/OpenBSD, {@code /proc/[pid]/usage} on Solaris). On macOS, the split is only available for
+     * the current process; for other processes this returns 0.
+     *
+     * @return involuntary context switches if available, 0 otherwise.
+     */
+    default long getInvoluntaryContextSwitches() {
         return 0L;
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/linux/LinuxLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/linux/LinuxLibcFunctions.java
@@ -130,6 +130,15 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
     private static final VarHandle RLIMIT_MAX = RLIMIT_LAYOUT
             .varHandle(MemoryLayout.PathElement.groupElement("rlim_max"));
 
+    /** Size of {@code struct rusage} on LP64 Linux (18 longs = 144 bytes). */
+    public static final long RUSAGE_SIZE = 144L;
+    /** Byte offset of {@code ru_nvcsw} in {@code struct rusage} (16th long). */
+    public static final long RUSAGE_NVCSW_OFFSET = 128L;
+    /** Byte offset of {@code ru_nivcsw} in {@code struct rusage} (17th long). */
+    public static final long RUSAGE_NIVCSW_OFFSET = 136L;
+
+    public static final int RUSAGE_SELF = 0;
+
     /**
      * {@code struct addrinfo} layout (64-bit Linux).
      *
@@ -217,6 +226,7 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
     private static final MethodHandle freeaddrinfo;
     private static final MethodHandle gai_strerror;
     private static final MethodHandle getrlimit;
+    private static final MethodHandle getrusage;
 
     private static final boolean HAS_GETTID;
 
@@ -244,6 +254,8 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
         gai_strerror = LINKER.downcallHandle(libc.findOrThrow("gai_strerror"),
                 FunctionDescriptor.of(ADDRESS, JAVA_INT));
         getrlimit = LINKER.downcallHandle(libc.findOrThrow("getrlimit"),
+                FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
+        getrusage = LINKER.downcallHandle(libc.findOrThrow("getrusage"),
                 FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
 
         MethodHandle hGettid = null;
@@ -555,6 +567,18 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
      */
     public static int getrlimit(int resource, MemorySegment rlim) throws Throwable {
         return (int) getrlimit.invokeExact(resource, rlim);
+    }
+
+    /**
+     * Calls {@code getrusage(who, rusage)}.
+     *
+     * @param who    RUSAGE_SELF (0)
+     * @param rusage segment of at least {@link #RUSAGE_SIZE} bytes
+     * @return 0 on success, -1 on failure
+     * @throws Throwable on FFM invocation error
+     */
+    public static int getrusage(int who, MemorySegment rusage) throws Throwable {
+        return (int) getrusage.invokeExact(who, rusage);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/mac/MacSystemFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/mac/MacSystemFunctions.java
@@ -97,6 +97,23 @@ public final class MacSystemFunctions extends MacForeignFunctions {
         return (int) getpid.invokeExact();
     }
 
+    // int getrusage(int who, struct rusage *rusage);
+
+    public static final int RUSAGE_SELF = 0;
+    /** Size of struct rusage on macOS LP64 (2 timevals of 16 bytes + 14 longs = 144 bytes). */
+    public static final long RUSAGE_SIZE = 144L;
+    /** Byte offset of ru_nvcsw in struct rusage. */
+    public static final long RUSAGE_NVCSW_OFFSET = 128L;
+    /** Byte offset of ru_nivcsw in struct rusage. */
+    public static final long RUSAGE_NIVCSW_OFFSET = 136L;
+
+    private static final MethodHandle getrusage = LINKER.downcallHandle(SYSTEM_LIBRARY.findOrThrow("getrusage"),
+            FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
+
+    public static int getrusage(int who, MemorySegment rusage) throws Throwable {
+        return (int) getrusage.invokeExact(who, rusage);
+    }
+
     // int sysctl(int *name, u_int namelen, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
 
     private static final MethodHandle sysctl = LINKER.downcallHandle(SYSTEM_LIBRARY.findOrThrow("sysctl"),

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
@@ -6,6 +6,7 @@ package oshi.software.os.linux;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,15 +17,56 @@ import oshi.software.common.os.linux.LinuxOSProcess;
 import oshi.software.common.os.linux.LinuxOperatingSystem;
 
 /**
- * FFM-based Linux OS process. Implements {@code getrlimit} via FFM.
+ * FFM-based Linux OS process. Implements {@code getrlimit} and {@code getrusage} via FFM.
  */
 @ThreadSafe
 public class LinuxOSProcessFFM extends LinuxOSProcess {
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxOSProcessFFM.class);
 
+    private boolean rusagePopulated;
+    private long cachedVoluntaryContextSwitches;
+    private long cachedInvoluntaryContextSwitches;
+
     public LinuxOSProcessFFM(int pid, LinuxOperatingSystem os) {
         super(pid, os);
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        boolean result = super.updateAttributes();
+        if (getProcessID() == getOs().getProcessId()) {
+            this.rusagePopulated = false;
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment rusage = arena.allocate(LinuxLibcFunctions.RUSAGE_SIZE);
+                if (0 == LinuxLibcFunctions.getrusage(LinuxLibcFunctions.RUSAGE_SELF, rusage)) {
+                    this.cachedVoluntaryContextSwitches = rusage.get(ValueLayout.JAVA_LONG,
+                            LinuxLibcFunctions.RUSAGE_NVCSW_OFFSET);
+                    this.cachedInvoluntaryContextSwitches = rusage.get(ValueLayout.JAVA_LONG,
+                            LinuxLibcFunctions.RUSAGE_NIVCSW_OFFSET);
+                    this.rusagePopulated = true;
+                }
+            } catch (Throwable e) {
+                LOG.debug("FFM getrusage failed: {}", e.toString());
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public long getVoluntaryContextSwitches() {
+        if (rusagePopulated) {
+            return cachedVoluntaryContextSwitches;
+        }
+        return super.getVoluntaryContextSwitches();
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        if (rusagePopulated) {
+            return cachedInvoluntaryContextSwitches;
+        }
+        return super.getInvoluntaryContextSwitches();
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
@@ -87,6 +87,7 @@ import oshi.driver.common.mac.ThreadInfo;
 import oshi.ffm.ForeignFunctions;
 import oshi.ffm.mac.IOKit.IOIterator;
 import oshi.ffm.mac.IOKit.IORegistryEntry;
+import oshi.ffm.mac.MacSystemFunctions;
 import oshi.ffm.util.platform.mac.IOKitUtilFFM;
 import oshi.software.common.AbstractOSProcess;
 import oshi.software.common.os.mac.MacOSThread;
@@ -182,6 +183,8 @@ public class MacOSProcessFFM extends AbstractOSProcess {
     private long minorFaults;
     private long majorFaults;
     private long contextSwitches;
+    private long voluntaryContextSwitches;
+    private long involuntaryContextSwitches;
 
     public MacOSProcessFFM(int pid, int major, int minor, MacOperatingSystemFFM os) {
         super(pid);
@@ -456,6 +459,16 @@ public class MacOSProcessFFM extends AbstractOSProcess {
     }
 
     @Override
+    public long getVoluntaryContextSwitches() {
+        return this.voluntaryContextSwitches;
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        return this.involuntaryContextSwitches;
+    }
+
+    @Override
     public boolean updateAttributes() {
         long now = System.currentTimeMillis();
         int pid = getProcessID();
@@ -550,6 +563,26 @@ public class MacOSProcessFFM extends AbstractOSProcess {
             // testing using getrusage confirms pti_faults includes both major and minor
             this.minorFaults = totalFaults - this.majorFaults;
             this.contextSwitches = ptinfo.get(JAVA_INT, PROC_TASK_INFO.byteOffset(PTI_CSW));
+            // getrusage(RUSAGE_SELF) aggregates across all threads for current process
+            if (getProcessID() == this.os.getProcessId()) {
+                try {
+                    MemorySegment rusageSegment = arena.allocate(MacSystemFunctions.RUSAGE_SIZE);
+                    if (0 == MacSystemFunctions.getrusage(MacSystemFunctions.RUSAGE_SELF, rusageSegment)) {
+                        this.voluntaryContextSwitches = rusageSegment.get(JAVA_LONG,
+                                MacSystemFunctions.RUSAGE_NVCSW_OFFSET);
+                        this.involuntaryContextSwitches = rusageSegment.get(JAVA_LONG,
+                                MacSystemFunctions.RUSAGE_NIVCSW_OFFSET);
+                        this.contextSwitches = this.voluntaryContextSwitches + this.involuntaryContextSwitches;
+                    } else {
+                        this.voluntaryContextSwitches = 0L;
+                        this.involuntaryContextSwitches = 0L;
+                    }
+                } catch (Throwable t) {
+                    LOG.debug("FFM getrusage failed: {}", t.toString());
+                    this.voluntaryContextSwitches = 0L;
+                    this.involuntaryContextSwitches = 0L;
+                }
+            }
 
             // Get rusage info for newer OS versions
             if (this.majorVersion > 10 || (this.majorVersion == 10 && this.minorVersion >= 9)) {

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/LinuxLibc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 The OSHI Project Contributors
+ * Copyright 2019-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.jna.platform.linux;
@@ -93,4 +93,30 @@ public interface LinuxLibc extends LibC, CLibrary {
      *         success. A -1 return value indicates an error, and an error code is stored in errno.
      */
     NativeLong syscall(NativeLong number, Object... args);
+
+    @FieldOrder({ "ru_utime_sec", "ru_utime_usec", "ru_stime_sec", "ru_stime_usec", "ru_maxrss", "ru_ixrss", "ru_idrss",
+            "ru_isrss", "ru_minflt", "ru_majflt", "ru_nswap", "ru_inblock", "ru_oublock", "ru_msgsnd", "ru_msgrcv",
+            "ru_nsignals", "ru_nvcsw", "ru_nivcsw" })
+    class Rusage extends Structure {
+        public NativeLong ru_utime_sec;
+        public NativeLong ru_utime_usec;
+        public NativeLong ru_stime_sec;
+        public NativeLong ru_stime_usec;
+        public NativeLong ru_maxrss;
+        public NativeLong ru_ixrss;
+        public NativeLong ru_idrss;
+        public NativeLong ru_isrss;
+        public NativeLong ru_minflt;
+        public NativeLong ru_majflt;
+        public NativeLong ru_nswap;
+        public NativeLong ru_inblock;
+        public NativeLong ru_oublock;
+        public NativeLong ru_msgsnd;
+        public NativeLong ru_msgrcv;
+        public NativeLong ru_nsignals;
+        public NativeLong ru_nvcsw;
+        public NativeLong ru_nivcsw;
+    }
+
+    int getrusage(int who, Rusage rusage);
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/SystemB.java
@@ -5,6 +5,7 @@
 package oshi.jna.platform.mac;
 
 import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.Union;
@@ -186,4 +187,30 @@ public interface SystemB extends com.sun.jna.platform.mac.SystemB, CLibrary {
 
     // kern_return_t vm_deallocate(vm_map_t target_task, vm_address_t address, vm_size_t size);
     int vm_deallocate(int targetTask, long address, long size);
+
+    @FieldOrder({ "ru_utime_sec", "ru_utime_usec", "ru_stime_sec", "ru_stime_usec", "ru_maxrss", "ru_ixrss", "ru_idrss",
+            "ru_isrss", "ru_minflt", "ru_majflt", "ru_nswap", "ru_inblock", "ru_oublock", "ru_msgsnd", "ru_msgrcv",
+            "ru_nsignals", "ru_nvcsw", "ru_nivcsw" })
+    class Rusage extends Structure {
+        public NativeLong ru_utime_sec;
+        public int ru_utime_usec;
+        public NativeLong ru_stime_sec;
+        public int ru_stime_usec;
+        public NativeLong ru_maxrss;
+        public NativeLong ru_ixrss;
+        public NativeLong ru_idrss;
+        public NativeLong ru_isrss;
+        public NativeLong ru_minflt;
+        public NativeLong ru_majflt;
+        public NativeLong ru_nswap;
+        public NativeLong ru_inblock;
+        public NativeLong ru_oublock;
+        public NativeLong ru_msgsnd;
+        public NativeLong ru_msgrcv;
+        public NativeLong ru_nsignals;
+        public NativeLong ru_nvcsw;
+        public NativeLong ru_nivcsw;
+    }
+
+    int getrusage(int who, Rusage rusage);
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/unix/CLibrary.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/unix/CLibrary.java
@@ -22,6 +22,8 @@ public interface CLibrary extends LibCAPI, Library {
 
     int AI_CANONNAME = 2;
 
+    int RUSAGE_SELF = 0;
+
     int UT_LINESIZE = 32;
     int UT_NAMESIZE = 32;
     int UT_HOSTSIZE = 256;

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcessJNA.java
@@ -12,13 +12,48 @@ import oshi.software.common.os.linux.LinuxOSProcess;
 import oshi.software.common.os.linux.LinuxOperatingSystem;
 
 /**
- * JNA-based Linux OS process. Implements {@code getrlimit} via JNA.
+ * JNA-based Linux OS process. Implements {@code getrlimit} and {@code getrusage} via JNA.
  */
 @ThreadSafe
 public class LinuxOSProcessJNA extends LinuxOSProcess {
 
+    private boolean rusagePopulated;
+    private long cachedVoluntaryContextSwitches;
+    private long cachedInvoluntaryContextSwitches;
+
     public LinuxOSProcessJNA(int pid, LinuxOperatingSystem os) {
         super(pid, os);
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        boolean result = super.updateAttributes();
+        if (getProcessID() == getOs().getProcessId()) {
+            this.rusagePopulated = false;
+            LinuxLibc.Rusage rusage = new LinuxLibc.Rusage();
+            if (0 == LinuxLibc.INSTANCE.getrusage(LinuxLibc.RUSAGE_SELF, rusage)) {
+                this.cachedVoluntaryContextSwitches = rusage.ru_nvcsw.longValue();
+                this.cachedInvoluntaryContextSwitches = rusage.ru_nivcsw.longValue();
+                this.rusagePopulated = true;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public long getVoluntaryContextSwitches() {
+        if (rusagePopulated) {
+            return cachedVoluntaryContextSwitches;
+        }
+        return super.getVoluntaryContextSwitches();
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        if (rusagePopulated) {
+            return cachedInvoluntaryContextSwitches;
+        }
+        return super.getInvoluntaryContextSwitches();
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
@@ -32,7 +32,6 @@ import com.sun.jna.Native;
 import com.sun.jna.platform.mac.IOKit.IOIterator;
 import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
 import com.sun.jna.platform.mac.IOKitUtil;
-import com.sun.jna.platform.mac.SystemB;
 import com.sun.jna.platform.mac.SystemB.Group;
 import com.sun.jna.platform.mac.SystemB.Passwd;
 import com.sun.jna.platform.unix.LibCAPI.size_t;
@@ -43,6 +42,7 @@ import oshi.driver.common.mac.ThreadInfo;
 import oshi.jna.Struct.CloseableProcTaskAllInfo;
 import oshi.jna.Struct.CloseableRUsageInfoV2;
 import oshi.jna.Struct.CloseableVnodePathInfo;
+import oshi.jna.platform.mac.SystemB;
 import oshi.software.common.AbstractOSProcess;
 import oshi.software.common.os.mac.MacOSThread;
 import oshi.software.common.os.mac.MacOperatingSystem;
@@ -138,6 +138,8 @@ public class MacOSProcessJNA extends AbstractOSProcess {
     private long minorFaults;
     private long majorFaults;
     private long contextSwitches;
+    private long voluntaryContextSwitches;
+    private long involuntaryContextSwitches;
 
     public MacOSProcessJNA(int pid, int major, int minor, MacOperatingSystem os) {
         super(pid);
@@ -401,6 +403,16 @@ public class MacOSProcessJNA extends AbstractOSProcess {
     }
 
     @Override
+    public long getVoluntaryContextSwitches() {
+        return this.voluntaryContextSwitches;
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        return this.involuntaryContextSwitches;
+    }
+
+    @Override
     public boolean updateAttributes() {
         long now = System.currentTimeMillis();
         try (CloseableProcTaskAllInfo taskAllInfo = new CloseableProcTaskAllInfo()) {
@@ -469,7 +481,24 @@ public class MacOSProcessJNA extends AbstractOSProcess {
             this.majorFaults = taskAllInfo.ptinfo.pti_pageins;
             // testing using getrusage confirms pti_faults includes both major and minor
             this.minorFaults = taskAllInfo.ptinfo.pti_faults - taskAllInfo.ptinfo.pti_pageins; // NOSONAR squid:S2184
-            this.contextSwitches = taskAllInfo.ptinfo.pti_csw;
+            // getrusage(RUSAGE_SELF) aggregates across all threads for current process
+            if (getProcessID() == this.os.getProcessId()) {
+                oshi.jna.platform.mac.SystemB.Rusage rusage = new oshi.jna.platform.mac.SystemB.Rusage();
+                if (0 == oshi.jna.platform.mac.SystemB.INSTANCE.getrusage(oshi.jna.platform.mac.SystemB.RUSAGE_SELF,
+                        rusage)) {
+                    this.voluntaryContextSwitches = rusage.ru_nvcsw.longValue();
+                    this.involuntaryContextSwitches = rusage.ru_nivcsw.longValue();
+                    this.contextSwitches = this.voluntaryContextSwitches + this.involuntaryContextSwitches;
+                } else {
+                    // getrusage failed; fall back to pti_csw (combined only)
+                    this.contextSwitches = taskAllInfo.ptinfo.pti_csw;
+                    this.voluntaryContextSwitches = 0L;
+                    this.involuntaryContextSwitches = 0L;
+                }
+            } else {
+                // For other processes, only combined total is available via pti_csw
+                this.contextSwitches = taskAllInfo.ptinfo.pti_csw;
+            }
         }
         if (this.majorVersion > 10 || (this.majorVersion == 10 && this.minorVersion >= 9)) {
             try (CloseableRUsageInfoV2 rUsageInfoV2 = new CloseableRUsageInfoV2()) {

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcess.java
@@ -26,13 +26,13 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import com.sun.jna.platform.unix.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sun.jna.Memory;
 import com.sun.jna.Native;
 import com.sun.jna.platform.unix.LibCAPI.size_t;
+import com.sun.jna.platform.unix.Resource;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseableSizeTByReference;
@@ -93,7 +93,8 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
     private long bytesWritten;
     private long minorFaults;
     private long majorFaults;
-    private long contextSwitches;
+    private long voluntaryContextSwitches;
+    private long involuntaryContextSwitches;
     private String commandLineBackup;
 
     public FreeBsdOSProcess(int pid, Map<PsKeywords, String> psMap, FreeBsdOperatingSystem os) {
@@ -367,8 +368,13 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
+    public long getVoluntaryContextSwitches() {
+        return this.voluntaryContextSwitches;
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        return this.involuntaryContextSwitches;
     }
 
     @Override
@@ -430,11 +436,12 @@ public class FreeBsdOSProcess extends AbstractOSProcess {
         this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.TIME), 0L) - this.kernelTime;
         this.path = psMap.get(PsKeywords.COMM);
         this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
-        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
-        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
-        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
-        this.contextSwitches = voluntaryContextSwitches + nonVoluntaryContextSwitches;
+        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
+        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
+        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
+        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
+        this.voluntaryContextSwitches = voluntaryContextSwitches;
+        this.involuntaryContextSwitches = nonVoluntaryContextSwitches;
         this.commandLineBackup = psMap.get(PsKeywords.ARGS);
         return true;
     }

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcess.java
@@ -25,7 +25,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import com.sun.jna.platform.unix.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +32,7 @@ import com.sun.jna.Memory;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.unix.LibCAPI.size_t;
+import com.sun.jna.platform.unix.Resource;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseableSizeTByReference;
@@ -106,7 +106,8 @@ public class OpenBsdOSProcess extends AbstractOSProcess {
     private long bytesWritten;
     private long minorFaults;
     private long majorFaults;
-    private long contextSwitches;
+    private long voluntaryContextSwitches;
+    private long involuntaryContextSwitches;
     private int bitness;
     private String commandLineBackup;
 
@@ -383,8 +384,13 @@ public class OpenBsdOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
+    public long getVoluntaryContextSwitches() {
+        return this.voluntaryContextSwitches;
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        return this.involuntaryContextSwitches;
     }
 
     @Override
@@ -452,7 +458,8 @@ public class OpenBsdOSProcess extends AbstractOSProcess {
         this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
         long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
         long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        this.contextSwitches = voluntaryContextSwitches + nonVoluntaryContextSwitches;
+        this.voluntaryContextSwitches = voluntaryContextSwitches;
+        this.involuntaryContextSwitches = nonVoluntaryContextSwitches;
         this.commandLineBackup = psMap.get(PsKeywords.ARGS);
         return true;
     }

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcess.java
@@ -30,11 +30,11 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.sun.jna.platform.unix.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sun.jna.Native;
+import com.sun.jna.platform.unix.Resource;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.solaris.PsInfo;
@@ -87,7 +87,8 @@ public class SolarisOSProcess extends AbstractOSProcess {
     private long bytesWritten;
     private long minorFaults;
     private long majorFaults;
-    private long contextSwitches = 0; // default
+    private long voluntaryContextSwitches;
+    private long involuntaryContextSwitches;
 
     public SolarisOSProcess(int pid, SolarisOperatingSystem os) {
         super(pid);
@@ -247,8 +248,13 @@ public class SolarisOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
+    public long getVoluntaryContextSwitches() {
+        return this.voluntaryContextSwitches;
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        return this.involuntaryContextSwitches;
     }
 
     @Override
@@ -386,7 +392,8 @@ public class SolarisOSProcess extends AbstractOSProcess {
             this.bytesRead = usage.pr_ioch.longValue();
             this.majorFaults = usage.pr_majf.longValue();
             this.minorFaults = usage.pr_minf.longValue();
-            this.contextSwitches = usage.pr_ictx.longValue() + usage.pr_vctx.longValue();
+            this.voluntaryContextSwitches = usage.pr_vctx.longValue();
+            this.involuntaryContextSwitches = usage.pr_ictx.longValue();
         }
         return true;
     }

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -173,7 +173,7 @@ Not implemented — OSHI does not expose system-level major/minor page fault cou
 | `process.thread.count` | Gauge | `{thread}` | — | Thread count |
 | `process.open_file_descriptor.count` | Gauge | `{file_descriptor}` | — | Open file descriptors |
 | `process.paging.faults` | FunctionCounter | `{fault}` | `system.paging.fault.type` (major, minor) | Page faults |
-| `process.context_switches` | FunctionCounter | `{context_switch}` | `process.context_switch.type` (total) | Context switches |
+| `process.context_switches` | FunctionCounter | `{context_switch}` | `process.context_switch.type` (voluntary, involuntary or total) | Context switches; split via getrusage on POSIX for current process, total-only on Windows |
 | `process.uptime` | Gauge | `s` | — | Process uptime |
 
 #### Not implemented

--- a/oshi-metrics/src/main/java/oshi/metrics/ProcessMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/ProcessMetrics.java
@@ -30,7 +30,8 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * <li>{@code process.thread.count} — thread count</li>
  * <li>{@code process.open_file_descriptor.count} — open file descriptors</li>
  * <li>{@code process.paging.faults} — page faults by type (major, minor)</li>
- * <li>{@code process.context_switches} — context switches (total; voluntary/involuntary split unavailable)</li>
+ * <li>{@code process.context_switches} — context switches by type (voluntary/involuntary on POSIX, or total on
+ * Windows)</li>
  * <li>{@code process.uptime} — process uptime in seconds</li>
  * </ul>
  *
@@ -110,10 +111,26 @@ public class ProcessMetrics implements MeterBinder {
                 .baseUnit("{fault}").register(registry);
 
         // process.context_switches — Counter, unit "{context_switch}", attr process.context_switch.type (Required)
-        FunctionCounter.builder(CONTEXT_SWITCHES, processSupplier, s -> s.get().getContextSwitches())
-                .tag("process.context_switch.type", "total")
-                .description("Number of times the process has been context switched").baseUnit("{context_switch}")
-                .register(registry);
+        // Only emit voluntary/involuntary if the platform provides the split; otherwise emit total only
+        OSProcess probe = processSupplier.get();
+        long vol = probe.getVoluntaryContextSwitches();
+        long invol = probe.getInvoluntaryContextSwitches();
+        long total = probe.getContextSwitches();
+        if (vol + invol == total && total > 0) {
+            FunctionCounter.builder(CONTEXT_SWITCHES, processSupplier, s -> s.get().getVoluntaryContextSwitches())
+                    .tag("process.context_switch.type", "voluntary")
+                    .description("Number of times the process has been context switched").baseUnit("{context_switch}")
+                    .register(registry);
+            FunctionCounter.builder(CONTEXT_SWITCHES, processSupplier, s -> s.get().getInvoluntaryContextSwitches())
+                    .tag("process.context_switch.type", "involuntary")
+                    .description("Number of times the process has been context switched").baseUnit("{context_switch}")
+                    .register(registry);
+        } else if (total > 0) {
+            FunctionCounter.builder(CONTEXT_SWITCHES, processSupplier, s -> s.get().getContextSwitches())
+                    .tag("process.context_switch.type", "total")
+                    .description("Number of times the process has been context switched").baseUnit("{context_switch}")
+                    .register(registry);
+        }
 
         // process.uptime — Gauge, unit "s"
         Gauge.builder(UPTIME, processSupplier, s -> s.get().getUpTime() / MS_PER_SECOND)


### PR DESCRIPTION
## Summary

Resolves #2904

Adds `getVoluntaryContextSwitches()` and `getInvoluntaryContextSwitches()` to the `OSProcess` interface. The default `getContextSwitches()` now returns their sum.

## Design

- **Current process**: `getrusage(RUSAGE_SELF)` on all POSIX platforms (aggregates across all threads — the core fix for #2904)
- **Other processes**: platform-specific fallback (`/proc`, `ps`, etc.)
- **Default `getContextSwitches()`**: returns `getVoluntaryContextSwitches() + getInvoluntaryContextSwitches()` — no need to override on platforms with the split

## Platform support

| Platform | Split available | Scope | Source |
|---|---|---|---|
| Linux (JNA + FFM) | ✅ | Any process (current via getrusage, others via /proc) | getrusage / /proc/[pid]/status |
| macOS (JNA + FFM) | ✅ | Current process only | getrusage(RUSAGE_SELF) |
| FreeBSD | ✅ | Any process | ps nvcsw/nivcsw |
| OpenBSD | ✅ | Any process | ps nvcsw/nivcsw |
| Solaris | ✅ | Any process | /proc/[pid]/usage pr_vctx/pr_ictx |
| Windows | ❌ | Total only (from perfmon) | Overrides getContextSwitches() |
| AIX | ❌ | Returns 0 | Default |

## Metrics

`ProcessMetrics` emits:
- `voluntary` + `involuntary` when `vol + invol == total` (POSIX current process)
- `total` only when split is unavailable (Windows)
- Nothing when all are 0 (AIX)

## Changes

- `OSProcess.java`: Added split methods with defaults; `getContextSwitches()` returns their sum
- `LinuxOSProcess.java`: Stores split values from /proc
- `LinuxOSProcessJNA.java`: Overrides split with getrusage for current process
- `LinuxOSProcessFFM.java`: Same via FFM
- `LinuxLibcFunctions.java`: Added getrusage downcall + RUSAGE constants
- `MacOSProcessJNA.java`: getrusage for current process, pti_csw for others
- `MacOSProcessFFM.java`: Same via FFM
- `MacSystemFunctions.java`: Added getrusage downcall + RUSAGE constants
- `LinuxLibc.java` / `SystemB.java`: Platform-specific Rusage structs
- `CLibrary.java`: RUSAGE_SELF constant
- `FreeBsdOSProcess.java` / `OpenBsdOSProcess.java` / `SolarisOSProcess.java`: Expose split values
- `ProcessMetrics.java`: Emits split or total based on availability
- `NativeComparisonTest.java`: JNA vs FFM assertions
- `CHANGELOG.md`: Entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Process metrics now report separate voluntary and involuntary context-switch counts on POSIX hosts, with total fallback when per-type counts aren’t available.

* **Documentation**
  * Metrics docs updated to describe per-type context-switch metrics, getrusage usage for POSIX, platform differences, and fallback behavior.

* **Tests**
  * Tests/benchmarks extended to validate parity of the new per-type context-switch metrics across implementations.

* **Changelog**
  * Added release note entry describing per-type context-switch reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->