### PR TITLE
Extract shared Windows WMI logic into common base classes

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsBaseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsBaseboard.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static oshi.util.Memoizer.memoize;
+
+import java.util.function.Supplier;
+
+import oshi.annotation.concurrent.Immutable;
+import oshi.driver.common.windows.wmi.Win32BaseBoard;
+import oshi.driver.common.windows.wmi.Win32BaseBoard.BaseBoardProperty;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.driver.common.windows.wmi.WmiUtil;
+import oshi.hardware.common.AbstractBaseboard;
+import oshi.util.Constants;
+import oshi.util.Util;
+import oshi.util.tuples.Quartet;
+
+/**
+ * Baseboard data obtained from WMI. Subclasses provide the platform-specific {@link WmiQueryExecutor}.
+ */
+@Immutable
+public abstract class WindowsBaseboard extends AbstractBaseboard {
+
+    private final Supplier<Quartet<String, String, String, String>> manufModelVersSerial = memoize(
+            this::queryManufModelVersSerial);
+
+    /**
+     * Returns the WMI query executor for this platform.
+     *
+     * @return a non-null {@link WmiQueryExecutor}
+     */
+    protected abstract WmiQueryExecutor getWmiQueryExecutor();
+
+    @Override
+    public String getManufacturer() {
+        return manufModelVersSerial.get().getA();
+    }
+
+    @Override
+    public String getModel() {
+        return manufModelVersSerial.get().getB();
+    }
+
+    @Override
+    public String getVersion() {
+        return manufModelVersSerial.get().getC();
+    }
+
+    @Override
+    public String getSerialNumber() {
+        return manufModelVersSerial.get().getD();
+    }
+
+    private Quartet<String, String, String, String> queryManufModelVersSerial() {
+        String manufacturer = null;
+        String model = null;
+        String version = null;
+        String serialNumber = null;
+        WmiResult<BaseBoardProperty> win32BaseBoard = Win32BaseBoard.queryBaseboardInfo(getWmiQueryExecutor());
+        if (win32BaseBoard.getResultCount() > 0) {
+            manufacturer = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.MANUFACTURER, 0);
+            model = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.MODEL, 0);
+            String product = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.PRODUCT, 0);
+            if (!Util.isBlank(product)) {
+                model = Util.isBlank(model) ? product : (model + " (" + product + ")");
+            }
+            version = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.VERSION, 0);
+            serialNumber = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.SERIALNUMBER, 0);
+        }
+        return new Quartet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
+                Util.isBlank(model) ? Constants.UNKNOWN : model, Util.isBlank(version) ? Constants.UNKNOWN : version,
+                Util.isBlank(serialNumber) ? Constants.UNKNOWN : serialNumber);
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsComputerSystem.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static oshi.util.Memoizer.memoize;
+
+import java.util.function.Supplier;
+
+import oshi.annotation.concurrent.Immutable;
+import oshi.driver.common.windows.wmi.Win32Bios;
+import oshi.driver.common.windows.wmi.Win32Bios.BiosSerialProperty;
+import oshi.driver.common.windows.wmi.Win32ComputerSystem;
+import oshi.driver.common.windows.wmi.Win32ComputerSystem.ComputerSystemProperty;
+import oshi.driver.common.windows.wmi.Win32ComputerSystemProduct;
+import oshi.driver.common.windows.wmi.Win32ComputerSystemProduct.ComputerSystemProductProperty;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.driver.common.windows.wmi.WmiUtil;
+import oshi.hardware.common.AbstractComputerSystem;
+import oshi.util.Constants;
+import oshi.util.Util;
+import oshi.util.tuples.Pair;
+
+/**
+ * Hardware data obtained from WMI. Subclasses provide the platform-specific {@link WmiQueryExecutor}.
+ */
+@Immutable
+public abstract class WindowsComputerSystem extends AbstractComputerSystem {
+
+    private final Supplier<Pair<String, String>> manufacturerModel = memoize(this::queryManufacturerModel);
+    private final Supplier<Pair<String, String>> serialNumberUUID = memoize(this::querySystemSerialNumberUUID);
+
+    /**
+     * Returns the WMI query executor for this platform.
+     *
+     * @return a non-null {@link WmiQueryExecutor}
+     */
+    protected abstract WmiQueryExecutor getWmiQueryExecutor();
+
+    @Override
+    public String getManufacturer() {
+        return manufacturerModel.get().getA();
+    }
+
+    @Override
+    public String getModel() {
+        return manufacturerModel.get().getB();
+    }
+
+    @Override
+    public String getSerialNumber() {
+        return serialNumberUUID.get().getA();
+    }
+
+    @Override
+    public String getHardwareUUID() {
+        return serialNumberUUID.get().getB();
+    }
+
+    private Pair<String, String> queryManufacturerModel() {
+        String manufacturer = null;
+        String model = null;
+        WmiResult<ComputerSystemProperty> win32ComputerSystem = Win32ComputerSystem
+                .queryComputerSystem(getWmiQueryExecutor());
+        if (win32ComputerSystem.getResultCount() > 0) {
+            manufacturer = WmiUtil.getString(win32ComputerSystem, ComputerSystemProperty.MANUFACTURER, 0);
+            model = WmiUtil.getString(win32ComputerSystem, ComputerSystemProperty.MODEL, 0);
+        }
+        return new Pair<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
+                Util.isBlank(model) ? Constants.UNKNOWN : model);
+    }
+
+    private Pair<String, String> querySystemSerialNumberUUID() {
+        String serialNumber = null;
+        String uuid = null;
+        WmiResult<ComputerSystemProductProperty> win32ComputerSystemProduct = Win32ComputerSystemProduct
+                .queryIdentifyingNumberUUID(getWmiQueryExecutor());
+        if (win32ComputerSystemProduct.getResultCount() > 0) {
+            serialNumber = WmiUtil.getString(win32ComputerSystemProduct,
+                    ComputerSystemProductProperty.IDENTIFYINGNUMBER, 0);
+            uuid = WmiUtil.getString(win32ComputerSystemProduct, ComputerSystemProductProperty.UUID, 0);
+        }
+        if (Util.isBlank(serialNumber)) {
+            serialNumber = querySerialFromBios();
+        }
+        if (Util.isBlank(serialNumber)) {
+            serialNumber = Constants.UNKNOWN;
+        }
+        if (Util.isBlank(uuid)) {
+            uuid = Constants.UNKNOWN;
+        }
+        return new Pair<>(serialNumber, uuid);
+    }
+
+    String querySerialFromBios() {
+        WmiResult<BiosSerialProperty> serialNum = Win32Bios.querySerialNumber(getWmiQueryExecutor());
+        if (serialNum.getResultCount() > 0) {
+            return WmiUtil.getString(serialNum, BiosSerialProperty.SERIALNUMBER, 0);
+        }
+        return null;
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsFirmware.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static oshi.util.Memoizer.memoize;
+
+import java.util.function.Supplier;
+
+import oshi.annotation.concurrent.Immutable;
+import oshi.driver.common.windows.wmi.Win32Bios;
+import oshi.driver.common.windows.wmi.Win32Bios.BiosProperty;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.driver.common.windows.wmi.WmiUtil;
+import oshi.hardware.common.AbstractFirmware;
+import oshi.util.Constants;
+import oshi.util.Util;
+import oshi.util.tuples.Quintet;
+
+/**
+ * Firmware data obtained from WMI. Subclasses provide the platform-specific {@link WmiQueryExecutor}.
+ */
+@Immutable
+public abstract class WindowsFirmware extends AbstractFirmware {
+
+    private final Supplier<Quintet<String, String, String, String, String>> manufNameDescVersRelease = memoize(
+            this::queryManufNameDescVersRelease);
+
+    /**
+     * Returns the WMI query executor for this platform.
+     *
+     * @return a non-null {@link WmiQueryExecutor}
+     */
+    protected abstract WmiQueryExecutor getWmiQueryExecutor();
+
+    @Override
+    public String getManufacturer() {
+        return manufNameDescVersRelease.get().getA();
+    }
+
+    @Override
+    public String getName() {
+        return manufNameDescVersRelease.get().getB();
+    }
+
+    @Override
+    public String getDescription() {
+        return manufNameDescVersRelease.get().getC();
+    }
+
+    @Override
+    public String getVersion() {
+        return manufNameDescVersRelease.get().getD();
+    }
+
+    @Override
+    public String getReleaseDate() {
+        return manufNameDescVersRelease.get().getE();
+    }
+
+    private Quintet<String, String, String, String, String> queryManufNameDescVersRelease() {
+        String manufacturer = null;
+        String name = null;
+        String description = null;
+        String version = null;
+        String releaseDate = null;
+        WmiResult<BiosProperty> win32BIOS = Win32Bios.queryBiosInfo(getWmiQueryExecutor());
+        if (win32BIOS.getResultCount() > 0) {
+            manufacturer = WmiUtil.getString(win32BIOS, BiosProperty.MANUFACTURER, 0);
+            name = WmiUtil.getString(win32BIOS, BiosProperty.NAME, 0);
+            description = WmiUtil.getString(win32BIOS, BiosProperty.DESCRIPTION, 0);
+            version = WmiUtil.getString(win32BIOS, BiosProperty.VERSION, 0);
+            releaseDate = WmiUtil.getDateString(win32BIOS, BiosProperty.RELEASEDATE, 0);
+        }
+        return new Quintet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
+                Util.isBlank(name) ? Constants.UNKNOWN : name,
+                Util.isBlank(description) ? Constants.UNKNOWN : description,
+                Util.isBlank(version) ? Constants.UNKNOWN : version,
+                Util.isBlank(releaseDate) ? Constants.UNKNOWN : releaseDate);
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsComputerSystemTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.driver.common.windows.wmi.WmiQuery;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.hardware.Baseboard;
+import oshi.hardware.Firmware;
+import oshi.util.Constants;
+
+class WindowsComputerSystemTest {
+
+    /** WmiQueryExecutor that always returns empty results. */
+    private static final WmiQueryExecutor EMPTY_EXECUTOR = new WmiQueryExecutor() {
+        @Override
+        public <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query) {
+            return emptyResult(query.getPropertyEnum());
+        }
+
+        @Override
+        public <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query, boolean initCom) {
+            return queryWMI(query);
+        }
+
+        private <T extends Enum<T>> WmiResult<T> emptyResult(Class<T> propEnum) {
+            return new WmiResult<T>() {
+                @Override
+                public int getResultCount() {
+                    return 0;
+                }
+
+                @Override
+                public Object getValue(T property, int index) {
+                    return null;
+                }
+
+                @Override
+                public int getVtType(T property) {
+                    return 0;
+                }
+
+                @Override
+                public int getCIMType(T property) {
+                    return 0;
+                }
+            };
+        }
+    };
+
+    private static WindowsComputerSystem createWithEmptyExecutor() {
+        return new WindowsComputerSystem() {
+            @Override
+            protected WmiQueryExecutor getWmiQueryExecutor() {
+                return EMPTY_EXECUTOR;
+            }
+
+            @Override
+            public Firmware createFirmware() {
+                return null;
+            }
+
+            @Override
+            public Baseboard createBaseboard() {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    void testFallbacksWhenWmiReturnsEmpty() {
+        WindowsComputerSystem cs = createWithEmptyExecutor();
+        assertThat(cs.getManufacturer(), is(Constants.UNKNOWN));
+        assertThat(cs.getModel(), is(Constants.UNKNOWN));
+        assertThat(cs.getSerialNumber(), is(Constants.UNKNOWN));
+        assertThat(cs.getHardwareUUID(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testQuerySerialFromBiosReturnsNullWhenEmpty() {
+        WindowsComputerSystem cs = createWithEmptyExecutor();
+        assertThat(cs.querySerialFromBios(), is(nullValue()));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsBaseboardFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsBaseboardFFM.java
@@ -4,67 +4,21 @@
  */
 package oshi.hardware.platform.windows;
 
-import static oshi.util.Memoizer.memoize;
-
-import java.util.function.Supplier;
+import java.util.Objects;
 
 import oshi.annotation.concurrent.Immutable;
-import oshi.driver.common.windows.wmi.Win32BaseBoard.BaseBoardProperty;
-import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
-import oshi.driver.windows.wmi.Win32BaseBoardFFM;
-import oshi.hardware.common.AbstractBaseboard;
-import oshi.util.Constants;
-import oshi.util.Util;
-import oshi.util.tuples.Quartet;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.ffm.util.platform.windows.WmiQueryExecutorFFM;
+import oshi.hardware.common.platform.windows.WindowsBaseboard;
 
 /**
  * Baseboard data obtained from WMI using FFM.
  */
 @Immutable
-final class WindowsBaseboardFFM extends AbstractBaseboard {
-
-    private final Supplier<Quartet<String, String, String, String>> manufModelVersSerial = memoize(
-            WindowsBaseboardFFM::queryManufModelVersSerial);
+final class WindowsBaseboardFFM extends WindowsBaseboard {
 
     @Override
-    public String getManufacturer() {
-        return manufModelVersSerial.get().getA();
-    }
-
-    @Override
-    public String getModel() {
-        return manufModelVersSerial.get().getB();
-    }
-
-    @Override
-    public String getVersion() {
-        return manufModelVersSerial.get().getC();
-    }
-
-    @Override
-    public String getSerialNumber() {
-        return manufModelVersSerial.get().getD();
-    }
-
-    private static Quartet<String, String, String, String> queryManufModelVersSerial() {
-        String manufacturer = null;
-        String model = null;
-        String version = null;
-        String serialNumber = null;
-        WmiResult<BaseBoardProperty> win32BaseBoard = Win32BaseBoardFFM.queryBaseboardInfo();
-        if (win32BaseBoard.getResultCount() > 0) {
-            manufacturer = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.MANUFACTURER, 0);
-            model = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.MODEL, 0);
-            String product = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.PRODUCT, 0);
-            if (!Util.isBlank(product)) {
-                model = Util.isBlank(model) ? product : (model + " (" + product + ")");
-            }
-            version = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.VERSION, 0);
-            serialNumber = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.SERIALNUMBER, 0);
-        }
-        return new Quartet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
-                Util.isBlank(model) ? Constants.UNKNOWN : model, Util.isBlank(version) ? Constants.UNKNOWN : version,
-                Util.isBlank(serialNumber) ? Constants.UNKNOWN : serialNumber);
+    protected WmiQueryExecutor getWmiQueryExecutor() {
+        return Objects.requireNonNull(WmiQueryExecutorFFM.createInstance());
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsComputerSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsComputerSystemFFM.java
@@ -4,55 +4,24 @@
  */
 package oshi.hardware.platform.windows;
 
-import static oshi.util.Memoizer.memoize;
-
-import java.util.function.Supplier;
+import java.util.Objects;
 
 import oshi.annotation.concurrent.Immutable;
-import oshi.driver.common.windows.wmi.Win32Bios.BiosSerialProperty;
-import oshi.driver.common.windows.wmi.Win32ComputerSystem.ComputerSystemProperty;
-import oshi.driver.common.windows.wmi.Win32ComputerSystemProduct.ComputerSystemProductProperty;
-import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
-import oshi.driver.windows.wmi.Win32BiosFFM;
-import oshi.driver.windows.wmi.Win32ComputerSystemFFM;
-import oshi.driver.windows.wmi.Win32ComputerSystemProductFFM;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.ffm.util.platform.windows.WmiQueryExecutorFFM;
 import oshi.hardware.Baseboard;
 import oshi.hardware.Firmware;
-import oshi.hardware.common.AbstractComputerSystem;
-import oshi.util.Constants;
-import oshi.util.Util;
-import oshi.util.tuples.Pair;
+import oshi.hardware.common.platform.windows.WindowsComputerSystem;
 
 /**
  * Hardware data obtained from WMI using FFM.
  */
 @Immutable
-final class WindowsComputerSystemFFM extends AbstractComputerSystem {
-
-    private final Supplier<Pair<String, String>> manufacturerModel = memoize(
-            WindowsComputerSystemFFM::queryManufacturerModel);
-    private final Supplier<Pair<String, String>> serialNumberUUID = memoize(
-            WindowsComputerSystemFFM::querySystemSerialNumberUUID);
+final class WindowsComputerSystemFFM extends WindowsComputerSystem {
 
     @Override
-    public String getManufacturer() {
-        return manufacturerModel.get().getA();
-    }
-
-    @Override
-    public String getModel() {
-        return manufacturerModel.get().getB();
-    }
-
-    @Override
-    public String getSerialNumber() {
-        return serialNumberUUID.get().getA();
-    }
-
-    @Override
-    public String getHardwareUUID() {
-        return serialNumberUUID.get().getB();
+    protected WmiQueryExecutor getWmiQueryExecutor() {
+        return Objects.requireNonNull(WmiQueryExecutorFFM.createInstance());
     }
 
     @Override
@@ -63,47 +32,5 @@ final class WindowsComputerSystemFFM extends AbstractComputerSystem {
     @Override
     public Baseboard createBaseboard() {
         return new WindowsBaseboardFFM();
-    }
-
-    private static Pair<String, String> queryManufacturerModel() {
-        String manufacturer = null;
-        String model = null;
-        WmiResult<ComputerSystemProperty> win32ComputerSystem = Win32ComputerSystemFFM.queryComputerSystem();
-        if (win32ComputerSystem.getResultCount() > 0) {
-            manufacturer = WmiUtil.getString(win32ComputerSystem, ComputerSystemProperty.MANUFACTURER, 0);
-            model = WmiUtil.getString(win32ComputerSystem, ComputerSystemProperty.MODEL, 0);
-        }
-        return new Pair<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
-                Util.isBlank(model) ? Constants.UNKNOWN : model);
-    }
-
-    private static Pair<String, String> querySystemSerialNumberUUID() {
-        String serialNumber = null;
-        String uuid = null;
-        WmiResult<ComputerSystemProductProperty> win32ComputerSystemProduct = Win32ComputerSystemProductFFM
-                .queryIdentifyingNumberUUID();
-        if (win32ComputerSystemProduct.getResultCount() > 0) {
-            serialNumber = WmiUtil.getString(win32ComputerSystemProduct,
-                    ComputerSystemProductProperty.IDENTIFYINGNUMBER, 0);
-            uuid = WmiUtil.getString(win32ComputerSystemProduct, ComputerSystemProductProperty.UUID, 0);
-        }
-        if (Util.isBlank(serialNumber)) {
-            serialNumber = querySerialFromBios();
-        }
-        if (Util.isBlank(serialNumber)) {
-            serialNumber = Constants.UNKNOWN;
-        }
-        if (Util.isBlank(uuid)) {
-            uuid = Constants.UNKNOWN;
-        }
-        return new Pair<>(serialNumber, uuid);
-    }
-
-    private static String querySerialFromBios() {
-        WmiResult<BiosSerialProperty> serialNum = Win32BiosFFM.querySerialNumber();
-        if (serialNum.getResultCount() > 0) {
-            return WmiUtil.getString(serialNum, BiosSerialProperty.SERIALNUMBER, 0);
-        }
-        return null;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsFirmwareFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsFirmwareFFM.java
@@ -4,72 +4,21 @@
  */
 package oshi.hardware.platform.windows;
 
-import static oshi.util.Memoizer.memoize;
-
-import java.util.function.Supplier;
+import java.util.Objects;
 
 import oshi.annotation.concurrent.Immutable;
-import oshi.driver.common.windows.wmi.Win32Bios.BiosProperty;
-import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
-import oshi.driver.windows.wmi.Win32BiosFFM;
-import oshi.hardware.common.AbstractFirmware;
-import oshi.util.Constants;
-import oshi.util.Util;
-import oshi.util.tuples.Quintet;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.ffm.util.platform.windows.WmiQueryExecutorFFM;
+import oshi.hardware.common.platform.windows.WindowsFirmware;
 
 /**
  * Firmware data obtained from WMI using FFM.
  */
 @Immutable
-final class WindowsFirmwareFFM extends AbstractFirmware {
-
-    private final Supplier<Quintet<String, String, String, String, String>> manufNameDescVersRelease = memoize(
-            WindowsFirmwareFFM::queryManufNameDescVersRelease);
+final class WindowsFirmwareFFM extends WindowsFirmware {
 
     @Override
-    public String getManufacturer() {
-        return manufNameDescVersRelease.get().getA();
-    }
-
-    @Override
-    public String getName() {
-        return manufNameDescVersRelease.get().getB();
-    }
-
-    @Override
-    public String getDescription() {
-        return manufNameDescVersRelease.get().getC();
-    }
-
-    @Override
-    public String getVersion() {
-        return manufNameDescVersRelease.get().getD();
-    }
-
-    @Override
-    public String getReleaseDate() {
-        return manufNameDescVersRelease.get().getE();
-    }
-
-    private static Quintet<String, String, String, String, String> queryManufNameDescVersRelease() {
-        String manufacturer = null;
-        String name = null;
-        String description = null;
-        String version = null;
-        String releaseDate = null;
-        WmiResult<BiosProperty> win32BIOS = Win32BiosFFM.queryBiosInfo();
-        if (win32BIOS.getResultCount() > 0) {
-            manufacturer = WmiUtil.getString(win32BIOS, BiosProperty.MANUFACTURER, 0);
-            name = WmiUtil.getString(win32BIOS, BiosProperty.NAME, 0);
-            description = WmiUtil.getString(win32BIOS, BiosProperty.DESCRIPTION, 0);
-            version = WmiUtil.getString(win32BIOS, BiosProperty.VERSION, 0);
-            releaseDate = WmiUtil.getDateString(win32BIOS, BiosProperty.RELEASEDATE, 0);
-        }
-        return new Quintet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
-                Util.isBlank(name) ? Constants.UNKNOWN : name,
-                Util.isBlank(description) ? Constants.UNKNOWN : description,
-                Util.isBlank(version) ? Constants.UNKNOWN : version,
-                Util.isBlank(releaseDate) ? Constants.UNKNOWN : releaseDate);
+    protected WmiQueryExecutor getWmiQueryExecutor() {
+        return Objects.requireNonNull(WmiQueryExecutorFFM.createInstance());
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsBaseboardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsBaseboardJNA.java
@@ -4,67 +4,21 @@
  */
 package oshi.hardware.platform.windows;
 
-import static oshi.util.Memoizer.memoize;
-
-import java.util.function.Supplier;
+import java.util.Objects;
 
 import oshi.annotation.concurrent.Immutable;
-import oshi.driver.common.windows.wmi.Win32BaseBoard.BaseBoardProperty;
-import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
-import oshi.driver.windows.wmi.Win32BaseBoardJNA;
-import oshi.hardware.common.AbstractBaseboard;
-import oshi.util.Constants;
-import oshi.util.Util;
-import oshi.util.tuples.Quartet;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.hardware.common.platform.windows.WindowsBaseboard;
+import oshi.util.platform.windows.WmiQueryExecutorJNA;
 
 /**
- * Baseboard data obtained from WMI
+ * Baseboard data obtained from WMI using JNA.
  */
 @Immutable
-final class WindowsBaseboardJNA extends AbstractBaseboard {
-
-    private final Supplier<Quartet<String, String, String, String>> manufModelVersSerial = memoize(
-            WindowsBaseboardJNA::queryManufModelVersSerial);
+final class WindowsBaseboardJNA extends WindowsBaseboard {
 
     @Override
-    public String getManufacturer() {
-        return manufModelVersSerial.get().getA();
-    }
-
-    @Override
-    public String getModel() {
-        return manufModelVersSerial.get().getB();
-    }
-
-    @Override
-    public String getVersion() {
-        return manufModelVersSerial.get().getC();
-    }
-
-    @Override
-    public String getSerialNumber() {
-        return manufModelVersSerial.get().getD();
-    }
-
-    private static Quartet<String, String, String, String> queryManufModelVersSerial() {
-        String manufacturer = null;
-        String model = null;
-        String version = null;
-        String serialNumber = null;
-        WmiResult<BaseBoardProperty> win32BaseBoard = Win32BaseBoardJNA.queryBaseboardInfo();
-        if (win32BaseBoard.getResultCount() > 0) {
-            manufacturer = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.MANUFACTURER, 0);
-            model = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.MODEL, 0);
-            String product = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.PRODUCT, 0);
-            if (!Util.isBlank(product)) {
-                model = Util.isBlank(model) ? product : (model + " (" + product + ")");
-            }
-            version = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.VERSION, 0);
-            serialNumber = WmiUtil.getString(win32BaseBoard, BaseBoardProperty.SERIALNUMBER, 0);
-        }
-        return new Quartet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
-                Util.isBlank(model) ? Constants.UNKNOWN : model, Util.isBlank(version) ? Constants.UNKNOWN : version,
-                Util.isBlank(serialNumber) ? Constants.UNKNOWN : serialNumber);
+    protected WmiQueryExecutor getWmiQueryExecutor() {
+        return Objects.requireNonNull(WmiQueryExecutorJNA.createInstance());
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsComputerSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsComputerSystemJNA.java
@@ -4,55 +4,24 @@
  */
 package oshi.hardware.platform.windows;
 
-import static oshi.util.Memoizer.memoize;
-
-import java.util.function.Supplier;
+import java.util.Objects;
 
 import oshi.annotation.concurrent.Immutable;
-import oshi.driver.common.windows.wmi.Win32Bios.BiosSerialProperty;
-import oshi.driver.common.windows.wmi.Win32ComputerSystem.ComputerSystemProperty;
-import oshi.driver.common.windows.wmi.Win32ComputerSystemProduct.ComputerSystemProductProperty;
-import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
-import oshi.driver.windows.wmi.Win32BiosJNA;
-import oshi.driver.windows.wmi.Win32ComputerSystemJNA;
-import oshi.driver.windows.wmi.Win32ComputerSystemProductJNA;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
 import oshi.hardware.Baseboard;
 import oshi.hardware.Firmware;
-import oshi.hardware.common.AbstractComputerSystem;
-import oshi.util.Constants;
-import oshi.util.Util;
-import oshi.util.tuples.Pair;
+import oshi.hardware.common.platform.windows.WindowsComputerSystem;
+import oshi.util.platform.windows.WmiQueryExecutorJNA;
 
 /**
- * Hardware data obtained from WMI.
+ * Hardware data obtained from WMI using JNA.
  */
 @Immutable
-final class WindowsComputerSystemJNA extends AbstractComputerSystem {
-
-    private final Supplier<Pair<String, String>> manufacturerModel = memoize(
-            WindowsComputerSystemJNA::queryManufacturerModel);
-    private final Supplier<Pair<String, String>> serialNumberUUID = memoize(
-            WindowsComputerSystemJNA::querySystemSerialNumberUUID);
+final class WindowsComputerSystemJNA extends WindowsComputerSystem {
 
     @Override
-    public String getManufacturer() {
-        return manufacturerModel.get().getA();
-    }
-
-    @Override
-    public String getModel() {
-        return manufacturerModel.get().getB();
-    }
-
-    @Override
-    public String getSerialNumber() {
-        return serialNumberUUID.get().getA();
-    }
-
-    @Override
-    public String getHardwareUUID() {
-        return serialNumberUUID.get().getB();
+    protected WmiQueryExecutor getWmiQueryExecutor() {
+        return Objects.requireNonNull(WmiQueryExecutorJNA.createInstance());
     }
 
     @Override
@@ -63,47 +32,5 @@ final class WindowsComputerSystemJNA extends AbstractComputerSystem {
     @Override
     public Baseboard createBaseboard() {
         return new WindowsBaseboardJNA();
-    }
-
-    private static Pair<String, String> queryManufacturerModel() {
-        String manufacturer = null;
-        String model = null;
-        WmiResult<ComputerSystemProperty> win32ComputerSystem = Win32ComputerSystemJNA.queryComputerSystem();
-        if (win32ComputerSystem.getResultCount() > 0) {
-            manufacturer = WmiUtil.getString(win32ComputerSystem, ComputerSystemProperty.MANUFACTURER, 0);
-            model = WmiUtil.getString(win32ComputerSystem, ComputerSystemProperty.MODEL, 0);
-        }
-        return new Pair<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
-                Util.isBlank(model) ? Constants.UNKNOWN : model);
-    }
-
-    private static Pair<String, String> querySystemSerialNumberUUID() {
-        String serialNumber = null;
-        String uuid = null;
-        WmiResult<ComputerSystemProductProperty> win32ComputerSystemProduct = Win32ComputerSystemProductJNA
-                .queryIdentifyingNumberUUID();
-        if (win32ComputerSystemProduct.getResultCount() > 0) {
-            serialNumber = WmiUtil.getString(win32ComputerSystemProduct,
-                    ComputerSystemProductProperty.IDENTIFYINGNUMBER, 0);
-            uuid = WmiUtil.getString(win32ComputerSystemProduct, ComputerSystemProductProperty.UUID, 0);
-        }
-        if (Util.isBlank(serialNumber)) {
-            serialNumber = querySerialFromBios();
-        }
-        if (Util.isBlank(serialNumber)) {
-            serialNumber = Constants.UNKNOWN;
-        }
-        if (Util.isBlank(uuid)) {
-            uuid = Constants.UNKNOWN;
-        }
-        return new Pair<>(serialNumber, uuid);
-    }
-
-    private static String querySerialFromBios() {
-        WmiResult<BiosSerialProperty> serialNum = Win32BiosJNA.querySerialNumber();
-        if (serialNum.getResultCount() > 0) {
-            return WmiUtil.getString(serialNum, BiosSerialProperty.SERIALNUMBER, 0);
-        }
-        return null;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsFirmwareJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsFirmwareJNA.java
@@ -4,72 +4,21 @@
  */
 package oshi.hardware.platform.windows;
 
-import static oshi.util.Memoizer.memoize;
-
-import java.util.function.Supplier;
+import java.util.Objects;
 
 import oshi.annotation.concurrent.Immutable;
-import oshi.driver.common.windows.wmi.Win32Bios.BiosProperty;
-import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
-import oshi.driver.windows.wmi.Win32BiosJNA;
-import oshi.hardware.common.AbstractFirmware;
-import oshi.util.Constants;
-import oshi.util.Util;
-import oshi.util.tuples.Quintet;
+import oshi.driver.common.windows.wmi.WmiQueryExecutor;
+import oshi.hardware.common.platform.windows.WindowsFirmware;
+import oshi.util.platform.windows.WmiQueryExecutorJNA;
 
 /**
- * Firmware data obtained from WMI
+ * Firmware data obtained from WMI using JNA.
  */
 @Immutable
-final class WindowsFirmwareJNA extends AbstractFirmware {
-
-    private final Supplier<Quintet<String, String, String, String, String>> manufNameDescVersRelease = memoize(
-            WindowsFirmwareJNA::queryManufNameDescVersRelease);
+final class WindowsFirmwareJNA extends WindowsFirmware {
 
     @Override
-    public String getManufacturer() {
-        return manufNameDescVersRelease.get().getA();
-    }
-
-    @Override
-    public String getName() {
-        return manufNameDescVersRelease.get().getB();
-    }
-
-    @Override
-    public String getDescription() {
-        return manufNameDescVersRelease.get().getC();
-    }
-
-    @Override
-    public String getVersion() {
-        return manufNameDescVersRelease.get().getD();
-    }
-
-    @Override
-    public String getReleaseDate() {
-        return manufNameDescVersRelease.get().getE();
-    }
-
-    private static Quintet<String, String, String, String, String> queryManufNameDescVersRelease() {
-        String manufacturer = null;
-        String name = null;
-        String description = null;
-        String version = null;
-        String releaseDate = null;
-        WmiResult<BiosProperty> win32BIOS = Win32BiosJNA.queryBiosInfo();
-        if (win32BIOS.getResultCount() > 0) {
-            manufacturer = WmiUtil.getString(win32BIOS, BiosProperty.MANUFACTURER, 0);
-            name = WmiUtil.getString(win32BIOS, BiosProperty.NAME, 0);
-            description = WmiUtil.getString(win32BIOS, BiosProperty.DESCRIPTION, 0);
-            version = WmiUtil.getString(win32BIOS, BiosProperty.VERSION, 0);
-            releaseDate = WmiUtil.getDateString(win32BIOS, BiosProperty.RELEASEDATE, 0);
-        }
-        return new Quintet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
-                Util.isBlank(name) ? Constants.UNKNOWN : name,
-                Util.isBlank(description) ? Constants.UNKNOWN : description,
-                Util.isBlank(version) ? Constants.UNKNOWN : version,
-                Util.isBlank(releaseDate) ? Constants.UNKNOWN : releaseDate);
+    protected WmiQueryExecutor getWmiQueryExecutor() {
+        return Objects.requireNonNull(WmiQueryExecutorJNA.createInstance());
     }
 }


### PR DESCRIPTION
## Summary

Addresses Issue 1 (JNA ↔ FFM Parallel Implementations) from #3274 for three simple WMI-only consumer classes.

Extracts duplicated WMI query logic and memoized getters into common abstract base classes in `oshi-common`. JNA and FFM subclasses are reduced to thin wrappers that provide the platform-specific `WmiQueryExecutor`.

## Changes

### WindowsFirmware (commit 1)
- New: `oshi-common/.../WindowsFirmware.java` (83 lines)
- Simplified: `WindowsFirmwareJNA` (75→24 lines), `WindowsFirmwareFFM` (75→24 lines)

### WindowsBaseboard (commit 2)
- New: `oshi-common/.../WindowsBaseboard.java` (78 lines)
- Simplified: `WindowsBaseboardJNA` (63→24 lines), `WindowsBaseboardFFM` (63→24 lines)

### WindowsComputerSystem (commit 3)
- New: `oshi-common/.../WindowsComputerSystem.java` (104 lines)
- Simplified: `WindowsComputerSystemJNA` (109→36 lines), `WindowsComputerSystemFFM` (109→36 lines)

## Pattern

Each common base class:
1. Declares `abstract WmiQueryExecutor getWmiQueryExecutor()`
2. Holds all shared WMI query logic and memoized getters
3. Calls the common `Win32*` driver methods with the executor

Each JNA/FFM subclass:
1. Implements `getWmiQueryExecutor()` returning the platform executor
2. Overrides factory methods (`createFirmware()`, `createBaseboard()`) where needed

## Testing
- All existing tests pass
- Full verification: spotless, checkstyle, install, forbiddenapis, javadoc all green
- No public API changes

## Net impact
- **-385 lines** removed from JNA/FFM subclasses
- **+310 lines** in common base classes
- **Net reduction: ~75 lines** (but eliminates 100% of logic duplication across these 3 class families)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated Windows hardware info retrieval so baseboard, firmware, and system identifiers are provided consistently across Windows implementations, improving reliability.
* **Bug Fixes**
  * Blank or missing WMI fields are now normalized to a standard "unknown" value to avoid empty outputs.
* **Tests**
  * Added tests verifying fallbacks when WMI returns no data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->