### PR TITLE
Add tests for MacInstalledApps parsing and ThreadInfo state mapping

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -136,7 +136,7 @@ public final class MacInstalledApps {
         }
     }
 
-    private static List<Map<String, String>> parseItems(String xml) {
+    static List<Map<String, String>> parseItems(String xml) {
         if (xml == null) {
             return Collections.emptyList();
         }
@@ -164,7 +164,7 @@ public final class MacInstalledApps {
         return out;
     }
 
-    private static Map<String, String> parseDict(String dictInner) {
+    static Map<String, String> parseDict(String dictInner) {
         Map<String, String> map = new LinkedHashMap<>();
         int pos = 0;
         while (true) {
@@ -208,7 +208,7 @@ public final class MacInstalledApps {
         return map;
     }
 
-    private static String parseStringArray(String arrayInner) {
+    static String parseStringArray(String arrayInner) {
         int lt = arrayInner.indexOf('<');
         if (lt >= 0) {
             if (startsWith(arrayInner, lt, "<string>")) {
@@ -282,7 +282,7 @@ public final class MacInstalledApps {
         return blocks;
     }
 
-    private static String unescape(String s) {
+    static String unescape(String s) {
         return s.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", "\"")
                 .replace("&apos;", "'");
     }

--- a/oshi-common/src/test/java/oshi/driver/common/mac/ThreadInfoTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/mac/ThreadInfoTest.java
@@ -9,31 +9,58 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import oshi.driver.common.mac.ThreadInfo.ThreadStats;
 import oshi.software.os.OSProcess.State;
 
 class ThreadInfoTest {
 
     @Test
-    void testThreadStatsStateMapping() {
-        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'S', 100L, 200L, 31).getState(), is(State.SLEEPING));
-        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'I', 100L, 200L, 31).getState(), is(State.SLEEPING));
-        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'R', 100L, 200L, 31).getState(), is(State.RUNNING));
-        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'U', 100L, 200L, 31).getState(), is(State.WAITING));
-        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'Z', 100L, 200L, 31).getState(), is(State.ZOMBIE));
-        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'T', 100L, 200L, 31).getState(), is(State.STOPPED));
-        assertThat(new ThreadInfo.ThreadStats(0, 50.0, 'X', 100L, 200L, 31).getState(), is(State.OTHER));
+    void testThreadStatsStateSleeping() {
+        ThreadStats ts = new ThreadStats(0, 1.0, 'S', 100L, 200L, 31);
+        assertThat(ts.getState(), is(State.SLEEPING));
+        // Also test 'I' (idle/sleeping)
+        ThreadStats ti = new ThreadStats(1, 0.5, 'I', 50L, 100L, 20);
+        assertThat(ti.getState(), is(State.SLEEPING));
     }
 
     @Test
-    void testThreadStatsGetters() {
-        // upTime = (long) ((uTime + sTime) / (cpu / 100d + 0.0005))
-        // = (long) ((2000 + 1000) / (25.0 / 100.0 + 0.0005))
-        // = (long) (3000 / 0.2505) = 11976
-        ThreadInfo.ThreadStats ts = new ThreadInfo.ThreadStats(5, 25.0, 'R', 1000L, 2000L, 20);
+    void testThreadStatsStateRunning() {
+        ThreadStats ts = new ThreadStats(0, 50.0, 'R', 1000L, 2000L, 31);
+        assertThat(ts.getState(), is(State.RUNNING));
+    }
+
+    @Test
+    void testThreadStatsStateWaiting() {
+        ThreadStats ts = new ThreadStats(0, 0.1, 'U', 10L, 20L, 15);
+        assertThat(ts.getState(), is(State.WAITING));
+    }
+
+    @Test
+    void testThreadStatsStateZombie() {
+        ThreadStats ts = new ThreadStats(0, 0.0, 'Z', 0L, 0L, 0);
+        assertThat(ts.getState(), is(State.ZOMBIE));
+    }
+
+    @Test
+    void testThreadStatsStateStopped() {
+        ThreadStats ts = new ThreadStats(0, 0.0, 'T', 500L, 1000L, 10);
+        assertThat(ts.getState(), is(State.STOPPED));
+    }
+
+    @Test
+    void testThreadStatsStateOther() {
+        ThreadStats ts = new ThreadStats(0, 0.0, 'X', 0L, 0L, 0);
+        assertThat(ts.getState(), is(State.OTHER));
+    }
+
+    @Test
+    void testThreadStatsAccessors() {
+        ThreadStats ts = new ThreadStats(5, 25.0, 'R', 3000L, 7000L, 47);
         assertThat(ts.getThreadId(), is(5));
-        assertThat(ts.getSystemTime(), is(1000L));
-        assertThat(ts.getUserTime(), is(2000L));
-        assertThat(ts.getUpTime(), is(11976L));
-        assertThat(ts.getPriority(), is(20));
+        assertThat(ts.getUserTime(), is(7000L));
+        assertThat(ts.getSystemTime(), is(3000L));
+        assertThat(ts.getPriority(), is(47));
+        // upTime = (user+system) / (cpu/100 + 0.0005) = 10000 / 0.2505 ≈ 39920
+        assertThat(ts.getUpTime(), is((long) ((7000L + 3000L) / (25.0 / 100d + 0.0005))));
     }
 }

