### PR TITLE
Add FFM arena call helpers

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -17,6 +17,10 @@ import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
 
 /**
  * Base class providing utility methods for working with the Java Foreign Function and Memory (FFM) API.
@@ -25,6 +29,97 @@ import java.lang.invoke.VarHandle;
  * native memory segments.
  */
 public abstract class ForeignFunctions {
+
+    /**
+     * Represents an operation that uses a confined {@link Arena} and returns an object.
+     *
+     * @param <T> the return type
+     */
+    @FunctionalInterface
+    public interface ArenaCallable<T> {
+        /**
+         * Executes this operation with the provided arena.
+         *
+         * @param arena the confined arena scoped to this operation
+         * @return the operation result
+         * @throws Throwable if the operation fails
+         */
+        T call(Arena arena) throws Throwable;
+    }
+
+    /**
+     * Represents an operation that uses a confined {@link Arena} and returns an {@code int}.
+     */
+    @FunctionalInterface
+    public interface ArenaIntCallable {
+        /**
+         * Executes this operation with the provided arena.
+         *
+         * @param arena the confined arena scoped to this operation
+         * @return the operation result
+         * @throws Throwable if the operation fails
+         */
+        int call(Arena arena) throws Throwable;
+    }
+
+    /**
+     * Represents an operation that uses a confined {@link Arena} and returns a {@code long}.
+     */
+    @FunctionalInterface
+    public interface ArenaLongCallable {
+        /**
+         * Executes this operation with the provided arena.
+         *
+         * @param arena the confined arena scoped to this operation
+         * @return the operation result
+         * @throws Throwable if the operation fails
+         */
+        long call(Arena arena) throws Throwable;
+    }
+
+    /**
+     * Represents an operation that uses a confined {@link Arena} and returns a {@code double}.
+     */
+    @FunctionalInterface
+    public interface ArenaDoubleCallable {
+        /**
+         * Executes this operation with the provided arena.
+         *
+         * @param arena the confined arena scoped to this operation
+         * @return the operation result
+         * @throws Throwable if the operation fails
+         */
+        double call(Arena arena) throws Throwable;
+    }
+
+    /**
+     * Represents an operation that uses a confined {@link Arena} and returns a {@code boolean}.
+     */
+    @FunctionalInterface
+    public interface ArenaBooleanCallable {
+        /**
+         * Executes this operation with the provided arena.
+         *
+         * @param arena the confined arena scoped to this operation
+         * @return the operation result
+         * @throws Throwable if the operation fails
+         */
+        boolean call(Arena arena) throws Throwable;
+    }
+
+    /**
+     * Represents an operation that uses a confined {@link Arena} and does not return a value.
+     */
+    @FunctionalInterface
+    public interface ArenaRunnable {
+        /**
+         * Executes this operation with the provided arena.
+         *
+         * @param arena the confined arena scoped to this operation
+         * @throws Throwable if the operation fails
+         */
+        void run(Arena arena) throws Throwable;
+    }
 
     /** The native linker for the current platform. */
     protected static final Linker LINKER = Linker.nativeLinker();
@@ -46,6 +141,153 @@ public abstract class ForeignFunctions {
 
     /** Not intended for instantiation. */
     protected ForeignFunctions() {
+    }
+
+    /**
+     * Executes an operation in a confined arena, returning a default value if the operation throws.
+     * <p>
+     * This helper centralizes the common FFM call pattern where temporary native memory is scoped to a confined arena
+     * and failures from method-handle invocation or native binding are logged at the caller's chosen level. The
+     * provided arena is closed before this method returns, so returned objects must not depend on memory allocated from
+     * it.
+     *
+     * @param <T>          the return type
+     * @param callable     the operation to execute
+     * @param logger       the logger for the calling class
+     * @param level        the level at which to log thrown failures
+     * @param message      the message to log if the operation throws
+     * @param defaultValue the value to return if the operation throws
+     * @return the operation result, or {@code defaultValue} if the operation throws
+     */
+    public static <T> T callInArenaOrDefault(ArenaCallable<T> callable, Logger logger, Level level, String message,
+            T defaultValue) {
+        Objects.requireNonNull(callable, "callable");
+        try (Arena arena = Arena.ofConfined()) {
+            return callable.call(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes an {@code int}-returning operation in a confined arena, returning a default value if the operation
+     * throws.
+     * <p>
+     * Use this primitive-specialized variant to avoid boxing when wrapping FFM calls whose result is an {@code int}.
+     * The provided arena is closed before this method returns.
+     *
+     * @param callable     the operation to execute
+     * @param logger       the logger for the calling class
+     * @param level        the level at which to log thrown failures
+     * @param message      the message to log if the operation throws
+     * @param defaultValue the value to return if the operation throws
+     * @return the operation result, or {@code defaultValue} if the operation throws
+     */
+    public static int callInArenaIntOrDefault(ArenaIntCallable callable, Logger logger, Level level, String message,
+            int defaultValue) {
+        Objects.requireNonNull(callable, "callable");
+        try (Arena arena = Arena.ofConfined()) {
+            return callable.call(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes a {@code long}-returning operation in a confined arena, returning a default value if the operation
+     * throws.
+     * <p>
+     * Use this primitive-specialized variant to avoid boxing when wrapping FFM calls whose result is a {@code long}.
+     * The provided arena is closed before this method returns.
+     *
+     * @param callable     the operation to execute
+     * @param logger       the logger for the calling class
+     * @param level        the level at which to log thrown failures
+     * @param message      the message to log if the operation throws
+     * @param defaultValue the value to return if the operation throws
+     * @return the operation result, or {@code defaultValue} if the operation throws
+     */
+    public static long callInArenaLongOrDefault(ArenaLongCallable callable, Logger logger, Level level, String message,
+            long defaultValue) {
+        Objects.requireNonNull(callable, "callable");
+        try (Arena arena = Arena.ofConfined()) {
+            return callable.call(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes a {@code double}-returning operation in a confined arena, returning a default value if the operation
+     * throws.
+     * <p>
+     * Use this primitive-specialized variant to avoid boxing when wrapping FFM calls whose result is a {@code double}.
+     * The provided arena is closed before this method returns.
+     *
+     * @param callable     the operation to execute
+     * @param logger       the logger for the calling class
+     * @param level        the level at which to log thrown failures
+     * @param message      the message to log if the operation throws
+     * @param defaultValue the value to return if the operation throws
+     * @return the operation result, or {@code defaultValue} if the operation throws
+     */
+    public static double callInArenaDoubleOrDefault(ArenaDoubleCallable callable, Logger logger, Level level,
+            String message, double defaultValue) {
+        Objects.requireNonNull(callable, "callable");
+        try (Arena arena = Arena.ofConfined()) {
+            return callable.call(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes a {@code boolean}-returning operation in a confined arena, returning a default value if the operation
+     * throws.
+     * <p>
+     * Use this primitive-specialized variant to avoid boxing when wrapping FFM calls whose result is a {@code boolean}.
+     * The provided arena is closed before this method returns.
+     *
+     * @param callable     the operation to execute
+     * @param logger       the logger for the calling class
+     * @param level        the level at which to log thrown failures
+     * @param message      the message to log if the operation throws
+     * @param defaultValue the value to return if the operation throws
+     * @return the operation result, or {@code defaultValue} if the operation throws
+     */
+    public static boolean callInArenaBooleanOrDefault(ArenaBooleanCallable callable, Logger logger, Level level,
+            String message, boolean defaultValue) {
+        Objects.requireNonNull(callable, "callable");
+        try (Arena arena = Arena.ofConfined()) {
+            return callable.call(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes an operation in a confined arena, logging and swallowing any thrown failure.
+     * <p>
+     * This helper is intended for FFM operations whose useful result is a side effect. The provided arena is closed
+     * before this method returns.
+     *
+     * @param runnable the operation to execute
+     * @param logger   the logger for the calling class
+     * @param level    the level at which to log thrown failures
+     * @param message  the message to log if the operation throws
+     */
+    public static void runInArenaCatchingThrowable(ArenaRunnable runnable, Logger logger, Level level, String message) {
+        Objects.requireNonNull(runnable, "runnable");
+        try (Arena arena = Arena.ofConfined()) {
+            runnable.run(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t);
+        }
     }
 
     /**
@@ -151,5 +393,11 @@ public abstract class ForeignFunctions {
      */
     public static int getErrno(MemorySegment callState) {
         return (int) ERRNO_HANDLE.get(callState, 0);
+    }
+
+    private static void logThrowable(Logger logger, Level level, String message, Throwable t) {
+        Objects.requireNonNull(logger, "logger");
+        Objects.requireNonNull(level, "level");
+        logger.atLevel(level).setCause(t).log(message + ": {}", t.getMessage());
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryFFM.java
@@ -6,6 +6,8 @@ package oshi.hardware.platform.mac;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static org.slf4j.event.Level.DEBUG;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
 import static oshi.ffm.mac.MacSystem.VM_FREE_COUNT;
 import static oshi.ffm.mac.MacSystem.VM_INACTIVE_COUNT;
 import static oshi.ffm.mac.MacSystem.VM_STATISTICS;
@@ -30,7 +32,7 @@ final class MacGlobalMemoryFFM extends MacGlobalMemory {
 
     @Override
     protected long queryVmStats() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             // Allocate memory for VM statistics structure and count
             MemorySegment vmStats = arena.allocate(VM_STATISTICS);
             if (MacMemoryUtilFFM.callVmStat(arena, vmStats)) {
@@ -40,10 +42,8 @@ final class MacGlobalMemoryFFM extends MacGlobalMemory {
 
                 return (freeCount + inactiveCount) * getPageSize();
             }
-        } catch (Throwable e) {
-            // Ignore
-        }
-        return 0L;
+            return 0L;
+        }, LOG, DEBUG, "Failed to query host VM statistics", 0L);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxFileSystemFFM.java
@@ -4,7 +4,9 @@
  */
 package oshi.software.os.linux;
 
-import java.lang.foreign.Arena;
+import static org.slf4j.event.Level.DEBUG;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+
 import java.lang.foreign.MemorySegment;
 
 import org.slf4j.Logger;
@@ -24,7 +26,7 @@ final class LinuxFileSystemFFM extends LinuxFileSystem {
 
     @Override
     protected long[] queryStatvfs(String path) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment pathSeg = arena.allocateFrom(path);
             MemorySegment buf = arena.allocate(LinuxLibcFunctions.STATVFS_LAYOUT);
             if (0 == LinuxLibcFunctions.statvfs(pathSeg, buf)) {
@@ -34,9 +36,7 @@ final class LinuxFileSystemFFM extends LinuxFileSystem {
                         LinuxLibcFunctions.statvfsBfree(buf) * frsize };
             }
             LOG.debug("statvfs failed for path: {}", path);
-        } catch (Throwable e) {
-            LOG.debug("FFM statvfs error for path {}: {}", path, e.toString());
-        }
-        return null;
+            return null;
+        }, LOG, DEBUG, "FFM statvfs error for path " + path, null);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
@@ -4,6 +4,9 @@
  */
 package oshi.software.os.linux;
 
+import static org.slf4j.event.Level.DEBUG;
+import static oshi.ffm.ForeignFunctions.runInArenaCatchingThrowable;
+
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -37,7 +40,7 @@ public class LinuxOSProcessFFM extends LinuxOSProcess {
         boolean result = super.updateAttributes();
         if (getProcessID() == getOs().getProcessId()) {
             this.rusagePopulated = false;
-            try (Arena arena = Arena.ofConfined()) {
+            runInArenaCatchingThrowable(arena -> {
                 MemorySegment rusage = arena.allocate(LinuxLibcFunctions.RUSAGE_SIZE);
                 if (0 == LinuxLibcFunctions.getrusage(LinuxLibcFunctions.RUSAGE_SELF, rusage)) {
                     this.cachedVoluntaryContextSwitches = rusage.get(ValueLayout.JAVA_LONG,
@@ -46,9 +49,7 @@ public class LinuxOSProcessFFM extends LinuxOSProcess {
                             LinuxLibcFunctions.RUSAGE_NIVCSW_OFFSET);
                     this.rusagePopulated = true;
                 }
-            } catch (Throwable e) {
-                LOG.debug("FFM getrusage failed: {}", e.toString());
-            }
+            }, LOG, DEBUG, "FFM getrusage failed");
         }
         return result;
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
@@ -4,9 +4,11 @@
  */
 package oshi.software.os.linux;
 
+import static org.slf4j.event.Level.ERROR;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+
 import java.io.File;
 import java.io.IOException;
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.nio.file.Files;
 import java.util.List;
@@ -164,15 +166,13 @@ public class LinuxOperatingSystemFFM extends LinuxOperatingSystem {
 
     @Override
     public int getThreadCount() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaIntOrDefault(arena -> {
             MemorySegment info = arena.allocate(LinuxLibcFunctions.SYSINFO_LAYOUT);
             if (0 == LinuxLibcFunctions.sysinfo(info)) {
                 return LinuxLibcFunctions.sysinfoProcs(info);
             }
             LOG.error("FFM sysinfo failed");
-        } catch (Throwable e) {
-            LOG.error("FFM sysinfo error: {}", e.toString());
-        }
-        return 0;
+            return 0;
+        }, LOG, ERROR, "FFM sysinfo error", 0);
     }
 }

--- a/oshi-core-ffm/src/test/java/oshi/ffm/ForeignFunctionsTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/ForeignFunctionsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.slf4j.event.Level.DEBUG;
+
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for {@link ForeignFunctions} helper methods.
+ */
+@EnabledForJreRange(min = JRE.JAVA_25)
+class ForeignFunctionsTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForeignFunctionsTest.class);
+
+    @Test
+    void testCallInArenaOrDefaultReturnsValue() {
+        String result = ForeignFunctions.callInArenaOrDefault(arena -> {
+            MemorySegment value = arena.allocate(JAVA_INT);
+            value.set(JAVA_INT, 0, 7);
+            return "value-" + value.get(JAVA_INT, 0);
+        }, LOG, DEBUG, "object success", "default");
+
+        assertThat(result, is("value-7"));
+    }
+
+    @Test
+    void testCallInArenaOrDefaultReturnsDefaultOnThrowable() {
+        String result = ForeignFunctions.callInArenaOrDefault(arena -> {
+            throw new Throwable("object failure");
+        }, LOG, DEBUG, "object failure", "default");
+
+        assertThat(result, is("default"));
+    }
+
+    @Test
+    void testCallInArenaIntOrDefaultReturnsValue() {
+        int result = ForeignFunctions.callInArenaIntOrDefault(arena -> {
+            MemorySegment value = arena.allocate(JAVA_INT);
+            value.set(JAVA_INT, 0, 42);
+            return value.get(JAVA_INT, 0);
+        }, LOG, DEBUG, "int success", -1);
+
+        assertThat(result, is(42));
+    }
+
+    @Test
+    void testCallInArenaIntOrDefaultReturnsDefaultOnThrowable() {
+        int result = ForeignFunctions.callInArenaIntOrDefault(arena -> {
+            throw new Throwable("int failure");
+        }, LOG, DEBUG, "int failure", -1);
+
+        assertThat(result, is(-1));
+    }
+
+    @Test
+    void testCallInArenaLongOrDefaultReturnsValue() {
+        long result = ForeignFunctions.callInArenaLongOrDefault(arena -> 42L, LOG, DEBUG, "long success", -1L);
+
+        assertThat(result, is(42L));
+    }
+
+    @Test
+    void testCallInArenaLongOrDefaultReturnsDefaultOnThrowable() {
+        long result = ForeignFunctions.callInArenaLongOrDefault(arena -> {
+            throw new Throwable("long failure");
+        }, LOG, DEBUG, "long failure", -1L);
+
+        assertThat(result, is(-1L));
+    }
+
+    @Test
+    void testCallInArenaDoubleOrDefaultReturnsValue() {
+        double result = ForeignFunctions.callInArenaDoubleOrDefault(arena -> 42.5, LOG, DEBUG, "double success", -1d);
+
+        assertThat(result, is(42.5));
+    }
+
+    @Test
+    void testCallInArenaDoubleOrDefaultReturnsDefaultOnThrowable() {
+        double result = ForeignFunctions.callInArenaDoubleOrDefault(arena -> {
+            throw new Throwable("double failure");
+        }, LOG, DEBUG, "double failure", -1d);
+
+        assertThat(result, is(-1d));
+    }
+
+    @Test
+    void testCallInArenaBooleanOrDefaultReturnsValue() {
+        boolean result = ForeignFunctions.callInArenaBooleanOrDefault(arena -> true, LOG, DEBUG, "boolean success",
+                false);
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    void testCallInArenaBooleanOrDefaultReturnsDefaultOnThrowable() {
+        boolean result = ForeignFunctions.callInArenaBooleanOrDefault(arena -> {
+            throw new Throwable("boolean failure");
+        }, LOG, DEBUG, "boolean failure", false);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    void testRunInArenaCatchingThrowableRunsOperation() {
+        AtomicBoolean called = new AtomicBoolean();
+
+        ForeignFunctions.runInArenaCatchingThrowable(arena -> called.set(true), LOG, DEBUG, "void success");
+
+        assertThat(called.get(), is(true));
+    }
+
+    @Test
+    void testRunInArenaCatchingThrowableSwallowsThrowable() {
+        AtomicBoolean called = new AtomicBoolean();
+
+        ForeignFunctions.runInArenaCatchingThrowable(arena -> {
+            called.set(true);
+            throw new Throwable("void failure");
+        }, LOG, DEBUG, "void failure");
+
+        assertThat(called.get(), is(true));
+    }
+}


### PR DESCRIPTION
## Summary

- Add lambda-first ForeignFunctions helpers for running FFM work in a confined arena while logging Throwable failures and returning defaults.
- Include object, int, long, double, boolean, and void helper variants to avoid boxing for common primitive paths.
- Migrate a small representative set of existing arena/Throwable call sites to validate the pattern before broader follow-up migration.
- Add focused tests covering success and thrown-Throwable fallback behavior for every helper variant.

## Notes

This intentionally keeps scope small as a pattern-validation PR. Cleanup-aware variants for cases such as CoreFoundation/native-resource release paths can be considered separately after this base API is reviewed.

## Validation

- mvn -pl oshi-core-ffm -am spotless:apply
- mvn -pl oshi-core-ffm -am checkstyle:check
- mvn -pl oshi-core-ffm -am clean compile forbiddenapis:check
- mvn -pl oshi-core-ffm -am javadoc:javadoc (passes with existing warnings)
- mvn -pl oshi-core-ffm -am test -Dtest=oshi.ffm.ForeignFunctionsTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling and resource management for Foreign Function & Memory operations with new helper utilities.
  * Standardized exception logging and arena lifecycle management across FFM-dependent modules for better debugging and consistency.

* **Tests**
  * Added comprehensive test coverage for Foreign Function & Memory execution helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->