### PR TITLE
Make IOObject and CFTypeRef AutoCloseable, migrate macOS call sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ release.properties
 bin/
 META-INF/
 AGENTS.md
+.kiro/

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
@@ -259,7 +259,7 @@ public final class IOReportClientFFM {
 
     private long extractGpuEnergyMicrojoules(MemorySegment delta) throws Throwable {
         CFStringRef channelsKey = CFStringRef.createCFString(KEY_CHANNELS);
-        try {
+        try (channelsKey) {
             MemorySegment arrSeg = new CFDictionaryRef(delta).getValue(channelsKey);
             if (arrSeg.equals(MemorySegment.NULL)) {
                 return -1L;
@@ -283,15 +283,13 @@ public final class IOReportClientFFM {
                 }
                 return IOReportFunctions.IOReportSimpleGetIntegerValue(entrySeg, 0);
             }
-        } finally {
-            channelsKey.release();
         }
         return -1L;
     }
 
     private Map<String, Long> extractChannelStates(MemorySegment dict, String group, String subgroup) throws Throwable {
         CFStringRef channelsKey = CFStringRef.createCFString(KEY_CHANNELS);
-        try {
+        try (channelsKey) {
             MemorySegment arrSeg = new CFDictionaryRef(dict).getValue(channelsKey);
             if (arrSeg.equals(MemorySegment.NULL)) {
                 return Collections.emptyMap();
@@ -328,8 +326,6 @@ public final class IOReportClientFFM {
                 }
             }
             return result;
-        } finally {
-            channelsKey.release();
         }
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/WindowInfoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/WindowInfoFFM.java
@@ -64,7 +64,7 @@ public final class WindowInfoFFM {
                 return windowList;
             }
             CFArrayRef windowInfo = new CFArrayRef(rawArray);
-            try {
+            try (windowInfo) {
                 int numWindows = windowInfo.getCount();
 
                 CFStringRef kCGWindowIsOnscreen = CFStringRef.createCFString("kCGWindowIsOnscreen");
@@ -74,7 +74,13 @@ public final class WindowInfoFFM {
                 CFStringRef kCGWindowBounds = CFStringRef.createCFString("kCGWindowBounds");
                 CFStringRef kCGWindowName = CFStringRef.createCFString("kCGWindowName");
                 CFStringRef kCGWindowOwnerName = CFStringRef.createCFString("kCGWindowOwnerName");
-                try {
+                try (kCGWindowIsOnscreen;
+                        kCGWindowNumber;
+                        kCGWindowOwnerPID;
+                        kCGWindowLayer;
+                        kCGWindowBounds;
+                        kCGWindowName;
+                        kCGWindowOwnerName) {
                     for (int i = 0; i < numWindows; i++) {
                         MemorySegment dictSeg = windowInfo.getValueAtIndex(i);
                         if (dictSeg.equals(MemorySegment.NULL)) {
@@ -121,17 +127,7 @@ public final class WindowInfoFFM {
                         windowList.add(new OSDesktopWindow(windowNumber, windowName, ownerName, windowBounds, ownerPID,
                                 windowLayer, visible));
                     }
-                } finally {
-                    kCGWindowIsOnscreen.release();
-                    kCGWindowNumber.release();
-                    kCGWindowOwnerPID.release();
-                    kCGWindowLayer.release();
-                    kCGWindowBounds.release();
-                    kCGWindowName.release();
-                    kCGWindowOwnerName.release();
                 }
-            } finally {
-                windowInfo.release();
             }
         } catch (Throwable e) {
             return windowList;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/mac/CoreFoundation.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/mac/CoreFoundation.java
@@ -88,7 +88,7 @@ public interface CoreFoundation {
     /**
      * Base class for all CoreFoundation objects
      */
-    class CFTypeRef {
+    class CFTypeRef implements AutoCloseable {
         private final MemorySegment segment;
 
         public CFTypeRef(MemorySegment segment) {
@@ -141,6 +141,11 @@ public interface CoreFoundation {
             if (!isNull()) {
                 runSilently(() -> CFRelease(segment()));
             }
+        }
+
+        @Override
+        public void close() {
+            release();
         }
 
         @Override

--- a/oshi-core-ffm/src/main/java/oshi/ffm/mac/IOKit.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/mac/IOKit.java
@@ -53,7 +53,7 @@ public interface IOKit {
     double kIOPSTimeRemainingUnlimited = -2.0;
     double kIOPSTimeRemainingUnknown = -1.0;
 
-    class IOObject {
+    class IOObject implements AutoCloseable {
         private final MemorySegment segment;
 
         public IOObject(MemorySegment segment) {
@@ -73,6 +73,11 @@ public interface IOKit {
                 return 0;
             }
             return getIntOrDefault(() -> IOObjectRelease(segment), -1);
+        }
+
+        @Override
+        public void close() {
+            release();
         }
 
         public boolean conformsTo(String className) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/IOKitProviderFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/IOKitProviderFFM.java
@@ -26,10 +26,8 @@ final class IOKitProviderFFM implements IOKitProvider {
     public <T> T withMatchingService(String serviceName, Function<RegistryEntry, T> extractor) {
         IORegistryEntry entry = IOKitUtilFFM.getMatchingService(serviceName);
         if (entry != null) {
-            try {
+            try (entry) {
                 return extractor.apply(new FfmRegistryEntry(entry));
-            } finally {
-                entry.release();
             }
         }
         return null;
@@ -47,20 +45,16 @@ final class IOKitProviderFFM implements IOKitProvider {
     public void forEachMatchingServiceUntil(String serviceName, Function<RegistryEntry, Boolean> visitor) {
         IOIterator iter = IOKitUtilFFM.getMatchingServices(serviceName);
         if (iter != null) {
-            try {
+            try (iter) {
                 IORegistryEntry entry = iter.next();
                 while (entry != null) {
-                    try {
-                        if (Boolean.TRUE.equals(visitor.apply(new FfmRegistryEntry(entry)))) {
+                    try (IORegistryEntry current = entry) {
+                        if (Boolean.TRUE.equals(visitor.apply(new FfmRegistryEntry(current)))) {
                             return;
                         }
-                    } finally {
-                        entry.release();
                     }
                     entry = iter.next();
                 }
-            } finally {
-                iter.release();
             }
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
@@ -58,13 +58,11 @@ final class MacDisplayFFM extends AbstractDisplay {
                             MemorySegment edidRaw = propertySource.createCFProperty(cfEdid.segment());
                             if (edidRaw != null && !edidRaw.equals(MemorySegment.NULL)) {
                                 CFDataRef edid = new CFDataRef(edidRaw);
-                                try {
+                                try (edid) {
                                     byte[] bytes = edid.getBytes();
                                     if (bytes.length > 0) {
                                         displays.add(new MacDisplayFFM(bytes));
                                     }
-                                } finally {
-                                    edid.release();
                                 }
                             }
                         } finally {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacFirmwareFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacFirmwareFFM.java
@@ -31,56 +31,52 @@ final class MacFirmwareFFM extends MacFirmware {
 
         IORegistryEntry platformExpert = IOKitUtilFFM.getMatchingService("IOPlatformExpertDevice");
         if (platformExpert != null) {
-            try {
+            try (platformExpert) {
                 IOIterator iter = platformExpert.getChildIterator("IODeviceTree");
                 if (iter != null) {
-                    try {
+                    try (iter) {
                         IORegistryEntry entry = iter.next();
                         while (entry != null) {
-                            try {
-                                String entryName = entry.getName();
+                            try (IORegistryEntry current = entry) {
+                                String entryName = current.getName();
                                 if (entryName != null) {
                                     switch (entryName) {
                                         case "rom":
-                                            byte[] data = entry.getByteArrayProperty("vendor");
+                                            byte[] data = current.getByteArrayProperty("vendor");
                                             if (data != null) {
                                                 manufacturer = toUtf8(data);
                                             }
-                                            data = entry.getByteArrayProperty("version");
+                                            data = current.getByteArrayProperty("version");
                                             if (data != null) {
                                                 version = toUtf8(data);
                                             }
-                                            data = entry.getByteArrayProperty("release-date");
+                                            data = current.getByteArrayProperty("release-date");
                                             if (data != null) {
                                                 releaseDate = toUtf8(data);
                                             }
                                             break;
                                         case "chosen":
-                                            data = entry.getByteArrayProperty("booter-name");
+                                            data = current.getByteArrayProperty("booter-name");
                                             if (data != null) {
                                                 name = toUtf8(data);
                                             }
                                             break;
                                         case "efi":
-                                            data = entry.getByteArrayProperty("firmware-abi");
+                                            data = current.getByteArrayProperty("firmware-abi");
                                             if (data != null) {
                                                 description = toUtf8(data);
                                             }
                                             break;
                                         default:
                                             if (Util.isBlank(name)) {
-                                                name = entry.getStringProperty("IONameMatch");
+                                                name = current.getStringProperty("IONameMatch");
                                             }
                                             break;
                                     }
                                 }
-                            } finally {
-                                entry.release();
                             }
                             entry = iter.next();
                         }
-                    } finally {
-                        iter.release();
                     }
                 }
                 if (Util.isBlank(manufacturer)) {
@@ -101,8 +97,6 @@ final class MacFirmwareFFM extends MacFirmware {
                         name = toUtf8(data);
                     }
                 }
-            } finally {
-                platformExpert.release();
             }
         }
         return new Quintet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -103,27 +103,21 @@ final class MacGpuStatsFFM implements GpuStats {
         if (perfStats == null) {
             return -1d;
         }
-        try {
+        try (perfStats) {
             CFStringRef coreUtilKey = CFStringRef.createCFString(GPU_CORE_UTIL_KEY);
-            try {
+            try (coreUtilKey) {
                 MemorySegment result = perfStats.getValue(coreUtilKey);
                 if (!result.equals(MemorySegment.NULL)) {
                     return new CFNumberRef(result).longValue() / GPU_UTIL_DIVISOR * 100.0;
                 }
-            } finally {
-                coreUtilKey.release();
             }
             CFStringRef devUtilKey = CFStringRef.createCFString(DEVICE_UTIL_KEY);
-            try {
+            try (devUtilKey) {
                 MemorySegment result = perfStats.getValue(devUtilKey);
                 if (!result.equals(MemorySegment.NULL)) {
                     return new CFNumberRef(result).longValue();
                 }
-            } finally {
-                devUtilKey.release();
             }
-        } finally {
-            perfStats.release();
         }
         return -1d;
     }
@@ -135,29 +129,23 @@ final class MacGpuStatsFFM implements GpuStats {
         if (perfStats == null) {
             return -1L;
         }
-        try {
+        try (perfStats) {
             String primaryKey = isAppleSilicon ? VRAM_USED_KEY_AS : VRAM_USED_KEY;
             String fallbackKey = isAppleSilicon ? VRAM_USED_KEY : VRAM_USED_KEY_AS;
             CFStringRef key = CFStringRef.createCFString(primaryKey);
-            try {
+            try (key) {
                 MemorySegment result = perfStats.getValue(key);
                 if (!result.equals(MemorySegment.NULL)) {
                     return new CFNumberRef(result).longValue();
                 }
-            } finally {
-                key.release();
             }
             CFStringRef fallback = CFStringRef.createCFString(fallbackKey);
-            try {
+            try (fallback) {
                 MemorySegment result = perfStats.getValue(fallback);
                 if (!result.equals(MemorySegment.NULL)) {
                     return new CFNumberRef(result).longValue();
                 }
-            } finally {
-                fallback.release();
             }
-        } finally {
-            perfStats.release();
         }
         return -1L;
     }
@@ -188,9 +176,9 @@ final class MacGpuStatsFFM implements GpuStats {
         if (perfStats == null) {
             return -1d;
         }
-        try {
+        try (perfStats) {
             CFStringRef tempKey = CFStringRef.createCFString("Temperature(C)");
-            try {
+            try (tempKey) {
                 MemorySegment result = perfStats.getValue(tempKey);
                 if (!result.equals(MemorySegment.NULL)) {
                     long val = new CFNumberRef(result).longValue();
@@ -198,11 +186,7 @@ final class MacGpuStatsFFM implements GpuStats {
                         return val;
                     }
                 }
-            } finally {
-                tempKey.release();
             }
-        } finally {
-            perfStats.release();
         }
         return -1d;
     }
@@ -248,15 +232,15 @@ final class MacGpuStatsFFM implements GpuStats {
         }
         CFStringRef perfStatsKey = CFStringRef.createCFString(PERF_STATS_KEY);
         CFStringRef modelKey = CFStringRef.createCFString("model");
-        try {
+        try (iter; perfStatsKey; modelKey) {
             IORegistryEntry service = iter.next();
             while (service != null) {
                 CFMutableDictionaryRef result = null;
-                try {
-                    MemorySegment propsSeg = service.createCFProperties();
+                try (IORegistryEntry current = service) {
+                    MemorySegment propsSeg = current.createCFProperties();
                     if (!propsSeg.equals(MemorySegment.NULL)) {
                         CFDictionaryRef props = new CFDictionaryRef(propsSeg);
-                        try {
+                        try (props) {
                             MemorySegment modelSeg = props.getValue(modelKey);
                             if (!modelSeg.equals(MemorySegment.NULL)) {
                                 String model = new CFStringRef(modelSeg).stringValue();
@@ -272,22 +256,14 @@ final class MacGpuStatsFFM implements GpuStats {
                                     }
                                 }
                             }
-                        } finally {
-                            props.release();
                         }
                     }
-                } finally {
-                    service.release();
                 }
                 if (result != null) {
                     return result;
                 }
                 service = iter.next();
             }
-        } finally {
-            iter.release();
-            perfStatsKey.release();
-            modelKey.release();
         }
         return null;
     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
@@ -46,7 +46,7 @@ public final class MacNetworkIfFFM extends MacNetworkIF {
                 return name;
             }
             CFArrayRef cfArray = new CFArrayRef(ifArray);
-            try {
+            try (cfArray) {
                 int count = cfArray.getCount();
                 for (int i = 0; i < count; i++) {
                     MemorySegment pNetIf = cfArray.getValueAtIndex(i);
@@ -61,8 +61,6 @@ public final class MacNetworkIfFFM extends MacNetworkIF {
                         }
                     }
                 }
-            } finally {
-                cfArray.release();
             }
         } catch (Throwable e) {
             LOG.debug("Failed to query SC network interface display name for {}", name);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
@@ -145,7 +145,7 @@ public final class MacUsbDeviceFFM extends MacUsbDevice {
 
         IOIterator childIter = device.getChildIterator(IOUSB);
         if (childIter != null) {
-            try {
+            try (childIter) {
                 IORegistryEntry childDevice = childIter.next();
                 while (childDevice != null) {
                     addDeviceAndChildrenToMaps(childDevice, id, nameMap, vendorMap, vendorIdMap, productIdMap,
@@ -153,8 +153,6 @@ public final class MacUsbDeviceFFM extends MacUsbDevice {
                     childDevice.release();
                     childDevice = childIter.next();
                 }
-            } finally {
-                childIter.release();
             }
         }
     }
@@ -176,7 +174,7 @@ public final class MacUsbDeviceFFM extends MacUsbDevice {
 
             boolean found = false;
             if (serviceIterator != null) {
-                try {
+                try (serviceIterator) {
                     IORegistryEntry matchingService = serviceIterator.next();
                     while (matchingService != null && !found) {
                         IORegistryEntry parent = matchingService.getParentEntry(IOSERVICE);
@@ -196,8 +194,6 @@ public final class MacUsbDeviceFFM extends MacUsbDevice {
                         matchingService.release();
                         matchingService = serviceIterator.next();
                     }
-                } finally {
-                    serviceIterator.release();
                 }
             }
         }, LOG, "Failed to retrieve controller vendor/product IDs for id {}");

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
@@ -115,18 +115,16 @@ public class MacOSProcessFFM extends AbstractOSProcess {
         if (iter != null) {
             IORegistryEntry cpu = iter.next();
             while (cpu != null) {
-                try {
-                    String s = cpu.getName().toLowerCase(Locale.ROOT);
+                try (IORegistryEntry current = cpu) {
+                    String s = current.getName().toLowerCase(Locale.ROOT);
                     if (s.startsWith("cpu") && s.length() > 3) {
                         // Frequency is typically only on lowest-numbered P-core
-                        byte[] data = cpu.getByteArrayProperty("timebase-frequency");
+                        byte[] data = current.getByteArrayProperty("timebase-frequency");
                         if (data != null) {
                             ticksPerSec = ParseUtil.byteArrayToLong(data, 4, false);
                             break;
                         }
                     }
-                } finally {
-                    cpu.release();
                 }
                 cpu = iter.next();
             }


### PR DESCRIPTION
Make `IOObject` and `CFTypeRef` implement `AutoCloseable` (delegating to their existing `release()` methods), enabling try-with-resources for IOKit and CoreFoundation object lifecycle management. This is PR 3 in the NativeHandle/AutoCloseable series (#3290, #3291).

## Infrastructure
- `IOKit.IOObject` now implements `AutoCloseable` with `close()` → `release()`
- `CoreFoundation.CFTypeRef` now implements `AutoCloseable` with `close()` → `release()`

## Migrated call sites (11 files)
- `IOKitProviderFFM`, `MacDisplayFFM`, `MacFirmwareFFM`, `MacGpuStatsFFM`
- `MacNetworkIfFFM`, `MacUsbDeviceFFM`, `MacOSProcessFFM`
- `IOReportClientFFM`, `WindowInfoFFM`

## Remaining for follow-up
Complex patterns not addressed in this PR:
- `MacHWDiskStoreFFM` — deeply nested with conditional releases and reassigned variables
- `MacSensorsFFM` — `smcClose(int)` not AutoCloseable
- `MacPowerSourceFFM`, `MacFileSystemFFM` — multi-release with null checks
- `IOKit.java` — `releaseCFObjects()` multi-release helper
- `IOReportClientFFM` — raw `cfRelease` with null checks
- `MacNetworkParamsFFM` — `freeaddrinfo` (not a release pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved resource and lifecycle handling across macOS platform modules, enhancing stability and reliability by switching to deterministic automatic cleanup for system resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->