### PR TITLE
Migrate macOS FFM arena calls to helpers

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
@@ -4,7 +4,10 @@
  */
 package oshi.hardware.platform.mac;
 
+import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.ERROR;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.ForeignFunctions.getErrno;
 import static oshi.util.ExceptionUtil.runOrLog;
 
@@ -40,8 +43,8 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
 
     @Override
     public long[] querySystemCpuLoadTicks() {
-        long[] ticks = new long[TickType.values().length];
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
+            long[] ticks = new long[TickType.values().length];
             MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
             MemorySegment cpuLoadInfo = arena.allocate(MacSystem.HOST_CPU_LOAD_INFO_DATA);
             MemorySegment count = arena.allocateFrom(ValueLayout.JAVA_INT,
@@ -62,10 +65,8 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
                     .toUnsignedLong((int) cpuTicksHandle.get(cpuLoadInfo, 0L, (long) MacSystem.CPU_STATE_SYSTEM));
             ticks[TickType.IDLE.getIndex()] = Integer
                     .toUnsignedLong((int) cpuTicksHandle.get(cpuLoadInfo, 0L, (long) MacSystem.CPU_STATE_IDLE));
-        } catch (Throwable e) {
-            LOG.error("Failed to get System CPU ticks", e);
-        }
-        return ticks;
+            return ticks;
+        }, LOG, ERROR, "Failed to get System CPU ticks", new long[TickType.values().length]);
     }
 
     @Override
@@ -73,8 +74,10 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
         if (nelem < 1 || nelem > 3) {
             throw new IllegalArgumentException("Must include from one to three elements.");
         }
-        double[] average = new double[nelem];
-        try (Arena arena = Arena.ofConfined()) {
+        double[] defaultAverage = new double[nelem];
+        Arrays.fill(defaultAverage, -1d);
+        return callInArenaOrDefault(arena -> {
+            double[] average = new double[nelem];
             MemorySegment loadavgSeg = arena.allocate(ValueLayout.JAVA_DOUBLE, nelem);
             int retval = MacSystemFunctions.getloadavg(loadavgSeg, nelem);
             if (retval < nelem) {
@@ -84,10 +87,8 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
                     average[i] = loadavgSeg.getAtIndex(ValueLayout.JAVA_DOUBLE, i);
                 }
             }
-        } catch (Throwable e) {
-            Arrays.fill(average, -1d);
-        }
-        return average;
+            return average;
+        }, LOG, DEBUG, "Failed to query system load average", defaultAverage);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryFFM.java
@@ -7,13 +7,13 @@ package oshi.hardware.platform.mac;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.ERROR;
 import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
 import static oshi.ffm.mac.MacSystem.VM_FREE_COUNT;
 import static oshi.ffm.mac.MacSystem.VM_INACTIVE_COUNT;
 import static oshi.ffm.mac.MacSystem.VM_STATISTICS;
 import static oshi.ffm.mac.MacSystemFunctions.mach_host_self;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
 import org.slf4j.Logger;
@@ -53,18 +53,15 @@ final class MacGlobalMemoryFFM extends MacGlobalMemory {
 
     @Override
     protected long queryPageSize() {
-        int result = -1;
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment pageSize = arena.allocate(JAVA_LONG);
-            result = MacSystemFunctions.host_page_size(mach_host_self(), pageSize);
+            int result = MacSystemFunctions.host_page_size(mach_host_self(), pageSize);
             if (result == 0) {
                 return pageSize.get(JAVA_LONG, 0);
             }
-        } catch (Throwable t) {
-            // IGNORED
-        }
-        LOG.error("Failed to get host page size. Error code: {}", result);
-        return 4096L;
+            LOG.error("Failed to get host page size. Error code: {}", result);
+            return 4096L;
+        }, LOG, ERROR, "Failed to get host page size", 4096L);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacVirtualMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacVirtualMemoryFFM.java
@@ -6,11 +6,12 @@ package oshi.hardware.platform.mac;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static org.slf4j.event.Level.DEBUG;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.mac.MacSystem.VM_STATISTICS;
 import static oshi.ffm.mac.MacSystem.XSW_USAGE_TOTAL;
 import static oshi.ffm.mac.MacSystem.XSW_USAGE_USED;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
 import org.slf4j.Logger;
