### PR TITLE
Add native-free Linux SystemInfoProvider in oshi-common

### DIFF
--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeFreeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeFreeComparisonTest.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.api.condition.OS;
 
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.GlobalMemory;
+import oshi.hardware.HWDiskStore;
 import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.NetworkIF;
 import oshi.hardware.VirtualMemory;
 import oshi.software.common.os.linux.LinuxOperatingSystem;
 import oshi.software.os.FileSystem;
@@ -169,6 +171,51 @@ class NativeFreeComparisonTest {
         assertThat(nf.getParentProcessID()).isEqualTo(jna.getParentProcessID());
         assertThat(nf.getCommandLine()).isEqualTo(jna.getCommandLine());
         assertThat(nf.getStartTime()).isEqualTo(jna.getStartTime());
+    }
+
+    // ---- Hardware: Disks ----
+
+    @Test
+    void diskStores() {
+        List<HWDiskStore> jna = jnaHal.getDiskStores();
+        List<HWDiskStore> nf = nfHal.getDiskStores();
+        assertThat(nf).hasSameSizeAs(jna);
+        Map<String, HWDiskStore> nfByName = nf.stream()
+                .collect(Collectors.toMap(HWDiskStore::getName, Function.identity()));
+        for (HWDiskStore j : jna) {
+            HWDiskStore n = nfByName.get(j.getName());
+            assertThat(n).as("disk %s", j.getName()).isNotNull();
+            // Model may differ in space vs underscore: sysfs uses raw kernel string,
+            // udev may normalize spaces to underscores (or vice versa depending on device)
+            assertThat(n.getModel().replace('_', ' ')).isEqualTo(j.getModel().replace('_', ' '));
+            // Serial: udev ID_SERIAL_SHORT may expose serials not available in sysfs device/serial
+            if (!n.getSerial().isEmpty()) {
+                assertThat(n.getSerial()).isEqualTo(j.getSerial());
+            }
+            assertThat(n.getSize()).isEqualTo(j.getSize());
+            assertThat(n.getReads()).as("reads(%s)", j.getName()).isGreaterThanOrEqualTo(j.getReads());
+            assertThat(n.getPartitions().size()).as("partitions(%s)", j.getName()).isEqualTo(j.getPartitions().size());
+        }
+    }
+
+    // ---- Hardware: Network Interfaces ----
+
+    @Test
+    void networkInterfaces() {
+        List<NetworkIF> jna = jnaHal.getNetworkIFs();
+        List<NetworkIF> nf = nfHal.getNetworkIFs();
+        assertThat(nf).hasSameSizeAs(jna);
+        Map<String, NetworkIF> nfByName = nf.stream()
+                .collect(Collectors.toMap(NetworkIF::getName, Function.identity()));
+        for (NetworkIF j : jna) {
+            NetworkIF n = nfByName.get(j.getName());
+            assertThat(n).as("networkIF %s", j.getName()).isNotNull();
+            assertThat(n.getMacaddr()).isEqualTo(j.getMacaddr());
+            assertThat(n.getIPv4addr()).isEqualTo(j.getIPv4addr());
+            assertThat(n.getIPv6addr()).isEqualTo(j.getIPv6addr());
+            assertThat(n.getMTU()).isEqualTo(j.getMTU());
+            assertThat(n.getSpeed()).isEqualTo(j.getSpeed());
+        }
     }
 
     // ---- OS: FileSystem ----

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeFreeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeFreeComparisonTest.java
@@ -116,7 +116,7 @@ class NativeFreeComparisonTest {
     void processorFrequencies() {
         CentralProcessor jna = jnaHal.getProcessor();
         CentralProcessor nf = nfHal.getProcessor();
-        assertWithinRatio(nf.getMaxFreq(), jna.getMaxFreq(), 0.05, "maxFreq");
+        assertWithinRatio(nf.getMaxFreq(), jna.getMaxFreq(), 0.10, "maxFreq");
         long[] jnaFreqs = jna.getCurrentFreq();
         long[] nfFreqs = nf.getCurrentFreq();
         assertThat(nfFreqs).hasSameSizeAs(jnaFreqs);

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeFreeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeFreeComparisonTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.comparison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static oshi.comparison.ComparisonAssertions.assertWithinRatio;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.VirtualMemory;
+import oshi.software.common.os.linux.LinuxOperatingSystem;
+import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
+import oshi.software.os.OSFileStore;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OperatingSystem;
+
+/**
+ * Compares the native-free (NF) provider against the JNA provider on Linux to verify that procfs/sysfs/command-line
+ * implementations produce the same results as native calls.
+ * <p>
+ * JNA is the baseline (stable, well-tested). NF values should match for deterministic fields and be within tolerance
+ * for dynamic values.
+ */
+@EnabledOnOs(OS.LINUX)
+class NativeFreeComparisonTest {
+
+    private static HardwareAbstractionLayer jnaHal;
+    private static HardwareAbstractionLayer nfHal;
+    private static OperatingSystem jnaOs;
+    private static OperatingSystem nfOs;
+
+    @BeforeAll
+    static void setup() {
+        oshi.SystemInfo jnaSi = new oshi.SystemInfo();
+        jnaHal = jnaSi.getHardware();
+        jnaOs = jnaSi.getOperatingSystem();
+
+        oshi.nativefree.SystemInfo nfSi = new oshi.nativefree.SystemInfo();
+        nfHal = nfSi.getHardware();
+        nfOs = nfSi.getOperatingSystem();
+    }
+
+    // ---- OS: System constants (getconf vs native) ----
+
+    @Test
+    void hzMatchesNative() {
+        assertThat(((LinuxOperatingSystem) nfOs).getHz()).as("CLK_TCK: getconf vs native")
+                .isEqualTo(((LinuxOperatingSystem) jnaOs).getHz());
+    }
+
+    @Test
+    void pageSizeMatchesNative() {
+        assertThat(((LinuxOperatingSystem) nfOs).getPageSize()).as("PAGE_SIZE: getconf vs native")
+                .isEqualTo(((LinuxOperatingSystem) jnaOs).getPageSize());
+    }
+
+    // ---- OS: Basic info ----
+
+    @Test
+    void operatingSystemInfo() {
+        assertThat(nfOs.getFamily()).isEqualTo(jnaOs.getFamily());
+        assertThat(nfOs.getManufacturer()).isEqualTo(jnaOs.getManufacturer());
+        assertThat(nfOs.getBitness()).isEqualTo(jnaOs.getBitness());
+        assertThat(nfOs.getVersionInfo()).usingRecursiveComparison().isEqualTo(jnaOs.getVersionInfo());
+        assertThat(nfOs.getSystemBootTime()).isEqualTo(jnaOs.getSystemBootTime());
+        assertThat(nfOs.getSystemUptime()).isGreaterThanOrEqualTo(jnaOs.getSystemUptime());
+        assertThat(nfOs.getProcessId()).isEqualTo(jnaOs.getProcessId());
+        assertThat(nfOs.getThreadId()).isEqualTo(jnaOs.getThreadId());
+        assertWithinRatio(nfOs.getThreadCount(), jnaOs.getThreadCount(), 0.1, "threadCount");
+    }
+
+    // ---- Hardware: Processor ----
+
+    @Test
+    void processorIdentifier() {
+        CentralProcessor.ProcessorIdentifier nfId = nfHal.getProcessor().getProcessorIdentifier();
+        CentralProcessor.ProcessorIdentifier jnaId = jnaHal.getProcessor().getProcessorIdentifier();
+        assertThat(nfId.getVendor()).isEqualTo(jnaId.getVendor());
+        assertThat(nfId.getName()).isEqualTo(jnaId.getName());
+        assertThat(nfId.getFamily()).isEqualTo(jnaId.getFamily());
+        assertThat(nfId.getModel()).isEqualTo(jnaId.getModel());
+        assertThat(nfId.getStepping()).isEqualTo(jnaId.getStepping());
+        assertThat(nfId.isCpu64bit()).isEqualTo(jnaId.isCpu64bit());
+        assertThat(nfId.getProcessorID()).as("processorID").isEqualTo(jnaId.getProcessorID());
+    }
+
+    @Test
+    void processorTopology() {
+        CentralProcessor jna = jnaHal.getProcessor();
+        CentralProcessor nf = nfHal.getProcessor();
+        assertThat(nf.getLogicalProcessorCount()).isEqualTo(jna.getLogicalProcessorCount());
+        assertThat(nf.getPhysicalProcessorCount()).isEqualTo(jna.getPhysicalProcessorCount());
+        assertThat(nf.getPhysicalPackageCount()).isEqualTo(jna.getPhysicalPackageCount());
+        assertThat(nf.getLogicalProcessors()).usingRecursiveComparison().isEqualTo(jna.getLogicalProcessors());
+        assertThat(nf.getProcessorCaches()).usingRecursiveComparison().isEqualTo(jna.getProcessorCaches());
+        assertThat(nf.getFeatureFlags()).isEqualTo(jna.getFeatureFlags());
+    }
+
+    @Test
+    void processorFrequencies() {
+        CentralProcessor jna = jnaHal.getProcessor();
+        CentralProcessor nf = nfHal.getProcessor();
+        assertWithinRatio(nf.getMaxFreq(), jna.getMaxFreq(), 0.05, "maxFreq");
+        long[] jnaFreqs = jna.getCurrentFreq();
+        long[] nfFreqs = nf.getCurrentFreq();
+        assertThat(nfFreqs).hasSameSizeAs(jnaFreqs);
+    }
+
+    @Test
+    void processorCpuLoadTicks() {
+        CentralProcessor jna = jnaHal.getProcessor();
+        CentralProcessor nf = nfHal.getProcessor();
+        long[] jnaTicks = jna.getSystemCpuLoadTicks();
+        long[] nfTicks = nf.getSystemCpuLoadTicks();
+        assertThat(nfTicks).hasSameSizeAs(jnaTicks);
+        long[][] jnaProc = jna.getProcessorCpuLoadTicks();
+        long[][] nfProc = nf.getProcessorCpuLoadTicks();
+        assertThat(nfProc.length).isEqualTo(jnaProc.length);
+    }
+
+    // ---- Hardware: Memory ----
+
+    @Test
+    void globalMemory() {
+        GlobalMemory jna = jnaHal.getMemory();
+        GlobalMemory nf = nfHal.getMemory();
+        assertThat(nf.getTotal()).isEqualTo(jna.getTotal());
+        assertThat(nf.getPageSize()).isEqualTo(jna.getPageSize());
+        assertWithinRatio(nf.getAvailable(), jna.getAvailable(), 0.25, "availableMemory");
+    }
+
+    @Test
+    void virtualMemory() {
+        VirtualMemory jna = jnaHal.getMemory().getVirtualMemory();
+        VirtualMemory nf = nfHal.getMemory().getVirtualMemory();
+        assertThat(nf.getSwapTotal()).isEqualTo(jna.getSwapTotal());
+        assertWithinRatio(nf.getSwapUsed(), jna.getSwapUsed(), 0.25, "swapUsed");
+    }
+
+    // ---- OS: Current Process ----
+
+    @Test
+    void currentProcess() {
+        int pid = jnaOs.getProcessId();
+        OSProcess jna = jnaOs.getProcess(pid);
+        OSProcess nf = nfOs.getProcess(pid);
+        assertThat(nf).isNotNull();
+        assertThat(nf.getProcessID()).isEqualTo(jna.getProcessID());
+        assertThat(nf.getName()).isEqualTo(jna.getName());
+        assertThat(nf.getPath()).isEqualTo(jna.getPath());
+        assertThat(nf.getUser()).isEqualTo(jna.getUser());
+        assertThat(nf.getUserID()).isEqualTo(jna.getUserID());
+        assertThat(nf.getGroup()).isEqualTo(jna.getGroup());
+        assertThat(nf.getGroupID()).isEqualTo(jna.getGroupID());
+        assertThat(nf.getParentProcessID()).isEqualTo(jna.getParentProcessID());
+        assertThat(nf.getCommandLine()).isEqualTo(jna.getCommandLine());
+        assertThat(nf.getStartTime()).isEqualTo(jna.getStartTime());
+    }
+
+    // ---- OS: FileSystem ----
+
+    @Test
+    void fileSystem() {
+        FileSystem jnaFs = jnaOs.getFileSystem();
+        FileSystem nfFs = nfOs.getFileSystem();
+
+        List<OSFileStore> jnaStores = jnaFs.getFileStores();
+        List<OSFileStore> nfStores = nfFs.getFileStores();
+        assertThat(nfStores).hasSameSizeAs(jnaStores);
+        Map<String, OSFileStore> nfByMount = nfStores.stream()
+                .collect(Collectors.toMap(OSFileStore::getMount, Function.identity(), (a, b) -> a));
+        for (OSFileStore j : jnaStores) {
+            OSFileStore nf = nfByMount.get(j.getMount());
+            assertThat(nf).as("fileStore at %s", j.getMount()).isNotNull();
+            assertThat(nf.getName()).isEqualTo(j.getName());
+            assertThat(nf.getType()).isEqualTo(j.getType());
+            assertThat(nf.getVolume()).isEqualTo(j.getVolume());
+            assertThat(nf.getTotalSpace()).isEqualTo(j.getTotalSpace());
+            assertWithinRatio(nf.getUsableSpace(), j.getUsableSpace(), 0.25, "usableSpace(" + j.getMount() + ")");
+        }
+    }
+
+    // ---- OS: Network Params ----
+
+    @Test
+    void networkParams() {
+        NetworkParams jna = jnaOs.getNetworkParams();
+        NetworkParams nf = nfOs.getNetworkParams();
+        // NF uses Java InetAddress (short hostname); JNA uses native gethostname (may return FQDN)
+        assertThat(jna.getHostName()).startsWith(nf.getHostName());
+        assertThat(nf.getDnsServers()).isEqualTo(jna.getDnsServers());
+        assertThat(nf.getIpv4DefaultGateway()).isEqualTo(jna.getIpv4DefaultGateway());
+        assertThat(nf.getIpv6DefaultGateway()).isEqualTo(jna.getIpv6DefaultGateway());
+    }
+}

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module com.github.oshi.common {
     exports oshi.hardware.common.platform.mac;
     exports oshi.hardware.common.platform.unix;
     exports oshi.hardware.common.platform.windows;
+    exports oshi.nativefree;
     exports oshi.software.common;
     exports oshi.software.common.os.linux;
     exports oshi.software.common.os.mac;
@@ -45,6 +46,8 @@ module com.github.oshi.common {
     exports oshi.util.tuples;
 
     uses oshi.spi.SystemInfoProvider;
+
+    provides oshi.spi.SystemInfoProvider with oshi.nativefree.SystemInfo;
 
     requires transitive java.desktop;
     requires org.slf4j;

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -366,12 +366,14 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
                         processorIdBytes |= 1L << 48;
                         break;
                     case "pse-36":
+                    case "pse36":
                         processorIdBytes |= 1L << 49;
                         break;
                     case "psn":
                         processorIdBytes |= 1L << 50;
                         break;
                     case "clfsh":
+                    case "clflush":
                         processorIdBytes |= 1L << 51;
                         break;
                     case "ds":
@@ -396,6 +398,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
                         processorIdBytes |= 1L << 59;
                         break;
                     case "htt":
+                    case "ht":
                         processorIdBytes |= 1L << 60;
                         break;
                     case "tm":

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxCentralProcessorNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxCentralProcessorNF.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux.nativefree;
+
+import java.util.List;
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.common.platform.linux.LinuxCentralProcessor;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Quartet;
+
+/**
+ * Native-free Linux central processor implementation. Extends {@link LinuxCentralProcessor}, overriding udev-dependent
+ * methods with sysfs-based alternatives.
+ */
+@ThreadSafe
+public final class LinuxCentralProcessorNF extends LinuxCentralProcessor {
+
+    private static final long USER_HZ = queryUserHz();
+
+    /**
+     * Creates a new native-free Linux central processor.
+     */
+    public LinuxCentralProcessorNF() {
+        super(USER_HZ);
+    }
+
+    private static long queryUserHz() {
+        long hz = ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf CLK_TCK"), 0L);
+        return hz > 0 ? hz : 100L;
+    }
+
+    @Override
+    protected Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyWithUdev() {
+        return readTopologyFromSysfs();
+    }
+
+    @Override
+    protected boolean queryCurrentFreqFromUdev(long[] freqs) {
+        return queryCurrentFreqFromSysfs(freqs);
+    }
+
+    @Override
+    protected long queryMaxFreqFromUdev() {
+        return queryMaxFreqFromSysfs();
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxGraphicsCardNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxGraphicsCardNF.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux.nativefree;
+
+import java.util.List;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.GpuStats;
+import oshi.hardware.GraphicsCard;
+import oshi.hardware.common.platform.linux.LinuxGpuStats;
+import oshi.hardware.common.platform.linux.LinuxGraphicsCard;
+
+/**
+ * Native-free Linux graphics card implementation. Uses {@code lspci}/{@code lshw} for enumeration (already in
+ * superclass) and provides a {@link GpuStats} that reads sysfs for AMD/Intel but has no NVML support.
+ */
+@ThreadSafe
+final class LinuxGraphicsCardNF extends LinuxGraphicsCard {
+
+    LinuxGraphicsCardNF(String name, String deviceId, String vendor, String versionInfo, long vram,
+            String drmDevicePath, String driverName, String pciBusId) {
+        super(name, deviceId, vendor, versionInfo, vram, drmDevicePath, driverName, pciBusId);
+    }
+
+    @Override
+    public GpuStats createStatsSession() {
+        return new LinuxGpuStatsNF(getDrmDevicePath(), getDriverName(), getPciBusId(), getName());
+    }
+
+    /**
+     * Gets graphics cards using command-line tools (lspci/lshw).
+     *
+     * @return list of graphics cards
+     */
+    public static List<GraphicsCard> getGraphicsCards() {
+        return LinuxGraphicsCard
+                .getGraphicsCards(a -> new LinuxGraphicsCardNF(a.getName(), a.getDeviceId(), a.getVendor(),
+                        a.getVersionInfo(), a.getVram(), a.getDrmDevicePath(), a.getDriverName(), a.getPciBusId()));
+    }
+
+    /**
+     * Native-free GPU stats — sysfs-based metrics for AMD/Intel, no NVML.
+     */
+    private static final class LinuxGpuStatsNF extends LinuxGpuStats {
+
+        LinuxGpuStatsNF(String drmDevicePath, String driverName, String pciBusId, String name) {
+            super(drmDevicePath, driverName, pciBusId, name);
+        }
+
+        @Override
+        protected boolean nvmlIsAvailable() {
+            return false;
+        }
+
+        @Override
+        protected String nvmlFindDevice(String busId) {
+            return null;
+        }
+
+        @Override
+        protected String nvmlFindDeviceByName(String name) {
+            return null;
+        }
+
+        @Override
+        protected long nvmlGetVramUsed(String deviceId) {
+            return -1L;
+        }
+
+        @Override
+        protected double nvmlGetTemperature(String deviceId) {
+            return -1d;
+        }
+
+        @Override
+        protected double nvmlGetPowerDraw(String deviceId) {
+            return -1d;
+        }
+
+        @Override
+        protected long nvmlGetCoreClockMhz(String deviceId) {
+            return -1L;
+        }
+
+        @Override
+        protected long nvmlGetMemoryClockMhz(String deviceId) {
+            return -1L;
+        }
+
+        @Override
+        protected double nvmlGetFanSpeedPercent(String deviceId) {
+            return -1d;
+        }
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHWDiskStoreNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHWDiskStoreNF.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux.nativefree;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.HWDiskStore;
+import oshi.hardware.HWPartition;
+import oshi.hardware.common.platform.linux.LinuxHWDiskStore;
+import oshi.util.FileUtil;
+import oshi.util.ParseUtil;
+import oshi.util.linux.DevPath;
+import oshi.util.linux.SysPath;
+
+/**
+ * Native-free Linux disk store implementation. Enumerates block devices from {@code /sys/block/} and reads stats from
+ * sysfs, without requiring udev.
+ */
+@ThreadSafe
+public final class LinuxHWDiskStoreNF extends LinuxHWDiskStore {
+
+    private static final String SYS_BLOCK = SysPath.SYS + "block/";
+
+    LinuxHWDiskStoreNF(String name, String model, String serial, long size, String diskType) {
+        super(name, model, serial, size, diskType);
+    }
+
+    /**
+     * Gets disk stores on this machine.
+     *
+     * @return a list of {@link HWDiskStore} objects
+     */
+    public static List<HWDiskStore> getDisks() {
+        List<HWDiskStore> result = new ArrayList<>();
+        Map<String, String> mountsMap = readMountsMap();
+
+        File[] blockDevices = new File(SYS_BLOCK).listFiles();
+        if (blockDevices == null) {
+            return result;
+        }
+        for (File blockDev : blockDevices) {
+            String name = blockDev.getName();
+            String sysPath = SYS_BLOCK + name + "/";
+
+            // Filter to real disks (skip loop, ram, etc.)
+            String devType = FileUtil.getStringFromFile(sysPath + "device/type").trim();
+            if (devType.isEmpty()) {
+                // No device/type means it's a virtual device; check if it has a device/ subdir
+                if (!new File(sysPath + "device").exists()) {
+                    continue;
+                }
+            }
+
+            String model = FileUtil.getStringFromFile(sysPath + "device/model").trim();
+            String serial = FileUtil.getStringFromFile(sysPath + "device/serial").trim();
+            long size = ParseUtil.parseLongOrDefault(FileUtil.getStringFromFile(sysPath + SIZE).trim(), 0L)
+                    * SECTORSIZE;
+            String rotational = FileUtil.getStringFromFile(sysPath + "queue/rotational").trim();
+            String diskType = "1".equals(rotational) ? "HDD" : "0".equals(rotational) ? "SSD" : "";
+
+            LinuxHWDiskStoreNF store = new LinuxHWDiskStoreNF(DevPath.DEV + name, model, serial, size, diskType);
+
+            // Read stats
+            String statStr = FileUtil.getStringFromFile(sysPath + STAT).trim();
+            if (!statStr.isEmpty()) {
+                computeDiskStats(store, statStr);
+            }
+
+            // Enumerate partitions
+            File[] partDirs = blockDev.listFiles(f -> f.isDirectory() && f.getName().startsWith(name));
+            if (partDirs != null) {
+                for (File partDir : partDirs) {
+                    String partName = partDir.getName();
+                    String partPath = sysPath + partName + "/";
+                    long partSize = ParseUtil.parseLongOrDefault(FileUtil.getStringFromFile(partPath + SIZE).trim(), 0L)
+                            * SECTORSIZE;
+                    String devStr = FileUtil.getStringFromFile(partPath + "dev").trim();
+                    int major = 0;
+                    int minor = 0;
+                    if (devStr.contains(":")) {
+                        String[] majMin = devStr.split(":");
+                        major = ParseUtil.parseIntOrDefault(majMin[0], 0);
+                        minor = ParseUtil.parseIntOrDefault(majMin[1], 0);
+                    }
+                    String mountPoint = mountsMap.getOrDefault(DevPath.DEV + partName, "");
+                    store.getMutablePartitionList()
+                            .add(new HWPartition(partName, partName, "", "", "", partSize, major, minor, mountPoint));
+                }
+            }
+
+            result.add(store);
+        }
+        finalizePartitions(result);
+        return result;
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        String devName = getName().replace(DevPath.DEV, "");
+        String statStr = FileUtil.getStringFromFile(SYS_BLOCK + devName + "/" + STAT).trim();
+        if (statStr.isEmpty()) {
+            return false;
+        }
+        computeDiskStats(this, statStr);
+        return true;
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHardwareAbstractionLayerNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHardwareAbstractionLayerNF.java
@@ -17,14 +17,15 @@ import oshi.hardware.PowerSource;
 import oshi.hardware.UsbDevice;
 import oshi.hardware.common.platform.linux.LinuxGlobalMemory;
 import oshi.hardware.common.platform.linux.LinuxHardwareAbstractionLayer;
+import oshi.hardware.common.platform.linux.LinuxPowerSource;
 import oshi.software.common.os.linux.nativefree.LinuxOperatingSystemNF;
 
 /**
  * Native-free hardware abstraction layer for Linux. Extends {@link LinuxHardwareAbstractionLayer}, providing
  * implementations that require no native access.
  * <p>
- * Currently provides full CPU and memory support. Disk, network, power, USB, and graphics card enumeration return empty
- * lists and will be implemented in future phases.
+ * Currently provides full CPU, memory, disk, network, and power source support. USB and graphics card enumeration
+ * return empty lists and will be implemented in future phases.
  */
 @ThreadSafe
 public final class LinuxHardwareAbstractionLayerNF extends LinuxHardwareAbstractionLayer {
@@ -41,17 +42,17 @@ public final class LinuxHardwareAbstractionLayerNF extends LinuxHardwareAbstract
 
     @Override
     public List<HWDiskStore> getDiskStores() {
-        return Collections.emptyList();
+        return LinuxHWDiskStoreNF.getDisks();
     }
 
     @Override
     public List<NetworkIF> getNetworkIFs(boolean includeLocalInterfaces) {
-        return Collections.emptyList();
+        return LinuxNetworkIFNF.getNetworks(includeLocalInterfaces);
     }
 
     @Override
     public List<PowerSource> getPowerSources() {
-        return Collections.emptyList();
+        return LinuxPowerSource.getPowerSources();
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHardwareAbstractionLayerNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHardwareAbstractionLayerNF.java
@@ -4,7 +4,6 @@
  */
 package oshi.hardware.common.platform.linux.nativefree;
 
-import java.util.Collections;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -23,9 +22,6 @@ import oshi.software.common.os.linux.nativefree.LinuxOperatingSystemNF;
 /**
  * Native-free hardware abstraction layer for Linux. Extends {@link LinuxHardwareAbstractionLayer}, providing
  * implementations that require no native access.
- * <p>
- * Currently provides full CPU, memory, disk, network, and power source support. USB and graphics card enumeration
- * return empty lists and will be implemented in future phases.
  */
 @ThreadSafe
 public final class LinuxHardwareAbstractionLayerNF extends LinuxHardwareAbstractionLayer {
@@ -47,7 +43,7 @@ public final class LinuxHardwareAbstractionLayerNF extends LinuxHardwareAbstract
 
     @Override
     public List<NetworkIF> getNetworkIFs(boolean includeLocalInterfaces) {
-        return LinuxNetworkIFNF.getNetworks(includeLocalInterfaces);
+        return LinuxNetworkIfNF.getNetworks(includeLocalInterfaces);
     }
 
     @Override
@@ -57,11 +53,11 @@ public final class LinuxHardwareAbstractionLayerNF extends LinuxHardwareAbstract
 
     @Override
     public List<UsbDevice> getUsbDevices(boolean tree) {
-        return Collections.emptyList();
+        return LinuxUsbDeviceNF.getUsbDevices(tree);
     }
 
     @Override
     public List<GraphicsCard> getGraphicsCards() {
-        return Collections.emptyList();
+        return LinuxGraphicsCardNF.getGraphicsCards();
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHardwareAbstractionLayerNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHardwareAbstractionLayerNF.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux.nativefree;
+
+import java.util.Collections;
+import java.util.List;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.GraphicsCard;
+import oshi.hardware.HWDiskStore;
+import oshi.hardware.NetworkIF;
+import oshi.hardware.PowerSource;
+import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.linux.LinuxGlobalMemory;
+import oshi.hardware.common.platform.linux.LinuxHardwareAbstractionLayer;
+import oshi.software.common.os.linux.nativefree.LinuxOperatingSystemNF;
+
+/**
+ * Native-free hardware abstraction layer for Linux. Extends {@link LinuxHardwareAbstractionLayer}, providing
+ * implementations that require no native access.
+ * <p>
+ * Currently provides full CPU and memory support. Disk, network, power, USB, and graphics card enumeration return empty
+ * lists and will be implemented in future phases.
+ */
+@ThreadSafe
+public final class LinuxHardwareAbstractionLayerNF extends LinuxHardwareAbstractionLayer {
+
+    @Override
+    public GlobalMemory createMemory() {
+        return new LinuxGlobalMemory(LinuxOperatingSystemNF.pageSize());
+    }
+
+    @Override
+    public CentralProcessor createProcessor() {
+        return new LinuxCentralProcessorNF();
+    }
+
+    @Override
+    public List<HWDiskStore> getDiskStores() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NetworkIF> getNetworkIFs(boolean includeLocalInterfaces) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<PowerSource> getPowerSources() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<UsbDevice> getUsbDevices(boolean tree) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<GraphicsCard> getGraphicsCards() {
+        return Collections.emptyList();
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxNetworkIFNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxNetworkIFNF.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux.nativefree;
+
+import java.net.NetworkInterface;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.NetworkIF;
+import oshi.hardware.common.platform.linux.LinuxNetworkIF;
+
+/**
+ * Native-free Linux network interface implementation. Uses sysfs for model identification.
+ */
+@ThreadSafe
+public final class LinuxNetworkIFNF extends LinuxNetworkIF {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxNetworkIFNF.class);
+
+    LinuxNetworkIFNF(NetworkInterface netint) throws InstantiationException {
+        super(netint, queryIfModelFromSysfs(netint.getName()));
+    }
+
+    /**
+     * Gets network interfaces on this machine.
+     *
+     * @param includeLocalInterfaces include local interfaces in the result
+     * @return a list of {@link NetworkIF} objects
+     */
+    public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
+        List<NetworkIF> ifList = new ArrayList<>();
+        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
+            try {
+                ifList.add(new LinuxNetworkIFNF(ni));
+            } catch (InstantiationException e) {
+                LOG.debug("Network Interface Instantiation failed: {}", e.toString());
+            }
+        }
+        return ifList;
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxNetworkIfNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxNetworkIfNF.java
@@ -19,11 +19,11 @@ import oshi.hardware.common.platform.linux.LinuxNetworkIF;
  * Native-free Linux network interface implementation. Uses sysfs for model identification.
  */
 @ThreadSafe
-public final class LinuxNetworkIFNF extends LinuxNetworkIF {
+public final class LinuxNetworkIfNF extends LinuxNetworkIF {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LinuxNetworkIFNF.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxNetworkIfNF.class);
 
-    LinuxNetworkIFNF(NetworkInterface netint) throws InstantiationException {
+    LinuxNetworkIfNF(NetworkInterface netint) throws InstantiationException {
         super(netint, queryIfModelFromSysfs(netint.getName()));
     }
 
@@ -37,7 +37,7 @@ public final class LinuxNetworkIFNF extends LinuxNetworkIF {
         List<NetworkIF> ifList = new ArrayList<>();
         for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
             try {
-                ifList.add(new LinuxNetworkIFNF(ni));
+                ifList.add(new LinuxNetworkIfNF(ni));
             } catch (InstantiationException e) {
                 LOG.debug("Network Interface Instantiation failed: {}", e.toString());
             }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNF.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux.nativefree;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.linux.LinuxUsbDevice;
+import oshi.util.FileUtil;
+import oshi.util.linux.SysPath;
+
+/**
+ * Native-free Linux USB device enumeration from {@code /sys/bus/usb/devices/}.
+ */
+public final class LinuxUsbDeviceNF extends LinuxUsbDevice {
+
+    private static final String SYS_USB = SysPath.SYS + "bus/usb/devices/";
+
+    private LinuxUsbDeviceNF() {
+    }
+
+    /**
+     * Gets USB devices on this machine.
+     *
+     * @param tree if true, returns controllers with device tree; if false, flat list excluding controllers
+     * @return a list of {@link UsbDevice} objects
+     */
+    public static List<UsbDevice> getUsbDevices(boolean tree) {
+        List<UsbDevice> devices = queryUsbDevices();
+        if (tree) {
+            return devices;
+        }
+        List<UsbDevice> deviceList = new ArrayList<>();
+        for (UsbDevice device : devices) {
+            addDevicesToList(deviceList, device.getConnectedDevices());
+        }
+        return deviceList;
+    }
+
+    private static List<UsbDevice> queryUsbDevices() {
+        File usbDir = new File(SYS_USB);
+        File[] deviceDirs = usbDir.listFiles();
+        if (deviceDirs == null) {
+            return new ArrayList<>();
+        }
+
+        List<String> usbControllers = new ArrayList<>();
+        Map<String, String> nameMap = new HashMap<>();
+        Map<String, String> vendorMap = new HashMap<>();
+        Map<String, String> vendorIdMap = new HashMap<>();
+        Map<String, String> productIdMap = new HashMap<>();
+        Map<String, String> serialMap = new HashMap<>();
+        Map<String, List<String>> hubMap = new HashMap<>();
+
+        for (File devDir : deviceDirs) {
+            String syspath = devDir.getAbsolutePath();
+            String devtype = FileUtil.getStringFromFile(syspath + "/devnum").trim();
+            if (devtype.isEmpty()) {
+                continue;
+            }
+
+            String product = FileUtil.getStringFromFile(syspath + "/product").trim();
+            if (!product.isEmpty()) {
+                nameMap.put(syspath, product);
+            }
+            String manufacturer = FileUtil.getStringFromFile(syspath + "/manufacturer").trim();
+            if (!manufacturer.isEmpty()) {
+                vendorMap.put(syspath, manufacturer);
+            }
+            String idVendor = FileUtil.getStringFromFile(syspath + "/idVendor").trim();
+            if (!idVendor.isEmpty()) {
+                vendorIdMap.put(syspath, idVendor);
+            }
+            String idProduct = FileUtil.getStringFromFile(syspath + "/idProduct").trim();
+            if (!idProduct.isEmpty()) {
+                productIdMap.put(syspath, idProduct);
+            }
+            String serial = FileUtil.getStringFromFile(syspath + "/serial").trim();
+            if (!serial.isEmpty()) {
+                serialMap.put(syspath, serial);
+            }
+
+            // Determine parent: USB root hubs have names like "usbN", children have "N-N.N..."
+            String name = devDir.getName();
+            if (name.startsWith("usb")) {
+                usbControllers.add(syspath);
+            } else {
+                String parentName;
+                if (name.contains(".")) {
+                    parentName = name.substring(0, name.lastIndexOf('.'));
+                } else if (name.contains("-")) {
+                    parentName = "usb" + name.substring(0, name.indexOf('-'));
+                } else {
+                    parentName = name;
+                }
+                String parentPath = SYS_USB + parentName;
+                hubMap.computeIfAbsent(parentPath, x -> new ArrayList<>()).add(syspath);
+            }
+        }
+
+        List<UsbDevice> controllerDevices = new ArrayList<>();
+        for (String controller : usbControllers) {
+            controllerDevices.add(getDeviceAndChildren(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
+                    productIdMap, serialMap, hubMap));
+        }
+        return controllerDevices;
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/package-info.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Native-free Linux hardware implementations using only procfs, sysfs, and command-line utilities.
+ */
+package oshi.hardware.common.platform.linux.nativefree;

--- a/oshi-common/src/main/java/oshi/nativefree/SystemInfo.java
+++ b/oshi-common/src/main/java/oshi/nativefree/SystemInfo.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.nativefree;
+
+import static oshi.util.Memoizer.memoize;
+
+import java.util.function.Supplier;
+
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.common.platform.linux.nativefree.LinuxHardwareAbstractionLayerNF;
+import oshi.software.common.os.linux.nativefree.LinuxOperatingSystemNF;
+import oshi.software.os.OperatingSystem;
+import oshi.spi.SystemInfoProvider;
+import oshi.util.PlatformEnum;
+
+/**
+ * Native-free {@link SystemInfoProvider} for Linux. Uses only procfs, sysfs, and standard Java APIs — no JNA, no FFM,
+ * no {@code --enable-native-access} required.
+ * <p>
+ * This provider is registered at priority 0 (lowest) and is only selected when no higher-priority provider (JNA or FFM)
+ * is available on the classpath.
+ *
+ * @see oshi.spi.SystemInfoFactory
+ */
+public class SystemInfo implements SystemInfoProvider {
+
+    private final Supplier<OperatingSystem> os = memoize(LinuxOperatingSystemNF::new);
+    private final Supplier<HardwareAbstractionLayer> hardware = memoize(LinuxHardwareAbstractionLayerNF::new);
+
+    /**
+     * Creates a new native-free Linux {@code SystemInfo} instance.
+     */
+    public SystemInfo() {
+    }
+
+    @Override
+    public OperatingSystem getOperatingSystem() {
+        return os.get();
+    }
+
+    @Override
+    public HardwareAbstractionLayer getHardware() {
+        return hardware.get();
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return PlatformEnum.getCurrentPlatform() == PlatformEnum.LINUX;
+    }
+}

--- a/oshi-common/src/main/java/oshi/nativefree/package-info.java
+++ b/oshi-common/src/main/java/oshi/nativefree/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Native-free OSHI entry point for Linux. See {@link oshi.nativefree.SystemInfo}.
+ */
+package oshi.nativefree;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxFileSystemNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxFileSystemNF.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.linux.nativefree;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.os.linux.LinuxFileSystem;
+
+/**
+ * Native-free Linux file system implementation. Extends {@link LinuxFileSystem}, returning {@code null} from
+ * {@link #queryStatvfs(String)} to trigger the Java {@link java.io.File} fallback for space/inode values.
+ */
+@ThreadSafe
+public class LinuxFileSystemNF extends LinuxFileSystem {
+
+    @Override
+    protected long[] queryStatvfs(String path) {
+        return null;
+    }
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxNetworkParamsNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxNetworkParamsNF.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.linux.nativefree;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.os.linux.LinuxNetworkParams;
+
+/**
+ * Native-free Linux network parameters implementation. Extends {@link LinuxNetworkParams}, using the Java-based
+ * hostname and domain name resolution from {@link oshi.software.common.AbstractNetworkParams}.
+ */
+@ThreadSafe
+public class LinuxNetworkParamsNF extends LinuxNetworkParams {
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOSProcessNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOSProcessNF.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.linux.nativefree;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.os.linux.LinuxOSProcess;
+import oshi.software.common.os.linux.LinuxOperatingSystem;
+
+/**
+ * Native-free Linux OS process implementation. Extends {@link LinuxOSProcess}, providing implementations that require
+ * no native access.
+ */
+@ThreadSafe
+public class LinuxOSProcessNF extends LinuxOSProcess {
+
+    /**
+     * Creates a new native-free Linux OS process.
+     *
+     * @param pid the process ID
+     * @param os  the operating system instance
+     */
+    public LinuxOSProcessNF(int pid, LinuxOperatingSystem os) {
+        super(pid, os);
+    }
+
+    @Override
+    protected long queryRlimitSoft() {
+        return getProcessOpenFileLimit(getProcessID(), 1);
+    }
+
+    @Override
+    protected long queryRlimitHard() {
+        return getProcessOpenFileLimit(getProcessID(), 2);
+    }
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOperatingSystemNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOperatingSystemNF.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.linux.nativefree;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.os.linux.LinuxOperatingSystem;
+import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OSProcess.State;
+import oshi.util.ExecutingCommand;
+import oshi.util.FileUtil;
+import oshi.util.ParseUtil;
+import oshi.util.linux.ProcPath;
+
+/**
+ * Native-free Linux operating system implementation. Extends {@link LinuxOperatingSystem}, providing implementations
+ * that require no native access.
+ */
+@ThreadSafe
+public class LinuxOperatingSystemNF extends LinuxOperatingSystem {
+
+    private static final long USER_HZ;
+    private static final long PAGE_SIZE;
+
+    static {
+        USER_HZ = ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf CLK_TCK"), 100L);
+        PAGE_SIZE = ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf PAGE_SIZE"), 4096L);
+    }
+
+    /**
+     * Gets Jiffies per second.
+     *
+     * @return Jiffies per second.
+     */
+    public static long hz() {
+        return USER_HZ;
+    }
+
+    /**
+     * Gets Page Size in bytes.
+     *
+     * @return Page Size in bytes.
+     */
+    public static long pageSize() {
+        return PAGE_SIZE;
+    }
+
+    @Override
+    public long getHz() {
+        return USER_HZ;
+    }
+
+    @Override
+    public long getPageSize() {
+        return PAGE_SIZE;
+    }
+
+    @Override
+    public FileSystem getFileSystem() {
+        return new LinuxFileSystemNF();
+    }
+
+    @Override
+    public NetworkParams getNetworkParams() {
+        return new LinuxNetworkParamsNF();
+    }
+
+    @Override
+    public OSProcess getProcess(int pid) {
+        OSProcess proc = createOSProcess(pid);
+        if (!proc.getState().equals(State.INVALID)) {
+            return proc;
+        }
+        return null;
+    }
+
+    @Override
+    protected OSProcess createOSProcess(int pid) {
+        return new LinuxOSProcessNF(pid, this);
+    }
+
+    @Override
+    public int getProcessId() {
+        // First field of /proc/self/stat is the PID
+        String stat = FileUtil.getStringFromFile(ProcPath.SELF_STAT);
+        int space = stat.indexOf(' ');
+        if (space > 0) {
+            return ParseUtil.parseIntOrDefault(stat.substring(0, space), 0);
+        }
+        return 0;
+    }
+
+    @Override
+    public int getThreadId() {
+        try {
+            return ParseUtil.parseIntOrDefault(
+                    Files.readSymbolicLink(Paths.get(ProcPath.THREAD_SELF)).getFileName().toString(), 0);
+        } catch (IOException e) {
+            return 0;
+        }
+    }
+
+    @Override
+    public int getThreadCount() {
+        // /proc/loadavg format: "load1 load5 load15 running/total lastpid"
+        String loadavg = FileUtil.getStringFromFile(ProcPath.LOADAVG);
+        if (!loadavg.isEmpty()) {
+            String[] split = loadavg.split("\\s+");
+            if (split.length >= 4) {
+                String[] runTotal = split[3].split("/");
+                if (runTotal.length == 2) {
+                    return ParseUtil.parseIntOrDefault(runTotal[1], 0);
+                }
+            }
+        }
+        return 0;
+    }
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/package-info.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Native-free Linux operating system implementations using only procfs, sysfs, and command-line utilities.
+ */
+package oshi.software.common.os.linux.nativefree;

--- a/oshi-common/src/main/java/oshi/spi/SystemInfoFactory.java
+++ b/oshi-common/src/main/java/oshi/spi/SystemInfoFactory.java
@@ -66,7 +66,8 @@ public final class SystemInfoFactory {
         }
         if (best == null) {
             throw new IllegalStateException(
-                    "No SystemInfoProvider found. Add oshi-core or oshi-core-ffm as a dependency.");
+                    "No SystemInfoProvider found. Add oshi-core or oshi-core-ffm as a dependency,"
+                            + " or use oshi-common alone if on Linux (native-free provider).");
         }
         return best;
     }

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -1,6 +1,10 @@
 --add-opens
   com.github.oshi.common/oshi=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.spi=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.nativefree=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.hardware=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.hardware.common=org.junit.platform.commons
@@ -10,6 +14,8 @@
   com.github.oshi.common/oshi.software.common=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.hardware.common.platform.linux=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.hardware.common.platform.linux.nativefree=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.hardware.common.platform.mac=org.junit.platform.commons
 --add-opens
@@ -22,6 +28,8 @@
   com.github.oshi.common/oshi.software.common.os.mac=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.software.common.os.linux=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.software.common.os.linux.nativefree=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.util.driver.linux=org.junit.platform.commons
 --add-opens

--- a/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
+++ b/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.nativefree;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.CentralProcessor.LogicalProcessor;
+import oshi.hardware.CentralProcessor.PhysicalProcessor;
+import oshi.hardware.CentralProcessor.ProcessorCache;
+import oshi.hardware.CentralProcessor.TickType;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.VirtualMemory;
+import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
+import oshi.software.os.OSFileStore;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OperatingSystem;
+
+/**
+ * Exercises the native-free Linux provider and logs human-readable output for validation.
+ */
+@EnabledOnOs(OS.LINUX)
+class SystemInfoTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(SystemInfoTest.class);
+
+    private static oshi.nativefree.SystemInfo si;
+    private static OperatingSystem os;
+    private static HardwareAbstractionLayer hal;
+
+    @BeforeAll
+    static void setUp() {
+        si = new oshi.nativefree.SystemInfo();
+        os = si.getOperatingSystem();
+        hal = si.getHardware();
+    }
+
+    @Test
+    void testOperatingSystem() {
+        assertThat(os, is(notNullValue()));
+        logger.info("OS: {} {} {}", os.getFamily(), os.getManufacturer(), os.getVersionInfo());
+        logger.info("Bitness: {}", os.getBitness());
+        logger.info("Boot time: {}", os.getSystemBootTime());
+        logger.info("Uptime: {} sec", os.getSystemUptime());
+        logger.info("Process ID: {}", os.getProcessId());
+        logger.info("Thread ID: {}", os.getThreadId());
+        logger.info("Thread count: {}", os.getThreadCount());
+        logger.info("Process count: {}", os.getProcessCount());
+
+        assertThat(os.getFamily(), is(not("")));
+        assertThat(os.getProcessId(), greaterThan(0));
+        assertThat(os.getThreadCount(), greaterThan(0));
+        assertThat(os.getSystemBootTime(), greaterThan(0L));
+        assertThat(os.getSystemUptime(), greaterThan(0L));
+    }
+
+    @Test
+    void testProcessor() {
+        CentralProcessor cpu = hal.getProcessor();
+        assertThat(cpu, is(notNullValue()));
+
+        logger.info("Processor: {}", cpu.getProcessorIdentifier().getName());
+        logger.info("  Vendor: {}", cpu.getProcessorIdentifier().getVendor());
+        logger.info("  Logical CPUs: {}", cpu.getLogicalProcessorCount());
+        logger.info("  Physical CPUs: {}", cpu.getPhysicalProcessorCount());
+        logger.info("  Packages: {}", cpu.getPhysicalPackageCount());
+        logger.info("  Max freq: {} Hz", cpu.getMaxFreq());
+
+        assertThat(cpu.getLogicalProcessorCount(), greaterThan(0));
+        assertThat(cpu.getPhysicalProcessorCount(), greaterThan(0));
+        assertThat(cpu.getProcessorIdentifier().getName(), is(not("")));
+
+        List<LogicalProcessor> logProcs = cpu.getLogicalProcessors();
+        assertThat(logProcs.size(), is(cpu.getLogicalProcessorCount()));
+
+        List<PhysicalProcessor> physProcs = cpu.getPhysicalProcessors();
+        assertThat(physProcs.size(), is(cpu.getPhysicalProcessorCount()));
+
+        List<ProcessorCache> caches = cpu.getProcessorCaches();
+        for (ProcessorCache cache : caches) {
+            logger.info("  Cache: L{} {} {} KB", cache.getLevel(), cache.getType(), cache.getCacheSize() / 1024);
+        }
+
+        long[] ticks = cpu.getSystemCpuLoadTicks();
+        assertThat(ticks.length, is(TickType.values().length));
+        logger.info("  Ticks: {}", Arrays.toString(ticks));
+
+        long[] freqs = cpu.getCurrentFreq();
+        assertThat(freqs.length, is(cpu.getLogicalProcessorCount()));
+    }
+
+    @Test
+    void testMemory() {
+        GlobalMemory mem = hal.getMemory();
+        assertThat(mem, is(notNullValue()));
+
+        logger.info("Memory: {} total, {} available", mem.getTotal(), mem.getAvailable());
+        logger.info("  Page size: {}", mem.getPageSize());
+
+        assertThat(mem.getTotal(), greaterThan(0L));
+        assertThat(mem.getAvailable(), greaterThanOrEqualTo(0L));
+        assertThat(mem.getPageSize(), greaterThan(0L));
+
+        VirtualMemory vm = mem.getVirtualMemory();
+        logger.info("  Swap: {} total, {} used", vm.getSwapTotal(), vm.getSwapUsed());
+        assertThat(vm.getSwapTotal(), greaterThanOrEqualTo(0L));
+    }
+
+    @Test
+    void testFileSystem() {
+        FileSystem fs = os.getFileSystem();
+        assertThat(fs, is(notNullValue()));
+
+        List<OSFileStore> stores = fs.getFileStores();
+        assertThat(stores.size(), greaterThan(0));
+
+        for (OSFileStore store : stores) {
+            logger.info("  {} ({}) at {} - {} total, {} usable", store.getName(), store.getType(), store.getMount(),
+                    store.getTotalSpace(), store.getUsableSpace());
+        }
+    }
+
+    @Test
+    void testNetworkParams() {
+        NetworkParams net = os.getNetworkParams();
+        assertThat(net, is(notNullValue()));
+
+        logger.info("Network: host={}, domain={}", net.getHostName(), net.getDomainName());
+        logger.info("  DNS: {}", Arrays.toString(net.getDnsServers()));
+        logger.info("  IPv4 gateway: {}", net.getIpv4DefaultGateway());
+        logger.info("  IPv6 gateway: {}", net.getIpv6DefaultGateway());
+
+        assertThat(net.getHostName(), is(not("")));
+    }
+
+    @Test
+    void testCurrentProcess() {
+        int pid = os.getProcessId();
+        OSProcess proc = os.getProcess(pid);
+        assertThat(proc, is(notNullValue()));
+
+        logger.info("Current process [{}]: {}", pid, proc.getName());
+        logger.info("  Path: {}", proc.getPath());
+        logger.info("  User: {} ({})", proc.getUser(), proc.getUserID());
+        logger.info("  Group: {} ({})", proc.getGroup(), proc.getGroupID());
+        logger.info("  Threads: {}", proc.getThreadCount());
+        logger.info("  RSS: {}", proc.getResidentMemory());
+        logger.info("  Open files: {}", proc.getOpenFiles());
+
+        assertThat(proc.getName(), is(not("")));
+        assertThat(proc.getProcessID(), is(pid));
+    }
+}

--- a/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
+++ b/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
@@ -153,6 +153,31 @@ class SystemInfoTest {
     }
 
     @Test
+    void testDiskStores() {
+        List<oshi.hardware.HWDiskStore> disks = hal.getDiskStores();
+        assertThat(disks.size(), greaterThan(0));
+
+        for (oshi.hardware.HWDiskStore disk : disks) {
+            logger.info("Disk: {} ({}) serial={} size={} type={}", disk.getName(), disk.getModel(), disk.getSerial(),
+                    disk.getSize(), disk.getDiskType());
+            assertThat(disk.getName(), is(not("")));
+            assertThat(disk.getSize(), greaterThan(0L));
+        }
+    }
+
+    @Test
+    void testNetworkInterfaces() {
+        List<oshi.hardware.NetworkIF> nets = hal.getNetworkIFs();
+        assertThat(nets.size(), greaterThan(0));
+
+        for (oshi.hardware.NetworkIF net : nets) {
+            logger.info("Net: {} mac={} speed={} ipv4={}", net.getName(), net.getMacaddr(), net.getSpeed(),
+                    Arrays.toString(net.getIPv4addr()));
+            assertThat(net.getName(), is(not("")));
+        }
+    }
+
+    @Test
     void testCurrentProcess() {
         int pid = os.getProcessId();
         OSProcess proc = os.getProcess(pid);

--- a/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
+++ b/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
@@ -5,193 +5,134 @@
 package oshi.nativefree;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
+import static oshi.util.SystemInfoHelper.printComputerSystem;
+import static oshi.util.SystemInfoHelper.printCpu;
+import static oshi.util.SystemInfoHelper.printDisks;
+import static oshi.util.SystemInfoHelper.printDisplays;
+import static oshi.util.SystemInfoHelper.printFileSystem;
+import static oshi.util.SystemInfoHelper.printGraphicsCards;
+import static oshi.util.SystemInfoHelper.printInternetProtocolStats;
+import static oshi.util.SystemInfoHelper.printLVgroups;
+import static oshi.util.SystemInfoHelper.printMemory;
+import static oshi.util.SystemInfoHelper.printNetworkInterfaces;
+import static oshi.util.SystemInfoHelper.printNetworkParameters;
+import static oshi.util.SystemInfoHelper.printOperatingSystem;
+import static oshi.util.SystemInfoHelper.printPowerSources;
+import static oshi.util.SystemInfoHelper.printProcesses;
+import static oshi.util.SystemInfoHelper.printProcessor;
+import static oshi.util.SystemInfoHelper.printSensors;
+import static oshi.util.SystemInfoHelper.printServices;
+import static oshi.util.SystemInfoHelper.printSoundCards;
+import static oshi.util.SystemInfoHelper.printUsbDevices;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import oshi.hardware.CentralProcessor;
-import oshi.hardware.CentralProcessor.LogicalProcessor;
-import oshi.hardware.CentralProcessor.PhysicalProcessor;
-import oshi.hardware.CentralProcessor.ProcessorCache;
-import oshi.hardware.CentralProcessor.TickType;
-import oshi.hardware.GlobalMemory;
 import oshi.hardware.HardwareAbstractionLayer;
-import oshi.hardware.VirtualMemory;
-import oshi.software.os.FileSystem;
-import oshi.software.os.NetworkParams;
-import oshi.software.os.OSFileStore;
-import oshi.software.os.OSProcess;
 import oshi.software.os.OperatingSystem;
+import oshi.util.PlatformEnum;
 
 /**
- * Exercises the native-free Linux provider and logs human-readable output for validation.
+ * Exercises the native-free Linux provider and logs human-readable output, mirroring the JNA and FFM SystemInfoTest
+ * classes.
  */
+@Execution(ExecutionMode.SAME_THREAD)
 @EnabledOnOs(OS.LINUX)
-class SystemInfoTest {
+public class SystemInfoTest {
 
     private static final Logger logger = LoggerFactory.getLogger(SystemInfoTest.class);
 
-    private static oshi.nativefree.SystemInfo si;
-    private static OperatingSystem os;
-    private static HardwareAbstractionLayer hal;
-
-    @BeforeAll
-    static void setUp() {
-        si = new oshi.nativefree.SystemInfo();
-        os = si.getOperatingSystem();
-        hal = si.getHardware();
+    @Test
+    public void testPlatformEnum() {
+        assertThat("Unsupported OS", PlatformEnum.getCurrentPlatform(), is(not(PlatformEnum.UNKNOWN)));
+        main(null);
     }
 
-    @Test
-    void testOperatingSystem() {
-        assertThat(os, is(notNullValue()));
-        logger.info("OS: {} {} {}", os.getFamily(), os.getManufacturer(), os.getVersionInfo());
-        logger.info("Bitness: {}", os.getBitness());
-        logger.info("Boot time: {}", os.getSystemBootTime());
-        logger.info("Uptime: {} sec", os.getSystemUptime());
-        logger.info("Process ID: {}", os.getProcessId());
-        logger.info("Thread ID: {}", os.getThreadId());
-        logger.info("Thread count: {}", os.getThreadCount());
-        logger.info("Process count: {}", os.getProcessCount());
+    public static void main(String[] args) {
+        logger.info("------------------------------------------------------------------------");
+        logger.info("Using Native-Free (NF)");
+        logger.info("------------------------------------------------------------------------");
+        logger.info("Initializing System...");
+        SystemInfo si = new SystemInfo();
 
-        assertThat(os.getFamily(), is(not("")));
-        assertThat(os.getProcessId(), greaterThan(0));
-        assertThat(os.getThreadCount(), greaterThan(0));
-        assertThat(os.getSystemBootTime(), greaterThan(0L));
-        assertThat(os.getSystemUptime(), greaterThan(0L));
-    }
+        HardwareAbstractionLayer hal = si.getHardware();
+        OperatingSystem os = si.getOperatingSystem();
 
-    @Test
-    void testProcessor() {
-        CentralProcessor cpu = hal.getProcessor();
-        assertThat(cpu, is(notNullValue()));
+        List<String> lines = new ArrayList<>();
 
-        logger.info("Processor: {}", cpu.getProcessorIdentifier().getName());
-        logger.info("  Vendor: {}", cpu.getProcessorIdentifier().getVendor());
-        logger.info("  Logical CPUs: {}", cpu.getLogicalProcessorCount());
-        logger.info("  Physical CPUs: {}", cpu.getPhysicalProcessorCount());
-        logger.info("  Packages: {}", cpu.getPhysicalPackageCount());
-        logger.info("  Max freq: {} Hz", cpu.getMaxFreq());
+        printOperatingSystem(lines, os);
 
-        assertThat(cpu.getLogicalProcessorCount(), greaterThan(0));
-        assertThat(cpu.getPhysicalProcessorCount(), greaterThan(0));
-        assertThat(cpu.getProcessorIdentifier().getName(), is(not("")));
+        logger.info("Checking computer system...");
+        printComputerSystem(lines, hal.getComputerSystem());
 
-        List<LogicalProcessor> logProcs = cpu.getLogicalProcessors();
-        assertThat(logProcs.size(), is(cpu.getLogicalProcessorCount()));
+        logger.info("Checking Processor...");
+        printProcessor(lines, hal.getProcessor());
 
-        List<PhysicalProcessor> physProcs = cpu.getPhysicalProcessors();
-        assertThat(physProcs.size(), is(cpu.getPhysicalProcessorCount()));
+        logger.info("Checking Memory...");
+        printMemory(lines, hal.getMemory());
 
-        List<ProcessorCache> caches = cpu.getProcessorCaches();
-        for (ProcessorCache cache : caches) {
-            logger.info("  Cache: L{} {} {} KB", cache.getLevel(), cache.getType(), cache.getCacheSize() / 1024);
+        logger.info("Checking CPU...");
+        printCpu(lines, hal.getProcessor());
+
+        logger.info("Checking Processes...");
+        printProcesses(lines, os, hal.getMemory());
+
+        logger.info("Checking Services...");
+        printServices(lines, os);
+
+        logger.info("Checking Sensors...");
+        printSensors(lines, hal.getSensors());
+
+        logger.info("Checking Power sources...");
+        printPowerSources(lines, hal.getPowerSources());
+
+        logger.info("Checking Disks...");
+        printDisks(lines, hal.getDiskStores());
+
+        logger.info("Checking Logical Volume Groups ...");
+        printLVgroups(lines, hal.getLogicalVolumeGroups());
+
+        logger.info("Checking File System...");
+        printFileSystem(lines, os.getFileSystem());
+
+        logger.info("Checking Network interfaces...");
+        printNetworkInterfaces(lines, hal.getNetworkIFs());
+
+        logger.info("Checking Network parameters...");
+        printNetworkParameters(lines, os.getNetworkParams());
+
+        logger.info("Checking IP statistics...");
+        printInternetProtocolStats(lines, os.getInternetProtocolStats());
+
+        logger.info("Checking Displays...");
+        printDisplays(lines, hal.getDisplays());
+
+        logger.info("Checking USB Devices...");
+        printUsbDevices(lines, hal.getUsbDevices(true));
+
+        logger.info("Checking Sound Cards...");
+        printSoundCards(lines, hal.getSoundCards());
+
+        logger.info("Checking Graphics Cards...");
+        printGraphicsCards(lines, hal.getGraphicsCards());
+
+        StringBuilder output = new StringBuilder();
+        for (String line : lines) {
+            output.append(line);
+            if (line != null && !line.endsWith("\n")) {
+                output.append('\n');
+            }
         }
-
-        long[] ticks = cpu.getSystemCpuLoadTicks();
-        assertThat(ticks.length, is(TickType.values().length));
-        logger.info("  Ticks: {}", Arrays.toString(ticks));
-
-        long[] freqs = cpu.getCurrentFreq();
-        assertThat(freqs.length, is(cpu.getLogicalProcessorCount()));
-    }
-
-    @Test
-    void testMemory() {
-        GlobalMemory mem = hal.getMemory();
-        assertThat(mem, is(notNullValue()));
-
-        logger.info("Memory: {} total, {} available", mem.getTotal(), mem.getAvailable());
-        logger.info("  Page size: {}", mem.getPageSize());
-
-        assertThat(mem.getTotal(), greaterThan(0L));
-        assertThat(mem.getAvailable(), greaterThanOrEqualTo(0L));
-        assertThat(mem.getPageSize(), greaterThan(0L));
-
-        VirtualMemory vm = mem.getVirtualMemory();
-        logger.info("  Swap: {} total, {} used", vm.getSwapTotal(), vm.getSwapUsed());
-        assertThat(vm.getSwapTotal(), greaterThanOrEqualTo(0L));
-    }
-
-    @Test
-    void testFileSystem() {
-        FileSystem fs = os.getFileSystem();
-        assertThat(fs, is(notNullValue()));
-
-        List<OSFileStore> stores = fs.getFileStores();
-        assertThat(stores.size(), greaterThan(0));
-
-        for (OSFileStore store : stores) {
-            logger.info("  {} ({}) at {} - {} total, {} usable", store.getName(), store.getType(), store.getMount(),
-                    store.getTotalSpace(), store.getUsableSpace());
-        }
-    }
-
-    @Test
-    void testNetworkParams() {
-        NetworkParams net = os.getNetworkParams();
-        assertThat(net, is(notNullValue()));
-
-        logger.info("Network: host={}, domain={}", net.getHostName(), net.getDomainName());
-        logger.info("  DNS: {}", Arrays.toString(net.getDnsServers()));
-        logger.info("  IPv4 gateway: {}", net.getIpv4DefaultGateway());
-        logger.info("  IPv6 gateway: {}", net.getIpv6DefaultGateway());
-
-        assertThat(net.getHostName(), is(not("")));
-    }
-
-    @Test
-    void testDiskStores() {
-        List<oshi.hardware.HWDiskStore> disks = hal.getDiskStores();
-        assertThat(disks.size(), greaterThan(0));
-
-        for (oshi.hardware.HWDiskStore disk : disks) {
-            logger.info("Disk: {} ({}) serial={} size={} type={}", disk.getName(), disk.getModel(), disk.getSerial(),
-                    disk.getSize(), disk.getDiskType());
-            assertThat(disk.getName(), is(not("")));
-            assertThat(disk.getSize(), greaterThan(0L));
-        }
-    }
-
-    @Test
-    void testNetworkInterfaces() {
-        List<oshi.hardware.NetworkIF> nets = hal.getNetworkIFs();
-        assertThat(nets.size(), greaterThan(0));
-
-        for (oshi.hardware.NetworkIF net : nets) {
-            logger.info("Net: {} mac={} speed={} ipv4={}", net.getName(), net.getMacaddr(), net.getSpeed(),
-                    Arrays.toString(net.getIPv4addr()));
-            assertThat(net.getName(), is(not("")));
-        }
-    }
-
-    @Test
-    void testCurrentProcess() {
-        int pid = os.getProcessId();
-        OSProcess proc = os.getProcess(pid);
-        assertThat(proc, is(notNullValue()));
-
-        logger.info("Current process [{}]: {}", pid, proc.getName());
-        logger.info("  Path: {}", proc.getPath());
-        logger.info("  User: {} ({})", proc.getUser(), proc.getUserID());
-        logger.info("  Group: {} ({})", proc.getGroup(), proc.getGroupID());
-        logger.info("  Threads: {}", proc.getThreadCount());
-        logger.info("  RSS: {}", proc.getResidentMemory());
-        logger.info("  Open files: {}", proc.getOpenFiles());
-
-        assertThat(proc.getName(), is(not("")));
-        assertThat(proc.getProcessID(), is(pid));
+        logger.info("Printing Operating System and Hardware Info:{}{}", '\n', output);
     }
 }

--- a/oshi-common/src/test/java/oshi/spi/LinuxNativeFreeProviderTest.java
+++ b/oshi-common/src/test/java/oshi/spi/LinuxNativeFreeProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.spi;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.nativefree.SystemInfo;
+import oshi.software.os.OperatingSystem;
+
+@EnabledOnOs(OS.LINUX)
+class LinuxNativeFreeProviderTest {
+
+    private static SystemInfo provider;
+
+    @BeforeAll
+    static void setUp() {
+        provider = new SystemInfo();
+    }
+
+    @Test
+    void testIsAvailable() {
+        assertThat(provider.isAvailable(), is(true));
+    }
+
+    @Test
+    void testPriority() {
+        assertThat(provider.getPriority(), is(0));
+    }
+
+    @Test
+    void testOperatingSystem() {
+        OperatingSystem os = provider.getOperatingSystem();
+        assertThat(os, is(notNullValue()));
+        assertThat(os.getProcessId(), greaterThan(0));
+        assertThat(os.getThreadCount(), greaterThan(0));
+        assertThat(os.getFamily(), is(notNullValue()));
+        assertThat(os.getFamily(), is(not("")));
+    }
+
+    @Test
+    void testProcessor() {
+        HardwareAbstractionLayer hal = provider.getHardware();
+        CentralProcessor cpu = hal.getProcessor();
+        assertThat(cpu, is(notNullValue()));
+        assertThat(cpu.getLogicalProcessorCount(), greaterThan(0));
+        assertThat(cpu.getPhysicalProcessorCount(), greaterThan(0));
+        assertThat(cpu.getProcessorIdentifier().getName(), is(not("")));
+    }
+
+    @Test
+    void testMemory() {
+        HardwareAbstractionLayer hal = provider.getHardware();
+        GlobalMemory mem = hal.getMemory();
+        assertThat(mem, is(notNullValue()));
+        assertThat(mem.getTotal(), greaterThan(0L));
+        assertThat(mem.getAvailable(), greaterThanOrEqualTo(0L));
+    }
+
+    @Test
+    void testFileSystem() {
+        OperatingSystem os = provider.getOperatingSystem();
+        assertThat(os.getFileSystem(), is(notNullValue()));
+        assertThat(os.getFileSystem().getFileStores().size(), greaterThan(0));
+    }
+}


### PR DESCRIPTION
## Summary

Implements a priority-0 `SystemInfoProvider` (`oshi.nativefree.SystemInfo`) in `oshi-common` that works on Linux using only procfs, sysfs, `getconf`, command-line tools, and standard Java APIs. No JNA, no FFM, no `--enable-native-access` required.

This is the lowest-priority provider — it is only selected by `SystemInfoFactory` when neither `oshi-core` (JNA, priority 10) nor `oshi-core-ffm` (FFM, priority 20) is on the classpath.

## Feature-complete — all HAL and OS methods implemented

| Category | Implementation | Source |
|----------|---------------|--------|
| CentralProcessor | `LinuxCentralProcessorNF` | sysfs topology/freq, `/proc/stat` ticks |
| GlobalMemory / VirtualMemory | Concrete superclass | `/proc/meminfo`, `/proc/vmstat` |
| OperatingSystem | `LinuxOperatingSystemNF` | `getconf`, `/proc/self/stat`, `/proc/loadavg` |
| OSProcess / OSThread | `LinuxOSProcessNF` | `/proc/[pid]/*`, `/proc/[pid]/limits`, `/proc/[pid]/task/` |
| FileSystem | `LinuxFileSystemNF` | `/proc/mounts`, Java `File` API fallback |
| NetworkParams | `LinuxNetworkParamsNF` | Java `InetAddress`, `route` command |
| HWDiskStore | `LinuxHWDiskStoreNF` | `/sys/block/`, sysfs stat |
| NetworkIF | `LinuxNetworkIFNF` | Java `NetworkInterface`, `/sys/class/net/` |
| PowerSource | Concrete superclass | `/sys/class/power_supply/` |
| UsbDevice | `LinuxUsbDeviceNF` | `/sys/bus/usb/devices/` |
| GraphicsCard | `LinuxGraphicsCardNF` | `lspci`/`lshw`, sysfs GPU stats (AMD/Intel) |
| Sensors | Concrete superclass | `/sys/class/hwmon/`, `/sys/class/thermal/` |
| ComputerSystem / Baseboard / Firmware | Concrete superclass | `/sys/class/dmi/id/` |
| SoundCard | Concrete superclass | `/proc/asound/cards` |
| Display | Concrete superclass | `/sys/class/drm/` |

## Bug fix included

Fixes a long-standing bug in `AbstractCentralProcessor.createProcessorID()` where three `/proc/cpuinfo` flag names did not match the CPUID mnemonics used in the switch statement:

| EDX Bit | Was | `/proc/cpuinfo` actual | Fixed |
|---------|-----|----------------------|-------|
| 17 | `pse-36` | `pse36` | ✓ |
| 19 | `clfsh` | `clflush` | ✓ |
| 28 | `htt` | `ht` | ✓ |

This caused 3 feature bits to be missing from the processor ID when constructed from flags (the fallback path used in unprivileged containers where `dmidecode` and `cpuid` are unavailable).

## Testing

- `LinuxNativeFreeProviderTest` — integration test verifying provider basics
- `SystemInfoTest` — human-readable output exercising CPU, memory, OS, disk, network, filesystem, process
- `NativeFreeComparisonTest` (oshi-benchmark) — conformance test comparing NF vs JNA field-by-field, confirming identical results for deterministic values (hz, pageSize, processorID, topology, memory total, disk sizes, network MACs/IPs)

## Design

Each `*NF` class extends the existing abstract Linux class in `oshi-common` and overrides only the methods that require native access (udev, ioctl, sysconf, getrlimit) with procfs/sysfs/command-line alternatives. The `nativefree` package name explains the `NF` suffix.

Package structure:
- `oshi.nativefree` — public entry point (`SystemInfo`)
- `oshi.hardware.common.platform.linux.nativefree` — hardware implementations
- `oshi.software.common.os.linux.nativefree` — OS/process implementations

## Known differences vs JNA/FFM

- **Disk model**: sysfs returns raw kernel string (spaces); udev may normalize to underscores. Both are correct.
- **Disk serial**: some virtual disks expose serial only via udev properties, not sysfs `device/serial`.
- **Hostname**: Java `InetAddress` returns short hostname; native `gethostname` may return FQDN.
- **GPU stats**: NVML metrics unavailable (returns -1); sysfs-based metrics work for AMD/Intel.

## Related

Closes #3237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native-free Linux provider added for hardware/OS info (CPU, memory, disks, network, USB, graphics, filesystem) that works without native libraries and uses sysfs/procfs/CLI fallbacks.
  * Filesystem and GPU stats gracefully fall back when native data isn’t available.

* **Bug Fixes**
  * Improved CPU feature flag recognition.
  * Clearer error when no provider is available.

* **Tests**
  * Added Linux-only and parity tests validating native-free behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->