### PR TITLE
Migrate Linux FFM arena calls to helpers

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
@@ -4,9 +4,12 @@
  */
 package oshi.hardware.platform.linux;
 
+import static org.slf4j.event.Level.WARN;
+import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.software.os.linux.LinuxOperatingSystemFFM.HAS_UDEV;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.util.ArrayList;
@@ -53,18 +56,16 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
         if (nelem < 1 || nelem > 3) {
             throw new IllegalArgumentException("Must include from one to three elements.");
         }
-        try (Arena arena = Arena.ofConfined()) {
+        double[] average = callInArenaOrDefault(arena -> {
             MemorySegment loadavg = arena.allocate(ValueLayout.JAVA_DOUBLE, nelem);
             int retval = LinuxLibcFunctions.getloadavg(loadavg, nelem);
-            double[] average = new double[nelem];
+            double[] result = new double[nelem];
             for (int i = 0; i < nelem; i++) {
-                average[i] = retval > i ? loadavg.getAtIndex(ValueLayout.JAVA_DOUBLE, i) : -1d;
+                result[i] = retval > i ? loadavg.getAtIndex(ValueLayout.JAVA_DOUBLE, i) : -1d;
             }
-            return average;
-        } catch (Throwable e) {
-            LOG.warn("FFM getloadavg failed: {}", e.toString());
-            return super.getSystemLoadAverage(nelem);
-        }
+            return result;
+        }, LOG, WARN, "FFM getloadavg failed", null);
+        return average == null ? super.getSystemLoadAverage(nelem) : average;
     }
 
     @Override
@@ -76,46 +77,46 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
         Set<ProcessorCache> caches = new HashSet<>();
         Map<Integer, Integer> coreEfficiencyMap = new HashMap<>();
         Map<Integer, String> modAliasMap = new HashMap<>();
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment udev = UdevFunctions.udev_new();
-            if (MemorySegment.NULL.equals(udev)) {
-                return readTopologyFromSysfs();
-            }
-            try {
-                MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try {
-                    UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
-                    UdevFunctions.udev_enumerate_scan_devices(enumerate);
-                    for (MemorySegment entry = UdevFunctions
-                            .udev_enumerate_get_list_entry(enumerate); !MemorySegment.NULL
-                                    .equals(entry); entry = UdevFunctions.udev_list_entry_get_next(entry)) {
-                        String syspath = UdevFunctions.getString(UdevFunctions.udev_list_entry_get_name(entry), arena);
-                        if (syspath == null) {
-                            continue;
-                        }
-                        MemorySegment device = UdevFunctions.deviceNewFromSyspath(udev, syspath, arena);
-                        String modAlias = null;
-                        if (!MemorySegment.NULL.equals(device)) {
-                            try {
-                                modAlias = UdevFunctions.getPropertyValue(device, "MODALIAS", arena);
-                            } finally {
-                                UdevFunctions.udev_device_unref(device);
-                            }
-                        }
-                        logProcs.add(getLogicalProcessorFromSyspath(syspath, caches, modAlias, coreEfficiencyMap,
-                                modAliasMap));
+        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> topology = callInArenaOrDefault(
+                arena -> {
+                    MemorySegment udev = UdevFunctions.udev_new();
+                    if (MemorySegment.NULL.equals(udev)) {
+                        return readTopologyFromSysfs();
                     }
-                } finally {
-                    UdevFunctions.udev_enumerate_unref(enumerate);
-                }
-            } finally {
-                UdevFunctions.udev_unref(udev);
-            }
-        } catch (Throwable e) {
-            LOG.warn("Error reading CPU topology via udev, falling back to sysfs: {}", e.toString());
-            return readTopologyFromSysfs();
-        }
-        return new Quartet<>(logProcs, orderedProcCaches(caches), coreEfficiencyMap, modAliasMap);
+                    try {
+                        MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
+                        try {
+                            UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
+                            UdevFunctions.udev_enumerate_scan_devices(enumerate);
+                            for (MemorySegment entry = UdevFunctions
+                                    .udev_enumerate_get_list_entry(enumerate); !MemorySegment.NULL
+                                            .equals(entry); entry = UdevFunctions.udev_list_entry_get_next(entry)) {
+                                String syspath = UdevFunctions.getString(UdevFunctions.udev_list_entry_get_name(entry),
+                                        arena);
+                                if (syspath == null) {
+                                    continue;
+                                }
+                                MemorySegment device = UdevFunctions.deviceNewFromSyspath(udev, syspath, arena);
+                                String modAlias = null;
+                                if (!MemorySegment.NULL.equals(device)) {
+                                    try {
+                                        modAlias = UdevFunctions.getPropertyValue(device, "MODALIAS", arena);
+                                    } finally {
+                                        UdevFunctions.udev_device_unref(device);
+                                    }
+                                }
+                                logProcs.add(getLogicalProcessorFromSyspath(syspath, caches, modAlias,
+                                        coreEfficiencyMap, modAliasMap));
+                            }
+                        } finally {
+                            UdevFunctions.udev_enumerate_unref(enumerate);
+                        }
+                    } finally {
+                        UdevFunctions.udev_unref(udev);
+                    }
+                    return new Quartet<>(logProcs, orderedProcCaches(caches), coreEfficiencyMap, modAliasMap);
+                }, LOG, WARN, "Error reading CPU topology via udev, falling back to sysfs", null);
+        return topology == null ? readTopologyFromSysfs() : topology;
     }
 
     @Override
