### PR TITLE
Extract IOKit iteration into IOKitProvider callback pattern

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOKitProvider.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOKitProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Abstracts IOKit registry operations so that iteration logic can be shared between JNA and FFM implementations.
+ */
+public interface IOKitProvider {
+
+    /**
+     * Looks up a single IORegistry service by class name, extracts a result, and releases the entry.
+     *
+     * @param <T>         the result type
+     * @param serviceName the IOService class name (e.g. "IOPlatformExpertDevice")
+     * @param extractor   function applied to the matched entry; receives a non-null {@link RegistryEntry}
+     * @return the extracted value, or {@code null} if the service was not found
+     */
+    <T> T withMatchingService(String serviceName, Function<RegistryEntry, T> extractor);
+
+    /**
+     * Iterates all IORegistry services matching a class name, invoking a consumer for each entry. Entries and the
+     * iterator are released automatically.
+     *
+     * @param serviceName the IOService class name (e.g. "IOPlatformDevice")
+     * @param consumer    consumer invoked for each matched entry
+     */
+    void forEachMatchingService(String serviceName, Consumer<RegistryEntry> consumer);
+
+    /**
+     * Iterates all IORegistry services matching a class name, invoking a function for each entry. If the function
+     * returns {@code true}, iteration stops early. Entries and the iterator are released automatically.
+     *
+     * @param serviceName the IOService class name (e.g. "AppleARMIODevice")
+     * @param visitor     function invoked for each matched entry; return {@code true} to stop iteration
+     */
+    void forEachMatchingServiceUntil(String serviceName, Function<RegistryEntry, Boolean> visitor);
+
+    /**
+     * A handle to an IORegistry entry, providing property access.
+     */
+    interface RegistryEntry {
+
+        /**
+         * Gets the name of this registry entry.
+         *
+         * @return the entry name, or {@code null} if unavailable
+         */
+        String getName();
+
+        /**
+         * Gets a byte array property from this registry entry.
+         *
+         * @param key the property key
+         * @return the property value as a byte array, or {@code null} if not found
+         */
+        byte[] getByteArrayProperty(String key);
+
+        /**
+         * Gets a string property from this registry entry.
+         *
+         * @param key the property key
+         * @return the property value as a string, or {@code null} if not found
+         */
+        String getStringProperty(String key);
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacBaseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacBaseboard.java
@@ -6,10 +6,13 @@ package oshi.hardware.common.platform.mac;
 
 import static oshi.util.Memoizer.memoize;
 
+import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.common.AbstractBaseboard;
+import oshi.util.Constants;
+import oshi.util.Util;
 import oshi.util.tuples.Quartet;
 
 /**
@@ -47,9 +50,42 @@ public abstract class MacBaseboard extends AbstractBaseboard {
     }
 
     /**
+     * Returns the IOKit provider for this implementation.
+     *
+     * @return the IOKit provider
+     */
+    protected abstract IOKitProvider ioKitProvider();
+
+    /**
      * Queries platform baseboard information.
      *
      * @return a quartet of manufacturer, model, version, serial number
      */
-    protected abstract Quartet<String, String, String, String> queryPlatform();
+    protected Quartet<String, String, String, String> queryPlatform() {
+        Quartet<String, String, String, String> result = ioKitProvider().withMatchingService("IOPlatformExpertDevice",
+                entry -> {
+                    String mfr = bytesToString(entry.getByteArrayProperty("manufacturer"));
+                    String mdl = bytesToString(entry.getByteArrayProperty("board-id"));
+                    if (Util.isBlank(mdl)) {
+                        mdl = bytesToString(entry.getByteArrayProperty("model-number"));
+                    }
+                    String ver = bytesToString(entry.getByteArrayProperty("version"));
+                    String sn = bytesToString(entry.getByteArrayProperty("mlb-serial-number"));
+                    if (Util.isBlank(sn)) {
+                        sn = entry.getStringProperty("IOPlatformSerialNumber");
+                    }
+                    return new Quartet<>(mfr, mdl, ver, sn);
+                });
+        if (result == null) {
+            result = new Quartet<>(null, null, null, null);
+        }
+        return new Quartet<>(Util.isBlank(result.getA()) ? "Apple Inc." : result.getA(),
+                Util.isBlank(result.getB()) ? Constants.UNKNOWN : result.getB(),
+                Util.isBlank(result.getC()) ? Constants.UNKNOWN : result.getC(),
+                Util.isBlank(result.getD()) ? Constants.UNKNOWN : result.getD());
+    }
+
+    private static String bytesToString(byte[] data) {
+        return data != null ? new String(data, StandardCharsets.UTF_8).replace("\0", "").trim() : null;
+    }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
@@ -6,6 +6,7 @@ package oshi.hardware.common.platform.mac;
 
 import static oshi.util.Memoizer.memoize;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -16,6 +17,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -43,6 +46,8 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     private static final Set<String> ARM_P_CORES = Stream
             .of("apple,firestorm arm,v8", "apple,avalanche arm,v8", "apple,everest arm,v8", "apple,donan arm,v8")
             .collect(Collectors.toSet());
+
+    private static final Pattern CPU_N = Pattern.compile("^cpu(\\d+)");
 
     /** ARM CPU type constant. */
     protected static final int ARM_CPUTYPE = 0x0100000C;
@@ -111,23 +116,63 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     protected abstract String sysctlStringNoWarn(String name, String defaultValue);
 
     /**
+     * Returns the IOKit provider for this implementation.
+     *
+     * @return the IOKit provider
+     */
+    protected abstract IOKitProvider ioKitProvider();
+
+    /**
      * Queries the platform expert vendor string.
      *
      * @return the vendor string
      */
-    protected abstract String platformExpert();
+    protected String platformExpert() {
+        String manufacturer = ioKitProvider().withMatchingService("IOPlatformExpertDevice", entry -> {
+            byte[] data = entry.getByteArrayProperty("manufacturer");
+            return data != null ? new String(data, StandardCharsets.UTF_8).replace("\0", "").trim() : null;
+        });
+        return Util.isBlank(manufacturer) ? "Apple Inc." : manufacturer;
+    }
 
     /**
      * Queries compatible strings for CPU identification.
      *
      * @return a map of physical processor numbers to compatible strings
      */
-    protected abstract Map<Integer, String> queryCompatibleStrings();
+    protected Map<Integer, String> queryCompatibleStrings() {
+        Map<Integer, String> compatibleStrMap = new HashMap<>();
+        ioKitProvider().forEachMatchingService("IOPlatformDevice", entry -> {
+            String name = entry.getName();
+            if (name != null) {
+                Matcher m = CPU_N.matcher(name.toLowerCase(Locale.ROOT));
+                if (m.matches()) {
+                    int procId = ParseUtil.parseIntOrDefault(m.group(1), 0);
+                    byte[] data = entry.getByteArrayProperty("compatible");
+                    if (data != null) {
+                        compatibleStrMap.put(procId,
+                                new String(data, StandardCharsets.UTF_8).replace('\0', ' ').trim());
+                    }
+                }
+            }
+        });
+        return compatibleStrMap;
+    }
 
     /**
      * Calculates nominal frequencies for performance and efficiency cores.
      */
-    protected abstract void calculateNominalFrequencies();
+    protected void calculateNominalFrequencies() {
+        ioKitProvider().forEachMatchingServiceUntil("AppleARMIODevice", entry -> {
+            if ("pmgr".equalsIgnoreCase(entry.getName())) {
+                setPerformanceCoreFrequency(
+                        getMaxFreqFromByteArray(entry.getByteArrayProperty("voltage-states5-sram")));
+                setEfficiencyCoreFrequency(getMaxFreqFromByteArray(entry.getByteArrayProperty("voltage-states1-sram")));
+                return true;
+            }
+            return false;
+        });
+    }
 
     /**
      * Gets the performance core frequency.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacComputerSystem.java
@@ -6,10 +6,13 @@ package oshi.hardware.common.platform.mac;
 
 import static oshi.util.Memoizer.memoize;
 
+import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.common.AbstractComputerSystem;
+import oshi.util.Constants;
+import oshi.util.Util;
 import oshi.util.tuples.Quartet;
 
 /**
@@ -48,9 +51,36 @@ public abstract class MacComputerSystem extends AbstractComputerSystem {
     }
 
     /**
+     * Returns the IOKit provider for this implementation.
+     *
+     * @return the IOKit provider
+     */
+    protected abstract IOKitProvider ioKitProvider();
+
+    /**
      * Queries platform expert computer system information.
      *
      * @return a quartet of manufacturer, model, serial number, UUID
      */
-    protected abstract Quartet<String, String, String, String> platformExpert();
+    protected Quartet<String, String, String, String> platformExpert() {
+        Quartet<String, String, String, String> result = ioKitProvider().withMatchingService("IOPlatformExpertDevice",
+                entry -> {
+                    byte[] data = entry.getByteArrayProperty("manufacturer");
+                    String mfr = data != null ? new String(data, StandardCharsets.UTF_8).replace("\0", "").trim()
+                            : null;
+                    data = entry.getByteArrayProperty("model");
+                    String mdl = data != null ? new String(data, StandardCharsets.UTF_8).replace("\0", "").trim()
+                            : null;
+                    String sn = entry.getStringProperty("IOPlatformSerialNumber");
+                    String uuid = entry.getStringProperty("IOPlatformUUID");
+                    return new Quartet<>(mfr, mdl, sn, uuid);
+                });
+        if (result == null) {
+            result = new Quartet<>(null, null, null, null);
+        }
+        return new Quartet<>(Util.isBlank(result.getA()) ? "Apple Inc." : result.getA(),
+                Util.isBlank(result.getB()) ? Constants.UNKNOWN : result.getB(),
+                Util.isBlank(result.getC()) ? Constants.UNKNOWN : result.getC(),
+                Util.isBlank(result.getD()) ? Constants.UNKNOWN : result.getD());
+    }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
@@ -84,6 +84,11 @@ class MacCentralProcessorTest {
         }
 
         @Override
+        protected IOKitProvider ioKitProvider() {
+            return null; // Not used; platformExpert/queryCompatibleStrings/calculateNominalFrequencies are overridden
+        }
+
+        @Override
         protected String platformExpert() {
             return "Apple";
         }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/IOKitProviderFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/IOKitProviderFFM.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.mac;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import oshi.ffm.mac.IOKit.IOIterator;
+import oshi.ffm.mac.IOKit.IORegistryEntry;
+import oshi.ffm.util.platform.mac.IOKitUtilFFM;
+import oshi.hardware.common.platform.mac.IOKitProvider;
+
+/**
+ * FFM-based {@link IOKitProvider} implementation.
+ */
+final class IOKitProviderFFM implements IOKitProvider {
+
+    static final IOKitProviderFFM INSTANCE = new IOKitProviderFFM();
+
+    private IOKitProviderFFM() {
+    }
+
+    @Override
+    public <T> T withMatchingService(String serviceName, Function<RegistryEntry, T> extractor) {
+        IORegistryEntry entry = IOKitUtilFFM.getMatchingService(serviceName);
+        if (entry != null) {
+            try {
+                return extractor.apply(new FfmRegistryEntry(entry));
+            } finally {
+                entry.release();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void forEachMatchingService(String serviceName, Consumer<RegistryEntry> consumer) {
+        forEachMatchingServiceUntil(serviceName, entry -> {
+            consumer.accept(entry);
+            return false;
+        });
+    }
+
+    @Override
+    public void forEachMatchingServiceUntil(String serviceName, Function<RegistryEntry, Boolean> visitor) {
+        IOIterator iter = IOKitUtilFFM.getMatchingServices(serviceName);
+        if (iter != null) {
+            try {
+                IORegistryEntry entry = iter.next();
+                while (entry != null) {
+                    try {
+                        if (Boolean.TRUE.equals(visitor.apply(new FfmRegistryEntry(entry)))) {
+                            return;
+                        }
+                    } finally {
+                        entry.release();
+                    }
+                    entry = iter.next();
+                }
+            } finally {
+                iter.release();
+            }
+        }
+    }
+
+    private static final class FfmRegistryEntry implements RegistryEntry {
+        private final IORegistryEntry entry;
+
+        FfmRegistryEntry(IORegistryEntry entry) {
+            this.entry = entry;
+        }
+
+        @Override
+        public String getName() {
+            return entry.getName();
+        }
+
+        @Override
+        public byte[] getByteArrayProperty(String key) {
+            return entry.getByteArrayProperty(key);
+        }
+
+        @Override
+        public String getStringProperty(String key) {
+            return entry.getStringProperty(key);
+        }
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacBaseboardFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacBaseboardFFM.java
@@ -4,60 +4,18 @@
  */
 package oshi.hardware.platform.mac;
 
-import java.nio.charset.StandardCharsets;
-
 import oshi.annotation.concurrent.Immutable;
-import oshi.ffm.mac.IOKit.IORegistryEntry;
-import oshi.ffm.util.platform.mac.IOKitUtilFFM;
+import oshi.hardware.common.platform.mac.IOKitProvider;
 import oshi.hardware.common.platform.mac.MacBaseboard;
-import oshi.util.Constants;
-import oshi.util.Util;
-import oshi.util.tuples.Quartet;
 
 /**
- * Baseboard data obtained from ioreg
+ * Baseboard data obtained from ioreg using FFM.
  */
 @Immutable
 final class MacBaseboardFFM extends MacBaseboard {
 
     @Override
-    protected Quartet<String, String, String, String> queryPlatform() {
-        String manufacturer = null;
-        String model = null;
-        String version = null;
-        String serialNumber = null;
-
-        IORegistryEntry platformExpert = IOKitUtilFFM.getMatchingService("IOPlatformExpertDevice");
-        if (platformExpert != null) {
-            byte[] data = platformExpert.getByteArrayProperty("manufacturer");
-            if (data != null) {
-                manufacturer = new String(data, StandardCharsets.UTF_8).trim().replace("\0", "");
-            }
-            data = platformExpert.getByteArrayProperty("board-id");
-            if (data != null) {
-                model = new String(data, StandardCharsets.UTF_8).trim().replace("\0", "");
-            }
-            if (Util.isBlank(model)) {
-                data = platformExpert.getByteArrayProperty("model-number");
-                if (data != null) {
-                    model = new String(data, StandardCharsets.UTF_8).trim().replace("\0", "");
-                }
-            }
-            data = platformExpert.getByteArrayProperty("version");
-            if (data != null) {
-                version = new String(data, StandardCharsets.UTF_8).trim().replace("\0", "");
-            }
-            data = platformExpert.getByteArrayProperty("mlb-serial-number");
-            if (data != null) {
-                serialNumber = new String(data, StandardCharsets.UTF_8).trim().replace("\0", "");
-            }
-            if (Util.isBlank(serialNumber)) {
-                serialNumber = platformExpert.getStringProperty("IOPlatformSerialNumber");
-            }
-            platformExpert.release();
-        }
-        return new Quartet<>(Util.isBlank(manufacturer) ? "Apple Inc." : manufacturer,
-                Util.isBlank(model) ? Constants.UNKNOWN : model, Util.isBlank(version) ? Constants.UNKNOWN : version,
-                Util.isBlank(serialNumber) ? Constants.UNKNOWN : serialNumber);
+    protected IOKitProvider ioKitProvider() {
+        return IOKitProviderFFM.INSTANCE;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
@@ -11,28 +11,18 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.ffm.mac.IOKit.IOIterator;
-import oshi.ffm.mac.IOKit.IORegistryEntry;
 import oshi.ffm.mac.MacSystem;
 import oshi.ffm.mac.MacSystemFunctions;
-import oshi.ffm.util.platform.mac.IOKitUtilFFM;
 import oshi.ffm.util.platform.mac.SysctlUtilFFM;
+import oshi.hardware.common.platform.mac.IOKitProvider;
 import oshi.hardware.common.platform.mac.MacCentralProcessor;
 import oshi.util.FormatUtil;
-import oshi.util.ParseUtil;
-import oshi.util.Util;
 
 /**
  * A CPU using FFM.
@@ -41,7 +31,6 @@ import oshi.util.Util;
 final class MacCentralProcessorFFM extends MacCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacCentralProcessorFFM.class);
-    private static final Pattern CPU_N = Pattern.compile("^cpu(\\d+)");
 
     @Override
     protected int sysctlInt(String name, int defaultValue) {
@@ -121,6 +110,11 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
     }
 
     @Override
+    protected IOKitProvider ioKitProvider() {
+        return IOKitProviderFFM.INSTANCE;
+    }
+
+    @Override
     public long[][] queryProcessorCpuLoadTicks() {
         long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
         try (Arena arena = Arena.ofConfined()) {
@@ -169,82 +163,4 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
         return ticks;
     }
 
-    @Override
-    protected String platformExpert() {
-        String manufacturer = null;
-        IORegistryEntry platformExpert = IOKitUtilFFM.getMatchingService("IOPlatformExpertDevice");
-        if (platformExpert != null) {
-            try {
-                byte[] data = platformExpert.getByteArrayProperty("manufacturer");
-                if (data != null) {
-                    manufacturer = new String(data, StandardCharsets.UTF_8).replace("\0", "").trim();
-                }
-            } finally {
-                platformExpert.release();
-            }
-        }
-        return Util.isBlank(manufacturer) ? "Apple Inc." : manufacturer;
-    }
-
-    @Override
-    protected Map<Integer, String> queryCompatibleStrings() {
-        Map<Integer, String> compatibleStrMap = new HashMap<>();
-        IOIterator iter = IOKitUtilFFM.getMatchingServices("IOPlatformDevice");
-        if (iter != null) {
-            try {
-                IORegistryEntry cpu = iter.next();
-                while (cpu != null) {
-                    try {
-                        String name = cpu.getName();
-                        if (name != null) {
-                            Matcher m = CPU_N.matcher(name.toLowerCase(Locale.ROOT));
-                            if (m.matches()) {
-                                int procId = ParseUtil.parseIntOrDefault(m.group(1), 0);
-                                byte[] data = cpu.getByteArrayProperty("compatible");
-                                if (data != null) {
-                                    compatibleStrMap.put(procId,
-                                            new String(data, StandardCharsets.UTF_8).replace('\0', ' ').trim());
-                                }
-                            }
-                        }
-                    } finally {
-                        cpu.release();
-                    }
-                    cpu = iter.next();
-                }
-            } finally {
-                iter.release();
-            }
-        }
-        return compatibleStrMap;
-    }
-
-    @Override
-    protected void calculateNominalFrequencies() {
-        IOIterator iter = IOKitUtilFFM.getMatchingServices("AppleARMIODevice");
-        if (iter != null) {
-            try {
-                IORegistryEntry device = iter.next();
-                try {
-                    while (device != null) {
-                        if ("pmgr".equalsIgnoreCase(device.getName())) {
-                            setPerformanceCoreFrequency(
-                                    getMaxFreqFromByteArray(device.getByteArrayProperty("voltage-states5-sram")));
-                            setEfficiencyCoreFrequency(
-                                    getMaxFreqFromByteArray(device.getByteArrayProperty("voltage-states1-sram")));
-                            return;
-                        }
-                        device.release();
-                        device = iter.next();
-                    }
-                } finally {
-                    if (device != null) {
-                        device.release();
-                    }
-                }
-            } finally {
-                iter.release();
-            }
-        }
-    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacComputerSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacComputerSystemFFM.java
@@ -4,20 +4,14 @@
  */
 package oshi.hardware.platform.mac;
 
-import java.nio.charset.StandardCharsets;
-
 import oshi.annotation.concurrent.Immutable;
-import oshi.ffm.mac.IOKit.IORegistryEntry;
-import oshi.ffm.util.platform.mac.IOKitUtilFFM;
 import oshi.hardware.Baseboard;
 import oshi.hardware.Firmware;
+import oshi.hardware.common.platform.mac.IOKitProvider;
 import oshi.hardware.common.platform.mac.MacComputerSystem;
-import oshi.util.Constants;
-import oshi.util.Util;
-import oshi.util.tuples.Quartet;
 
 /**
- * Hardware data obtained from ioreg.
+ * Hardware data obtained from ioreg using FFM.
  */
 @Immutable
 final class MacComputerSystemFFM extends MacComputerSystem {
@@ -33,29 +27,7 @@ final class MacComputerSystemFFM extends MacComputerSystem {
     }
 
     @Override
-    protected Quartet<String, String, String, String> platformExpert() {
-        String manufacturer = null;
-        String model = null;
-        String serialNumber = null;
-        String uuid = null;
-
-        IORegistryEntry platformExpert = IOKitUtilFFM.getMatchingService("IOPlatformExpertDevice");
-        if (platformExpert != null) {
-            byte[] data = platformExpert.getByteArrayProperty("manufacturer");
-            if (data != null) {
-                manufacturer = new String(data, StandardCharsets.UTF_8).trim().replace("\0", "");
-            }
-            data = platformExpert.getByteArrayProperty("model");
-            if (data != null) {
-                model = new String(data, StandardCharsets.UTF_8).trim().replace("\0", "");
-            }
-            serialNumber = platformExpert.getStringProperty("IOPlatformSerialNumber");
-            uuid = platformExpert.getStringProperty("IOPlatformUUID");
-            platformExpert.release();
-        }
-        return new Quartet<>(Util.isBlank(manufacturer) ? "Apple Inc." : manufacturer,
-                Util.isBlank(model) ? Constants.UNKNOWN : model,
-                Util.isBlank(serialNumber) ? Constants.UNKNOWN : serialNumber,
-                Util.isBlank(uuid) ? Constants.UNKNOWN : uuid);
+    protected IOKitProvider ioKitProvider() {
+        return IOKitProviderFFM.INSTANCE;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/IOKitProviderJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/IOKitProviderJNA.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.mac;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.sun.jna.platform.mac.IOKit.IOIterator;
+import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
+import com.sun.jna.platform.mac.IOKitUtil;
+
+import oshi.hardware.common.platform.mac.IOKitProvider;
+
+/**
+ * JNA-based {@link IOKitProvider} implementation.
+ */
+final class IOKitProviderJNA implements IOKitProvider {
+
+    static final IOKitProviderJNA INSTANCE = new IOKitProviderJNA();
+
+    private IOKitProviderJNA() {
+    }
+
+    @Override
+    public <T> T withMatchingService(String serviceName, Function<RegistryEntry, T> extractor) {
+        IORegistryEntry entry = IOKitUtil.getMatchingService(serviceName);
+        if (entry != null) {
+            try {
+                return extractor.apply(new JnaRegistryEntry(entry));
+            } finally {
+                entry.release();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void forEachMatchingService(String serviceName, Consumer<RegistryEntry> consumer) {
+        forEachMatchingServiceUntil(serviceName, entry -> {
+            consumer.accept(entry);
+            return false;
+        });
+    }
+
+    @Override
+    public void forEachMatchingServiceUntil(String serviceName, Function<RegistryEntry, Boolean> visitor) {
+        IOIterator iter = IOKitUtil.getMatchingServices(serviceName);
+        if (iter != null) {
+            try {
+                IORegistryEntry entry = iter.next();
+                while (entry != null) {
+                    try {
+                        if (Boolean.TRUE.equals(visitor.apply(new JnaRegistryEntry(entry)))) {
+                            return;
+                        }
+                    } finally {
+                        entry.release();
+                    }
+                    entry = iter.next();
+                }
+            } finally {
+                iter.release();
+            }
+        }
+    }
+
+    private static final class JnaRegistryEntry implements RegistryEntry {
+        private final IORegistryEntry entry;
+
+        JnaRegistryEntry(IORegistryEntry entry) {
+            this.entry = entry;
+        }
+
+        @Override
+        public String getName() {
+            return entry.getName();
+        }
+
+        @Override
+        public byte[] getByteArrayProperty(String key) {
+            return entry.getByteArrayProperty(key);
+        }
+
+        @Override
+        public String getStringProperty(String key) {
+            return entry.getStringProperty(key);
+        }
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacBaseboardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacBaseboardJNA.java
@@ -4,17 +4,9 @@
  */
 package oshi.hardware.platform.mac;
 
-import java.nio.charset.StandardCharsets;
-
-import com.sun.jna.Native;
-import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
-import com.sun.jna.platform.mac.IOKitUtil;
-
 import oshi.annotation.concurrent.Immutable;
+import oshi.hardware.common.platform.mac.IOKitProvider;
 import oshi.hardware.common.platform.mac.MacBaseboard;
-import oshi.util.Constants;
-import oshi.util.Util;
-import oshi.util.tuples.Quartet;
 
 /**
  * Baseboard data obtained from ioreg using JNA.
@@ -23,43 +15,7 @@ import oshi.util.tuples.Quartet;
 final class MacBaseboardJNA extends MacBaseboard {
 
     @Override
-    protected Quartet<String, String, String, String> queryPlatform() {
-        String manufacturer = null;
-        String model = null;
-        String version = null;
-        String serialNumber = null;
-
-        IORegistryEntry platformExpert = IOKitUtil.getMatchingService("IOPlatformExpertDevice");
-        if (platformExpert != null) {
-            byte[] data = platformExpert.getByteArrayProperty("manufacturer");
-            if (data != null) {
-                manufacturer = Native.toString(data, StandardCharsets.UTF_8);
-            }
-            data = platformExpert.getByteArrayProperty("board-id");
-            if (data != null) {
-                model = Native.toString(data, StandardCharsets.UTF_8);
-            }
-            if (Util.isBlank(model)) {
-                data = platformExpert.getByteArrayProperty("model-number");
-                if (data != null) {
-                    model = Native.toString(data, StandardCharsets.UTF_8);
-                }
-            }
-            data = platformExpert.getByteArrayProperty("version");
-            if (data != null) {
-                version = Native.toString(data, StandardCharsets.UTF_8);
-            }
-            data = platformExpert.getByteArrayProperty("mlb-serial-number");
-            if (data != null) {
-                serialNumber = Native.toString(data, StandardCharsets.UTF_8);
-            }
-            if (Util.isBlank(serialNumber)) {
-                serialNumber = platformExpert.getStringProperty("IOPlatformSerialNumber");
-            }
-            platformExpert.release();
-        }
-        return new Quartet<>(Util.isBlank(manufacturer) ? "Apple Inc." : manufacturer,
-                Util.isBlank(model) ? Constants.UNKNOWN : model, Util.isBlank(version) ? Constants.UNKNOWN : version,
-                Util.isBlank(serialNumber) ? Constants.UNKNOWN : serialNumber);
+    protected IOKitProvider ioKitProvider() {
+        return IOKitProviderJNA.INSTANCE;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorJNA.java
@@ -4,31 +4,20 @@
  */
 package oshi.hardware.platform.mac;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.Native;
-import com.sun.jna.platform.mac.IOKit.IOIterator;
-import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
-import com.sun.jna.platform.mac.IOKitUtil;
 import com.sun.jna.platform.mac.SystemB;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.common.platform.mac.IOKitProvider;
 import oshi.hardware.common.platform.mac.MacCentralProcessor;
 import oshi.jna.ByRef.CloseableIntByReference;
 import oshi.jna.ByRef.CloseablePointerByReference;
 import oshi.jna.Struct.CloseableHostCpuLoadInfo;
 import oshi.util.FormatUtil;
-import oshi.util.ParseUtil;
-import oshi.util.Util;
 import oshi.util.platform.mac.SysctlUtil;
 
 /**
@@ -38,7 +27,6 @@ import oshi.util.platform.mac.SysctlUtil;
 final class MacCentralProcessorJNA extends MacCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacCentralProcessorJNA.class);
-    private static final Pattern CPU_N = Pattern.compile("^cpu(\\d+)");
 
     @Override
     protected int sysctlInt(String name, int defaultValue) {
@@ -99,6 +87,11 @@ final class MacCentralProcessorJNA extends MacCentralProcessor {
     }
 
     @Override
+    protected IOKitProvider ioKitProvider() {
+        return IOKitProviderJNA.INSTANCE;
+    }
+
+    @Override
     public long[][] queryProcessorCpuLoadTicks() {
         long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
 
@@ -138,70 +131,4 @@ final class MacCentralProcessorJNA extends MacCentralProcessor {
         return ticks;
     }
 
-    @Override
-    protected String platformExpert() {
-        String manufacturer = null;
-        IORegistryEntry platformExpert = IOKitUtil.getMatchingService("IOPlatformExpertDevice");
-        if (platformExpert != null) {
-            byte[] data = platformExpert.getByteArrayProperty("manufacturer");
-            if (data != null) {
-                manufacturer = Native.toString(data, StandardCharsets.UTF_8);
-            }
-            platformExpert.release();
-        }
-        return Util.isBlank(manufacturer) ? "Apple Inc." : manufacturer;
-    }
-
-    @Override
-    protected Map<Integer, String> queryCompatibleStrings() {
-        Map<Integer, String> compatibleStrMap = new HashMap<>();
-        IOIterator iter = IOKitUtil.getMatchingServices("IOPlatformDevice");
-        if (iter != null) {
-            IORegistryEntry cpu = iter.next();
-            while (cpu != null) {
-                Matcher m = CPU_N.matcher(cpu.getName().toLowerCase(Locale.ROOT));
-                if (m.matches()) {
-                    int procId = ParseUtil.parseIntOrDefault(m.group(1), 0);
-                    byte[] data = cpu.getByteArrayProperty("compatible");
-                    if (data != null) {
-                        compatibleStrMap.put(procId,
-                                new String(data, StandardCharsets.UTF_8).replace('\0', ' ').trim());
-                    }
-                }
-                cpu.release();
-                cpu = iter.next();
-            }
-            iter.release();
-        }
-        return compatibleStrMap;
-    }
-
-    @Override
-    protected void calculateNominalFrequencies() {
-        IOIterator iter = IOKitUtil.getMatchingServices("AppleARMIODevice");
-        if (iter != null) {
-            try {
-                IORegistryEntry device = iter.next();
-                try {
-                    while (device != null) {
-                        if (device.getName().equalsIgnoreCase("pmgr")) {
-                            setPerformanceCoreFrequency(
-                                    getMaxFreqFromByteArray(device.getByteArrayProperty("voltage-states5-sram")));
-                            setEfficiencyCoreFrequency(
-                                    getMaxFreqFromByteArray(device.getByteArrayProperty("voltage-states1-sram")));
-                            return;
-                        }
-                        device.release();
-                        device = iter.next();
-                    }
-                } finally {
-                    if (device != null) {
-                        device.release();
-                    }
-                }
-            } finally {
-                iter.release();
-            }
-        }
-    }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacComputerSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacComputerSystemJNA.java
@@ -4,19 +4,11 @@
  */
 package oshi.hardware.platform.mac;
 
-import java.nio.charset.StandardCharsets;
-
-import com.sun.jna.Native;
-import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
-import com.sun.jna.platform.mac.IOKitUtil;
-
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Baseboard;
 import oshi.hardware.Firmware;
+import oshi.hardware.common.platform.mac.IOKitProvider;
 import oshi.hardware.common.platform.mac.MacComputerSystem;
-import oshi.util.Constants;
-import oshi.util.Util;
-import oshi.util.tuples.Quartet;
 
 /**
  * Hardware data obtained from ioreg using JNA.
@@ -35,28 +27,7 @@ final class MacComputerSystemJNA extends MacComputerSystem {
     }
 
     @Override
-    protected Quartet<String, String, String, String> platformExpert() {
-        String manufacturer = null;
-        String model = null;
-        String serialNumber = null;
-        String uuid = null;
-        IORegistryEntry platformExpert = IOKitUtil.getMatchingService("IOPlatformExpertDevice");
-        if (platformExpert != null) {
-            byte[] data = platformExpert.getByteArrayProperty("manufacturer");
-            if (data != null) {
-                manufacturer = Native.toString(data, StandardCharsets.UTF_8);
-            }
-            data = platformExpert.getByteArrayProperty("model");
-            if (data != null) {
-                model = Native.toString(data, StandardCharsets.UTF_8);
-            }
-            serialNumber = platformExpert.getStringProperty("IOPlatformSerialNumber");
-            uuid = platformExpert.getStringProperty("IOPlatformUUID");
-            platformExpert.release();
-        }
-        return new Quartet<>(Util.isBlank(manufacturer) ? "Apple Inc." : manufacturer,
-                Util.isBlank(model) ? Constants.UNKNOWN : model,
-                Util.isBlank(serialNumber) ? Constants.UNKNOWN : serialNumber,
-                Util.isBlank(uuid) ? Constants.UNKNOWN : uuid);
+    protected IOKitProvider ioKitProvider() {
+        return IOKitProviderJNA.INSTANCE;
     }
 }


### PR DESCRIPTION
Closes #3260

Introduces an `IOKitProvider` interface in `oshi-common` that abstracts IOKit registry operations, with JNA and FFM singleton implementations. Duplicated IOKit iteration logic is moved from subclasses into the common base classes.

**New files:**
- `IOKitProvider.java` — interface with `withMatchingService`, `forEachMatchingService`, `forEachMatchingServiceUntil`, and `RegistryEntry`
- `IOKitProviderJNA.java` / `IOKitProviderFFM.java` — implementations

**Refactored base classes (logic moved in):**
- `MacCentralProcessor` — `platformExpert()`, `queryCompatibleStrings()`, `calculateNominalFrequencies()`
- `MacBaseboard` — `queryPlatform()`
- `MacComputerSystem` — `platformExpert()`

**Simplified subclasses (~330 lines removed):**
- `MacCentralProcessorJNA/FFM` — removed IOKit methods, just implement `ioKitProvider()`
- `MacBaseboardJNA/FFM` — reduced to `ioKitProvider()` only
- `MacComputerSystemJNA/FFM` — reduced to `ioKitProvider()` + factory methods

Classes using `getChildIterator` (MacFirmware, MacUsbDevice) are not addressed here as they require a more complex lifecycle pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified macOS hardware access behind a new provider abstraction to reduce duplication and simplify platform implementations.
* **Bug Fixes**
  * Improved extraction and normalization of Mac manufacturer, model, serial and UUID with sensible defaults (e.g., "Apple Inc.", "Unknown") when values are missing or blank.
* **Tests**
  * Tests updated to avoid invoking native provider behavior during unit runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->