### PR TITLE
Replace abstract sysctl methods with injectable SysctlProvider

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
@@ -71,13 +71,22 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     private long efficiencyCoreFrequency = DEFAULT_FREQUENCY;
 
     /**
+     * Returns the sysctl provider for this implementation.
+     *
+     * @return the sysctl provider
+     */
+    protected abstract SysctlProvider sysctlProvider();
+
+    /**
      * Queries a sysctl integer value.
      *
      * @param name         the sysctl name
      * @param defaultValue the default value if not found
      * @return the sysctl value
      */
-    protected abstract int sysctlInt(String name, int defaultValue);
+    protected int sysctlInt(String name, int defaultValue) {
+        return sysctlProvider().sysctlInt(name, defaultValue);
+    }
 
     /**
      * Queries a sysctl integer value without logging warnings.
@@ -86,7 +95,9 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @param defaultValue the default value if not found
      * @return the sysctl value
      */
-    protected abstract int sysctlIntNoWarn(String name, int defaultValue);
+    protected int sysctlIntNoWarn(String name, int defaultValue) {
+        return sysctlProvider().sysctlIntNoWarn(name, defaultValue);
+    }
 
     /**
      * Queries a sysctl long value.
@@ -95,7 +106,9 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @param defaultValue the default value if not found
      * @return the sysctl value
      */
-    protected abstract long sysctlLong(String name, long defaultValue);
+    protected long sysctlLong(String name, long defaultValue) {
+        return sysctlProvider().sysctlLong(name, defaultValue);
+    }
 
     /**
      * Queries a sysctl string value.
@@ -104,7 +117,9 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @param defaultValue the default value if not found
      * @return the sysctl value
      */
-    protected abstract String sysctlString(String name, String defaultValue);
+    protected String sysctlString(String name, String defaultValue) {
+        return sysctlProvider().sysctlString(name, defaultValue);
+    }
 
     /**
      * Queries a sysctl string value without logging warnings.
@@ -113,7 +128,9 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @param defaultValue the default value if not found
      * @return the sysctl value
      */
-    protected abstract String sysctlStringNoWarn(String name, String defaultValue);
+    protected String sysctlStringNoWarn(String name, String defaultValue) {
+        return sysctlProvider().sysctlStringNoWarn(name, defaultValue);
+    }
 
     /**
      * Returns the IOKit provider for this implementation.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
@@ -172,13 +172,22 @@ public abstract class MacGlobalMemory extends AbstractGlobalMemory {
     protected abstract long queryVmStats();
 
     /**
+     * Returns the sysctl provider for this implementation.
+     *
+     * @return the sysctl provider
+     */
+    protected abstract SysctlProvider sysctlProvider();
+
+    /**
      * Queries a sysctl long value.
      *
      * @param name         the sysctl name
      * @param defaultValue the default value
      * @return the sysctl value
      */