@@ -123,10 +124,10 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
         if (!HAS_UDEV) {
             return queryCurrentFreqFromSysfs(freqs);
         }
-        try (Arena arena = Arena.ofConfined()) {
+        boolean success = callInArenaBooleanOrDefault(arena -> {
             MemorySegment udev = UdevFunctions.udev_new();
             if (MemorySegment.NULL.equals(udev)) {
-                return queryCurrentFreqFromSysfs(freqs);
+                return false;
             }
             try {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
@@ -164,10 +165,9 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
             } finally {
                 UdevFunctions.udev_unref(udev);
             }
-        } catch (Throwable e) {
-            LOG.warn("Error reading CPU frequencies via udev: {}", e.toString());
-        }
-        return queryCurrentFreqFromSysfs(freqs);
+            return false;
+        }, LOG, WARN, "Error reading CPU frequencies via udev", false);
+        return success || queryCurrentFreqFromSysfs(freqs);
     }
 
     @Override
@@ -175,10 +175,10 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
         if (!HAS_UDEV) {
             return queryMaxFreqFromSysfs();
         }
-        try (Arena arena = Arena.ofConfined()) {
+        long maxFreq = callInArenaLongOrDefault(arena -> {
             MemorySegment udev = UdevFunctions.udev_new();
             if (MemorySegment.NULL.equals(udev)) {
-                return queryMaxFreqFromSysfs();
+                return -1L;
             }
             try {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
@@ -199,9 +199,8 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
             } finally {
                 UdevFunctions.udev_unref(udev);
             }
-        } catch (Throwable e) {
-            LOG.warn("Error reading max CPU frequency via udev: {}", e.toString());
-        }
-        return queryMaxFreqFromSysfs();
+            return -1L;
+        }, LOG, WARN, "Error reading max CPU frequency via udev", -1L);
+        return maxFreq < 0L ? queryMaxFreqFromSysfs() : maxFreq;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupFFM.java
@@ -4,10 +4,11 @@
  */
 package oshi.hardware.platform.linux;
 
+import static org.slf4j.event.Level.WARN;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.software.os.linux.LinuxOperatingSystemFFM.HAS_UDEV;
 
 import java.io.File;
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,10 +43,9 @@ final class LinuxLogicalVolumeGroupFFM extends LinuxLogicalVolumeGroup {
             LOG.warn("Logical Volume Group information requires libudev, which is not present.");
             return Collections.emptyList();
         }
