### PR TITLE
Introduce PerfCounterQueryExecutor with common perfmon methods

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/GpuInformation.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/GpuInformation.java
@@ -4,7 +4,14 @@
  */
 package oshi.driver.common.windows.perfmon;
 
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.GPU_ADAPTER_MEMORY;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.GPU_ENGINE;
+
+import java.util.List;
+import java.util.Map;
+
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.tuples.Pair;
 
 /**
  * GPU performance counter enums. Available on Windows 10 version 1709 and later.
@@ -60,5 +67,27 @@ public final class GpuInformation {
     }
 
     private GpuInformation() {
+    }
+
+    /**
+     * Queries GPU Engine counters for all instances.
+     *
+     * @param executor the performance counter query executor
+     * @return pair of instance name list and counter value map
+     */
+    public static Pair<List<String>, Map<GpuEngineProperty, List<Long>>> queryGpuEngineCounters(
+            PerfCounterQueryExecutor executor) {
+        return executor.queryInstancesAndValuesFromPDH(GpuEngineProperty.class, GPU_ENGINE);
+    }
+
+    /**
+     * Queries GPU Adapter Memory counters for all instances.
+     *
+     * @param executor the performance counter query executor
+     * @return pair of instance name list and counter value map
+     */
+    public static Pair<List<String>, Map<GpuAdapterMemoryProperty, List<Long>>> queryGpuAdapterMemoryCounters(
+            PerfCounterQueryExecutor executor) {
+        return executor.queryInstancesAndValuesFromPDH(GpuAdapterMemoryProperty.class, GPU_ADAPTER_MEMORY);
     }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/MemoryInformation.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/MemoryInformation.java
@@ -4,6 +4,12 @@
  */
 package oshi.driver.common.windows.perfmon;
 
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.MEMORY;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_MEMORY;
+
+import java.util.Collections;
+import java.util.Map;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -41,5 +47,18 @@ public final class MemoryInformation {
     }
 
     private MemoryInformation() {
+    }
+
+    /**
+     * Returns page swap counters.
+     *
+     * @param executor the performance counter query executor
+     * @return Page swap counters for memory, or empty map if OS counters are disabled.
+     */
+    public static Map<PageSwapProperty, Long> queryPageSwaps(PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return Collections.emptyMap();
+        }
+        return executor.queryValues(PageSwapProperty.class, MEMORY, WIN32_PERF_RAW_DATA_PERF_OS_MEMORY);
     }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PagingFile.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PagingFile.java
@@ -4,7 +4,12 @@
  */
 package oshi.driver.common.windows.perfmon;
 
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.PAGING_FILE;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.TOTAL_INSTANCE;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PAGING_FILE;
+
+import java.util.Collections;
+import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 
@@ -41,5 +46,18 @@ public final class PagingFile {
     }
 
     private PagingFile() {
+    }
+
+    /**
+     * Returns paging file usage counters.
+     *
+     * @param executor the performance counter query executor
+     * @return Paging file usage, or empty map if OS counters are disabled.
+     */
+    public static Map<PagingPercentProperty, Long> querySwapUsed(PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return Collections.emptyMap();
+        }
+        return executor.queryValues(PagingPercentProperty.class, PAGING_FILE, WIN32_PERF_RAW_DATA_PERF_OS_PAGING_FILE);
     }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PerfCounterQueryExecutor.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PerfCounterQueryExecutor.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.perfmon;
