### PR TITLE
Add NativeHandle AutoCloseable wrapper for native resource cleanup

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/NativeHandle.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/NativeHandle.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An {@link AutoCloseable} wrapper around a native handle (represented as a {@link MemorySegment}). When closed, the
+ * provided closer function is invoked to release the native resource.
+ * <p>
+ * This class is intended for use in try-with-resources blocks to ensure native handles are properly released, even when
+ * exceptions occur.
+ * <p>
+ * Example usage:
+ *
+ * <pre>{@code
+ * try (NativeHandle h = NativeHandle.of(Kernel32FFM.OpenProcess(...), Kernel32FFM::CloseHandle)) {
+ *     // use h.get()
+ * }
+ * }</pre>
+ */
+public final class NativeHandle implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NativeHandle.class);
+
+    /**
+     * A consumer that accepts a {@link MemorySegment} and may throw.
+     */
+    @FunctionalInterface
+    public interface ThrowingCloser {
+        /**
+         * Performs the close operation on the given handle.
+         *
+         * @param handle the native handle to close
+         * @throws Throwable if the close operation fails
+         */
+        void close(MemorySegment handle) throws Throwable;
+    }
+
+    private final MemorySegment handle;
+    private final ThrowingCloser closer;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private NativeHandle(MemorySegment handle, ThrowingCloser closer) {
+        this.handle = handle;
+        this.closer = Objects.requireNonNull(closer, "closer");
+    }
+
+    /**
+     * Creates a new {@code NativeHandle} wrapping the given segment with the specified closer.
+     *
+     * @param handle the native handle segment; may be {@code null} or {@link MemorySegment#NULL}
+     * @param closer the function to call to release the handle
+     * @return a new {@code NativeHandle}
+     */
+    public static NativeHandle of(MemorySegment handle, ThrowingCloser closer) {
+        return new NativeHandle(handle, closer);
+    }
+
+    /**
+     * Returns the underlying handle segment.
+     *
+     * @return the handle, which may be {@code null} or {@link MemorySegment#NULL}
+     */
+    public MemorySegment get() {
+        return handle;
+    }
+
+    /**
+     * Tests whether this handle is null or points to address zero.
+     *
+     * @return {@code true} if the handle is {@code null} or {@link MemorySegment#NULL}
+     */
+    public boolean isNull() {
+        return handle == null || handle.address() == 0;
+    }
+
+    /**
+     * Releases the native handle by invoking the closer. Does nothing if the handle is null or zero, or if already
+     * closed. Any exception thrown by the closer is logged and suppressed. This method is idempotent.
+     */
+    @Override
+    public void close() {
+        if (!isNull() && closed.compareAndSet(false, true)) {
+            try {
+                closer.close(handle);
+            } catch (Throwable t) {
+                LOG.debug("Failed to close native handle: {}", t.getMessage());
+            }
+        }
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
@@ -35,6 +35,7 @@ import oshi.driver.windows.perfmon.LoadAverageFFM;
 import oshi.driver.windows.perfmon.ProcessorInformationFFM;
 import oshi.driver.windows.perfmon.SystemInformationFFM;
 import oshi.driver.windows.wmi.Win32ProcessorFFM;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.windows.Advapi32FFM;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.ffm.windows.VersionHelpersFFM;
@@ -120,13 +121,12 @@ final class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
             MemorySegment hKey = arena.allocate(ValueLayout.ADDRESS);
             MemorySegment subKey = WindowsForeignFunctions.toWideString(arena, cpuRegistryRoot);
             if (Advapi32FFM.RegOpenKeyEx(HKLM, subKey, 0, WinNTFFM.KEY_READ, hKey) == 0) {
-                MemorySegment openedKey = hKey.get(ValueLayout.ADDRESS, 0);
-                try {
+                try (NativeHandle key = NativeHandle.of(hKey.get(ValueLayout.ADDRESS, 0), Advapi32FFM::RegCloseKey)) {
                     // Get first subkey name
                     MemorySegment nameBuffer = arena.allocate(256 * 2L); // WCHAR[256]
                     MemorySegment nameLen = arena.allocate(ValueLayout.JAVA_INT);
                     nameLen.set(ValueLayout.JAVA_INT, 0, 256);
-                    if (Advapi32FFM.RegEnumKeyEx(openedKey, 0, nameBuffer, nameLen, MemorySegment.NULL,
+                    if (Advapi32FFM.RegEnumKeyEx(key.get(), 0, nameBuffer, nameLen, MemorySegment.NULL,
                             MemorySegment.NULL, MemorySegment.NULL, MemorySegment.NULL) == 0) {
                         String firstKey = WindowsForeignFunctions.readWideString(nameBuffer);
                         String cpuRegistryPath = cpuRegistryRoot + firstKey;
@@ -135,8 +135,6 @@ final class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
                         cpuIdentifier = registryGetString(arena, cpuRegistryPath, "Identifier");
                         cpuVendorFreq = registryGetDword(arena, cpuRegistryPath, "~MHz") * 1_000_000L;
                     }
-                } finally {
-                    Advapi32FFM.RegCloseKey(openedKey);
                 }
             }
         } catch (Throwable t) {
@@ -403,18 +401,15 @@ final class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
             MemorySegment hKey = arena.allocate(ValueLayout.ADDRESS);
             MemorySegment subKey = WindowsForeignFunctions.toWideString(arena, path);
             if (Advapi32FFM.RegOpenKeyEx(HKLM, subKey, 0, WinNTFFM.KEY_READ, hKey) == 0) {
-                MemorySegment openedKey = hKey.get(ValueLayout.ADDRESS, 0);
-                try {
+                try (NativeHandle key = NativeHandle.of(hKey.get(ValueLayout.ADDRESS, 0), Advapi32FFM::RegCloseKey)) {
                     MemorySegment valueNameSeg = WindowsForeignFunctions.toWideString(arena, valueName);
                     MemorySegment dataSize = arena.allocate(ValueLayout.JAVA_INT);
                     dataSize.set(ValueLayout.JAVA_INT, 0, 512);
                     MemorySegment data = arena.allocate(512);
-                    if (Advapi32FFM.RegQueryValueEx(openedKey, valueNameSeg, 0, MemorySegment.NULL, data,
+                    if (Advapi32FFM.RegQueryValueEx(key.get(), valueNameSeg, 0, MemorySegment.NULL, data,
                             dataSize) == 0) {
                         return WindowsForeignFunctions.readWideString(data);
                     }
-                } finally {
-                    Advapi32FFM.RegCloseKey(openedKey);
                 }
             }
         } catch (Throwable t) {
@@ -428,18 +423,15 @@ final class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
             MemorySegment hKey = arena.allocate(ValueLayout.ADDRESS);
             MemorySegment subKey = WindowsForeignFunctions.toWideString(arena, path);
             if (Advapi32FFM.RegOpenKeyEx(HKLM, subKey, 0, WinNTFFM.KEY_READ, hKey) == 0) {
-                MemorySegment openedKey = hKey.get(ValueLayout.ADDRESS, 0);
-                try {
+                try (NativeHandle key = NativeHandle.of(hKey.get(ValueLayout.ADDRESS, 0), Advapi32FFM::RegCloseKey)) {
                     MemorySegment valueNameSeg = WindowsForeignFunctions.toWideString(arena, valueName);
                     MemorySegment dataSize = arena.allocate(ValueLayout.JAVA_INT);
                     dataSize.set(ValueLayout.JAVA_INT, 0, 4);
                     MemorySegment data = arena.allocate(4);
-                    if (Advapi32FFM.RegQueryValueEx(openedKey, valueNameSeg, 0, MemorySegment.NULL, data,
+                    if (Advapi32FFM.RegQueryValueEx(key.get(), valueNameSeg, 0, MemorySegment.NULL, data,
                             dataSize) == 0) {
                         return Integer.toUnsignedLong(data.get(ValueLayout.JAVA_INT, 0));
                     }
-                } finally {
-                    Advapi32FFM.RegCloseKey(openedKey);
                 }
             }
         } catch (Throwable t) {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -31,6 +31,7 @@ import oshi.driver.common.windows.wmi.Win32LogicalDisk.LogicalDiskProperty;
 import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.driver.windows.perfmon.ProcessInformationFFM;
 import oshi.driver.windows.wmi.Win32LogicalDiskFFM;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.software.common.AbstractFileSystem;
 import oshi.software.os.OSFileStore;
@@ -157,7 +158,7 @@ public class WindowsFileSystemFFM extends AbstractFileSystem {
                 return fs;
             }
             MemorySegment hVol = hVolOpt.get();
-            try {
+            try (NativeHandle ignored = NativeHandle.of(hVol, Kernel32FFM::FindVolumeClose)) {
                 do {
                     String volume = readWideString(volumeNameBuf);
                     if (volumeToMatch != null && !volume.equals(volumeToMatch)) {
@@ -225,8 +226,6 @@ public class WindowsFileSystemFFM extends AbstractFileSystem {
                     }
                 } while (Kernel32FFM.FindNextVolume(hVol, volumeNameBuf, BUFSIZE).orElse(0) != 0);
                 return fs;
-            } finally {
-                Kernel32FFM.FindVolumeClose(hVol);
             }
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -49,6 +49,7 @@ import oshi.driver.windows.registry.ProcessWtsDataFFM;
 import oshi.driver.windows.registry.ThreadPerformanceDataFFM;
 import oshi.driver.windows.wmi.Win32ProcessCachedFFM;
 import oshi.driver.windows.wmi.Win32ProcessFFM;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.windows.Advapi32FFM;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.ffm.windows.NtDllFFM;
@@ -82,15 +83,13 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
     public long getAffinityMask() {
         Optional<MemorySegment> pHandleOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION, false, getProcessID());
         if (pHandleOpt.isPresent()) {
-            MemorySegment pHandle = pHandleOpt.get();
-            try (Arena arena = Arena.ofConfined()) {
+            try (NativeHandle pHandle = NativeHandle.of(pHandleOpt.get(), Kernel32FFM::CloseHandle);
+                    Arena arena = Arena.ofConfined()) {
                 MemorySegment processAffinity = arena.allocate(JAVA_LONG);
                 MemorySegment systemAffinity = arena.allocate(JAVA_LONG);
-                if (Kernel32FFM.GetProcessAffinityMask(pHandle, processAffinity, systemAffinity)) {
+                if (Kernel32FFM.GetProcessAffinityMask(pHandle.get(), processAffinity, systemAffinity)) {
                     return processAffinity.get(JAVA_LONG, 0);
                 }
-            } finally {
-                Kernel32FFM.CloseHandle(pHandle);
             }
         }
         return 0L;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -49,6 +49,7 @@ import oshi.driver.windows.registry.SessionWtsDataFFM;
 import oshi.driver.windows.registry.ThreadPerformanceDataFFM;
 import oshi.driver.windows.wmi.Win32OperatingSystemFFM;
 import oshi.driver.windows.wmi.Win32ProcessorFFM;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.util.platform.windows.Advapi32UtilFFM;
 import oshi.ffm.util.platform.windows.Kernel32UtilFFM;
 import oshi.ffm.windows.Advapi32FFM;
@@ -85,8 +86,6 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     }
 
     private static boolean enableDebugPrivilege() {
-
-        MemorySegment hToken = null;
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment hTokenPtr = arena.allocate(ADDRESS);
 
@@ -100,30 +99,26 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
                 LOG.error("OpenProcessToken failed, error: {}", GetLastError());
                 return false;
             }
-            hToken = hTokenPtr.get(ADDRESS, 0);
+            try (NativeHandle hToken = NativeHandle.of(hTokenPtr.get(ADDRESS, 0), Kernel32FFM::CloseHandle)) {
+                MemorySegment luid = arena.allocate(WinNTFFM.LUID);
+                success = Advapi32FFM.LookupPrivilegeValue("SeDebugPrivilege", luid, arena);
+                if (!success) {
+                    LOG.error("LookupPrivilegeValue failed, error: {}", GetLastError());
+                    return false;
+                }
 
-            MemorySegment luid = arena.allocate(WinNTFFM.LUID);
-            success = Advapi32FFM.LookupPrivilegeValue("SeDebugPrivilege", luid, arena);
-            if (!success) {
-                LOG.error("LookupPrivilegeValue failed, error: {}", GetLastError());
-                return false;
+                MemorySegment tkp = setupTokenPrivileges(arena, luid);
+                success = Advapi32FFM.AdjustTokenPrivileges(hToken.get(), tkp);
+                if (!success) {
+                    LOG.error("AdjustTokenPrivileges failed, error: {}", GetLastError());
+                    return false;
+                }
+
+                return true;
             }
-
-            MemorySegment tkp = setupTokenPrivileges(arena, luid);
-            success = Advapi32FFM.AdjustTokenPrivileges(hToken, tkp);
-            if (!success) {
-                LOG.error("AdjustTokenPrivileges failed, error: {}", GetLastError());
-                return false;
-            }
-
-            return true;
         } catch (Throwable t) {
             LOG.error("enableDebugPrivilege exception: {}", t.getMessage());
             return false;
-        } finally {
-            if (hToken != null && hToken.address() != 0) {
-                Kernel32FFM.CloseHandle(hToken);
-            }
         }
     }
 
@@ -157,7 +152,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
                 LOG.error("Failed to open Service Control Manager");
                 return Collections.emptyList();
             }
-            try {
+            try (NativeHandle ignored = NativeHandle.of(hSCManager, Advapi32FFM::CloseServiceHandle)) {
                 // First call to get required buffer size
                 MemorySegment pcbBytesNeeded = arena.allocate(JAVA_INT);
                 MemorySegment lpServicesReturned = arena.allocate(JAVA_INT);
@@ -205,8 +200,6 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
                     svcArray.add(new OSService(displayName, processId, state));
                 }
                 return svcArray;
-            } finally {
-                Advapi32FFM.CloseServiceHandle(hSCManager);
             }
         } catch (Throwable t) {
             LOG.error("Error enumerating services: {}", t.getMessage());

--- a/oshi-core-ffm/src/test/java/oshi/ffm/NativeHandleTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/NativeHandleTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+class NativeHandleTest {
+
+    @Test
+    void testCloseInvokesCloser() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        MemorySegment fakeHandle = MemorySegment.ofAddress(0x1234);
+        try (NativeHandle h = NativeHandle.of(fakeHandle, seg -> closed.set(true))) {
+            assertThat(h.get(), is(fakeHandle));
+            assertThat(h.isNull(), is(false));
+        }
+        assertThat(closed.get(), is(true));
+    }
+
+    @Test
+    void testNullHandleSkipsCloser() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        try (NativeHandle h = NativeHandle.of(null, seg -> closed.set(true))) {
+            assertThat(h.isNull(), is(true));
+        }
+        assertThat(closed.get(), is(false));
+    }
+
+    @Test
+    void testZeroAddressSkipsCloser() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        try (NativeHandle h = NativeHandle.of(MemorySegment.NULL, seg -> closed.set(true))) {
+            assertThat(h.isNull(), is(true));
+        }
+        assertThat(closed.get(), is(false));
+    }
+
+    @Test
+    void testCloserExceptionIsSuppressed() {
+        AtomicReference<MemorySegment> closedWith = new AtomicReference<>();
+        MemorySegment fakeHandle = MemorySegment.ofAddress(0x5678);
+        try (NativeHandle h = NativeHandle.of(fakeHandle, seg -> {
+            closedWith.set(seg);
+            throw new RuntimeException("simulated close failure");
+        })) {
+            assertThat(h.isNull(), is(false));
+        }
+        // Should not throw, and closer was still called
+        assertThat(closedWith.get(), is(fakeHandle));
+    }
+
+    @Test
+    void testCloseIsIdempotent() {
+        AtomicInteger closeCount = new AtomicInteger(0);
+        MemorySegment fakeHandle = MemorySegment.ofAddress(0xABCD);
+        NativeHandle h = NativeHandle.of(fakeHandle, seg -> closeCount.incrementAndGet());
+        h.close();
+        h.close();
+        h.close();
+        assertThat(closeCount.get(), is(1));
+    }
+
+    @Test
+    void testNullCloserThrows() {
+        assertThrows(NullPointerException.class, () -> NativeHandle.of(MemorySegment.ofAddress(0x1), null));
+    }
+}


### PR DESCRIPTION
Introduce `NativeHandle`, a lightweight `AutoCloseable` wrapper around native `MemorySegment` handles that ensures proper cleanup via try-with-resources. This eliminates error-prone manual `finally` blocks for native handle lifecycle management.

## NativeHandle

- Wraps a `MemorySegment` with a `ThrowingCloser` callback
- Skips close if handle is null or zero-address
- Logs and suppresses exceptions from the closer
- Fully tested with unit tests

## Reference migrations (Windows)

Simple single-handle cases migrated as examples:
- `WindowsFileSystemFFM.getLocalVolumes()` — `FindVolumeClose`
- `WindowsCentralProcessorFFM` registry methods — `RegCloseKey`
- `WindowsOperatingSystemFFM.enableDebugPrivilege()` — `CloseHandle`
- `WindowsOperatingSystemFFM.queryServicesFFM()` — `CloseServiceHandle`
- `WindowsOSProcessFFM.getAffinityMask()` — `CloseHandle`

## Future PRs

- PR 2: Migrate remaining Windows + nested Linux handle patterns
- PR 3: macOS (`IOObject`/`CFTypeRef` → `AutoCloseable`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Windows native resource handling across platform components for more reliable cleanup and fewer resource leaks; safer automatic handle management reduces spurious errors during teardown.

* **Tests**
  * Added tests validating handle cleanup semantics, idempotent close behavior, and robust suppression of errors during resource release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->