### PR TITLE
Read EDID from /sys/class/drm on Linux, fall back to xrandr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ##### Bug Fixes and Improvements
 
+* [#3249](https://github.com/oshi/oshi/pull/3249): Read EDID from `/sys/class/drm` on Linux, fixing display detection on Wayland - [@dbwiddis](https://github.com/dbwiddis).
 * [#3245](https://github.com/oshi/oshi/pull/3245): Fix `MacGlobalMemory.getPhysicalMemory()` returning empty data on Apple Silicon Macs - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.1.0 (2026-05-06)

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
@@ -5,6 +5,7 @@
 package oshi.hardware.common.platform.linux;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor;
@@ -16,6 +17,7 @@ import oshi.hardware.Sensors;
 import oshi.hardware.SoundCard;
 import oshi.hardware.common.AbstractHardwareAbstractionLayer;
 import oshi.hardware.common.platform.unix.UnixDisplay;
+import oshi.util.driver.linux.DrmEdid;
 
 /**
  * LinuxHardwareAbstractionLayer class.
@@ -47,6 +49,10 @@ public abstract class LinuxHardwareAbstractionLayer extends AbstractHardwareAbst
 
     @Override
     public List<Display> getDisplays() {
+        List<byte[]> edids = DrmEdid.getEdidArrays();
+        if (!edids.isEmpty()) {
+            return edids.stream().map(UnixDisplay::new).collect(Collectors.toList());
+        }
         return UnixDisplay.getDisplays();
     }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
@@ -23,7 +23,7 @@ public final class UnixDisplay extends AbstractDisplay {
      *
      * @param edid a byte array representing a display EDID
      */
-    UnixDisplay(byte[] edid) {
+    public UnixDisplay(byte[] edid) {
         super(edid);
     }
 

--- a/oshi-common/src/main/java/oshi/util/driver/linux/DrmEdid.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/DrmEdid.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.driver.linux;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.FileUtil;
+import oshi.util.linux.SysPath;
+
+/**
+ * Utility to read EDID data from the Linux DRM (Direct Rendering Manager) subsystem. The kernel exposes raw EDID bytes
+ * for each connected display at {@code /sys/class/drm/card<N>-<connector>/edid}, which works regardless of whether X11
+ * or Wayland is in use.
+ */
+@ThreadSafe
+public final class DrmEdid {
+
+    private DrmEdid() {
+    }
+
+    /**
+     * Read EDID byte arrays from /sys/class/drm for all connected displays.
+     *
+     * @return a list of EDID byte arrays (at least 128 bytes each), or empty if none found
+     */
+    public static List<byte[]> getEdidArrays() {
+        return getEdidArrays(new File(SysPath.DRM));
+    }
+
+    /**
+     * Read EDID byte arrays from the given DRM directory.
+     *
+     * @param drmDir the directory containing card*-* subdirectories
+     * @return a list of EDID byte arrays (at least 128 bytes each), or empty if none found
+     */
+    static List<byte[]> getEdidArrays(File drmDir) {
+        if (!drmDir.isDirectory()) {
+            return Collections.emptyList();
+        }
+        File[] connectors = drmDir.listFiles(f -> f.isDirectory() && f.getName().matches("card\\d+-.+"));
+        if (connectors == null || connectors.length == 0) {
+            return Collections.emptyList();
+        }
+        List<byte[]> displays = new ArrayList<>();
+        for (File connector : connectors) {
+            File statusFile = new File(connector, "status");
+            if (statusFile.exists()) {
+                String status = FileUtil.getStringFromFile(statusFile.getPath()).trim();
+                if (!"connected".equals(status)) {
+                    continue;
+                }
+            }
+            File edidFile = new File(connector, "edid");
+            if (edidFile.exists() && edidFile.length() >= 128) {
+                byte[] edid = FileUtil.readAllBytes(edidFile.getPath(), false);
+                if (edid != null && edid.length >= 128) {
+                    displays.add(edid);
+                }
+            }
+        }
+        return displays;
+    }
+}

--- a/oshi-common/src/main/java/oshi/util/linux/SysPath.java
+++ b/oshi-common/src/main/java/oshi/util/linux/SysPath.java
@@ -39,6 +39,8 @@ public final class SysPath {
     public static final String THERMAL = SYS + "class/thermal/";
     /** Path to cgroup filesystem. */
     public static final String CGROUP = SYS + "fs/cgroup/";
+    /** Path to DRM (Direct Rendering Manager) class. */
+    public static final String DRM = SYS + "class/drm/";
 
     private SysPath() {
     }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static oshi.hardware.common.platform.linux.TestFileUtil.writeFile;
+import static oshi.util.TestFileUtil.writeFile;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGpuStatsTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static oshi.hardware.common.platform.linux.TestFileUtil.writeFile;
+import static oshi.util.TestFileUtil.writeFile;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxNetworkIFTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxNetworkIFTest.java
@@ -6,7 +6,7 @@ package oshi.hardware.common.platform.linux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static oshi.hardware.common.platform.linux.TestFileUtil.writeFile;
+import static oshi.util.TestFileUtil.writeFile;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSensorsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSensorsTest.java
@@ -7,7 +7,7 @@ package oshi.hardware.common.platform.linux;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
-import static oshi.hardware.common.platform.linux.TestFileUtil.writeFile;
+import static oshi.util.TestFileUtil.writeFile;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSoundCardTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static oshi.hardware.common.platform.linux.TestFileUtil.writeFile;
+import static oshi.util.TestFileUtil.writeFile;
 
 import java.io.File;
 import java.io.IOException;

--- a/oshi-common/src/test/java/oshi/util/TestFileUtil.java
+++ b/oshi-common/src/test/java/oshi/util/TestFileUtil.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.common.platform.linux;
+package oshi.util;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -12,19 +12,19 @@ import java.nio.file.Path;
 /**
  * Shared test utility for writing files in synthetic sysfs trees.
  */
-final class TestFileUtil {
+public final class TestFileUtil {
 
     private TestFileUtil() {
     }
 
     /**
-     * Writes a string to a file, creating parent directories as needed.
+     * Writes a string to a file using UTF-8 encoding, creating parent directories as needed.
      *
      * @param path    the file path
      * @param content the content to write
      * @throws IOException if writing fails
      */
-    static void writeFile(Path path, String content) throws IOException {
+    public static void writeFile(Path path, String content) throws IOException {
         Files.createDirectories(path.getParent());
         Files.write(path, content.getBytes(StandardCharsets.UTF_8));
     }

--- a/oshi-common/src/test/java/oshi/util/driver/linux/DrmEdidTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/DrmEdidTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.driver.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static oshi.util.TestFileUtil.writeFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+@EnabledOnOs(OS.LINUX)
+class DrmEdidTest {
+
+    // Minimal valid 128-byte EDID with standard header
+    private static final byte[] VALID_EDID = createValidEdid();
+
+    private static byte[] createValidEdid() {
+        byte[] edid = new byte[128];
+        // EDID magic header: 00 FF FF FF FF FF FF 00
+        edid[0] = 0x00;
+        edid[1] = (byte) 0xFF;
+        edid[2] = (byte) 0xFF;
+        edid[3] = (byte) 0xFF;
+        edid[4] = (byte) 0xFF;
+        edid[5] = (byte) 0xFF;
+        edid[6] = (byte) 0xFF;
+        edid[7] = 0x00;
+        return edid;
+    }
+
+    @Test
+    void testConnectedDisplayWithEdid(@TempDir Path tempDir) throws IOException {
+        Path connector = Files.createDirectories(tempDir.resolve("card0-HDMI-1"));
+        writeFile(connector.resolve("status"), "connected\n");
+        Files.write(connector.resolve("edid"), VALID_EDID);
+
+        List<byte[]> edids = DrmEdid.getEdidArrays(tempDir.toFile());
+        assertThat(edids, hasSize(1));
+        assertThat(edids.get(0).length, greaterThanOrEqualTo(128));
+        assertThat(edids.get(0)[0], is((byte) 0x00));
+        assertThat(edids.get(0)[1], is((byte) 0xFF));
+    }
+
+    @Test
+    void testDisconnectedDisplaySkipped(@TempDir Path tempDir) throws IOException {
+        Path connector = Files.createDirectories(tempDir.resolve("card0-DP-1"));
+        writeFile(connector.resolve("status"), "disconnected\n");
+        Files.write(connector.resolve("edid"), VALID_EDID);
+
+        assertThat(DrmEdid.getEdidArrays(tempDir.toFile()), is(empty()));
+    }
+
+    @Test
+    void testEmptyEdidSkipped(@TempDir Path tempDir) throws IOException {
+        Path connector = Files.createDirectories(tempDir.resolve("card0-HDMI-1"));
+        writeFile(connector.resolve("status"), "connected\n");
+        Files.write(connector.resolve("edid"), new byte[0]);
+
+        assertThat(DrmEdid.getEdidArrays(tempDir.toFile()), is(empty()));
+    }
+
+    @Test
+    void testMultipleConnectors(@TempDir Path tempDir) throws IOException {
+        Path hdmi = Files.createDirectories(tempDir.resolve("card0-HDMI-1"));
+        writeFile(hdmi.resolve("status"), "connected\n");
+        Files.write(hdmi.resolve("edid"), VALID_EDID);
+
+        Path dp = Files.createDirectories(tempDir.resolve("card0-DP-1"));
+        writeFile(dp.resolve("status"), "connected\n");
+        Files.write(dp.resolve("edid"), VALID_EDID);
+
+        Path disconnected = Files.createDirectories(tempDir.resolve("card0-DP-2"));
+        writeFile(disconnected.resolve("status"), "disconnected\n");
+        Files.write(disconnected.resolve("edid"), VALID_EDID);
+
+        assertThat(DrmEdid.getEdidArrays(tempDir.toFile()), hasSize(2));
+    }
+
+    @Test
+    void testNonExistentDirectory(@TempDir Path tempDir) {
+        assertThat(DrmEdid.getEdidArrays(tempDir.resolve("nonexistent").toFile()), is(empty()));
+    }
+
+    @Test
+    void testIgnoresNonConnectorDirectories(@TempDir Path tempDir) throws IOException {
+        // "card0" alone (no dash-connector suffix) should be ignored
+        Path card = Files.createDirectories(tempDir.resolve("card0"));
+        writeFile(card.resolve("status"), "connected\n");
+        Files.write(card.resolve("edid"), VALID_EDID);
+
+        assertThat(DrmEdid.getEdidArrays(tempDir.toFile()), is(empty()));
+    }
+
+    @Test
+    void testMissingStatusFileStillReadsEdid(@TempDir Path tempDir) throws IOException {
+        Path connector = Files.createDirectories(tempDir.resolve("card0-HDMI-1"));
+        // No status file created - should still read EDID
+        Files.write(connector.resolve("edid"), VALID_EDID);
+
+        List<byte[]> edids = DrmEdid.getEdidArrays(tempDir.toFile());
+        assertThat(edids, hasSize(1));
+        assertThat(edids.get(0).length, greaterThanOrEqualTo(128));
+    }
+}


### PR DESCRIPTION
On Wayland, `xrandr --verbose` runs via XWayland but does not include EDID data in its output. This means `UnixDisplay` finds no displays on Linux systems using Wayland.

This PR adds a `DrmEdid` driver that reads EDID directly from the kernel's DRM subsystem at `/sys/class/drm/card<N>-<connector>/edid`. This works regardless of display server (X11 or Wayland).

On Linux, DRM is now the primary source. If no EDID data is found via DRM (e.g., older systems without DRM), it falls back to the existing xrandr approach. Other Unix platforms (FreeBSD, Solaris, etc.) are unaffected.

Fixes #3248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display detection on Wayland/Linux by reading EDID from the system DRM interface, fixing missed or undetected displays.

* **New Features**
  * Added Linux DRM EDID support to gather display information when available.

* **Tests**
  * Added comprehensive tests for connected/disconnected displays, multiple connectors, missing/empty EDID, and edge cases; test utilities consolidated and made reusable.

* **Documentation**
  * Updated changelog with the new Linux display detection entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3249)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->