### PR TITLE
Extract shared WindowsGpuStats logic into common base class

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGpuStats.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.GpuInformation.GpuAdapterMemoryProperty;
+import oshi.driver.common.windows.perfmon.GpuInformation.GpuEngineProperty;
+import oshi.driver.common.windows.wmi.LhmSensor.LhmSensorProperty;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.driver.common.windows.wmi.WmiUtil;
+import oshi.hardware.GpuStats;
+import oshi.hardware.GpuTicks;
+import oshi.util.tuples.Pair;
+
+/**
+ * Common Windows {@link GpuStats} implementation. Subclasses provide platform-specific native dispatch.
+ */
+@ThreadSafe
+public abstract class WindowsGpuStats implements GpuStats {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsGpuStats.class);
+
+    private static final long MB_TO_BYTES = 1_048_576L;
+
+    private final String luidPrefix;
+    private final String lhmParent;
+    private final int pciBusNumber;
+    private final String pciBusId;
+    private final String cardName;
+
+    private boolean closed;
+
+    private String cachedNvmlDevice;
+    private int cachedAdlIndex = Integer.MIN_VALUE;
+    private GpuTicks prevUtilTicks;
+
+    /**
+     * Constructor.
+     *
+     * @param luidPrefix   the LUID prefix for PDH counter matching
+     * @param lhmParent    the LHM parent identifier
+     * @param pciBusNumber the PCI bus number
+     * @param pciBusId     the PCI bus ID string
+     * @param cardName     the card name
+     */
+    protected WindowsGpuStats(String luidPrefix, String lhmParent, int pciBusNumber, String pciBusId, String cardName) {
+        this.luidPrefix = luidPrefix;
+        this.lhmParent = lhmParent;
+        this.pciBusNumber = pciBusNumber;
+        this.pciBusId = pciBusId;
+        this.cardName = cardName;
+    }
+
+    // -- Abstract native dispatch methods --
+
+    /**
+     * Queries GPU engine performance counters.
+     *
+     * @return engine counter data
+     */
+    protected abstract Pair<List<String>, Map<GpuEngineProperty, List<Long>>> queryGpuEngineCounters();
+
+    /**
+     * Queries GPU adapter memory performance counters.
+     *
+     * @return adapter memory counter data
+     */
+    protected abstract Pair<List<String>, Map<GpuAdapterMemoryProperty, List<Long>>> queryGpuAdapterMemoryCounters();
+
+    /**
+     * Queries LHM sensors.
+     *
+     * @param parent     the parent identifier
+     * @param sensorType the sensor type
+     * @return the WMI result
+     */
+    protected abstract WmiResult<LhmSensorProperty> queryLhmSensors(String parent, String sensorType);
+
+    /**
+     * @return whether NVML is available
+     */
+    protected abstract boolean isNvmlAvailable();
+
+    /**
+     * Finds an NVML device by PCI bus ID.
+     *
+     * @param pciBusId the PCI bus ID
+     * @return the device handle string, or null
+     */
+    protected abstract String nvmlFindDevice(String pciBusId);
+
+    /**
+     * Finds an NVML device by name.
+     *
+     * @param gpuName the GPU name
+     * @return the device handle string, or null
+     */
+    protected abstract String nvmlFindDeviceByName(String gpuName);
+
+    /**
+     * @param device the NVML device handle
+     * @return temperature in degrees C, or negative if unavailable
+     */
+    protected abstract double nvmlGetTemperature(String device);
+
+    /**
+     * @param device the NVML device handle
+     * @return power draw in watts, or negative if unavailable
+     */
+    protected abstract double nvmlGetPowerDraw(String device);
+
+    /**
+     * @param device the NVML device handle
+     * @return core clock in MHz, or negative if unavailable
+     */
+    protected abstract long nvmlGetCoreClockMhz(String device);
+
+    /**
+     * @param device the NVML device handle
+     * @return memory clock in MHz, or negative if unavailable
+     */
+    protected abstract long nvmlGetMemoryClockMhz(String device);
+
+    /**
+     * @param device the NVML device handle
+     * @return fan speed percent, or negative if unavailable
+     */
+    protected abstract double nvmlGetFanSpeedPercent(String device);
+
+    /**
+     * @return whether ADL is available
+     */
+    protected abstract boolean isAdlAvailable();
+
+    /**
+     * Finds an ADL adapter index by PCI bus number.
+     *
+     * @param pciBusNumber the PCI bus number
+     * @return the adapter index, or -1 if not found
+     */
+    protected abstract int adlFindAdapterIndex(int pciBusNumber);
+
+    /**
+     * @param adapterIndex the ADL adapter index
+     * @return temperature in degrees C, or negative if unavailable
+     */
+    protected abstract double adlGetTemperature(int adapterIndex);
+
+    /**
+     * @param adapterIndex the ADL adapter index
+     * @return power draw in watts, or negative if unavailable
+     */
+    protected abstract double adlGetPowerDraw(int adapterIndex);
+
+    /**
+     * @param adapterIndex the ADL adapter index
+     * @return core clock in MHz, or negative if unavailable
+     */
+    protected abstract long adlGetCoreClockMhz(int adapterIndex);
+
+    /**
+     * @param adapterIndex the ADL adapter index
+     * @return memory clock in MHz, or negative if unavailable
+     */
+    protected abstract long adlGetMemoryClockMhz(int adapterIndex);
+
+    /**
+     * @param adapterIndex the ADL adapter index
+     * @return fan speed percent, or negative if unavailable
+     */
+    protected abstract double adlGetFanSpeedPercent(int adapterIndex);
+
+    // -- GpuStats implementation --
+
+    @Override
+    public synchronized void close() {
+        closed = true;
+    }
+
+    @Override
+    public synchronized boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public synchronized GpuTicks getGpuTicks() {
+        checkOpen();
+        if (luidPrefix.isEmpty()) {
+            return new GpuTicks(0L, 0L);
+        }
+        Pair<List<String>, Map<GpuEngineProperty, List<Long>>> engineData = queryGpuEngineCounters();
+        List<String> instances = engineData.getA();
+        Map<GpuEngineProperty, List<Long>> values = engineData.getB();
+        List<Long> runningTimes = values.get(GpuEngineProperty.RUNNING_TIME);
+        List<Long> runningTimeBases = values.get(GpuEngineProperty.RUNNING_TIME_BASE);
+        if (instances.isEmpty() || runningTimes == null || runningTimeBases == null) {
+            return new GpuTicks(0L, 0L);
+        }
+        Map<String, Long> activeByType = new HashMap<>();
+        Map<String, Long> baseByType = new HashMap<>();
+        String luidLower = luidPrefix.toLowerCase(Locale.ROOT);
+        int limit = Math.min(instances.size(), Math.min(runningTimes.size(), runningTimeBases.size()));
+        for (int i = 0; i < limit; i++) {
+            String inst = instances.get(i).toLowerCase(Locale.ROOT);
+            if (!inst.contains(luidLower)) {
+                continue;
+            }
+            int engTypeIdx = inst.lastIndexOf("_engtype_");
+            String engType = engTypeIdx >= 0 ? inst.substring(engTypeIdx) : inst;
+            activeByType.merge(engType, runningTimes.get(i), Long::sum);
+            baseByType.merge(engType, runningTimeBases.get(i), Long::sum);
+        }
+        if (activeByType.isEmpty()) {
+            return new GpuTicks(0L, 0L);
+        }
+        long totalActive = 0L;
+        long totalBase = 0L;
+        for (Map.Entry<String, Long> entry : activeByType.entrySet()) {
+            totalActive += entry.getValue();
+            totalBase += baseByType.getOrDefault(entry.getKey(), 0L);
+        }
+        long idle = totalBase >= totalActive ? totalBase - totalActive : 0L;
+        return new GpuTicks(totalActive, idle);
+    }
+
+    @Override
+    public synchronized double getGpuUtilization() {
+        checkOpen();
+        if (!lhmParent.isEmpty()) {
+            try {
+                WmiResult<LhmSensorProperty> sensors = queryLhmSensors(lhmParent, "Load");
+                for (int i = 0; i < sensors.getResultCount(); i++) {
+                    if ("GPU Core".equals(WmiUtil.getString(sensors, LhmSensorProperty.NAME, i))) {
+                        return WmiUtil.getFloat(sensors, LhmSensorProperty.VALUE, i);
+                    }
+                }
+            } catch (Exception e) {
+                LOG.debug("LHM GPU utilization query failed: {}", e.getMessage());
+            }
+        }
+        GpuTicks curr = getGpuTicks();
+        if (prevUtilTicks != null) {
+            long dActive = curr.getActiveTicks() - prevUtilTicks.getActiveTicks();
+            long dIdle = curr.getIdleTicks() - prevUtilTicks.getIdleTicks();
+            if (dActive < 0 || dIdle < 0) {
+                prevUtilTicks = curr;
+                return -1d;
+            }
+            long dTotal = dActive + dIdle;
+            prevUtilTicks = curr;
+            return dTotal > 0 ? dActive * 100.0 / dTotal : -1d;
+        }
+        prevUtilTicks = curr;
+        return -1d;
+    }
+
+    @Override
+    public synchronized long getVramUsed() {
+        checkOpen();
+        long pdhResult = queryAdapterMemory(GpuAdapterMemoryProperty.DEDICATED_USAGE);
+        if (pdhResult >= 0) {
+            return pdhResult;
+        }
+        if (!lhmParent.isEmpty()) {
+            try {
+                WmiResult<LhmSensorProperty> sensors = queryLhmSensors(lhmParent, "SmallData");
+                for (int i = 0; i < sensors.getResultCount(); i++) {
+                    if ("GPU Memory Used".equals(WmiUtil.getString(sensors, LhmSensorProperty.NAME, i))) {
+                        float mb = WmiUtil.getFloat(sensors, LhmSensorProperty.VALUE, i);
+                        return (long) (mb * MB_TO_BYTES);
+                    }
+                }
+            } catch (Exception e) {
+                LOG.debug("LHM GPU memory used query failed: {}", e.getMessage());
+            }
+        }
+        return -1L;
+    }
+
+    @Override
+    public synchronized long getSharedMemoryUsed() {
+        checkOpen();
+        if (luidPrefix.isEmpty()) {
+            return -1L;
+        }
+        return queryAdapterMemory(GpuAdapterMemoryProperty.SHARED_USAGE);
+    }
+
+    @Override
+    public synchronized double getTemperature() {
+        checkOpen();
+        String nvmlDevice = findNvmlDevice();
+        if (nvmlDevice != null) {
+            double val = nvmlGetTemperature(nvmlDevice);
+            if (val >= 0) {
+                return val;
+            }
+        }
+        int adlIndex = findAdlIndex();
+        if (adlIndex >= 0) {
+            double val = adlGetTemperature(adlIndex);
+            if (val >= 0) {
+                return val;
+            }
+        }
+        return lhmFloatSensor("Temperature", "GPU Core");
+    }
+
+    @Override
+    public synchronized double getPowerDraw() {
+        checkOpen();
+        String nvmlDevice = findNvmlDevice();
+        if (nvmlDevice != null) {
+            double val = nvmlGetPowerDraw(nvmlDevice);
+            if (val >= 0) {
+                return val;
+            }
+        }
+        int adlIndex = findAdlIndex();
+        if (adlIndex >= 0) {
+            double val = adlGetPowerDraw(adlIndex);
+            if (val >= 0) {
+                return val;
+            }
+        }
+        double lhm = lhmFloatSensor("Power", "GPU Package");
+        if (lhm >= 0) {
+            return lhm;
+        }
+        return lhmFloatSensor("Power", "GPU Power");
+    }
+
+    @Override
+    public synchronized long getCoreClockMhz() {
+        checkOpen();
+        String nvmlDevice = findNvmlDevice();
+        if (nvmlDevice != null) {
+            long val = nvmlGetCoreClockMhz(nvmlDevice);
+            if (val >= 0) {
+                return val;
+            }
+        }
+        int adlIndex = findAdlIndex();
+        if (adlIndex >= 0) {
+            long val = adlGetCoreClockMhz(adlIndex);
+            if (val >= 0) {
+                return val;
+            }
+        }
+        double lhm = lhmFloatSensor("Clock", "GPU Core");
+        return lhm >= 0 ? (long) lhm : -1L;
+    }
+
+    @Override
+    public synchronized long getMemoryClockMhz() {
+        checkOpen();
+        String nvmlDevice = findNvmlDevice();
+        if (nvmlDevice != null) {
+            long val = nvmlGetMemoryClockMhz(nvmlDevice);
+            if (val >= 0) {
+                return val;
+            }
+        }
+        int adlIndex = findAdlIndex();
+        if (adlIndex >= 0) {
+            long val = adlGetMemoryClockMhz(adlIndex);
+            if (val >= 0) {
+                return val;
+            }
+        }
+        double lhm = lhmFloatSensor("Clock", "GPU Memory");
+        return lhm >= 0 ? (long) lhm : -1L;
+    }
+
+    @Override
+    public synchronized double getFanSpeedPercent() {
+        checkOpen();
+        String nvmlDevice = findNvmlDevice();
+        if (nvmlDevice != null) {
+            double val = nvmlGetFanSpeedPercent(nvmlDevice);
+            if (val >= 0) {
+                return val;
+            }
+        }
+        int adlIndex = findAdlIndex();
+        if (adlIndex >= 0) {
+            double val = adlGetFanSpeedPercent(adlIndex);
+            if (val >= 0) {
+                return val;
+            }
+        }
+        double lhm = lhmFloatSensor("Control", "GPU Fan");
+        if (lhm >= 0) {
+            return lhm;
+        }
+        return lhmFloatSensor("Control", "GPU Fan 1");
+    }
+
+    private void checkOpen() {
+        if (closed) {
+            throw new IllegalStateException(
+                    "GpuStats session has been closed. Obtain a new session via GraphicsCard.createStatsSession().");
+        }
+    }
+
+    private long queryAdapterMemory(GpuAdapterMemoryProperty property) {
+        if (luidPrefix.isEmpty()) {
+            return -1L;
+        }
+        Pair<List<String>, Map<GpuAdapterMemoryProperty, List<Long>>> adapterData = queryGpuAdapterMemoryCounters();
+        List<String> instances = adapterData.getA();
+        List<Long> values = adapterData.getB().get(property);
+        if (values != null) {
+            String luidLower = luidPrefix.toLowerCase(Locale.ROOT);
+            int limit = Math.min(instances.size(), values.size());
+            for (int i = 0; i < limit; i++) {
+                if (instances.get(i).toLowerCase(Locale.ROOT).contains(luidLower)) {
+                    return values.get(i);
+                }
+            }
+        }
+        return -1L;
+    }
+
+    private String findNvmlDevice() {
+        if (cachedNvmlDevice != null) {
+            return cachedNvmlDevice.isEmpty() ? null : cachedNvmlDevice;
+        }
+        if (!isNvmlAvailable()) {
+            cachedNvmlDevice = "";
+            return null;
+        }
+        String id = null;
+        if (!pciBusId.isEmpty()) {
+            id = nvmlFindDevice(pciBusId);
+        }
+        if (id == null) {
+            id = nvmlFindDeviceByName(cardName);
+        }
+        cachedNvmlDevice = id != null ? id : "";
+        return id;
+    }
+
+    private int findAdlIndex() {
+        if (cachedAdlIndex != Integer.MIN_VALUE) {
+            return cachedAdlIndex;
+        }
+        if (!isAdlAvailable() || pciBusNumber < 0) {
+            cachedAdlIndex = -1;
+            return -1;
+        }
+        cachedAdlIndex = adlFindAdapterIndex(pciBusNumber);
+        return cachedAdlIndex;
+    }
+
+    private double lhmFloatSensor(String sensorType, String sensorName) {
+        if (lhmParent.isEmpty()) {
+            return -1d;
+        }
+        try {
+            WmiResult<LhmSensorProperty> sensors = queryLhmSensors(lhmParent, sensorType);
+            for (int i = 0; i < sensors.getResultCount(); i++) {
+                if (sensorName.equals(WmiUtil.getString(sensors, LhmSensorProperty.NAME, i))) {
+                    return WmiUtil.getFloat(sensors, LhmSensorProperty.VALUE, i);
+                }
+            }
+        } catch (Exception e) {
+            LOG.debug("LHM {} {} query failed: {}", sensorType, sensorName, e.getMessage());
+        }
+        return -1d;
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGpuStatsFFM.java
@@ -4,357 +4,118 @@
  */
 package oshi.hardware.platform.windows;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.GpuInformation.GpuAdapterMemoryProperty;
 import oshi.driver.common.windows.perfmon.GpuInformation.GpuEngineProperty;
 import oshi.driver.common.windows.wmi.LhmSensor.LhmSensorProperty;
 import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.driver.windows.perfmon.GpuInformationFFM;
 import oshi.driver.windows.wmi.LhmSensorFFM;
 import oshi.ffm.util.gpu.AdlUtilFFM;
 import oshi.ffm.util.gpu.NvmlUtilFFM;
-import oshi.hardware.GpuStats;
-import oshi.hardware.GpuTicks;
+import oshi.hardware.common.platform.windows.WindowsGpuStats;
 import oshi.util.tuples.Pair;
 
 /**
- * Windows {@link GpuStats} session using FFM.
+ * Windows {@link oshi.hardware.GpuStats} session using FFM.
  */
 @ThreadSafe
-final class WindowsGpuStatsFFM implements GpuStats {
-
-    private static final String GPU_CORE = "GPU Core";
-
-    private static final Logger LOG = LoggerFactory.getLogger(WindowsGpuStatsFFM.class);
-
-    private static final long MB_TO_BYTES = 1_048_576L;
-
-    private final String luidPrefix;
-    private final String lhmParent;
-    private final int pciBusNumber;
-    private final String pciBusId;
-    private final String cardName;
-
-    private boolean closed;
-
-    private String cachedNvmlDevice;
-    private int cachedAdlIndex = Integer.MIN_VALUE;
-    private GpuTicks prevUtilTicks;
+final class WindowsGpuStatsFFM extends WindowsGpuStats {
 
     WindowsGpuStatsFFM(String luidPrefix, String lhmParent, int pciBusNumber, String pciBusId, String cardName) {
-        this.luidPrefix = luidPrefix;
-        this.lhmParent = lhmParent;
-        this.pciBusNumber = pciBusNumber;
-        this.pciBusId = pciBusId;
-        this.cardName = cardName;
+        super(luidPrefix, lhmParent, pciBusNumber, pciBusId, cardName);
     }
 
     @Override
-    public synchronized void close() {
-        closed = true;
+    protected Pair<List<String>, Map<GpuEngineProperty, List<Long>>> queryGpuEngineCounters() {
+        return GpuInformationFFM.queryGpuEngineCounters();
     }
 
     @Override
-    public synchronized boolean isClosed() {
-        return closed;
+    protected Pair<List<String>, Map<GpuAdapterMemoryProperty, List<Long>>> queryGpuAdapterMemoryCounters() {
+        return GpuInformationFFM.queryGpuAdapterMemoryCounters();
     }
 
     @Override
-    public synchronized GpuTicks getGpuTicks() {
-        checkOpen();
-        if (luidPrefix.isEmpty()) {
-            return new GpuTicks(0L, 0L);
-        }
-        Pair<List<String>, Map<GpuEngineProperty, List<Long>>> engineData = GpuInformationFFM.queryGpuEngineCounters();
-        List<String> instances = engineData.getA();
-        Map<GpuEngineProperty, List<Long>> values = engineData.getB();
-        List<Long> runningTimes = values.get(GpuEngineProperty.RUNNING_TIME);
-        List<Long> runningTimeBases = values.get(GpuEngineProperty.RUNNING_TIME_BASE);
-        if (instances.isEmpty() || runningTimes == null || runningTimeBases == null) {
-            return new GpuTicks(0L, 0L);
-        }
-        Map<String, Long> activeByType = new HashMap<>();
-        Map<String, Long> baseByType = new HashMap<>();
-        String luidLower = luidPrefix.toLowerCase(Locale.ROOT);
-        int limit = Math.min(instances.size(), Math.min(runningTimes.size(), runningTimeBases.size()));
-        for (int i = 0; i < limit; i++) {
-            String inst = instances.get(i).toLowerCase(Locale.ROOT);
-            if (!inst.contains(luidLower)) {
-                continue;
-            }
-            int engTypeIdx = inst.lastIndexOf("_engtype_");
-            String engType = engTypeIdx >= 0 ? inst.substring(engTypeIdx) : inst;
-            activeByType.merge(engType, runningTimes.get(i), Long::sum);
-            baseByType.merge(engType, runningTimeBases.get(i), Long::sum);
-        }
-        if (activeByType.isEmpty()) {
-            return new GpuTicks(0L, 0L);
-        }
-        long totalActive = 0L;
-        long totalBase = 0L;
-        for (Map.Entry<String, Long> entry : activeByType.entrySet()) {
-            totalActive += entry.getValue();
-            totalBase += baseByType.getOrDefault(entry.getKey(), 0L);
-        }
-        long idle = totalBase >= totalActive ? totalBase - totalActive : 0L;
-        return new GpuTicks(totalActive, idle);
+    protected WmiResult<LhmSensorProperty> queryLhmSensors(String parent, String sensorType) {
+        return LhmSensorFFM.querySensors(parent, sensorType);
     }
 
     @Override
-    public synchronized double getGpuUtilization() {
-        checkOpen();
-        if (!lhmParent.isEmpty()) {
-            try {
-                WmiResult<LhmSensorProperty> sensors = LhmSensorFFM.querySensors(lhmParent, "Load");
-                for (int i = 0; i < sensors.getResultCount(); i++) {
-                    if (GPU_CORE.equals(WmiUtil.getString(sensors, LhmSensorProperty.NAME, i))) {
-                        return WmiUtil.getFloat(sensors, LhmSensorProperty.VALUE, i);
-                    }
-                }
-            } catch (Exception e) {
-                LOG.debug("LHM GPU utilization query failed: {}", e.getMessage());
-            }
-        }
-        GpuTicks curr = getGpuTicks();
-        if (prevUtilTicks != null) {
-            long dActive = curr.getActiveTicks() - prevUtilTicks.getActiveTicks();
-            long dIdle = curr.getIdleTicks() - prevUtilTicks.getIdleTicks();
-            if (dActive < 0 || dIdle < 0) {
-                // Counter reset or empty snapshot; discard and wait for next sample
-                prevUtilTicks = curr;
-                return -1d;
-            }
-            long dTotal = dActive + dIdle;
-            prevUtilTicks = curr;
-            return dTotal > 0 ? dActive * 100.0 / dTotal : -1d;
-        }
-        prevUtilTicks = curr;
-        return -1d;
+    protected boolean isNvmlAvailable() {
+        return NvmlUtilFFM.isAvailable();
     }
 
     @Override
-    public synchronized long getVramUsed() {
-        checkOpen();
-        long pdhResult = queryAdapterMemory(GpuAdapterMemoryProperty.DEDICATED_USAGE);
-        if (pdhResult >= 0) {
-            return pdhResult;
-        }
-        if (!lhmParent.isEmpty()) {
-            try {
-                WmiResult<LhmSensorProperty> sensors = LhmSensorFFM.querySensors(lhmParent, "SmallData");
-                for (int i = 0; i < sensors.getResultCount(); i++) {
-                    if ("GPU Memory Used".equals(WmiUtil.getString(sensors, LhmSensorProperty.NAME, i))) {
-                        float mb = WmiUtil.getFloat(sensors, LhmSensorProperty.VALUE, i);
-                        return (long) (mb * MB_TO_BYTES);
-                    }
-                }
-            } catch (Exception e) {
-                LOG.debug("LHM GPU memory used query failed: {}", e.getMessage());
-            }
-        }
-        return -1L;
+    protected String nvmlFindDevice(String pciBusId) {
+        return NvmlUtilFFM.findDevice(pciBusId);
     }
 
     @Override
-    public synchronized long getSharedMemoryUsed() {
-        checkOpen();
-        if (luidPrefix.isEmpty()) {
-            return -1L;
-        }
-        return queryAdapterMemory(GpuAdapterMemoryProperty.SHARED_USAGE);
+    protected String nvmlFindDeviceByName(String gpuName) {
+        return NvmlUtilFFM.findDeviceByName(gpuName);
     }
 
     @Override
-    public synchronized double getTemperature() {
-        checkOpen();
-        String nvmlDevice = findNvmlDevice();
-        if (nvmlDevice != null) {
-            double val = NvmlUtilFFM.getTemperature(nvmlDevice);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        int adlIndex = findAdlIndex();
-        if (adlIndex >= 0) {
-            double val = AdlUtilFFM.getTemperature(adlIndex);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        return lhmFloatSensor("Temperature", GPU_CORE);
+    protected double nvmlGetTemperature(String device) {
+        return NvmlUtilFFM.getTemperature(device);
     }
 
     @Override
-    public synchronized double getPowerDraw() {
-        checkOpen();
-        String nvmlDevice = findNvmlDevice();
-        if (nvmlDevice != null) {
-            double val = NvmlUtilFFM.getPowerDraw(nvmlDevice);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        int adlIndex = findAdlIndex();
-        if (adlIndex >= 0) {
-            double val = AdlUtilFFM.getPowerDraw(adlIndex);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        double lhm = lhmFloatSensor("Power", "GPU Package");
-        if (lhm >= 0) {
-            return lhm;
-        }
-        return lhmFloatSensor("Power", "GPU Power");
+    protected double nvmlGetPowerDraw(String device) {
+        return NvmlUtilFFM.getPowerDraw(device);
     }
 
     @Override
-    public synchronized long getCoreClockMhz() {
-        checkOpen();
-        String nvmlDevice = findNvmlDevice();
-        if (nvmlDevice != null) {
-            long val = NvmlUtilFFM.getCoreClockMhz(nvmlDevice);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        int adlIndex = findAdlIndex();
-        if (adlIndex >= 0) {
-            long val = AdlUtilFFM.getCoreClockMhz(adlIndex);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        double lhm = lhmFloatSensor("Clock", GPU_CORE);
-        return lhm >= 0 ? (long) lhm : -1L;
+    protected long nvmlGetCoreClockMhz(String device) {
+        return NvmlUtilFFM.getCoreClockMhz(device);
     }
 
     @Override
-    public synchronized long getMemoryClockMhz() {
-        checkOpen();
-        String nvmlDevice = findNvmlDevice();
-        if (nvmlDevice != null) {
-            long val = NvmlUtilFFM.getMemoryClockMhz(nvmlDevice);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        int adlIndex = findAdlIndex();
-        if (adlIndex >= 0) {
-            long val = AdlUtilFFM.getMemoryClockMhz(adlIndex);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        double lhm = lhmFloatSensor("Clock", "GPU Memory");
-        return lhm >= 0 ? (long) lhm : -1L;
+    protected long nvmlGetMemoryClockMhz(String device) {
+        return NvmlUtilFFM.getMemoryClockMhz(device);
     }
 
     @Override
-    public synchronized double getFanSpeedPercent() {
-        checkOpen();
-        String nvmlDevice = findNvmlDevice();
-        if (nvmlDevice != null) {
-            double val = NvmlUtilFFM.getFanSpeedPercent(nvmlDevice);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        int adlIndex = findAdlIndex();
-        if (adlIndex >= 0) {
-            double val = AdlUtilFFM.getFanSpeedPercent(adlIndex);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        double lhm = lhmFloatSensor("Control", "GPU Fan");
-        if (lhm >= 0) {
-            return lhm;
-        }
-        return lhmFloatSensor("Control", "GPU Fan 1");
+    protected double nvmlGetFanSpeedPercent(String device) {
+        return NvmlUtilFFM.getFanSpeedPercent(device);
     }
 
-    private void checkOpen() {
-        if (closed) {
-            throw new IllegalStateException(
-                    "GpuStats session has been closed. Obtain a new session via GraphicsCard.createStatsSession().");
-        }
+    @Override
+    protected boolean isAdlAvailable() {
+        return AdlUtilFFM.isAvailable();
     }
 
-    private long queryAdapterMemory(GpuAdapterMemoryProperty property) {
-        if (luidPrefix.isEmpty()) {
-            return -1L;
-        }
-        Pair<List<String>, Map<GpuAdapterMemoryProperty, List<Long>>> adapterData = GpuInformationFFM
-                .queryGpuAdapterMemoryCounters();
-        List<String> instances = adapterData.getA();
-        List<Long> values = adapterData.getB().get(property);
-        if (values != null) {
-            String luidLower = luidPrefix.toLowerCase(Locale.ROOT);
-            int limit = Math.min(instances.size(), values.size());
-            for (int i = 0; i < limit; i++) {
-                if (instances.get(i).toLowerCase(Locale.ROOT).contains(luidLower)) {
-                    return values.get(i);
-                }
-            }
-        }
-        return -1L;
+    @Override
+    protected int adlFindAdapterIndex(int pciBusNumber) {
+        return AdlUtilFFM.findAdapterIndex(pciBusNumber);
     }
 
-    private String findNvmlDevice() {
-        if (cachedNvmlDevice != null) {
-            return cachedNvmlDevice.isEmpty() ? null : cachedNvmlDevice;
-        }
-        if (!NvmlUtilFFM.isAvailable()) {
-            cachedNvmlDevice = "";
-            return null;
-        }
-        String id = null;
-        if (!pciBusId.isEmpty()) {
-            id = NvmlUtilFFM.findDevice(pciBusId);
-        }
-        if (id == null) {
-            id = NvmlUtilFFM.findDeviceByName(cardName);
-        }
-        cachedNvmlDevice = id != null ? id : "";
-        return id;
+    @Override
+    protected double adlGetTemperature(int adapterIndex) {
+        return AdlUtilFFM.getTemperature(adapterIndex);
     }
 
-    private int findAdlIndex() {
-        if (cachedAdlIndex != Integer.MIN_VALUE) {
-            return cachedAdlIndex;
-        }
-        if (!AdlUtilFFM.isAvailable() || pciBusNumber < 0) {
-            cachedAdlIndex = -1;
-            return -1;
-        }
-        cachedAdlIndex = AdlUtilFFM.findAdapterIndex(pciBusNumber);
-        return cachedAdlIndex;
+    @Override
+    protected double adlGetPowerDraw(int adapterIndex) {
+        return AdlUtilFFM.getPowerDraw(adapterIndex);
     }
 
-    private double lhmFloatSensor(String sensorType, String sensorName) {
-        if (lhmParent.isEmpty()) {
-            return -1d;
-        }
-        try {
-            WmiResult<LhmSensorProperty> sensors = LhmSensorFFM.querySensors(lhmParent, sensorType);
-            for (int i = 0; i < sensors.getResultCount(); i++) {
-                if (sensorName.equals(WmiUtil.getString(sensors, LhmSensorProperty.NAME, i))) {
-                    return WmiUtil.getFloat(sensors, LhmSensorProperty.VALUE, i);
-                }
-            }
-        } catch (Exception e) {
-            LOG.debug("LHM {} {} query failed: {}", sensorType, sensorName, e.getMessage());
-        }
-        return -1d;
+    @Override
+    protected long adlGetCoreClockMhz(int adapterIndex) {
+        return AdlUtilFFM.getCoreClockMhz(adapterIndex);
+    }
+
+    @Override
+    protected long adlGetMemoryClockMhz(int adapterIndex) {
+        return AdlUtilFFM.getMemoryClockMhz(adapterIndex);
+    }
+
+    @Override
+    protected double adlGetFanSpeedPercent(int adapterIndex) {
+        return AdlUtilFFM.getFanSpeedPercent(adapterIndex);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGpuStatsJNA.java
@@ -4,373 +4,118 @@
  */
 package oshi.hardware.platform.windows;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.GpuInformation.GpuAdapterMemoryProperty;
 import oshi.driver.common.windows.perfmon.GpuInformation.GpuEngineProperty;
 import oshi.driver.common.windows.wmi.LhmSensor.LhmSensorProperty;
 import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.driver.windows.perfmon.GpuInformationJNA;
 import oshi.driver.windows.wmi.LhmSensorJNA;
-import oshi.hardware.GpuStats;
-import oshi.hardware.GpuTicks;
+import oshi.hardware.common.platform.windows.WindowsGpuStats;
 import oshi.util.gpu.AdlUtilJNA;
 import oshi.util.gpu.NvmlUtilJNA;
 import oshi.util.tuples.Pair;
 
 /**
- * Windows {@link GpuStats} session.
- *
- * <p>
- * Metric source priority by method:
- * <ul>
- * <li>{@code getGpuTicks()}: PDH GPU Engine counters ({@code Running Time} / {@code Running Time_Base}).</li>
- * <li>{@code getGpuUtilization()}: LHM WMI {@code GPU Core} load sensor. Falls back to PDH tick-delta
- * ({@code getGpuTicks()} delta) when LHM is not running; returns -1 on the first call (priming).</li>
- * <li>{@code getVramUsed()}: PDH GPU Adapter Memory {@code DedicatedUsage}, then LHM {@code GPU Memory Used}.</li>
- * <li>{@code getSharedMemoryUsed()}: PDH GPU Adapter Memory {@code SharedUsage}.</li>
- * <li>{@code getTemperature()}: NVML, then ADL, then LHM {@code GPU Core} temperature.</li>
- * <li>{@code getPowerDraw()}: NVML, then ADL, then LHM {@code GPU Package} / {@code GPU Power}.</li>
- * <li>{@code getCoreClockMhz()}: NVML, then ADL, then LHM {@code GPU Core} clock.</li>
- * <li>{@code getMemoryClockMhz()}: NVML, then ADL, then LHM {@code GPU Memory} clock.</li>
- * <li>{@code getFanSpeedPercent()}: NVML, then ADL, then LHM {@code GPU Fan} / {@code GPU Fan 1}.</li>
- * </ul>
- *
- * <p>
- * PDH metrics require a valid LUID prefix (populated from DXGI). NVML requires an NVIDIA GPU with the NVML library
- * present. ADL requires an AMD GPU with the ADL library present. LHM requires LibreHardwareMonitor to be running.
+ * Windows {@link oshi.hardware.GpuStats} session using JNA.
  */
 @ThreadSafe
-final class WindowsGpuStatsJNA implements GpuStats {
-
-    private static final Logger LOG = LoggerFactory.getLogger(WindowsGpuStatsJNA.class);
-
-    private static final long MB_TO_BYTES = 1_048_576L;
-
-    private final String luidPrefix;
-    private final String lhmParent;
-    private final int pciBusNumber;
-    private final String pciBusId;
-    private final String cardName;
-
-    private boolean closed;
-
-    // Cached device lookups; null = not yet resolved, empty = unavailable
-    private String cachedNvmlDevice;
-    // Integer.MIN_VALUE = not yet resolved, -1 = unavailable
-    private int cachedAdlIndex = Integer.MIN_VALUE;
-    // Previous tick snapshot for PDH-based utilization fallback; null = not yet sampled
-    private GpuTicks prevUtilTicks;
+final class WindowsGpuStatsJNA extends WindowsGpuStats {
 
     WindowsGpuStatsJNA(String luidPrefix, String lhmParent, int pciBusNumber, String pciBusId, String cardName) {
-        this.luidPrefix = luidPrefix;
-        this.lhmParent = lhmParent;
-        this.pciBusNumber = pciBusNumber;
-        this.pciBusId = pciBusId;
-        this.cardName = cardName;
+        super(luidPrefix, lhmParent, pciBusNumber, pciBusId, cardName);
     }
 
     @Override
-    public synchronized void close() {
-        closed = true;
+    protected Pair<List<String>, Map<GpuEngineProperty, List<Long>>> queryGpuEngineCounters() {
+        return GpuInformationJNA.queryGpuEngineCounters();
     }
 
     @Override
-    public synchronized boolean isClosed() {
-        return closed;
+    protected Pair<List<String>, Map<GpuAdapterMemoryProperty, List<Long>>> queryGpuAdapterMemoryCounters() {
+        return GpuInformationJNA.queryGpuAdapterMemoryCounters();
     }
 
     @Override
-    public synchronized GpuTicks getGpuTicks() {
-        checkOpen();
-        if (luidPrefix.isEmpty()) {
-            return new GpuTicks(0L, 0L);
-        }
-        Pair<List<String>, Map<GpuEngineProperty, List<Long>>> engineData = GpuInformationJNA.queryGpuEngineCounters();
-        List<String> instances = engineData.getA();
-        Map<GpuEngineProperty, List<Long>> values = engineData.getB();
-        List<Long> runningTimes = values.get(GpuEngineProperty.RUNNING_TIME);
-        List<Long> runningTimeBases = values.get(GpuEngineProperty.RUNNING_TIME_BASE);
-        if (instances.isEmpty() || runningTimes == null || runningTimeBases == null) {
-            return new GpuTicks(0L, 0L);
-        }
-        Map<String, Long> activeByType = new HashMap<>();
-        Map<String, Long> baseByType = new HashMap<>();
-        String luidLower = luidPrefix.toLowerCase(Locale.ROOT);
-        int limit = Math.min(instances.size(), Math.min(runningTimes.size(), runningTimeBases.size()));
-        for (int i = 0; i < limit; i++) {
-            String inst = instances.get(i).toLowerCase(Locale.ROOT);
-            if (!inst.contains(luidLower)) {
-                continue;
-            }
-            int engTypeIdx = inst.lastIndexOf("_engtype_");
-            String engType = engTypeIdx >= 0 ? inst.substring(engTypeIdx) : inst;
-            activeByType.merge(engType, runningTimes.get(i), Long::sum);
-            baseByType.merge(engType, runningTimeBases.get(i), Long::sum);
-        }
-        if (activeByType.isEmpty()) {
-            return new GpuTicks(0L, 0L);
-        }
-        long totalActive = 0L;
-        long totalBase = 0L;
-        for (String key : activeByType.keySet()) {
-            totalActive += activeByType.get(key);
-            totalBase += baseByType.getOrDefault(key, 0L);
-        }
-        long idle = totalBase >= totalActive ? totalBase - totalActive : 0L;
-        return new GpuTicks(totalActive, idle);
+    protected WmiResult<LhmSensorProperty> queryLhmSensors(String parent, String sensorType) {
+        return LhmSensorJNA.querySensors(parent, sensorType);
     }
 
     @Override
-    public synchronized double getGpuUtilization() {
-        checkOpen();
-        if (!lhmParent.isEmpty()) {
-            try {
-                WmiResult<LhmSensorProperty> sensors = LhmSensorJNA.querySensors(lhmParent, "Load");
-                for (int i = 0; i < sensors.getResultCount(); i++) {
-                    if ("GPU Core".equals(WmiUtil.getString(sensors, LhmSensorProperty.NAME, i))) {
-                        return WmiUtil.getFloat(sensors, LhmSensorProperty.VALUE, i);
-                    }
-                }
-            } catch (Exception e) {
-                LOG.debug("LHM GPU utilization query failed: {}", e.getMessage());
-            }
-        }
-        // Fallback: derive utilization from PDH tick counters
-        GpuTicks curr = getGpuTicks();
-        if (prevUtilTicks != null) {
-            long dActive = curr.getActiveTicks() - prevUtilTicks.getActiveTicks();
-            long dIdle = curr.getIdleTicks() - prevUtilTicks.getIdleTicks();
-            long dTotal = dActive + dIdle;
-            prevUtilTicks = curr;
-            return dTotal > 0 ? dActive * 100.0 / dTotal : -1d;
-        }
-        prevUtilTicks = curr;
-        return -1d;
+    protected boolean isNvmlAvailable() {
+        return NvmlUtilJNA.isAvailable();
     }
 
     @Override
-    public synchronized long getVramUsed() {
-        checkOpen();
-        long pdhResult = queryAdapterMemory(GpuAdapterMemoryProperty.DEDICATED_USAGE);
-        if (pdhResult >= 0) {
-            return pdhResult;
-        }
-        if (!lhmParent.isEmpty()) {
-            try {
-                WmiResult<LhmSensorProperty> sensors = LhmSensorJNA.querySensors(lhmParent, "SmallData");
-                for (int i = 0; i < sensors.getResultCount(); i++) {
-                    if ("GPU Memory Used".equals(WmiUtil.getString(sensors, LhmSensorProperty.NAME, i))) {
-                        float mb = WmiUtil.getFloat(sensors, LhmSensorProperty.VALUE, i);
-                        return (long) (mb * MB_TO_BYTES);
-                    }
-                }
-            } catch (Exception e) {
-                LOG.debug("LHM GPU memory used query failed: {}", e.getMessage());
-            }
-        }
-        return -1L;
+    protected String nvmlFindDevice(String pciBusId) {
+        return NvmlUtilJNA.findDevice(pciBusId);
     }
 
     @Override
-    public synchronized long getSharedMemoryUsed() {
-        checkOpen();
-        if (luidPrefix.isEmpty()) {
-            return -1L;
-        }
-        return queryAdapterMemory(GpuAdapterMemoryProperty.SHARED_USAGE);
+    protected String nvmlFindDeviceByName(String gpuName) {
+        return NvmlUtilJNA.findDeviceByName(gpuName);
     }
 
     @Override
-    public synchronized double getTemperature() {
-        checkOpen();
-        String nvmlDevice = findNvmlDevice();
-        if (nvmlDevice != null) {
-            double val = NvmlUtilJNA.getTemperature(nvmlDevice);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        int adlIndex = findAdlIndex();
-        if (adlIndex >= 0) {
-            double val = AdlUtilJNA.getTemperature(adlIndex);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        return lhmFloatSensor("Temperature", "GPU Core");
+    protected double nvmlGetTemperature(String device) {
+        return NvmlUtilJNA.getTemperature(device);
     }
 
     @Override
-    public synchronized double getPowerDraw() {
-        checkOpen();
-        String nvmlDevice = findNvmlDevice();
-        if (nvmlDevice != null) {
-            double val = NvmlUtilJNA.getPowerDraw(nvmlDevice);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        int adlIndex = findAdlIndex();
-        if (adlIndex >= 0) {
-            double val = AdlUtilJNA.getPowerDraw(adlIndex);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        double lhm = lhmFloatSensor("Power", "GPU Package");
-        if (lhm >= 0) {
-            return lhm;
-        }
-        return lhmFloatSensor("Power", "GPU Power");
+    protected double nvmlGetPowerDraw(String device) {
+        return NvmlUtilJNA.getPowerDraw(device);
     }
 
     @Override
-    public synchronized long getCoreClockMhz() {
-        checkOpen();
-        String nvmlDevice = findNvmlDevice();
-        if (nvmlDevice != null) {
-            long val = NvmlUtilJNA.getCoreClockMhz(nvmlDevice);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        int adlIndex = findAdlIndex();
-        if (adlIndex >= 0) {
-            long val = AdlUtilJNA.getCoreClockMhz(adlIndex);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        double lhm = lhmFloatSensor("Clock", "GPU Core");
-        return lhm >= 0 ? (long) lhm : -1L;
+    protected long nvmlGetCoreClockMhz(String device) {
+        return NvmlUtilJNA.getCoreClockMhz(device);
     }
 
     @Override
-    public synchronized long getMemoryClockMhz() {
-        checkOpen();
-        String nvmlDevice = findNvmlDevice();
-        if (nvmlDevice != null) {
-            long val = NvmlUtilJNA.getMemoryClockMhz(nvmlDevice);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        int adlIndex = findAdlIndex();
-        if (adlIndex >= 0) {
-            long val = AdlUtilJNA.getMemoryClockMhz(adlIndex);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        double lhm = lhmFloatSensor("Clock", "GPU Memory");
-        return lhm >= 0 ? (long) lhm : -1L;
+    protected long nvmlGetMemoryClockMhz(String device) {
+        return NvmlUtilJNA.getMemoryClockMhz(device);
     }
 
     @Override
-    public synchronized double getFanSpeedPercent() {
-        checkOpen();
-        String nvmlDevice = findNvmlDevice();
-        if (nvmlDevice != null) {
-            double val = NvmlUtilJNA.getFanSpeedPercent(nvmlDevice);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        int adlIndex = findAdlIndex();
-        if (adlIndex >= 0) {
-            double val = AdlUtilJNA.getFanSpeedPercent(adlIndex);
-            if (val >= 0) {
-                return val;
-            }
-        }
-        double lhm = lhmFloatSensor("Control", "GPU Fan");
-        if (lhm >= 0) {
-            return lhm;
-        }
-        return lhmFloatSensor("Control", "GPU Fan 1");
+    protected double nvmlGetFanSpeedPercent(String device) {
+        return NvmlUtilJNA.getFanSpeedPercent(device);
     }
 
-    private void checkOpen() {
-        if (closed) {
-            throw new IllegalStateException(
-                    "GpuStats session has been closed. Obtain a new session via GraphicsCard.createStatsSession().");
-        }
+    @Override
+    protected boolean isAdlAvailable() {
+        return AdlUtilJNA.isAvailable();
     }
 
-    private long queryAdapterMemory(GpuAdapterMemoryProperty property) {
-        if (luidPrefix.isEmpty()) {
-            return -1L;
-        }
-        Pair<List<String>, Map<GpuAdapterMemoryProperty, List<Long>>> adapterData = GpuInformationJNA
-                .queryGpuAdapterMemoryCounters();
-        List<String> instances = adapterData.getA();
-        List<Long> values = adapterData.getB().get(property);
-        if (values != null) {
-            String luidLower = luidPrefix.toLowerCase(Locale.ROOT);
-            int limit = Math.min(instances.size(), values.size());
-            for (int i = 0; i < limit; i++) {
-                if (instances.get(i).toLowerCase(Locale.ROOT).contains(luidLower)) {
-                    return values.get(i);
-                }
-            }
-        }
-        return -1L;
+    @Override
+    protected int adlFindAdapterIndex(int pciBusNumber) {
+        return AdlUtilJNA.findAdapterIndex(pciBusNumber);
     }
 
-    private String findNvmlDevice() {
-        if (cachedNvmlDevice != null) {
-            return cachedNvmlDevice.isEmpty() ? null : cachedNvmlDevice;
-        }
-        if (!NvmlUtilJNA.isAvailable()) {
-            cachedNvmlDevice = "";
-            return null;
-        }
-        String id = null;
-        if (!pciBusId.isEmpty()) {
-            id = NvmlUtilJNA.findDevice(pciBusId);
-        }
-        if (id == null) {
-            id = NvmlUtilJNA.findDeviceByName(cardName);
-        }
-        cachedNvmlDevice = id != null ? id : "";
-        return id;
+    @Override
+    protected double adlGetTemperature(int adapterIndex) {
+        return AdlUtilJNA.getTemperature(adapterIndex);
     }
 
-    private int findAdlIndex() {
-        if (cachedAdlIndex != Integer.MIN_VALUE) {
-            return cachedAdlIndex;
-        }
-        if (!AdlUtilJNA.isAvailable() || pciBusNumber < 0) {
-            cachedAdlIndex = -1;
-            return -1;
-        }
-        cachedAdlIndex = AdlUtilJNA.findAdapterIndex(pciBusNumber);
-        return cachedAdlIndex;
+    @Override
+    protected double adlGetPowerDraw(int adapterIndex) {
+        return AdlUtilJNA.getPowerDraw(adapterIndex);
     }
 
-    private double lhmFloatSensor(String sensorType, String sensorName) {
-        if (lhmParent.isEmpty()) {
-            return -1d;
-        }
-        try {
-            WmiResult<LhmSensorProperty> sensors = LhmSensorJNA.querySensors(lhmParent, sensorType);
-            for (int i = 0; i < sensors.getResultCount(); i++) {
-                if (sensorName.equals(WmiUtil.getString(sensors, LhmSensorProperty.NAME, i))) {
-                    return WmiUtil.getFloat(sensors, LhmSensorProperty.VALUE, i);
-                }
-            }
-        } catch (Exception e) {
-            LOG.debug("LHM {} {} query failed: {}", sensorType, sensorName, e.getMessage());
-        }
-        return -1d;
+    @Override
+    protected long adlGetCoreClockMhz(int adapterIndex) {
+        return AdlUtilJNA.getCoreClockMhz(adapterIndex);
+    }
+
+    @Override
+    protected long adlGetMemoryClockMhz(int adapterIndex) {
+        return AdlUtilJNA.getMemoryClockMhz(adapterIndex);
+    }
+
+    @Override
+    protected double adlGetFanSpeedPercent(int adapterIndex) {
+        return AdlUtilJNA.getFanSpeedPercent(adapterIndex);
     }
 }


### PR DESCRIPTION
## Summary

Addresses Issue 1 (JNA ↔ FFM Parallel Implementations) from #3274 for the WindowsGpuStats class (222 lines duplicated).

## Changes

- New: `oshi-common/.../WindowsGpuStats.java` (483 lines) — all business logic for GPU metrics
- Simplified: `WindowsGpuStatsJNA` (311→121 lines) — native dispatch only
- Simplified: `WindowsGpuStatsFFM` (287→121 lines) — native dispatch only

## Pattern

The common base class holds all GPU metrics logic:
- Tick aggregation from PDH GPU Engine counters
- Utilization calculation (LHM → PDH tick-delta fallback)
- VRAM/shared memory from PDH Adapter Memory counters
- Temperature/power/clock/fan fallback chains (NVML → ADL → LHM)
- Device caching for NVML and ADL

Subclasses implement 18 abstract methods that dispatch to platform-specific utilities:
- **PDH**: `queryGpuEngineCounters()`, `queryGpuAdapterMemoryCounters()`
- **LHM WMI**: `queryLhmSensors()`
- **NVML**: `isNvmlAvailable()`, `nvmlFindDevice()`, `nvmlFindDeviceByName()`, `nvmlGet*()`
- **ADL**: `isAdlAvailable()`, `adlFindAdapterIndex()`, `adlGet*()`

## Testing
- All existing tests pass (Linux CI)
- spotless:apply clean

## Notes
- Also reconciled a minor behavioral difference: FFM had a counter-reset guard (`dActive < 0 || dIdle < 0`) in `getGpuUtilization()` that JNA lacked. The common class includes this guard (safer behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU statistics monitoring for Windows, including utilization, temperature, power draw, memory usage, and fan speed metrics with multi-source support.

* **Refactor**
  * Consolidated GPU statistics implementations into a shared base class to reduce code duplication and improve maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->