### PR TITLE
Add tests for LinuxUsbDeviceNF, FileUtil buffers, and distro parsing

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNF.java
@@ -32,7 +32,7 @@ public final class LinuxUsbDeviceNF extends LinuxUsbDevice {
      * @return a list of {@link UsbDevice} objects
      */
     public static List<UsbDevice> getUsbDevices(boolean tree) {
-        List<UsbDevice> devices = queryUsbDevices();
+        List<UsbDevice> devices = queryUsbDevices(SYS_USB);
         if (tree) {
             return devices;
         }
@@ -43,8 +43,17 @@ public final class LinuxUsbDeviceNF extends LinuxUsbDevice {
         return deviceList;
     }
 
-    private static List<UsbDevice> queryUsbDevices() {
-        File usbDir = new File(SYS_USB);
+    /**
+     * Queries USB devices from the specified sysfs path.
+     *
+     * @param sysUsbPath the path to the USB devices directory (e.g., /sys/bus/usb/devices/)
+     * @return a list of USB device trees rooted at controllers
+     */
+    static List<UsbDevice> queryUsbDevices(String sysUsbPath) {
+        if (!sysUsbPath.endsWith(File.separator)) {
+            sysUsbPath += File.separator;
+        }
+        File usbDir = new File(sysUsbPath);
         File[] deviceDirs = usbDir.listFiles();
         if (deviceDirs == null) {
             return new ArrayList<>();
@@ -99,7 +108,7 @@ public final class LinuxUsbDeviceNF extends LinuxUsbDevice {
                 } else {
                     parentName = name;
                 }
-                String parentPath = SYS_USB + parentName;
+                String parentPath = sysUsbPath + parentName;
                 hubMap.computeIfAbsent(parentPath, x -> new ArrayList<>()).add(syspath);
             }
         }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNFTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNFTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux.nativefree;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import oshi.hardware.UsbDevice;
+
+@EnabledOnOs(OS.LINUX)
+class LinuxUsbDeviceNFTest {
+
+    @Test
+    void testQueryUsbDevicesNonexistentPath(@TempDir Path tempDir) {
+        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(tempDir.resolve("missing").toString() + "/");
+        assertThat(devices, is(empty()));
+    }
+
+    @Test
+    void testQueryUsbDevicesEmptyDir(@TempDir Path tempDir) throws IOException {
+        Path usbDir = tempDir.resolve("usb");
+        Files.createDirectories(usbDir);
+        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/");
+        assertThat(devices, is(empty()));
+    }
+
+    @Test
+    void testQueryUsbDevicesNoDevnum(@TempDir Path tempDir) throws IOException {
+        Path usbDir = tempDir.resolve("usb");
+        Path dev = usbDir.resolve("usb1");
+        Files.createDirectories(dev);
+        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/");
+        assertThat(devices, is(empty()));
+    }
+
+    @Test
+    void testQueryUsbDevicesSingleController(@TempDir Path tempDir) throws IOException {
+        Path usbDir = tempDir.resolve("usb");
+        Path usb1 = usbDir.resolve("usb1");
+        Files.createDirectories(usb1);
+        writeFile(usb1.resolve("devnum"), "1");
+        writeFile(usb1.resolve("product"), "xHCI Host Controller");
+        writeFile(usb1.resolve("manufacturer"), "Linux Foundation");
+        writeFile(usb1.resolve("idVendor"), "1d6b");
+        writeFile(usb1.resolve("idProduct"), "0003");
+        writeFile(usb1.resolve("serial"), "0000:00:14.0");
+
+        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/");
+        assertThat(devices, hasSize(1));
+        assertThat(devices.get(0).getName(), is("xHCI Host Controller"));
+        assertThat(devices.get(0).getVendor(), is("Linux Foundation"));
+        assertThat(devices.get(0).getVendorId(), is("1d6b"));
+        assertThat(devices.get(0).getProductId(), is("0003"));
+        assertThat(devices.get(0).getSerialNumber(), is("0000:00:14.0"));
+    }
+
+    @Test
+    void testQueryUsbDevicesWithChild(@TempDir Path tempDir) throws IOException {
+        Path usbDir = tempDir.resolve("usb");
+
+        Path usb1 = usbDir.resolve("usb1");
+        Files.createDirectories(usb1);
+        writeFile(usb1.resolve("devnum"), "1");
+        writeFile(usb1.resolve("product"), "Root Hub");
+        writeFile(usb1.resolve("idVendor"), "1d6b");
+        writeFile(usb1.resolve("idProduct"), "0002");
+
+        Path child = usbDir.resolve("1-1");
+        Files.createDirectories(child);
+        writeFile(child.resolve("devnum"), "2");
+        writeFile(child.resolve("product"), "USB Mouse");
+        writeFile(child.resolve("manufacturer"), "Logitech");
+        writeFile(child.resolve("idVendor"), "046d");
+        writeFile(child.resolve("idProduct"), "c077");
+
+        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/");
+        assertThat(devices, hasSize(1));
+        assertThat(devices.get(0).getConnectedDevices(), hasSize(1));
+        assertThat(devices.get(0).getConnectedDevices().get(0).getName(), is("USB Mouse"));
+    }
+
+    @Test
+    void testQueryUsbDevicesWithNestedChild(@TempDir Path tempDir) throws IOException {
+        Path usbDir = tempDir.resolve("usb");
+
+        Path usb1 = usbDir.resolve("usb1");
+        Files.createDirectories(usb1);
+        writeFile(usb1.resolve("devnum"), "1");
+        writeFile(usb1.resolve("idVendor"), "1d6b");
+        writeFile(usb1.resolve("idProduct"), "0002");
+
+        Path hub = usbDir.resolve("1-1");
+        Files.createDirectories(hub);
+        writeFile(hub.resolve("devnum"), "2");
+        writeFile(hub.resolve("product"), "USB Hub");
+        writeFile(hub.resolve("idVendor"), "0424");
+        writeFile(hub.resolve("idProduct"), "2514");
+
+        Path device = usbDir.resolve("1-1.2");
+        Files.createDirectories(device);
+        writeFile(device.resolve("devnum"), "3");
+        writeFile(device.resolve("product"), "Keyboard");
+        writeFile(device.resolve("idVendor"), "04f2");
+        writeFile(device.resolve("idProduct"), "0112");
+
+        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/");
+        assertThat(devices, hasSize(1));
+        UsbDevice root = devices.get(0);
+        assertThat(root.getConnectedDevices(), hasSize(1));
+        UsbDevice hubDev = root.getConnectedDevices().get(0);
+        assertThat(hubDev.getName(), is("USB Hub"));
+        assertThat(hubDev.getConnectedDevices(), hasSize(1));
+        assertThat(hubDev.getConnectedDevices().get(0).getName(), is("Keyboard"));
+    }
+
+    private static void writeFile(Path path, String content) throws IOException {
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemDistroTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemDistroTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.util.Constants;
+import oshi.util.tuples.Triplet;
+
+/**
+ * Tests LinuxOperatingSystem release file parsing with fixtures from various distributions.
+ */
+@EnabledOnOs(OS.LINUX)
+class LinuxOperatingSystemDistroTest {
+
+    // --- os-release fixtures ---
+
+    private static final List<String> OS_RELEASE_FEDORA = Arrays.asList("NAME=\"Fedora Linux\"",
+            "VERSION=\"39 (Workstation Edition)\"", "ID=fedora", "VERSION_ID=39",
+            "PRETTY_NAME=\"Fedora Linux 39 (Workstation Edition)\"");
+
+    private static final List<String> OS_RELEASE_ARCH = Arrays.asList("NAME=\"Arch Linux\"", "ID=arch",
+            "PRETTY_NAME=\"Arch Linux\"", "BUILD_ID=rolling");
+
+    private static final List<String> OS_RELEASE_DEBIAN = Arrays.asList("NAME=\"Debian GNU/Linux\"",
+            "VERSION=\"12 (bookworm)\"", "VERSION_ID=\"12\"", "ID=debian",
+            "PRETTY_NAME=\"Debian GNU/Linux 12 (bookworm)\"");
+
+    private static final List<String> OS_RELEASE_ALPINE = Arrays.asList("NAME=\"Alpine Linux\"", "ID=alpine",
+            "VERSION_ID=3.19.0", "PRETTY_NAME=\"Alpine Linux v3.19\"");
+
+    private static final List<String> OS_RELEASE_RHEL = Arrays.asList("NAME=\"Red Hat Enterprise Linux\"",
+            "VERSION=\"9.3 (Plow)\"", "ID=\"rhel\"", "VERSION_ID=\"9.3\"",
+            "PRETTY_NAME=\"Red Hat Enterprise Linux 9.3 (Plow)\"");
+
+    private static final List<String> OS_RELEASE_OPENSUSE = Arrays.asList("NAME=\"openSUSE Leap\"", "VERSION=\"15.5\"",
+            "ID=\"opensuse-leap\"", "VERSION_ID=\"15.5\"", "PRETTY_NAME=\"openSUSE Leap 15.5\"");
+
+    @Test
+    void testReadOsReleaseFedora() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_FEDORA);
+        assertThat(result.getA(), is("Fedora Linux"));
+        assertThat(result.getB(), is("39"));
+        assertThat(result.getC(), is("Workstation Edition"));
+    }
+
+    @Test
+    void testReadOsReleaseArch() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_ARCH);
+        assertThat(result.getA(), is("Arch Linux"));
+        // Arch has no VERSION or VERSION_ID
+        assertThat(result.getB(), is(Constants.UNKNOWN));
+        assertThat(result.getC(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testReadOsReleaseDebian() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_DEBIAN);
+        assertThat(result.getA(), is("Debian GNU/Linux"));
+        assertThat(result.getB(), is("12"));
+        assertThat(result.getC(), is("bookworm"));
+    }
+
+    @Test
+    void testReadOsReleaseAlpine() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_ALPINE);
+        assertThat(result.getA(), is("Alpine Linux"));
+        assertThat(result.getB(), is("3.19.0"));
+        assertThat(result.getC(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testReadOsReleaseRHEL() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_RHEL);
+        assertThat(result.getA(), is("Red Hat Enterprise Linux"));
+        assertThat(result.getB(), is("9.3"));
+        assertThat(result.getC(), is("Plow"));
+    }
+
+    @Test
+    void testReadOsReleaseOpenSUSE() {
+        Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_OPENSUSE);
+        assertThat(result.getA(), is("openSUSE Leap"));
+        assertThat(result.getB(), is("15.5"));
+        assertThat(result.getC(), is(Constants.UNKNOWN));
+    }
+
+    // --- distrib-release fixtures ---
+
+    @Test
+    void testReadDistribReleaseAmazonLinux() {
+        List<String> lines = Arrays.asList("Amazon Linux release 2023 (Amazon Linux)");
+        Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertThat(result.getA(), is("Amazon Linux"));
+        assertThat(result.getB(), is("2023"));
+        assertThat(result.getC(), is("Amazon Linux"));
+    }
+
+    @Test
+    void testReadDistribReleaseOracle() {
+        List<String> lines = Arrays.asList("Oracle Linux Server release 8.9");
+        Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertThat(result.getA(), is("Oracle Linux Server"));
+        assertThat(result.getB(), is("8.9"));
+        assertThat(result.getC(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testReadDistribReleaseRocky() {
+        List<String> lines = Arrays.asList("Rocky Linux release 9.3 (Blue Onyx)");
+        Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertThat(result.getA(), is("Rocky Linux"));
+        assertThat(result.getB(), is("9.3"));
+        assertThat(result.getC(), is("Blue Onyx"));
+    }
+
+    // --- lsb-release fixtures ---
+
+    @Test
+    void testReadLsbReleaseFedora() {
+        List<String> lines = Arrays.asList("DISTRIB_ID=Fedora", "DISTRIB_RELEASE=39", "DISTRIB_CODENAME=ThirtyNine");
+        Triplet<String, String, String> result = LinuxOperatingSystem.readLsbRelease(lines);
+        assertThat(result.getA(), is("Fedora"));
+        assertThat(result.getB(), is("39"));
+        assertThat(result.getC(), is("ThirtyNine"));
+    }
+
+    // --- execLsbRelease fixtures ---
+
+    @Test
+    void testExecLsbReleaseDebian() {
+        List<String> lines = Arrays.asList("Distributor ID:\tDebian", "Description:\tDebian GNU/Linux 12 (bookworm)",
+                "Release:\t12", "Codename:\tbookworm");
+        Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(lines);
+        assertThat(result.getA(), is("Debian"));
+        assertThat(result.getB(), is("12"));
+        assertThat(result.getC(), is("bookworm"));
+    }
+
+    @Test
+    void testExecLsbReleaseNoCodename() {
+        List<String> lines = Arrays.asList("Distributor ID:\tArch", "Description:\tArch Linux", "Release:\trolling",
+                "Codename:\tn/a");
+        Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(lines);
+        assertThat(result.getA(), is("Arch"));
+        assertThat(result.getB(), is("rolling"));
+    }
+
+    // --- filenameToFamily ---
+
+    @Test
+    void testFilenameToFamilyKnownDistros() {
+        assertThat(LinuxOperatingSystem.filenameToFamily("redhat"), is("Red Hat Linux"));
+        assertThat(LinuxOperatingSystem.filenameToFamily("yellowdog"), is("Yellow Dog"));
+        assertThat(LinuxOperatingSystem.filenameToFamily("centos"), is("Centos"));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/FileUtilBufferTest.java
+++ b/oshi-common/src/test/java/oshi/util/FileUtilBufferTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.jupiter.api.Test;
+
+class FileUtilBufferTest {
+
+    @Test
+    void testReadByteFromBuffer() {
+        ByteBuffer buf = ByteBuffer.wrap(new byte[] { 0x42, 0x13 });
+        assertThat(FileUtil.readByteFromBuffer(buf), is((byte) 0x42));
+        assertThat(FileUtil.readByteFromBuffer(buf), is((byte) 0x13));
+    }
+
+    @Test
+    void testReadByteFromBufferEmpty() {
+        ByteBuffer buf = ByteBuffer.allocate(0);
+        assertThat(FileUtil.readByteFromBuffer(buf), is((byte) 0));
+    }
+
+    @Test
+    void testReadShortFromBuffer() {
+        ByteBuffer buf = ByteBuffer.allocate(4);
+        buf.order(ByteOrder.nativeOrder());
+        buf.putShort((short) 1234);
+        buf.putShort((short) -1);
+        buf.flip();
+        assertThat(FileUtil.readShortFromBuffer(buf), is((short) 1234));
+        assertThat(FileUtil.readShortFromBuffer(buf), is((short) -1));
+    }
+
+    @Test
+    void testReadShortFromBufferInsufficient() {
+        ByteBuffer buf = ByteBuffer.wrap(new byte[] { 0x01 });
+        assertThat(FileUtil.readShortFromBuffer(buf), is((short) 0));
+    }
+
+    @Test
+    void testReadIntFromBuffer() {
+        ByteBuffer buf = ByteBuffer.allocate(4);
+        buf.order(ByteOrder.nativeOrder());
+        buf.putInt(305419896);
+        buf.flip();
+        assertThat(FileUtil.readIntFromBuffer(buf), is(305419896));
+    }
+
+    @Test
+    void testReadIntFromBufferInsufficient() {
+        ByteBuffer buf = ByteBuffer.wrap(new byte[] { 0x01, 0x02 });
+        assertThat(FileUtil.readIntFromBuffer(buf), is(0));
+    }
+
+    @Test
+    void testReadLongFromBuffer() {
+        ByteBuffer buf = ByteBuffer.allocate(8);
+        buf.order(ByteOrder.nativeOrder());
+        buf.putLong(123456789012345L);
+        buf.flip();
+        assertThat(FileUtil.readLongFromBuffer(buf), is(123456789012345L));
+    }
+
+    @Test
+    void testReadLongFromBufferInsufficient() {
+        ByteBuffer buf = ByteBuffer.wrap(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        assertThat(FileUtil.readLongFromBuffer(buf), is(0L));
+    }
+
+    @Test
+    void testReadByteArrayFromBuffer() {
+        ByteBuffer buf = ByteBuffer.wrap(new byte[] { 1, 2, 3, 4, 5 });
+        byte[] arr = new byte[3];
+        FileUtil.readByteArrayFromBuffer(buf, arr);
+        assertThat(arr[0], is((byte) 1));
+        assertThat(arr[1], is((byte) 2));
+        assertThat(arr[2], is((byte) 3));
+    }
+
+    @Test
+    void testReadByteArrayFromBufferInsufficient() {
+        ByteBuffer buf = ByteBuffer.wrap(new byte[] { 1, 2 });
+        byte[] arr = new byte[5];
+        FileUtil.readByteArrayFromBuffer(buf, arr);
+        // Array should remain zeroed since buffer doesn't have enough
+        assertThat(arr[0], is((byte) 0));
+    }
+
+    @Test
+    void testReadAllBytesAsBuffer() {
+        // This tests the readAllBytesAsBuffer method with a non-existent file
+        ByteBuffer buf = FileUtil.readAllBytesAsBuffer("/nonexistent/file/path");
+        assertThat(buf.remaining(), is(0));
+    }
+}


### PR DESCRIPTION
## Summary

Add 29 new tests covering three areas with significant coverage gaps.

### LinuxUsbDeviceNF (6 tests)
- Make `queryUsbDevices()` accept a path parameter for testability (was hardcoded to `/sys/bus/usb/devices/`)
- Test with `@TempDir` sysfs fixtures: nonexistent path, empty dir, no devnum, single controller, child device, nested hub hierarchy
- Exercises all parsing branches: product, manufacturer, idVendor, idProduct, serial, parent determination (usb prefix, dash, dot)

### FileUtil ByteBuffer methods (10 tests)
- Cover `readByteFromBuffer`, `readShortFromBuffer`, `readIntFromBuffer`, `readLongFromBuffer`, `readByteArrayFromBuffer`
- Test both normal reads and boundary cases (empty/insufficient buffer returning 0)
- Cover `readAllBytesAsBuffer` with nonexistent file

### LinuxOperatingSystem distro parsing (13 tests)
- os-release fixtures: Fedora, Arch, Debian, Alpine, RHEL, openSUSE
- distrib-release fixtures: Amazon Linux, Oracle Linux, Rocky Linux
- lsb-release and `lsb_release -a` fixtures: Fedora, Debian, Arch
- `filenameToFamily` with properties file lookup and fallback capitalization

## Verification
- All 786 tests pass (772 successful, 14 skipped)
- spotless:apply ✅
- checkstyle:check ✅ (0 violations)
- forbiddenapis:check ✅
- javadoc:javadoc ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * USB device enumeration updated to accept a configurable system path for more flexible discovery on Linux.

* **Tests**
  * Added comprehensive tests covering USB enumeration across multiple sysfs scenarios (missing, empty, single controller, nested hubs).
  * Added tests for Linux distribution detection across many distro formats.
  * Added tests for file buffer reading utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->