### PR TITLE
Reduce Auxv duplication with functional interface

### DIFF
--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/Auxv.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/Auxv.java
@@ -4,11 +4,20 @@
  */
 package oshi.util.driver.linux.proc;
 
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.FileUtil;
+import oshi.util.linux.ProcPath;
+
 /**
- * Constants for the Linux auxiliary vector ({@code /proc/self/auxv}).
+ * Constants and shared logic for the Linux auxiliary vector ({@code /proc/self/auxv}).
  *
  * @see <a href="https://github.com/torvalds/linux/blob/v3.19/include/uapi/linux/auxvec.h">auxvec.h</a>
  */
+@ThreadSafe
 public final class Auxv {
 
     private Auxv() {
@@ -22,4 +31,38 @@ public final class Auxv {
     public static final int AT_HWCAP = 16;
     /** frequency at which times() increments */
     public static final int AT_CLKTCK = 17;
+
+    /**
+     * Reads a native-long value from a {@link ByteBuffer} and returns it as a Java {@code long}.
+     */
+    @FunctionalInterface
+    public interface NativeLongReader {
+        /**
+         * Reads the next native-long value from the buffer.
+         *
+         * @param buffer the buffer to read from
+         * @return the value as a Java long
+         */
+        long read(ByteBuffer buffer);
+    }
+
+    /**
+     * Retrieve the auxiliary vector for the current process.
+     *
+     * @param reader a function that reads a native-long from a {@link ByteBuffer}
+     * @return A map of auxiliary vector keys to their respective values
+     * @see <a href="https://github.com/torvalds/linux/blob/v3.19/include/uapi/linux/auxvec.h">auxvec.h</a>
+     */
+    public static Map<Integer, Long> queryAuxv(NativeLongReader reader) {
+        ByteBuffer buff = FileUtil.readAllBytesAsBuffer(ProcPath.AUXV);
+        Map<Integer, Long> auxvMap = new HashMap<>();
+        int key;
+        do {
+            key = (int) reader.read(buff);
+            if (key != AT_NULL) {
+                auxvMap.put(key, reader.read(buff));
+            }
+        } while (key != AT_NULL);
+        return auxvMap;
+    }
 }

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/AuxvTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/AuxvTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.driver.linux.proc;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.util.FileUtil;
+
+@EnabledOnOs(OS.LINUX)
+class AuxvTest {
+
+    private static final boolean IS_64_BIT = "amd64".equals(System.getProperty("os.arch"))
+            || "aarch64".equals(System.getProperty("os.arch"));
+
+    private static final Auxv.NativeLongReader READER = IS_64_BIT ? FileUtil::readLongFromBuffer
+            : buff -> FileUtil.readIntFromBuffer(buff);
+
+    @Test
+    void testQueryAuxv() {
+        Map<Integer, Long> auxv = Auxv.queryAuxv(READER);
+        assertNotNull(auxv, "Aux vector should not be null");
+        assertThat("Clock Ticks should be positive", auxv.getOrDefault(Auxv.AT_CLKTCK, 0L), greaterThan(0L));
+        assertThat("Page Size should be positive", auxv.getOrDefault(Auxv.AT_PAGESZ, 0L), greaterThan(0L));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/driver/linux/proc/AuxvFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/linux/proc/AuxvFFM.java
@@ -4,15 +4,11 @@
  */
 package oshi.driver.linux.proc;
 
-import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.util.FileUtilFFM;
-import oshi.util.FileUtil;
 import oshi.util.driver.linux.proc.Auxv;
-import oshi.util.linux.ProcPath;
 
 /**
  * FFM-based utility to read the auxiliary vector from {@code /proc/self/auxv}.
@@ -30,15 +26,6 @@ public final class AuxvFFM {
      * @see <a href= "https://github.com/torvalds/linux/blob/v3.19/include/uapi/linux/auxvec.h">auxvec.h</a>
      */
     public static Map<Integer, Long> queryAuxv() {
-        ByteBuffer buff = FileUtil.readAllBytesAsBuffer(ProcPath.AUXV);
-        Map<Integer, Long> auxvMap = new HashMap<>();
-        int key;
-        do {
-            key = (int) FileUtilFFM.readNativeLongFromBuffer(buff);
-            if (key != Auxv.AT_NULL) {
-                auxvMap.put(key, FileUtilFFM.readNativeLongFromBuffer(buff));
-            }
-        } while (key != Auxv.AT_NULL);
-        return auxvMap;
+        return Auxv.queryAuxv(FileUtilFFM::readNativeLongFromBuffer);
     }
 }

--- a/oshi-core/src/main/java/oshi/driver/linux/proc/AuxvJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/linux/proc/AuxvJNA.java
@@ -4,15 +4,11 @@
  */
 package oshi.driver.linux.proc;
 
-import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.util.FileUtilJNA;
-import oshi.util.FileUtil;
 import oshi.util.driver.linux.proc.Auxv;
-import oshi.util.linux.ProcPath;
 
 /**
  * JNA-based utility to read the auxiliary vector from {@code /proc/self/auxv}.
@@ -30,15 +26,6 @@ public final class AuxvJNA {
      * @see <a href= "https://github.com/torvalds/linux/blob/v3.19/include/uapi/linux/auxvec.h">auxvec.h</a>
      */
     public static Map<Integer, Long> queryAuxv() {
-        ByteBuffer buff = FileUtil.readAllBytesAsBuffer(ProcPath.AUXV);
-        Map<Integer, Long> auxvMap = new HashMap<>();
-        int key;
-        do {
-            key = FileUtilJNA.readNativeLongFromBuffer(buff).intValue();
-            if (key != Auxv.AT_NULL) {
-                auxvMap.put(key, FileUtilJNA.readNativeLongFromBuffer(buff).longValue());
-            }
-        } while (key != Auxv.AT_NULL);
-        return auxvMap;
+        return Auxv.queryAuxv(buff -> FileUtilJNA.readNativeLongFromBuffer(buff).longValue());
     }
 }


### PR DESCRIPTION
Closes #3262

Introduces a `NativeLongReader` functional interface in the common `Auxv` class and moves the buffer-reading loop into `Auxv.queryAuxv(NativeLongReader)`. The JNA and FFM subclasses now each supply their reader as a one-liner delegation.

**Changes:**
- `Auxv.java` (oshi-common): Added `NativeLongReader` interface and `queryAuxv()` method
- `AuxvJNA.java`: Reduced to single delegation call
- `AuxvFFM.java`: Reduced to single delegation call  
- New `AuxvTest.java` in oshi-common testing the shared implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Linux auxiliary-vector query capability exposing system auxiliary data and metrics.

* **Refactor**
  * Consolidated parsing into a shared helper and updated implementations to delegate to it for consistency and reduced duplication.

* **Tests**
  * Added Linux-focused tests to validate retrieval of auxiliary vector entries and key system parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->