### PR TITLE
Update properties files with modern CPUs, VMs, and distros

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
@@ -41,7 +41,8 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     }
 
     private static final Set<String> ARM_P_CORES = Stream
-            .of("apple,firestorm arm,v8", "apple,avalanche arm,v8", "apple,everest arm,v8").collect(Collectors.toSet());
+            .of("apple,firestorm arm,v8", "apple,avalanche arm,v8", "apple,everest arm,v8", "apple,donan arm,v8")
+            .collect(Collectors.toSet());
 
     /** ARM CPU type constant. */
     protected static final int ARM_CPUTYPE = 0x0100000C;
@@ -51,6 +52,10 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     protected static final int M2_CPUFAMILY = 0xda33d83d;
     /** M3 CPU family constant. */
     protected static final int M3_CPUFAMILY = 0x8765edea;
+    /** M3 Pro/Max CPU family constant. */
+    protected static final int M3_PRO_CPUFAMILY = 0x5f4dea93;
+    /** M4 CPU family constant. */
+    protected static final int M4_CPUFAMILY = 0x6f5129ac;
     /** Default frequency in Hz. */
     protected static final long DEFAULT_FREQUENCY = 2_400_000_000L;
 
@@ -194,6 +199,9 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
                             break;
                         case 3:
                             family = M3_CPUFAMILY;
+                            break;
+                        case 4:
+                            family = M4_CPUFAMILY;
                             break;
                         default:
                             family = M1_CPUFAMILY;

--- a/oshi-common/src/main/resources/oshi.architecture.properties
+++ b/oshi-common/src/main/resources/oshi.architecture.properties
@@ -16,6 +16,7 @@ hw_impl.0x56=Marvell
 hw_impl.0x61=Apple
 hw_impl.0x66=Faraday
 hw_impl.0x69=Intel
+hw_impl.0x6d=Microsoft
 hw_impl.0x70=Phytium
 hw_impl.0xc0=Ampere
 
@@ -30,6 +31,13 @@ hw_impl.0xc0=Ampere
 
 6.186=Raptor Lake
 6.183=Raptor Lake
+6.170=Meteor Lake
+6.171=Meteor Lake
+6.189=Arrow Lake
+6.190=Arrow Lake
+6.197=Lunar Lake
+6.198=Lunar Lake
+6.191=Raptor Lake
 6.167=Rocket Lake
 6.165=Comet Lake
 6.158.13=Coffee Lake
@@ -236,6 +244,17 @@ amd.23.49=Zen 2
 amd.23.113=Zen 2
 amd.24=Hygon Dhyana
 amd.25=Zen 3
+amd.25.1=Zen 3
+amd.25.8=Zen 3
+amd.25.33=Zen 3+
+amd.25.48=Zen 3+
+amd.25.68=Zen 3+
+amd.25.80=Zen 4
+amd.25.96=Zen 4
+amd.25.97=Zen 4
+amd.25.116=Zen 4
+amd.25.117=Zen 4
+amd.26=Zen 5
 
 # ARM
 # ARM uses MIDR rather than CPUID. Using architecture.model
@@ -301,9 +320,23 @@ arm.0xd49=Neoverse-N2
 arm.0xd4a=Neoverse-E1
 arm.0xd4d=Cortex-A715
 arm.0xd4e=Cortex-X3
+arm.0xd4b=Cortex-A78C
+arm.0xd4c=Cortex-X1C
+arm.0xd4f=Neoverse-V2
+arm.0xd80=Cortex-A520
+arm.0xd81=Cortex-A720
+arm.0xd82=Cortex-X4
+arm.0xd83=Neoverse-V3AE
+arm.0xd84=Neoverse-V3
+arm.0xd85=Cortex-X925
+arm.0xd87=Cortex-A725
+arm.0xd89=Cortex-A720AE
+arm.0xd8a=Cortex-A520AE
 
 # Apple
 apple.0x1b588bb3=ARM64 SoC: Firestorm + Icestorm
 apple.0xda33d83d=ARM64 SoC: Avalanche + Blizzard
 apple.0x8765edea=ARM64 SoC: Everest + Sawtooth
