### PR TITLE
Use % Processor Performance counter for Windows CPU frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 * [#2857](https://github.com/oshi/oshi/issues/2857): Add disk type information (SSD, HDD, Removable, Virtual) - [@dbwiddis](https://github.com/dbwiddis).
 * [#2904](https://github.com/oshi/oshi/issues/2904): Add voluntary/involuntary context switch methods to OSProcess - [@dbwiddis](https://github.com/dbwiddis).
 * [#3223](https://github.com/oshi/oshi/issues/3223): Add `oshi-metrics` module with Micrometer integration for system metrics following OpenTelemetry semantic conventions - [@dbwiddis](https://github.com/dbwiddis).
-* Your contribution here!
+
+##### Bug Fixes and Improvements
+
+* [#3233](https://github.com/oshi/oshi/pull/3233): Use WMI formatted `% Processor Performance` counter for Windows CPU frequency, reporting actual turbo boost speeds above base frequency - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.0.0 (2026-04-30), 7.0.1 (2026-05-02)
 

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PerfmonConstants.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PerfmonConstants.java
@@ -53,6 +53,7 @@ public final class PerfmonConstants {
     // For Win7+ ... NAME field includes NUMA nodes
     public static final String PROCESSOR_INFORMATION = "Processor Information";
     public static final String WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL = "Win32_PerfRawData_Counters_ProcessorInformation WHERE NOT Name LIKE \"%_Total\"";
+    public static final String WIN32_PERF_FORMATTED_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL = "Win32_PerfFormattedData_Counters_ProcessorInformation WHERE NOT Name LIKE \"%_Total\"";
 
     public static final String SYSTEM = "System";
     public static final String WIN32_PERF_RAW_DATA_PERF_OS_SYSTEM = "Win32_PerfRawData_PerfOS_System";

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/ProcessorInformation.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/ProcessorInformation.java
@@ -118,6 +118,28 @@ public final class ProcessorInformation {
     }
 
     /**
+     * Processor Performance counters from the WMI Formatted Data table. Reports above 100% with turbo boost. Requires
+     * Win8 or greater.
+     */
+    public enum ProcessorPerformanceProperty implements PdhCounterWildcardProperty {
+        // First element defines WMI instance name field and PDH instance filter
+        NAME(NOT_TOTAL_INSTANCES),
+        // Remaining elements define counters
+        PERCENTPROCESSORPERFORMANCE("% Processor Performance");
+
+        private final String counter;
+
+        ProcessorPerformanceProperty(String counter) {
+            this.counter = counter;
+        }
+
+        @Override
+        public String getCounter() {
+            return counter;
+        }
+    }
+
+    /**
      * System performance counters
      */
     public enum SystemTickCountProperty implements PdhCounterProperty {

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/perfmon/ProcessorInformationFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/perfmon/ProcessorInformationFFM.java
@@ -6,6 +6,7 @@ package oshi.driver.windows.perfmon;
 
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESSOR;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESSOR_INFORMATION;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_FORMATTED_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_NOT_TOTAL;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_TOTAL;
@@ -16,6 +17,7 @@ import java.util.Map;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.InterruptsProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorFrequencyProperty;
+import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorPerformanceProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorTickCountProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorUtilityTickCountProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.SystemTickCountProperty;
@@ -87,5 +89,15 @@ public final class ProcessorInformationFFM {
     public static Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> queryFrequencyCounters() {
         return PerfCounterWildcardQueryFFM.queryInstancesAndValues(ProcessorFrequencyProperty.class,
                 PROCESSOR_INFORMATION, WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL);
+    }
+
+    /**
+     * Returns processor performance percentage (cooked) from the WMI Formatted Data table.
+     *
+     * @return Processor performance percentage for each processor, or empty if unavailable.
+     */
+    public static Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> queryProcessorPerformanceCounters() {
+        return PerfCounterWildcardQueryFFM.queryInstancesAndValuesFromWMI(ProcessorPerformanceProperty.class,
+                WIN32_PERF_FORMATTED_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.InterruptsProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorFrequencyProperty;
+import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorPerformanceProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorTickCountProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorUtilityTickCountProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.SystemTickCountProperty;
@@ -226,36 +227,55 @@ final class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
     @Override
     public long[] queryCurrentFreq() {
         if (VersionHelpersFFM.IsWindows7OrGreater()) {
-            Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> instanceValuePair = ProcessorInformationFFM
-                    .queryFrequencyCounters();
-            List<String> instances = instanceValuePair.getA();
-            Map<ProcessorFrequencyProperty, List<Long>> valueMap = instanceValuePair.getB();
-            List<Long> percentMaxList = valueMap.get(ProcessorFrequencyProperty.PERCENTOFMAXIMUMFREQUENCY);
-            if (!instances.isEmpty() && percentMaxList != null) {
-                long maxFreq = this.getMaxFreq();
-                if (maxFreq > 0) {
-                    long[] freqs = new long[getLogicalProcessorCount()];
-                    for (int i = 0; i < instances.size(); i++) {
-                        String instance = instances.get(i);
-                        int cpu;
-                        if (instance.contains(",")) {
-                            if (!getNumaNodeProcToLogicalProcMap().containsKey(instance)) {
-                                continue;
-                            }
-                            cpu = getNumaNodeProcToLogicalProcMap().get(instance);
-                        } else {
-                            cpu = ParseUtil.parseIntOrDefault(instance, -1);
-                        }
-                        if (cpu < 0 || cpu >= getLogicalProcessorCount() || i >= percentMaxList.size()) {
-                            continue;
-                        }
-                        freqs[cpu] = percentMaxList.get(i) * maxFreq / 100L;
-                    }
+            long maxFreq = this.getMaxFreq();
+            if (maxFreq > 0) {
+                // Prefer % Processor Performance from WMI formatted table (Win8+, reports >100% with turbo)
+                Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> perfPair = ProcessorInformationFFM
+                        .queryProcessorPerformanceCounters();
+                List<Long> perfList = perfPair.getB().get(ProcessorPerformanceProperty.PERCENTPROCESSORPERFORMANCE);
+                long[] freqs = mapPercentToFreqs(perfPair.getA(), perfList, maxFreq);
+                if (freqs != null) {
+                    return freqs;
+                }
+                // Fall back to % of Maximum Frequency (Win7, caps at 100%)
+                Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> freqPair = ProcessorInformationFFM
+                        .queryFrequencyCounters();
+                List<Long> percentMaxList = freqPair.getB().get(ProcessorFrequencyProperty.PERCENTOFMAXIMUMFREQUENCY);
+                freqs = mapPercentToFreqs(freqPair.getA(), percentMaxList, maxFreq);
+                if (freqs != null) {
                     return freqs;
                 }
             }
         }
         return queryNTPower(2);
+    }
+
+    private long[] mapPercentToFreqs(List<String> instances, List<Long> percentList, long maxFreq) {
+        if (instances.isEmpty() || percentList == null) {
+            return null;
+        }
+        long[] freqs = new long[getLogicalProcessorCount()];
+        boolean populated = false;
+        for (int i = 0; i < instances.size(); i++) {
+            String instance = instances.get(i);
+            int cpu;
+            if (instance.contains(",")) {
+                if (!getNumaNodeProcToLogicalProcMap().containsKey(instance)) {
+                    continue;
+                }
+                cpu = getNumaNodeProcToLogicalProcMap().get(instance);
+            } else {
+                cpu = ParseUtil.parseIntOrDefault(instance, -1);
+            }
+            if (cpu < 0 || cpu >= getLogicalProcessorCount() || i >= percentList.size()) {
+                continue;
+            }
+            freqs[cpu] = percentList.get(i) * maxFreq / 100L;
+            if (freqs[cpu] > 0) {
+                populated = true;
+            }
+        }
+        return populated ? freqs : null;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessorInformationJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/ProcessorInformationJNA.java
@@ -6,6 +6,7 @@ package oshi.driver.windows.perfmon;
 
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESSOR;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESSOR_INFORMATION;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_FORMATTED_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_NOT_TOTAL;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_TOTAL;
@@ -19,6 +20,7 @@ import com.sun.jna.platform.win32.VersionHelpers;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.InterruptsProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorFrequencyProperty;
+import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorPerformanceProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorTickCountProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorUtilityTickCountProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.SystemTickCountProperty;
@@ -102,5 +104,19 @@ public final class ProcessorInformationJNA {
         }
         return PerfCounterWildcardQuery.queryInstancesAndValues(ProcessorFrequencyProperty.class, PROCESSOR_INFORMATION,
                 WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL);
+    }
+
+    /**
+     * Returns processor performance percentage (cooked) from the WMI Formatted Data table. Values above 100 indicate
+     * turbo boost.
+     *
+     * @return Processor performance percentage for each processor, or empty if unavailable.
+     */
+    public static Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> queryProcessorPerformanceCounters() {
+        if (PerfmonDisabled.PERF_OS_DISABLED) {
+            return new Pair<>(Collections.emptyList(), Collections.emptyMap());
+        }
+        return PerfCounterWildcardQuery.queryInstancesAndValuesFromWMI(ProcessorPerformanceProperty.class,
+                WIN32_PERF_FORMATTED_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorJNA.java
@@ -28,6 +28,7 @@ import com.sun.jna.platform.win32.WinReg;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.InterruptsProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorFrequencyProperty;
+import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorPerformanceProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorTickCountProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorUtilityTickCountProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.SystemTickCountProperty;
@@ -200,27 +201,48 @@ final class WindowsCentralProcessorJNA extends WindowsCentralProcessor {
     @Override
     public long[] queryCurrentFreq() {
         if (VersionHelpers.IsWindows7OrGreater()) {
-            Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> instanceValuePair = ProcessorInformationJNA
-                    .queryFrequencyCounters();
-            List<String> instances = instanceValuePair.getA();
-            Map<ProcessorFrequencyProperty, List<Long>> valueMap = instanceValuePair.getB();
-            List<Long> percentMaxList = valueMap.get(ProcessorFrequencyProperty.PERCENTOFMAXIMUMFREQUENCY);
-            if (!instances.isEmpty()) {
-                long maxFreq = this.getMaxFreq();
-                long[] freqs = new long[getLogicalProcessorCount()];
-                for (String instance : instances) {
-                    int cpu = instance.contains(",") ? getNumaNodeProcToLogicalProcMap().getOrDefault(instance, 0)
-                            : ParseUtil.parseIntOrDefault(instance, 0);
-                    if (cpu >= getLogicalProcessorCount()) {
-                        continue;
-                    }
-                    freqs[cpu] = percentMaxList.get(cpu) * maxFreq / 100L;
+            long maxFreq = this.getMaxFreq();
+            if (maxFreq > 0) {
+                // Prefer % Processor Performance from WMI formatted table (Win8+, reports >100% with turbo)
+                Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> perfPair = ProcessorInformationJNA
+                        .queryProcessorPerformanceCounters();
+                List<Long> perfList = perfPair.getB().get(ProcessorPerformanceProperty.PERCENTPROCESSORPERFORMANCE);
+                long[] freqs = mapPercentToFreqs(perfPair.getA(), perfList, maxFreq);
+                if (freqs != null) {
+                    return freqs;
                 }
-                return freqs;
+                // Fall back to % of Maximum Frequency (Win7, caps at 100%)
+                Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> freqPair = ProcessorInformationJNA
+                        .queryFrequencyCounters();
+                List<Long> percentMaxList = freqPair.getB().get(ProcessorFrequencyProperty.PERCENTOFMAXIMUMFREQUENCY);
+                freqs = mapPercentToFreqs(freqPair.getA(), percentMaxList, maxFreq);
+                if (freqs != null) {
+                    return freqs;
+                }
             }
         }
         // If <Win7 or anything failed in PDH/WMI, use the native call
         return queryNTPower(2); // Current is field index 2
+    }
+
+    private long[] mapPercentToFreqs(List<String> instances, List<Long> percentList, long maxFreq) {
+        if (instances.isEmpty() || percentList == null) {
+            return null;
+        }
+        long[] freqs = new long[getLogicalProcessorCount()];
+        boolean populated = false;
+        for (String instance : instances) {
+            int cpu = instance.contains(",") ? getNumaNodeProcToLogicalProcMap().getOrDefault(instance, 0)
+                    : ParseUtil.parseIntOrDefault(instance, 0);
+            if (cpu >= getLogicalProcessorCount()) {
+                continue;
+            }
+            freqs[cpu] = percentList.get(cpu) * maxFreq / 100L;
+            if (freqs[cpu] > 0) {
+                populated = true;
+            }
+        }
+        return populated ? freqs : null;
     }
 
     @Override

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/CentralProcessorTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/CentralProcessorTest.java
@@ -67,8 +67,8 @@ class CentralProcessorTest {
                 p.getLogicalProcessorCount(), is(curr.length));
         if (max >= 0) {
             for (long freq : curr) {
-                assertThat("Logical processor frequency should be at most its max frequency", freq,
-                        is(lessThanOrEqualTo(max)));
+                assertThat("Logical processor frequency should be within 3x its max frequency", freq,
+                        is(lessThanOrEqualTo(max * 3)));
             }
         }
     }


### PR DESCRIPTION
## Summary

Resolves #2933

On Windows, `getCurrentFreq()` was using the `% of Maximum Frequency` raw performance counter which caps at 100%. This means turbo boost frequencies were never reported — a CPU running at 4.8 GHz on a 3.6 GHz base would still report 3.6 GHz.

## Fix

Query `PercentProcessorPerformance` from the WMI formatted data table (`Win32_PerfFormattedData_Counters_ProcessorInformation`) which reports above 100% when turbo boost is active (e.g., 133% = 4.8 GHz on a 3.6 GHz base).

WMI formatted counters handle the two-sample delta computation internally, returning ready-to-use cooked values on every query — no polling or two-call dance needed.

- **Windows 8+**: Uses `PercentProcessorPerformance` from formatted WMI table (accurate with turbo)
- **Windows 7**: Falls back to `% of Maximum Frequency` raw counter (capped at 100%)
- **Pre-Win7 / all fail**: Falls back to `CallNtPowerInformation`

## Changes

- `PerfmonConstants.java`: Added `WIN32_PERF_FORMATTED_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL`
- `ProcessorInformation.java`: Added `ProcessorPerformanceProperty` enum
- `ProcessorInformationJNA.java`: Added `queryProcessorPerformanceCounters()` using formatted WMI table
- `ProcessorInformationFFM.java`: Same
- `WindowsCentralProcessorJNA.java`: Prefer formatted counter, fall back to raw
- `WindowsCentralProcessorFFM.java`: Same
- `CHANGELOG.md`: Bug fix entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes and Improvements**
  * Improved Windows CPU frequency reporting to capture turbo-boosted frequencies above base clock, preferring a formatted WMI performance-counter path with robust fallbacks.

* **Documentation**
  * Updated unreleased changelog entry to describe the Windows-specific CPU frequency improvement.

* **Tests**
  * Relaxed frequency validation to allow reported values up to three times the base frequency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->