### PR TITLE
Add ExceptionUtil to reduce repetitive exception handling

### DIFF
--- a/oshi-common/src/main/java/oshi/util/ExceptionUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ExceptionUtil.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import org.slf4j.Logger;
+
+import oshi.annotation.concurrent.ThreadSafe;
+
+/**
+ * Utility methods for reducing repetitive exception handling boilerplate, particularly around FFM (Foreign Function and
+ * Memory) native calls that require catching {@link Throwable}.
+ */
+@ThreadSafe
+public final class ExceptionUtil {
+
+    private ExceptionUtil() {
+    }
+
+    /**
+     * A supplier that may throw any {@link Throwable}, including checked exceptions.
+     *
+     * @param <T> the type of result supplied
+     */
+    @FunctionalInterface
+    public interface ThrowingSupplier<T> {
+        T get() throws Throwable;
+    }
+
+    /**
+     * An int-returning supplier that may throw any {@link Throwable}.
+     */
+    @FunctionalInterface
+    public interface ThrowingIntSupplier {
+        int getAsInt() throws Throwable;
+    }
+
+    /**
+     * A long-returning supplier that may throw any {@link Throwable}.
+     */
+    @FunctionalInterface
+    public interface ThrowingLongSupplier {
+        long getAsLong() throws Throwable;
+    }
+
+    /**
+     * A boolean-returning supplier that may throw any {@link Throwable}.
+     */
+    @FunctionalInterface
+    public interface ThrowingBooleanSupplier {
+        boolean getAsBoolean() throws Throwable;
+    }
+
+    /**
+     * A double-returning supplier that may throw any {@link Throwable}.
+     */
+    @FunctionalInterface
+    public interface ThrowingDoubleSupplier {
+        double getAsDouble() throws Throwable;
+    }
+
+    /**
+     * A runnable that may throw any {@link Throwable}.
+     */
+    @FunctionalInterface
+    public interface ThrowingRunnable {
+        void run() throws Throwable;
+    }
+
+    /**
+     * Executes the supplier, returning its result on success or the default value if any {@link Throwable} is thrown.
+     *
+     * @param <T>          the result type
+     * @param supplier     the operation to attempt
+     * @param defaultValue the value to return on failure
+     * @return the supplier's result or the default value
+     */
+    public static <T> T getOrDefault(ThrowingSupplier<T> supplier, T defaultValue) {
+        try {
+            return supplier.get();
+        } catch (Throwable t) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes the supplier, returning its result on success or the default value if any {@link Throwable} is thrown.
+     * Logs the exception at debug level.
+     *
+     * @param <T>          the result type
+     * @param supplier     the operation to attempt
+     * @param defaultValue the value to return on failure
+     * @param log          the logger to use
+     * @param msg          the log message (use {} for the exception message placeholder)
+     * @return the supplier's result or the default value
+     */
+    public static <T> T getOrDefault(ThrowingSupplier<T> supplier, T defaultValue, Logger log, String msg) {
+        try {
+            return supplier.get();
+        } catch (Throwable t) {
+            log.debug(msg, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes the int supplier, returning its result on success or the default value on failure.
+     *
+     * @param supplier     the operation to attempt
+     * @param defaultValue the value to return on failure
+     * @return the supplier's result or the default value
+     */
+    public static int getIntOrDefault(ThrowingIntSupplier supplier, int defaultValue) {
+        try {
+            return supplier.getAsInt();
+        } catch (Throwable t) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes the int supplier, returning its result on success or the default value on failure. Logs the exception at
+     * debug level.
+     *
+     * @param supplier     the operation to attempt
+     * @param defaultValue the value to return on failure
+     * @param log          the logger to use
+     * @param msg          the log message
+     * @return the supplier's result or the default value
+     */
+    public static int getIntOrDefault(ThrowingIntSupplier supplier, int defaultValue, Logger log, String msg) {
+        try {
+            return supplier.getAsInt();
+        } catch (Throwable t) {
+            log.debug(msg, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes the long supplier, returning its result on success or the default value on failure.
+     *
+     * @param supplier     the operation to attempt
+     * @param defaultValue the value to return on failure
+     * @return the supplier's result or the default value
+     */
+    public static long getLongOrDefault(ThrowingLongSupplier supplier, long defaultValue) {
+        try {
+            return supplier.getAsLong();
+        } catch (Throwable t) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes the long supplier, returning its result on success or the default value on failure. Logs the exception
+     * at debug level.
+     *
+     * @param supplier     the operation to attempt
+     * @param defaultValue the value to return on failure
+     * @param log          the logger to use
+     * @param msg          the log message
+     * @return the supplier's result or the default value
+     */
+    public static long getLongOrDefault(ThrowingLongSupplier supplier, long defaultValue, Logger log, String msg) {
+        try {
+            return supplier.getAsLong();
+        } catch (Throwable t) {
+            log.debug(msg, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes the boolean supplier, returning its result on success or the default value on failure.
+     *
+     * @param supplier     the operation to attempt
+     * @param defaultValue the value to return on failure
+     * @return the supplier's result or the default value
+     */
+    public static boolean getBooleanOrDefault(ThrowingBooleanSupplier supplier, boolean defaultValue) {
+        try {
+            return supplier.getAsBoolean();
+        } catch (Throwable t) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes the boolean supplier, returning its result on success or the default value on failure. Logs the
+     * exception at debug level.
+     *
+     * @param supplier     the operation to attempt
+     * @param defaultValue the value to return on failure
+     * @param log          the logger to use
+     * @param msg          the log message
+     * @return the supplier's result or the default value
+     */
+    public static boolean getBooleanOrDefault(ThrowingBooleanSupplier supplier, boolean defaultValue, Logger log,
+            String msg) {
+        try {
+            return supplier.getAsBoolean();
+        } catch (Throwable t) {
+            log.debug(msg, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes the double supplier, returning its result on success or the default value on failure.
+     *
+     * @param supplier     the operation to attempt
+     * @param defaultValue the value to return on failure
+     * @return the supplier's result or the default value
+     */
+    public static double getDoubleOrDefault(ThrowingDoubleSupplier supplier, double defaultValue) {
+        try {
+            return supplier.getAsDouble();
+        } catch (Throwable t) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes the double supplier, returning its result on success or the default value on failure. Logs the exception
+     * at debug level.
+     *
+     * @param supplier     the operation to attempt
+     * @param defaultValue the value to return on failure
+     * @param log          the logger to use
+     * @param msg          the log message
+     * @return the supplier's result or the default value
+     */
+    public static double getDoubleOrDefault(ThrowingDoubleSupplier supplier, double defaultValue, Logger log,
+            String msg) {
+        try {
+            return supplier.getAsDouble();
+        } catch (Throwable t) {
+            log.debug(msg, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes the supplier, wrapping the result in an {@link Optional}. Returns {@link Optional#empty()} on failure.
+     *
+     * @param <T>      the result type
+     * @param supplier the operation to attempt
+     * @param log      the logger to use
+     * @param msg      the log message
+     * @return an Optional containing the result, or empty on failure
+     */
+    public static <T> Optional<T> getOptional(ThrowingSupplier<T> supplier, Logger log, String msg) {
+        try {
+            return Optional.ofNullable(supplier.get());
+        } catch (Throwable t) {
+            log.debug(msg, t);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Executes the int supplier, wrapping the result in an {@link OptionalInt}. Returns {@link OptionalInt#empty()} on
+     * failure.
+     *
+     * @param supplier the operation to attempt
+     * @param log      the logger to use
+     * @param msg      the log message
+     * @return an OptionalInt containing the result, or empty on failure
+     */
+    public static OptionalInt getOptionalInt(ThrowingIntSupplier supplier, Logger log, String msg) {
+        try {
+            return OptionalInt.of(supplier.getAsInt());
+        } catch (Throwable t) {
+            log.debug(msg, t);
+            return OptionalInt.empty();
+        }
+    }
+
+    /**
+     * Executes the long supplier, wrapping the result in an {@link OptionalLong}. Returns {@link OptionalLong#empty()}
+     * on failure.
+     *
+     * @param supplier the operation to attempt
+     * @param log      the logger to use
+     * @param msg      the log message
+     * @return an OptionalLong containing the result, or empty on failure
+     */
+    public static OptionalLong getOptionalLong(ThrowingLongSupplier supplier, Logger log, String msg) {
+        try {
+            return OptionalLong.of(supplier.getAsLong());
+        } catch (Throwable t) {
+            log.debug(msg, t);
+            return OptionalLong.empty();
+        }
+    }
+
+    /**
+     * Executes the runnable, silently swallowing any {@link Throwable}.
+     *
+     * @param runnable the operation to attempt
+     */
+    public static void runSilently(ThrowingRunnable runnable) {
+        try {
+            runnable.run();
+        } catch (Throwable t) {
+            // intentionally silent
+        }
+    }
+
+    /**
+     * Executes the runnable, logging any {@link Throwable} at debug level.
+     *
+     * @param runnable the operation to attempt
+     * @param log      the logger to use
+     * @param msg      the log message
+     */
+    public static void runOrLog(ThrowingRunnable runnable, Logger log, String msg) {
+        try {
+            runnable.run();
+        } catch (Throwable t) {
+            log.debug(msg, t);
+        }
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for {@link ExceptionUtil}.
+ */
+class ExceptionUtilTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExceptionUtilTest.class);
+
+    // -- getOrDefault --
+
+    @Test
+    void testGetOrDefaultReturnsValue() {
+        String result = ExceptionUtil.getOrDefault(() -> "hello", "default");
+        assertThat(result, is(equalTo("hello")));
+    }
+
+    @Test
+    void testGetOrDefaultReturnsDefaultOnException() {
+        String result = ExceptionUtil.getOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, "default");
+        assertThat(result, is(equalTo("default")));
+    }
+
+    @Test
+    void testGetOrDefaultReturnsDefaultOnError() {
+        String result = ExceptionUtil.getOrDefault(() -> {
+            throw new OutOfMemoryError("simulated");
+        }, "default");
+        assertThat(result, is(equalTo("default")));
+    }
+
+    @Test
+    void testGetOrDefaultWithNullDefault() {
+        String result = ExceptionUtil.getOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, null);
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    void testGetOrDefaultWithLogging() {
+        String result = ExceptionUtil.getOrDefault(() -> {
+            throw new RuntimeException("test error");
+        }, "fallback", LOG, "Operation failed: {}");
+        assertThat(result, is(equalTo("fallback")));
+    }
+
+    @Test
+    void testGetOrDefaultWithLoggingSuccess() {
+        String result = ExceptionUtil.getOrDefault(() -> "success", "fallback", LOG, "Should not log");
+        assertThat(result, is(equalTo("success")));
+    }
+
+    // -- getIntOrDefault --
+
+    @Test
+    void testGetIntOrDefaultReturnsValue() {
+        int result = ExceptionUtil.getIntOrDefault(() -> 42, -1);
+        assertThat(result, is(42));
+    }
+
+    @Test
+    void testGetIntOrDefaultReturnsDefaultOnException() {
+        int result = ExceptionUtil.getIntOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, -1);
+        assertThat(result, is(-1));
+    }
+
+    @Test
+    void testGetIntOrDefaultWithLogging() {
+        int result = ExceptionUtil.getIntOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, 0, LOG, "Int op failed: {}");
+        assertThat(result, is(0));
+    }
+
+    // -- getLongOrDefault --
+
+    @Test
+    void testGetLongOrDefaultReturnsValue() {
+        long result = ExceptionUtil.getLongOrDefault(() -> 100L, -1L);
+        assertThat(result, is(100L));
+    }
+
+    @Test
+    void testGetLongOrDefaultReturnsDefaultOnException() {
+        long result = ExceptionUtil.getLongOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, -1L);
+        assertThat(result, is(-1L));
+    }
+
+    @Test
+    void testGetLongOrDefaultWithLogging() {
+        long result = ExceptionUtil.getLongOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, 0L, LOG, "Long op failed: {}");
+        assertThat(result, is(0L));
+    }
+
+    // -- getBooleanOrDefault --
+
+    @Test
+    void testGetBooleanOrDefaultReturnsValue() {
+        boolean result = ExceptionUtil.getBooleanOrDefault(() -> true, false);
+        assertThat(result, is(true));
+    }
+
+    @Test
+    void testGetBooleanOrDefaultReturnsDefaultOnException() {
+        boolean result = ExceptionUtil.getBooleanOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, false);
+        assertThat(result, is(false));
+    }
+
+    @Test
+    void testGetBooleanOrDefaultWithLogging() {
+        boolean result = ExceptionUtil.getBooleanOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, true, LOG, "Bool op failed: {}");
+        assertThat(result, is(true));
+    }
+
+    // -- getDoubleOrDefault --
+
+    @Test
+    void testGetDoubleOrDefaultReturnsValue() {
+        double result = ExceptionUtil.getDoubleOrDefault(() -> 3.14, -1d);
+        assertThat(result, is(3.14));
+    }
+
+    @Test
+    void testGetDoubleOrDefaultReturnsDefaultOnException() {
+        double result = ExceptionUtil.getDoubleOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, -1d);
+        assertThat(result, is(-1d));
+    }
+
+    @Test
+    void testGetDoubleOrDefaultWithLogging() {
+        double result = ExceptionUtil.getDoubleOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, -1d, LOG, "Double op failed: {}");
+        assertThat(result, is(-1d));
+    }
+
+    // -- getOptional --
+
+    @Test
+    void testGetOptionalReturnsValue() {
+        Optional<String> result = ExceptionUtil.getOptional(() -> "value", LOG, "msg");
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get(), is(equalTo("value")));
+    }
+
+    @Test
+    void testGetOptionalReturnsEmptyOnException() {
+        Optional<String> result = ExceptionUtil.getOptional(() -> {
+            throw new RuntimeException("fail");
+        }, LOG, "Optional op failed: {}");
+        assertThat(result.isPresent(), is(false));
+    }
+
+    @Test
+    void testGetOptionalReturnsEmptyOnNull() {
+        Optional<String> result = ExceptionUtil.getOptional(() -> null, LOG, "msg");
+        assertThat(result.isPresent(), is(false));
+    }
+
+    // -- getOptionalInt --
+
+    @Test
+    void testGetOptionalIntReturnsValue() {
+        OptionalInt result = ExceptionUtil.getOptionalInt(() -> 7, LOG, "msg");
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.getAsInt(), is(7));
+    }
+
+    @Test
+    void testGetOptionalIntReturnsEmptyOnException() {
+        OptionalInt result = ExceptionUtil.getOptionalInt(() -> {
+            throw new RuntimeException("fail");
+        }, LOG, "OptionalInt op failed: {}");
+        assertThat(result.isPresent(), is(false));
+    }
+
+    // -- getOptionalLong --
+
+    @Test
+    void testGetOptionalLongReturnsValue() {
+        OptionalLong result = ExceptionUtil.getOptionalLong(() -> 99L, LOG, "msg");
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.getAsLong(), is(99L));
+    }
+
+    @Test
+    void testGetOptionalLongReturnsEmptyOnException() {
+        OptionalLong result = ExceptionUtil.getOptionalLong(() -> {
+            throw new RuntimeException("fail");
+        }, LOG, "OptionalLong op failed: {}");
+        assertThat(result.isPresent(), is(false));
+    }
+
+    // -- runSilently --
+
+    @Test
+    void testRunSilentlyExecutes() {
+        List<String> evidence = new ArrayList<>();
+        ExceptionUtil.runSilently(() -> evidence.add("executed"));
+        assertThat(evidence.size(), is(1));
+    }
+
+    @Test
+    void testRunSilentlySwallowsException() {
+        // Should not throw
+        ExceptionUtil.runSilently(() -> {
+            throw new RuntimeException("fail");
+        });
+    }
+
+    @Test
+    void testRunSilentlySwallowsError() {
+        // Should not throw
+        ExceptionUtil.runSilently(() -> {
+            throw new StackOverflowError("simulated");
+        });
+    }
+
+    // -- runOrLog --
+
+    @Test
+    void testRunOrLogExecutes() {
+        List<String> evidence = new ArrayList<>();
+        ExceptionUtil.runOrLog(() -> evidence.add("executed"), LOG, "msg");
+        assertThat(evidence.size(), is(1));
+    }
+
+    @Test
+    void testRunOrLogHandlesException() {
+        // Should not throw
+        ExceptionUtil.runOrLog(() -> {
+            throw new RuntimeException("test error");
+        }, LOG, "RunOrLog failed: {}");
+    }
+
+    // -- Edge cases --
+
+    @Test
+    void testGetOrDefaultWithCollectionDefault() {
+        List<String> result = ExceptionUtil.getOrDefault(() -> {
+            throw new RuntimeException("fail");
+        }, Collections.emptyList());
+        assertThat(result, is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
@@ -98,6 +98,12 @@ class ExceptionUtilTest {
         assertThat(result, is(0));
     }
 
+    @Test
+    void testGetIntOrDefaultWithLoggingSuccess() {
+        int result = ExceptionUtil.getIntOrDefault(() -> 42, -1, LOG, "Should not log");
+        assertThat(result, is(42));
+    }
+
     // -- getLongOrDefault --
 
     @Test
@@ -120,6 +126,12 @@ class ExceptionUtilTest {
             throw new RuntimeException("fail");
         }, 0L, LOG, "Long op failed: {}");
         assertThat(result, is(0L));
+    }
+
+    @Test
+    void testGetLongOrDefaultWithLoggingSuccess() {
+        long result = ExceptionUtil.getLongOrDefault(() -> 100L, -1L, LOG, "Should not log");
+        assertThat(result, is(100L));
     }
 
     // -- getBooleanOrDefault --
@@ -146,6 +158,12 @@ class ExceptionUtilTest {
         assertThat(result, is(true));
     }
 
+    @Test
+    void testGetBooleanOrDefaultWithLoggingSuccess() {
+        boolean result = ExceptionUtil.getBooleanOrDefault(() -> true, false, LOG, "Should not log");
+        assertThat(result, is(true));
+    }
+
     // -- getDoubleOrDefault --
 
     @Test
@@ -168,6 +186,12 @@ class ExceptionUtilTest {
             throw new RuntimeException("fail");
         }, -1d, LOG, "Double op failed: {}");
         assertThat(result, is(-1d));
+    }
+
+    @Test
+    void testGetDoubleOrDefaultWithLoggingSuccess() {
+        double result = ExceptionUtil.getDoubleOrDefault(() -> 3.14, -1d, LOG, "Should not log");
+        assertThat(result, is(3.14));
     }
 
     // -- getOptional --

--- a/oshi-core-ffm/src/main/java/oshi/ffm/common/NvmlFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/common/NvmlFunctions.java
@@ -8,6 +8,7 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemoryLayout;
@@ -154,12 +155,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int init() {
-        try {
-            return (int) nvmlInit_v2.invokeExact();
-        } catch (Throwable t) {
-            LOG.debug("nvmlInit_v2 failed: {}", t.getMessage());
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlInit_v2.invokeExact(), -1, LOG, "nvmlInit_v2 failed: {}");
     }
 
     /**
@@ -168,12 +164,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int shutdown() {
-        try {
-            return (int) nvmlShutdown.invokeExact();
-        } catch (Throwable t) {
-            LOG.debug("nvmlShutdown failed: {}", t.getMessage());
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlShutdown.invokeExact(), -1, LOG, "nvmlShutdown failed: {}");
     }
 
     /**
@@ -183,11 +174,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int deviceGetCount(MemorySegment countSeg) {
-        try {
-            return (int) nvmlDeviceGetCount_v2.invokeExact(countSeg);
-        } catch (Throwable t) {
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlDeviceGetCount_v2.invokeExact(countSeg), -1);
     }
 
     /**
@@ -198,11 +185,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int deviceGetHandleByIndex(int index, MemorySegment handleSeg) {
-        try {
-            return (int) nvmlDeviceGetHandleByIndex_v2.invokeExact(index, handleSeg);
-        } catch (Throwable t) {
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlDeviceGetHandleByIndex_v2.invokeExact(index, handleSeg), -1);
     }
 
     /**
@@ -214,11 +197,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int deviceGetName(MemorySegment device, MemorySegment nameSeg, int length) {
-        try {
-            return (int) nvmlDeviceGetName.invokeExact(device, nameSeg, length);
-        } catch (Throwable t) {
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlDeviceGetName.invokeExact(device, nameSeg, length), -1);
     }
 
     /**
@@ -229,11 +208,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int deviceGetPciInfo(MemorySegment device, MemorySegment pciSeg) {
-        try {
-            return (int) nvmlDeviceGetPciInfo_v3.invokeExact(device, pciSeg);
-        } catch (Throwable t) {
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlDeviceGetPciInfo_v3.invokeExact(device, pciSeg), -1);
     }
 
     /**
@@ -244,11 +219,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int deviceGetUtilizationRates(MemorySegment device, MemorySegment utilSeg) {
-        try {
-            return (int) nvmlDeviceGetUtilizationRates.invokeExact(device, utilSeg);
-        } catch (Throwable t) {
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlDeviceGetUtilizationRates.invokeExact(device, utilSeg), -1);
     }
 
     /**
@@ -259,11 +230,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int deviceGetMemoryInfo(MemorySegment device, MemorySegment memSeg) {
-        try {
-            return (int) nvmlDeviceGetMemoryInfo.invokeExact(device, memSeg);
-        } catch (Throwable t) {
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlDeviceGetMemoryInfo.invokeExact(device, memSeg), -1);
     }
 
     /**
@@ -275,11 +242,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int deviceGetTemperature(MemorySegment device, int sensorType, MemorySegment tempSeg) {
-        try {
-            return (int) nvmlDeviceGetTemperature.invokeExact(device, sensorType, tempSeg);
-        } catch (Throwable t) {
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlDeviceGetTemperature.invokeExact(device, sensorType, tempSeg), -1);
     }
 
     /**
@@ -290,11 +253,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int deviceGetPowerUsage(MemorySegment device, MemorySegment powerSeg) {
-        try {
-            return (int) nvmlDeviceGetPowerUsage.invokeExact(device, powerSeg);
-        } catch (Throwable t) {
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlDeviceGetPowerUsage.invokeExact(device, powerSeg), -1);
     }
 
     /**
@@ -306,11 +265,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int deviceGetClockInfo(MemorySegment device, int clockType, MemorySegment clockSeg) {
-        try {
-            return (int) nvmlDeviceGetClockInfo.invokeExact(device, clockType, clockSeg);
-        } catch (Throwable t) {
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlDeviceGetClockInfo.invokeExact(device, clockType, clockSeg), -1);
     }
 
     /**
@@ -321,11 +276,7 @@ public final class NvmlFunctions extends ForeignFunctions {
      * @return NVML return code
      */
     public static int deviceGetFanSpeed(MemorySegment device, MemorySegment speedSeg) {
-        try {
-            return (int) nvmlDeviceGetFanSpeed.invokeExact(device, speedSeg);
-        } catch (Throwable t) {
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) nvmlDeviceGetFanSpeed.invokeExact(device, speedSeg), -1);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/mac/CoreFoundation.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/mac/CoreFoundation.java
@@ -34,6 +34,12 @@ import static oshi.ffm.mac.CoreFoundationFunctions.DATA_TYPE_ID;
 import static oshi.ffm.mac.CoreFoundationFunctions.DICTIONARY_TYPE_ID;
 import static oshi.ffm.mac.CoreFoundationFunctions.NUMBER_TYPE_ID;
 import static oshi.ffm.mac.CoreFoundationFunctions.STRING_TYPE_ID;
+import static oshi.util.ExceptionUtil.getBooleanOrDefault;
+import static oshi.util.ExceptionUtil.getDoubleOrDefault;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
+import static oshi.util.ExceptionUtil.getLongOrDefault;
+import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.ExceptionUtil.runSilently;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -106,11 +112,7 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try {
-                return CFGetTypeID(segment());
-            } catch (Throwable e) {
-                return 0;
-            }
+            return getLongOrDefault(() -> CFGetTypeID(segment()), 0);
         }
 
         /**
@@ -128,11 +130,7 @@ public interface CoreFoundation {
          */
         public void retain() {
             if (!isNull()) {
-                try {
-                    CFRetain(segment());
-                } catch (Throwable e) {
-                    // Ignore
-                }
+                runSilently(() -> CFRetain(segment()));
             }
         }
 
@@ -141,11 +139,7 @@ public interface CoreFoundation {
          */
         public void release() {
             if (!isNull()) {
-                try {
-                    CFRelease(segment());
-                } catch (Throwable e) {
-                    // Ignore
-                }
+                runSilently(() -> CFRelease(segment()));
             }
         }
 
@@ -161,11 +155,7 @@ public interface CoreFoundation {
             if (isNull() || cfTypeRef.isNull()) {
                 return isNull() == cfTypeRef.isNull();
             }
-            try {
-                return CFEqual(segment(), cfTypeRef.segment);
-            } catch (Throwable e) {
-                return false;
-            }
+            return getBooleanOrDefault(() -> CFEqual(segment(), cfTypeRef.segment()), false);
         }
 
         @Override
@@ -173,11 +163,7 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try {
-                return Long.hashCode(CFHash(segment()));
-            } catch (Throwable e) {
-                return Objects.hash(segment());
-            }
+            return getIntOrDefault(() -> Long.hashCode(CFHash(segment())), Objects.hash(segment()));
         }
     }
 
@@ -210,15 +196,15 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_LONG);
-                if (CFNumberGetValue(segment(), kCFNumberLongLongType, valuePtr)) {
-                    return valuePtr.get(ValueLayout.JAVA_LONG, 0);
+            return getLongOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_LONG);
+                    if (CFNumberGetValue(segment(), kCFNumberLongLongType, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_LONG, 0);
+                    }
+                    return 0L;
                 }
-                return 0;
-            } catch (Throwable e) {
-                return 0;
-            }
+            }, 0);
         }
 
         /**
@@ -230,15 +216,15 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_INT);
-                if (CFNumberGetValue(segment(), kCFNumberIntType, valuePtr)) {
-                    return valuePtr.get(ValueLayout.JAVA_INT, 0);
+            return getIntOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_INT);
+                    if (CFNumberGetValue(segment(), kCFNumberIntType, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_INT, 0);
+                    }
+                    return 0;
                 }
-                return 0;
-            } catch (Throwable e) {
-                return 0;
-            }
+            }, 0);
         }
 
         /**
@@ -250,15 +236,15 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_SHORT);
-                if (CFNumberGetValue(segment(), kCFNumberShortType, valuePtr)) {
-                    return valuePtr.get(ValueLayout.JAVA_SHORT, 0);
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_SHORT);
+                    if (CFNumberGetValue(segment(), kCFNumberShortType, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_SHORT, 0);
+                    }
+                    return (short) 0;
                 }
-                return 0;
-            } catch (Throwable e) {
-                return 0;
-            }
+            }, (short) 0);
         }
 
         /**
@@ -270,15 +256,15 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_BYTE);
-                if (CFNumberGetValue(segment(), kCFNumberCharType, valuePtr)) {
-                    return valuePtr.get(ValueLayout.JAVA_BYTE, 0);
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_BYTE);
+                    if (CFNumberGetValue(segment(), kCFNumberCharType, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_BYTE, 0);
+                    }
+                    return (byte) 0;
                 }
-                return 0;
-            } catch (Throwable e) {
-                return 0;
-            }
+            }, (byte) 0);
         }
 
         /**
@@ -290,15 +276,15 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_DOUBLE);
-                if (CFNumberGetValue(segment(), kCFNumberDoubleType, valuePtr)) {
-                    return valuePtr.get(ValueLayout.JAVA_DOUBLE, 0);
+            return getDoubleOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_DOUBLE);
+                    if (CFNumberGetValue(segment(), kCFNumberDoubleType, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_DOUBLE, 0);
+                    }
+                    return 0d;
                 }
-                return 0;
-            } catch (Throwable e) {
-                return 0;
-            }
+            }, 0);
         }
 
         /**
@@ -310,15 +296,15 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_FLOAT);
-                if (CFNumberGetValue(segment(), kCFNumberFloatType, valuePtr)) {
-                    return valuePtr.get(ValueLayout.JAVA_FLOAT, 0);
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_FLOAT);
+                    if (CFNumberGetValue(segment(), kCFNumberFloatType, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_FLOAT, 0);
+                    }
+                    return 0f;
                 }
-                return 0;
-            } catch (Throwable e) {
-                return 0;
-            }
+            }, 0f);
         }
     }
 
@@ -342,11 +328,7 @@ public interface CoreFoundation {
             if (isNull()) {
                 return false;
             }
-            try {
-                return CFBooleanGetValue(segment()) != 0;
-            } catch (Throwable e) {
-                return false;
-            }
+            return getBooleanOrDefault(() -> CFBooleanGetValue(segment()) != 0, false);
         }
     }
 
@@ -370,11 +352,7 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try {
-                return (int) CFArrayGetCount(segment());
-            } catch (Throwable e) {
-                return 0;
-            }
+            return getIntOrDefault(() -> (int) CFArrayGetCount(segment()), 0);
         }
 
         /**
@@ -387,11 +365,7 @@ public interface CoreFoundation {
             if (isNull()) {
                 return MemorySegment.NULL;
             }
-            try {
-                return CFArrayGetValueAtIndex(segment(), idx);
-            } catch (Throwable e) {
-                return MemorySegment.NULL;
-            }
+            return getOrDefault(() -> CFArrayGetValueAtIndex(segment(), idx), MemorySegment.NULL);
         }
     }
 
@@ -415,11 +389,7 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try {
-                return (int) CFDataGetLength(segment());
-            } catch (Throwable e) {
-                return 0;
-            }
+            return getIntOrDefault(() -> (int) CFDataGetLength(segment()), 0);
         }
 
         /**
@@ -431,11 +401,7 @@ public interface CoreFoundation {
             if (isNull()) {
                 return MemorySegment.NULL;
             }
-            try {
-                return CFDataGetBytePtr(segment());
-            } catch (Throwable e) {
-                return MemorySegment.NULL;
-            }
+            return getOrDefault(() -> CFDataGetBytePtr(segment()), MemorySegment.NULL);
         }
 
         /**
@@ -447,13 +413,13 @@ public interface CoreFoundation {
             if (isNull()) {
                 return new byte[0];
             }
-            try (Arena arena = Arena.ofConfined()) {
-                int length = getLength();
-                MemorySegment bytePtr = getBytePtr();
-                return getByteArrayFromNativePointer(bytePtr, length, arena);
-            } catch (Throwable e) {
-                return new byte[0];
-            }
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    int length = getLength();
+                    MemorySegment bytePtr = getBytePtr();
+                    return getByteArrayFromNativePointer(bytePtr, length, arena);
+                }
+            }, new byte[0]);
         }
     }
 
@@ -478,11 +444,7 @@ public interface CoreFoundation {
             if (isNull() || key == null || key.isNull()) {
                 return MemorySegment.NULL;
             }
-            try {
-                return CFDictionaryGetValue(segment(), key.segment);
-            } catch (Throwable e) {
-                return MemorySegment.NULL;
-            }
+            return getOrDefault(() -> CFDictionaryGetValue(segment(), key.segment()), MemorySegment.NULL);
         }
 
         /**
@@ -494,11 +456,7 @@ public interface CoreFoundation {
             if (isNull()) {
                 return 0;
             }
-            try {
-                return CFDictionaryGetCount(segment());
-            } catch (Throwable e) {
-                return 0;
-            }
+            return getLongOrDefault(() -> CFDictionaryGetCount(segment()), 0);
         }
 
         /**
@@ -512,11 +470,8 @@ public interface CoreFoundation {
             if (isNull() || key == null || key.isNull()) {
                 return false;
             }
-            try {
-                return CFDictionaryGetValueIfPresent(segment(), key.segment, value) != 0;
-            } catch (Throwable e) {
-                return false;
-            }
+            return getBooleanOrDefault(() -> CFDictionaryGetValueIfPresent(segment(), key.segment(), value) != 0,
+                    false);
         }
     }
 
@@ -538,11 +493,7 @@ public interface CoreFoundation {
             if (isNull() || key == null || key.isNull() || value == null || value.isNull()) {
                 return;
             }
-            try {
-                CFDictionarySetValue(segment(), key.segment, value.segment);
-            } catch (Throwable e) {
-                // Ignore
-            }
+            runSilently(() -> CFDictionarySetValue(segment(), key.segment(), value.segment()));
         }
     }
 
@@ -564,17 +515,17 @@ public interface CoreFoundation {
          * @return The CFString
          */
         public static CFStringRef createCFString(String s) {
-            try (Arena arena = Arena.ofConfined()) {
-                char[] chars = s.toCharArray();
-                MemorySegment charsSeg = arena.allocateFrom(ValueLayout.JAVA_CHAR, chars);
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    char[] chars = s.toCharArray();
+                    MemorySegment charsSeg = arena.allocateFrom(ValueLayout.JAVA_CHAR, chars);
 
-                MemorySegment allocator = CFAllocatorGetDefault();
-                MemorySegment stringRef = CFStringCreateWithCharacters(allocator, charsSeg, chars.length);
+                    MemorySegment allocator = CFAllocatorGetDefault();
+                    MemorySegment stringRef = CFStringCreateWithCharacters(allocator, charsSeg, chars.length);
 
-                return new CFStringRef(stringRef);
-            } catch (Throwable e) {
-                return new CFStringRef(MemorySegment.NULL);
-            }
+                    return new CFStringRef(stringRef);
+                }
+            }, new CFStringRef(MemorySegment.NULL));
         }
 
         /**
@@ -586,30 +537,29 @@ public interface CoreFoundation {
             if (isNull()) {
                 return "";
             }
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    // Get length and calculate buffer size
+                    long length = CFStringGetLength(segment());
+                    if (length == 0) {
+                        return "";
+                    }
 
-            try (Arena arena = Arena.ofConfined()) {
-                // Get length and calculate buffer size
-                long length = CFStringGetLength(segment());
-                if (length == 0) {
-                    return "";
+                    long maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
+                    if (maxSize == CoreFoundation.kCFNotFound) {
+                        throw new StringIndexOutOfBoundsException("CFString maximum number of bytes exceeds LONG_MAX.");
+                    }
+
+                    // Allocate buffer (add 1 for null terminator)
+                    MemorySegment buf = arena.allocate(maxSize + 1);
+
+                    if (CFStringGetCString(segment(), buf, maxSize + 1, kCFStringEncodingUTF8)) {
+                        return buf.getString(0);
+                    }
+
+                    throw new IllegalArgumentException("CFString conversion failed or buffer too small.");
                 }
-
-                long maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
-                if (maxSize == CoreFoundation.kCFNotFound) {
-                    throw new StringIndexOutOfBoundsException("CFString maximum number of bytes exceeds LONG_MAX.");
-                }
-
-                // Allocate buffer (add 1 for null terminator)
-                MemorySegment buf = arena.allocate(maxSize + 1);
-
-                if (CFStringGetCString(segment(), buf, maxSize + 1, kCFStringEncodingUTF8)) {
-                    return buf.getString(0);
-                }
-
-                throw new IllegalArgumentException("CFString conversion failed or buffer too small.");
-            } catch (Throwable e) {
-                return "";
-            }
+            }, "");
         }
     }
 
@@ -627,11 +577,7 @@ public interface CoreFoundation {
          * @return The current locale
          */
         public static CFLocale copyCurrent() {
-            try {
-                return new CFLocale(CFLocaleCopyCurrent());
-            } catch (Throwable e) {
-                return new CFLocale(MemorySegment.NULL);
-            }
+            return getOrDefault(() -> new CFLocale(CFLocaleCopyCurrent()), new CFLocale(MemorySegment.NULL));
         }
     }
 