+
+import java.util.List;
+import java.util.Map;
+
+import oshi.util.tuples.Pair;
+
+/**
+ * Common interface for querying Windows performance counters, abstracting JNA and FFM implementations.
+ * <p>
+ * Implementations perform raw queries and do not check whether counters are disabled. Callers should use
+ * {@link #isPerfOsDisabled()}, {@link #isPerfProcDisabled()}, and {@link #isPerfDiskDisabled()} to gate queries and
+ * return empty results when the relevant counter category is disabled.
+ */
+public interface PerfCounterQueryExecutor {
+
+    /**
+     * Queries performance counter values for a fixed set of counters.
+     *
+     * @param <T>          the enum type implementing {@link PdhCounterProperty}
+     * @param propertyEnum the property enum class
+     * @param perfObject   the performance object name
+     * @param perfWmiClass the WMI class name for fallback queries
+     * @return a map of enum constants to their counter values, or an empty map if disabled
+     */
+    <T extends Enum<T> & PdhCounterProperty> Map<T, Long> queryValues(Class<T> propertyEnum, String perfObject,
+            String perfWmiClass);
+
+    /**
+     * Queries performance counter values for wildcard (multi-instance) counters.
+     *
+     * @param <T>          the enum type implementing {@link PdhCounterWildcardProperty}
+     * @param propertyEnum the property enum class
+     * @param perfObject   the performance object name
+     * @param perfWmiClass the WMI class name for fallback queries
+     * @return a pair of instance names and a map of enum constants to lists of values, or empty if disabled
+     */
+    <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
+            Class<T> propertyEnum, String perfObject, String perfWmiClass);
+
+    /**
+     * Queries performance counter values for wildcard counters with a custom instance filter.
+     *
+     * @param <T>          the enum type implementing {@link PdhCounterWildcardProperty}
+     * @param propertyEnum the property enum class
+     * @param perfObject   the performance object name
+     * @param perfWmiClass the WMI class name for fallback queries
+     * @param customFilter custom PDH instance filter
+     * @return a pair of instance names and a map of enum constants to lists of values, or empty if disabled
+     */
+    <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
+            Class<T> propertyEnum, String perfObject, String perfWmiClass, String customFilter);
+
+    /**
+     * Queries performance counter values from WMI directly (formatted/cooked data).
+     *
+     * @param <T>          the enum type implementing {@link PdhCounterWildcardProperty}
+     * @param propertyEnum the property enum class
+     * @param perfWmiClass the WMI class name
+     * @return a pair of instance names and a map of enum constants to lists of values, or empty if disabled
+     */
+    <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromWMI(
+            Class<T> propertyEnum, String perfWmiClass);
+
+    /**
+     * Queries performance counter values from PDH only (no WMI fallback).
+     *
+     * @param <T>          the enum type implementing {@link PdhCounterWildcardProperty}
+     * @param propertyEnum the property enum class
+     * @param perfObject   the performance object name
+     * @return a pair of instance names and a map of enum constants to lists of values
+     */
+    <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromPDH(
+            Class<T> propertyEnum, String perfObject);
+
+    /**
+     * Returns whether the OS performance counters are disabled.
+     *
+     * @return true if PerfOS counters are disabled
+     */
+    boolean isPerfOsDisabled();
+
+    /**
+     * Returns whether the process performance counters are disabled.
+     *
+     * @return true if PerfProc counters are disabled
+     */
+    boolean isPerfProcDisabled();
+
+    /**
+     * Returns whether the disk performance counters are disabled.
+     *
+     * @return true if PerfDisk counters are disabled
+     */
+    boolean isPerfDiskDisabled();
+
+    /**
+     * Returns whether the OS is Windows 7 or greater.
+     *
+     * @return true if Windows 7+
+     */
+    boolean isWin7OrGreater();
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PhysicalDisk.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PhysicalDisk.java
@@ -5,8 +5,15 @@
 package oshi.driver.common.windows.perfmon;
 
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.NOT_TOTAL_INSTANCE;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.PHYSICAL_DISK;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_DISK_PHYSICAL_DISK_WHERE_NAME_NOT_TOTAL;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.tuples.Pair;
 
 /**
  * Physical Disk performance counter enums
@@ -46,5 +53,20 @@ public final class PhysicalDisk {
     }
 
     private PhysicalDisk() {
+    }
+
+    /**
+     * Returns physical disk performance counters.
+     *
+     * @param executor the performance counter query executor
+     * @return Performance Counters for physical disks, or empty if disk counters are disabled.
+     */
+    public static Pair<List<String>, Map<PhysicalDiskProperty, List<Long>>> queryDiskCounters(
+            PerfCounterQueryExecutor executor) {
+        if (executor.isPerfDiskDisabled()) {
+            return new Pair<>(Collections.emptyList(), Collections.emptyMap());
+        }
+        return executor.queryInstancesAndValues(PhysicalDiskProperty.class, PHYSICAL_DISK,
+                WIN32_PERF_RAW_DATA_PERF_DISK_PHYSICAL_DISK_WHERE_NAME_NOT_TOTAL);
     }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/ProcessInformation.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/ProcessInformation.java