-        Map<String, Map<String, Set<String>>> logicalVolumesMap = new HashMap<>();
-        Map<String, Set<String>> physicalVolumesMap = queryPhysicalVolumes();
-
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
+            Map<String, Map<String, Set<String>>> logicalVolumesMap = new HashMap<>();
+            Map<String, Set<String>> physicalVolumesMap = queryPhysicalVolumes();
             MemorySegment udev = UdevFunctions.udev_new();
             if (MemorySegment.NULL.equals(udev)) {
                 return Collections.emptyList();
@@ -102,13 +102,10 @@ final class LinuxLogicalVolumeGroupFFM extends LinuxLogicalVolumeGroup {
             } finally {
                 UdevFunctions.udev_unref(udev);
             }
-        } catch (Throwable e) {
-            LOG.warn("Error enumerating logical volume groups: {}", e.toString());
-            return Collections.emptyList();
-        }
-        return logicalVolumesMap.entrySet().stream()
-                .map(e -> new LinuxLogicalVolumeGroupFFM(e.getKey(), e.getValue(),
-                        physicalVolumesMap.getOrDefault(e.getKey(), Collections.emptySet())))
-                .collect(Collectors.toList());
+            return logicalVolumesMap.entrySet().stream()
+                    .map(e -> new LinuxLogicalVolumeGroupFFM(e.getKey(), e.getValue(),
+                            physicalVolumesMap.getOrDefault(e.getKey(), Collections.emptySet())))
+                    .collect(Collectors.toList());
+        }, LOG, WARN, "Error enumerating logical volume groups", Collections.emptyList());
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
@@ -4,9 +4,10 @@
  */
 package oshi.hardware.platform.linux;
 
+import static org.slf4j.event.Level.WARN;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.software.os.linux.LinuxOperatingSystemFFM.HAS_UDEV;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.net.NetworkInterface;
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ public final class LinuxNetworkIFFFM extends LinuxNetworkIF {
         if (!HAS_UDEV) {
             return queryIfModelFromSysfs(name);
         }
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment udev = UdevFunctions.udev_new();
             if (MemorySegment.NULL.equals(udev)) {
                 return queryIfModelFromSysfs(name);
@@ -63,10 +64,8 @@ public final class LinuxNetworkIFFFM extends LinuxNetworkIF {
             } finally {
                 UdevFunctions.udev_unref(udev);
             }
-        } catch (Throwable e) {
-            LOG.warn("Error querying network interface model for {}: {}", name, e.toString());
-        }
-        return name;
+            return name;
+        }, LOG, WARN, "Error querying network interface model for " + name, name);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceFFM.java
@@ -4,10 +4,11 @@
  */
 package oshi.hardware.platform.linux;
 
+import static org.slf4j.event.Level.WARN;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.software.os.linux.LinuxOperatingSystemFFM.HAS_UDEV;
 
 import java.io.File;
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -49,11 +50,11 @@ public final class LinuxPowerSourceFFM extends LinuxPowerSource {
         if (!HAS_UDEV) {
             return LinuxPowerSource.getPowerSources();
         }
-        List<PowerSource> psList = new ArrayList<>();
-        try (Arena arena = Arena.ofConfined()) {
+        List<PowerSource> psList = callInArenaOrDefault(arena -> {
+            List<PowerSource> result = new ArrayList<>();
             MemorySegment udev = UdevFunctions.udev_new();
             if (MemorySegment.NULL.equals(udev)) {
-                return LinuxPowerSource.getPowerSources();
+                return null;
             }
             try {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
@@ -86,7 +87,7 @@ public final class LinuxPowerSourceFFM extends LinuxPowerSource {
                                         props.put(p, val);
                                     }
                                 }
-                                psList.add(new LinuxPowerSourceFFM(buildPowerSource(name, props)));
+                                result.add(new LinuxPowerSourceFFM(buildPowerSource(name, props)));
                             }
                         } finally {
                             UdevFunctions.udev_device_unref(device);
@@ -98,8 +99,9 @@ public final class LinuxPowerSourceFFM extends LinuxPowerSource {
             } finally {
                 UdevFunctions.udev_unref(udev);
             }
-        } catch (Throwable e) {
-            LOG.warn("Error enumerating power sources via udev, falling back to sysfs: {}", e.toString());
+            return result;
+        }, LOG, WARN, "Error enumerating power sources via udev, falling back to sysfs", null);
+        if (psList == null) {
             return LinuxPowerSource.getPowerSources();
         }
         return psList;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceFFM.java
@@ -5,9 +5,10 @@
 package oshi.hardware.platform.linux;
 
 import static java.util.Collections.emptyList;
+import static org.slf4j.event.Level.WARN;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.software.os.linux.LinuxOperatingSystemFFM.HAS_UDEV;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -64,15 +65,15 @@ public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
             LOG.warn("USB Device information requires libudev, which is not present.");
             return emptyList();
         }
