### PR TITLE
Update UPGRADING.md with additional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Legacy Versions
 Usage
 -----
 1. Include OSHI and its dependencies on your classpath.
-   - We strongly recommend you add `oshi-core` as a dependency to your project dependency manager such as Maven or Gradle.
+   - We strongly recommend you add `oshi-core` as a dependency to your project dependency manager such as Maven or Gradle. Transitive dependencies (including `oshi-common` and JNA) are resolved automatically.
+   - If you manage JAR files manually, download all needed JARs from the [oshi-dist](https://repo1.maven.org/maven2/com/github/oshi/oshi-dist/) zip files. See [UPGRADING.md](UPGRADING.md#project-dependencies) for details.
    - For Windows, consider the optional `jLibreHardwareMonitor` dependency if you need sensor information. Note the binary DLLs in this dependency are licensed under MPL 2.0.
    - For Android, you'll need to add the [AAR artifact for JNA](https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android) and exclude OSHI's transitive (JAR) dependency.
    - See the [FAQ](FAQ.md#how-do-i-resolve-jna-noclassdeffounderror-or-nosuchmethoderror-issues) if you encounter `NoClassDefFoundError` or `NoSuchMethodError` problems.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,23 @@
+# Project Dependencies
+
+Dependency management tools such as Maven or Gradle automatically handle transitive dependencies. If you manage JAR files manually, the following notes may help.
+
+## JNA version coupling
+
+OSHI's `oshi-core` module is tightly coupled with [JNA](https://github.com/java-native-access/jna) and requires at least the version specified in the POM. Using an older JNA version may cause `NoClassDefFoundError` or `NoSuchMethodError` at runtime due to missing classes or methods. See the [FAQ](FAQ.md#how-do-i-resolve-jna-noclassdeffounderror-or-nosuchmethoderror-issues) for troubleshooting.
+
+## Module split (6.12.0+)
+
+Starting with version 6.12.0, OSHI was split from a single `oshi-core` artifact into multiple modules:
+
+- **`oshi-common`** — shared API interfaces and utilities that do not require JNA or FFM.
+- **`oshi-core`** — JNA-based implementation (depends on `oshi-common`).
+- **`oshi-core-ffm`** — FFM-based implementation (depends on `oshi-common`, requires JDK 25+).
+
+Both `oshi-core` and `oshi-core-ffm` declare a transitive dependency on `oshi-common`, so dependency managers resolve it automatically. If you use raw JAR files, you must include `oshi-common` on the classpath alongside your chosen implementation module. All needed JARs are available in the [oshi-dist](https://repo1.maven.org/maven2/com/github/oshi/oshi-dist/) zip files on Maven Central.
+
+---
+
 # Guide to upgrading from OSHI 6.x to 7.x
 
 ## Configuration property key changes (7.1.0)
@@ -75,10 +95,6 @@ The JPMS module name for the FFM module has changed from `com.github.oshi` to `c
 ```java
 requires com.github.oshi.ffm;
 ```
-
-## Additional need for oshi-commons
-
-If you do not use Maven or similar tools but the raw JAR files, this subject is for you. Since Version 7, oshi-commons is a new dependency of oshi-core. Therefore, in addition to the oshi-core JAR file, you will need the JAR file for oshi-commons in the classpath / modulepath. Otherwise, some classes may not be accessible, since e.g. the subpackage oshi.tuples (used e.g. for the Pair class) will not be found during import.
 
 # Guide to upgrading from OSHI 5.x to 6.x
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -76,6 +76,10 @@ The JPMS module name for the FFM module has changed from `com.github.oshi` to `c
 requires com.github.oshi.ffm;
 ```
 
+## Additional need for oshi-commons
+
+If you do not use Maven or similar tools but the raw JAR files, this subject is for you. Since Version 7, oshi-commons is a new dependency of oshi-core. Therefore, in addition to the oshi-core JAR file, you will need the JAR file for oshi-commons in the classpath / modulepath. Otherwise, some classes may not be accessible, since e.g. the subpackage oshi.tuples (used e.g. for the Pair class) will not be found during import.
+
 # Guide to upgrading from OSHI 5.x to 6.x
 
 OSHI 6.0.0 is functionally equivalent to 5.8.7, with minor API updates as noted below.


### PR DESCRIPTION
The described issue came up during regular after-library-upgrade-tests within my project: The Pair class was not more accessible, therefore I had to additionally import the oshi-commons JAR file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Usage and upgrade docs updated with guidance for manual JAR setups: a companion runtime library is required alongside the core implementation for recent versions, and a minimum native-access library version is needed to avoid runtime linkage issues. README now covers recommended dependency manager usage plus instructions for downloading distribution ZIPs (see upgrade notes for details).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3246)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->