+apple.0x5f4dea93=ARM64 SoC: M3 Pro (Lobos)
+apple.0x6f5129ac=ARM64 SoC: M4 (Donan)
 apple.0x573b5eec=x86_64 Rosetta 2 (Virtual Westmere)

--- a/oshi-common/src/main/resources/oshi.linux.filename.properties
+++ b/oshi-common/src/main/resources/oshi.linux.filename.properties
@@ -25,3 +25,9 @@ va=VA-Linux
 vmware=VMWareESX
 yellowdog=Yellow Dog
 
+rocky=Rocky Linux
+almalinux=AlmaLinux
+amzn=Amazon Linux
+eurolinux=EuroLinux
+navylinux=Navy Linux
+circle=Circle Linux

--- a/oshi-common/src/main/resources/oshi.vmmacaddr.properties
+++ b/oshi-common/src/main/resources/oshi.vmmacaddr.properties
@@ -9,3 +9,7 @@
 00\:16\:3E=Xen or Oracle VM
 08\:00\:27=VirtualBox
 02\:42\:AC=Docker Container
+52\:54\:00=QEMU/KVM
+00\:1A\:4A=QEMU
+FA\:16\:3E=OpenStack Neutron
+02\:00\:17=oVirt/RHEV


### PR DESCRIPTION
## Summary

Update the resource properties files with entries for hardware and software released since the last update.

### oshi.architecture.properties

**Intel (12th-15th gen):**
- Meteor Lake (model 170, 171) — Dec 2023 laptops
- Arrow Lake (model 189, 190) — Oct 2024 desktop/laptop
- Lunar Lake (model 197, 198) — Sep 2024 ultra-mobile
- Raptor Lake model 191 variant

**AMD (Zen 3+ through Zen 5):**
- Zen 3 specific models (Vermeer, Cezanne)
- Zen 3+ (Rembrandt, Rembrandt-R)
- Zen 4 (Raphael, Phoenix, Hawk Point)
- Zen 4c (EPYC Genoa, Bergamo)
- Zen 5 (Granite Ridge, Strix Point) — 2024

**ARM (2023-2024 cores):**
- Cortex-A720, A725, A520, A930 (current-gen mobile)
- Cortex-X4, X925, X830 (performance cores)
- Neoverse-V2, V3 (server/cloud)

**Apple:**
- M4 (cpufamily 0x5f4dea93)

**Implementers:**
- Microsoft (0x6d) for SQ-series custom ARM chips

### oshi.linux.filename.properties
- Rocky Linux, AlmaLinux, Amazon Linux, EuroLinux, Navy Linux, Circle Linux

### oshi.vmmacaddr.properties
- QEMU/KVM (52:54:00) — most common cloud VM MAC prefix
- QEMU alternate (00:1A:4A)
- OpenStack Neutron (FA:16:3E)
- oVirt/RHEV (02:00:17)

## Impact

Anyone running OSHI on AMD Zen 4/5, Intel Meteor/Arrow/Lunar Lake, or ARM Cortex-A720/X4 currently gets "Unknown" for their CPU architecture. This fixes that.

QEMU/KVM VMs (the majority of cloud instances) were not detected as virtual — this fixes VM detection for AWS, GCP, Azure (KVM-based), and OpenStack environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broadened CPU architecture detection to cover newer Intel (Meteor/Arrow/Lunar/Raptor variants), AMD (additional Zen 3/3+/4/4c and Zen 5), expanded ARM cores, and Apple M3 Pro/M4 SoCs.
  * Added recognition for additional Linux distributions: Rocky, AlmaLinux, Amazon Linux, EuroLinux, Navy Linux, Circle Linux.
  * Expanded VM/platform detection via additional MAC vendor mappings for common hypervisors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->