### PR TITLE
Add updateAttributes() comparison tests for all native APIs

### DIFF
--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.ComputerSystem;
@@ -46,6 +45,7 @@ import oshi.software.os.OSThread;
 import oshi.software.os.OperatingSystem;
 import oshi.util.GlobalConfig;
 import oshi.util.PlatformEnum;
+import oshi.util.Util;
 
 /**
  * Compares JNA and FFM implementations of the OSHI API to detect regressions, missing implementations, or incorrect
@@ -245,7 +245,6 @@ class NativeComparisonTest {
     // ---- Hardware: Disks ----
 
     @Test
-    @DisabledIf("isLinux")
     void diskStores() {
         List<HWDiskStore> jna = jnaHal.getDiskStores();
         List<HWDiskStore> ffm = ffmHal.getDiskStores();
@@ -264,8 +263,12 @@ class NativeComparisonTest {
             assertThat(f.getReadBytes()).as("readBytes(%s)", j.getName()).isGreaterThanOrEqualTo(j.getReadBytes());
             assertThat(f.getWrites()).as("writes(%s)", j.getName()).isGreaterThanOrEqualTo(j.getWrites());
             assertThat(f.getWriteBytes()).as("writeBytes(%s)", j.getName()).isGreaterThanOrEqualTo(j.getWriteBytes());
-            // Partitions should match exactly
-            assertThat(f.getPartitions()).usingRecursiveComparison().isEqualTo(j.getPartitions());
+            // TODO: Remove isLinux() skip after upgrading JNA past 5.18.1.
+            // JNA's UdevDevice.getSysname() returns full syspath on Linux; fixed by
+            // https://github.com/java-native-access/jna/pull/1715
+            if (!isLinux()) {
+                assertThat(f.getPartitions()).usingRecursiveComparison().isEqualTo(j.getPartitions());
+            }
         }
     }
 
@@ -406,14 +409,173 @@ class NativeComparisonTest {
         OSProcess ffm = ffmOs.getProcess(pid);
         assertThat(jna).isNotNull();
         assertThat(ffm).isNotNull();
+        // Snapshot initial times
+        long jnaKernelBefore = jna.getKernelTime();
+        long jnaUserBefore = jna.getUserTime();
+        long ffmKernelBefore = ffm.getKernelTime();
+        long ffmUserBefore = ffm.getUserTime();
+        // Delay to accumulate CPU time
+        Util.sleep(100);
         // Call updateAttributes to refresh and verify it succeeds
-        assertThat(jna.updateAttributes()).as("JNA updateAttributes").isTrue();
-        assertThat(ffm.updateAttributes()).as("FFM updateAttributes").isTrue();
+        assertThat(jna.updateAttributes()).as("JNA process updateAttributes").isTrue();
+        assertThat(ffm.updateAttributes()).as("FFM process updateAttributes").isTrue();
         // After refresh, basic fields should still match
         assertThat(ffm.getName()).isEqualTo(jna.getName());
         assertThat(ffm.getProcessID()).isEqualTo(jna.getProcessID());
         // Command line exercises Win32ProcessCached when batch mode is enabled
         assertThat(ffm.getCommandLine()).isEqualTo(jna.getCommandLine());
+        // Kernel and user time are monotonically nondecreasing
+        assertThat(jna.getKernelTime()).as("JNA kernelTime").isGreaterThanOrEqualTo(jnaKernelBefore);
+        assertThat(jna.getUserTime()).as("JNA userTime").isGreaterThanOrEqualTo(jnaUserBefore);
+        assertThat(ffm.getKernelTime()).as("FFM kernelTime").isGreaterThanOrEqualTo(ffmKernelBefore);
+        assertThat(ffm.getUserTime()).as("FFM userTime").isGreaterThanOrEqualTo(ffmUserBefore);
+    }
+
+    @Test
+    void currentThreadUpdateAttributes() {
+        OSThread jnaThread = jnaOs.getCurrentThread();
+        OSThread ffmThread = ffmOs.getCurrentThread();
+        assertThat(jnaThread).isNotNull();
+        assertThat(ffmThread).isNotNull();
+        // Snapshot initial times
+        long jnaKernelBefore = jnaThread.getKernelTime();
+        long jnaUserBefore = jnaThread.getUserTime();
+        long ffmKernelBefore = ffmThread.getKernelTime();
+        long ffmUserBefore = ffmThread.getUserTime();
+        // Delay to accumulate CPU time
+        Util.sleep(100);
+        // Call updateAttributes; not implemented on macOS (returns false)
+        boolean jnaUpdated = jnaThread.updateAttributes();
+        boolean ffmUpdated = ffmThread.updateAttributes();
+        assertThat(ffmUpdated).as("JNA and FFM should agree").isEqualTo(jnaUpdated);
+        if (!jnaUpdated) {
+            return;
+        }
+        // Kernel and user time are monotonically nondecreasing
+        assertThat(jnaThread.getKernelTime()).as("JNA thread kernelTime").isGreaterThanOrEqualTo(jnaKernelBefore);
+        assertThat(jnaThread.getUserTime()).as("JNA thread userTime").isGreaterThanOrEqualTo(jnaUserBefore);
+        assertThat(ffmThread.getKernelTime()).as("FFM thread kernelTime").isGreaterThanOrEqualTo(ffmKernelBefore);
+        assertThat(ffmThread.getUserTime()).as("FFM thread userTime").isGreaterThanOrEqualTo(ffmUserBefore);
+    }
+
+    @Test
+    void diskStoreUpdateAttributes() {
+        List<HWDiskStore> jna = jnaHal.getDiskStores();
+        List<HWDiskStore> ffm = ffmHal.getDiskStores();
+        assertThat(ffm).isNotEmpty();
+        Map<String, HWDiskStore> ffmByName = ffm.stream()
+                .collect(Collectors.toMap(HWDiskStore::getName, Function.identity()));
+        int matched = 0;
+        for (HWDiskStore j : jna) {
+            HWDiskStore f = ffmByName.get(j.getName());
+            if (f == null) {
+                continue;
+            }
+            matched++;
+            // Snapshot before values
+            long jnaReadsBefore = j.getReads();
+            long jnaWritesBefore = j.getWrites();
+            long ffmReadsBefore = f.getReads();
+            long ffmWritesBefore = f.getWrites();
+            // Delay to allow I/O activity
+            Util.sleep(100);
+            // Refresh
+            assertThat(j.updateAttributes()).as("JNA disk %s updateAttributes", j.getName()).isTrue();
+            assertThat(f.updateAttributes()).as("FFM disk %s updateAttributes", f.getName()).isTrue();
+            // Reads and writes are monotonically nondecreasing
+            assertThat(j.getReads()).as("JNA reads(%s)", j.getName()).isGreaterThanOrEqualTo(jnaReadsBefore);
+            assertThat(j.getWrites()).as("JNA writes(%s)", j.getName()).isGreaterThanOrEqualTo(jnaWritesBefore);
+            assertThat(f.getReads()).as("FFM reads(%s)", f.getName()).isGreaterThanOrEqualTo(ffmReadsBefore);
+            assertThat(f.getWrites()).as("FFM writes(%s)", f.getName()).isGreaterThanOrEqualTo(ffmWritesBefore);
+        }
+        assertThat(matched).as("matched disk stores").isGreaterThan(0);
+    }
+
+    @Test
+    void networkIfUpdateAttributes() {
+        List<NetworkIF> jna = jnaHal.getNetworkIFs();
+        List<NetworkIF> ffm = ffmHal.getNetworkIFs();
+        assertThat(ffm).isNotEmpty();
+        Map<String, NetworkIF> ffmByName = ffm.stream()
+                .collect(Collectors.toMap(NetworkIF::getName, Function.identity()));
+        int matched = 0;
+        for (NetworkIF j : jna) {
+            NetworkIF f = ffmByName.get(j.getName());
+            if (f == null) {
+                continue;
+            }
+            matched++;
+            // Snapshot before values
+            long jnaBytesSentBefore = j.getBytesSent();
+            long jnaBytesRecvBefore = j.getBytesRecv();
+            long ffmBytesSentBefore = f.getBytesSent();
+            long ffmBytesRecvBefore = f.getBytesRecv();
+            // Delay to allow network activity
+            Util.sleep(100);
+            // Refresh
+            assertThat(j.updateAttributes()).as("JNA net %s updateAttributes", j.getName()).isTrue();
+            assertThat(f.updateAttributes()).as("FFM net %s updateAttributes", f.getName()).isTrue();
+            // Traffic counters are monotonically nondecreasing
+            assertThat(j.getBytesSent()).as("JNA bytesSent(%s)", j.getName())
+                    .isGreaterThanOrEqualTo(jnaBytesSentBefore);
+            assertThat(j.getBytesRecv()).as("JNA bytesRecv(%s)", j.getName())
+                    .isGreaterThanOrEqualTo(jnaBytesRecvBefore);
+            assertThat(f.getBytesSent()).as("FFM bytesSent(%s)", f.getName())
+                    .isGreaterThanOrEqualTo(ffmBytesSentBefore);
+            assertThat(f.getBytesRecv()).as("FFM bytesRecv(%s)", f.getName())
+                    .isGreaterThanOrEqualTo(ffmBytesRecvBefore);
+        }
+        assertThat(matched).as("matched network interfaces").isGreaterThan(0);
+    }
+
+    @Test
+    void fileStoreUpdateAttributes() {
+        List<OSFileStore> jnaStores = jnaOs.getFileSystem().getFileStores();
+        List<OSFileStore> ffmStores = ffmOs.getFileSystem().getFileStores();
+        assertThat(ffmStores).isNotEmpty();
+        Map<String, OSFileStore> ffmByMount = ffmStores.stream()
+                .collect(Collectors.toMap(OSFileStore::getMount, Function.identity(), (a, b) -> a));
+        int matched = 0;
+        for (OSFileStore j : jnaStores) {
+            OSFileStore f = ffmByMount.get(j.getMount());
+            if (f == null) {
+                continue;
+            }
+            matched++;
+            // Delay before refresh
+            Util.sleep(100);
+            // Refresh
+            assertThat(j.updateAttributes()).as("JNA fileStore %s updateAttributes", j.getMount()).isTrue();
+            assertThat(f.updateAttributes()).as("FFM fileStore %s updateAttributes", f.getMount()).isTrue();
+            // Space values should remain valid (non-negative, total unchanged)
+            assertThat(j.getTotalSpace()).as("JNA totalSpace(%s)", j.getMount()).isGreaterThanOrEqualTo(0L);
+            assertThat(f.getTotalSpace()).as("FFM totalSpace(%s)", f.getMount()).isEqualTo(j.getTotalSpace());
+            assertThat(j.getUsableSpace()).as("JNA usableSpace(%s)", j.getMount()).isGreaterThanOrEqualTo(0L);
+            assertThat(f.getUsableSpace()).as("FFM usableSpace(%s)", f.getMount()).isGreaterThanOrEqualTo(0L);
+        }
+        assertThat(matched).as("matched file stores").isGreaterThan(0);
+    }
+
+    @Test
+    void powerSourceUpdateAttributes() {
+        List<PowerSource> jna = jnaHal.getPowerSources();
+        List<PowerSource> ffm = ffmHal.getPowerSources();
+        if (jna.isEmpty()) {
+            assertThat(ffm).as("both JNA and FFM should be empty").isEmpty();
+            return;
+        }
+        assertThat(ffm).hasSameSizeAs(jna);
+        Map<String, PowerSource> ffmByName = ffm.stream()
+                .collect(Collectors.toMap(PowerSource::getName, Function.identity()));
+        // Delay before refresh
+        Util.sleep(100);
+        for (PowerSource j : jna) {
+            PowerSource f = ffmByName.get(j.getName());
+            assertThat(f).as("powerSource %s", j.getName()).isNotNull();
+            assertThat(j.updateAttributes()).as("JNA powerSource %s updateAttributes", j.getName()).isTrue();
+            assertThat(f.updateAttributes()).as("FFM powerSource %s updateAttributes", f.getName()).isTrue();
+            assertThat(f.getMaxCapacity()).as("FFM maxCapacity(%s)", f.getName()).isEqualTo(j.getMaxCapacity());
+        }
     }
 
     // ---- OS: FileSystem ----

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/PowerSourceTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/PowerSourceTest.java
@@ -37,6 +37,13 @@ class PowerSourceTest {
                     "Power Source's estimated remaining time should be greater than zero or within error margin of -1 or within error margin of -2",
                     ps.getTimeRemainingEstimated(),
                     is(either(greaterThan(0d)).or(closeTo(-1d, epsilon)).or(closeTo(-2d, epsilon))));
+            // updateAttributes should succeed and static values should not change
+            int maxCapBefore = ps.getMaxCapacity();
+            assertThat("Power Source updateAttributes should succeed for " + ps.getName(), ps.updateAttributes(),
+                    is(true));
+            assertThat("Max capacity should not change after update", ps.getMaxCapacity(), is(maxCapBefore));
+            assertThat("Remaining capacity should still be valid after update", ps.getRemainingCapacityPercent(),
+                    is(greaterThanOrEqualTo(0d)));
         }
     }
 }

--- a/oshi-core/src/test/java/oshi/software/os/shared/FileSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/FileSystemTest.java
@@ -63,6 +63,13 @@ class FileSystemTest {
                         "File store's usable space should be less than or equal to the total space on non-network drives",
                         store.getUsableSpace() <= store.getTotalSpace(), is(true));
             }
+            // updateAttributes should succeed and total space should not change
+            long totalBefore = store.getTotalSpace();
+            assertThat("File store updateAttributes should succeed for " + store.getMount(), store.updateAttributes(),
+                    is(true));
+            assertThat("File store total space should not change after update", store.getTotalSpace(), is(totalBefore));
+            assertThat("File store usable space should remain valid after update", store.getUsableSpace(),
+                    greaterThanOrEqualTo(0L));
         }
     }
 }

--- a/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
@@ -49,6 +49,7 @@ import oshi.software.os.OperatingSystem;
 import oshi.software.os.OperatingSystem.OSVersionInfo;
 import oshi.software.os.OperatingSystem.ProcessFiltering;
 import oshi.software.os.OperatingSystem.ProcessSorting;
+import oshi.util.Util;
 
 /**
  * Test OS
@@ -172,6 +173,15 @@ class OperatingSystemTest {
                 is(greaterThanOrEqualTo(-1L)));
         assertThat("Hard open file limit for process should be -1 or higher", proc.getHardOpenFileLimit(),
                 is(greaterThanOrEqualTo(-1L)));
+        // updateAttributes should succeed and kernel/user time should be nondecreasing
+        long kernelBefore = proc.getKernelTime();
+        long userBefore = proc.getUserTime();
+        Util.sleep(500);
+        assertThat("Process updateAttributes should succeed", proc.updateAttributes(), is(true));
+        assertThat("Kernel time should be nondecreasing after update", proc.getKernelTime(),
+                is(greaterThanOrEqualTo(kernelBefore)));
+        assertThat("User time should be nondecreasing after update", proc.getUserTime(),
+                is(greaterThanOrEqualTo(userBefore)));
     }
 
     @Test
@@ -179,6 +189,17 @@ class OperatingSystemTest {
         List<OSThread> threads = proc.getThreadDetails();
         for (OSThread thread : threads) {
             assertThat("OS thread shouldn't be null", thread, is(notNullValue()));
+        }
+        // Test updateAttributes on current thread (not implemented on all platforms)
+        OSThread currentThread = os.getCurrentThread();
+        assertThat("Current thread shouldn't be null", currentThread, is(notNullValue()));
+        long preKernel = currentThread.getKernelTime();
+        long preUser = currentThread.getUserTime();
+        if (currentThread.updateAttributes()) {
+            assertThat("Thread kernel time should be nondecreasing after update", currentThread.getKernelTime(),
+                    is(greaterThanOrEqualTo(preKernel)));
+            assertThat("Thread user time should be nondecreasing after update", currentThread.getUserTime(),
+                    is(greaterThanOrEqualTo(preUser)));
         }
     }
 


### PR DESCRIPTION
Add JNA vs FFM comparison tests exercising `updateAttributes()` on all interfaces that define it: `OSProcess`, `OSThread`, `HWDiskStore`, `NetworkIF`, `OSFileStore`, and `PowerSource`.

Each test snapshots values, sleeps briefly, calls `updateAttributes()` on both JNA and FFM instances, then verifies:
- `updateAttributes()` returns true
- Monotonically nondecreasing counters have not decreased (kernel/user time, disk reads/writes, network bytes sent/received)
- Static values remain consistent between JNA and FFM

Also narrows the Linux disk test skip: instead of disabling the entire `diskStores()` test on Linux, only skip the partition name comparison which is affected by the JNA `UdevDevice.getSysname()` bug fixed in https://github.com/java-native-access/jna/pull/1715 (not yet released past 5.18.1).

Motivated by #3287 where patch coverage showed `updateAttributes()` was not being exercised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Restored disk-store comparisons on Linux with platform-conditional expectations for partition equality.
  * Expanded attribute-update validation to processes, threads, disk stores, network interfaces, file stores, and power sources.
  * Added assertions that update calls succeed; counters/times are monotonic/nondecreasing; identity, total/max capacity remain equal after refresh.
  * Verifies usable/remaining capacities are non-negative and handles empty or unmatched platform data gracefully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->