@@ -653,15 +599,13 @@ public interface CoreFoundation {
          * @return A new date formatter
          */
         public static CFDateFormatter create(CFAllocatorRef allocator, CFLocale locale, int dateStyle, int timeStyle) {
-            try {
+            return getOrDefault(() -> {
                 MemorySegment allocSeg = allocator != null ? allocator.segment() : MemorySegment.NULL;
                 MemorySegment localeSeg = locale != null ? locale.segment() : MemorySegment.NULL;
 
                 MemorySegment formatter = CFDateFormatterCreate(allocSeg, localeSeg, dateStyle, timeStyle);
                 return new CFDateFormatter(formatter);
-            } catch (Throwable e) {
-                return new CFDateFormatter(MemorySegment.NULL);
-            }
+            }, new CFDateFormatter(MemorySegment.NULL));
         }
 
         /**
@@ -673,11 +617,8 @@ public interface CoreFoundation {
             if (isNull()) {
                 return new CFStringRef(MemorySegment.NULL);
             }
-            try {
-                return new CFStringRef(CFDateFormatterGetFormat(segment()));
-            } catch (Throwable e) {
-                return new CFStringRef(MemorySegment.NULL);
-            }
+            return getOrDefault(() -> new CFStringRef(CFDateFormatterGetFormat(segment())),
+                    new CFStringRef(MemorySegment.NULL));
         }
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/mac/IOKit.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/mac/IOKit.java
@@ -29,6 +29,11 @@ import static oshi.ffm.mac.IOKitFunctions.IORegistryEntryGetName;
 import static oshi.ffm.mac.IOKitFunctions.IORegistryEntryGetParentEntry;
 import static oshi.ffm.mac.IOKitFunctions.IORegistryEntryGetRegistryEntryID;
 import static oshi.ffm.mac.IOKitFunctions.IORegistryEntrySearchCFProperty;
+import static oshi.util.ExceptionUtil.getBooleanOrDefault;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
+import static oshi.util.ExceptionUtil.getLongOrDefault;
+import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.ExceptionUtil.runSilently;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -67,23 +72,19 @@ public interface IOKit {
             if (isNull()) {
                 return 0;
             }
-            try {
-                return IOObjectRelease(segment);
-            } catch (Throwable e) {
-                return -1;
-            }
+            return getIntOrDefault(() -> IOObjectRelease(segment), -1);
         }
 
         public boolean conformsTo(String className) {
             if (isNull()) {
                 return false;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment classNameStr = arena.allocateFrom(className);
-                return IOObjectConformsTo(segment, classNameStr);
-            } catch (Throwable e) {
-                return false;
-            }
+            return getBooleanOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment classNameStr = arena.allocateFrom(className);
+                    return IOObjectConformsTo(segment, classNameStr);
+                }
+            }, false);
         }
     }
 
@@ -96,12 +97,10 @@ public interface IOKit {
             if (isNull()) {
                 return null;
             }
-            try {
+            return getOrDefault(() -> {
                 MemorySegment nextObj = IOIteratorNext(segment());
                 return nextObj.equals(MemorySegment.NULL) ? null : new IORegistryEntry(nextObj);
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         public List<IORegistryEntry> listEntries() {
@@ -127,251 +126,249 @@ public interface IOKit {
             if (isNull()) {
                 return 0;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment idSeg = arena.allocate(ValueLayout.JAVA_LONG);
-                int result = IORegistryEntryGetRegistryEntryID(segment(), idSeg);
-                if (result != 0) {
-                    return 0;
+            return getLongOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment idSeg = arena.allocate(ValueLayout.JAVA_LONG);
+                    int result = IORegistryEntryGetRegistryEntryID(segment(), idSeg);
+                    if (result != 0) {
+                        return 0L;
+                    }
+                    return idSeg.get(ValueLayout.JAVA_LONG, 0);
                 }
-                return idSeg.get(ValueLayout.JAVA_LONG, 0);
-            } catch (Throwable e) {
-                return 0;
-            }
+            }, 0);
         }
 
         public String getName() {
             if (isNull()) {
                 return null;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment nameSeg = arena.allocate(128);
-                int result = IORegistryEntryGetName(segment(), nameSeg);
-                if (result != 0) {
-                    return null;
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment nameSeg = arena.allocate(128);
+                    int result = IORegistryEntryGetName(segment(), nameSeg);
+                    if (result != 0) {
+                        return null;
+                    }
+                    return nameSeg.getString(0);
                 }
-                return nameSeg.getString(0);
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         public IOIterator getChildIterator(String plane) {
             if (isNull()) {
                 return null;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment planeStr = arena.allocateFrom(plane);
-                MemorySegment iterSeg = arena.allocate(ADDRESS);
-                int result = IORegistryEntryGetChildIterator(segment(), planeStr, iterSeg);
-                if (result != 0) {
-                    return null;
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment planeStr = arena.allocateFrom(plane);
+                    MemorySegment iterSeg = arena.allocate(ADDRESS);
+                    int result = IORegistryEntryGetChildIterator(segment(), planeStr, iterSeg);
+                    if (result != 0) {
+                        return null;
+                    }
+                    MemorySegment iterator = iterSeg.get(ADDRESS, 0);
+                    return iterator.equals(MemorySegment.NULL) ? null : new IOIterator(iterator);
                 }
-                MemorySegment iterator = iterSeg.get(ADDRESS, 0);
-                return iterator.equals(MemorySegment.NULL) ? null : new IOIterator(iterator);
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         public IORegistryEntry getChildEntry(String plane) {
             if (isNull()) {
                 return null;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment planeStr = arena.allocateFrom(plane);
-                MemorySegment childSeg = arena.allocate(ADDRESS);
-                int result = IORegistryEntryGetChildEntry(segment(), planeStr, childSeg);
-                if (result == kIOReturnNoDevice || result != 0) {
-                    return null;
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment planeStr = arena.allocateFrom(plane);
+                    MemorySegment childSeg = arena.allocate(ADDRESS);
+                    int result = IORegistryEntryGetChildEntry(segment(), planeStr, childSeg);
+                    if (result == kIOReturnNoDevice || result != 0) {
+                        return null;
+                    }
+                    MemorySegment child = childSeg.get(ADDRESS, 0);
+                    return child.equals(MemorySegment.NULL) ? null : new IORegistryEntry(child);
                 }
-                MemorySegment child = childSeg.get(ADDRESS, 0);
-                return child.equals(MemorySegment.NULL) ? null : new IORegistryEntry(child);
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         public IORegistryEntry getParentEntry(String plane) {
             if (isNull()) {
                 return null;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment planeStr = arena.allocateFrom(plane);
-                MemorySegment parentSeg = arena.allocate(ADDRESS);
-                int result = IORegistryEntryGetParentEntry(segment(), planeStr, parentSeg);
-                if (result == kIOReturnNoDevice || result != 0) {
-                    return null;
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment planeStr = arena.allocateFrom(plane);
+                    MemorySegment parentSeg = arena.allocate(ADDRESS);
+                    int result = IORegistryEntryGetParentEntry(segment(), planeStr, parentSeg);
+                    if (result == kIOReturnNoDevice || result != 0) {
+                        return null;
+                    }
+                    MemorySegment parent = parentSeg.get(ADDRESS, 0);
+                    return parent.equals(MemorySegment.NULL) ? null : new IORegistryEntry(parent);
                 }
-                MemorySegment parent = parentSeg.get(ADDRESS, 0);
-                return parent.equals(MemorySegment.NULL) ? null : new IORegistryEntry(parent);
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         public MemorySegment createCFProperty(MemorySegment key) {
             if (isNull()) {
                 return MemorySegment.NULL;
             }
-            try {
+            return getOrDefault(() -> {
                 MemorySegment allocator = CFAllocatorGetDefault();
                 return IORegistryEntryCreateCFProperty(segment(), key, allocator, 0);
-            } catch (Throwable e) {
-                return MemorySegment.NULL;
-            }
+            }, MemorySegment.NULL);
         }
 
         public MemorySegment createCFProperties() {
             if (isNull()) {
                 return MemorySegment.NULL;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment propsSeg = arena.allocate(ADDRESS);
-                MemorySegment allocator = CFAllocatorGetDefault();
-                int result = IORegistryEntryCreateCFProperties(segment(), propsSeg, allocator, 0);
-                if (result != 0) {
-                    return MemorySegment.NULL;
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment propsSeg = arena.allocate(ADDRESS);
+                    MemorySegment allocator = CFAllocatorGetDefault();
+                    int result = IORegistryEntryCreateCFProperties(segment(), propsSeg, allocator, 0);
+                    if (result != 0) {
+                        return MemorySegment.NULL;
+                    }
+                    return propsSeg.get(ADDRESS, 0);
                 }
-                return propsSeg.get(ADDRESS, 0);
-            } catch (Throwable e) {
-                return MemorySegment.NULL;
-            }
+            }, MemorySegment.NULL);
         }
 
         public MemorySegment searchCFProperty(String plane, MemorySegment key, int options) {
             if (isNull()) {
                 return MemorySegment.NULL;
             }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment planeStr = arena.allocateFrom(plane);
-                MemorySegment allocator = CFAllocatorGetDefault();
-                return IORegistryEntrySearchCFProperty(segment(), planeStr, key, allocator, options);
-            } catch (Throwable e) {
-                return MemorySegment.NULL;
-            }
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment planeStr = arena.allocateFrom(plane);
+                    MemorySegment allocator = CFAllocatorGetDefault();
+                    return IORegistryEntrySearchCFProperty(segment(), planeStr, key, allocator, options);
+                }
+            }, MemorySegment.NULL);
         }
 
         // Property accessor methods
         public String getStringProperty(String key) {
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment cfKey = createCFString(key, arena);
-                MemorySegment cfValue = null;
-                try {
-                    cfValue = createCFProperty(cfKey);
-                    if (cfValue.equals(MemorySegment.NULL)) {
-                        return null;
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment cfKey = createCFString(key, arena);
+                    MemorySegment cfValue = null;
+                    try {
+                        cfValue = createCFProperty(cfKey);
+                        if (cfValue.equals(MemorySegment.NULL)) {
+                            return null;
+                        }
+                        return getStringFromCFString(cfValue, arena);
+                    } finally {
+                        releaseCFObjects(cfKey, cfValue);
                     }
-                    return getStringFromCFString(cfValue, arena);
-                } finally {
-                    releaseCFObjects(cfKey, cfValue);
                 }
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         public Long getLongProperty(String key) {
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment cfKey = createCFString(key, arena);
-                MemorySegment cfValue = null;
-                try {
-                    cfValue = createCFProperty(cfKey);
-                    if (cfValue.equals(MemorySegment.NULL)) {
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment cfKey = createCFString(key, arena);
+                    MemorySegment cfValue = null;
+                    try {
+                        cfValue = createCFProperty(cfKey);
+                        if (cfValue.equals(MemorySegment.NULL)) {
+                            return null;
+                        }
+                        MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_LONG);
+                        if (CFNumberGetValue(cfValue, kCFNumberSInt64Type, valuePtr)) {
+                            return valuePtr.get(ValueLayout.JAVA_LONG, 0);
+                        }
                         return null;
+                    } finally {
+                        releaseCFObjects(cfKey, cfValue);
                     }
-                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_LONG);
-                    if (CFNumberGetValue(cfValue, kCFNumberSInt64Type, valuePtr)) {
-                        return valuePtr.get(ValueLayout.JAVA_LONG, 0);
-                    }
-                    return null;
-                } finally {
-                    releaseCFObjects(cfKey, cfValue);
                 }
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         public Integer getIntegerProperty(String key) {
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment cfKey = createCFString(key, arena);
-                MemorySegment cfValue = null;
-                try {
-                    cfValue = createCFProperty(cfKey);
-                    if (cfValue.equals(MemorySegment.NULL)) {
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment cfKey = createCFString(key, arena);
+                    MemorySegment cfValue = null;
+                    try {
+                        cfValue = createCFProperty(cfKey);
+                        if (cfValue.equals(MemorySegment.NULL)) {
+                            return null;
+                        }
+                        MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_INT);
+                        if (CFNumberGetValue(cfValue, kCFNumberSInt32Type, valuePtr)) {
+                            return valuePtr.get(ValueLayout.JAVA_INT, 0);
+                        }
                         return null;
+                    } finally {
+                        releaseCFObjects(cfKey, cfValue);
                     }
-                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_INT);
-                    if (CFNumberGetValue(cfValue, kCFNumberSInt32Type, valuePtr)) {
-                        return valuePtr.get(ValueLayout.JAVA_INT, 0);
-                    }
-                    return null;
-                } finally {
-                    releaseCFObjects(cfKey, cfValue);
                 }
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         public Double getDoubleProperty(String key) {
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment cfKey = createCFString(key, arena);
-                MemorySegment cfValue = null;
-                try {
-                    cfValue = createCFProperty(cfKey);
-                    if (cfValue.equals(MemorySegment.NULL)) {
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment cfKey = createCFString(key, arena);
+                    MemorySegment cfValue = null;
+                    try {
+                        cfValue = createCFProperty(cfKey);
+                        if (cfValue.equals(MemorySegment.NULL)) {
+                            return null;
+                        }
+                        MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_DOUBLE);
+                        if (CFNumberGetValue(cfValue, kCFNumberFloat64Type, valuePtr)) {
+                            return valuePtr.get(ValueLayout.JAVA_DOUBLE, 0);
+                        }
                         return null;
+                    } finally {
+                        releaseCFObjects(cfKey, cfValue);
                     }
-                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_DOUBLE);
-                    if (CFNumberGetValue(cfValue, kCFNumberFloat64Type, valuePtr)) {
-                        return valuePtr.get(ValueLayout.JAVA_DOUBLE, 0);
-                    }
-                    return null;
-                } finally {
-                    releaseCFObjects(cfKey, cfValue);
                 }
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         public byte[] getByteArrayProperty(String key) {
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment cfKey = createCFString(key, arena);
-                MemorySegment cfValue = null;
-                try {
-                    cfValue = createCFProperty(cfKey);
-                    if (cfValue.equals(MemorySegment.NULL)) {
-                        return null;
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment cfKey = createCFString(key, arena);
+                    MemorySegment cfValue = null;
+                    try {
+                        cfValue = createCFProperty(cfKey);
+                        if (cfValue.equals(MemorySegment.NULL)) {
+                            return null;
+                        }
+                        long length = CFDataGetLength(cfValue);
+                        MemorySegment bytePtr = CFDataGetBytePtr(cfValue);
+                        return getByteArrayFromNativePointer(bytePtr, length, arena);
+                    } finally {
+                        releaseCFObjects(cfKey, cfValue);
                     }
-                    long length = CFDataGetLength(cfValue);
-                    MemorySegment bytePtr = CFDataGetBytePtr(cfValue);
-                    return getByteArrayFromNativePointer(bytePtr, length, arena);
-                } finally {
-                    releaseCFObjects(cfKey, cfValue);
                 }
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         public Boolean getBooleanProperty(String key) {
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment cfKey = createCFString(key, arena);
-                MemorySegment cfValue = null;
-                try {
-                    cfValue = createCFProperty(cfKey);
-                    if (cfValue.equals(MemorySegment.NULL)) {
-                        return null;
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment cfKey = createCFString(key, arena);
+                    MemorySegment cfValue = null;
+                    try {
+                        cfValue = createCFProperty(cfKey);
+                        if (cfValue.equals(MemorySegment.NULL)) {
+                            return null;
+                        }
+                        return CFBooleanGetValue(cfValue) != 0;
+                    } finally {
+                        releaseCFObjects(cfKey, cfValue);
                     }
-                    return CFBooleanGetValue(cfValue) != 0;
-                } finally {
-                    releaseCFObjects(cfKey, cfValue);
                 }
-            } catch (Throwable e) {
-                return null;
-            }
+            }, null);
         }
 
         private static MemorySegment createCFString(String str, Arena arena) throws Throwable {
@@ -410,11 +407,7 @@ public interface IOKit {
     private static void releaseCFObjects(MemorySegment... cfObjects) {
         for (MemorySegment segment : cfObjects) {
             if (segment != null && !segment.equals(MemorySegment.NULL)) {
-                try {
-                    CoreFoundationFunctions.CFRelease(segment);
-                } catch (Throwable e) {
-                    // Ignore
-                }
+                runSilently(() -> CoreFoundationFunctions.CFRelease(segment));
             }
         }
     }


### PR DESCRIPTION
## Summary

Introduces `oshi.util.ExceptionUtil` — a utility class that consolidates the repetitive try/catch/return-default pattern used extensively in FFM native call wrappers.

## Problem

The codebase has **278 `catch (Throwable)` blocks**, almost all in the FFM module, following the same pattern:
```java
try {
    return (int) handle.invokeExact(args);
} catch (Throwable t) {
    LOG.debug("X failed: {}", t.getMessage());
    return -1;
}
```

This creates significant duplication (~760 lines of boilerplate) and makes the error-handling paths untestable.

## Solution

`ExceptionUtil` provides functional interfaces and utility methods:
- `getOrDefault(ThrowingSupplier<T>, T)` — silent variant
- `getOrDefault(ThrowingSupplier<T>, T, Logger, String)` — logging variant
- `getIntOrDefault`, `getLongOrDefault`, `getBooleanOrDefault`, `getDoubleOrDefault` — primitive variants
- `getOptional`, `getOptionalInt`, `getOptionalLong` — Optional-returning variants
- `runSilently`, `runOrLog` — void operation variants

### Before:
```java
public static int deviceGetCount(MemorySegment countSeg) {
    try {
        return (int) nvmlDeviceGetCount_v2.invokeExact(countSeg);
    } catch (Throwable t) {
        return -1;
    }
}
```

### After:
```java
public static int deviceGetCount(MemorySegment countSeg) {
    return ExceptionUtil.getIntOrDefault(() -> (int) nvmlDeviceGetCount_v2.invokeExact(countSeg), -1);
}
```

## Changes

- **New**: `oshi-common/.../util/ExceptionUtil.java` — the utility class
- **New**: `oshi-common/.../util/ExceptionUtilTest.java` — 30 test cases
- **Refactored**: `NvmlFunctions.java` (13 catch blocks → one-liners)
- **Refactored**: `CoreFoundation.java` (26 catch blocks → one-liners)
- **Refactored**: `IOKit.java` (18 catch blocks → one-liners)

Net: ~400 lines of boilerplate eliminated in this PR. The same pattern can be applied to the remaining ~220 `catch(Throwable)` blocks in follow-up PRs.

## Testing

- `ExceptionUtilTest` covers all methods with success, exception, and error (Throwable) paths
- `oshi-common` full test suite passes
- Both `oshi-common` and `oshi-core-ffm` compile cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized exception handling via a new utility so native/system modules consistently return safe defaults (or empty optionals) and avoid propagating errors.
* **Tests**
  * Added tests validating default-returning, optional-returning, and silent/logging behaviors to ensure consistent fallback behavior across failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->