### PR TITLE
Add SystemInfoProvider overloads to OshiMetrics builder and constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 * [#3249](https://github.com/oshi/oshi/pull/3249): Read EDID from `/sys/class/drm` on Linux, fixing display detection on Wayland - [@dbwiddis](https://github.com/dbwiddis).
 * [#3245](https://github.com/oshi/oshi/pull/3245): Fix `MacGlobalMemory.getPhysicalMemory()` returning empty data on Apple Silicon Macs - [@dbwiddis](https://github.com/dbwiddis).
-* [#3278](https://github.com/oshi/oshi/pull/3278): Add `OshiMetrics.bindTo(MeterRegistry, SystemInfoProvider)` convenience method - [@dbwiddis](https://github.com/dbwiddis).
+* [#3278](https://github.com/oshi/oshi/pull/3278),
+  [#3280](https://github.com/oshi/oshi/pull/3280): Add `SystemInfoProvider` convenience overloads to `OshiMetrics` constructor, `bindTo`, and `builder` methods - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.1.0 (2026-05-06)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractHWDiskStore.java
@@ -6,6 +6,7 @@ package oshi.hardware.common;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.HWDiskStore;
@@ -31,7 +32,7 @@ public abstract class AbstractHWDiskStore implements HWDiskStore {
     private volatile long currentQueueLength;
     private volatile long transferTime;
     private volatile long timeStamp;
-    private volatile List<HWPartition> partitionList = Collections.emptyList();
+    private final AtomicReference<List<HWPartition>> partitionList = new AtomicReference<>(Collections.emptyList());
 
     /**
      * Creates an AbstractHWDiskStore with unknown disk type.
@@ -124,7 +125,7 @@ public abstract class AbstractHWDiskStore implements HWDiskStore {
 
     @Override
     public List<HWPartition> getPartitions() {
-        return this.partitionList;
+        return this.partitionList.get();
     }
 
     /**
@@ -218,7 +219,7 @@ public abstract class AbstractHWDiskStore implements HWDiskStore {
      * @param partitionList the partition list
      */
     protected void setPartitionList(List<HWPartition> partitionList) {
-        this.partitionList = partitionList;
+        this.partitionList.set(partitionList);
     }
 
     @Override

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -47,8 +47,7 @@ Add `oshi-metrics` alongside your OSHI implementation and a Micrometer registry:
 ### Register all metrics
 
 ```java
-SystemInfoProvider si = SystemInfoFactory.create();
-OshiMetrics.bindTo(registry, si.getHardware(), si.getOperatingSystem());
+OshiMetrics.bindTo(registry, SystemInfoFactory.create());
 ```
 
 `SystemInfoFactory.create()` auto-selects the best available implementation (JNA, FFM, or native-free on Linux).
@@ -57,8 +56,7 @@ See the [project README](../README.md) for details on implementation choices.
 ### Selective registration (Builder API)
 
 ```java
-SystemInfoProvider si = SystemInfoFactory.create();
-OshiMetrics.builder(si.getHardware(), si.getOperatingSystem())
+OshiMetrics.builder(SystemInfoFactory.create())
     .enableGeneral(true)
     .enableCpu(true)
     .enableMemory(true)
@@ -83,8 +81,7 @@ bridge is auto-configured and metrics flow to your OTel backend automatically.
 ```java
 @Bean
 public OshiMetrics oshiMetrics() {
-    SystemInfoProvider si = SystemInfoFactory.create();
-    return new OshiMetrics(si.getHardware(), si.getOperatingSystem());
+    return new OshiMetrics(SystemInfoFactory.create());
 }
 ```
 
@@ -108,8 +105,7 @@ register OSHI metrics with Micrometer's global registry:
 ```java
 import io.micrometer.core.instrument.Metrics;
 
-SystemInfoProvider si = SystemInfoFactory.create();
-OshiMetrics.bindTo(Metrics.globalRegistry, si.getHardware(), si.getOperatingSystem());
+OshiMetrics.bindTo(Metrics.globalRegistry, SystemInfoFactory.create());
 ```
 
 The agent automatically bridges `Metrics.globalRegistry` to the OpenTelemetry SDK — no additional wiring needed.
@@ -136,8 +132,7 @@ import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegist
 OpenTelemetry otel = // your configured OpenTelemetry SDK instance
 MeterRegistry otelRegistry = OpenTelemetryMeterRegistry.create(otel);
 
-SystemInfoProvider si = SystemInfoFactory.create();
-OshiMetrics.bindTo(otelRegistry, si.getHardware(), si.getOperatingSystem());
+OshiMetrics.bindTo(otelRegistry, SystemInfoFactory.create());
 ```
 
 See [Register all metrics](#register-all-metrics) for `SystemInfoFactory` options (JNA, FFM, or native-free on Linux).

--- a/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/OshiMetrics.java
@@ -4,6 +4,8 @@
  */
 package oshi.metrics;
 
+import java.util.Objects;
+
 import oshi.hardware.HardwareAbstractionLayer;
 import oshi.software.os.OperatingSystem;
 import oshi.spi.SystemInfoProvider;
@@ -29,8 +31,8 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * Usage (selective):
  *
  * <pre>{@code
- * OshiMetrics.builder(si.getHardware(), si.getOperatingSystem()).enableCpu(true).enableMemory(true).enableDisk(false)
- *         .build().bindTo(registry);
+ * OshiMetrics.builder(SystemInfoFactory.create()).enableCpu(true).enableMemory(true).enableDisk(false).build()
+ *         .bindTo(registry);
  * }</pre>
  *
  * <p>
@@ -69,12 +71,21 @@ public final class OshiMetrics implements MeterBinder {
     /**
      * Creates a new {@code OshiMetrics} instance that registers all metrics.
      *
+     * @param si the system info provider
+     */
+    public OshiMetrics(SystemInfoProvider si) {
+        this(Objects.requireNonNull(si, "si must not be null").getHardware(), si.getOperatingSystem());
+    }
+
+    /**
+     * Creates a new {@code OshiMetrics} instance that registers all metrics.
+     *
      * @param hal the hardware abstraction layer
      * @param os  the operating system
      */
     public OshiMetrics(HardwareAbstractionLayer hal, OperatingSystem os) {
-        this.hal = java.util.Objects.requireNonNull(hal, "hal must not be null");
-        this.os = java.util.Objects.requireNonNull(os, "os must not be null");
+        this.hal = Objects.requireNonNull(hal, "hal must not be null");
+        this.os = Objects.requireNonNull(os, "os must not be null");
         this.general = true;
         this.cpu = true;
         this.memory = true;
@@ -93,6 +104,7 @@ public final class OshiMetrics implements MeterBinder {
      * @param si       the system info provider
      */
     public static void bindTo(MeterRegistry registry, SystemInfoProvider si) {
+        Objects.requireNonNull(si, "si must not be null");
         bindTo(registry, si.getHardware(), si.getOperatingSystem());
     }
 
@@ -141,6 +153,17 @@ public final class OshiMetrics implements MeterBinder {
     /**
      * Creates a new builder for selective metric registration.
      *
+     * @param si the system info provider
+     * @return a new {@link Builder}
+     */
+    public static Builder builder(SystemInfoProvider si) {
+        Objects.requireNonNull(si, "si must not be null");
+        return builder(si.getHardware(), si.getOperatingSystem());
+    }
+
+    /**
+     * Creates a new builder for selective metric registration.
+     *
      * @param hal the hardware abstraction layer
      * @param os  the operating system
      * @return a new {@link Builder}
@@ -170,8 +193,8 @@ public final class OshiMetrics implements MeterBinder {
         private boolean container = true;
 
         private Builder(HardwareAbstractionLayer hal, OperatingSystem os) {
-            this.hal = java.util.Objects.requireNonNull(hal, "hal must not be null");
-            this.os = java.util.Objects.requireNonNull(os, "os must not be null");
+            this.hal = Objects.requireNonNull(hal, "hal must not be null");
+            this.os = Objects.requireNonNull(os, "os must not be null");
         }
 
         /**

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -250,9 +250,17 @@ class OshiMetricsTest {
     }
 
     @Test
+    void constructorWithSystemInfoProvider() {
+        MeterRegistry r = new SimpleMeterRegistry();
+        new OshiMetrics(new SystemInfo()).bindTo(r);
+        assertNotNull(r.find("system.uptime").gauge(), "system.uptime should be registered");
+    }
+
+    @Test
     void builderSelectiveRegistration() {
         MeterRegistry selective = new SimpleMeterRegistry();
-        OshiMetrics.builder(hal, os).enableCpu(true).enableMemory(false).enablePaging(false).enableDisk(false)
+        SystemInfoProvider si = new SystemInfo();
+        OshiMetrics.builder(si).enableCpu(true).enableMemory(false).enablePaging(false).enableDisk(false)
                 .enableFileSystem(false).enableNetwork(false).enableGeneral(false).enableProcess(false)
                 .enableContainer(false).build().bindTo(selective);
         // CPU should be registered

--- a/oshi-metrics/src/test/java/oshi/metrics/PrometheusDemoTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/PrometheusDemoTest.java
@@ -39,7 +39,7 @@ public class PrometheusDemoTest {
             }
         });
         SystemInfo si = new SystemInfo();
-        this.oshiMetrics = new OshiMetrics(si.getHardware(), si.getOperatingSystem());
+        this.oshiMetrics = new OshiMetrics(si);
         this.oshiMetrics.bindTo(registry);
     }
 


### PR DESCRIPTION
Add `SystemInfoProvider` convenience overloads to `OshiMetrics`:

- `OshiMetrics(SystemInfoProvider)` constructor
- `OshiMetrics.builder(SystemInfoProvider)` factory method
- Update README examples to use the one-liner `SystemInfoFactory.create()` pattern
- Replace `volatile List` with `AtomicReference` in `AbstractHWDiskStore` (Sonar fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OshiMetrics constructor that accepts a SystemInfoProvider for simpler initialization.
  * Added a builder(SystemInfoProvider) overload to support selective metric registration.

* **Documentation**
  * Updated oshi-metrics README examples to use the simplified SystemInfoProvider-based initialization patterns.
  * Clarified changelog entries by grouping related items.

* **Bug Fixes**
  * Improved internal disk partition handling to be more thread-safe.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->