@@ -5,10 +5,19 @@
 package oshi.driver.common.windows.perfmon;
 
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.NOT_TOTAL_INSTANCES;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESS;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.TOTAL_INSTANCE;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.TOTAL_OR_IDLE_INSTANCES;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.tuples.Pair;
 
 /**
  * Process performance counter enums
@@ -103,5 +112,48 @@ public final class ProcessInformation {
     }
 
     private ProcessInformation() {
+    }
+
+    /**
+     * Returns process performance counters.
+     *
+     * @param executor the performance counter query executor
+     * @return Performance Counters for processes, or empty if process counters are disabled.
+     */
+    public static Pair<List<String>, Map<ProcessPerformanceProperty, List<Long>>> queryProcessCounters(
+            PerfCounterQueryExecutor executor) {
+        if (executor.isPerfProcDisabled()) {
+            return new Pair<>(Collections.emptyList(), Collections.emptyMap());
+        }
+        return executor.queryInstancesAndValues(ProcessPerformanceProperty.class, PROCESS,
+                WIN32_PERFPROC_PROCESS_WHERE_NOT_NAME_LIKE_TOTAL);
+    }
+
+    /**
+     * Returns handle count.
+     *
+     * @param executor the performance counter query executor
+     * @return Handle count, or empty map if process counters are disabled.
+     */
+    public static Map<HandleCountProperty, Long> queryHandles(PerfCounterQueryExecutor executor) {
+        if (executor.isPerfProcDisabled()) {
+            return Collections.emptyMap();
+        }
+        return executor.queryValues(HandleCountProperty.class, PROCESS, WIN32_PERFPROC_PROCESS_WHERE_NAME_TOTAL);
+    }
+
+    /**
+     * Returns idle process counters (for load average calculation).
+     *
+     * @param executor the performance counter query executor
+     * @return Idle process counters, or empty if OS counters are disabled.
+     */
+    public static Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> queryIdleProcessCounters(
+            PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return new Pair<>(Collections.emptyList(), Collections.emptyMap());
+        }
+        return executor.queryInstancesAndValues(IdleProcessorTimeProperty.class, PROCESS,
+                WIN32_PERFPROC_PROCESS_WHERE_IDPROCESS_0);
     }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/ProcessorInformation.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/ProcessorInformation.java
@@ -5,9 +5,20 @@
 package oshi.driver.common.windows.perfmon;
 
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.NOT_TOTAL_INSTANCES;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESSOR;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.PROCESSOR_INFORMATION;
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.TOTAL_INSTANCE;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_FORMATTED_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_NOT_TOTAL;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_TOTAL;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.tuples.Pair;
 
 /**
  * Processor performance counter enums
@@ -179,5 +190,96 @@ public final class ProcessorInformation {
     }
 
     private ProcessorInformation() {
+    }
+
+    /**
+     * Returns processor performance counters.
+     *
+     * @param executor the performance counter query executor
+     * @return Performance Counters for processors, or empty if OS counters are disabled.
+     */
+    public static Pair<List<String>, Map<ProcessorTickCountProperty, List<Long>>> queryProcessorCounters(
+            PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return new Pair<>(Collections.emptyList(), Collections.emptyMap());
+        }
+        return executor.isWin7OrGreater()
+                ? executor.queryInstancesAndValues(ProcessorTickCountProperty.class, PROCESSOR_INFORMATION,
+                        WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL)
+                : executor.queryInstancesAndValues(ProcessorTickCountProperty.class, PROCESSOR,
+                        WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_NOT_TOTAL);
+    }
+
+    /**
+     * Returns system performance counters.
+     *
+     * @param executor the performance counter query executor
+     * @return Performance Counters for the total of all processors, or empty if OS counters are disabled.
+     */
+    public static Map<SystemTickCountProperty, Long> querySystemCounters(PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return Collections.emptyMap();
+        }
+        return executor.queryValues(SystemTickCountProperty.class, PROCESSOR,
+                WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_TOTAL);
+    }
+
+    /**
+     * Returns processor capacity performance counters.
+     *
+     * @param executor the performance counter query executor
+     * @return Performance Counters for processor capacity, or empty if OS counters are disabled.
+     */
+    public static Pair<List<String>, Map<ProcessorUtilityTickCountProperty, List<Long>>> queryProcessorCapacityCounters(
+            PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return new Pair<>(Collections.emptyList(), Collections.emptyMap());
+        }
+        return executor.queryInstancesAndValues(ProcessorUtilityTickCountProperty.class, PROCESSOR_INFORMATION,
+                WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL);
+    }
+
+    /**
+     * Returns system interrupts counters.
+     *
+     * @param executor the performance counter query executor
+     * @return Interrupts counter for the total of all processors, or empty if OS counters are disabled.
+     */
+    public static Map<InterruptsProperty, Long> queryInterruptCounters(PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return Collections.emptyMap();
+        }
+        return executor.queryValues(InterruptsProperty.class, PROCESSOR,
+                WIN32_PERF_RAW_DATA_PERF_OS_PROCESSOR_WHERE_NAME_TOTAL);
+    }
+
+    /**
+     * Returns processor frequency counters.
+     *
+     * @param executor the performance counter query executor
+     * @return Processor frequency counter for each processor, or empty if OS counters are disabled.
+     */
+    public static Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> queryFrequencyCounters(
+            PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return new Pair<>(Collections.emptyList(), Collections.emptyMap());
+        }
+        return executor.queryInstancesAndValues(ProcessorFrequencyProperty.class, PROCESSOR_INFORMATION,
+                WIN32_PERF_RAW_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL);
+    }
+
+    /**
+     * Returns processor performance percentage (cooked) from the WMI Formatted Data table.
+     *
+     * @param executor the performance counter query executor
+     * @return Processor performance percentage for each processor, or empty if OS counters are disabled.
+     */
+    public static Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> queryProcessorPerformanceCounters(
+            PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return new Pair<>(Collections.emptyList(), Collections.emptyMap());
+        }
+        return executor.queryInstancesAndValuesFromWMI(ProcessorPerformanceProperty.class,
+                WIN32_PERF_FORMATTED_DATA_COUNTERS_PROCESSOR_INFORMATION_WHERE_NOT_NAME_LIKE_TOTAL);
     }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/SystemInformation.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/SystemInformation.java
