### PR TITLE
Migrate MacFileSystemFFM to AutoCloseable try-with-resources

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
@@ -88,9 +88,9 @@ public class MacFileSystemFFM extends MacFileSystem {
                 return fsList;
             }
 
-            try {
+            try (session) {
                 CFStringRef daVolumeNameKey = CFStringRef.createCFString("DAVolumeName");
-                try {
+                try (daVolumeNameKey) {
                     for (int f = 0; f < numfs; f++) {
                         MemorySegment statfs = statfsBuffer.asSlice(f * statfsSize, statfsSize);
                         // Mount on name will match mounted path, e.g. /Volumes/foo
@@ -138,46 +138,37 @@ public class MacFileSystemFFM extends MacFileSystem {
                         String bsdName = volume.replace("/dev/disk", "disk");
                         if (bsdName.startsWith("disk")) {
                             // Get the DiskArbitration dictionary for this disk
-                            DADiskRef disk = null;
-                            CFDictionaryRef diskInfo = null;
-                            try {
-                                disk = DADiskRef.createFromBSDName(allocator, session, volume);
+                            try (DADiskRef disk = DADiskRef.createFromBSDName(allocator, session, volume)) {
                                 if (!disk.isNull()) {
-                                    diskInfo = disk.copyDescription();
-                                    if (!diskInfo.isNull()) {
-                                        // Get volume name
-                                        MemorySegment result = diskInfo.getValue(daVolumeNameKey);
-                                        if (!result.equals(MemorySegment.NULL)) {
-                                            name = CFUtilFFM.cfPointerToString(result);
+                                    try (CFDictionaryRef diskInfo = disk.copyDescription()) {
+                                        if (!diskInfo.isNull()) {
+                                            // Get volume name
+                                            MemorySegment result = diskInfo.getValue(daVolumeNameKey);
+                                            if (!result.equals(MemorySegment.NULL)) {
+                                                name = CFUtilFFM.cfPointerToString(result);
+                                            }
                                         }
                                     }
-                                }
-                            } finally {
-                                if (diskInfo != null) {
-                                    diskInfo.release();
-                                }
-                                if (disk != null) {
-                                    disk.release();
                                 }
                             }
                             // Search for bsd name in IOKit registry for UUID
                             MemorySegment matchingDict = IOKitUtilFFM.getBSDNameMatchingDict(bsdName);
                             if (matchingDict != null) {
                                 // search for all IOservices that match the bsd name
-                                IOIterator fsIter = IOKitUtilFFM.getMatchingServices(matchingDict);
-                                if (fsIter != null) {
-                                    // getMatchingServices releases matchingDict
-                                    // Should only match one logical drive
-                                    IORegistryEntry fsEntry = fsIter.next();
-                                    if (fsEntry != null && fsEntry.conformsTo("IOMedia")) {
-                                        // Now get the UUID
-                                        uuid = fsEntry.getStringProperty("UUID");
-                                        if (uuid != null) {
-                                            uuid = uuid.toLowerCase(Locale.ROOT);
+                                try (IOIterator fsIter = IOKitUtilFFM.getMatchingServices(matchingDict)) {
+                                    if (fsIter != null) {
+                                        // getMatchingServices releases matchingDict
+                                        // Should only match one logical drive
+                                        try (IORegistryEntry fsEntry = fsIter.next()) {
+                                            if (fsEntry != null && fsEntry.conformsTo("IOMedia")) {
+                                                // Now get the UUID
+                                                uuid = fsEntry.getStringProperty("UUID");
+                                                if (uuid != null) {
+                                                    uuid = uuid.toLowerCase(Locale.ROOT);
+                                                }
+                                            }
                                         }
-                                        fsEntry.release();
                                     }
-                                    fsIter.release();
                                 }
                             }
                         }
@@ -190,11 +181,7 @@ public class MacFileSystemFFM extends MacFileSystem {
                                 uuid == null ? "" : uuid, isLocal, "", description, type, file.getFreeSpace(),
                                 file.getUsableSpace(), file.getTotalSpace(), ffree, files));
                     }
-                } finally {
-                    daVolumeNameKey.release();
                 }
-            } finally {
-                session.release();
             }
         } catch (Throwable e) {
             LOG.warn("Failed to query file systems: {}", e.getMessage(), e);

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
@@ -142,11 +142,13 @@ public class MacFileSystemJNA extends MacFileSystem {
                                 // getMatchingServices releases matchingDict
                                 // Should only match one logical drive
                                 IORegistryEntry fsEntry = fsIter.next();
-                                if (fsEntry != null && fsEntry.conformsTo("IOMedia")) {
-                                    // Now get the UUID
-                                    uuid = fsEntry.getStringProperty("UUID");
-                                    if (uuid != null) {
-                                        uuid = uuid.toLowerCase(Locale.ROOT);
+                                if (fsEntry != null) {
+                                    if (fsEntry.conformsTo("IOMedia")) {
+                                        // Now get the UUID
+                                        uuid = fsEntry.getStringProperty("UUID");
+                                        if (uuid != null) {
+                                            uuid = uuid.toLowerCase(Locale.ROOT);
+                                        }
                                     }
                                     fsEntry.release();
                                 }


### PR DESCRIPTION
Replace manual `finally` blocks with try-with-resources for CF/IOKit object lifecycle management in `MacFileSystemFFM`.

## Changes
- Outer: `try (session)` and `try (daVolumeNameKey)`
- Inner: `try (DADiskRef disk)` and `try (CFDictionaryRef diskInfo)` for DiskArbitration lookups
- IOKit: `try (IOIterator fsIter)` and `try (IORegistryEntry fsEntry)` for UUID lookup

## Bug fix: IORegistryEntry leak (JNA + FFM)
The AutoCloseable migration revealed a pre-existing resource leak in both the JNA and FFM implementations: when `fsEntry.conformsTo("IOMedia")` returned `false`, the `IORegistryEntry` was never released. This was invisible in the original code because the release was inside the `if` block. The try-with-resources refactoring made the missing cleanup path obvious.

Fixed in both:
- `MacFileSystemFFM.java` — `try (IORegistryEntry fsEntry = ...)` ensures unconditional release
- `MacFileSystemJNA.java` — moved `fsEntry.release()` outside the `conformsTo` check

## Deferred
`MacHWDiskStoreFFM` — deeply nested (18 finally blocks across 3 methods), requires dedicated careful attention in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved macOS file system handling to ensure native resources are cleaned up reliably, reducing risk of leaks and intermittent failures.
  * Simplified logic for reading volume identifiers and names to make resource management more predictable.

* **Bug Fixes**
  * Ensures consistent release of native handles, improving stability when detecting and accessing mounted volumes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->