### PR TITLE
Migrate Windows FFM classes to arena call helpers

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGlobalMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGlobalMemoryFFM.java
@@ -4,10 +4,11 @@
  */
 package oshi.hardware.platform.windows;
 
+import static org.slf4j.event.Level.ERROR;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -106,7 +107,7 @@ final class WindowsGlobalMemoryFFM extends WindowsGlobalMemory {
     }
 
     private static Triplet<Long, Long, Long> readPerfInfo() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment perfInfo = arena.allocate(PsapiFFM.PERFORMANCE_INFORMATION_LAYOUT);
             int size = (int) PsapiFFM.PERFORMANCE_INFORMATION_LAYOUT.byteSize();
             if (!PsapiFFM.GetPerformanceInfo(perfInfo, size)) {
@@ -122,9 +123,6 @@ final class WindowsGlobalMemoryFFM extends WindowsGlobalMemory {
             long memAvailable = pageSize * physAvail;
             long memTotal = pageSize * physTotal;
             return new Triplet<>(memAvailable, memTotal, pageSize);
-        } catch (Throwable t) {
-            LOG.error("Failed to get Performance Info: {}", t.getMessage());
-            return new Triplet<>(0L, 0L, 4096L);
-        }
+        }, LOG, ERROR, "Failed to get Performance Info", new Triplet<>(0L, 0L, 4096L));
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
@@ -4,7 +4,9 @@
  */
 package oshi.hardware.platform.windows;
 
-import java.lang.foreign.Arena;
+import static org.slf4j.event.Level.ERROR;
+import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
+
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.net.NetworkInterface;
@@ -81,7 +83,7 @@ public final class WindowsNetworkIfFFM extends AbstractNetworkIF {
     @Override
     public boolean updateAttributes() {
         // FFM targets JDK 25+ which requires Vista+; use GetIfEntry2 directly
-        try (Arena arena = Arena.ofConfined()) {
+        boolean success = callInArenaBooleanOrDefault(arena -> {
             MemorySegment ifRow = arena.allocate(IPHlpAPIFFM.MIB_IF_ROW2_SIZE);
             ifRow.fill((byte) 0);
             // Set InterfaceIndex at offset 8
@@ -109,13 +111,13 @@ public final class WindowsNetworkIfFFM extends AbstractNetworkIF {
             this.ifAlias = readWideString(aliasSlice);
             int operStatus = ifRow.get(ValueLayout.JAVA_INT, IPHlpAPIFFM.OFFSET_OPER_STATUS);
             this.ifOperStatus = IfOperStatus.byValue(operStatus);
-        } catch (Throwable t) {
-            LOG.error("Failed to retrieve data for interface {}, {}: {}", queryNetworkInterface().getIndex(), getName(),
-                    t.getMessage());
-            return false;
+            return true;
+        }, LOG, ERROR, "Failed to retrieve data for interface " + queryNetworkInterface().getIndex() + ", " + getName(),
+                false);
+        if (success) {
+            setTimeStamp(System.currentTimeMillis());
         }
-        setTimeStamp(System.currentTimeMillis());
-        return true;
+        return success;
     }
 
     private static String readWideString(MemorySegment seg) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsVirtualMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsVirtualMemoryFFM.java
@@ -4,10 +4,11 @@
  */
 package oshi.hardware.platform.windows;
 
+import static org.slf4j.event.Level.ERROR;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -85,7 +86,7 @@ final class WindowsVirtualMemoryFFM extends AbstractVirtualMemory {
     }
 
     private static Triplet<Long, Long, Long> querySwapTotalVirtMaxVirtUsed() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment perfInfo = arena.allocate(PsapiFFM.PERFORMANCE_INFORMATION_LAYOUT);
             int size = (int) PsapiFFM.PERFORMANCE_INFORMATION_LAYOUT.byteSize();
             if (!PsapiFFM.GetPerformanceInfo(perfInfo, size)) {
@@ -99,10 +100,7 @@ final class WindowsVirtualMemoryFFM extends AbstractVirtualMemory {
             long physTotal = perfInfo.get(ValueLayout.JAVA_LONG, PsapiFFM.PERFORMANCE_INFORMATION_LAYOUT
                     .byteOffset(MemoryLayout.PathElement.groupElement("PhysicalTotal")));
             return new Triplet<>(commitLimit - physTotal, commitLimit, commitTotal);
-        } catch (Throwable t) {
-            LOG.error("Failed to get Performance Info: {}", t.getMessage());
-            return new Triplet<>(0L, 0L, 0L);
-        }
+        }, LOG, ERROR, "Failed to get Performance Info", new Triplet<>(0L, 0L, 0L));
     }
 
     private static Pair<Long, Long> queryPageSwaps() {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -6,6 +6,8 @@ package oshi.software.os.windows;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.slf4j.event.Level.ERROR;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.windows.Kernel32FFM.GetLastError;
 import static oshi.ffm.windows.WinNTFFM.PERFORMANCE_INFORMATION;
 import static oshi.ffm.windows.WindowsForeignFunctions.readWideString;
@@ -263,7 +265,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     }
 
     private int getPerformanceInfoField(String fieldName) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaIntOrDefault(arena -> {
             MemorySegment perfInfo = arena.allocate(PERFORMANCE_INFORMATION);
             int size = (int) PERFORMANCE_INFORMATION.byteSize();
             perfInfo.set(JAVA_INT, PERFORMANCE_INFORMATION.byteOffset(MemoryLayout.PathElement.groupElement("cb")),
@@ -274,10 +276,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
             }
             return perfInfo.get(JAVA_INT,
                     PERFORMANCE_INFORMATION.byteOffset(MemoryLayout.PathElement.groupElement(fieldName)));
-        } catch (Throwable t) {
-            LOG.error("Exception getting {}", fieldName, t);
-            return 0;
-        }
+        }, LOG, ERROR, "Exception getting " + fieldName, 0);
     }
 
     @Override


### PR DESCRIPTION
Migrate simple `try (Arena) { ... } catch (Throwable)` patterns in Windows FFM classes to use the centralized arena call helpers from `ForeignFunctions`, consistent with the Linux (#3285) and macOS (#3287) migrations.

**Migrated methods:**
- `WindowsGlobalMemoryFFM.readPerfInfo()` → `callInArenaOrDefault`
- `WindowsVirtualMemoryFFM.querySwapTotalVirtMaxVirtUsed()` → `callInArenaOrDefault`
- `WindowsNetworkIfFFM.updateAttributes()` → `callInArenaBooleanOrDefault`
- `WindowsOperatingSystemFFM.getPerformanceInfoField()` → `callInArenaIntOrDefault`

Methods requiring handle/resource closing in `finally` blocks are deferred for a future refactoring pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Windows system information collection code through improved error handling and resource management patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->