@@ -33,21 +34,20 @@ final class MacVirtualMemoryFFM extends MacVirtualMemory {
 
     @Override
     protected Pair<Long, Long> querySwapUsage() {
-        long swapUsed = 0L;
-        long swapTotal = 0L;
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             var xswUsage = arena.allocate(MacSystem.XSW_USAGE);
             if (SysctlUtilFFM.sysctl("vm.swapusage", xswUsage)) {
-                swapUsed = xswUsage.get(JAVA_LONG, MacSystem.XSW_USAGE.byteOffset(XSW_USAGE_USED));
-                swapTotal = xswUsage.get(JAVA_LONG, MacSystem.XSW_USAGE.byteOffset(XSW_USAGE_TOTAL));
+                long swapUsed = xswUsage.get(JAVA_LONG, MacSystem.XSW_USAGE.byteOffset(XSW_USAGE_USED));
+                long swapTotal = xswUsage.get(JAVA_LONG, MacSystem.XSW_USAGE.byteOffset(XSW_USAGE_TOTAL));
+                return new Pair<>(swapUsed, swapTotal);
             }
-        }
-        return new Pair<>(swapUsed, swapTotal);
+            return new Pair<>(0L, 0L);
+        }, LOG, DEBUG, "Failed to query swap usage", new Pair<>(0L, 0L));
     }
 
     @Override
     protected Pair<Long, Long> queryVmStat() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             // Allocate memory for VM statistics structure and count
             MemorySegment vmStats = arena.allocate(VM_STATISTICS);
             if (MacMemoryUtilFFM.callVmStat(arena, vmStats)) {
@@ -57,9 +57,7 @@ final class MacVirtualMemoryFFM extends MacVirtualMemory {
                         vmStats.get(JAVA_INT, MacSystem.VM_STATISTICS.byteOffset(MacSystem.VM_PAGEOUTS)));
                 return new Pair<>(swapPagesIn, swapPagesOut);
             }
-        } catch (Throwable e) {
-            // Ignored
-        }
-        return new Pair<>(0L, 0L);
+            return new Pair<>(0L, 0L);
+        }, LOG, DEBUG, "Failed to query VM statistics", new Pair<>(0L, 0L));
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacNetworkParamsFFM.java
@@ -6,6 +6,8 @@ package oshi.software.os.mac;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.slf4j.event.Level.DEBUG;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.mac.MacSystem.ADDRINFO;
 import static oshi.ffm.mac.MacSystem.ADDRINFO_CANONNAME;
 import static oshi.ffm.mac.MacSystem.AI_CANONNAME;