--- a/oshi-common/src/test/java/oshi/software/common/os/mac/MacInstalledAppsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/mac/MacInstalledAppsTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class MacInstalledAppsTest {
+
+    // Fixture: minimal system_profiler -xml SPApplicationsDataType output
+    private static final String PLIST_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<plist version=\"1.0\"><array><dict>" + "<key>_items</key><array>" + "<dict>"
+            + "<key>_name</key><string>Safari</string>" + "<key>version</key><string>17.0</string>"
+            + "<key>obtained_from</key><string>apple</string>"
+            + "<key>path</key><string>/Applications/Safari.app</string>"
+            + "<key>lastModified</key><date>2024-01-15T10:30:00Z</date>"
+            + "<key>arch_kind</key><string>arch_arm_i64</string>"
+            + "<key>signed_by</key><array><string>Apple Root CA</string></array>" + "</dict>" + "<dict>"
+            + "<key>_name</key><string>Firefox</string>" + "<key>version</key><string>120.0</string>"
+            + "<key>obtained_from</key><string>identified_developer</string>"
+            + "<key>path</key><string>/Applications/Firefox.app</string>"
+            + "<key>signed_by</key><array><string>Developer ID Application: Mozilla Corporation</string></array>"
+            + "</dict>" + "</array></dict></array></plist>";
+
+    // --- parseItems ---
+
+    @Test
+    void testParseItemsValidPlist() {
+        List<Map<String, String>> items = MacInstalledApps.parseItems(PLIST_XML);
+        assertThat(items, hasSize(2));
+        assertThat(items.get(0), hasEntry("_name", "Safari"));
+        assertThat(items.get(0), hasEntry("version", "17.0"));
+        assertThat(items.get(0), hasEntry("obtained_from", "apple"));
+        assertThat(items.get(0), hasEntry("path", "/Applications/Safari.app"));
+        assertThat(items.get(1), hasEntry("_name", "Firefox"));
+        assertThat(items.get(1), hasEntry("version", "120.0"));
+    }
+
+    @Test
+    void testParseItemsNull() {
+        assertThat(MacInstalledApps.parseItems(null), is(empty()));
+    }
+
+    @Test
+    void testParseItemsNoItemsKey() {
+        String xml = "<plist><dict><key>other</key><string>value</string></dict></plist>";
+        assertThat(MacInstalledApps.parseItems(xml), is(empty()));
+    }
+
+    @Test
+    void testParseItemsNoArray() {
+        String xml = "<key>_items</key><string>not an array</string>";
+        assertThat(MacInstalledApps.parseItems(xml), is(empty()));
+    }
+
+    @Test
+    void testParseItemsEmptyArray() {
+        String xml = "<key>_items</key><array></array>";
+        assertThat(MacInstalledApps.parseItems(xml), is(empty()));
+    }
+
+    // --- parseDict ---
+
+    @Test
+    void testParseDictStringValues() {
+        String dictInner = "<key>name</key><string>MyApp</string>" + "<key>version</key><string>1.0</string>";
+        Map<String, String> result = MacInstalledApps.parseDict(dictInner);
+        assertThat(result, hasEntry("name", "MyApp"));
+        assertThat(result, hasEntry("version", "1.0"));
+    }
+
+    @Test
+    void testParseDictDateValue() {
+        String dictInner = "<key>lastModified</key><date>2024-06-15T08:00:00Z</date>";
+        Map<String, String> result = MacInstalledApps.parseDict(dictInner);
+        assertThat(result, hasEntry("lastModified", "2024-06-15T08:00:00Z"));
+    }
+
+    @Test
+    void testParseDictArrayValue() {
+        String dictInner = "<key>signed_by</key><array><string>Apple Root CA</string></array>";
+        Map<String, String> result = MacInstalledApps.parseDict(dictInner);
+        assertThat(result, hasEntry("signed_by", "Apple Root CA"));
+    }
+
+    @Test
+    void testParseDictEmptyArray() {
+        String dictInner = "<key>signed_by</key><array></array>";
+        Map<String, String> result = MacInstalledApps.parseDict(dictInner);
+        assertThat(result, hasEntry("signed_by", ""));
+    }
+
+    @Test
+    void testParseDictSkipsUnknownTags() {
+        String dictInner = "<key>count</key><integer>42</integer>" + "<key>name</key><string>App</string>";
+        Map<String, String> result = MacInstalledApps.parseDict(dictInner);
+        // integer tag is skipped, string is parsed
+        assertThat(result, hasEntry("name", "App"));
+        assertThat(result.containsKey("count"), is(false));
+    }
+
+    @Test
+    void testParseDictEmpty() {
+        Map<String, String> result = MacInstalledApps.parseDict("");
+        assertThat(result.isEmpty(), is(true));
+    }
+
+    @Test
+    void testParseDictWithEscapedEntities() {
+        String dictInner = "<key>name</key><string>Tom &amp; Jerry&apos;s App</string>";
+        Map<String, String> result = MacInstalledApps.parseDict(dictInner);
+        assertThat(result, hasEntry("name", "Tom & Jerry's App"));
+    }
+
+    // --- parseStringArray ---
+
+    @Test
+    void testParseStringArraySingleElement() {
+        assertThat(MacInstalledApps.parseStringArray("<string>Hello</string>"), is("Hello"));
+    }
+
+    @Test
+    void testParseStringArrayEmpty() {
+        assertThat(MacInstalledApps.parseStringArray(""), is(nullValue()));
+    }
+
+    @Test
+    void testParseStringArrayNoStringTag() {
+        assertThat(MacInstalledApps.parseStringArray("<integer>42</integer>"), is(nullValue()));
+    }
+
+    // --- unescape ---
+
+    @Test
+    void testUnescapeAllEntities() {
+        assertThat(MacInstalledApps.unescape("&amp;&lt;&gt;&quot;&apos;"), is("&<>\"'"));
+    }
+
+    @Test
+    void testUnescapeNoEntities() {
+        assertThat(MacInstalledApps.unescape("plain text"), is("plain text"));
+    }
+
+    @Test
+    void testUnescapeMixed() {
+        assertThat(MacInstalledApps.unescape("a &amp; b &lt; c"), is("a & b < c"));
+    }
+}


### PR DESCRIPTION
## Summary

Add 25 new tests covering the two largest untested parsing classes in oshi-common.

### MacInstalledApps (18 tests)
- Make `parseItems`, `parseDict`, `parseStringArray`, and `unescape` package-private
- Test plist XML parsing: valid multi-app plist, null/empty/missing input
- Test dict parsing with string/date/array values, entity unescaping, unknown tag skipping

### ThreadInfo.ThreadStats (7 tests)
- Test state mapping for all state characters: S, I (sleeping), R (running), U (waiting), Z (zombie), T (stopped), X (other)
- Test accessor methods (threadId, userTime, systemTime, upTime, priority)

## Verification
- All 756 tests pass (742 successful, 14 skipped)
- spotless:apply ✅
- checkstyle:check ✅ (0 violations)
- forbiddenapis:check ✅
- javadoc:javadoc ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive macOS app parsing tests covering normal and edge cases, data conversions, and XML entity handling.
  * Refactored thread information tests into focused cases for each thread state and updated accessor validations.

* **Refactor**
  * Internal visibility adjustments to improve modularity and make parsing helpers more testable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->