### PR TITLE
Migrate remaining macOS AutoCloseable call sites

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import oshi.ffm.mac.CoreFoundation.CFArrayRef;
 import oshi.ffm.mac.CoreFoundation.CFDictionaryRef;
 import oshi.ffm.mac.CoreFoundation.CFStringRef;
+import oshi.ffm.mac.CoreFoundation.CFTypeRef;
 import oshi.ffm.mac.IOReportFunctions;
 import oshi.hardware.GpuTicks;
 
@@ -63,44 +64,35 @@ public final class IOReportClientFFM {
         }
         CFStringRef gpuGroup = CFStringRef.createCFString(GROUP_GPU_STATS);
         CFStringRef energyGroup = CFStringRef.createCFString(GROUP_ENERGY);
-        MemorySegment gpuChannels = MemorySegment.NULL;
-        MemorySegment energyChannels = MemorySegment.NULL;
-        try {
-            gpuChannels = IOReportFunctions.IOReportCopyChannelsInGroup(gpuGroup.segment(), MemorySegment.NULL, 0, 0,
-                    0);
+        try (gpuGroup; energyGroup) {
+            MemorySegment gpuChannels = IOReportFunctions.IOReportCopyChannelsInGroup(gpuGroup.segment(),
+                    MemorySegment.NULL, 0, 0, 0);
             if (gpuChannels.equals(MemorySegment.NULL)) {
                 return null;
             }
-            energyChannels = IOReportFunctions.IOReportCopyChannelsInGroup(energyGroup.segment(), MemorySegment.NULL, 0,
-                    0, 0);
-            if (!energyChannels.equals(MemorySegment.NULL)) {
-                IOReportFunctions.IOReportMergeChannels(gpuChannels, energyChannels, MemorySegment.NULL);
-            }
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment subRefOut = arena.allocate(ValueLayout.ADDRESS);
-                MemorySegment sub = IOReportFunctions.IOReportCreateSubscription(MemorySegment.NULL, gpuChannels,
-                        subRefOut, 0, MemorySegment.NULL);
-                if (sub.equals(MemorySegment.NULL)) {
-                    return null;
+            MemorySegment energyChannels = IOReportFunctions.IOReportCopyChannelsInGroup(energyGroup.segment(),
+                    MemorySegment.NULL, 0, 0, 0);
+            try (CFTypeRef gpuRef = new CFTypeRef(gpuChannels); CFTypeRef energyRef = new CFTypeRef(energyChannels)) {
+                if (!energyChannels.equals(MemorySegment.NULL)) {
+                    IOReportFunctions.IOReportMergeChannels(gpuChannels, energyChannels, MemorySegment.NULL);
                 }
-                MemorySegment subPtr = subRefOut.get(ValueLayout.ADDRESS, 0);
-                if (subPtr.equals(MemorySegment.NULL)) {
-                    cfRelease(sub);
-                    return null;
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment subRefOut = arena.allocate(ValueLayout.ADDRESS);
+                    MemorySegment sub = IOReportFunctions.IOReportCreateSubscription(MemorySegment.NULL, gpuChannels,
+                            subRefOut, 0, MemorySegment.NULL);
+                    if (sub.equals(MemorySegment.NULL)) {
+                        return null;
+                    }
+                    MemorySegment subPtr = subRefOut.get(ValueLayout.ADDRESS, 0);
+                    if (subPtr.equals(MemorySegment.NULL)) {
+                        cfRelease(sub);
+                        return null;
+                    }
+                    return new IOReportClientFFM(sub, subPtr);
                 }
-                return new IOReportClientFFM(sub, subPtr);
             }
         } catch (Throwable e) {
             return null;
-        } finally {
-            gpuGroup.release();
-            energyGroup.release();
-            if (!gpuChannels.equals(MemorySegment.NULL)) {
-                cfRelease(gpuChannels);
-            }
-            if (!energyChannels.equals(MemorySegment.NULL)) {
-                cfRelease(energyChannels);
-            }
         }
     }
 
@@ -113,25 +105,23 @@ public final class IOReportClientFFM {
         if (closed) {
             return new GpuTicks(0L, 0L);
         }
-        MemorySegment sample = MemorySegment.NULL;
         try {
-            sample = IOReportFunctions.IOReportCreateSamples(subscription, subscribedChannels, MemorySegment.NULL);
-            if (sample.equals(MemorySegment.NULL)) {
-                return new GpuTicks(0L, 0L);
+            MemorySegment sample = IOReportFunctions.IOReportCreateSamples(subscription, subscribedChannels,
+                    MemorySegment.NULL);
+            try (CFTypeRef sampleRef = new CFTypeRef(sample)) {
+                if (sample.equals(MemorySegment.NULL)) {
+                    return new GpuTicks(0L, 0L);
+                }
+                Map<String, Long> states = extractChannelStates(sample, GROUP_GPU_STATS, SUBGROUP_GPU_PERF_STATES);
+                if (states.isEmpty()) {
+                    return new GpuTicks(0L, 0L);
+                }
+                long idle = states.getOrDefault(STATE_OFF, 0L);
+                long total = states.values().stream().mapToLong(Long::longValue).sum();
+                return new GpuTicks(total - idle, idle);
             }
-            Map<String, Long> states = extractChannelStates(sample, GROUP_GPU_STATS, SUBGROUP_GPU_PERF_STATES);
-            if (states.isEmpty()) {
-                return new GpuTicks(0L, 0L);
-            }
-            long idle = states.getOrDefault(STATE_OFF, 0L);
-            long total = states.values().stream().mapToLong(Long::longValue).sum();
-            return new GpuTicks(total - idle, idle);
         } catch (Throwable e) {
             return new GpuTicks(0L, 0L);
-        } finally {
-            if (!sample.equals(MemorySegment.NULL)) {
-                cfRelease(sample);
-            }
         }
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/mac/IOKit.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/mac/IOKit.java
@@ -33,13 +33,14 @@ import static oshi.util.ExceptionUtil.getBooleanOrDefault;
 import static oshi.util.ExceptionUtil.getIntOrDefault;
 import static oshi.util.ExceptionUtil.getLongOrDefault;
 import static oshi.util.ExceptionUtil.getOrDefault;
-import static oshi.util.ExceptionUtil.runSilently;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.util.ArrayList;
 import java.util.List;
+
+import oshi.ffm.mac.CoreFoundation.CFTypeRef;
 
 /**
  * The I/O Kit framework implements non-kernel access to I/O Kit objects (drivers and nubs) through the device-interface
@@ -258,15 +259,12 @@ public interface IOKit {
             return getOrDefault(() -> {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
-                    MemorySegment cfValue = null;
-                    try {
-                        cfValue = createCFProperty(cfKey);
+                    MemorySegment cfValue = createCFProperty(cfKey);
+                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
                         return getStringFromCFString(cfValue, arena);
-                    } finally {
-                        releaseCFObjects(cfKey, cfValue);
                     }
                 }
             }, null);
@@ -276,9 +274,8 @@ public interface IOKit {
             return getOrDefault(() -> {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
-                    MemorySegment cfValue = null;
-                    try {
-                        cfValue = createCFProperty(cfKey);
+                    MemorySegment cfValue = createCFProperty(cfKey);
+                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
@@ -287,8 +284,6 @@ public interface IOKit {
                             return valuePtr.get(ValueLayout.JAVA_LONG, 0);
                         }
                         return null;
-                    } finally {
-                        releaseCFObjects(cfKey, cfValue);
                     }
                 }
             }, null);
@@ -298,9 +293,8 @@ public interface IOKit {
             return getOrDefault(() -> {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
-                    MemorySegment cfValue = null;
-                    try {
-                        cfValue = createCFProperty(cfKey);
+                    MemorySegment cfValue = createCFProperty(cfKey);
+                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
@@ -309,8 +303,6 @@ public interface IOKit {
                             return valuePtr.get(ValueLayout.JAVA_INT, 0);
                         }
                         return null;
-                    } finally {
-                        releaseCFObjects(cfKey, cfValue);
                     }
                 }
             }, null);
@@ -320,9 +312,8 @@ public interface IOKit {
             return getOrDefault(() -> {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
-                    MemorySegment cfValue = null;
-                    try {
-                        cfValue = createCFProperty(cfKey);
+                    MemorySegment cfValue = createCFProperty(cfKey);
+                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
@@ -331,8 +322,6 @@ public interface IOKit {
                             return valuePtr.get(ValueLayout.JAVA_DOUBLE, 0);
                         }
                         return null;
-                    } finally {
-                        releaseCFObjects(cfKey, cfValue);
                     }
                 }
             }, null);
@@ -342,17 +331,14 @@ public interface IOKit {
             return getOrDefault(() -> {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
-                    MemorySegment cfValue = null;
-                    try {
-                        cfValue = createCFProperty(cfKey);
+                    MemorySegment cfValue = createCFProperty(cfKey);
+                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
                         long length = CFDataGetLength(cfValue);
                         MemorySegment bytePtr = CFDataGetBytePtr(cfValue);
                         return getByteArrayFromNativePointer(bytePtr, length, arena);
-                    } finally {
-                        releaseCFObjects(cfKey, cfValue);
                     }
                 }
             }, null);
@@ -362,15 +348,12 @@ public interface IOKit {
             return getOrDefault(() -> {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
-                    MemorySegment cfValue = null;
-                    try {
-                        cfValue = createCFProperty(cfKey);
+                    MemorySegment cfValue = createCFProperty(cfKey);
+                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
                         return CFBooleanGetValue(cfValue) != 0;
-                    } finally {
-                        releaseCFObjects(cfKey, cfValue);
                     }
                 }
             }, null);
@@ -409,11 +392,4 @@ public interface IOKit {
         }
     }
 
-    private static void releaseCFObjects(MemorySegment... cfObjects) {
-        for (MemorySegment segment : cfObjects) {
-            if (segment != null && !segment.equals(MemorySegment.NULL)) {
-                runSilently(() -> CoreFoundationFunctions.CFRelease(segment));
-            }
-        }
-    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
@@ -47,38 +47,30 @@ final class MacDisplayFFM extends AbstractDisplay {
             return displays;
         }
         CFStringRef cfEdid = CFStringRef.createCFString(edidKeyName);
-        try {
+        try (serviceIterator; cfEdid) {
             IORegistryEntry sdService = serviceIterator.next();
             while (sdService != null) {
-                try {
-                    IORegistryEntry propertySource = childEntryName == null ? sdService
-                            : sdService.getChildEntry(childEntryName);
-                    if (propertySource != null) {
-                        try {
-                            MemorySegment edidRaw = propertySource.createCFProperty(cfEdid.segment());
-                            if (edidRaw != null && !edidRaw.equals(MemorySegment.NULL)) {
-                                CFDataRef edid = new CFDataRef(edidRaw);
-                                try (edid) {
-                                    byte[] bytes = edid.getBytes();
-                                    if (bytes.length > 0) {
-                                        displays.add(new MacDisplayFFM(bytes));
-                                    }
+                try (IORegistryEntry current = sdService) {
+                    IORegistryEntry childEntry = childEntryName == null ? null : current.getChildEntry(childEntryName);
+                    IORegistryEntry propertySource = childEntry != null ? childEntry : current;
+                    try {
+                        MemorySegment edidRaw = propertySource.createCFProperty(cfEdid.segment());
+                        if (edidRaw != null && !edidRaw.equals(MemorySegment.NULL)) {
+                            try (CFDataRef edid = new CFDataRef(edidRaw)) {
+                                byte[] bytes = edid.getBytes();
+                                if (bytes.length > 0) {
+                                    displays.add(new MacDisplayFFM(bytes));
                                 }
                             }
-                        } finally {
-                            if (childEntryName != null) {
-                                propertySource.release();
-                            }
+                        }
+                    } finally {
+                        if (childEntry != null) {
+                            childEntry.release();
                         }
                     }
-                } finally {
-                    sdService.release();
-                    sdService = serviceIterator.next();
                 }
+                sdService = serviceIterator.next();
             }
-        } finally {
-            serviceIterator.release();
-            cfEdid.release();
         }
         return displays;
     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
@@ -21,7 +21,7 @@ import oshi.ffm.mac.CoreFoundation.CFBooleanRef;
 import oshi.ffm.mac.CoreFoundation.CFDictionaryRef;
 import oshi.ffm.mac.CoreFoundation.CFNumberRef;
 import oshi.ffm.mac.CoreFoundation.CFStringRef;
-import oshi.ffm.mac.CoreFoundationFunctions;
+import oshi.ffm.mac.CoreFoundation.CFTypeRef;
 import oshi.ffm.mac.IOKit.IOService;
 import oshi.ffm.util.platform.mac.CFUtilFFM;
 import oshi.ffm.util.platform.mac.IOKitUtilFFM;
@@ -74,7 +74,7 @@ public final class MacPowerSourceFFM extends MacPowerSource {
 
         IOService smartBattery = IOKitUtilFFM.getMatchingService("AppleSmartBattery");
         if (smartBattery != null) {
-            try {
+            try (smartBattery) {
                 String s = smartBattery.getStringProperty("DeviceName");
                 if (s != null) {
                     psDeviceName = s;
@@ -145,8 +145,6 @@ public final class MacPowerSourceFFM extends MacPowerSource {
                     psCharging = bool;
                 }
                 psDischarging = !psCharging && !psPowerOnLine;
-            } finally {
-                smartBattery.release();
             }
         }
 
@@ -170,84 +168,57 @@ public final class MacPowerSourceFFM extends MacPowerSource {
         final String fSerialNumber = psSerialNumber;
         final double fTemperature = psTemperature;
 
-        MemorySegment powerSourcesInfo = MemorySegment.NULL;
-        CFArrayRef cfList = null;
-        CFStringRef nameKey = null;
-        CFStringRef isPresentKey = null;
-        CFStringRef currentCapacityKey = null;
-        CFStringRef maxCapacityKey = null;
-        try {
-            powerSourcesInfo = IOPSCopyPowerSourcesInfo();
-            cfList = new CFArrayRef(IOPSCopyPowerSourcesList(powerSourcesInfo));
-            double psTimeRemainingEstimated = IOPSGetTimeRemainingEstimate();
-            int powerSourcesCount = cfList.getCount();
+        CFStringRef nameKey = CFStringRef.createCFString("Name");
+        CFStringRef isPresentKey = CFStringRef.createCFString("Is Present");
+        CFStringRef currentCapacityKey = CFStringRef.createCFString("Current Capacity");
+        CFStringRef maxCapacityKey = CFStringRef.createCFString("Max Capacity");
+        try (nameKey; isPresentKey; currentCapacityKey; maxCapacityKey) {
+            MemorySegment powerSourcesInfo = IOPSCopyPowerSourcesInfo();
+            try (CFTypeRef infoRef = new CFTypeRef(powerSourcesInfo)) {
+                CFArrayRef cfList = new CFArrayRef(IOPSCopyPowerSourcesList(powerSourcesInfo));
+                try (cfList) {
+                    double psTimeRemainingEstimated = IOPSGetTimeRemainingEstimate();
+                    int powerSourcesCount = cfList.getCount();
 
-            nameKey = CFStringRef.createCFString("Name");
-            isPresentKey = CFStringRef.createCFString("Is Present");
-            currentCapacityKey = CFStringRef.createCFString("Current Capacity");
-            maxCapacityKey = CFStringRef.createCFString("Max Capacity");
+                    List<PowerSource> psList = new ArrayList<>(powerSourcesCount);
+                    for (int ps = 0; ps < powerSourcesCount; ps++) {
+                        MemorySegment pwrSrcPtr = cfList.getValueAtIndex(ps);
+                        MemorySegment dictionary = IOPSGetPowerSourceDescription(powerSourcesInfo, pwrSrcPtr);
+                        CFDictionaryRef dict = new CFDictionaryRef(dictionary);
 
-            List<PowerSource> psList = new ArrayList<>(powerSourcesCount);
-            for (int ps = 0; ps < powerSourcesCount; ps++) {
-                MemorySegment pwrSrcPtr = cfList.getValueAtIndex(ps);
-                MemorySegment dictionary = IOPSGetPowerSourceDescription(powerSourcesInfo, pwrSrcPtr);
-                CFDictionaryRef dict = new CFDictionaryRef(dictionary);
+                        MemorySegment result = dict.getValue(isPresentKey);
+                        if (!result.equals(MemorySegment.NULL)) {
+                            CFBooleanRef isPresentRef = new CFBooleanRef(result);
+                            if (isPresentRef.booleanValue()) {
+                                result = dict.getValue(nameKey);
+                                String psName = CFUtilFFM.cfPointerToString(result);
 
-                MemorySegment result = dict.getValue(isPresentKey);
-                if (!result.equals(MemorySegment.NULL)) {
-                    CFBooleanRef isPresentRef = new CFBooleanRef(result);
-                    if (isPresentRef.booleanValue()) {
-                        result = dict.getValue(nameKey);
-                        String psName = CFUtilFFM.cfPointerToString(result);
+                                double currentCapacity = 0d;
+                                if (dict.getValueIfPresent(currentCapacityKey, MemorySegment.NULL)) {
+                                    result = dict.getValue(currentCapacityKey);
+                                    currentCapacity = new CFNumberRef(result).intValue();
+                                }
+                                double maxCapacity = 1d;
+                                if (dict.getValueIfPresent(maxCapacityKey, MemorySegment.NULL)) {
+                                    result = dict.getValue(maxCapacityKey);
+                                    maxCapacity = new CFNumberRef(result).intValue();
+                                }
+                                double psRemainingCapacityPercent = maxCapacity <= 0 ? 0d
+                                        : Math.min(1d, currentCapacity / maxCapacity);
 
-                        double currentCapacity = 0d;
-                        if (dict.getValueIfPresent(currentCapacityKey, MemorySegment.NULL)) {
-                            result = dict.getValue(currentCapacityKey);
-                            currentCapacity = new CFNumberRef(result).intValue();
+                                psList.add(new MacPowerSourceFFM(psName, fDeviceName, psRemainingCapacityPercent,
+                                        psTimeRemainingEstimated, fTimeRemainingInstant, fPowerUsageRate, fVoltage,
+                                        fAmperage, fPowerOnLine, fCharging, fDischarging, fCapacityUnits,
+                                        fCurrentCapacity, fMaxCapacity, fDesignCapacity, fCycleCount, fChemistry,
+                                        fManufactureDate, fManufacturer, fSerialNumber, fTemperature));
+                            }
                         }
-                        double maxCapacity = 1d;
-                        if (dict.getValueIfPresent(maxCapacityKey, MemorySegment.NULL)) {
-                            result = dict.getValue(maxCapacityKey);
-                            maxCapacity = new CFNumberRef(result).intValue();
-                        }
-                        double psRemainingCapacityPercent = maxCapacity <= 0 ? 0d
-                                : Math.min(1d, currentCapacity / maxCapacity);
-
-                        psList.add(new MacPowerSourceFFM(psName, fDeviceName, psRemainingCapacityPercent,
-                                psTimeRemainingEstimated, fTimeRemainingInstant, fPowerUsageRate, fVoltage, fAmperage,
-                                fPowerOnLine, fCharging, fDischarging, fCapacityUnits, fCurrentCapacity, fMaxCapacity,
-                                fDesignCapacity, fCycleCount, fChemistry, fManufactureDate, fManufacturer,
-                                fSerialNumber, fTemperature));
                     }
+                    return psList;
                 }
             }
-            return psList;
         } catch (Throwable e) {
             return new ArrayList<>();
-        } finally {
-            if (isPresentKey != null) {
-                isPresentKey.release();
-            }
-            if (nameKey != null) {
-                nameKey.release();
-            }
-            if (currentCapacityKey != null) {
-                currentCapacityKey.release();
-            }
-            if (maxCapacityKey != null) {
-                maxCapacityKey.release();
-            }
-            if (cfList != null) {
-                cfList.release();
-            }
-            if (!powerSourcesInfo.equals(MemorySegment.NULL)) {
-                // powerSourcesInfo owns powerSourcesList; release info last
-                try {
-                    CoreFoundationFunctions.CFRelease(powerSourcesInfo);
-                } catch (Throwable ignored) {
-                    // CFRelease declares throws Throwable; swallow to keep finally clean
-                }
-            }
         }
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
@@ -79,7 +79,7 @@ public final class MacUsbDeviceFFM extends MacUsbDevice {
         if (iter != null) {
             CFStringRef locationIDKey = CFStringRef.createCFString("locationID");
             CFStringRef ioPropertyMatchKey = CFStringRef.createCFString("IOPropertyMatch");
-            try {
+            try (iter; locationIDKey; ioPropertyMatchKey) {
                 IORegistryEntry device = iter.next();
                 while (device != null) {
                     long id = 0L;
@@ -104,10 +104,6 @@ public final class MacUsbDeviceFFM extends MacUsbDevice {
                     device.release();
                     device = iter.next();
                 }
-            } finally {
-                locationIDKey.release();
-                ioPropertyMatchKey.release();
-                iter.release();
             }
         }
         root.release();

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacNetworkParamsFFM.java
@@ -13,7 +13,6 @@ import static oshi.ffm.mac.MacSystem.ADDRINFO_CANONNAME;
 import static oshi.ffm.mac.MacSystem.AI_CANONNAME;
 import static oshi.ffm.mac.MacSystem.AI_FLAGS;
 import static oshi.ffm.mac.MacSystem.HOST_NAME_MAX;
-import static oshi.ffm.mac.MacSystemFunctions.freeaddrinfo;
 import static oshi.ffm.mac.MacSystemFunctions.gai_strerror;
 import static oshi.ffm.mac.MacSystemFunctions.getaddrinfo;
 import static oshi.ffm.mac.MacSystemFunctions.gethostname;
@@ -27,6 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.NativeHandle;
+import oshi.ffm.mac.MacSystemFunctions;
 import oshi.software.common.AbstractNetworkParams;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -69,16 +70,14 @@ final class MacNetworkParamsFFM extends AbstractNetworkParams {
                 LOG.debug("Failed getaddrinfo(): {}", gai_strerror(res));
                 return "";
             }
-            try {
+            try (NativeHandle addrInfo = NativeHandle.of(resPtr.get(ADDRESS, 0), MacSystemFunctions::freeaddrinfo)) {
                 // resPtr holds a pointer to the first addrinfo struct
-                MemorySegment infoPtr = resPtr.get(ADDRESS, 0).reinterpret(ADDRINFO.byteSize(), arena, null);
+                MemorySegment infoPtr = addrInfo.get().reinterpret(ADDRINFO.byteSize(), arena, null);
                 MemorySegment canonPtr = infoPtr.get(ADDRESS, ADDRINFO.byteOffset(ADDRINFO_CANONNAME));
                 if (canonPtr.equals(MemorySegment.NULL)) {
                     return "";
                 }
                 return canonPtr.reinterpret(256, arena, null).getString(0).trim();
-            } finally {
-                freeaddrinfo(resPtr.get(ADDRESS, 0));
             }
         }, LOG, DEBUG, "Failed getDomainName()", "");
     }


### PR DESCRIPTION
Continue the AutoCloseable migration for macOS FFM classes. Eliminates the `releaseCFObjects` helper entirely and migrates additional call sites.

## Changes

- **IOKit.java** — Replace all 6 `releaseCFObjects` usages with `CFTypeRef` try-with-resources; delete the now-unused helper method
- **IOReportClientFFM** — Migrate `create()` and `sampleGpuTicks()` to try-with-resources
- **MacDisplayFFM** — Restructure loop: outer `try (serviceIterator; cfEdid)`, inner `try (IORegistryEntry current)`, separate `childEntry` variable for conditional release
- **MacPowerSourceFFM** — Create CFStringRef keys upfront, nested try-with-resources for `powerSourcesInfo` and `cfList`
- **MacUsbDeviceFFM** — Multi-resource `try (iter; locationIDKey; ioPropertyMatchKey)`
- **MacNetworkParamsFFM** — `NativeHandle` for `freeaddrinfo`

## Intentionally left
- `MacHWDiskStoreFFM` / `MacFileSystemFFM` — queued for a dedicated follow-up PR
- `MacSensorsFFM` / `MacGpuStatsFFM` — `smcClose(int)` not a MemorySegment handle
- `MacCentralProcessorFFM` — `vm_deallocate` (raw memory, not CF/IOKit)
- `IOReportClientFFM` (4 remaining) — stateful cross-call sample lifecycle
- `WhoFFM` — `endutxent()` no-arg cleanup, not a handle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved resource management and lifecycle handling across macOS platform modules to enhance code safety and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->