### PR TITLE
Add OshiMetrics.bindTo(registry, SystemInfoProvider) convenience method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#3249](https://github.com/oshi/oshi/pull/3249): Read EDID from `/sys/class/drm` on Linux, fixing display detection on Wayland - [@dbwiddis](https://github.com/dbwiddis).
 * [#3245](https://github.com/oshi/oshi/pull/3245): Fix `MacGlobalMemory.getPhysicalMemory()` returning empty data on Apple Silicon Macs - [@dbwiddis](https://github.com/dbwiddis).
+* [#3278](https://github.com/oshi/oshi/pull/3278): Add `OshiMetrics.bindTo(MeterRegistry, SystemInfoProvider)` convenience method - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.1.0 (2026-05-06)
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ See the [oshi-demo README](oshi-demo/) for all available demos and usage instruc
 First-party [Micrometer](https://micrometer.io/) integration providing system, process, and container metrics following [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/). Works with Prometheus, Grafana, Datadog, and any Micrometer-compatible backend.
 
 ```java
-OshiMetrics.bindTo(registry, si.getHardware(), si.getOperatingSystem());
+OshiMetrics.bindTo(registry, SystemInfoFactory.create());
 ```
 
 See the [oshi-metrics README](oshi-metrics/) for full setup, selective registration, and the complete list of metrics.

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -6,6 +6,7 @@ package oshi.metrics;
 
 import oshi.hardware.HardwareAbstractionLayer;
 import oshi.software.os.OperatingSystem;
+import oshi.spi.SystemInfoProvider;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
@@ -21,8 +22,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * Usage (all metrics):
  *
  * <pre>{@code
- * SystemInfoProvider si = SystemInfoFactory.create();
- * OshiMetrics.bindTo(registry, si.getHardware(), si.getOperatingSystem());
+ * OshiMetrics.bindTo(registry, SystemInfoFactory.create());
  * }</pre>
  *
  * <p>
@@ -84,6 +84,16 @@ public final class OshiMetrics implements MeterBinder {
         this.network = true;
         this.process = true;
         this.container = true;
+    }
+
+    /**
+     * Convenience method to create and bind all OSHI metrics in one call.
+     *
+     * @param registry the meter registry
+     * @param si       the system info provider
+     */
+    public static void bindTo(MeterRegistry registry, SystemInfoProvider si) {
+        bindTo(registry, si.getHardware(), si.getOperatingSystem());
     }
 
     /**

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import oshi.SystemInfo;
 import oshi.hardware.HardwareAbstractionLayer;
 import oshi.software.os.OperatingSystem;
+import oshi.spi.SystemInfoProvider;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
@@ -29,10 +30,10 @@ class OshiMetricsTest {
     @BeforeAll
     static void setUp() {
         registry = new SimpleMeterRegistry();
-        SystemInfo si = new SystemInfo();
+        SystemInfoProvider si = new SystemInfo();
         hal = si.getHardware();
         os = si.getOperatingSystem();
-        OshiMetrics.bindTo(registry, hal, os);
+        OshiMetrics.bindTo(registry, si);
     }
 
     @Test

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -127,7 +127,7 @@ See the [oshi-demo README](https://github.com/oshi/oshi/blob/master/oshi-demo/) 
 First-party [Micrometer](https://micrometer.io/) integration providing system, process, and container metrics following [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/). Works with Prometheus, Grafana, Datadog, and any Micrometer-compatible backend.
 
 ```java
-OshiMetrics.bindTo(registry, si.getHardware(), si.getOperatingSystem());
+OshiMetrics.bindTo(registry, SystemInfoFactory.create());
 ```
 
 See the [oshi-metrics README](https://github.com/oshi/oshi/blob/master/oshi-metrics/) for full setup, selective registration, and the complete list of metrics.


### PR DESCRIPTION
Adds a convenience overload that accepts `SystemInfoProvider` directly, delegating to the existing `bindTo(registry, hal, os)` method.

Updates javadoc and README/index.md examples to use the simpler form:
```java
SystemInfoProvider si = SystemInfoFactory.create();
OshiMetrics.bindTo(registry, si);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined metrics registration with a new convenience option that accepts system information directly, so callers no longer need to extract and pass hardware and OS components separately.

* **Documentation**
  * README, website examples, and changelog updated to show the simplified registration usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->