@@ -4,6 +4,12 @@
  */
 package oshi.driver.common.windows.perfmon;
 
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.SYSTEM;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_OS_SYSTEM;
+
+import java.util.Collections;
+import java.util.Map;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -65,5 +71,31 @@ public final class SystemInformation {
     }
 
     private SystemInformation() {
+    }
+
+    /**
+     * Returns context switch counters.
+     *
+     * @param executor the performance counter query executor
+     * @return Context switch counters, or empty map if OS counters are disabled.
+     */
+    public static Map<ContextSwitchProperty, Long> queryContextSwitchCounters(PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return Collections.emptyMap();
+        }
+        return executor.queryValues(ContextSwitchProperty.class, SYSTEM, WIN32_PERF_RAW_DATA_PERF_OS_SYSTEM);
+    }
+
+    /**
+     * Returns processor queue length.
+     *
+     * @param executor the performance counter query executor
+     * @return Processor Queue Length, or empty map if OS counters are disabled.
+     */
+    public static Map<ProcessorQueueLengthProperty, Long> queryProcessorQueueLength(PerfCounterQueryExecutor executor) {
+        if (executor.isPerfOsDisabled()) {
+            return Collections.emptyMap();
+        }
+        return executor.queryValues(ProcessorQueueLengthProperty.class, SYSTEM, WIN32_PERF_RAW_DATA_PERF_OS_SYSTEM);
     }
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/ThreadInformation.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/ThreadInformation.java
@@ -5,8 +5,16 @@
 package oshi.driver.common.windows.perfmon;
 
 import static oshi.driver.common.windows.perfmon.PerfmonConstants.NOT_TOTAL_INSTANCES;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.THREAD;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_PROC_THREAD;
