### PR TITLE
Introduce common WmiQueryExecutor interface and WmiUtil

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32DiskDrive.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32DiskDrive.java
@@ -42,4 +42,15 @@ public class Win32DiskDrive {
      */
     protected Win32DiskDrive() {
     }
+
+    /**
+     * Queries disk drive information.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @return Information regarding each disk drive.
+     */
+    public static WmiResult<DiskDriveProperty> queryDiskDrive(WmiQueryExecutor h) {
+        WmiQuery<DiskDriveProperty> diskDriveQuery = new WmiQuery<>(WIN32_DISK_DRIVE, DiskDriveProperty.class);
+        return h.queryWMI(diskDriveQuery, false);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiConstants.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiConstants.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.wmi;
+
+/**
+ * WMI type constants used for interpreting {@link WmiResult} values.
+ */
+public final class WmiConstants {
+
+    private WmiConstants() {
+    }
+
+    // CIM types (from Wbemcli.h)
+    /** CIM type for signed 32-bit integer. */
+    public static final int CIM_SINT32 = 3;
+    /** CIM type for 32-bit real. */
+    public static final int CIM_REAL32 = 4;
+    /** CIM type for string. */
+    public static final int CIM_STRING = 8;
+    /** CIM type for unsigned 16-bit integer. */
+    public static final int CIM_UINT16 = 18;
+    /** CIM type for unsigned 32-bit integer. */
+    public static final int CIM_UINT32 = 19;
+    /** CIM type for unsigned 64-bit integer. */
+    public static final int CIM_UINT64 = 21;
+    /** CIM type for datetime. */
+    public static final int CIM_DATETIME = 101;
+    /** CIM type for reference. */
+    public static final int CIM_REFERENCE = 102;
+
+    // Variant types (from OAIdl.h)
+    /** Variant type for 32-bit integer. */
+    public static final int VT_I4 = 3;
+    /** Variant type for 32-bit real. */
+    public static final int VT_R4 = 4;
+    /** Variant type for BSTR (string). */
+    public static final int VT_BSTR = 8;
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiQuery.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiQuery.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.wmi;
+
+import java.util.Objects;
+
+/**
+ * Encapsulates a WMI query with a namespace, class name, and property enum.
+ *
+ * @param <T> the enum type representing the properties to query
+ */
+public class WmiQuery<T extends Enum<T>> {
+
+    private final String nameSpace;
+    private final String wmiClassName;
+    private final Class<T> propertyEnum;
+
+    /**
+     * Creates a WMI query for the default namespace ({@code ROOT\CIMV2}).
+     *
+     * @param wmiClassName the WMI class name
+     * @param propertyEnum the property enum class
+     */
+    public WmiQuery(String wmiClassName, Class<T> propertyEnum) {
+        this("ROOT\\CIMV2", wmiClassName, propertyEnum);
+    }
+
+    /**
+     * Creates a WMI query for a specific namespace.
+     *
+     * @param nameSpace    the WMI namespace
+     * @param wmiClassName the WMI class name
+     * @param propertyEnum the property enum class
+     */
+    public WmiQuery(String nameSpace, String wmiClassName, Class<T> propertyEnum) {
+        this.nameSpace = Objects.requireNonNull(nameSpace, "nameSpace");
+        this.wmiClassName = Objects.requireNonNull(wmiClassName, "wmiClassName");
+        this.propertyEnum = Objects.requireNonNull(propertyEnum, "propertyEnum");
+    }
+
+    /**
+     * Gets the WMI namespace.
+     *
+     * @return the namespace
+     */
+    public String getNameSpace() {
+        return nameSpace;
+    }
+
+    /**
+     * Gets the WMI class name.
+     *
+     * @return the class name
+     */
+    public String getWmiClassName() {
+        return wmiClassName;
+    }
+
+    /**
+     * Gets the property enum class.
+     *
+     * @return the property enum class
+     */
+    public Class<T> getPropertyEnum() {
+        return propertyEnum;
+    }
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiQueryExecutor.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiQueryExecutor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.wmi;
+
+/**
+ * Common interface for executing WMI queries, abstracting JNA and FFM implementations.
+ * <p>
+ * JNA users who wish to customize COM initialization (e.g., to avoid per-query COM init/uninit overhead) should extend
+ * {@code oshi.util.platform.windows.WmiQueryHandler} in the {@code oshi-core} module. See the {@code oshi-demo} module
+ * for examples.
+ */
+public interface WmiQueryExecutor {
+
+    /**
+     * Query WMI for values. Initializes and uninitializes COM for each query.
+     *
+     * @param <T>   the enum type for the query properties
+     * @param query the WMI query
+     * @return the query results
+     */
+    <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query);
+
+    /**
+     * Query WMI for values.
+     *
+     * @param <T>     the enum type for the query properties
+     * @param query   the WMI query
+     * @param initCom whether to initialize COM for this query. If {@code false}, assumes COM is already initialized.
+     * @return the query results
+     */
+    <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query, boolean initCom);
+
+    /**
+     * Creates a new instance of the platform-appropriate WMI query executor.
+     * <p>
+     * On JNA, this returns an instance of {@code WmiQueryHandler} (or a user-configured subclass). On FFM, this returns
+     * an instance of {@code WmiQueryHandlerFFM}.
+     *
+     * @return a new executor instance, or {@code null} if creation fails
+     */
+    static WmiQueryExecutor createInstance() {
+        throw new UnsupportedOperationException("Use platform-specific createInstance()");
+    }
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiResult.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiResult.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.wmi;
+
+/**
+ * Common interface for WMI query results, abstracting JNA and FFM implementations.
+ *
+ * @param <T> the enum type representing the queried properties
+ */
+public interface WmiResult<T extends Enum<T>> {
+
+    /**
+     * Gets the number of results in this result set.
+     *
+     * @return the result count
+     */
+    int getResultCount();
+
+    /**
+     * Gets the value of a property at the given index.
+     *
+     * @param property the property enum constant
+     * @param index    the row index
+     * @return the value
+     */
+    Object getValue(T property, int index);
+
+    /**
+     * Gets the variant type of a property.
+     *
+     * @param property the property enum constant
+     * @return the VT type constant
+     */
+    int getVtType(T property);
+
+    /**
+     * Gets the CIM type of a property.
+     *
+     * @param property the property enum constant
+     * @return the CIM type constant
+     */
+    int getCIMType(T property);
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiUtil.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiUtil.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.wmi;
+
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_DATETIME;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_REAL32;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_REFERENCE;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_SINT32;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_STRING;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT16;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT32;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT64;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_BSTR;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_I4;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_R4;
+
+import java.time.OffsetDateTime;
+import java.util.Locale;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.Constants;
+import oshi.util.ParseUtil;
+
+/**
+ * Helper class for extracting typed values from {@link WmiResult} objects.
+ */
+@ThreadSafe
+public final class WmiUtil {
+
+    /** The namespace where Open Hardware Monitor publishes to WMI. */
+    public static final String OHM_NAMESPACE = "ROOT\\OpenHardwareMonitor";
+
+    /** The namespace where LibreHardwareMonitor publishes to WMI. */
+    public static final String LHM_NAMESPACE = "ROOT\\LibreHardwareMonitor";
+
+    private static final String CLASS_CAST_MSG = "%s is not a %s type. CIM Type is %d and VT type is %d";
+
+    private WmiUtil() {
+    }
+
+    /**
+     * Translate a WmiQuery to the actual query string.
+     *
+     * @param <T>   the property enum type
+     * @param query The WmiQuery object
+     * @return The string that is queried in WMI
+     */
+    public static <T extends Enum<T>> String queryToString(WmiQuery<T> query) {
+        T[] props = query.getPropertyEnum().getEnumConstants();
+        if (props.length == 0) {
+            throw new IllegalArgumentException("Property enum must have at least one constant");
+        }
+        StringBuilder sb = new StringBuilder("SELECT ");
+        sb.append(props[0].name());
+        for (int i = 1; i < props.length; i++) {
+            sb.append(',').append(props[i].name());
+        }
+        sb.append(" FROM ").append(query.getWmiClassName());
+        return sb.toString();
+    }
+
+    /**
+     * Gets a String value from a WmiResult.
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null, an empty-string otherwise
+     */
+    public static <T extends Enum<T>> String getString(WmiResult<T> result, T property, int index) {
+        if (result.getCIMType(property) == CIM_STRING) {
+            return getStr(result, property, index);
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "String",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    /**
+     * Gets a Date value from a WmiResult as a String in ISO 8601 format.
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null, an empty-string otherwise
+     */
+    public static <T extends Enum<T>> String getDateString(WmiResult<T> result, T property, int index) {
+        OffsetDateTime dateTime = getDateTime(result, property, index);
+        if (dateTime.equals(Constants.UNIX_EPOCH)) {
+            return "";
+        }
+        return dateTime.toLocalDate().toString();
+    }
+
+    /**
+     * Gets a DateTime value from a WmiResult as an OffsetDateTime.
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null, otherwise {@link Constants#UNIX_EPOCH}
+     */
+    public static <T extends Enum<T>> OffsetDateTime getDateTime(WmiResult<T> result, T property, int index) {
+        if (result.getCIMType(property) == CIM_DATETIME) {
+            return ParseUtil.parseCimDateTimeToOffset(getStr(result, property, index));
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "DateTime",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    /**
+     * Gets a Reference value from a WmiResult as a String.
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null, an empty-string otherwise
+     */
+    public static <T extends Enum<T>> String getRefString(WmiResult<T> result, T property, int index) {
+        if (result.getCIMType(property) == CIM_REFERENCE) {
+            return getStr(result, property, index);
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "Reference",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    private static <T extends Enum<T>> String getStr(WmiResult<T> result, T property, int index) {
+        Object o = result.getValue(property, index);
+        if (o == null) {
+            return "";
+        } else if (result.getVtType(property) == VT_BSTR) {
+            return (String) o;
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "String-mapped",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    /**
+     * Gets a Uint64 value from a WmiResult (parsing the String).
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null and parseable as a long, 0 otherwise
+     */
+    public static <T extends Enum<T>> long getUint64(WmiResult<T> result, T property, int index) {
+        Object o = result.getValue(property, index);
+        if (o == null) {
+            return 0L;
+        } else if (result.getCIMType(property) == CIM_UINT64 && result.getVtType(property) == VT_BSTR) {
+            return ParseUtil.parseLongOrDefault((String) o, 0L);
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "UINT64",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    /**
+     * Gets an UINT32 value from a WmiResult.
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null, 0 otherwise
+     */
+    public static <T extends Enum<T>> int getUint32(WmiResult<T> result, T property, int index) {
+        if (result.getCIMType(property) == CIM_UINT32) {
+            return getInt(result, property, index);
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "UINT32",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    /**
+     * Gets an UINT32 value from a WmiResult as a long, preserving the unsignedness.
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null, 0 otherwise
+     */
+    public static <T extends Enum<T>> long getUint32asLong(WmiResult<T> result, T property, int index) {
+        if (result.getCIMType(property) == CIM_UINT32) {
+            return getInt(result, property, index) & 0xFFFFFFFFL;
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "UINT32",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    /**
+     * Gets a Sint32 value from a WmiResult.
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null, 0 otherwise
+     */
+    public static <T extends Enum<T>> int getSint32(WmiResult<T> result, T property, int index) {
+        if (result.getCIMType(property) == CIM_SINT32) {
+            return getInt(result, property, index);
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "SINT32",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    /**
+     * Gets a Uint16 value from a WmiResult.
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null, 0 otherwise
+     */
+    public static <T extends Enum<T>> int getUint16(WmiResult<T> result, T property, int index) {
+        if (result.getCIMType(property) == CIM_UINT16) {
+            return getInt(result, property, index);
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "UINT16",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    private static <T extends Enum<T>> int getInt(WmiResult<T> result, T property, int index) {
+        Object o = result.getValue(property, index);
+        if (o == null) {
+            return 0;
+        } else if (result.getVtType(property) == VT_I4) {
+            return (int) o;
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "32-bit integer",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    /**
+     * Gets a Float value from a WmiResult.
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null, 0 otherwise
+     */
+    public static <T extends Enum<T>> float getFloat(WmiResult<T> result, T property, int index) {
+        Object o = result.getValue(property, index);
+        if (o == null) {
+            return 0f;
+        } else if (result.getCIMType(property) == CIM_REAL32 && result.getVtType(property) == VT_R4) {
+            return (float) o;
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "Float",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryExecutorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryExecutorFFM.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.util.platform.windows;
+
+import java.util.Objects;
+
+import oshi.driver.common.windows.wmi.WmiQuery;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.driver.common.windows.wmi.WmiResult;
+
+/**
+ * Adapts the FFM {@link WmiQueryHandlerFFM} to the common {@link WmiQueryExecutor} interface.
+ */
+public class WmiQueryExecutorFFM implements WmiQueryExecutor {
+
+    private final WmiQueryHandlerFFM handler;
+
+    /**
+     * Creates an executor wrapping the given handler.
+     *
+     * @param handler the FFM WMI query handler
+     */
+    public WmiQueryExecutorFFM(WmiQueryHandlerFFM handler) {
+        this.handler = Objects.requireNonNull(handler, "handler");
+    }
+
+    /**
+     * Creates an executor using a new default handler instance.
+     *
+     * @return a new executor, or {@code null} if handler creation fails
+     */
+    public static WmiQueryExecutorFFM createInstance() {
+        WmiQueryHandlerFFM h = WmiQueryHandlerFFM.createInstance();
+        return h == null ? null : new WmiQueryExecutorFFM(h);
+    }
+
+    /**
+     * Returns the underlying FFM handler, for COM init/uninit operations.
+     *
+     * @return the FFM handler
+     */
+    public WmiQueryHandlerFFM getHandler() {
+        return handler;
+    }
+
+    @Override
+    public <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query) {
+        return queryWMI(query, true);
+    }
+
+    @Override
+    public <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query, boolean initCom) {
+        WbemcliUtilFFM.WmiQuery<T> ffmQuery = new WbemcliUtilFFM.WmiQuery<>(query.getNameSpace(),
+                query.getWmiClassName(), query.getPropertyEnum());
+        WbemcliUtilFFM.WmiResult<T> ffmResult = handler.queryWMI(ffmQuery, initCom);
+        return new FfmWmiResult<>(ffmResult);
+    }
+
+    private static final class FfmWmiResult<T extends Enum<T>> implements WmiResult<T> {
+        private final WbemcliUtilFFM.WmiResult<T> delegate;
+
+        FfmWmiResult(WbemcliUtilFFM.WmiResult<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int getResultCount() {
+            return delegate.getResultCount();
+        }
+
+        @Override
+        public Object getValue(T property, int index) {
+            return delegate.getValue(property, index);
+        }
+
+        @Override
+        public int getVtType(T property) {
+            return delegate.getVtType(property);
+        }
+
+        @Override
+        public int getCIMType(T property) {
+            return delegate.getCIMType(property);
+        }
+    }
+}

--- a/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryExecutorJNA.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryExecutorJNA.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.platform.windows;
+
+import java.util.Objects;
+
+import com.sun.jna.platform.win32.COM.WbemcliUtil;
+
+import oshi.driver.common.windows.wmi.WmiQuery;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.driver.common.windows.wmi.WmiResult;
+
+/**
+ * Adapts the JNA {@link WmiQueryHandler} to the common {@link WmiQueryExecutor} interface.
+ */
+public class WmiQueryExecutorJNA implements WmiQueryExecutor {
+
+    private final WmiQueryHandler handler;
+
+    /**
+     * Creates an executor wrapping the given handler.
+     *
+     * @param handler the JNA WMI query handler
+     */
+    public WmiQueryExecutorJNA(WmiQueryHandler handler) {
+        this.handler = Objects.requireNonNull(handler, "handler");
+    }
+
+    /**
+     * Creates an executor using a new default handler instance.
+     *
+     * @return a new executor, or {@code null} if handler creation fails
+     */
+    public static WmiQueryExecutorJNA createInstance() {
+        WmiQueryHandler h = WmiQueryHandler.createInstance();
+        return h == null ? null : new WmiQueryExecutorJNA(h);
+    }
+
+    /**
+     * Returns the underlying JNA handler, for COM init/uninit operations.
+     *
+     * @return the JNA handler
+     */
+    public WmiQueryHandler getHandler() {
+        return handler;
+    }
+
+    @Override
+    public <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query) {
+        return queryWMI(query, true);
+    }
+
+    @Override
+    public <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query, boolean initCom) {
+        WbemcliUtil.WmiQuery<T> jnaQuery = new WbemcliUtil.WmiQuery<>(query.getNameSpace(), query.getWmiClassName(),
+                query.getPropertyEnum());
+        WbemcliUtil.WmiResult<T> jnaResult = handler.queryWMI(jnaQuery, initCom);
+        return new JnaWmiResult<>(jnaResult);
+    }
+
+    private static final class JnaWmiResult<T extends Enum<T>> implements WmiResult<T> {
+        private final WbemcliUtil.WmiResult<T> delegate;
+
+        JnaWmiResult(WbemcliUtil.WmiResult<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int getResultCount() {
+            return delegate.getResultCount();
+        }
+
+        @Override
+        public Object getValue(T property, int index) {
+            return delegate.getValue(property, index);
+        }
+
+        @Override
+        public int getVtType(T property) {
+            return delegate.getVtType(property);
+        }
+
+        @Override
+        public int getCIMType(T property) {
+            return delegate.getCIMType(property);
+        }
+    }
+}


### PR DESCRIPTION
Partial fix for #3257

Adds shared WMI infrastructure to `oshi-common` enabling consolidation of the 21 duplicated JNA/FFM WMI driver pairs.

**New in oshi-common:**
- `WmiQuery<T>` — common query class
- `WmiResult<T>` — common result interface
- `WmiQueryExecutor` — common handler interface
- `WmiConstants` — CIM/VT type constants
- `WmiUtil` — typed result extraction helpers (getString, getUint32, getUint64, etc.)

**New adapters:**
- `WmiQueryExecutorJNA` (oshi-core) — wraps `WmiQueryHandler`
- `WmiQueryExecutorFFM` (oshi-core-ffm) — wraps `WmiQueryHandlerFFM`

**Proof of concept:**
- `Win32DiskDrive.queryDiskDrive(WmiQueryExecutor)` added to the common base class

The existing `WmiQueryHandler` class and its extensibility pattern (used in `oshi-demo` for COM init customization) are preserved unchanged. A follow-up PR will migrate the remaining 20 drivers and their callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized Windows WMI query infrastructure for more consistent, maintainable system data retrieval.
  * Introduced common result and executor abstractions enabling multiple backend implementations.

* **New Features**
  * Added robust, typed utilities for extracting and converting WMI values (strings, dates, integers, floats, references).
  * Improved disk drive query pathway for more reliable hardware reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->