### PR TITLE
Add common WMI query methods to all driver base classes

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/LhmSensor.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/LhmSensor.java
@@ -81,4 +81,30 @@ public class LhmSensor {
     public static String buildGpuHardwareWmiClassName() {
         return HARDWARE + " WHERE HardwareType=\"GpuNvidia\" OR HardwareType=\"GpuAmd\" OR HardwareType=\"GpuIntel\"";
     }
+
+    /**
+     * Queries all sensors of a given type belonging to a specific hardware parent.
+     *
+     * @param h          An instantiated {@link WmiQueryExecutor}.
+     * @param parent     the LHM hardware identifier (e.g. {@code /gpu-nvidia/0})
+     * @param sensorType the sensor type string (e.g. {@code "Load"}, {@code "SmallData"})
+     * @return WMI result containing NAME, VALUE, and PARENT columns
+     */
+    public static WmiResult<LhmSensorProperty> querySensors(WmiQueryExecutor h, String parent, String sensorType) {
+        WmiQuery<LhmSensorProperty> query = new WmiQuery<>(LHM_NAMESPACE,
+                buildSensorWmiClassNameWithWhere(parent, sensorType), LhmSensorProperty.class);
+        return h.queryWMI(query);
+    }
+
+    /**
+     * Queries all GPU hardware entries from LHM to discover parent identifiers.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return WMI result with IDENTIFIER and NAME columns for all GPU hardware entries
+     */
+    public static WmiResult<LhmHardwareProperty> queryGpuHardware(WmiQueryExecutor h) {
+        WmiQuery<LhmHardwareProperty> query = new WmiQuery<>(LHM_NAMESPACE, buildGpuHardwareWmiClassName(),
+                LhmHardwareProperty.class);
+        return h.queryWMI(query);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/MSAcpiThermalZoneTemperature.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/MSAcpiThermalZoneTemperature.java
@@ -35,4 +35,16 @@ public class MSAcpiThermalZoneTemperature {
      */
     protected MSAcpiThermalZoneTemperature() {
     }
+
+    /**
+     * Queries current temperature from thermal zone.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Temperature information.
+     */
+    public static WmiResult<TemperatureProperty> queryCurrentTemperature(WmiQueryExecutor h) {
+        WmiQuery<TemperatureProperty> query = new WmiQuery<>(WMI_NAMESPACE, MS_ACPI_THERMAL_ZONE_TEMPERATURE,
+                TemperatureProperty.class);
+        return h.queryWMI(query);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/MSFTStorage.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/MSFTStorage.java
@@ -85,4 +85,52 @@ public class MSFTStorage {
      */
     protected MSFTStorage() {
     }
+
+    /**
+     * Queries storage pools.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @return Storage pool information.
+     */
+    public static WmiResult<StoragePoolProperty> queryStoragePools(WmiQueryExecutor h) {
+        WmiQuery<StoragePoolProperty> query = new WmiQuery<>(STORAGE_NAMESPACE,
+                MSFT_STORAGE_POOL_WHERE_IS_PRIMORDIAL_FALSE, StoragePoolProperty.class);
+        return h.queryWMI(query, false);
+    }
+
+    /**
+     * Queries storage pool to physical disk mapping.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @return Storage pool to physical disk mapping.
+     */
+    public static WmiResult<StoragePoolToPhysicalDiskProperty> queryStoragePoolPhysicalDisks(WmiQueryExecutor h) {
+        WmiQuery<StoragePoolToPhysicalDiskProperty> query = new WmiQuery<>(STORAGE_NAMESPACE,
+                MSFT_STORAGE_POOL_TO_PHYSICAL_DISK, StoragePoolToPhysicalDiskProperty.class);
+        return h.queryWMI(query, false);
+    }
+
+    /**
+     * Queries physical disks.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @return Physical disk information.
+     */
+    public static WmiResult<PhysicalDiskProperty> queryPhysicalDisks(WmiQueryExecutor h) {
+        WmiQuery<PhysicalDiskProperty> query = new WmiQuery<>(STORAGE_NAMESPACE, MSFT_PHYSICAL_DISK,
+                PhysicalDiskProperty.class);
+        return h.queryWMI(query, false);
+    }
+
+    /**
+     * Queries virtual disks.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @return Virtual disk information.
+     */
+    public static WmiResult<VirtualDiskProperty> queryVirtualDisks(WmiQueryExecutor h) {
+        WmiQuery<VirtualDiskProperty> query = new WmiQuery<>(STORAGE_NAMESPACE, MSFT_VIRTUAL_DISK,
+                VirtualDiskProperty.class);
+        return h.queryWMI(query, false);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/OhmHardware.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/OhmHardware.java
@@ -48,4 +48,19 @@ public class OhmHardware {
         sb.append(" WHERE ").append(typeToQuery).append("Type=\"").append(typeName).append('"');
         return sb.toString();
     }
+
+    /**
+     * Queries the hardware identifiers for a monitored type.
+     *
+     * @param h           An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @param typeToQuery which type to filter based on
+     * @param typeName    the name of the type
+     * @return WmiResult of hardware identifier properties.
+     */
+    public static WmiResult<IdentifierProperty> queryHwIdentifier(WmiQueryExecutor h, String typeToQuery,
+            String typeName) {
+        WmiQuery<IdentifierProperty> hwIdentifierQuery = new WmiQuery<>(OHM_NAMESPACE,
+                buildHardwareWmiClassNameWithWhere(typeToQuery, typeName), IdentifierProperty.class);
+        return h.queryWMI(hwIdentifierQuery, false);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/OhmSensor.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/OhmSensor.java
@@ -49,4 +49,18 @@ public class OhmSensor {
         sb.append("\" AND SensorType = \"").append(sensorType).append('"');
         return sb.toString();
     }
+
+    /**
+     * Queries the sensor value of a hardware identifier and sensor type.
+     *
+     * @param h          An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @param identifier The identifier whose value to query.
+     * @param sensorType The type of sensor to query.
+     * @return The sensor value.
+     */
+    public static WmiResult<ValueProperty> querySensorValue(WmiQueryExecutor h, String identifier, String sensorType) {
+        WmiQuery<ValueProperty> ohmSensorQuery = new WmiQuery<>(OHM_NAMESPACE,
+                buildSensorWmiClassNameWithWhere(identifier, sensorType), ValueProperty.class);
+        return h.queryWMI(ohmSensorQuery, false);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32BaseBoard.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32BaseBoard.java
@@ -38,4 +38,15 @@ public class Win32BaseBoard {
      */
     protected Win32BaseBoard() {
     }
+
+    /**
+     * Queries baseboard information.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Baseboard information.
+     */
+    public static WmiResult<BaseBoardProperty> queryBaseboardInfo(WmiQueryExecutor h) {
+        WmiQuery<BaseBoardProperty> baseboardQuery = new WmiQuery<>(WIN32_BASEBOARD, BaseBoardProperty.class);
+        return h.queryWMI(baseboardQuery);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32Bios.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32Bios.java
@@ -46,4 +46,27 @@ public class Win32Bios {
      */
     protected Win32Bios() {
     }
+
+    /**
+     * Queries the BIOS serial number.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Assigned serial number of the software element.
+     */
+    public static WmiResult<BiosSerialProperty> querySerialNumber(WmiQueryExecutor h) {
+        WmiQuery<BiosSerialProperty> serialNumQuery = new WmiQuery<>(WIN32_BIOS_WHERE_PRIMARY_BIOS_TRUE,
+                BiosSerialProperty.class);
+        return h.queryWMI(serialNumQuery);
+    }
+
+    /**
+     * Queries the BIOS description.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return BIOS name, description, and related fields.
+     */
+    public static WmiResult<BiosProperty> queryBiosInfo(WmiQueryExecutor h) {
+        WmiQuery<BiosProperty> biosQuery = new WmiQuery<>(WIN32_BIOS_WHERE_PRIMARY_BIOS_TRUE, BiosProperty.class);
+        return h.queryWMI(biosQuery);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32ComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32ComputerSystem.java
@@ -32,4 +32,15 @@ public class Win32ComputerSystem {
      */
     protected Win32ComputerSystem() {
     }
+
+    /**
+     * Queries computer system information.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Computer system information.
+     */
+    public static WmiResult<ComputerSystemProperty> queryComputerSystem(WmiQueryExecutor h) {
+        WmiQuery<ComputerSystemProperty> csQuery = new WmiQuery<>(WIN32_COMPUTER_SYSTEM, ComputerSystemProperty.class);
+        return h.queryWMI(csQuery);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32ComputerSystemProduct.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32ComputerSystemProduct.java
@@ -32,4 +32,16 @@ public class Win32ComputerSystemProduct {
      */
     protected Win32ComputerSystemProduct() {
     }
+
+    /**
+     * Queries the UUID and identifying number.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return UUID and identifying number.
+     */
+    public static WmiResult<ComputerSystemProductProperty> queryIdentifyingNumberUUID(WmiQueryExecutor h) {
+        WmiQuery<ComputerSystemProductProperty> cspQuery = new WmiQuery<>(WIN32_COMPUTER_SYSTEM_PRODUCT,
+                ComputerSystemProductProperty.class);
+        return h.queryWMI(cspQuery);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32DiskDriveToDiskPartition.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32DiskDriveToDiskPartition.java
@@ -32,4 +32,16 @@ public class Win32DiskDriveToDiskPartition {
      */
     protected Win32DiskDriveToDiskPartition() {
     }
+
+    /**
+     * Queries disk drive to partition mapping.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @return Drive to partition mapping.
+     */
+    public static WmiResult<DriveToPartitionProperty> queryDriveToPartition(WmiQueryExecutor h) {
+        WmiQuery<DriveToPartitionProperty> query = new WmiQuery<>(WIN32_DISK_DRIVE_TO_DISK_PARTITION,
+                DriveToPartitionProperty.class);
+        return h.queryWMI(query, false);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32DiskPartition.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32DiskPartition.java
@@ -42,4 +42,15 @@ public class Win32DiskPartition {
      */
     protected Win32DiskPartition() {
     }
+
+    /**
+     * Queries disk partition information.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @return Disk partition information.
+     */
+    public static WmiResult<DiskPartitionProperty> queryPartition(WmiQueryExecutor h) {
+        WmiQuery<DiskPartitionProperty> query = new WmiQuery<>(WIN32_DISK_PARTITION, DiskPartitionProperty.class);
+        return h.queryWMI(query, false);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32Fan.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32Fan.java
@@ -30,4 +30,15 @@ public class Win32Fan {
      */
     protected Win32Fan() {
     }
+
+    /**
+     * Queries fan speed.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Fan speed information.
+     */
+    public static WmiResult<SpeedProperty> querySpeed(WmiQueryExecutor h) {
+        WmiQuery<SpeedProperty> fanQuery = new WmiQuery<>(WIN32_FAN, SpeedProperty.class);
+        return h.queryWMI(fanQuery);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32LogicalDisk.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32LogicalDisk.java
@@ -67,4 +67,19 @@ public class Win32LogicalDisk {
         }
         return wmiClassName.toString();
     }
+
+    /**
+     * Queries logical disk information.
+     *
+     * @param h           An instantiated {@link WmiQueryExecutor}.
+     * @param nameToMatch an optional string to filter match, null otherwise
+     * @param localOnly   Whether to only search local drives
+     * @return Logical Disk Information
+     */
+    public static WmiResult<LogicalDiskProperty> queryLogicalDisk(WmiQueryExecutor h, String nameToMatch,
+            boolean localOnly) {
+        WmiQuery<LogicalDiskProperty> logicalDiskQuery = new WmiQuery<>(
+                buildWmiClassNameWithWhere(nameToMatch, localOnly), LogicalDiskProperty.class);
+        return h.queryWMI(logicalDiskQuery);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32LogicalDiskToPartition.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32LogicalDiskToPartition.java
@@ -36,4 +36,16 @@ public class Win32LogicalDiskToPartition {
      */
     protected Win32LogicalDiskToPartition() {
     }
+
+    /**
+     * Queries logical disk to partition mapping.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @return Logical disk to partition mapping.
+     */
+    public static WmiResult<DiskToPartitionProperty> queryDiskToPartition(WmiQueryExecutor h) {
+        WmiQuery<DiskToPartitionProperty> query = new WmiQuery<>(WIN32_LOGICAL_DISK_TO_PARTITION,
+                DiskToPartitionProperty.class);
+        return h.queryWMI(query, false);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32OperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32OperatingSystem.java
@@ -38,4 +38,15 @@ public class Win32OperatingSystem {
      */
     protected Win32OperatingSystem() {
     }
+
+    /**
+     * Queries the operating system version.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return OS version information.
+     */
+    public static WmiResult<OSVersionProperty> queryOsVersion(WmiQueryExecutor h) {
+        WmiQuery<OSVersionProperty> osVersionQuery = new WmiQuery<>(WIN32_OPERATING_SYSTEM, OSVersionProperty.class);
+        return h.queryWMI(osVersionQuery);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32PhysicalMemory.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32PhysicalMemory.java
@@ -62,4 +62,27 @@ public class Win32PhysicalMemory {
      */
     protected Win32PhysicalMemory() {
     }
+
+    /**
+     * Queries physical memory information.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Physical memory information.
+     */
+    public static WmiResult<PhysicalMemoryProperty> queryPhysicalMemory(WmiQueryExecutor h) {
+        WmiQuery<PhysicalMemoryProperty> query = new WmiQuery<>(WIN32_PHYSICAL_MEMORY, PhysicalMemoryProperty.class);
+        return h.queryWMI(query);
+    }
+
+    /**
+     * Queries physical memory information (Win8+ properties).
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Physical memory information with Win8+ properties.
+     */
+    public static WmiResult<PhysicalMemoryPropertyWin8> queryPhysicalMemoryWin8(WmiQueryExecutor h) {
+        WmiQuery<PhysicalMemoryPropertyWin8> query = new WmiQuery<>(WIN32_PHYSICAL_MEMORY,
+                PhysicalMemoryPropertyWin8.class);
+        return h.queryWMI(query);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32Printer.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32Printer.java
@@ -44,4 +44,15 @@ public class Win32Printer {
      */
     protected Win32Printer() {
     }
+
+    /**
+     * Queries printer information.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Printer information.
+     */
+    public static WmiResult<PrinterProperty> queryPrinters(WmiQueryExecutor h) {
+        WmiQuery<PrinterProperty> query = new WmiQuery<>(WIN32_PRINTER, PrinterProperty.class);
+        return h.queryWMI(query);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32Process.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32Process.java
@@ -5,6 +5,7 @@
 package oshi.driver.common.windows.wmi;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -70,5 +71,31 @@ public class Win32Process {
         }
         return WIN32_PROCESS + " WHERE ProcessID="
                 + pids.stream().map(String::valueOf).collect(Collectors.joining(" OR PROCESSID="));
+    }
+
+    /**
+     * Returns process command lines.
+     *
+     * @param h           An instantiated {@link WmiQueryExecutor}.
+     * @param pidsToQuery Process IDs to query for command lines. Pass {@code null} to query all processes.
+     * @return A {@link WmiResult} containing process IDs and command lines.
+     */
+    public static WmiResult<CommandLineProperty> queryCommandLines(WmiQueryExecutor h, Set<Integer> pidsToQuery) {
+        WmiQuery<CommandLineProperty> commandLineQuery = new WmiQuery<>(buildWmiClassNameWithPidFilter(pidsToQuery),
+                CommandLineProperty.class);
+        return h.queryWMI(commandLineQuery);
+    }
+
+    /**
+     * Returns process info.
+     *
+     * @param h    An instantiated {@link WmiQueryExecutor}.
+     * @param pids Process IDs to query.
+     * @return Information on the provided processes.
+     */
+    public static WmiResult<ProcessXPProperty> queryProcesses(WmiQueryExecutor h, Collection<Integer> pids) {
+        WmiQuery<ProcessXPProperty> processQueryXP = new WmiQuery<>(buildWmiClassNameWithPidFilter(pids),
+                ProcessXPProperty.class);
+        return h.queryWMI(processQueryXP);
     }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32Processor.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32Processor.java
@@ -46,4 +46,37 @@ public class Win32Processor {
      */
     protected Win32Processor() {
     }
+
+    /**
+     * Queries processor voltage.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Processor voltage.
+     */
+    public static WmiResult<VoltProperty> queryVoltage(WmiQueryExecutor h) {
+        WmiQuery<VoltProperty> query = new WmiQuery<>(WIN32_PROCESSOR, VoltProperty.class);
+        return h.queryWMI(query);
+    }
+
+    /**
+     * Queries processor ID.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Processor ID.
+     */
+    public static WmiResult<ProcessorIdProperty> queryProcessorId(WmiQueryExecutor h) {
+        WmiQuery<ProcessorIdProperty> query = new WmiQuery<>(WIN32_PROCESSOR, ProcessorIdProperty.class);
+        return h.queryWMI(query);
+    }
+
+    /**
+     * Queries processor bitness.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Processor bitness.
+     */
+    public static WmiResult<BitnessProperty> queryBitness(WmiQueryExecutor h) {
+        WmiQuery<BitnessProperty> query = new WmiQuery<>(WIN32_PROCESSOR, BitnessProperty.class);
+        return h.queryWMI(query);
+    }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32VideoController.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32VideoController.java
@@ -40,4 +40,15 @@ public class Win32VideoController {
      */
     protected Win32VideoController() {
     }
+
+    /**
+     * Queries video controller information.
+     *
+     * @param h An instantiated {@link WmiQueryExecutor}.
+     * @return Video controller information.
+     */
+    public static WmiResult<VideoControllerProperty> queryVideoController(WmiQueryExecutor h) {
+        WmiQuery<VideoControllerProperty> query = new WmiQuery<>(WIN32_VIDEO_CONTROLLER, VideoControllerProperty.class);
+        return h.queryWMI(query);
+    }
 }


### PR DESCRIPTION
Continuation of #3257 (infrastructure PR merged as #3266).

Adds `queryXxx(WmiQueryExecutor)` methods to all 20 WMI driver base classes in `oshi-common`. These methods use the common `WmiQuery`/`WmiResult`/`WmiQueryExecutor` types introduced in #3266.

**Pattern:** Each method that previously existed only in JNA/FFM subclasses now has a common equivalent accepting a `WmiQueryExecutor`:
- Methods that previously created their own handler now take an executor parameter (caller controls lifecycle)
- Methods that previously took a `WmiQueryHandler`/`WmiQueryHandlerFFM` now take a `WmiQueryExecutor`

**Classes updated (20):**
LhmSensor, MSAcpiThermalZoneTemperature, MSFTStorage, OhmHardware, OhmSensor, Win32BaseBoard, Win32Bios, Win32ComputerSystem, Win32ComputerSystemProduct, Win32DiskDrive (already done), Win32DiskDriveToDiskPartition, Win32DiskPartition, Win32Fan, Win32LogicalDisk, Win32LogicalDiskToPartition, Win32OperatingSystem, Win32PhysicalMemory, Win32Printer, Win32Process, Win32Processor, Win32VideoController

**Next steps:**
- Migrate callers to use common methods + `WmiQueryExecutorJNA`/`WmiQueryExecutorFFM`
- Delete the 42 JNA/FFM driver subclasses
- Update demo classes and docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WMI query helpers for comprehensive Windows system information retrieval, including processor, memory, storage, BIOS, thermal zones, hardware sensors, and device controllers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->