### PR TITLE
Migrate nested handle patterns to NativeHandle (Windows + Linux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ release.properties
 *.releaseBackup
 bin/
 META-INF/
+AGENTS.md

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.linux.proc.AuxvFFM;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.linux.LinuxLibcFunctions;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.common.platform.linux.LinuxCentralProcessor;
@@ -83,9 +84,10 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
                     if (MemorySegment.NULL.equals(udev)) {
                         return readTopologyFromSysfs();
                     }
-                    try {
+                    try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                         MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                        try {
+                        try (NativeHandle enumHandle = NativeHandle.of(enumerate,
+                                UdevFunctions::udev_enumerate_unref)) {
                             UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
                             UdevFunctions.udev_enumerate_scan_devices(enumerate);
                             for (MemorySegment entry = UdevFunctions
@@ -99,20 +101,15 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
                                 MemorySegment device = UdevFunctions.deviceNewFromSyspath(udev, syspath, arena);
                                 String modAlias = null;
                                 if (!MemorySegment.NULL.equals(device)) {
-                                    try {
+                                    try (NativeHandle devHandle = NativeHandle.of(device,
+                                            UdevFunctions::udev_device_unref)) {
                                         modAlias = UdevFunctions.getPropertyValue(device, "MODALIAS", arena);
-                                    } finally {
-                                        UdevFunctions.udev_device_unref(device);
                                     }
                                 }
                                 logProcs.add(getLogicalProcessorFromSyspath(syspath, caches, modAlias,
                                         coreEfficiencyMap, modAliasMap));
                             }
-                        } finally {
-                            UdevFunctions.udev_enumerate_unref(enumerate);
                         }
-                    } finally {
-                        UdevFunctions.udev_unref(udev);
                     }
                     return new Quartet<>(logProcs, orderedProcCaches(caches), coreEfficiencyMap, modAliasMap);
                 }, LOG, WARN, "Error reading CPU topology via udev, falling back to sysfs", null);
@@ -129,9 +126,9 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
             if (MemorySegment.NULL.equals(udev)) {
                 return false;
             }
-            try {
+            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try {
+                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
                     long max = 0L;
@@ -159,11 +156,7 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
                         }
                         return true;
                     }
-                } finally {
-                    UdevFunctions.udev_enumerate_unref(enumerate);
                 }
-            } finally {
-                UdevFunctions.udev_unref(udev);
             }
             return false;
         }, LOG, WARN, "Error reading CPU frequencies via udev", false);
@@ -180,9 +173,9 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
             if (MemorySegment.NULL.equals(udev)) {
                 return -1L;
             }
-            try {
+            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try {
+                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
                     MemorySegment entry = UdevFunctions.udev_enumerate_get_list_entry(enumerate);
@@ -193,11 +186,7 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
                                     syspath.substring(0, syspath.lastIndexOf('/')) + "/cpufreq");
                         }
                     }
-                } finally {
-                    UdevFunctions.udev_enumerate_unref(enumerate);
                 }
-            } finally {
-                UdevFunctions.udev_unref(udev);
             }
             return -1L;
         }, LOG, WARN, "Error reading max CPU frequency via udev", -1L);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
@@ -69,9 +70,9 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
                 }
                 return Collections.emptyList();
             }
-            try {
+            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try {
+                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, BLOCK, arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
                     for (MemorySegment entry = UdevFunctions
@@ -85,7 +86,7 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
                         if (MemorySegment.NULL.equals(device)) {
                             continue;
                         }
-                        try {
+                        try (NativeHandle devHandle = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                             String devnode = UdevFunctions.getString(UdevFunctions.udev_device_get_devnode(device),
                                     arena);
                             if (devnode != null && !devnode.startsWith(DevPath.LOOP)
@@ -172,15 +173,9 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
                                     }
                                 }
                             }
-                        } finally {
-                            UdevFunctions.udev_device_unref(device);
                         }
                     }
-                } finally {
-                    UdevFunctions.udev_enumerate_unref(enumerate);
                 }