-        List<String> usbControllers = new ArrayList<>();
-        Map<String, String> nameMap = new HashMap<>();
-        Map<String, String> vendorMap = new HashMap<>();
-        Map<String, String> vendorIdMap = new HashMap<>();
-        Map<String, String> productIdMap = new HashMap<>();
-        Map<String, String> serialMap = new HashMap<>();
-        Map<String, List<String>> hubMap = new HashMap<>();
+        return callInArenaOrDefault(arena -> {
+            List<String> usbControllers = new ArrayList<>();
+            Map<String, String> nameMap = new HashMap<>();
+            Map<String, String> vendorMap = new HashMap<>();
+            Map<String, String> vendorIdMap = new HashMap<>();
+            Map<String, String> productIdMap = new HashMap<>();
+            Map<String, String> serialMap = new HashMap<>();
+            Map<String, List<String>> hubMap = new HashMap<>();
 
-        try (Arena arena = Arena.ofConfined()) {
             MemorySegment udev = UdevFunctions.udev_new();
             if (MemorySegment.NULL.equals(udev)) {
                 return emptyList();
@@ -142,16 +143,13 @@ public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
             } finally {
                 UdevFunctions.udev_unref(udev);
             }
-        } catch (Throwable e) {
-            LOG.warn("Error enumerating USB devices: {}", e.getMessage());
-            return emptyList();
-        }
 
-        List<UsbDevice> controllerDevices = new ArrayList<>();
-        for (String controller : usbControllers) {
-            controllerDevices.add(getDeviceAndChildren(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
-                    productIdMap, serialMap, hubMap));
-        }
-        return controllerDevices;
+            List<UsbDevice> controllerDevices = new ArrayList<>();
+            for (String controller : usbControllers) {
+                controllerDevices.add(getDeviceAndChildren(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
+                        productIdMap, serialMap, hubMap));
+            }
+            return controllerDevices;
+        }, LOG, WARN, "Error enumerating USB devices", emptyList());
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
@@ -4,7 +4,9 @@
  */
 package oshi.software.os.linux;
 