-    protected abstract long sysctl(String name, long defaultValue);
+    protected long sysctl(String name, long defaultValue) {
+        return sysctlProvider().sysctlLong(name, defaultValue);
+    }
 
     private long queryPhysMem() {
         return sysctl("hw.memsize", 0L);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/SysctlProvider.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/SysctlProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+/**
+ * Abstracts sysctl operations so that Mac base classes can query sysctl values without depending on JNA or FFM
+ * directly.
+ */
+public interface SysctlProvider {
+
+    /**
+     * Gets a sysctl int value.
+     *
+     * @param name         the sysctl name
+     * @param defaultValue the default value if not found
+     * @return the sysctl value
+     */
+    int sysctlInt(String name, int defaultValue);
+
+    /**
+     * Gets a sysctl int value without logging warnings on failure.
+     *
+     * @param name         the sysctl name
+     * @param defaultValue the default value if not found
+     * @return the sysctl value
+     */
+    int sysctlIntNoWarn(String name, int defaultValue);
+
+    /**
+     * Gets a sysctl long value.
+     *
+     * @param name         the sysctl name
+     * @param defaultValue the default value if not found
+     * @return the sysctl value
+     */
+    long sysctlLong(String name, long defaultValue);
+
+    /**
+     * Gets a sysctl string value.
+     *
+     * @param name         the sysctl name
+     * @param defaultValue the default value if not found
+     * @return the sysctl value
+     */
+    String sysctlString(String name, String defaultValue);
+
+    /**
+     * Gets a sysctl string value without logging warnings on failure.
+     *
+     * @param name         the sysctl name
+     * @param defaultValue the default value if not found
+     * @return the sysctl value
+     */
+    String sysctlStringNoWarn(String name, String defaultValue);
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
@@ -84,6 +84,11 @@ class MacCentralProcessorTest {
         }
 
         @Override
+        protected SysctlProvider sysctlProvider() {
+            return null; // Not used; sysctl methods are overridden directly
+        }
+
+        @Override
         protected IOKitProvider ioKitProvider() {
             return null; // Not used; platformExpert/queryCompatibleStrings/calculateNominalFrequencies are overridden
         }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
@@ -19,9 +19,9 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.mac.MacSystem;
 import oshi.ffm.mac.MacSystemFunctions;
-import oshi.ffm.util.platform.mac.SysctlUtilFFM;
 import oshi.hardware.common.platform.mac.IOKitProvider;
 import oshi.hardware.common.platform.mac.MacCentralProcessor;
+import oshi.hardware.common.platform.mac.SysctlProvider;
 import oshi.util.FormatUtil;
 
 /**
@@ -33,28 +33,8 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(MacCentralProcessorFFM.class);
 
     @Override
-    protected int sysctlInt(String name, int defaultValue) {
-        return SysctlUtilFFM.sysctl(name, defaultValue);
-    }
-
-    @Override
-    protected int sysctlIntNoWarn(String name, int defaultValue) {
-        return SysctlUtilFFM.sysctl(name, defaultValue, false);
-    }
-
-    @Override
-    protected long sysctlLong(String name, long defaultValue) {
-        return SysctlUtilFFM.sysctl(name, defaultValue);
-    }
-
-    @Override
-    protected String sysctlString(String name, String defaultValue) {
-        return SysctlUtilFFM.sysctl(name, defaultValue);
-    }
-
-    @Override
-    protected String sysctlStringNoWarn(String name, String defaultValue) {
-        return SysctlUtilFFM.sysctl(name, defaultValue, false);
+    protected SysctlProvider sysctlProvider() {
+        return SysctlProviderFFM.INSTANCE;
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryFFM.java
@@ -19,9 +19,9 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.mac.MacSystemFunctions;
-import oshi.ffm.util.platform.mac.SysctlUtilFFM;
 import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.platform.mac.MacGlobalMemory;
+import oshi.hardware.common.platform.mac.SysctlProvider;
 
 @ThreadSafe
 final class MacGlobalMemoryFFM extends MacGlobalMemory {
@@ -47,8 +47,8 @@ final class MacGlobalMemoryFFM extends MacGlobalMemory {
     }
 
     @Override
-    protected long sysctl(String name, long defaultValue) {
-        return SysctlUtilFFM.sysctl(name, defaultValue);
+    protected SysctlProvider sysctlProvider() {
+        return SysctlProviderFFM.INSTANCE;
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/SysctlProviderFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/SysctlProviderFFM.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.mac;
+
+import oshi.ffm.util.platform.mac.SysctlUtilFFM;
+import oshi.hardware.common.platform.mac.SysctlProvider;
+
+/**
+ * FFM-based {@link SysctlProvider} implementation.
+ */
+final class SysctlProviderFFM implements SysctlProvider {
+
+    static final SysctlProviderFFM INSTANCE = new SysctlProviderFFM();
+
+    private SysctlProviderFFM() {
+    }
+
+    @Override
+    public int sysctlInt(String name, int defaultValue) {
+        return SysctlUtilFFM.sysctl(name, defaultValue);
+    }
+
+    @Override
+    public int sysctlIntNoWarn(String name, int defaultValue) {
+        return SysctlUtilFFM.sysctl(name, defaultValue, false);
+    }
+
+    @Override
+    public long sysctlLong(String name, long defaultValue) {
+        return SysctlUtilFFM.sysctl(name, defaultValue);
+    }
+
+    @Override
+    public String sysctlString(String name, String defaultValue) {
+        return SysctlUtilFFM.sysctl(name, defaultValue);
+    }
+
+    @Override
+    public String sysctlStringNoWarn(String name, String defaultValue) {
+        return SysctlUtilFFM.sysctl(name, defaultValue, false);
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorJNA.java
@@ -14,11 +14,11 @@ import com.sun.jna.platform.mac.SystemB;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.platform.mac.IOKitProvider;
 import oshi.hardware.common.platform.mac.MacCentralProcessor;
+import oshi.hardware.common.platform.mac.SysctlProvider;
 import oshi.jna.ByRef.CloseableIntByReference;
 import oshi.jna.ByRef.CloseablePointerByReference;
 import oshi.jna.Struct.CloseableHostCpuLoadInfo;
 import oshi.util.FormatUtil;
-import oshi.util.platform.mac.SysctlUtil;
 
 /**
  * A CPU using JNA.
@@ -29,28 +29,8 @@ final class MacCentralProcessorJNA extends MacCentralProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(MacCentralProcessorJNA.class);
 
     @Override
-    protected int sysctlInt(String name, int defaultValue) {
-        return SysctlUtil.sysctl(name, defaultValue);
-    }
-
-    @Override
-    protected int sysctlIntNoWarn(String name, int defaultValue) {
-        return SysctlUtil.sysctl(name, defaultValue, false);
-    }
-
-    @Override
-    protected long sysctlLong(String name, long defaultValue) {
-        return SysctlUtil.sysctl(name, defaultValue);
-    }
-
-    @Override
-    protected String sysctlString(String name, String defaultValue) {
-        return SysctlUtil.sysctl(name, defaultValue);
-    }
-
-    @Override
-    protected String sysctlStringNoWarn(String name, String defaultValue) {
-        return SysctlUtil.sysctl(name, defaultValue, false);
+    protected SysctlProvider sysctlProvider() {
+        return SysctlProviderJNA.INSTANCE;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryJNA.java
@@ -12,10 +12,10 @@ import com.sun.jna.platform.mac.SystemB;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.platform.mac.MacGlobalMemory;
+import oshi.hardware.common.platform.mac.SysctlProvider;
 import oshi.jna.ByRef.CloseableIntByReference;
 import oshi.jna.ByRef.CloseableLongByReference;
 import oshi.jna.Struct.CloseableVMStatistics;
-import oshi.util.platform.mac.SysctlUtil;
 
 @ThreadSafe
 final class MacGlobalMemoryJNA extends MacGlobalMemory {
@@ -37,8 +37,8 @@ final class MacGlobalMemoryJNA extends MacGlobalMemory {
     }
 
     @Override
-    protected long sysctl(String name, long defaultValue) {
-        return SysctlUtil.sysctl(name, defaultValue);
+    protected SysctlProvider sysctlProvider() {
+        return SysctlProviderJNA.INSTANCE;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/SysctlProviderJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/SysctlProviderJNA.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.mac;
+
+import oshi.hardware.common.platform.mac.SysctlProvider;
+import oshi.util.platform.mac.SysctlUtil;
+
+/**
+ * JNA-based {@link SysctlProvider} implementation.
+ */
+final class SysctlProviderJNA implements SysctlProvider {
+
+    static final SysctlProviderJNA INSTANCE = new SysctlProviderJNA();
+
+    private SysctlProviderJNA() {
+    }
+
+    @Override
+    public int sysctlInt(String name, int defaultValue) {
+        return SysctlUtil.sysctl(name, defaultValue);
+    }
+
+    @Override
+    public int sysctlIntNoWarn(String name, int defaultValue) {
+        return SysctlUtil.sysctl(name, defaultValue, false);
+    }
+
+    @Override
+    public long sysctlLong(String name, long defaultValue) {
+        return SysctlUtil.sysctl(name, defaultValue);
+    }
+
+    @Override
+    public String sysctlString(String name, String defaultValue) {
+        return SysctlUtil.sysctl(name, defaultValue);
+    }
+
+    @Override
+    public String sysctlStringNoWarn(String name, String defaultValue) {
+        return SysctlUtil.sysctl(name, defaultValue, false);
+    }
+}


### PR DESCRIPTION
Closes #3259

Introduces a `SysctlProvider` interface in `oshi-common` with JNA and FFM singleton implementations. The 5 abstract sysctl methods in `MacCentralProcessor` and the 1 in `MacGlobalMemory` are now concrete methods that delegate to the provider.

**New files:**
- `SysctlProvider.java` — interface with sysctlInt, sysctlIntNoWarn, sysctlLong, sysctlString, sysctlStringNoWarn
- `SysctlProviderJNA.java` / `SysctlProviderFFM.java` — singleton implementations

**Simplified subclasses:**
- `MacCentralProcessorJNA/FFM` — removed 5 sysctl overrides, replaced with `sysctlProvider()`
- `MacGlobalMemoryJNA/FFM` — removed sysctl override, replaced with `sysctlProvider()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured macOS system configuration access to use a centralized provider abstraction, improving internal code organization and maintainability across platform-specific implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->