@@ -16,7 +18,6 @@ import static oshi.ffm.mac.MacSystemFunctions.gai_strerror;
 import static oshi.ffm.mac.MacSystemFunctions.getaddrinfo;
 import static oshi.ffm.mac.MacSystemFunctions.gethostname;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -43,7 +44,7 @@ final class MacNetworkParamsFFM extends AbstractNetworkParams {
 
     @Override
     public String getDomainName() {
-        String hostname = "";
+        final String hostname;
         try {
             hostname = InetAddress.getLocalHost().getHostName();
             if (hostname == null || hostname.isEmpty()) {
@@ -54,7 +55,7 @@ final class MacNetworkParamsFFM extends AbstractNetworkParams {
             LOG.debug("Unknown host exception when getting address of local host: {}", e.getMessage());
             return "";
         }
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             // Allocate hint struct with AI_CANONNAME flag
             MemorySegment hint = arena.allocate(ADDRINFO);
             hint.set(JAVA_INT, ADDRINFO.byteOffset(AI_FLAGS), AI_CANONNAME);
@@ -79,23 +80,19 @@ final class MacNetworkParamsFFM extends AbstractNetworkParams {
             } finally {
                 freeaddrinfo(resPtr.get(ADDRESS, 0));
             }
-        } catch (Throwable e) {
-            LOG.debug("Failed getDomainName(): {}", e.getMessage());
-            return "";
-        }
+        }, LOG, DEBUG, "Failed getDomainName()", "");
     }
 
     @Override
     public String getHostName() {
-        try (Arena arena = Arena.ofConfined()) {
+        String hostname = callInArenaOrDefault(arena -> {
             MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
             if (gethostname(buf, HOST_NAME_MAX + 1L) == 0) {
                 return buf.getString(0);
             }
-        } catch (Throwable e) {
-            LOG.debug("Failed gethostname(): {}", e.getMessage());
-        }
-        return super.getHostName();
+            return null;
+        }, LOG, DEBUG, "Failed gethostname()", null);
+        return hostname == null ? super.getHostName() : hostname;
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSFileStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSFileStoreFFM.java
@@ -5,12 +5,13 @@
 package oshi.software.os.mac;
 
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static org.slf4j.event.Level.DEBUG;
+import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
 import static oshi.ffm.mac.MacSystem.F_FFREE;
 import static oshi.ffm.mac.MacSystem.F_FILES;
 import static oshi.ffm.mac.MacSystem.STATFS;
 
 import java.io.File;
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
 import org.slf4j.Logger;
@@ -39,7 +40,7 @@ public class MacOSFileStoreFFM extends MacOSFileStore {
     @Override
     public boolean updateAttributes() {
         // Fast path: call statfs64 directly on the known mount point
-        try (Arena arena = Arena.ofConfined()) {
+        if (callInArenaBooleanOrDefault(arena -> {
             MemorySegment buf = arena.allocate(STATFS);
             MemorySegment pathSeg = arena.allocateFrom(getMount());
             if (MacSystemFunctions.statfs64(pathSeg, buf) == 0) {
@@ -49,8 +50,9 @@ public class MacOSFileStoreFFM extends MacOSFileStore {
                 updateSpaceAndInodes(f.getFreeSpace(), f.getUsableSpace(), f.getTotalSpace(), ffree, files);
                 return true;
             }
-        } catch (Throwable e) {
-            LOG.debug("statfs64 fast path failed for {}: {}", getMount(), e.getMessage());
+            return false;
+        }, LOG, DEBUG, "statfs64 fast path failed for " + getMount(), false)) {
+            return true;
         }
         // Fall back to full enumeration
         for (OSFileStore fileStore : MacFileSystemFFM.getFileStoreMatching(getName(), isLocal())) {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
@@ -9,6 +9,8 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static org.slf4j.event.Level.DEBUG;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
 import static oshi.ffm.mac.MacSystem.GROUP;
 import static oshi.ffm.mac.MacSystem.MAXCOMLEN;
 import static oshi.ffm.mac.MacSystem.MAXPATHLEN;
@@ -400,16 +402,14 @@ public class MacOSProcessFFM extends AbstractOSProcess {
     @Override
     public long getSoftOpenFileLimit() {
         if (getProcessID() == this.os.getProcessId()) {
-            try (Arena arena = Arena.ofConfined()) {
+            return callInArenaLongOrDefault(arena -> {
                 MemorySegment buffer = arena.allocate(RLIMIT);
                 int result = getrlimit(MAC_RLIMIT_NOFILE, buffer);
                 if (result > 0) {
                     return buffer.get(JAVA_LONG, RLIMIT.byteOffset(RLIM_CUR));
                 }
-            } catch (Throwable e) {
-                // Ignore, return 0 below
-            }
-            return 0;
+                return 0L;
+            }, LOG, DEBUG, "Failed to query soft open file limit", 0L);
         }
         return -1L; // not supported
     }
@@ -417,16 +417,14 @@ public class MacOSProcessFFM extends AbstractOSProcess {
     @Override
     public long getHardOpenFileLimit() {
         if (getProcessID() == this.os.getProcessId()) {
-            try (Arena arena = Arena.ofConfined()) {
+            return callInArenaLongOrDefault(arena -> {
                 MemorySegment buffer = arena.allocate(RLIMIT);
                 int result = getrlimit(MAC_RLIMIT_NOFILE, buffer);
                 if (result > 0) {
                     return buffer.get(JAVA_LONG, RLIMIT.byteOffset(RLIM_MAX));
                 }
-            } catch (Throwable e) {
-                // Ignore, return 0 below
-            }
-            return 0;
+                return 0L;
+            }, LOG, DEBUG, "Failed to query hard open file limit", 0L);
         }
         return -1L; // not supported
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
@@ -6,6 +6,9 @@ package oshi.software.os.mac;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static org.slf4j.event.Level.WARN;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.mac.MacSystem.INT_SIZE;
 import static oshi.ffm.mac.MacSystem.PROC_ALL_PIDS;
 import static oshi.ffm.mac.MacSystem.PROC_PIDTASKINFO;
@@ -104,7 +107,7 @@ public class MacOperatingSystemFFM extends MacOperatingSystem {
 
     @Override
     public List<OSProcess> queryAllProcesses() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             // Calculate size needed, add a small buffer
             int numberOfProcesses = proc_listpids(PROC_ALL_PIDS, 0, MemorySegment.NULL, 0) / INT_SIZE;
             MemorySegment pidSegment = arena.allocate(JAVA_INT, numberOfProcesses + 10);
@@ -113,10 +116,7 @@ public class MacOperatingSystemFFM extends MacOperatingSystem {
             return Arrays.stream(pidSegment.asSlice(0, numberOfProcesses * INT_SIZE).toArray(ValueLayout.JAVA_INT))
                     .distinct().parallel().mapToObj(this::getProcess).filter(Objects::nonNull)
                     .filter(ProcessFiltering.VALID_PROCESS).toList();
-        } catch (Throwable e) {
-            LOG.warn("Failed to query processes", e.getMessage());
-            return Collections.emptyList();
-        }
+        }, LOG, WARN, "Failed to query processes", Collections.emptyList());
     }
 
     @Override
@@ -138,7 +138,7 @@ public class MacOperatingSystemFFM extends MacOperatingSystem {
 
     @Override
     public int getThreadCount() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaIntOrDefault(arena -> {
             int numberOfProcesses = proc_listpids(PROC_ALL_PIDS, 0, MemorySegment.NULL, 0) / INT_SIZE;
             MemorySegment pidSegment = arena.allocate(JAVA_INT, numberOfProcesses + 10);
             numberOfProcesses = proc_listpids(PROC_ALL_PIDS, 0, pidSegment, numberOfProcesses * INT_SIZE) / INT_SIZE;
@@ -151,10 +151,7 @@ public class MacOperatingSystemFFM extends MacOperatingSystem {
                 }
             }
             return numberOfThreads;
-        } catch (Throwable e) {
-            LOG.warn("Failed to query thread count: {}", e.getMessage(), e);
-            return 0;
-        }
+        }, LOG, WARN, "Failed to query thread count", 0);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- migrate straightforward macOS FFM arena/catch blocks to the new ForeignFunctions helpers
- preserve existing fallback behavior, including macOS open file limit return logic pending #3286
- leave cleanup-heavy CoreFoundation/IOKit/deallocation paths for later targeted batches

## Testing
- mvn -pl oshi-core-ffm -am spotless:apply
- mvn -pl oshi-core-ffm -am clean compile
- mvn -pl oshi-core-ffm -am checkstyle:check
- mvn -pl oshi-core-ffm -am clean compile forbiddenapis:check
- mvn -pl oshi-core-ffm -am javadoc:javadoc
- mvn -pl oshi-core-ffm -am test -Dtest=oshi.ffm.ForeignFunctionsTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined arena lifecycle management and error handling across macOS-specific modules (CPU processing, memory queries, virtual memory operations, network parameters, file storage, process limits, and OS information) through centralized helper methods, improving code consistency and maintainability in the platform-specific layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->