+import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW_DATA_PERF_PROC_THREAD_WHERE_NOT_NAME_LIKE_TOTAL;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.tuples.Pair;
 
 /**
  * Thread performance counter enums
@@ -54,5 +62,42 @@ public final class ThreadInformation {
     }
 
     private ThreadInformation() {
+    }
+
+    /**
+     * Returns thread counters for all threads.
+     *
+     * @param executor the performance counter query executor
+     * @return Thread counters for each thread.
+     */
+    public static Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> queryThreadCounters(
+            PerfCounterQueryExecutor executor) {
+        return executor.queryInstancesAndValues(ThreadPerformanceProperty.class, THREAD,
+                WIN32_PERF_RAW_DATA_PERF_PROC_THREAD_WHERE_NOT_NAME_LIKE_TOTAL);
+    }
+
+    /**
+     * Returns thread counters filtered to the specified process name and thread.
+     *
+     * @param executor  the performance counter query executor
+     * @param name      The process name to filter
+     * @param threadNum The thread number to match. -1 matches all threads.
+     * @return Thread counters for each thread.
+     */
+    public static Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> queryThreadCounters(
+            PerfCounterQueryExecutor executor, String name, int threadNum) {
+        String procName = name.toLowerCase(Locale.ROOT);
+        if (threadNum >= 0) {
+            Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> threads = executor
+                    .queryInstancesAndValues(
+                            ThreadPerformanceProperty.class, THREAD, WIN32_PERF_RAW_DATA_PERF_PROC_THREAD
+                                    + " WHERE Name LIKE \"" + procName + "/_%\" AND IDThread=" + threadNum,
+                            procName + "/*");
+            if (!threads.getA().isEmpty()) {
+                return threads;
+            }
+        }
+        return executor.queryInstancesAndValues(ThreadPerformanceProperty.class, THREAD,
+                WIN32_PERF_RAW_DATA_PERF_PROC_THREAD + " WHERE Name LIKE \"" + procName + "/_%\"", procName + "/*");
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/perfmon/PerfCounterQueryExecutorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/perfmon/PerfCounterQueryExecutorFFM.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.perfmon;
+
+import java.util.List;
+import java.util.Map;
+
+import oshi.driver.common.windows.perfmon.PdhCounterProperty;
+import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
+import oshi.driver.common.windows.perfmon.PerfCounterQueryExecutor;
+import oshi.ffm.util.platform.windows.PerfCounterQueryFFM;
+import oshi.ffm.util.platform.windows.PerfCounterWildcardQueryFFM;
+import oshi.ffm.windows.VersionHelpersFFM;
+import oshi.util.tuples.Pair;
+
+/**
+ * FFM-based {@link PerfCounterQueryExecutor} implementation.
+ */
+public final class PerfCounterQueryExecutorFFM implements PerfCounterQueryExecutor {
+
+    /** Singleton instance. */
+    public static final PerfCounterQueryExecutorFFM INSTANCE = new PerfCounterQueryExecutorFFM();
+
+    private static final boolean IS_WIN7_OR_GREATER = VersionHelpersFFM.IsWindows7OrGreater();
+
+    private PerfCounterQueryExecutorFFM() {
+    }
+
+    @Override
+    public <T extends Enum<T> & PdhCounterProperty> Map<T, Long> queryValues(Class<T> propertyEnum, String perfObject,
+            String perfWmiClass) {
+        return PerfCounterQueryFFM.queryValues(propertyEnum, perfObject, perfWmiClass);
+    }
+
+    @Override
+    public <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
+            Class<T> propertyEnum, String perfObject, String perfWmiClass) {
+        return PerfCounterWildcardQueryFFM.queryInstancesAndValues(propertyEnum, perfObject, perfWmiClass);
+    }
+
+    @Override
+    public <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
+            Class<T> propertyEnum, String perfObject, String perfWmiClass, String customFilter) {
+        return PerfCounterWildcardQueryFFM.queryInstancesAndValues(propertyEnum, perfObject, perfWmiClass,
+                customFilter);
+    }
+
+    @Override
+    public <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromWMI(
+            Class<T> propertyEnum, String perfWmiClass) {
+        return PerfCounterWildcardQueryFFM.queryInstancesAndValuesFromWMI(propertyEnum, perfWmiClass);
+    }
+
+    @Override
+    public <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromPDH(
+            Class<T> propertyEnum, String perfObject) {
+        return PerfCounterWildcardQueryFFM.queryInstancesAndValuesFromPDH(propertyEnum, perfObject);
+    }
+
+    @Override
+    public boolean isPerfOsDisabled() {
+        return PerfmonDisabledFFM.PERF_OS_DISABLED;
+    }
+
+    @Override
+    public boolean isPerfProcDisabled() {
+        return PerfmonDisabledFFM.PERF_PROC_DISABLED;
+    }
+
+    @Override
+    public boolean isPerfDiskDisabled() {
+        return PerfmonDisabledFFM.PERF_DISK_DISABLED;
+    }
+
+    @Override
+    public boolean isWin7OrGreater() {
+        return IS_WIN7_OR_GREATER;
+    }
+}

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/PerfCounterQueryExecutorJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/PerfCounterQueryExecutorJNA.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.windows.perfmon;
+
+import java.util.List;
+import java.util.Map;
+
+import com.sun.jna.platform.win32.VersionHelpers;
+
+import oshi.driver.common.windows.perfmon.PdhCounterProperty;
+import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
+import oshi.driver.common.windows.perfmon.PerfCounterQueryExecutor;
+import oshi.util.platform.windows.PerfCounterQuery;
+import oshi.util.platform.windows.PerfCounterWildcardQuery;
+import oshi.util.tuples.Pair;
+
+/**
+ * JNA-based {@link PerfCounterQueryExecutor} implementation.
+ */
+public final class PerfCounterQueryExecutorJNA implements PerfCounterQueryExecutor {
+
+    /** Singleton instance. */
+    public static final PerfCounterQueryExecutorJNA INSTANCE = new PerfCounterQueryExecutorJNA();
+
+    private static final boolean IS_WIN7_OR_GREATER = VersionHelpers.IsWindows7OrGreater();
+
+    private PerfCounterQueryExecutorJNA() {
+    }
+
+    @Override
+    public <T extends Enum<T> & PdhCounterProperty> Map<T, Long> queryValues(Class<T> propertyEnum, String perfObject,
+            String perfWmiClass) {
+        return PerfCounterQuery.queryValues(propertyEnum, perfObject, perfWmiClass);
+    }
+
+    @Override
+    public <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
+            Class<T> propertyEnum, String perfObject, String perfWmiClass) {
+        return PerfCounterWildcardQuery.queryInstancesAndValues(propertyEnum, perfObject, perfWmiClass);
+    }
+
+    @Override
+    public <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
+            Class<T> propertyEnum, String perfObject, String perfWmiClass, String customFilter) {
+        return PerfCounterWildcardQuery.queryInstancesAndValues(propertyEnum, perfObject, perfWmiClass, customFilter);
+    }
+
+    @Override
+    public <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromWMI(
+            Class<T> propertyEnum, String perfWmiClass) {
+        return PerfCounterWildcardQuery.queryInstancesAndValuesFromWMI(propertyEnum, perfWmiClass);
+    }
+
+    @Override
+    public <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromPDH(
+            Class<T> propertyEnum, String perfObject) {
+        return PerfCounterWildcardQuery.queryInstancesAndValuesFromPDH(propertyEnum, perfObject);
+    }
+
+    @Override
+    public boolean isPerfOsDisabled() {
+        return PerfmonDisabled.PERF_OS_DISABLED;
+    }
+
+    @Override
+    public boolean isPerfProcDisabled() {
+        return PerfmonDisabled.PERF_PROC_DISABLED;
+    }
+
+    @Override
+    public boolean isPerfDiskDisabled() {
+        return PerfmonDisabled.PERF_DISK_DISABLED;
+    }
+
+    @Override
+    public boolean isWin7OrGreater() {
+        return IS_WIN7_OR_GREATER;
+    }
+}


