### PR TITLE
Extract parsing logic for testability, add coverage tests

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
@@ -61,8 +61,17 @@ public abstract class MacGlobalMemory extends AbstractGlobalMemory {
 
     @Override
     public List<PhysicalMemory> getPhysicalMemory() {
+        return parseSystemProfilerMemory(ExecutingCommand.runNative("system_profiler SPMemoryDataType"));
+    }
+
+    /**
+     * Parses the output of {@code system_profiler SPMemoryDataType} into physical memory objects.
+     *
+     * @param lines the output lines from system_profiler
+     * @return a list of physical memory objects
+     */
+    static List<PhysicalMemory> parseSystemProfilerMemory(List<String> lines) {
         List<PhysicalMemory> pmList = new ArrayList<>();
-        List<String> sp = ExecutingCommand.runNative("system_profiler SPMemoryDataType");
         int bank = 0;
         String bankLabel = Constants.UNKNOWN;
         long capacity = 0L;
@@ -71,12 +80,12 @@ public abstract class MacGlobalMemory extends AbstractGlobalMemory {
         String memoryType = Constants.UNKNOWN;
         String partNumber = Constants.UNKNOWN;
         String serialNumber = Constants.UNKNOWN;
-        for (String line : sp) {
+        for (String line : lines) {
             if (line.trim().startsWith("BANK")) {
                 // Save previous bank
                 if (bank++ > 0) {
-                    pmList.add(new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memoryType,
-                            Constants.UNKNOWN, serialNumber));
+                    pmList.add(new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memoryType, partNumber,
+                            serialNumber));
                 }
                 bankLabel = line.trim();
                 int colon = bankLabel.lastIndexOf(':');

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacLogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacLogicalVolumeGroup.java
@@ -31,6 +31,16 @@ public final class MacLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
     }
 
     static List<LogicalVolumeGroup> getLogicalVolumeGroups() {
+        return parseDiskutilCsList(ExecutingCommand.runNative(DISKUTIL_CS_LIST));
+    }
+
+    /**
+     * Parses the output of {@code diskutil cs list} into logical volume groups.
+     *
+     * @param lines the output lines from diskutil cs list
+     * @return a list of logical volume groups
+     */
+    static List<LogicalVolumeGroup> parseDiskutilCsList(List<String> lines) {
         Map<String, Map<String, Set<String>>> logicalVolumesMap = new HashMap<>();
         Map<String, Set<String>> physicalVolumesMap = new HashMap<>();
 
@@ -38,8 +48,7 @@ public final class MacLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
         boolean lookForVGName = false;
         boolean lookForPVName = false;
         int indexOf;
-        // Parse `diskutil cs list` to populate logical volume map
-        for (String line : ExecutingCommand.runNative(DISKUTIL_CS_LIST)) {
+        for (String line : lines) {
             if (line.contains(LOGICAL_VOLUME_GROUP)) {
                 // Disks that follow should be attached to this VG
                 lookForVGName = true;

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Xwininfo.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Xwininfo.java
@@ -31,6 +31,9 @@ public final class Xwininfo {
     private static final String[] XWININFO_ROOT_TREE = ParseUtil.whitespaces.split("xwininfo -root -tree");
     private static final String[] XPROP_NET_WM_PID_ID = ParseUtil.whitespaces.split("xprop _NET_WM_PID -id");
 
+    private static final Pattern WINDOW_PATTERN = Pattern.compile(
+            "(0x\\S+) (?:\"(.+)\")?.*: \\((?:\"(.+)\" \".+\")?\\)  (\\d+)x(\\d+)\\+.+  \\+(-?\\d+)\\+(-?\\d+)");
+
     private Xwininfo() {
     }
 
@@ -41,18 +44,36 @@ public final class Xwininfo {
      * @return A list of {@link oshi.software.os.OSDesktopWindow} objects representing the desktop windows.
      */
     public static List<OSDesktopWindow> queryXWindows(boolean visibleOnly) {
-        // Attempted to implement using native X11 code. However, this produced native X
-        // errors (e.g., BadValue) which cannot be caught on the Java side and
-        // terminated the thread. Using x command lines which execute in a separate
-        // process. Errors are caught by the terminal process and safely ignored.
-
-        // Get visible windows in their Z order. Assign 1 to bottom and increment.
-        // All other non visible windows will be assigned 0.
-        Map<String, Integer> zOrderMap = new HashMap<>();
-        int z = 0;
-
         // X commands don't work with LC_ALL
         List<String> stacking = ExecutingCommand.runNative(NET_CLIENT_LIST_STACKING, null);
+        List<String> tree = ExecutingCommand.runNative(XWININFO_ROOT_TREE, null);
+
+        Map<String, Integer> zOrderMap = parseZOrder(stacking);
+        Map<String, String> windowNameMap = new HashMap<>();
+        Map<String, String> windowPathMap = new HashMap<>();
+        Map<String, Rectangle> windowMap = parseWindowTree(tree, visibleOnly, zOrderMap, windowNameMap, windowPathMap);
+
+        // Get PID for each window and build result list
+        List<OSDesktopWindow> windowList = new ArrayList<>();
+        for (Entry<String, Rectangle> e : windowMap.entrySet()) {
+            String id = e.getKey();
+            long pid = queryPidFromId(id);
+            boolean visible = zOrderMap.containsKey(id);
+            windowList.add(new OSDesktopWindow(ParseUtil.hexStringToLong(id, 0L), windowNameMap.getOrDefault(id, ""),
+                    windowPathMap.getOrDefault(id, ""), e.getValue(), pid, zOrderMap.getOrDefault(id, 0), visible));
+        }
+        return windowList;
+    }
+
+    /**
+     * Parses the z-order stacking from xprop _NET_CLIENT_LIST_STACKING output.
+     *
+     * @param stacking the output lines from xprop
+     * @return a map of window ID to z-order (1 = bottom)
+     */
+    static Map<String, Integer> parseZOrder(List<String> stacking) {
+        Map<String, Integer> zOrderMap = new HashMap<>();
+        int z = 0;
         if (!stacking.isEmpty()) {
             String stack = stacking.get(0);
             int bottom = stack.indexOf("0x");
@@ -62,16 +83,24 @@ public final class Xwininfo {
                 }
             }
         }
-        // Get all windows along with title and path info
-        Pattern windowPattern = Pattern.compile(
-                "(0x\\S+) (?:\"(.+)\")?.*: \\((?:\"(.+)\" \".+\")?\\)  (\\d+)x(\\d+)\\+.+  \\+(-?\\d+)\\+(-?\\d+)");
-        Map<String, String> windowNameMap = new HashMap<>();
-        Map<String, String> windowPathMap = new HashMap<>();
-        // This map will include all the windows, preserve the insertion order
+        return zOrderMap;
+    }
+
+    /**
+     * Parses the window tree from xwininfo -root -tree output.
+     *
+     * @param tree          the output lines from xwininfo
+     * @param visibleOnly   whether to restrict to visible windows
+     * @param zOrderMap     the z-order map for visibility filtering
+     * @param windowNameMap populated with window names (output parameter)
+     * @param windowPathMap populated with window paths (output parameter)
+     * @return a map of window ID to rectangle bounds, in insertion order
+     */
+    static Map<String, Rectangle> parseWindowTree(List<String> tree, boolean visibleOnly,
+            Map<String, Integer> zOrderMap, Map<String, String> windowNameMap, Map<String, String> windowPathMap) {
         Map<String, Rectangle> windowMap = new LinkedHashMap<>();
-        // X commands don't work with LC_ALL
-        for (String line : ExecutingCommand.runNative(XWININFO_ROOT_TREE, null)) {
-            Matcher m = windowPattern.matcher(line.trim());
+        for (String line : tree) {
+            Matcher m = WINDOW_PATTERN.matcher(line.trim());
             if (m.matches()) {
                 String id = m.group(1);
                 if (!visibleOnly || zOrderMap.containsKey(id)) {
@@ -89,17 +118,7 @@ public final class Xwininfo {
                 }
             }
         }
-        // Get info for each window
-        // Prepare a list to return
-        List<OSDesktopWindow> windowList = new ArrayList<>();
-        for (Entry<String, Rectangle> e : windowMap.entrySet()) {
-            String id = e.getKey();
-            long pid = queryPidFromId(id);
-            boolean visible = zOrderMap.containsKey(id);
-            windowList.add(new OSDesktopWindow(ParseUtil.hexStringToLong(id, 0L), windowNameMap.getOrDefault(id, ""),
-                    windowPathMap.getOrDefault(id, ""), e.getValue(), pid, zOrderMap.getOrDefault(id, 0), visible));
-        }
-        return windowList;
+        return windowMap;
     }
 
     private static long queryPidFromId(String id) {

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGlobalMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGlobalMemoryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.PhysicalMemory;
+import oshi.util.Constants;
+
+class MacGlobalMemoryTest {
+
+    // Fixture: typical system_profiler SPMemoryDataType output
+    // Note: real output has " :" (space before colon) in bank labels
+    private static final List<String> SP_MEMORY_TWO_BANKS = Arrays.asList("Memory:", "", "    Memory Slots:", "",
+            "      ECC: Disabled", "      Upgradeable Memory: Yes", "", "        BANK 0/DIMM0 :", "",
+            "          Size: 8 GB", "          Type: DDR4", "          Speed: 2400 MHz",
+            "          Manufacturer: Samsung", "          Part Number: M471A1K43CB1-CRC",
+            "          Serial Number: 12345678", "          Status: OK", "", "        BANK 1/DIMM0 :", "",
+            "          Size: 8 GB", "          Type: DDR4", "          Speed: 2400 MHz",
+            "          Manufacturer: Hynix", "          Part Number: HMA81GS6AFR8N-UH",
+            "          Serial Number: 87654321", "          Status: OK");
+
+    @Test
+    void testParseSystemProfilerMemoryTwoBanks() {
+        List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(SP_MEMORY_TWO_BANKS);
+        assertThat(result, hasSize(2));
+
+        PhysicalMemory bank0 = result.get(0);
+        assertThat(bank0.getBankLabel(), is("BANK 0/DIMM0"));
+        assertThat(bank0.getCapacity(), is(greaterThan(0L)));
+        assertThat(bank0.getMemoryType(), is("DDR4"));
+        assertThat(bank0.getManufacturer(), is("Samsung"));
+        assertThat(bank0.getClockSpeed(), is(greaterThan(0L)));
+        assertThat(bank0.getPartNumber(), is("M471A1K43CB1-CRC"));
+
+        PhysicalMemory bank1 = result.get(1);
+        assertThat(bank1.getBankLabel(), is("BANK 1/DIMM0"));
+        assertThat(bank1.getManufacturer(), is("Hynix"));
+        assertThat(bank1.getSerialNumber(), is("87654321"));
+        assertThat(bank1.getPartNumber(), is("HMA81GS6AFR8N-UH"));
+    }
+
+    @Test
+    void testParseSystemProfilerMemoryEmpty() {
+        List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(Collections.emptyList());
+        // Always returns at least one entry (the final add outside the loop)
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getBankLabel(), is(Constants.UNKNOWN));
+        assertThat(result.get(0).getCapacity(), is(0L));
+    }
+
+    @Test
+    void testParseSystemProfilerMemorySingleBank() {
+        List<String> singleBank = Arrays.asList("        BANK 0/DIMM0 :", "          Size: 16 GB",
+                "          Type: LPDDR4X", "          Speed: 4267 MHz", "          Manufacturer: Micron",
+                "          Part Number: MT53E1G32D4NQ-046", "          Serial Number: ABCDEF01");
+        List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(singleBank);
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getBankLabel(), is("BANK 0/DIMM0"));
+        assertThat(result.get(0).getMemoryType(), is("LPDDR4X"));
+        assertThat(result.get(0).getManufacturer(), is("Micron"));
+        assertThat(result.get(0).getPartNumber(), is("MT53E1G32D4NQ-046"));
+    }
+
+    @Test
+    void testParseSystemProfilerMemoryNoColon() {
+        // Bank label without trailing colon — substring logic skipped
+        List<String> noColon = Arrays.asList("        BANK 0", "          Size: 4 GB", "          Type: DDR3");
+        List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(noColon);
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getBankLabel(), is("BANK 0"));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacLogicalVolumeGroupTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacLogicalVolumeGroupTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.LogicalVolumeGroup;
+
+class MacLogicalVolumeGroupTest {
+
+    // Fixture: typical diskutil cs list output with one CoreStorage volume group
+    private static final List<String> DISKUTIL_CS_OUTPUT = Arrays.asList("CoreStorage logical volume groups (1 found)",
+            "|", "+-- Logical Volume Group B6D1A2C3-4E5F-6789-ABCD-EF0123456789",
+            "    =========================================================", "    Name:         Macintosh HD",
+            "    Status:       Online", "    Size:         499248103424 B (499.2 GB)",
+            "    Free Space:   12345678 B (12.3 MB)", "    |",
+            "    +-< Physical Volume 0A1B2C3D-4E5F-6789-ABCD-EF0123456789",
+            "    |   ----------------------------------------------------", "    |   Index:    0",
+            "    |   Disk:     disk0s2", "    |   Status:   Online", "    |   Size:     499248103424 B (499.2 GB)",
+            "    |", "    +-> Logical Volume Family 1A2B3C4D-5E6F-7890-ABCD-EF0123456789",
+            "        ----------------------------------------------------------",
+            "        +-> Logical Volume 2A3B4C5D-6E7F-8901-ABCD-EF0123456789",
+            "            ---------------------------------------------------",
+            "            Disk:                  disk1", "            Status:                Online",
+            "            Size (Total):          498877931520 B (498.9 GB)");
+
+    @Test
+    void testParseDiskutilCsListSingleGroup() {
+        List<LogicalVolumeGroup> groups = MacLogicalVolumeGroup.parseDiskutilCsList(DISKUTIL_CS_OUTPUT);
+        assertThat(groups, hasSize(1));
+
+        LogicalVolumeGroup group = groups.get(0);
+        assertThat(group.getName(), is("Macintosh HD"));
+        assertThat(group.getPhysicalVolumes(), hasItem("disk0s2"));
+        assertThat(group.getLogicalVolumes(), hasKey("disk1"));
+    }
+
+    @Test
+    void testParseDiskutilCsListEmpty() {
+        List<LogicalVolumeGroup> groups = MacLogicalVolumeGroup.parseDiskutilCsList(Collections.emptyList());
+        assertThat(groups, is(empty()));
+    }
+
+    @Test
+    void testParseDiskutilCsListNoGroups() {
+        List<String> noGroups = Arrays.asList("No CoreStorage logical volume groups found");
+        List<LogicalVolumeGroup> groups = MacLogicalVolumeGroup.parseDiskutilCsList(noGroups);
+        assertThat(groups, is(empty()));
+    }
+
+    @Test
+    void testParseDiskutilCsListMultipleGroups() {
+        List<String> twoGroups = Arrays.asList("+-- Logical Volume Group AAA", "    Name:         Group One",
+                "    +-< Physical Volume PV1", "    |   Disk:     disk0s2", "    +-> Logical Volume LV1",
+                "            Disk:                  disk1", "+-- Logical Volume Group BBB",
+                "    Name:         Group Two", "    +-< Physical Volume PV2", "    |   Disk:     disk2s1",
+                "    +-> Logical Volume LV2", "            Disk:                  disk3");
+        List<LogicalVolumeGroup> groups = MacLogicalVolumeGroup.parseDiskutilCsList(twoGroups);
+        assertThat(groups, hasSize(2));
+        assertThat(groups.get(0).getName(), is("Group One"));
+        assertThat(groups.get(1).getName(), is("Group Two"));
+        assertThat(groups.get(0).getPhysicalVolumes(), hasItem("disk0s2"));
+        assertThat(groups.get(1).getPhysicalVolumes(), hasItem("disk2s1"));
+    }
+
+    @Test
+    void testParseDiskutilCsListMultiplePVsAndLVs() {
+        List<String> multiPvLv = Arrays.asList("+-- Logical Volume Group CCC", "    Name:         Fusion Drive",
+                "    +-< Physical Volume PV1", "    |   Disk:     disk0s2", "    +-< Physical Volume PV2",
+                "    |   Disk:     disk1s1", "    +-> Logical Volume LV1", "            Disk:                  disk2",
+                "    +-> Logical Volume LV2", "            Disk:                  disk3");
+        List<LogicalVolumeGroup> groups = MacLogicalVolumeGroup.parseDiskutilCsList(multiPvLv);
+        assertThat(groups, hasSize(1));
+        assertThat(groups.get(0).getPhysicalVolumes(), hasItem("disk0s2"));
+        assertThat(groups.get(0).getPhysicalVolumes(), hasItem("disk1s1"));
+        assertThat(groups.get(0).getLogicalVolumes(), hasKey("disk2"));
+        assertThat(groups.get(0).getLogicalVolumes(), hasKey("disk3"));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoParsingTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoParsingTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.driver.unix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+
+import java.awt.Rectangle;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class XwininfoParsingTest {
+
+    // Fixture: xprop -root _NET_CLIENT_LIST_STACKING output
+    private static final List<String> STACKING_OUTPUT = Arrays
+            .asList("_NET_CLIENT_LIST_STACKING(WINDOW): window id # 0x1400003, 0x1600003, 0x1800003");
+
+    // Fixture: xwininfo -root -tree output (trimmed)
+    private static final List<String> XWININFO_TREE = Arrays.asList(
+            "     0x1400003 \"Terminal\": (\"gnome-terminal\" \"Gnome-terminal\")  800x600+0+0  +100+200",
+            "     0x1600003 \"Firefox\": (\"Navigator\" \"firefox\")  1920x1080+0+0  +0+0",
+            "     0x1800003 (has no name): ()  200x200+0+0  +50+-10",
+            "     0x1a00003 \"Hidden Window\": (\"hidden\" \"Hidden\")  400x300+0+0  +10+20");
+
+    @Test
+    void testParseZOrder() {
+        Map<String, Integer> zOrder = Xwininfo.parseZOrder(STACKING_OUTPUT);
+        assertThat(zOrder.size(), is(3));
+        assertThat(zOrder.get("0x1400003"), is(1));
+        assertThat(zOrder.get("0x1600003"), is(2));
+        assertThat(zOrder.get("0x1800003"), is(3));
+    }
+
+    @Test
+    void testParseZOrderEmpty() {
+        Map<String, Integer> zOrder = Xwininfo.parseZOrder(Collections.emptyList());
+        assertThat(zOrder, is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseZOrderNoHexIds() {
+        List<String> noIds = Arrays.asList("_NET_CLIENT_LIST_STACKING: no such atom on any window.");
+        Map<String, Integer> zOrder = Xwininfo.parseZOrder(noIds);
+        assertThat(zOrder, is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseWindowTreeAllWindows() {
+        Map<String, Integer> zOrder = Xwininfo.parseZOrder(STACKING_OUTPUT);
+        Map<String, String> nameMap = new HashMap<>();
+        Map<String, String> pathMap = new HashMap<>();
+
+        Map<String, Rectangle> windows = Xwininfo.parseWindowTree(XWININFO_TREE, false, zOrder, nameMap, pathMap);
+
+        // All 4 windows should be included (visibleOnly=false)
+        assertThat(windows.size(), is(4));
+        assertThat(windows, hasKey("0x1400003"));
+        assertThat(windows, hasKey("0x1a00003"));
+
+        // Check names
+        assertThat(nameMap.get("0x1400003"), is("Terminal"));
+        assertThat(nameMap.get("0x1600003"), is("Firefox"));
+        // 0x1800003 has no name, should not be in nameMap
+        assertThat(nameMap.containsKey("0x1800003"), is(false));
+
+        // Check paths
+        assertThat(pathMap.get("0x1400003"), is("gnome-terminal"));
+        assertThat(pathMap.get("0x1600003"), is("Navigator"));
+
+        // Check rectangle for Terminal: 800x600 at +100+200
+        Rectangle termRect = windows.get("0x1400003");
+        assertThat(termRect.width, is(800));
+        assertThat(termRect.height, is(600));
+        assertThat(termRect.x, is(100));
+        assertThat(termRect.y, is(200));
+
+        // Check negative coordinate
+        Rectangle noNameRect = windows.get("0x1800003");
+        assertThat(noNameRect.y, is(-10));
+    }
+
+    @Test
+    void testParseWindowTreeVisibleOnly() {
+        Map<String, Integer> zOrder = Xwininfo.parseZOrder(STACKING_OUTPUT);
+        Map<String, String> nameMap = new HashMap<>();
+        Map<String, String> pathMap = new HashMap<>();
+
+        Map<String, Rectangle> windows = Xwininfo.parseWindowTree(XWININFO_TREE, true, zOrder, nameMap, pathMap);
+
+        // Only 3 visible windows (in zOrderMap), 0x1a00003 is not visible
+        assertThat(windows.size(), is(3));
+        assertThat(windows.containsKey("0x1a00003"), is(false));
+    }
+
+    @Test
+    void testParseWindowTreeEmpty() {
+        Map<String, String> nameMap = new HashMap<>();
+        Map<String, String> pathMap = new HashMap<>();
+
+        Map<String, Rectangle> windows = Xwininfo.parseWindowTree(Collections.emptyList(), false,
+                Collections.emptyMap(), nameMap, pathMap);
+
+        assertThat(windows, is(anEmptyMap()));
+        assertThat(nameMap, is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseWindowTreeNonMatchingLines() {
+        List<String> nonMatching = Arrays.asList("xwininfo: Window id: 0x1e3 (the root window) \"i3\"",
+                "  Root window id: 0x1e3 (the root window) (has no name)", "  Parent window id: 0x0 (none)",
+                "     2 children:");
+        Map<String, String> nameMap = new HashMap<>();
+        Map<String, String> pathMap = new HashMap<>();
+
+        Map<String, Rectangle> windows = Xwininfo.parseWindowTree(nonMatching, false, Collections.emptyMap(), nameMap,
+                pathMap);
+
+        assertThat(windows, is(anEmptyMap()));
+    }
+}


### PR DESCRIPTION
## Summary

Refactor three classes to separate parsing from command execution, enabling unit tests with fixture data. All refactorings preserve existing behavior — the public API is unchanged.

## Changes

### MacLogicalVolumeGroup
- Extract `parseDiskutilCsList(List<String>)` from `getLogicalVolumeGroups()`
- Add `MacLogicalVolumeGroupTest` (5 tests): single/multiple groups, multiple PVs/LVs, empty input

### MacGlobalMemory
- Extract `parseSystemProfilerMemory(List<String>)` from `getPhysicalMemory()`
- Add `MacGlobalMemoryTest` (4 tests): multi-bank parsing, single bank, empty input, label edge cases

### Xwininfo
- Extract `parseZOrder(List<String>)` and `parseWindowTree(...)` from `queryXWindows()`
- Add `XwininfoParsingTest` (7 tests): z-order parsing, window tree with visible/all filtering, negative coordinates, non-matching lines

## Verification

- All 733 tests pass (719 successful, 14 skipped for platform/headless)
- spotless:apply ✅
- checkstyle:check ✅ (0 violations)
- forbiddenapis:check ✅
- javadoc:javadoc ✅
- Downstream modules (oshi-core, oshi-core-ffm) compile cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved parsing and internal organization for macOS memory and logical-volume detection, plus Unix/X11 window discovery — leading to more reliable hardware and window information.

* **Tests**
  * Added extensive tests validating macOS memory parsing, CoreStorage logical-volume parsing, and X11 window parsing to ensure robustness and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->