-import java.lang.foreign.Arena;
+import static org.slf4j.event.Level.WARN;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.net.InetAddress;
@@ -27,15 +29,14 @@ final class LinuxNetworkParamsFFM extends LinuxNetworkParams {
 
     @Override
     public String getHostName() {
-        try (Arena arena = Arena.ofConfined()) {
+        String hostname = callInArenaOrDefault(arena -> {
             MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
             if (0 == LinuxLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
                 return buf.getString(0);
             }
-        } catch (Throwable e) {
-            LOG.warn("FFM gethostname failed: {}", e.toString());
-        }
-        return super.getHostName();
+            return null;
+        }, LOG, WARN, "FFM gethostname failed", null);
+        return hostname == null ? super.getHostName() : hostname;
     }
 
     @Override
@@ -47,7 +48,7 @@ final class LinuxNetworkParamsFFM extends LinuxNetworkParams {
             LOG.warn("Unknown host exception when getting address of local host: {}", e.getMessage());
             return "";
         }
-        try (Arena arena = Arena.ofConfined()) {
+        String domainName = callInArenaOrDefault(arena -> {
             // Build hints: ai_flags = AI_CANONNAME, rest zero
             MemorySegment hints = arena.allocate(LinuxLibcFunctions.ADDRINFO_LAYOUT);
             hints.set(ValueLayout.JAVA_INT, 0, LinuxLibcFunctions.AI_CANONNAME);
@@ -69,9 +70,7 @@ final class LinuxNetworkParamsFFM extends LinuxNetworkParams {
             } finally {
                 LinuxLibcFunctions.freeaddrinfo(resPtr);
             }
-        } catch (Throwable e) {
-            LOG.warn("FFM getaddrinfo failed: {}", e.toString());
-        }
-        return super.getDomainName();
+        }, LOG, WARN, "FFM getaddrinfo failed", null);
+        return domainName == null ? super.getDomainName() : domainName;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
@@ -5,9 +5,10 @@
 package oshi.software.os.linux;
 
 import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.WARN;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
 import static oshi.ffm.ForeignFunctions.runInArenaCatchingThrowable;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 
@@ -72,29 +73,25 @@ public class LinuxOSProcessFFM extends LinuxOSProcess {
 
     @Override
     protected long queryRlimitSoft() {
-        try (Arena arena = Arena.ofConfined()) {
+        long limit = callInArenaLongOrDefault(arena -> {
             MemorySegment rlim = arena.allocate(LinuxLibcFunctions.RLIMIT_LAYOUT);
             if (0 == LinuxLibcFunctions.getrlimit(LinuxLibcFunctions.RLIMIT_NOFILE, rlim)) {
                 return LinuxLibcFunctions.rlimitCur(rlim);
             }
-            return getProcessOpenFileLimit(getProcessID(), 1);
-        } catch (Throwable e) {
-            LOG.warn("FFM getrlimit failed: {}", e.toString());
-            return getProcessOpenFileLimit(getProcessID(), 1);
-        }
+            return -1L;
+        }, LOG, WARN, "FFM getrlimit failed", -1L);
+        return limit < 0L ? getProcessOpenFileLimit(getProcessID(), 1) : limit;
     }
 
     @Override
     protected long queryRlimitHard() {
-        try (Arena arena = Arena.ofConfined()) {
+        long limit = callInArenaLongOrDefault(arena -> {
             MemorySegment rlim = arena.allocate(LinuxLibcFunctions.RLIMIT_LAYOUT);
             if (0 == LinuxLibcFunctions.getrlimit(LinuxLibcFunctions.RLIMIT_NOFILE, rlim)) {
                 return LinuxLibcFunctions.rlimitMax(rlim);
             }
-            return getProcessOpenFileLimit(getProcessID(), 2);
-        } catch (Throwable e) {
-            LOG.warn("FFM getrlimit failed: {}", e.toString());
-            return getProcessOpenFileLimit(getProcessID(), 2);
-        }
+            return -1L;
+        }, LOG, WARN, "FFM getrlimit failed", -1L);
+        return limit < 0L ? getProcessOpenFileLimit(getProcessID(), 2) : limit;
     }
 }


### PR DESCRIPTION
## Summary
- migrate Linux FFM arena/catch blocks to the new ForeignFunctions helper methods
- preserve existing fallback behavior by deferring fallback calls outside helper invocations where needed
- leave more complex cleanup-heavy Linux paths for a later targeted helper/fallback cleanup

## Testing
- mvn -pl oshi-core-ffm -am spotless:apply
- mvn -pl oshi-core-ffm -am clean compile
- mvn -pl oshi-core-ffm -am checkstyle:check
- mvn -pl oshi-core-ffm -am clean compile forbiddenapis:check
- mvn -pl oshi-core-ffm -am javadoc:javadoc
- mvn -pl oshi-core-ffm -am test -Dtest=oshi.ffm.ForeignFunctionsTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized native-call handling across Linux platform components, improving reliability of hardware and OS queries (CPU load, power, USB, network, storage, processes), centralizing error/fallback behavior, and reducing noisy local exception logging to provide more consistent results and safer resource management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->