### PR DESCRIPTION
Closes #3258, closes #3261

Introduces a `PerfCounterQueryExecutor` interface in `oshi-common` with JNA and FFM singleton implementations. Adds query methods to all 8 perfmon driver base classes.

**Fixes #3261 by design:** The common query methods check `executor.isPerfOsDisabled()` / `isPerfProcDisabled()` / `isPerfDiskDisabled()` before executing queries. The FFM executor now properly checks `PerfmonDisabledFFM`, fixing the inconsistency where FFM drivers previously skipped this check.

**New in oshi-common:**
- `PerfCounterQueryExecutor` interface — queryValues, queryInstancesAndValues, queryInstancesAndValuesFromWMI, queryInstancesAndValuesFromPDH, isPerfXxxDisabled, isWin7OrGreater

**New adapters:**
- `PerfCounterQueryExecutorJNA` (oshi-core)
- `PerfCounterQueryExecutorFFM` (oshi-core-ffm)

**Updated base classes (8):**
GpuInformation, MemoryInformation, PagingFile, PhysicalDisk, ProcessInformation, ProcessorInformation, SystemInformation, ThreadInformation

LoadAverage is not included as it has a more complex singleton/scheduling pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Windows performance queries to include GPU (engine & adapter memory), memory/page-swap, paging-file usage, disk, process, thread, processor, and system counters with multi-instance results where applicable.

* **Refactor**
  * Added a unified performance-counter executor interface plus two concrete implementations to standardize and simplify retrieving Windows perf data across multiple subsystems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->