### PR TITLE
Apply ExceptionUtil to remaining FFM files

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.driver.mac;
 
+import static oshi.util.ExceptionUtil.runSilently;
+
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -333,11 +335,7 @@ public final class IOReportClientFFM {
 
     private static void cfRelease(MemorySegment seg) {
         if (seg != null && !seg.equals(MemorySegment.NULL)) {
-            try {
-                oshi.ffm.mac.CoreFoundationFunctions.CFRelease(seg);
-            } catch (Throwable ignored) {
-                // CFRelease declares throws Throwable; swallow in cleanup path
-            }
+            runSilently(() -> oshi.ffm.mac.CoreFoundationFunctions.CFRelease(seg));
         }
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilFFM.java
@@ -27,6 +27,7 @@ import static oshi.ffm.windows.WinPerfFFM.PERF_OBJECT_TYPE_ObjectNameTitleIndex;
 import static oshi.ffm.windows.WinPerfFFM.PERF_OBJECT_TYPE_TotalByteLength;
 import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
+import static oshi.util.ExceptionUtil.getOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -229,7 +230,7 @@ public final class HkeyPerformanceDataUtilFFM extends HkeyPerformanceDataUtil {
         // Now load the data from the registry.
         // Use a global arena so the returned segment outlives this method
         Arena arena = Arena.ofAuto();
-        try {
+        return getOrDefault(() -> {
             MemorySegment lpValueName = toWideString(arena, objectIndexStr);
             MemorySegment lpcbData = arena.allocate(JAVA_INT);
             lpcbData.set(JAVA_INT, 0, maxPerfBufferSize);
@@ -254,10 +255,7 @@ public final class HkeyPerformanceDataUtilFFM extends HkeyPerformanceDataUtil {
                 return null;
             }
             return pPerfData;
-        } catch (Throwable t) {
-            LOG.error("Error reading performance data from registry for {}.", objectName, t);
-            return null;
-        }
+        }, null, LOG, "Error reading performance data from registry for {}.");
     }
 
     /*

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/HkeyUserDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/HkeyUserDataFFM.java
@@ -17,6 +17,8 @@ import static oshi.ffm.windows.WinErrorFFM.ERROR_SUCCESS;
 import static oshi.ffm.windows.WinNTFFM.KEY_READ;
 import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.windows.WindowsForeignFunctions.toWideString;
+import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.ExceptionUtil.runOrLog;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -53,7 +55,7 @@ public final class HkeyUserDataFFM {
     public static List<OSSession> queryUserSessions() {
         List<OSSession> sessions = new ArrayList<>();
         MemorySegment hKeyUsers = MemorySegment.ofAddress(WinRegFFM.HKEY_USERS);
-        try {
+        runOrLog(() -> {
             String[] sidKeys = Advapi32UtilFFM.registryGetKeys(hKeyUsers);
             for (String sidKey : sidKeys) {
                 if (!sidKey.startsWith(".") && !sidKey.endsWith("_Classes")) {
@@ -94,9 +96,7 @@ public final class HkeyUserDataFFM {
                     }
                 }
             }
-        } catch (Throwable t) {
-            LOG.warn("Error enumerating HKEY_USERS: {}", t.getMessage());
-        }
+        }, LOG, "Error enumerating HKEY_USERS: {}");
         return sessions;
     }
 
@@ -177,11 +177,7 @@ public final class HkeyUserDataFFM {
     }
 
     private static String[] getSubKeys(MemorySegment rootKey, String keyPath) {
-        try {
-            return Advapi32UtilFFM.registryGetKeys(rootKey, keyPath, 0);
-        } catch (Throwable t) {
-            LOG.debug("Error getting subkeys for {}: {}", keyPath, t.getMessage());
-            return new String[0];
-        }
+        return getOrDefault(() -> Advapi32UtilFFM.registryGetKeys(rootKey, keyPath, 0), new String[0], LOG,
+                "Error getting subkeys for {}: {}");
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/mac/DiskArbitration.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/mac/DiskArbitration.java
@@ -9,6 +9,7 @@ import static oshi.ffm.mac.DiskArbitrationFunctions.DADiskCreateFromBSDName;
 import static oshi.ffm.mac.DiskArbitrationFunctions.DADiskCreateFromIOMedia;
 import static oshi.ffm.mac.DiskArbitrationFunctions.DADiskGetBSDName;
 import static oshi.ffm.mac.DiskArbitrationFunctions.DASessionCreate;
+import static oshi.util.ExceptionUtil.getOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -39,13 +40,11 @@ public interface DiskArbitration {
          * @return A reference to a new DASession
          */
         public static DASessionRef create(CFAllocatorRef allocator) {
-            try {
+            return getOrDefault(() -> {
                 MemorySegment allocSeg = allocator != null ? allocator.segment() : MemorySegment.NULL;
                 MemorySegment sessionSeg = DASessionCreate(allocSeg);
                 return new DASessionRef(sessionSeg);
-            } catch (Throwable e) {
-                return new DASessionRef(MemorySegment.NULL);
-            }
+            }, new DASessionRef(MemorySegment.NULL));
         }
     }
 
@@ -87,15 +86,13 @@ public interface DiskArbitration {
          */
         public static DADiskRef createFromIOMedia(CFAllocatorRef allocator, DASessionRef session,
                 IOKit.IOObject media) {
-            try {
+            return getOrDefault(() -> {
                 MemorySegment allocSeg = allocator != null ? allocator.segment() : MemorySegment.NULL;
                 MemorySegment sessionSeg = session != null ? session.segment() : MemorySegment.NULL;
                 MemorySegment mediaSeg = media != null ? media.segment() : MemorySegment.NULL;
                 MemorySegment diskSeg = DADiskCreateFromIOMedia(allocSeg, sessionSeg, mediaSeg);
                 return new DADiskRef(diskSeg);
-            } catch (Throwable e) {
-                return new DADiskRef(MemorySegment.NULL);
-            }
+            }, new DADiskRef(MemorySegment.NULL));
         }
 
         /**
@@ -107,12 +104,10 @@ public interface DiskArbitration {
             if (isNull()) {
                 return new CFDictionaryRef(MemorySegment.NULL);
             }
-            try {
+            return getOrDefault(() -> {
                 MemorySegment dictSeg = DADiskCopyDescription(segment());
                 return new CFDictionaryRef(dictSeg);
-            } catch (Throwable e) {
-                return new CFDictionaryRef(MemorySegment.NULL);
-            }
+            }, new CFDictionaryRef(MemorySegment.NULL));
         }
 
         /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/IOKitUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/IOKitUtilFFM.java
@@ -14,6 +14,8 @@ import static oshi.ffm.mac.IOKitFunctions.IOServiceGetMatchingServices;
 import static oshi.ffm.mac.IOKitFunctions.IOServiceMatching;
 import static oshi.ffm.mac.MacSystemFunctions.mach_port_deallocate;
 import static oshi.ffm.mac.MacSystemFunctions.mach_task_self;
+import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.ExceptionUtil.runSilently;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -54,14 +56,12 @@ public final class IOKitUtilFFM {
      * @return a handle to the IORoot. Callers should release when finished.
      */
     public static IORegistryEntry getRoot() {
-        try {
+        return getOrDefault(() -> {
             int masterPort = getMasterPort();
             MemorySegment root = IORegistryGetRootEntry(masterPort);
             deallocatePort(masterPort);
             return root.equals(MemorySegment.NULL) ? null : new IORegistryEntry(root);
-        } catch (Throwable e) {
-            return null;
-        }
+        }, null);
     }
 
     /**
@@ -90,14 +90,12 @@ public final class IOKitUtilFFM {
      * @return a handle to an IOService if successful, {@code null} if failed. Callers should release when finished.
      */
     public static IOService getMatchingService(MemorySegment matchingDictionary) {
-        try {
+        return getOrDefault(() -> {
             int masterPort = getMasterPort();
             MemorySegment service = IOServiceGetMatchingService(masterPort, matchingDictionary);
             deallocatePort(masterPort);
             return service.equals(MemorySegment.NULL) ? null : new IOService(service);
-        } catch (Throwable e) {
-            return null;
-        }
+        }, null);
     }
 
     /**
@@ -169,12 +167,10 @@ public final class IOKitUtilFFM {
      * @param port the port to deallocate
      */
     private static void deallocatePort(int port) {
-        try {
+        runSilently(() -> {
             if (port != 0) {
                 mach_port_deallocate(mach_task_self(), port);
             }
-        } catch (Throwable e) {
-            // Ignore
-        }
+        });
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -23,6 +23,7 @@ import static oshi.ffm.mac.MacSystem.SMC_VAL_BYTES;
 import static oshi.ffm.mac.MacSystem.SMC_VAL_DATA_SIZE;
 import static oshi.ffm.mac.MacSystem.SMC_VAL_DATA_TYPE;
 import static oshi.ffm.mac.MacSystemFunctions.mach_task_self;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -117,11 +118,7 @@ public final class SmcUtilFFM {
      * @return 0 if successful, nonzero if failure
      */
     public static int smcClose(int conn) {
-        try {
-            return IOServiceClose(conn);
-        } catch (Throwable e) {
-            return -1;
-        }
+        return getIntOrDefault(() -> IOServiceClose(conn), -1);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/Advapi32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/Advapi32FFM.java
@@ -6,6 +6,7 @@ package oshi.ffm.windows;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.util.ExceptionUtil.getOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -60,16 +61,14 @@ public final class Advapi32FFM extends WindowsForeignFunctions {
     }
 
     public static Optional<MemorySegment> OpenEventLog(Arena arena, String source) {
-        try {
+        return getOrDefault(() -> {
             MemorySegment lpSource = WindowsForeignFunctions.toWideString(arena, source);
             MemorySegment handle = (MemorySegment) OpenEventLog.invokeExact(MemorySegment.NULL, lpSource);
             if (handle.address() == 0) {
                 return Optional.empty();
             }
             return Optional.of(handle);
-        } catch (Throwable t) {
-            return Optional.empty();
-        }
+        }, Optional.empty());
     }
 
     private static final MethodHandle OpenProcessToken = downcall(ADV, "OpenProcessToken", JAVA_INT, ADDRESS, JAVA_INT,

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/Kernel32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/Kernel32FFM.java
@@ -10,6 +10,9 @@ import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.windows.WinNTFFM.INVALID_HANDLE_VALUE;
+import static oshi.util.ExceptionUtil.getOptional;
+import static oshi.util.ExceptionUtil.getOptionalInt;
+import static oshi.util.ExceptionUtil.getOptionalLong;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -105,25 +108,15 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
 
     public static OptionalInt FindNextVolume(MemorySegment hFindVolume, MemorySegment lpszVolumeName,
             int cchBufferLength) {
-        try {
-            int result = (int) FindNextVolume.invokeExact(hFindVolume, lpszVolumeName, cchBufferLength);
-            return OptionalInt.of(result);
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.FindNextVolume failed: {}", t.getMessage());
-            return OptionalInt.empty();
-        }
+        return getOptionalInt(() -> (int) FindNextVolume.invokeExact(hFindVolume, lpszVolumeName, cchBufferLength), LOG,
+                "Kernel32FFM.FindNextVolume failed: {}");
     }
 
     private static final MethodHandle FindVolumeClose = downcall(K32, "FindVolumeClose", JAVA_INT, ADDRESS);
 
     public static OptionalInt FindVolumeClose(MemorySegment hFindVolume) {
-        try {
-            int result = (int) FindVolumeClose.invokeExact(hFindVolume);
-            return OptionalInt.of(result);
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.FindVolumeClose failed: {}", t.getMessage());
-            return OptionalInt.empty();
-        }
+        return getOptionalInt(() -> (int) FindVolumeClose.invokeExact(hFindVolume), LOG,
+                "Kernel32FFM.FindVolumeClose failed: {}");
     }
 
     private static final MethodHandle GetComputerName = downcall(K32, "GetComputerNameW", JAVA_INT, ADDRESS, ADDRESS);
@@ -181,12 +174,8 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
     private static final MethodHandle GetCurrentProcess = downcall(K32, "GetCurrentProcess", ADDRESS);
 
     public static Optional<MemorySegment> GetCurrentProcess() {
-        try {
-            return Optional.of((MemorySegment) GetCurrentProcess.invokeExact());
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.GetCurrentProcess failed: {}", t.getMessage());
-            return Optional.empty();
-        }
+        return getOptional(() -> (MemorySegment) GetCurrentProcess.invokeExact(), LOG,
+                "Kernel32FFM.GetCurrentProcess failed: {}");
     }
 
     private static final MethodHandle GetCurrentProcessId = downcall(K32, "GetCurrentProcessId", JAVA_INT);
@@ -229,26 +218,17 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
     public static OptionalInt GetDiskFreeSpaceEx(MemorySegment lpDirectoryName,
             MemorySegment lpFreeBytesAvailableToCaller, MemorySegment lpTotalNumberOfBytes,
             MemorySegment lpTotalNumberOfFreeBytes) {
-        try {
-            int result = (int) GetDiskFreeSpaceEx.invokeExact(lpDirectoryName, lpFreeBytesAvailableToCaller,
-                    lpTotalNumberOfBytes, lpTotalNumberOfFreeBytes);
-            return OptionalInt.of(result);
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.GetDiskFreeSpaceEx failed: {}", t.getMessage());
-            return OptionalInt.empty();
-        }
+        return getOptionalInt(
+                () -> (int) GetDiskFreeSpaceEx.invokeExact(lpDirectoryName, lpFreeBytesAvailableToCaller,
+                        lpTotalNumberOfBytes, lpTotalNumberOfFreeBytes),
+                LOG, "Kernel32FFM.GetDiskFreeSpaceEx failed: {}");
     }
 
     private static final MethodHandle GetDriveType = downcall(K32, "GetDriveTypeW", JAVA_INT, ADDRESS);
 
     public static OptionalInt GetDriveType(MemorySegment lpRootPathName) {
-        try {
-            int result = (int) GetDriveType.invokeExact(lpRootPathName);
-            return OptionalInt.of(result);
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.GetDriveType failed: {}", t.getMessage());
-            return OptionalInt.empty();
-        }
+        return getOptionalInt(() -> (int) GetDriveType.invokeExact(lpRootPathName), LOG,
+                "Kernel32FFM.GetDriveType failed: {}");
     }
 
     private static final MethodHandle GetVolumeInformation = downcall(K32, "GetVolumeInformationW", JAVA_INT, ADDRESS,
@@ -257,15 +237,9 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
     public static OptionalInt GetVolumeInformation(MemorySegment lpRootPathName, MemorySegment lpVolumeNameBuffer,
             int nVolumeNameSize, MemorySegment lpVolumeSerialNumber, MemorySegment lpMaximumComponentLength,
             MemorySegment lpFileSystemFlags, MemorySegment lpFileSystemNameBuffer, int nFileSystemNameSize) {
-        try {
-            int result = (int) GetVolumeInformation.invokeExact(lpRootPathName, lpVolumeNameBuffer, nVolumeNameSize,
-                    lpVolumeSerialNumber, lpMaximumComponentLength, lpFileSystemFlags, lpFileSystemNameBuffer,
-                    nFileSystemNameSize);
-            return OptionalInt.of(result);
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.GetVolumeInformation failed: {}", t.getMessage());
-            return OptionalInt.empty();
-        }
+        return getOptionalInt(() -> (int) GetVolumeInformation.invokeExact(lpRootPathName, lpVolumeNameBuffer,
+                nVolumeNameSize, lpVolumeSerialNumber, lpMaximumComponentLength, lpFileSystemFlags,
+                lpFileSystemNameBuffer, nFileSystemNameSize), LOG, "Kernel32FFM.GetVolumeInformation failed: {}");
     }
 
     private static final MethodHandle GetVolumePathNamesForVolumeName = downcall(K32,
@@ -273,25 +247,16 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
 
     public static OptionalInt GetVolumePathNamesForVolumeName(MemorySegment lpszVolumeName,
             MemorySegment lpszVolumePathNames, int cchBufferLength, MemorySegment lpcchReturnLength) {
-        try {
-            int result = (int) GetVolumePathNamesForVolumeName.invokeExact(lpszVolumeName, lpszVolumePathNames,
-                    cchBufferLength, lpcchReturnLength);
-            return OptionalInt.of(result);
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.GetVolumePathNamesForVolumeName failed: {}", t.getMessage());
-            return OptionalInt.empty();
-        }
+        return getOptionalInt(
+                () -> (int) GetVolumePathNamesForVolumeName.invokeExact(lpszVolumeName, lpszVolumePathNames,
+                        cchBufferLength, lpcchReturnLength),
+                LOG, "Kernel32FFM.GetVolumePathNamesForVolumeName failed: {}");
     }
 
     private static final MethodHandle GetTickCount = downcall(K32, "GetTickCount64", JAVA_LONG);
 
     public static OptionalLong GetTickCount() {
-        try {
-            return OptionalLong.of((long) GetTickCount.invokeExact());
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.GetTickCount64 failed: {}", t.getMessage());
-            return OptionalLong.empty();
-        }
+        return getOptionalLong(() -> (long) GetTickCount.invokeExact(), LOG, "Kernel32FFM.GetTickCount64 failed: {}");
     }
 
     private static final MethodHandle SetErrorMode = downcall(K32, "SetErrorMode", JAVA_INT, JAVA_INT);
@@ -318,14 +283,8 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
      */
     public static OptionalInt GetVolumeNameForVolumeMountPoint(MemorySegment lpszVolumeMountPoint,
             MemorySegment lpszVolumeName, int cchBufferLength) {
-        try {
-            int result = (int) GetVolumeNameForVolumeMountPoint.invokeExact(lpszVolumeMountPoint, lpszVolumeName,
-                    cchBufferLength);
-            return OptionalInt.of(result);
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.GetVolumeNameForVolumeMountPoint failed: {}", t.getMessage());
-            return OptionalInt.empty();
-        }
+        return getOptionalInt(() -> (int) GetVolumeNameForVolumeMountPoint.invokeExact(lpszVolumeMountPoint,
+                lpszVolumeName, cchBufferLength), LOG, "Kernel32FFM.GetVolumeNameForVolumeMountPoint failed: {}");
     }
 
     private static final MethodHandle OpenProcess = downcall(K32, "OpenProcess", ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/NtDllFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/NtDllFFM.java
@@ -12,6 +12,7 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -122,13 +123,10 @@ public final class NtDllFFM extends WindowsForeignFunctions {
      */
     public static int NtQueryInformationProcess(MemorySegment processHandle, int processInformationClass,
             MemorySegment processInformation, int processInformationLength, MemorySegment returnLength) {
-        try {
+        return getIntOrDefault(() -> {
             return (int) NtQueryInformationProcess.invokeExact(processHandle, processInformationClass,
                     processInformation, processInformationLength, returnLength);
-        } catch (Throwable t) {
-            LOG.debug("NtDllFFM.NtQueryInformationProcess failed", t);
-            return -1;
-        }
+        }, -1, LOG, "NtDllFFM.NtQueryInformationProcess failed");
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/BStrFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/BStrFFM.java
@@ -7,6 +7,9 @@ package oshi.ffm.windows.com;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
+import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.ExceptionUtil.runOrLog;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -48,13 +51,10 @@ public final class BStrFFM extends WindowsForeignFunctions {
         if (str == null) {
             return MemorySegment.NULL;
         }
-        try {
+        return getOrDefault(() -> {
             MemorySegment wideStr = toWideString(arena, str);
             return (MemorySegment) SysAllocString.invokeExact(wideStr);
-        } catch (Throwable t) {
-            LOG.debug("BStrFFM.fromString failed", t);
-            return MemorySegment.NULL;
-        }
+        }, MemorySegment.NULL, LOG, "BStrFFM.fromString failed");
     }
 
     // SysFreeString
@@ -69,11 +69,7 @@ public final class BStrFFM extends WindowsForeignFunctions {
         if (bstr == null || bstr.equals(MemorySegment.NULL)) {
             return;
         }
-        try {
-            SysFreeString.invokeExact(bstr);
-        } catch (Throwable t) {
-            LOG.debug("BStrFFM.free failed", t);
-        }
+        runOrLog(() -> SysFreeString.invokeExact(bstr), LOG, "BStrFFM.free failed");
     }
 
     // SysStringLen
@@ -89,12 +85,7 @@ public final class BStrFFM extends WindowsForeignFunctions {
         if (bstr == null || bstr.equals(MemorySegment.NULL)) {
             return 0;
         }
-        try {
-            return (int) SysStringLen.invokeExact(bstr);
-        } catch (Throwable t) {
-            LOG.debug("BStrFFM.length failed", t);
-            return 0;
-        }
+        return getIntOrDefault(() -> (int) SysStringLen.invokeExact(bstr), 0, LOG, "BStrFFM.length failed");
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/IEnumWbemClassObjectFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/IEnumWbemClassObjectFFM.java
@@ -7,6 +7,7 @@ package oshi.ffm.windows.com;
 import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.util.ExceptionUtil.getOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
@@ -73,7 +74,7 @@ public final class IEnumWbemClassObjectFFM extends ComObjectFFM {
         if (pEnum == null || pEnum.equals(NULL)) {
             return new NextResult(WbemcliFFM.WBEM_E_FAILED, NULL);
         }
-        try {
+        return getOrDefault(() -> {
             MemorySegment vtable = getVtable(pEnum, arena);
             MemorySegment fnNext = getVtableFunction(vtable, WbemcliFFM.IENUMWBEMCLASSOBJECT_NEXT);
             MethodHandle mh = createDowncall(fnNext, NEXT_DESC);
@@ -88,10 +89,7 @@ public final class IEnumWbemClassObjectFFM extends ComObjectFFM {
             MemorySegment pObject = returned > 0 ? apObjects.get(ADDRESS, 0) : NULL;
 
             return new NextResult(hr, pObject);
-        } catch (Throwable t) {
-            LOG.debug("IEnumWbemClassObjectFFM.next failed", t);
-            return new NextResult(WbemcliFFM.WBEM_E_FAILED, NULL);
-        }
+        }, new NextResult(WbemcliFFM.WBEM_E_FAILED, NULL), LOG, "IEnumWbemClassObjectFFM.next failed");
     }
 
     /**
@@ -119,15 +117,12 @@ public final class IEnumWbemClassObjectFFM extends ComObjectFFM {
         if (pEnum == null || pEnum.equals(NULL)) {
             return OptionalInt.empty();
         }
-        try {
+        return getOrDefault(() -> {
             MemorySegment vtable = getVtable(pEnum, arena);
             MemorySegment fnReset = getVtableFunction(vtable, WbemcliFFM.IENUMWBEMCLASSOBJECT_RESET);
             MethodHandle mh = createDowncall(fnReset, RESET_DESC);
             int hr = (int) mh.invokeExact(pEnum);
             return OptionalInt.of(hr);
-        } catch (Throwable t) {
-            LOG.debug("IEnumWbemClassObjectFFM.reset failed", t);
-            return OptionalInt.empty();
-        }
+        }, OptionalInt.empty(), LOG, "IEnumWbemClassObjectFFM.reset failed");
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/IUnknownFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/IUnknownFFM.java
@@ -7,6 +7,7 @@ package oshi.ffm.windows.com;
 import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
@@ -49,15 +50,12 @@ public class IUnknownFFM extends ForeignFunctions {
         if (pObject == null || pObject.equals(NULL)) {
             return 0;
         }
-        try {
+        return getIntOrDefault(() -> {
             MemorySegment vtable = ComObjectFFM.getVtable(pObject, arena);
             MemorySegment fnAddRef = ComObjectFFM.getVtableFunction(vtable, WbemcliFFM.IUNKNOWN_ADDREF);
             MethodHandle mh = ComObjectFFM.createDowncall(fnAddRef, ADDREF_DESC);
             return (int) mh.invokeExact(pObject);
-        } catch (Throwable t) {
-            LOG.debug("IUnknownFFM.addRef failed", t);
-            return 0;
-        }
+        }, 0, LOG, "IUnknownFFM.addRef failed");
     }
 
     /**
@@ -71,15 +69,12 @@ public class IUnknownFFM extends ForeignFunctions {
         if (pObject == null || pObject.equals(NULL)) {
             return 0;
         }
-        try {
+        return getIntOrDefault(() -> {
             MemorySegment vtable = ComObjectFFM.getVtable(pObject, arena);
             MemorySegment fnRelease = ComObjectFFM.getVtableFunction(vtable, WbemcliFFM.IUNKNOWN_RELEASE);
             MethodHandle mh = ComObjectFFM.createDowncall(fnRelease, RELEASE_DESC);
             return (int) mh.invokeExact(pObject);
-        } catch (Throwable t) {
-            LOG.debug("IUnknownFFM.release failed", t);
-            return 0;
-        }
+        }, 0, LOG, "IUnknownFFM.release failed");
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/IWbemClassObjectFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/IWbemClassObjectFFM.java
@@ -7,6 +7,7 @@ package oshi.ffm.windows.com;
 import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.util.ExceptionUtil.getOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
@@ -73,7 +74,7 @@ public final class IWbemClassObjectFFM extends ComObjectFFM {
         if (pObject == null || pObject.equals(NULL)) {
             return new GetResult(WbemcliFFM.WBEM_E_FAILED, NULL, WbemcliFFM.CIM_ILLEGAL);
         }
-        try {
+        return getOrDefault(() -> {
             MemorySegment vtable = getVtable(pObject, arena);
             MemorySegment fnGet = getVtableFunction(vtable, WbemcliFFM.IWBEMCLASSOBJECT_GET);
             MethodHandle mh = createDowncall(fnGet, GET_DESC);
@@ -89,10 +90,8 @@ public final class IWbemClassObjectFFM extends ComObjectFFM {
             // Only read pType on success; use CIM_ILLEGAL on failure
             int cimType = Ole32FFM.succeeded(hr) ? pType.get(JAVA_INT, 0) : WbemcliFFM.CIM_ILLEGAL;
             return new GetResult(hr, pVal, cimType);
-        } catch (Throwable t) {
-            LOG.debug("IWbemClassObjectFFM.get failed", t);
-            return new GetResult(WbemcliFFM.WBEM_E_FAILED, NULL, WbemcliFFM.CIM_ILLEGAL);
-        }
+        }, new GetResult(WbemcliFFM.WBEM_E_FAILED, NULL, WbemcliFFM.CIM_ILLEGAL), LOG,
+                "IWbemClassObjectFFM.get failed");
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/Ole32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/Ole32FFM.java
@@ -7,6 +7,8 @@ package oshi.ffm.windows.com;
 import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.ExceptionUtil.runOrLog;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -80,13 +82,10 @@ public final class Ole32FFM extends WindowsForeignFunctions {
      * @return HRESULT: S_OK if successful, S_FALSE if already initialized, or error code
      */
     public static OptionalInt CoInitializeEx(int coInit) {
-        try {
+        return getOrDefault(() -> {
             int hr = (int) CoInitializeEx.invokeExact(NULL, coInit);
             return OptionalInt.of(hr);
-        } catch (Throwable t) {
-            LOG.debug("Ole32FFM.CoInitializeEx failed", t);
-            return OptionalInt.empty();
-        }
+        }, OptionalInt.empty(), LOG, "Ole32FFM.CoInitializeEx failed");
     }
 
     // CoUninitialize
@@ -96,11 +95,7 @@ public final class Ole32FFM extends WindowsForeignFunctions {
      * Closes the COM library on the current thread.
      */
     public static void CoUninitialize() {
-        try {
-            CoUninitialize.invokeExact();
-        } catch (Throwable t) {
-            LOG.debug("Ole32FFM.CoUninitialize failed", t);
-        }
+        runOrLog(() -> CoUninitialize.invokeExact(), LOG, "Ole32FFM.CoUninitialize failed");
     }
 
     // CoInitializeSecurity
@@ -116,7 +111,7 @@ public final class Ole32FFM extends WindowsForeignFunctions {
      * @return HRESULT: S_OK if successful, RPC_E_TOO_LATE if already called, or error code
      */
     public static OptionalInt CoInitializeSecurity(int authnLevel, int impLevel, int capabilities) {
-        try {
+        return getOrDefault(() -> {
             int hr = (int) CoInitializeSecurity.invokeExact(NULL, // pSecDesc
                     -1, // cAuthSvc
                     NULL, // asAuthSvc
@@ -128,10 +123,7 @@ public final class Ole32FFM extends WindowsForeignFunctions {
                     NULL // pReserved3
             );
             return OptionalInt.of(hr);
-        } catch (Throwable t) {
-            LOG.debug("Ole32FFM.CoInitializeSecurity failed", t);
-            return OptionalInt.empty();
-        }
+        }, OptionalInt.empty(), LOG, "Ole32FFM.CoInitializeSecurity failed");
     }
 
     // CoCreateInstance
@@ -148,7 +140,7 @@ public final class Ole32FFM extends WindowsForeignFunctions {
      * @return the interface pointer, or NULL if failed
      */
     public static MemorySegment CoCreateInstance(Arena arena, MemorySegment clsid, int clsctx, MemorySegment iid) {
-        try {
+        return getOrDefault(() -> {
             MemorySegment ppv = arena.allocate(ADDRESS);
             int hr = (int) CoCreateInstance.invokeExact(clsid, NULL, clsctx, iid, ppv);
             if (hr != S_OK) {
@@ -156,10 +148,7 @@ public final class Ole32FFM extends WindowsForeignFunctions {
                 return NULL;
             }
             return ppv.get(ADDRESS, 0);
-        } catch (Throwable t) {
-            LOG.debug("Ole32FFM.CoCreateInstance failed", t);
-            return NULL;
-        }
+        }, NULL, LOG, "Ole32FFM.CoCreateInstance failed");
     }
 
     // CoSetProxyBlanket
@@ -179,7 +168,7 @@ public final class Ole32FFM extends WindowsForeignFunctions {
      */
     public static OptionalInt CoSetProxyBlanket(MemorySegment pProxy, int authnSvc, int authzSvc, int authnLevel,
             int impLevel, int capabilities) {
-        try {
+        return getOrDefault(() -> {
             int hr = (int) CoSetProxyBlanket.invokeExact(pProxy, authnSvc, // dwAuthnSvc
                     authzSvc, // dwAuthzSvc
                     NULL, // pServerPrincName
@@ -189,10 +178,7 @@ public final class Ole32FFM extends WindowsForeignFunctions {
                     capabilities // dwCapabilities
             );
             return OptionalInt.of(hr);
-        } catch (Throwable t) {
-            LOG.debug("Ole32FFM.CoSetProxyBlanket failed", t);
-            return OptionalInt.empty();
-        }
+        }, OptionalInt.empty(), LOG, "Ole32FFM.CoSetProxyBlanket failed");
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/VariantFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/VariantFFM.java
@@ -12,6 +12,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 import static oshi.ffm.windows.com.Ole32FFM.S_OK;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
@@ -224,11 +225,6 @@ public final class VariantFFM extends WindowsForeignFunctions {
         if (variant == null || variant.equals(MemorySegment.NULL)) {
             return S_OK;
         }
-        try {
-            return (int) VariantClear.invokeExact(variant);
-        } catch (Throwable t) {
-            LOG.debug("VariantFFM.clear failed", t);
-            return -1;
-        }
+        return getIntOrDefault(() -> (int) VariantClear.invokeExact(variant), -1, LOG, "VariantFFM.clear failed");
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
@@ -6,6 +6,7 @@ package oshi.hardware.platform.mac;
 
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
 import static oshi.ffm.ForeignFunctions.getErrno;
+import static oshi.util.ExceptionUtil.runOrLog;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
@@ -130,12 +131,10 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
                             procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, (long) offset + MacSystem.CPU_STATE_IDLE));
                 }
             } finally {
-                try {
+                runOrLog(() -> {
                     MacSystemFunctions.vm_deallocate(MacSystemFunctions.mach_task_self(), rawProcInfoPtr.address(),
                             (long) procInfoCount * MacSystem.INT_SIZE);
-                } catch (Throwable e) {
-                    LOG.warn("Failed to vm_deallocate processor info buffer", e);
-                }
+                }, LOG, "Failed to vm_deallocate processor info buffer");
             }
         } catch (Throwable e) {
             LOG.error("Failed to update CPU Load", e);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
@@ -5,6 +5,7 @@
 package oshi.hardware.platform.mac;
 
 import static java.util.Collections.emptyList;
+import static oshi.util.ExceptionUtil.runOrLog;
 
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
@@ -161,7 +162,7 @@ public final class MacUsbDeviceFFM extends MacUsbDevice {
     private static void getControllerIdByLocation(long id, CFTypeRef locationId, CFStringRef locationIDKey,
             CFStringRef ioPropertyMatchKey, Map<Long, String> vendorIdMap, Map<Long, String> productIdMap) {
         // Build matching dict: { IOPropertyMatch: { locationID: <locationId> } }
-        try {
+        runOrLog(() -> {
             CFAllocatorRef alloc = new CFAllocatorRef(CoreFoundationFunctions.CFAllocatorGetDefault());
             CFMutableDictionaryRef propertyDict = new CFMutableDictionaryRef(CoreFoundationFunctions
                     .CFDictionaryCreateMutable(alloc.segment(), 0, MemorySegment.NULL, MemorySegment.NULL));
@@ -199,8 +200,6 @@ public final class MacUsbDeviceFFM extends MacUsbDevice {
                     serviceIterator.release();
                 }
             }
-        } catch (Throwable e) {
-            LOG.debug("Failed to retrieve controller vendor/product IDs for id {}", id, e);
-        }
+        }, LOG, "Failed to retrieve controller vendor/product IDs for id {}");
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.platform.windows;
 
+import static oshi.util.ExceptionUtil.runOrLog;
+
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -85,7 +87,7 @@ final class WindowsGraphicsCardFFM extends AbstractGraphicsCard {
         TreeMap<Integer, GraphicsCard> dxgiOrdered = new TreeMap<>();
         List<GraphicsCard> cardList = new ArrayList<>();
 
-        try {
+        runOrLog(() -> {
             String[] keys = Advapi32UtilFFM.registryGetKeys(HKLM, DISPLAY_DEVICES_REGISTRY_PATH, 0);
             int index = 1;
             for (String key : keys) {
@@ -153,9 +155,7 @@ final class WindowsGraphicsCardFFM extends AbstractGraphicsCard {
                     LOG.debug("Error reading graphics card registry key {}: {}", key, t.getMessage());
                 }
             }
-        } catch (Throwable t) {
-            LOG.debug("Failed to enumerate display device registry keys: {}", t.getMessage());
-        }
+        }, LOG, "Failed to enumerate display device registry keys: {}");
 
         List<GraphicsCard> result = new ArrayList<>(dxgiOrdered.values());
         result.addAll(cardList);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
@@ -15,6 +15,7 @@ import static oshi.ffm.mac.MacSystem.TIMEVAL;
 import static oshi.ffm.mac.MacSystemFunctions.getpid;
 import static oshi.ffm.mac.MacSystemFunctions.proc_listpids;
 import static oshi.ffm.mac.MacSystemFunctions.proc_pidinfo;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -126,22 +127,13 @@ public class MacOperatingSystemFFM extends MacOperatingSystem {
 
     @Override
     public int getProcessId() {
-        try {
-            return getpid();
-        } catch (Throwable e) {
-            LOG.warn("Failed to get current pid: {}", e.getMessage(), e);
-            return 0;
-        }
+        return getIntOrDefault(() -> getpid(), 0, LOG, "Failed to get current pid: {}");
     }
 
     @Override
     public int getProcessCount() {
-        try {
-            return proc_listpids(PROC_ALL_PIDS, 0, MemorySegment.NULL, 0) / INT_SIZE;
-        } catch (Throwable e) {
-            LOG.warn("Failed to query processes: {}", e.getMessage(), e);
-            return 0;
-        }
+        return getIntOrDefault(() -> proc_listpids(PROC_ALL_PIDS, 0, MemorySegment.NULL, 0) / INT_SIZE, 0, LOG,
+                "Failed to query processes: {}");
     }
 
     @Override


### PR DESCRIPTION
## Summary

Follow-up to #3272. Applies the `ExceptionUtil` pattern to 19 additional files in `oshi-core-ffm`, eliminating ~98 total catch(Throwable) boilerplate blocks across both PRs.

## Changes

19 files refactored using static imports of `getOptionalInt`, `getOptional`, `getOptionalLong`, `getBooleanOrDefault`, `getIntOrDefault`, `getOrDefault`, `runSilently`, and `runOrLog`.

Net: -112 lines (108 insertions, 220 deletions).

## Remaining Work

178 catch(Throwable) blocks remain. These have patterns that don't mechanically convert:
- **Non-final variable captures**: try bodies that assign to variables declared before the try
- **Type inference issues**: lambdas returning `Optional.empty()` from multiple branches confuse type inference
- **Complex catch bodies**: blocks that check error codes, call `GetLastError`, or have conditional logic
- **Static initializer blocks**: library loading in static {} blocks

These can be addressed in future PRs with targeted manual refactoring.

## Verification

- ✅ spotless:apply
- ✅ checkstyle:check  
- ✅ install (compile + test, 0 failures)
- ✅ forbiddenapis:check
- ✅ javadoc:javadoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized exception handling patterns across the library by consolidating error-handling logic into centralized utility methods, improving code consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->