-            } finally {
-                UdevFunctions.udev_unref(udev);
             }
         } catch (Throwable e) {
             if (storeToUpdate == null) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupFFM.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import oshi.ffm.NativeHandle;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.LogicalVolumeGroup;
 import oshi.hardware.common.platform.linux.LinuxLogicalVolumeGroup;
@@ -50,9 +51,9 @@ final class LinuxLogicalVolumeGroupFFM extends LinuxLogicalVolumeGroup {
             if (MemorySegment.NULL.equals(udev)) {
                 return Collections.emptyList();
             }
-            try {
+            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try {
+                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, BLOCK, arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
                     for (MemorySegment entry = UdevFunctions
@@ -66,7 +67,7 @@ final class LinuxLogicalVolumeGroupFFM extends LinuxLogicalVolumeGroup {
                         if (MemorySegment.NULL.equals(device)) {
                             continue;
                         }
-                        try {
+                        try (NativeHandle devHandle = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                             String devnode = UdevFunctions.getString(UdevFunctions.udev_device_get_devnode(device),
                                     arena);
                             if (devnode != null && devnode.startsWith(DevPath.DM)) {
@@ -92,15 +93,9 @@ final class LinuxLogicalVolumeGroupFFM extends LinuxLogicalVolumeGroup {
                                     }
                                 }
                             }
-                        } finally {
-                            UdevFunctions.udev_device_unref(device);
                         }
                     }
-                } finally {
-                    UdevFunctions.udev_enumerate_unref(enumerate);
                 }
-            } finally {
-                UdevFunctions.udev_unref(udev);
             }
             return logicalVolumesMap.entrySet().stream()
                     .map(e -> new LinuxLogicalVolumeGroupFFM(e.getKey(), e.getValue(),

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.common.platform.linux.LinuxNetworkIF;
@@ -45,10 +46,10 @@ public final class LinuxNetworkIFFFM extends LinuxNetworkIF {
             if (MemorySegment.NULL.equals(udev)) {
                 return queryIfModelFromSysfs(name);
             }
-            try {
+            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment device = UdevFunctions.deviceNewFromSyspath(udev, SysPath.NET + name, arena);
                 if (!MemorySegment.NULL.equals(device)) {
-                    try {
+                    try (NativeHandle devHandle = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                         String devVendor = UdevFunctions.getPropertyValue(device, "ID_VENDOR_FROM_DATABASE", arena);
                         String devModel = UdevFunctions.getPropertyValue(device, "ID_MODEL_FROM_DATABASE", arena);
                         if (!Util.isBlank(devModel)) {
@@ -57,12 +58,8 @@ public final class LinuxNetworkIFFFM extends LinuxNetworkIF {
                             }
                             return devModel;
                         }
-                    } finally {
-                        UdevFunctions.udev_device_unref(device);
                     }
                 }
-            } finally {
-                UdevFunctions.udev_unref(udev);
             }
             return name;
         }, LOG, WARN, "Error querying network interface model for " + name, name);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceFFM.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.PowerSource;
 import oshi.hardware.common.platform.linux.LinuxPowerSource;
@@ -56,9 +57,9 @@ public final class LinuxPowerSourceFFM extends LinuxPowerSource {
             if (MemorySegment.NULL.equals(udev)) {
                 return null;
             }
-            try {
+            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try {
+                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, "power_supply", arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
                     for (MemorySegment entry = UdevFunctions
@@ -76,7 +77,7 @@ public final class LinuxPowerSourceFFM extends LinuxPowerSource {
                         if (MemorySegment.NULL.equals(device)) {
                             continue;
                         }
-                        try {
+                        try (NativeHandle devHandle = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                             if (ParseUtil.parseIntOrDefault(
                                     UdevFunctions.getPropertyValue(device, Prop.POWER_SUPPLY_PRESENT.name(), arena),
                                     1) > 0) {
@@ -89,15 +90,9 @@ public final class LinuxPowerSourceFFM extends LinuxPowerSource {
                                 }
                                 result.add(new LinuxPowerSourceFFM(buildPowerSource(name, props)));
                             }
-                        } finally {
-                            UdevFunctions.udev_device_unref(device);
                         }
                     }
-                } finally {
-                    UdevFunctions.udev_enumerate_unref(enumerate);
                 }
-            } finally {
-                UdevFunctions.udev_unref(udev);
             }
             return result;
         }, LOG, WARN, "Error enumerating power sources via udev, falling back to sysfs", null);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceFFM.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import oshi.ffm.NativeHandle;
 import oshi.ffm.linux.UdevFunctions;
 import oshi.hardware.UsbDevice;
 import oshi.hardware.common.platform.linux.LinuxUsbDevice;
@@ -78,9 +79,9 @@ public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
             if (MemorySegment.NULL.equals(udev)) {
                 return emptyList();
             }
-            try {
+            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try {
+                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, SUBSYSTEM_USB, arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
 
@@ -96,7 +97,7 @@ public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
                         if (MemorySegment.NULL.equals(device)) {
                             continue;
                         }
-                        try {
+                        try (NativeHandle devHandle = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                             String devtype = UdevFunctions.getString(UdevFunctions.udev_device_get_devtype(device),
                                     arena);
                             if (!DEVTYPE_USB_DEVICE.equals(devtype)) {
@@ -133,15 +134,9 @@ public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
                                     hubMap.computeIfAbsent(parentPath, x -> new ArrayList<>()).add(syspath);
                                 }
                             }
-                        } finally {
-                            UdevFunctions.udev_device_unref(device);
                         }
                     }
-                } finally {
-                    UdevFunctions.udev_enumerate_unref(enumerate);
                 }
-            } finally {
-                UdevFunctions.udev_unref(udev);
             }
 
             List<UsbDevice> controllerDevices = new ArrayList<>();

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsBluetoothDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsBluetoothDeviceFFM.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.Immutable;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.windows.BluetoothApisFFM;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.ffm.windows.VersionHelpersFFM;
@@ -68,19 +69,16 @@ public final class WindowsBluetoothDeviceFFM extends AbstractBluetoothDevice {
                 return Collections.emptyList();
             }
 
-            try {
+            try (NativeHandle findRadioHandle = NativeHandle.of(hFindRadio,
+                    BluetoothApisFFM::BluetoothFindRadioClose)) {
                 do {
                     MemorySegment hRadio = phRadio.get(ADDRESS, 0);
-                    try {
+                    try (NativeHandle radioHandle = NativeHandle.of(hRadio, Kernel32FFM::CloseHandle)) {
                         String adapterName = getRadioName(arena, hRadio);
                         queryDevicesForRadio(arena, hRadio, adapterName, devices);
-                    } finally {
-                        Kernel32FFM.CloseHandle(hRadio);
                     }
                 } while (WindowsForeignFunctions
                         .isSuccess(BluetoothApisFFM.BluetoothFindNextRadio(hFindRadio, phRadio)));
-            } finally {
-                BluetoothApisFFM.BluetoothFindRadioClose(hFindRadio);
             }
         } catch (Throwable t) {
             LOG.warn("Error enumerating Bluetooth devices: {}", t.getMessage());
@@ -120,14 +118,12 @@ public final class WindowsBluetoothDeviceFFM extends AbstractBluetoothDevice {
             return;
         }
 
-        try {
+        try (NativeHandle findDevHandle = NativeHandle.of(hFind, BluetoothApisFFM::BluetoothFindDeviceClose)) {
             do {
                 devices.add(parseDeviceInfo(deviceInfo, adapterName));
                 deviceInfo = arena.allocate(BLUETOOTH_DEVICE_INFO_LAYOUT);
                 deviceInfo.set(JAVA_INT, 0, (int) BLUETOOTH_DEVICE_INFO_LAYOUT.byteSize());
             } while (WindowsForeignFunctions.isSuccess(BluetoothApisFFM.BluetoothFindNextDevice(hFind, deviceInfo)));
-        } finally {
-            BluetoothApisFFM.BluetoothFindDeviceClose(hFind);
         }
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.Immutable;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.windows.Advapi32FFM;
 import oshi.ffm.windows.SetupApiFFM;
 import oshi.hardware.Display;
@@ -56,7 +57,7 @@ final class WindowsDisplayFFM extends AbstractDisplay {
                 return displays;
             }
             MemorySegment hDevInfo = hDevInfoOpt.get();
-            try {
+            try (NativeHandle devInfoHandle = NativeHandle.of(hDevInfo, SetupApiFFM::SetupDiDestroyDeviceInfoList)) {
                 MemorySegment devInfoData = arena.allocate(SetupApiFFM.SP_DEVINFO_DATA_SIZE);
                 MemorySegment edidName = arena.allocateFrom("EDID", java.nio.charset.StandardCharsets.UTF_16LE);
 
@@ -72,42 +73,39 @@ final class WindowsDisplayFFM extends AbstractDisplay {
                     if (key == null) {
                         continue;
                     }
-                    try {
-                        // First call to get size
-                        MemorySegment pType = arena.allocate(JAVA_INT);
-                        MemorySegment lpcbData = arena.allocate(JAVA_INT);
-                        MemorySegment dummyBuf = arena.allocate(1);
-                        lpcbData.set(JAVA_INT, 0, 1);
-
-                        int rc = Advapi32FFM.RegQueryValueEx(key, edidName, 0, pType, dummyBuf, lpcbData);
-                        if (rc != ERROR_MORE_DATA) {
-                            LOG.debug("Sizing call for EDID data for monitor {}: rc={}", i, rc);
-                        } else {
-                            int size = lpcbData.get(JAVA_INT, 0);
-                            MemorySegment edidBuf = arena.allocate(size);
-                            lpcbData.set(JAVA_INT, 0, size);
-                            rc = Advapi32FFM.RegQueryValueEx(key, edidName, 0, pType, edidBuf, lpcbData);
-                            if (rc == ERROR_SUCCESS) {
-                                byte[] edid = edidBuf.asSlice(0, size).toArray(JAVA_BYTE);
-                                displays.add(new WindowsDisplayFFM(edid));
-                            } else {
-                                LOG.debug("Failed to read EDID data for monitor {}: rc={}", i, rc);
-                            }
-                        }
-                    } catch (Throwable t) {
-                        LOG.debug("Failed to read EDID from registry", t);
-                    } finally {
-                        try {
-                            Advapi32FFM.RegCloseKey(key);
-                        } catch (Throwable t) {
-                            LOG.debug("RegCloseKey failed", t);
+                    try (NativeHandle regKey = NativeHandle.of(key, Advapi32FFM::RegCloseKey)) {
+                        byte[] edid = queryEdidFromKey(key, edidName, arena);
+                        if (edid != null) {
+                            displays.add(new WindowsDisplayFFM(edid));
                         }
                     }
                 }
-            } finally {
-                SetupApiFFM.SetupDiDestroyDeviceInfoList(hDevInfo);
             }
         }
         return displays;
+    }
+
+    private static byte[] queryEdidFromKey(MemorySegment key, MemorySegment edidName, Arena arena) {
+        try {
+            MemorySegment pType = arena.allocate(JAVA_INT);
+            MemorySegment lpcbData = arena.allocate(JAVA_INT);
+            MemorySegment dummyBuf = arena.allocate(1);
+            lpcbData.set(JAVA_INT, 0, 1);
+
+            int rc = Advapi32FFM.RegQueryValueEx(key, edidName, 0, pType, dummyBuf, lpcbData);
+            if (rc != ERROR_MORE_DATA) {
+                return null;
+            }
+            int size = lpcbData.get(JAVA_INT, 0);
+            MemorySegment edidBuf = arena.allocate(size);
+            lpcbData.set(JAVA_INT, 0, size);
+            rc = Advapi32FFM.RegQueryValueEx(key, edidName, 0, pType, edidBuf, lpcbData);
+            if (rc == ERROR_SUCCESS) {
+                return edidBuf.asSlice(0, size).toArray(JAVA_BYTE);
+            }
+        } catch (Throwable t) {
+            LOG.debug("Failed to read EDID from registry: {}", t.getMessage());
+        }
+        return null;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
@@ -50,6 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.NativeHandle;
 import oshi.ffm.windows.Kernel32FFM;
 import oshi.ffm.windows.SetupApiFFM;
 import oshi.ffm.windows.WindowsForeignFunctions;
@@ -130,7 +131,7 @@ public final class WindowsPowerSourceFFM extends WindowsPowerSource {
                 LOG.warn("SetupDiGetClassDevs failed for battery class");
             } else {
                 MemorySegment hdev = hdevOpt.get();
-                try {
+                try (NativeHandle devInfoHandle = NativeHandle.of(hdev, SetupApiFFM::SetupDiDestroyDeviceInfoList)) {
                     boolean batteryFound = false;
                     for (int idev = 0; !batteryFound && idev < 100; idev++) {
                         MemorySegment did = arena.allocate(SP_DEVICE_INTERFACE_DATA);
@@ -163,7 +164,7 @@ public final class WindowsPowerSourceFFM extends WindowsPowerSource {
                             continue;
                         }
                         MemorySegment hBattery = hBatteryOpt.get();
-                        try {
+                        try (NativeHandle batteryHandle = NativeHandle.of(hBattery, Kernel32FFM::CloseHandle)) {
                             // Ask the battery for its tag
                             MemorySegment dwWait = arena.allocate(JAVA_INT);
                             MemorySegment dwTag = arena.allocate(JAVA_INT);
@@ -289,12 +290,8 @@ public final class WindowsPowerSourceFFM extends WindowsPowerSource {
                             }
 
                             batteryFound = true;
-                        } finally {
-                            Kernel32FFM.CloseHandle(hBattery);
                         }
                     }
-                } finally {
-                    SetupApiFFM.SetupDiDestroyDeviceInfoList(hdev);
                 }
             }
         }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -124,24 +124,22 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
 
         Optional<MemorySegment> pHandleOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION, false, getProcessID());
         if (pHandleOpt.isPresent()) {
-            MemorySegment pHandle = pHandleOpt.get();
-            try (Arena arena = Arena.ofConfined()) {
+            try (NativeHandle pHandle = NativeHandle.of(pHandleOpt.get(), Kernel32FFM::CloseHandle);
+                    Arena arena = Arena.ofConfined()) {
                 // Test for 32-bit process on 64-bit windows
                 if (IS_VISTA_OR_GREATER && getBitness() == 64) {
                     MemorySegment wow64 = arena.allocate(JAVA_INT);
-                    if (Kernel32FFM.IsWow64Process(pHandle, wow64) && wow64.get(JAVA_INT, 0) > 0) {
+                    if (Kernel32FFM.IsWow64Process(pHandle.get(), wow64) && wow64.get(JAVA_INT, 0) > 0) {
                         setBitness(32);
                     }
                 }
                 // EXECUTABLEPATH
                 if (IS_WINDOWS7_OR_GREATER) {
-                    Optional<String> pathOpt = Kernel32FFM.QueryFullProcessImageName(pHandle, 0, arena);
+                    Optional<String> pathOpt = Kernel32FFM.QueryFullProcessImageName(pHandle.get(), 0, arena);
                     if (pathOpt.isPresent()) {
                         setPath(pathOpt.get());
                     }
                 }
-            } finally {
-                Kernel32FFM.CloseHandle(pHandle);
             }
         }
 
@@ -192,13 +190,13 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
         Pair<String, String> pair = null;
         Optional<MemorySegment> pHandleOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION, false, getProcessID());
         if (pHandleOpt.isPresent()) {
-            MemorySegment pHandle = pHandleOpt.get();
-            MemorySegment hToken = null;
-            try (Arena arena = Arena.ofConfined()) {
+            try (NativeHandle pHandle = NativeHandle.of(pHandleOpt.get(), Kernel32FFM::CloseHandle);
+                    Arena arena = Arena.ofConfined()) {
                 MemorySegment hTokenPtr = arena.allocate(ADDRESS);
-                if (Advapi32FFM.OpenProcessToken(pHandle, TOKEN_QUERY, hTokenPtr)) {
-                    hToken = hTokenPtr.get(ADDRESS, 0);
-                    pair = getTokenAccountInfo(hToken, TokenUser, arena);
+                if (Advapi32FFM.OpenProcessToken(pHandle.get(), TOKEN_QUERY, hTokenPtr)) {
+                    try (NativeHandle hToken = NativeHandle.of(hTokenPtr.get(ADDRESS, 0), Kernel32FFM::CloseHandle)) {
+                        pair = getTokenAccountInfo(hToken.get(), TokenUser, arena);
+                    }
                 } else {
                     int error = Kernel32FFM.GetLastError().orElse(0);
                     if (error != WinErrorFFM.ERROR_ACCESS_DENIED) {
@@ -208,11 +206,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
             } catch (Throwable e) {
                 LOG.warn("Failed to query user info for process {} ({}): {}", getProcessID(), getName(),
                         e.getMessage());
-            } finally {
-                if (hToken != null && hToken.address() != 0) {
-                    Kernel32FFM.CloseHandle(hToken);
-                }
-                Kernel32FFM.CloseHandle(pHandle);
             }
         }
         return pair != null ? pair : defaultPair();
@@ -223,13 +216,13 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
         Pair<String, String> pair = null;
         Optional<MemorySegment> pHandleOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION, false, getProcessID());
         if (pHandleOpt.isPresent()) {
-            MemorySegment pHandle = pHandleOpt.get();
-            MemorySegment hToken = null;
-            try (Arena arena = Arena.ofConfined()) {
+            try (NativeHandle pHandle = NativeHandle.of(pHandleOpt.get(), Kernel32FFM::CloseHandle);
+                    Arena arena = Arena.ofConfined()) {
                 MemorySegment hTokenPtr = arena.allocate(ADDRESS);
-                if (Advapi32FFM.OpenProcessToken(pHandle, TOKEN_QUERY, hTokenPtr)) {
-                    hToken = hTokenPtr.get(ADDRESS, 0);
-                    pair = getTokenAccountInfo(hToken, TokenPrimaryGroup, arena);
+                if (Advapi32FFM.OpenProcessToken(pHandle.get(), TOKEN_QUERY, hTokenPtr)) {
+                    try (NativeHandle hToken = NativeHandle.of(hTokenPtr.get(ADDRESS, 0), Kernel32FFM::CloseHandle)) {
+                        pair = getTokenAccountInfo(hToken.get(), TokenPrimaryGroup, arena);
+                    }
                 } else {
                     int error = Kernel32FFM.GetLastError().orElse(0);
                     if (error != WinErrorFFM.ERROR_ACCESS_DENIED) {
@@ -239,11 +232,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
             } catch (Throwable e) {
                 LOG.warn("Failed to query group info for process {} ({}): {}", getProcessID(), getName(),
                         e.getMessage());
-            } finally {
-                if (hToken != null && hToken.address() != 0) {
-                    Kernel32FFM.CloseHandle(hToken);
-                }
-                Kernel32FFM.CloseHandle(pHandle);
             }
         }
         return pair != null ? pair : defaultPair();
@@ -304,13 +292,13 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
         Optional<MemorySegment> hOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false,
                 getProcessID());
         if (hOpt.isPresent()) {
-            MemorySegment h = hOpt.get();
-            try (Arena arena = Arena.ofConfined()) {
-                if (WindowsOperatingSystemFFM.isX86() == isWow(h, arena)) {
+            try (NativeHandle h = NativeHandle.of(hOpt.get(), Kernel32FFM::CloseHandle);
+                    Arena arena = Arena.ofConfined()) {
+                if (WindowsOperatingSystemFFM.isX86() == isWow(h.get(), arena)) {
                     MemorySegment pbi = arena.allocate(PROCESS_BASIC_INFORMATION_STRUCT);
                     MemorySegment nRead = arena.allocate(JAVA_INT);
 
-                    int ret = NtDllFFM.NtQueryInformationProcess(h, PROCESS_BASIC_INFORMATION, pbi,
+                    int ret = NtDllFFM.NtQueryInformationProcess(h.get(), PROCESS_BASIC_INFORMATION, pbi,
                             (int) PROCESS_BASIC_INFORMATION_STRUCT.byteSize(), nRead);
                     if (ret != 0) {
                         return defaultCwdCommandlineEnvironment();
@@ -323,7 +311,7 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
 
                     MemorySegment peb = arena.allocate(PEB);
                     MemorySegment bytesRead = arena.allocate(JAVA_LONG);
-                    if (!Kernel32FFM.ReadProcessMemory(h, pebAddress, peb, PEB.byteSize(), bytesRead)) {
+                    if (!Kernel32FFM.ReadProcessMemory(h.get(), pebAddress, peb, PEB.byteSize(), bytesRead)) {
                         return defaultCwdCommandlineEnvironment();
                     }
                     if (bytesRead.get(JAVA_LONG, 0) == 0) {
@@ -336,7 +324,7 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                     }
 
                     MemorySegment upp = arena.allocate(RTL_USER_PROCESS_PARAMETERS);
-                    if (!Kernel32FFM.ReadProcessMemory(h, processParamsAddress, upp,
+                    if (!Kernel32FFM.ReadProcessMemory(h.get(), processParamsAddress, upp,
                             RTL_USER_PROCESS_PARAMETERS.byteSize(), bytesRead)) {
                         return defaultCwdCommandlineEnvironment();
                     }
@@ -346,18 +334,18 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
 
                     MemorySegment cwdUnicodeString = upp.asSlice(UPP_CURRENT_DIRECTORY_OFFSET,
                             UNICODE_STRING.byteSize());
-                    String cwd = readUnicodeString(h, cwdUnicodeString, arena);
+                    String cwd = readUnicodeString(h.get(), cwdUnicodeString, arena);
 
                     MemorySegment cmdLineUnicodeString = upp.asSlice(UPP_COMMAND_LINE_OFFSET,
                             UNICODE_STRING.byteSize());
-                    String cl = readUnicodeString(h, cmdLineUnicodeString, arena);
+                    String cl = readUnicodeString(h.get(), cmdLineUnicodeString, arena);
 
                     long envSize = upp.get(JAVA_LONG, UPP_ENVIRONMENT_SIZE_OFFSET);
                     if (envSize > 0 && envSize < Integer.MAX_VALUE) {
                         MemorySegment envAddress = upp.get(ADDRESS, UPP_ENVIRONMENT_OFFSET);
                         if (envAddress.address() != 0) {
                             MemorySegment envBuffer = arena.allocate((int) envSize);
-                            if (Kernel32FFM.ReadProcessMemory(h, envAddress, envBuffer, envSize, bytesRead)) {
+                            if (Kernel32FFM.ReadProcessMemory(h.get(), envAddress, envBuffer, envSize, bytesRead)) {
                                 if (bytesRead.get(JAVA_LONG, 0) > 0) {
                                     char[] env = new char[(int) (envSize / 2)];
                                     for (int i = 0; i < env.length; i++) {
@@ -372,8 +360,6 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                     }
                     return new Triplet<>(cwd, cl, Collections.emptyMap());
                 }
-            } finally {
-                Kernel32FFM.CloseHandle(h);
             }
         }
         return defaultCwdCommandlineEnvironment();


### PR DESCRIPTION
Replace manual `try/finally` blocks with `NativeHandle` try-with-resources for nested native handle lifecycle management. This is PR 2 of 3 in the NativeHandle migration series (#3290 introduced the class).

## Linux (udev handles)
- `LinuxCentralProcessorFFM` (3 methods: topology, current freq, max freq)
- `LinuxHWDiskStoreFFM`
- `LinuxLogicalVolumeGroupFFM`
- `LinuxNetworkIFFFM`
- `LinuxPowerSourceFFM`
- `LinuxUsbDeviceFFM`

## Windows
- `WindowsBluetoothDeviceFFM` (radio find + device find handles)
- `WindowsDisplayFFM` (SetupDi + registry key handles; extracted `queryEdidFromKey` helper)
- `WindowsPowerSourceFFM` (SetupDi + battery handles)
- `WindowsOSProcessFFM` (process + token handles)

## Summary
- 11 files changed, net -56 lines
- All nested `finally` blocks replaced with `NativeHandle` try-with-resources
- PR 3 will cover macOS (`IOObject`/`CFTypeRef` → `AutoCloseable`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved native resource management across platform-specific hardware and OS modules for better reliability and cleaner code handling.

* **Chores**
  * Updated project ignore patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->