### PR TITLE
Fix Apple Silicon memory parsing (closes #3241)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
@@ -120,7 +120,46 @@ public abstract class MacGlobalMemory extends AbstractGlobalMemory {
                 }
             }
         }
-        pmList.add(new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memoryType, partNumber, serialNumber));
+        if (bank > 0 && capacity > 0) {
+            // Intel/socketed format: save the last bank
+            pmList.add(
+                    new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memoryType, partNumber, serialNumber));
+        } else {
+            // Apple Silicon format: no BANK lines, parse top-level keys
+            for (String line : lines) {
+                String[] split = line.trim().split(":");
+                if (split.length == 2) {
+                    String key = split[0].trim();
+                    String value = split[1].trim();
+                    switch (key) {
+                        case "Memory":
+                            capacity = ParseUtil.parseDecimalMemorySizeToBinary(value);
+                            break;
+                        case "Type":
+                            memoryType = value;
+                            break;
+                        case "Speed":
+                            speed = ParseUtil.parseHertz(split[1]);
+                            break;
+                        case "Manufacturer":
+                            manufacturer = value;
+                            break;
+                        case "Part Number":
+                            partNumber = value;
+                            break;
+                        case "Serial Number":
+                            serialNumber = value;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+            if (capacity > 0) {
+                pmList.add(new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memoryType, partNumber,
+                        serialNumber));
+            }
+        }
 
         return pmList;
     }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGlobalMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGlobalMemoryTest.java
@@ -5,6 +5,7 @@
 package oshi.hardware.common.platform.mac;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -16,12 +17,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import oshi.hardware.PhysicalMemory;
-import oshi.util.Constants;
 
 class MacGlobalMemoryTest {
 
-    // Fixture: typical system_profiler SPMemoryDataType output
-    // Note: real output has " :" (space before colon) in bank labels
     private static final List<String> SP_MEMORY_TWO_BANKS = Arrays.asList("Memory:", "", "    Memory Slots:", "",
             "      ECC: Disabled", "      Upgradeable Memory: Yes", "", "        BANK 0/DIMM0 :", "",
             "          Size: 8 GB", "          Type: DDR4", "          Speed: 2400 MHz",
@@ -54,10 +52,7 @@ class MacGlobalMemoryTest {
     @Test
     void testParseSystemProfilerMemoryEmpty() {
         List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(Collections.emptyList());
-        // Always returns at least one entry (the final add outside the loop)
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getBankLabel(), is(Constants.UNKNOWN));
-        assertThat(result.get(0).getCapacity(), is(0L));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -75,10 +70,28 @@ class MacGlobalMemoryTest {
 
     @Test
     void testParseSystemProfilerMemoryNoColon() {
-        // Bank label without trailing colon — substring logic skipped
         List<String> noColon = Arrays.asList("        BANK 0", "          Size: 4 GB", "          Type: DDR3");
         List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(noColon);
         assertThat(result, hasSize(1));
         assertThat(result.get(0).getBankLabel(), is("BANK 0"));
+    }
+
+    @Test
+    void testParseSystemProfilerMemoryAppleSilicon() {
+        List<String> appleSilicon = Arrays.asList("Memory:", "", "      Memory: 36 GB", "      Type: LPDDR5",
+                "      Manufacturer: Micron");
+        List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(appleSilicon);
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getCapacity(), is(greaterThan(0L)));
+        assertThat(result.get(0).getMemoryType(), is("LPDDR5"));
+        assertThat(result.get(0).getManufacturer(), is("Micron"));
+    }
+
+    @Test
+    void testParseSystemProfilerMemoryAppleSiliconMinimal() {
+        List<String> minimal = Arrays.asList("      Memory: 8 GB");
+        List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(minimal);
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getCapacity(), is(greaterThan(0L)));
     }
 }


### PR DESCRIPTION
## Problem

On Apple Silicon Macs (M1/M2/M3/M4), `system_profiler SPMemoryDataType` outputs memory info without individual `BANK` entries:

```
Memory:

      Memory: 36 GB
      Type: LPDDR5
      Manufacturer: Micron
```

The parser only processed key-value lines when `bank > 0` (after seeing a `BANK` header), so capacity, type, and manufacturer were all lost. Result: `getPhysicalMemory()` returned a single entry with 0 capacity and all "unknown" fields.

## Fix

When no `BANK` lines are found in the output, fall back to parsing top-level key-value pairs, treating `Memory:` as the size field (equivalent to `Size:` in the BANK format). Only emit a `PhysicalMemory` entry if a valid capacity was parsed.

## Behavior Change

- **Apple Silicon**: Now correctly reports capacity, type, and manufacturer
- **Intel Macs**: No change (BANK-based parsing unchanged)
- **Empty input**: Now returns empty list instead of a phantom entry with all-unknown fields (more correct)

## Testing

- Added `testParseSystemProfilerMemoryAppleSilicon` — verifies 36 GB LPDDR5 from Micron is parsed
- Added `testParseSystemProfilerMemoryAppleSiliconMinimal` — verifies minimal output works
- Updated `testParseSystemProfilerMemoryEmpty` — empty input returns empty list
- All 788 tests pass

Closes #3241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory parsing on macOS to correctly handle both Intel (BANK-style) and Apple Silicon memory output formats; avoids adding a default "unknown" entry for empty input.

* **Tests**
  * Added and updated tests to cover Apple Silicon memory output variations and the empty-input case, ensuring accurate parsing across architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->