### PR TITLE
Fix macOS JNA CPU tick overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#3278](https://github.com/oshi/oshi/pull/3278),
   [#3280](https://github.com/oshi/oshi/pull/3280): Add `SystemInfoProvider` convenience overloads to `OshiMetrics` constructor, `bindTo`, and `builder` methods - [@dbwiddis](https://github.com/dbwiddis).
 * [#3281](https://github.com/oshi/oshi/pull/3281): Fix AIX processor count detection to use LPAR vcpu and SMT configuration instead of frame-level physical processor count - [@dbwiddis](https://github.com/dbwiddis).
+* [#3283](https://github.com/oshi/oshi/pull/3283): Fix macOS JNA system CPU ticks overflowing to negative values after long uptimes - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.1.0 (2026-05-06)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorJNA.java
@@ -45,10 +45,11 @@ final class MacCentralProcessorJNA extends MacCentralProcessor {
                 return ticks;
             }
 
-            ticks[TickType.USER.getIndex()] = cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_USER];
-            ticks[TickType.NICE.getIndex()] = cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_NICE];
-            ticks[TickType.SYSTEM.getIndex()] = cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_SYSTEM];
-            ticks[TickType.IDLE.getIndex()] = cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_IDLE];
+            ticks[TickType.USER.getIndex()] = FormatUtil.getUnsignedInt(cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_USER]);
+            ticks[TickType.NICE.getIndex()] = FormatUtil.getUnsignedInt(cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_NICE]);
+            ticks[TickType.SYSTEM.getIndex()] = FormatUtil
+                    .getUnsignedInt(cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_SYSTEM]);
+            ticks[TickType.IDLE.getIndex()] = FormatUtil.getUnsignedInt(cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_IDLE]);
         }
         return ticks;
     }


### PR DESCRIPTION
## Summary
- Treat macOS JNA host CPU load ticks as unsigned 32-bit counters
- Prevent system CPU tick values from becoming negative after long uptimes
- Add changelog entry for the fix

## Validation
- ./mvnw spotless:apply
- ./mvnw -pl oshi-metrics -Dtest=oshi.metrics.OshiMetricsTest#cpuTimeRegistered test -B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on macOS where system CPU statistics could overflow to negative values after extended system uptime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->