### PR TITLE
Migrate MacHWDiskStoreFFM to AutoCloseable try-with-resources

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -65,13 +65,15 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                 LOG.error("Unable to open session to DiskArbitration framework.");
                 return false;
             }
-            Map<CFKey, CFStringRef> cfKeyMap = mapCFKeys();
-            try {
+            Map<CFKey, CFStringRef> cfKeyMap = null;
+            try (session) {
+                cfKeyMap = mapCFKeys();
                 return updateDiskStats(session, FsstatFFM.queryPartitionToMountMap(), cfKeyMap);
             } finally {
-                session.release();
-                for (CFStringRef value : cfKeyMap.values()) {
-                    value.release();
+                if (cfKeyMap != null) {
+                    for (CFStringRef value : cfKeyMap.values()) {
+                        value.release();
+                    }
                 }
             }
         } catch (Throwable e) {
@@ -90,12 +92,12 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
         if (driveListIter == null) {
             return false;
         }
-        try {
+        try (driveListIter) {
             IORegistryEntry drive = driveListIter.next();
             if (drive == null) {
                 return false;
             }
-            try {
+            try (drive) {
                 if (!drive.conformsTo("IOMedia")) {
                     LOG.error("Unable to find IOMedia device or parent for {}", bsdName);
                     return false;
@@ -106,8 +108,7 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                             || parent.conformsTo("AppleAPFSContainerScheme"))) {
                         MemorySegment propertiesSeg = parent.createCFProperties();
                         if (!propertiesSeg.equals(MemorySegment.NULL)) {
-                            CFDictionaryRef properties = new CFDictionaryRef(propertiesSeg);
-                            try {
+                            try (CFDictionaryRef properties = new CFDictionaryRef(propertiesSeg)) {
                                 MemorySegment result = properties.getValue(cfKeyMap.get(CFKey.STATISTICS));
                                 if (!result.equals(MemorySegment.NULL)) {
                                     CFDictionaryRef statistics = new CFDictionaryRef(result);
@@ -139,8 +140,6 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                                         setTransferTime(xferTime / 1_000_000L);
                                     }
                                 }
-                            } finally {
-                                properties.release();
                             }
                         }
                     } else {
@@ -151,10 +150,8 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                     List<HWPartition> partitions = new ArrayList<>();
                     MemorySegment drivePropsSeg = drive.createCFProperties();
                     if (!drivePropsSeg.equals(MemorySegment.NULL)) {
-                        CFDictionaryRef driveProps = new CFDictionaryRef(drivePropsSeg);
-                        try {
+                        try (CFDictionaryRef driveProps = new CFDictionaryRef(drivePropsSeg)) {
                             MemorySegment bsdUnitSeg = driveProps.getValue(cfKeyMap.get(CFKey.BSD_UNIT));
-                            // cfFalse is the value stored under LEAF key for whole disks
                             MemorySegment cfFalseSeg = driveProps.getValue(cfKeyMap.get(CFKey.LEAF));
 
                             try {
@@ -180,54 +177,53 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                                 propertyDict.release();
 
                                 if (serviceIterator != null) {
-                                    try {
+                                    try (serviceIterator) {
                                         IORegistryEntry sdService = serviceIterator.next();
                                         while (sdService != null) {
-                                            String partBsdName = sdService.getStringProperty("BSD Name");
-                                            String name = partBsdName;
-                                            String type = "";
-                                            String label = "";
+                                            try (IORegistryEntry current = sdService) {
+                                                String partBsdName = current.getStringProperty("BSD Name");
+                                                String name = partBsdName;
+                                                String type = "";
+                                                String label = "";
 
-                                            DADiskRef disk = DADiskRef.createFromBSDName(alloc, session, partBsdName);
-                                            if (!disk.isNull()) {
-                                                CFDictionaryRef diskInfo = disk.copyDescription();
-                                                if (!diskInfo.isNull()) {
-                                                    MemorySegment r = diskInfo
-                                                            .getValue(cfKeyMap.get(CFKey.DA_MEDIA_NAME));
-                                                    type = CFUtilFFM.cfPointerToString(r);
-                                                    r = diskInfo.getValue(cfKeyMap.get(CFKey.DA_VOLUME_NAME));
-                                                    if (r.equals(MemorySegment.NULL)) {
-                                                        name = type;
-                                                    } else {
-                                                        String volumeName = CFUtilFFM.cfPointerToString(r);
-                                                        name = volumeName;
-                                                        label = volumeName;
+                                                try (DADiskRef disk = DADiskRef.createFromBSDName(alloc, session,
+                                                        partBsdName)) {
+                                                    if (!disk.isNull()) {
+                                                        try (CFDictionaryRef diskInfo = disk.copyDescription()) {
+                                                            if (!diskInfo.isNull()) {
+                                                                MemorySegment r = diskInfo
+                                                                        .getValue(cfKeyMap.get(CFKey.DA_MEDIA_NAME));
+                                                                type = CFUtilFFM.cfPointerToString(r);
+                                                                r = diskInfo
+                                                                        .getValue(cfKeyMap.get(CFKey.DA_VOLUME_NAME));
+                                                                if (r.equals(MemorySegment.NULL)) {
+                                                                    name = type;
+                                                                } else {
+                                                                    String volumeName = CFUtilFFM.cfPointerToString(r);
+                                                                    name = volumeName;
+                                                                    label = volumeName;
+                                                                }
+                                                            }
+                                                        }
                                                     }
-                                                    diskInfo.release();
                                                 }
-                                                disk.release();
+                                                String mountPoint = mountPointMap.getOrDefault(partBsdName, "");
+                                                Long size = current.getLongProperty("Size");
+                                                Integer bsdMajor = current.getIntegerProperty("BSD Major");
+                                                Integer bsdMinor = current.getIntegerProperty("BSD Minor");
+                                                String uuid = current.getStringProperty("UUID");
+                                                partitions.add(new HWPartition(partBsdName, name, type,
+                                                        uuid == null ? Constants.UNKNOWN : uuid, label,
+                                                        size == null ? 0L : size, bsdMajor == null ? 0 : bsdMajor,
+                                                        bsdMinor == null ? 0 : bsdMinor, mountPoint));
                                             }
-                                            String mountPoint = mountPointMap.getOrDefault(partBsdName, "");
-                                            Long size = sdService.getLongProperty("Size");
-                                            Integer bsdMajor = sdService.getIntegerProperty("BSD Major");
-                                            Integer bsdMinor = sdService.getIntegerProperty("BSD Minor");
-                                            String uuid = sdService.getStringProperty("UUID");
-                                            partitions.add(new HWPartition(partBsdName, name, type,
-                                                    uuid == null ? Constants.UNKNOWN : uuid, label,
-                                                    size == null ? 0L : size, bsdMajor == null ? 0 : bsdMajor,
-                                                    bsdMinor == null ? 0 : bsdMinor, mountPoint));
-                                            sdService.release();
                                             sdService = serviceIterator.next();
                                         }
-                                    } finally {
-                                        serviceIterator.release();
                                     }
                                 }
                             } catch (Throwable e) {
                                 LOG.debug("Error building partition list for {}", bsdName, e);
                             }
-                        } finally {
-                            driveProps.release();
                         }
                     }
                     setPartitionList(Collections.unmodifiableList(partitions.stream()
@@ -237,11 +233,7 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                         parent.release();
                     }
                 }
-            } finally {
-                drive.release();
             }
-        } finally {
-            driveListIter.release();
         }
         return true;
     }
@@ -258,29 +250,28 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                 LOG.error("Unable to open session to DiskArbitration framework.");
                 return Collections.emptyList();
             }
-            try {
+            try (session) {
                 List<String> bsdNames = new ArrayList<>();
                 IOIterator iter = IOKitUtilFFM.getMatchingServices("IOMedia");
                 if (iter != null) {
-                    try {
+                    try (iter) {
                         IORegistryEntry media = iter.next();
                         while (media != null) {
-                            Boolean whole = media.getBooleanProperty("Whole");
-                            if (Boolean.TRUE.equals(whole)) {
-                                DADiskRef disk = DADiskRef.createFromIOMedia(alloc, session, media);
-                                if (!disk.isNull()) {
-                                    String bsdName = disk.getBSDName();
-                                    if (bsdName != null) {
-                                        bsdNames.add(bsdName);
+                            try (IORegistryEntry current = media) {
+                                Boolean whole = current.getBooleanProperty("Whole");
+                                if (Boolean.TRUE.equals(whole)) {
+                                    try (DADiskRef disk = DADiskRef.createFromIOMedia(alloc, session, current)) {
+                                        if (!disk.isNull()) {
+                                            String bsdName = disk.getBSDName();
+                                            if (bsdName != null) {
+                                                bsdNames.add(bsdName);
+                                            }
+                                        }
                                     }
-                                    disk.release();
                                 }
                             }
-                            media.release();
                             media = iter.next();
                         }
-                    } finally {
-                        iter.release();
                     }
                 }
 
@@ -294,10 +285,9 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                     if (disk.isNull()) {
                         continue;
                     }
-                    try {
-                        CFDictionaryRef diskInfo = disk.copyDescription();
-                        if (!diskInfo.isNull()) {
-                            try {
+                    try (disk) {
+                        try (CFDictionaryRef diskInfo = disk.copyDescription()) {
+                            if (!diskInfo.isNull()) {
                                 MemorySegment result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_DEVICE_MODEL));
                                 model = CFUtilFFM.cfPointerToString(result);
                                 result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_MEDIA_SIZE));
@@ -306,8 +296,7 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                                 }
 
                                 if (!"Disk Image".equals(model)) {
-                                    CFStringRef modelNameRef = CFStringRef.createCFString(model);
-                                    try {
+                                    try (CFStringRef modelNameRef = CFStringRef.createCFString(model)) {
                                         CFMutableDictionaryRef propertyDict = new CFMutableDictionaryRef(
                                                 CoreFoundationFunctions.CFDictionaryCreateMutable(alloc.segment(), 0,
                                                         MemorySegment.NULL, MemorySegment.NULL));
@@ -322,33 +311,26 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                                         propertyDict.release();
 
                                         if (serviceIterator != null) {
-                                            try {
+                                            try (serviceIterator) {
                                                 IORegistryEntry sdService = serviceIterator.next();
                                                 while (sdService != null) {
-                                                    serial = sdService.getStringProperty("Serial Number");
-                                                    sdService.release();
+                                                    try (IORegistryEntry current = sdService) {
+                                                        serial = current.getStringProperty("Serial Number");
+                                                    }
                                                     if (serial != null) {
                                                         break;
                                                     }
                                                     sdService = serviceIterator.next();
                                                 }
-                                            } finally {
-                                                serviceIterator.release();
                                             }
                                         }
-                                    } finally {
-                                        modelNameRef.release();
                                     }
                                     if (serial == null) {
                                         serial = "";
                                     }
                                 }
-                            } finally {
-                                diskInfo.release();
                             }
                         }
-                    } finally {
-                        disk.release();
                     }
 
                     if (size <= 0) {
@@ -357,14 +339,13 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                     diskList.add(new MacHWDiskStoreFFM(bsdName, model.trim(), serial.trim(), size,
                             detectDiskType(bsdName), session, mountPointMap, cfKeyMap));
                 }
-            } finally {
-                session.release();
-                for (CFStringRef value : cfKeyMap.values()) {
-                    value.release();
-                }
             }
         } catch (Throwable e) {
             LOG.error("Error enumerating disks", e);
+        } finally {
+            for (CFStringRef value : cfKeyMap.values()) {
+                value.release();
+            }
         }
         return diskList;
     }
@@ -393,12 +374,12 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
         if (iter == null) {
             return "Unknown";
         }
-        try {
+        try (iter) {
             IORegistryEntry media = iter.next();
             if (media == null) {
                 return "Unknown";
             }
-            try {
+            try (media) {
                 // Check removable at the IOMedia level
                 Boolean removable = media.getBooleanProperty("Removable");
                 if (removable != null && removable) {
@@ -407,48 +388,41 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                 // Traverse up: IOMedia -> IOBlockStorageDriver -> IOBlockStorageDevice
                 IORegistryEntry driver = media.getParentEntry("IOService");
                 if (driver != null) {
-                    try {
+                    try (driver) {
                         IORegistryEntry device = driver.getParentEntry("IOService");
                         if (device != null) {
-                            try {
+                            try (device) {
                                 MemorySegment propsSeg = device.createCFProperties();
                                 if (!propsSeg.equals(MemorySegment.NULL)) {
-                                    CFDictionaryRef props = new CFDictionaryRef(propsSeg);
-                                    try {
-                                        MemorySegment charSeg = props
-                                                .getValue(CFStringRef.createCFString("Device Characteristics"));
-                                        if (!charSeg.equals(MemorySegment.NULL)) {
-                                            CFDictionaryRef chars = new CFDictionaryRef(charSeg);
-                                            MemorySegment typeSeg = chars
-                                                    .getValue(CFStringRef.createCFString("Medium Type"));
-                                            if (!typeSeg.equals(MemorySegment.NULL)) {
-                                                String type = new CFStringRef(typeSeg).stringValue();
-                                                if (type != null) {
-                                                    if (type.contains("Solid State") || type.contains("SSD")) {
-                                                        return "SSD";
-                                                    } else if (type.contains("Rotational")) {
-                                                        return "HDD";
+                                    try (CFDictionaryRef props = new CFDictionaryRef(propsSeg)) {
+                                        try (CFStringRef devCharKey = CFStringRef
+                                                .createCFString("Device Characteristics")) {
+                                            MemorySegment charSeg = props.getValue(devCharKey);
+                                            if (!charSeg.equals(MemorySegment.NULL)) {
+                                                CFDictionaryRef chars = new CFDictionaryRef(charSeg);
+                                                try (CFStringRef medTypeKey = CFStringRef
+                                                        .createCFString("Medium Type")) {
+                                                    MemorySegment typeSeg = chars.getValue(medTypeKey);
+                                                    if (!typeSeg.equals(MemorySegment.NULL)) {
+                                                        String type = new CFStringRef(typeSeg).stringValue();
+                                                        if (type != null) {
+                                                            if (type.contains("Solid State") || type.contains("SSD")) {
+                                                                return "SSD";
+                                                            } else if (type.contains("Rotational")) {
+                                                                return "HDD";
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
                                         }
-                                    } finally {
-                                        props.release();
                                     }
                                 }
-                            } finally {
-                                device.release();
                             }
                         }
-                    } finally {
-                        driver.release();
                     }
                 }
-            } finally {
-                media.release();
             }
-        } finally {
-            iter.release();
         }
         return "Unknown";
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
@@ -240,107 +240,115 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
 
         List<HWDiskStore> diskList = new ArrayList<>();
 
-        // Open a DiskArbitration session
-        DASessionRef session = DA.DASessionCreate(CF.CFAllocatorGetDefault());
-        if (session == null) {
-            LOG.error("Unable to open session to DiskArbitration framework.");
-            return Collections.emptyList();
-        }
-
-        // Get IOMedia objects representing whole drives
-        List<String> bsdNames = new ArrayList<>();
-        IOIterator iter = IOKitUtil.getMatchingServices("IOMedia");
-        if (iter != null) {
-            IORegistryEntry media = iter.next();
-            while (media != null) {
-                Boolean whole = media.getBooleanProperty("Whole");
-                if (whole != null && whole) {
-                    DADiskRef disk = DA.DADiskCreateFromIOMedia(CF.CFAllocatorGetDefault(), session, media);
-                    bsdNames.add(DA.DADiskGetBSDName(disk));
-                    disk.release();
-                }
-                media.release();
-                media = iter.next();
+        try {
+            // Open a DiskArbitration session
+            DASessionRef session = DA.DASessionCreate(CF.CFAllocatorGetDefault());
+            if (session == null) {
+                LOG.error("Unable to open session to DiskArbitration framework.");
+                return Collections.emptyList();
             }
-            iter.release();
-        }
+            try {
 
-        // Now iterate the bsdNames
-        for (String bsdName : bsdNames) {
-            String model = "";
-            String serial = "";
-            long size = 0L;
-
-            // Get a reference to the disk - only matching /dev/disk*
-            String path = "/dev/" + bsdName;
-
-            // Get the DiskArbitration dictionary for this disk, which has model
-            // and size (capacity)
-            DADiskRef disk = DA.DADiskCreateFromBSDName(CF.CFAllocatorGetDefault(), session, path);
-            if (disk != null) {
-                CFDictionaryRef diskInfo = DA.DADiskCopyDescription(disk);
-                if (diskInfo != null) {
-                    // Parse out model and size from their respective keys
-                    Pointer result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_DEVICE_MODEL));
-                    model = CFUtil.cfPointerToString(result);
-                    result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_MEDIA_SIZE));
-                    CFNumberRef sizePtr = new CFNumberRef(result);
-                    size = sizePtr.longValue();
-                    diskInfo.release();
-
-                    // Use the model as a key to get serial from IOKit
-                    if (!"Disk Image".equals(model)) {
-                        CFStringRef modelNameRef = CFStringRef.createCFString(model);
-                        CFMutableDictionaryRef propertyDict = CF.CFDictionaryCreateMutable(CF.CFAllocatorGetDefault(),
-                                new CFIndex(0), null, null);
-                        propertyDict.setValue(cfKeyMap.get(CFKey.MODEL), modelNameRef);
-                        CFMutableDictionaryRef matchingDict = CF.CFDictionaryCreateMutable(CF.CFAllocatorGetDefault(),
-                                new CFIndex(0), null, null);
-                        matchingDict.setValue(cfKeyMap.get(CFKey.IO_PROPERTY_MATCH), propertyDict);
-
-                        // search for all IOservices that match the model
-                        IOIterator serviceIterator = IOKitUtil.getMatchingServices(matchingDict);
-                        // getMatchingServices releases matchingDict
-                        modelNameRef.release();
-                        propertyDict.release();
-
-                        if (serviceIterator != null) {
-                            IORegistryEntry sdService = serviceIterator.next();
-                            while (sdService != null) {
-                                // look up the serial number
-                                serial = sdService.getStringProperty("Serial Number");
-                                sdService.release();
-                                if (serial != null) {
-                                    break;
+                // Get IOMedia objects representing whole drives
+                List<String> bsdNames = new ArrayList<>();
+                IOIterator iter = IOKitUtil.getMatchingServices("IOMedia");
+                if (iter != null) {
+                    IORegistryEntry media = iter.next();
+                    while (media != null) {
+                        Boolean whole = media.getBooleanProperty("Whole");
+                        if (whole != null && whole) {
+                            DADiskRef disk = DA.DADiskCreateFromIOMedia(CF.CFAllocatorGetDefault(), session, media);
+                            if (disk != null) {
+                                String bsdName = DA.DADiskGetBSDName(disk);
+                                if (bsdName != null) {
+                                    bsdNames.add(bsdName);
                                 }
-                                // iterate
-                                sdService.release();
-                                sdService = serviceIterator.next();
+                                disk.release();
                             }
-                            serviceIterator.release();
                         }
-                        if (serial == null) {
-                            serial = "";
+                        media.release();
+                        media = iter.next();
+                    }
+                    iter.release();
+                }
+
+                // Now iterate the bsdNames
+                for (String bsdName : bsdNames) {
+                    String model = "";
+                    String serial = "";
+                    long size = 0L;
+
+                    // Get a reference to the disk - only matching /dev/disk*
+                    String path = "/dev/" + bsdName;
+
+                    // Get the DiskArbitration dictionary for this disk, which has model
+                    // and size (capacity)
+                    DADiskRef disk = DA.DADiskCreateFromBSDName(CF.CFAllocatorGetDefault(), session, path);
+                    if (disk != null) {
+                        CFDictionaryRef diskInfo = DA.DADiskCopyDescription(disk);
+                        if (diskInfo != null) {
+                            // Parse out model and size from their respective keys
+                            Pointer result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_DEVICE_MODEL));
+                            model = CFUtil.cfPointerToString(result);
+                            result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_MEDIA_SIZE));
+                            CFNumberRef sizePtr = new CFNumberRef(result);
+                            size = sizePtr.longValue();
+                            diskInfo.release();
+
+                            // Use the model as a key to get serial from IOKit
+                            if (!"Disk Image".equals(model)) {
+                                CFStringRef modelNameRef = CFStringRef.createCFString(model);
+                                CFMutableDictionaryRef propertyDict = CF.CFDictionaryCreateMutable(
+                                        CF.CFAllocatorGetDefault(), new CFIndex(0), null, null);
+                                propertyDict.setValue(cfKeyMap.get(CFKey.MODEL), modelNameRef);
+                                CFMutableDictionaryRef matchingDict = CF.CFDictionaryCreateMutable(
+                                        CF.CFAllocatorGetDefault(), new CFIndex(0), null, null);
+                                matchingDict.setValue(cfKeyMap.get(CFKey.IO_PROPERTY_MATCH), propertyDict);
+
+                                // search for all IOservices that match the model
+                                IOIterator serviceIterator = IOKitUtil.getMatchingServices(matchingDict);
+                                // getMatchingServices releases matchingDict
+                                modelNameRef.release();
+                                propertyDict.release();
+
+                                if (serviceIterator != null) {
+                                    IORegistryEntry sdService = serviceIterator.next();
+                                    while (sdService != null) {
+                                        // look up the serial number
+                                        serial = sdService.getStringProperty("Serial Number");
+                                        sdService.release();
+                                        if (serial != null) {
+                                            break;
+                                        }
+                                        sdService = serviceIterator.next();
+                                    }
+                                    serviceIterator.release();
+                                }
+                                if (serial == null) {
+                                    serial = "";
+                                }
+                            }
                         }
+                        disk.release();
+
+                        // If empty, ignore
+                        if (size <= 0) {
+                            continue;
+                        }
+                        HWDiskStore diskStore = new MacHWDiskStoreJNA(bsdName, model.trim(), serial.trim(), size,
+                                detectDiskType(bsdName), session, mountPointMap, cfKeyMap);
+                        diskList.add(diskStore);
                     }
                 }
-                disk.release();
-
-                // If empty, ignore
-                if (size <= 0) {
-                    continue;
-                }
-                HWDiskStore diskStore = new MacHWDiskStoreJNA(bsdName, model.trim(), serial.trim(), size,
-                        detectDiskType(bsdName), session, mountPointMap, cfKeyMap);
-                diskList.add(diskStore);
+                return diskList;
+            } finally {
+                session.release();
+            }
+        } finally {
+            for (CFTypeRef value : cfKeyMap.values()) {
+                value.release();
             }
         }
-        // Close DA session
-        session.release();
-        for (CFTypeRef value : cfKeyMap.values()) {
-            value.release();
-        }
-        return diskList;
     }
 
     /**


### PR DESCRIPTION
🎉 **Final boss of the NativeHandle/AutoCloseable migration series!**

Replace 15 of 18 manual `finally` blocks with try-with-resources across all four methods in `MacHWDiskStoreFFM`.

## Pre-existing bugs found and fixed

The migration and subsequent review uncovered several native resource management bugs:

**FFM side:**
- `cfKeyMap` entries leaked in `getDisks()` when `session.isNull()` — moved release to outer finally
- `IORegistryEntry` leaked in iterator loops on exception — wrapped with `try (IORegistryEntry current = entry)`
- `CFStringRef` keys leaked in `detectDiskType()` — `createCFString()` calls never released

**JNA side (same file, same bugs):**
- `cfKeyMap` entries leaked in `getDisks()` when session is null — added outer try/finally
- `DASessionRef` leaked on exception — wrapped in try/finally
- **Double-release** of `sdService` in serial lookup loop — `release()` called twice per iteration when serial was null

## Migration details
- `updateAttributes()` — `try (session)`
- `updateDiskStats()` — `try (driveListIter)`, `try (drive)`, `try (properties)`, `try (driveProps)`, `try (serviceIterator)`, `try (DADiskRef)`, `try (CFDictionaryRef)`, `try (IORegistryEntry current)`
- `getDisks()` — `try (session)`, `try (iter)`, `try (IORegistryEntry current)`, `try (DADiskRef)`, `try (CFDictionaryRef)`, `try (modelNameRef)`, `try (serviceIterator)`
- `detectDiskType()` — `try (iter)`, `try (media)`, `try (driver)`, `try (device)`, `try (props)`, `try (CFStringRef keys)`

## Remaining 2 finally blocks
- `cfKeyMap.values()` iteration release — can't express map iteration as try-with-resources
- Conditional `parent.release()` — `getParentEntry()` can return Java null (NPE in try-with-resources)

## Migration series complete 🏆
PRs #3290 → #3291 → #3292 → #3293 → #3294 → **#3296**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified macOS disk discovery by centralizing resource lifecycle management, improving reliability of disk enumeration.
* **Bug Fixes**
  * More robust error handling and logging during disk detection and metadata collection to reduce leaks and ensure consistent size, model, and serial reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->