### PR TITLE
Fix SonarQube AutoCloseable findings for borrowed CF references

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
@@ -250,25 +250,23 @@ public final class IOReportClientFFM {
     private long extractGpuEnergyMicrojoules(MemorySegment delta) throws Throwable {
         CFStringRef channelsKey = CFStringRef.createCFString(KEY_CHANNELS);
         try (channelsKey) {
-            MemorySegment arrSeg = new CFDictionaryRef(delta).getValue(channelsKey);
+            MemorySegment arrSeg = CFDictionaryRef.getValue(delta, channelsKey);
             if (arrSeg.equals(MemorySegment.NULL)) {
                 return -1L;
             }
-            CFArrayRef arr = new CFArrayRef(arrSeg);
-            int count = arr.getCount();
+            int count = CFArrayRef.getCount(arrSeg);
             for (int i = 0; i < count; i++) {
-                MemorySegment entrySeg = arr.getValueAtIndex(i);
+                MemorySegment entrySeg = CFArrayRef.getValueAtIndex(arrSeg, i);
                 if (entrySeg.equals(MemorySegment.NULL)) {
                     continue;
                 }
                 MemorySegment groupSeg = IOReportFunctions.IOReportChannelGetGroup(entrySeg);
-                if (groupSeg.equals(MemorySegment.NULL)
-                        || !GROUP_ENERGY.equals(new CFStringRef(groupSeg).stringValue())) {
+                if (groupSeg.equals(MemorySegment.NULL) || !GROUP_ENERGY.equals(CFStringRef.stringValue(groupSeg))) {
                     continue;
                 }
                 MemorySegment nameSeg = IOReportFunctions.IOReportChannelGetChannelName(entrySeg);
                 if (nameSeg.equals(MemorySegment.NULL)
-                        || !CHANNEL_GPU_ENERGY.equals(new CFStringRef(nameSeg).stringValue())) {
+                        || !CHANNEL_GPU_ENERGY.equals(CFStringRef.stringValue(nameSeg))) {
                     continue;
                 }
                 return IOReportFunctions.IOReportSimpleGetIntegerValue(entrySeg, 0);
@@ -280,25 +278,24 @@ public final class IOReportClientFFM {
     private Map<String, Long> extractChannelStates(MemorySegment dict, String group, String subgroup) throws Throwable {
         CFStringRef channelsKey = CFStringRef.createCFString(KEY_CHANNELS);
         try (channelsKey) {
-            MemorySegment arrSeg = new CFDictionaryRef(dict).getValue(channelsKey);
+            MemorySegment arrSeg = CFDictionaryRef.getValue(dict, channelsKey);
             if (arrSeg.equals(MemorySegment.NULL)) {
                 return Collections.emptyMap();
             }
-            CFArrayRef arr = new CFArrayRef(arrSeg);
-            int count = arr.getCount();
+            int count = CFArrayRef.getCount(arrSeg);
             Map<String, Long> result = new HashMap<>();
             for (int i = 0; i < count; i++) {
-                MemorySegment entrySeg = arr.getValueAtIndex(i);
+                MemorySegment entrySeg = CFArrayRef.getValueAtIndex(arrSeg, i);
                 if (entrySeg.equals(MemorySegment.NULL)) {
                     continue;
                 }
                 MemorySegment groupSeg = IOReportFunctions.IOReportChannelGetGroup(entrySeg);
-                if (groupSeg.equals(MemorySegment.NULL) || !group.equals(new CFStringRef(groupSeg).stringValue())) {
+                if (groupSeg.equals(MemorySegment.NULL) || !group.equals(CFStringRef.stringValue(groupSeg))) {
                     continue;
                 }
                 if (subgroup != null) {
                     MemorySegment subSeg = IOReportFunctions.IOReportChannelGetSubGroup(entrySeg);
-                    if (subSeg.equals(MemorySegment.NULL) || !subgroup.equals(new CFStringRef(subSeg).stringValue())) {
+                    if (subSeg.equals(MemorySegment.NULL) || !subgroup.equals(CFStringRef.stringValue(subSeg))) {
                         continue;
                     }
                 }
@@ -308,7 +305,7 @@ public final class IOReportClientFFM {
                     if (nameSeg.equals(MemorySegment.NULL)) {
                         continue;
                     }
-                    String stateName = new CFStringRef(nameSeg).stringValue();
+                    String stateName = CFStringRef.stringValue(nameSeg);
                     long ticks = IOReportFunctions.IOReportStateGetResidency(entrySeg, s);
                     if (!stateName.isEmpty()) {
                         result.merge(stateName, ticks, Long::sum);

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/WindowInfoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/WindowInfoFFM.java
@@ -86,22 +86,21 @@ public final class WindowInfoFFM {
                         if (dictSeg.equals(MemorySegment.NULL)) {
                             continue;
                         }
-                        CFDictionaryRef windowRef = new CFDictionaryRef(dictSeg);
 
                         // kCGWindowIsOnscreen is optional — absent means visible
-                        MemorySegment onscreenSeg = windowRef.getValue(kCGWindowIsOnscreen);
+                        MemorySegment onscreenSeg = CFDictionaryRef.getValue(dictSeg, kCGWindowIsOnscreen);
                         boolean visible = onscreenSeg.equals(MemorySegment.NULL)
-                                || new CFBooleanRef(onscreenSeg).booleanValue();
+                                || CFBooleanRef.booleanValue(onscreenSeg);
                         if (visibleOnly && !visible) {
                             continue;
                         }
 
-                        long windowNumber = new CFNumberRef(windowRef.getValue(kCGWindowNumber)).longValue();
-                        long ownerPID = new CFNumberRef(windowRef.getValue(kCGWindowOwnerPID)).longValue();
-                        int windowLayer = new CFNumberRef(windowRef.getValue(kCGWindowLayer)).intValue();
+                        long windowNumber = CFNumberRef.longValue(CFDictionaryRef.getValue(dictSeg, kCGWindowNumber));
+                        long ownerPID = CFNumberRef.longValue(CFDictionaryRef.getValue(dictSeg, kCGWindowOwnerPID));
+                        int windowLayer = CFNumberRef.intValue(CFDictionaryRef.getValue(dictSeg, kCGWindowLayer));
 
                         // Parse CGRect from the bounds dictionary
-                        MemorySegment boundsSeg = windowRef.getValue(kCGWindowBounds);
+                        MemorySegment boundsSeg = CFDictionaryRef.getValue(dictSeg, kCGWindowBounds);
                         MemorySegment rectBuf = arena.allocate(CG_RECT);
                         Rectangle windowBounds = new Rectangle();
                         if (!boundsSeg.equals(MemorySegment.NULL)
@@ -116,8 +115,10 @@ public final class WindowInfoFFM {
                                     FormatUtil.roundToInt(w), FormatUtil.roundToInt(h));
                         }
 
-                        String windowName = CFUtilFFM.cfPointerToString(windowRef.getValue(kCGWindowName), false);
-                        String ownerName = CFUtilFFM.cfPointerToString(windowRef.getValue(kCGWindowOwnerName), false);
+                        String windowName = CFUtilFFM
+                                .cfPointerToString(CFDictionaryRef.getValue(dictSeg, kCGWindowName), false);
+                        String ownerName = CFUtilFFM
+                                .cfPointerToString(CFDictionaryRef.getValue(dictSeg, kCGWindowOwnerName), false);
                         if (windowName.isEmpty()) {
                             windowName = ownerName;
                         } else {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/mac/CoreFoundation.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/mac/CoreFoundation.java
@@ -213,6 +213,27 @@ public interface CoreFoundation {
         }
 
         /**
+         * Extract a long value from a borrowed CFNumber segment without creating an AutoCloseable instance.
+         *
+         * @param segment The memory segment pointing to a CFNumber
+         * @return The long value, or 0 if null
+         */
+        public static long longValue(MemorySegment segment) {
+            if (segment == null || segment.equals(MemorySegment.NULL)) {
+                return 0;
+            }
+            return getLongOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_LONG);
+                    if (CFNumberGetValue(segment, kCFNumberLongLongType, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_LONG, 0);
+                    }
+                    return 0L;
+                }
+            }, 0);
+        }
+
+        /**
          * Convert this CFNumber to an int
          *
          * @return The int value
@@ -225,6 +246,27 @@ public interface CoreFoundation {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_INT);
                     if (CFNumberGetValue(segment(), kCFNumberIntType, valuePtr)) {
+                        return valuePtr.get(ValueLayout.JAVA_INT, 0);
+                    }
+                    return 0;
+                }
+            }, 0);
+        }
+
+        /**
+         * Extract an int value from a borrowed CFNumber segment without creating an AutoCloseable instance.
+         *
+         * @param segment The memory segment pointing to a CFNumber
+         * @return The int value, or 0 if null
+         */
+        public static int intValue(MemorySegment segment) {
+            if (segment == null || segment.equals(MemorySegment.NULL)) {
+                return 0;
+            }
+            return getIntOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_INT);
+                    if (CFNumberGetValue(segment, kCFNumberIntType, valuePtr)) {
                         return valuePtr.get(ValueLayout.JAVA_INT, 0);
                     }
                     return 0;
@@ -335,6 +377,19 @@ public interface CoreFoundation {
             }
             return getBooleanOrDefault(() -> CFBooleanGetValue(segment()) != 0, false);
         }
+
+        /**
+         * Extract a boolean value from a borrowed CFBoolean segment without creating an AutoCloseable instance.
+         *
+         * @param segment The memory segment pointing to a CFBoolean
+         * @return The boolean value, or false if null
+         */
+        public static boolean booleanValue(MemorySegment segment) {
+            if (segment == null || segment.equals(MemorySegment.NULL)) {
+                return false;
+            }
+            return getBooleanOrDefault(() -> CFBooleanGetValue(segment) != 0, false);
+        }
     }
 
     /**
@@ -361,6 +416,19 @@ public interface CoreFoundation {
         }
 
         /**
+         * Get the count of items from a borrowed CFArray segment without creating an AutoCloseable instance.
+         *
+         * @param array The memory segment pointing to a CFArray
+         * @return Number of items, or 0 if null
+         */
+        public static int getCount(MemorySegment array) {
+            if (array == null || array.equals(MemorySegment.NULL)) {
+                return 0;
+            }
+            return getIntOrDefault(() -> (int) CFArrayGetCount(array), 0);
+        }
+
+        /**
          * Get a value at the specified index
          *
          * @param idx The index
@@ -371,6 +439,21 @@ public interface CoreFoundation {
                 return MemorySegment.NULL;
             }
             return getOrDefault(() -> CFArrayGetValueAtIndex(segment(), idx), MemorySegment.NULL);
+        }
+
+        /**
+         * Get a value at the specified index from a borrowed CFArray segment without creating an AutoCloseable
+         * instance.
+         *
+         * @param array The memory segment pointing to a CFArray
+         * @param idx   The index
+         * @return The value at that index, or NULL if null
+         */
+        public static MemorySegment getValueAtIndex(MemorySegment array, int idx) {
+            if (array == null || array.equals(MemorySegment.NULL)) {
+                return MemorySegment.NULL;
+            }
+            return getOrDefault(() -> CFArrayGetValueAtIndex(array, idx), MemorySegment.NULL);
         }
     }
 
@@ -450,6 +533,20 @@ public interface CoreFoundation {
                 return MemorySegment.NULL;
             }
             return getOrDefault(() -> CFDictionaryGetValue(segment(), key.segment()), MemorySegment.NULL);
+        }
+
+        /**
+         * Get a value from a borrowed CFDictionary segment without creating an AutoCloseable instance.
+         *
+         * @param dict The memory segment pointing to a CFDictionary
+         * @param key  The key
+         * @return The value associated with the key, or NULL if not found
+         */
+        public static MemorySegment getValue(MemorySegment dict, CFTypeRef key) {
+            if (dict == null || dict.equals(MemorySegment.NULL) || key == null || key.isNull()) {
+                return MemorySegment.NULL;
+            }
+            return getOrDefault(() -> CFDictionaryGetValue(dict, key.segment()), MemorySegment.NULL);
         }
 
         /**
@@ -559,6 +656,39 @@ public interface CoreFoundation {
                     MemorySegment buf = arena.allocate(maxSize + 1);
 
                     if (CFStringGetCString(segment(), buf, maxSize + 1, kCFStringEncodingUTF8)) {
+                        return buf.getString(0);
+                    }
+
+                    throw new IllegalArgumentException("CFString conversion failed or buffer too small.");
+                }
+            }, "");
+        }
+
+        /**
+         * Extract a String value from a borrowed CFString segment without creating an AutoCloseable instance.
+         *
+         * @param segment The memory segment pointing to a CFString
+         * @return The String value, or empty string if null
+         */
+        public static String stringValue(MemorySegment segment) {
+            if (segment == null || segment.equals(MemorySegment.NULL)) {
+                return "";
+            }
+            return getOrDefault(() -> {
+                try (Arena arena = Arena.ofConfined()) {
+                    long length = CFStringGetLength(segment);
+                    if (length == 0) {
+                        return "";
+                    }
+
+                    long maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
+                    if (maxSize == CoreFoundation.kCFNotFound) {
+                        throw new StringIndexOutOfBoundsException("CFString maximum number of bytes exceeds LONG_MAX.");
+                    }
+
+                    MemorySegment buf = arena.allocate(maxSize + 1);
+
+                    if (CFStringGetCString(segment, buf, maxSize + 1, kCFStringEncodingUTF8)) {
                         return buf.getString(0);
                     }
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/CFUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/CFUtilFFM.java
@@ -39,11 +39,7 @@ public final class CFUtilFFM {
     public static String cfPointerToString(MemorySegment segment, boolean returnUnknown) {
         String s = "";
         if (segment != null && !segment.equals(MemorySegment.NULL)) {
-            CFStringRef cfString = null;
-            cfString = new CFStringRef(segment);
-            s = cfString.stringValue();
-            // No need to release the string since we didn't create it,
-            // just accessed an existing one
+            s = CFStringRef.stringValue(segment);
         }
         if (returnUnknown && s.isEmpty()) {
             return Constants.UNKNOWN;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -108,14 +108,14 @@ final class MacGpuStatsFFM implements GpuStats {
             try (coreUtilKey) {
                 MemorySegment result = perfStats.getValue(coreUtilKey);
                 if (!result.equals(MemorySegment.NULL)) {
-                    return new CFNumberRef(result).longValue() / GPU_UTIL_DIVISOR * 100.0;
+                    return CFNumberRef.longValue(result) / GPU_UTIL_DIVISOR * 100.0;
                 }
             }
             CFStringRef devUtilKey = CFStringRef.createCFString(DEVICE_UTIL_KEY);
             try (devUtilKey) {
                 MemorySegment result = perfStats.getValue(devUtilKey);
                 if (!result.equals(MemorySegment.NULL)) {
-                    return new CFNumberRef(result).longValue();
+                    return CFNumberRef.longValue(result);
                 }
             }
         }
@@ -136,14 +136,14 @@ final class MacGpuStatsFFM implements GpuStats {
             try (key) {
                 MemorySegment result = perfStats.getValue(key);
                 if (!result.equals(MemorySegment.NULL)) {
-                    return new CFNumberRef(result).longValue();
+                    return CFNumberRef.longValue(result);
                 }
             }
             CFStringRef fallback = CFStringRef.createCFString(fallbackKey);
             try (fallback) {
                 MemorySegment result = perfStats.getValue(fallback);
                 if (!result.equals(MemorySegment.NULL)) {
-                    return new CFNumberRef(result).longValue();
+                    return CFNumberRef.longValue(result);
                 }
             }
         }
@@ -181,7 +181,7 @@ final class MacGpuStatsFFM implements GpuStats {
             try (tempKey) {
                 MemorySegment result = perfStats.getValue(tempKey);
                 if (!result.equals(MemorySegment.NULL)) {
-                    long val = new CFNumberRef(result).longValue();
+                    long val = CFNumberRef.longValue(result);
                     if (val > 0) {
                         return val;
                     }
@@ -243,7 +243,7 @@ final class MacGpuStatsFFM implements GpuStats {
                         try (props) {
                             MemorySegment modelSeg = props.getValue(modelKey);
                             if (!modelSeg.equals(MemorySegment.NULL)) {
-                                String model = new CFStringRef(modelSeg).stringValue();
+                                String model = CFStringRef.stringValue(modelSeg);
                                 if (matchesName(model)) {
                                     MemorySegment statsSeg = props.getValue(perfStatsKey);
                                     if (!statsSeg.equals(MemorySegment.NULL)) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -59,20 +59,22 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
     @Override
     public boolean updateAttributes() {
         try {
+            @SuppressWarnings("resource") // CFAllocatorGetDefault returns a borrowed singleton
             CFAllocatorRef alloc = new CFAllocatorRef(CoreFoundationFunctions.CFAllocatorGetDefault());
-            DASessionRef session = DASessionRef.create(alloc);
-            if (session.isNull()) {
-                LOG.error("Unable to open session to DiskArbitration framework.");
-                return false;
-            }
-            Map<CFKey, CFStringRef> cfKeyMap = null;
-            try (session) {
-                cfKeyMap = mapCFKeys();
-                return updateDiskStats(session, FsstatFFM.queryPartitionToMountMap(), cfKeyMap);
-            } finally {
-                if (cfKeyMap != null) {
-                    for (CFStringRef value : cfKeyMap.values()) {
-                        value.release();
+            try (DASessionRef session = DASessionRef.create(alloc)) {
+                if (session.isNull()) {
+                    LOG.error("Unable to open session to DiskArbitration framework.");
+                    return false;
+                }
+                Map<CFKey, CFStringRef> cfKeyMap = null;
+                try {
+                    cfKeyMap = mapCFKeys();
+                    return updateDiskStats(session, FsstatFFM.queryPartitionToMountMap(), cfKeyMap);
+                } finally {
+                    if (cfKeyMap != null) {
+                        for (CFStringRef value : cfKeyMap.values()) {
+                            value.release();
+                        }
                     }
                 }
             }
@@ -111,32 +113,34 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                             try (CFDictionaryRef properties = new CFDictionaryRef(propertiesSeg)) {
                                 MemorySegment result = properties.getValue(cfKeyMap.get(CFKey.STATISTICS));
                                 if (!result.equals(MemorySegment.NULL)) {
-                                    CFDictionaryRef statistics = new CFDictionaryRef(result);
+                                    MemorySegment statsSeg = result;
                                     setTimeStamp(System.currentTimeMillis());
 
-                                    result = statistics.getValue(cfKeyMap.get(CFKey.READ_OPS));
+                                    result = CFDictionaryRef.getValue(statsSeg, cfKeyMap.get(CFKey.READ_OPS));
                                     if (!result.equals(MemorySegment.NULL)) {
-                                        setReads(new CFNumberRef(result).longValue());
+                                        setReads(CFNumberRef.longValue(result));
                                     }
-                                    result = statistics.getValue(cfKeyMap.get(CFKey.READ_BYTES));
+                                    result = CFDictionaryRef.getValue(statsSeg, cfKeyMap.get(CFKey.READ_BYTES));
                                     if (!result.equals(MemorySegment.NULL)) {
-                                        setReadBytes(new CFNumberRef(result).longValue());
+                                        setReadBytes(CFNumberRef.longValue(result));
                                     }
-                                    result = statistics.getValue(cfKeyMap.get(CFKey.WRITE_OPS));
+                                    result = CFDictionaryRef.getValue(statsSeg, cfKeyMap.get(CFKey.WRITE_OPS));
                                     if (!result.equals(MemorySegment.NULL)) {
-                                        setWrites(new CFNumberRef(result).longValue());
+                                        setWrites(CFNumberRef.longValue(result));
                                     }
-                                    result = statistics.getValue(cfKeyMap.get(CFKey.WRITE_BYTES));
+                                    result = CFDictionaryRef.getValue(statsSeg, cfKeyMap.get(CFKey.WRITE_BYTES));
                                     if (!result.equals(MemorySegment.NULL)) {
-                                        setWriteBytes(new CFNumberRef(result).longValue());
+                                        setWriteBytes(CFNumberRef.longValue(result));
                                     }
 
-                                    MemorySegment readTimeResult = statistics.getValue(cfKeyMap.get(CFKey.READ_TIME));
-                                    MemorySegment writeTimeResult = statistics.getValue(cfKeyMap.get(CFKey.WRITE_TIME));
+                                    MemorySegment readTimeResult = CFDictionaryRef.getValue(statsSeg,
+                                            cfKeyMap.get(CFKey.READ_TIME));
+                                    MemorySegment writeTimeResult = CFDictionaryRef.getValue(statsSeg,
+                                            cfKeyMap.get(CFKey.WRITE_TIME));
                                     if (!readTimeResult.equals(MemorySegment.NULL)
                                             && !writeTimeResult.equals(MemorySegment.NULL)) {
-                                        long xferTime = new CFNumberRef(readTimeResult).longValue();
-                                        xferTime += new CFNumberRef(writeTimeResult).longValue();
+                                        long xferTime = CFNumberRef.longValue(readTimeResult);
+                                        xferTime += CFNumberRef.longValue(writeTimeResult);
                                         setTransferTime(xferTime / 1_000_000L);
                                     }
                                 }
@@ -155,8 +159,10 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                             MemorySegment cfFalseSeg = driveProps.getValue(cfKeyMap.get(CFKey.LEAF));
 
                             try {
+                                @SuppressWarnings("resource") // CFAllocatorGetDefault returns a borrowed singleton
                                 CFAllocatorRef alloc = new CFAllocatorRef(
                                         CoreFoundationFunctions.CFAllocatorGetDefault());
+                                @SuppressWarnings("resource") // propertyDict is consumed by partMatchingDict
                                 CFMutableDictionaryRef propertyDict = new CFMutableDictionaryRef(
                                         CoreFoundationFunctions.CFDictionaryCreateMutable(alloc.segment(), 0,
                                                 MemorySegment.NULL, MemorySegment.NULL));
@@ -167,6 +173,7 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                                     propertyDict.setValue(cfKeyMap.get(CFKey.WHOLE), new CFTypeRef(cfFalseSeg));
                                 }
 
+                                @SuppressWarnings("resource") // partMatchingDict is consumed by getMatchingServices
                                 CFMutableDictionaryRef partMatchingDict = new CFMutableDictionaryRef(
                                         CoreFoundationFunctions.CFDictionaryCreateMutable(alloc.segment(), 0,
                                                 MemorySegment.NULL, MemorySegment.NULL));
@@ -244,13 +251,13 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
         List<HWDiskStore> diskList = new ArrayList<>();
 
         try {
+            @SuppressWarnings("resource") // CFAllocatorGetDefault returns a borrowed singleton
             CFAllocatorRef alloc = new CFAllocatorRef(CoreFoundationFunctions.CFAllocatorGetDefault());
-            DASessionRef session = DASessionRef.create(alloc);
-            if (session.isNull()) {
-                LOG.error("Unable to open session to DiskArbitration framework.");
-                return Collections.emptyList();
-            }
-            try (session) {
+            try (DASessionRef session = DASessionRef.create(alloc)) {
+                if (session.isNull()) {
+                    LOG.error("Unable to open session to DiskArbitration framework.");
+                    return Collections.emptyList();
+                }
                 List<String> bsdNames = new ArrayList<>();
                 IOIterator iter = IOKitUtilFFM.getMatchingServices("IOMedia");
                 if (iter != null) {
@@ -281,26 +288,27 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                     long size = 0L;
 
                     String path = "/dev/" + bsdName;
-                    DADiskRef disk = DADiskRef.createFromBSDName(alloc, session, path);
-                    if (disk.isNull()) {
-                        continue;
-                    }
-                    try (disk) {
+                    try (DADiskRef disk = DADiskRef.createFromBSDName(alloc, session, path)) {
+                        if (disk.isNull()) {
+                            continue;
+                        }
                         try (CFDictionaryRef diskInfo = disk.copyDescription()) {
                             if (!diskInfo.isNull()) {
                                 MemorySegment result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_DEVICE_MODEL));
                                 model = CFUtilFFM.cfPointerToString(result);
                                 result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_MEDIA_SIZE));
                                 if (!result.equals(MemorySegment.NULL)) {
-                                    size = new CFNumberRef(result).longValue();
+                                    size = CFNumberRef.longValue(result);
                                 }
 
                                 if (!"Disk Image".equals(model)) {
                                     try (CFStringRef modelNameRef = CFStringRef.createCFString(model)) {
+                                        @SuppressWarnings("resource") // consumed by matchingDict
                                         CFMutableDictionaryRef propertyDict = new CFMutableDictionaryRef(
                                                 CoreFoundationFunctions.CFDictionaryCreateMutable(alloc.segment(), 0,
                                                         MemorySegment.NULL, MemorySegment.NULL));
                                         propertyDict.setValue(cfKeyMap.get(CFKey.MODEL), modelNameRef);
+                                        @SuppressWarnings("resource") // consumed by getMatchingServices
                                         CFMutableDictionaryRef matchingDict = new CFMutableDictionaryRef(
                                                 CoreFoundationFunctions.CFDictionaryCreateMutable(alloc.segment(), 0,
                                                         MemorySegment.NULL, MemorySegment.NULL));
@@ -399,12 +407,12 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                                                 .createCFString("Device Characteristics")) {
                                             MemorySegment charSeg = props.getValue(devCharKey);
                                             if (!charSeg.equals(MemorySegment.NULL)) {
-                                                CFDictionaryRef chars = new CFDictionaryRef(charSeg);
                                                 try (CFStringRef medTypeKey = CFStringRef
                                                         .createCFString("Medium Type")) {
-                                                    MemorySegment typeSeg = chars.getValue(medTypeKey);
+                                                    MemorySegment typeSeg = CFDictionaryRef.getValue(charSeg,
+                                                            medTypeKey);
                                                     if (!typeSeg.equals(MemorySegment.NULL)) {
-                                                        String type = new CFStringRef(typeSeg).stringValue();
+                                                        String type = CFStringRef.stringValue(typeSeg);
                                                         if (type != null) {
                                                             if (type.contains("Solid State") || type.contains("SSD")) {
                                                                 return "SSD";

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
@@ -52,11 +52,10 @@ public final class MacNetworkIfFFM extends MacNetworkIF {
                     MemorySegment pNetIf = cfArray.getValueAtIndex(i);
                     MemorySegment cfNameSeg = SCNetworkInterfaceGetBSDName(pNetIf);
                     if (!cfNameSeg.equals(MemorySegment.NULL)) {
-                        CFStringRef cfName = new CFStringRef(cfNameSeg);
-                        if (name.equals(cfName.stringValue())) {
+                        if (name.equals(CFStringRef.stringValue(cfNameSeg))) {
                             MemorySegment cfDisplayNameSeg = SCNetworkInterfaceGetLocalizedDisplayName(pNetIf);
                             if (!cfDisplayNameSeg.equals(MemorySegment.NULL)) {
-                                return new CFStringRef(cfDisplayNameSeg).stringValue();
+                                return CFStringRef.stringValue(cfDisplayNameSeg);
                             }
                         }
                     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
@@ -184,24 +184,24 @@ public final class MacPowerSourceFFM extends MacPowerSource {
                     for (int ps = 0; ps < powerSourcesCount; ps++) {
                         MemorySegment pwrSrcPtr = cfList.getValueAtIndex(ps);
                         MemorySegment dictionary = IOPSGetPowerSourceDescription(powerSourcesInfo, pwrSrcPtr);
+                        @SuppressWarnings("resource") // borrowed ref from IOPSGetPowerSourceDescription
                         CFDictionaryRef dict = new CFDictionaryRef(dictionary);
 
                         MemorySegment result = dict.getValue(isPresentKey);
                         if (!result.equals(MemorySegment.NULL)) {
-                            CFBooleanRef isPresentRef = new CFBooleanRef(result);
-                            if (isPresentRef.booleanValue()) {
+                            if (CFBooleanRef.booleanValue(result)) {
                                 result = dict.getValue(nameKey);
                                 String psName = CFUtilFFM.cfPointerToString(result);
 
                                 double currentCapacity = 0d;
                                 if (dict.getValueIfPresent(currentCapacityKey, MemorySegment.NULL)) {
                                     result = dict.getValue(currentCapacityKey);
-                                    currentCapacity = new CFNumberRef(result).intValue();
+                                    currentCapacity = CFNumberRef.intValue(result);
                                 }
                                 double maxCapacity = 1d;
                                 if (dict.getValueIfPresent(maxCapacityKey, MemorySegment.NULL)) {
                                     result = dict.getValue(maxCapacityKey);
-                                    maxCapacity = new CFNumberRef(result).intValue();
+                                    maxCapacity = CFNumberRef.intValue(result);
                                 }
                                 double psRemainingCapacityPercent = maxCapacity <= 0 ? 0d
                                         : Math.min(1d, currentCapacity / maxCapacity);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
@@ -81,14 +81,13 @@ public class MacFileSystemFFM extends MacFileSystem {
 
             // Open a DiskArbitration session to get VolumeName of file systems
             // with bsd names
+            @SuppressWarnings("resource") // CFAllocatorGetDefault returns a borrowed singleton
             CFAllocatorRef allocator = new CFAllocatorRef(CFAllocatorGetDefault());
-            DASessionRef session = new DASessionRef(DASessionCreate(allocator.segment()));
-            if (session.segment() == null) {
-                LOG.error("Unable to open session to DiskArbitration framework.");
-                return fsList;
-            }
-
-            try (session) {
+            try (DASessionRef session = new DASessionRef(DASessionCreate(allocator.segment()))) {
+                if (session.segment() == null) {
+                    LOG.error("Unable to open session to DiskArbitration framework.");
+                    return fsList;
+                }
                 CFStringRef daVolumeNameKey = CFStringRef.createCFString("DAVolumeName");
                 try (daVolumeNameKey) {
                     for (int f = 0; f < numfs; f++) {

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/HkeyUserData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/HkeyUserData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.registry;
@@ -51,28 +51,31 @@ public final class HkeyUserData {
                     String keyPath = sidKey + PATH_DELIMITER + VOLATILE_ENV_SUBKEY;
                     if (Advapi32Util.registryKeyExists(WinReg.HKEY_USERS, keyPath)) {
                         HKEY hKey = Advapi32Util.registryGetKey(WinReg.HKEY_USERS, keyPath, WinNT.KEY_READ).getValue();
-                        // InfoKey write time is user login time
-                        InfoKey info = Advapi32Util.registryQueryInfoKey(hKey, 0);
-                        loginTime = info.lpftLastWriteTime.toTime();
-                        for (String subKey : Advapi32Util.registryGetKeys(hKey)) {
-                            String subKeyPath = keyPath + PATH_DELIMITER + subKey;
-                            // Check for session and client name
-                            if (Advapi32Util.registryValueExists(WinReg.HKEY_USERS, subKeyPath, SESSIONNAME)) {
-                                String session = Advapi32Util.registryGetStringValue(WinReg.HKEY_USERS, subKeyPath,
-                                        SESSIONNAME);
-                                if (!session.isEmpty()) {
-                                    device = session;
+                        try {
+                            // InfoKey write time is user login time
+                            InfoKey info = Advapi32Util.registryQueryInfoKey(hKey, 0);
+                            loginTime = info.lpftLastWriteTime.toTime();
+                            for (String subKey : Advapi32Util.registryGetKeys(hKey)) {
+                                String subKeyPath = keyPath + PATH_DELIMITER + subKey;
+                                // Check for session and client name
+                                if (Advapi32Util.registryValueExists(WinReg.HKEY_USERS, subKeyPath, SESSIONNAME)) {
+                                    String session = Advapi32Util.registryGetStringValue(WinReg.HKEY_USERS, subKeyPath,
+                                            SESSIONNAME);
+                                    if (!session.isEmpty()) {
+                                        device = session;
+                                    }
+                                }
+                                if (Advapi32Util.registryValueExists(WinReg.HKEY_USERS, subKeyPath, CLIENTNAME)) {
+                                    String client = Advapi32Util.registryGetStringValue(WinReg.HKEY_USERS, subKeyPath,
+                                            CLIENTNAME);
+                                    if (!client.isEmpty() && !DEFAULT_DEVICE.equals(client)) {
+                                        host = client;
+                                    }
                                 }
                             }
-                            if (Advapi32Util.registryValueExists(WinReg.HKEY_USERS, subKeyPath, CLIENTNAME)) {
-                                String client = Advapi32Util.registryGetStringValue(WinReg.HKEY_USERS, subKeyPath,
-                                        CLIENTNAME);
-                                if (!client.isEmpty() && !DEFAULT_DEVICE.equals(client)) {
-                                    host = client;
-                                }
-                            }
+                        } finally {
+                            Advapi32Util.registryCloseKey(hKey);
                         }
-                        Advapi32Util.registryCloseKey(hKey);
                     }
                     sessions.add(new OSSession(name, device, loginTime, host));
                 } catch (Win32Exception ex) {

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessWtsData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessWtsData.java
@@ -69,20 +69,23 @@ public final class ProcessWtsData {
             }
             // extract the pointed-to pointer and create array
             Pointer pProcessInfo = ppProcessInfo.getValue();
-            final WTS_PROCESS_INFO_EX processInfoRef = new WTS_PROCESS_INFO_EX(pProcessInfo);
-            WTS_PROCESS_INFO_EX[] processInfo = (WTS_PROCESS_INFO_EX[]) processInfoRef.toArray(pCount.getValue());
-            for (WTS_PROCESS_INFO_EX info : processInfo) {
-                if (pids == null || pids.contains(info.ProcessId)) {
-                    wtsMap.put(info.ProcessId,
-                            new WtsInfo(info.pProcessName, "", info.NumberOfThreads, info.PagefileUsage & 0xffff_ffffL,
-                                    info.KernelTime.getValue() / 10_000L, info.UserTime.getValue() / 10_000,
-                                    info.HandleCount));
+            try {
+                final WTS_PROCESS_INFO_EX processInfoRef = new WTS_PROCESS_INFO_EX(pProcessInfo);
+                WTS_PROCESS_INFO_EX[] processInfo = (WTS_PROCESS_INFO_EX[]) processInfoRef.toArray(pCount.getValue());
+                for (WTS_PROCESS_INFO_EX info : processInfo) {
+                    if (pids == null || pids.contains(info.ProcessId)) {
+                        wtsMap.put(info.ProcessId,
+                                new WtsInfo(info.pProcessName, "", info.NumberOfThreads,
+                                        info.PagefileUsage & 0xffff_ffffL, info.KernelTime.getValue() / 10_000L,
+                                        info.UserTime.getValue() / 10_000, info.HandleCount));
+                    }
                 }
-            }
-            // Clean up memory
-            if (!Wtsapi32.INSTANCE.WTSFreeMemoryEx(Wtsapi32.WTS_PROCESS_INFO_LEVEL_1, pProcessInfo,
-                    pCount.getValue())) {
-                LOG.warn("Failed to Free Memory for Processes. Error code: {}", Kernel32.INSTANCE.GetLastError());
+            } finally {
+                // Clean up memory
+                if (!Wtsapi32.INSTANCE.WTSFreeMemoryEx(Wtsapi32.WTS_PROCESS_INFO_LEVEL_1, pProcessInfo,
+                        pCount.getValue())) {
+                    LOG.warn("Failed to Free Memory for Processes. Error code: {}", Kernel32.INSTANCE.GetLastError());
+                }
             }
         }
         return wtsMap;

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/SessionWtsData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/SessionWtsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.registry;
@@ -56,57 +56,89 @@ public final class SessionWtsData {
                     CloseableIntByReference pBytes = new CloseableIntByReference()) {
                 if (WTS.WTSEnumerateSessions(Wtsapi32.WTS_CURRENT_SERVER_HANDLE, 0, 1, ppSessionInfo, pCount)) {
                     Pointer pSessionInfo = ppSessionInfo.getValue();
-                    if (pCount.getValue() > 0) {
-                        WTS_SESSION_INFO sessionInfoRef = new WTS_SESSION_INFO(pSessionInfo);
-                        WTS_SESSION_INFO[] sessionInfo = (WTS_SESSION_INFO[]) sessionInfoRef.toArray(pCount.getValue());
-                        for (WTS_SESSION_INFO session : sessionInfo) {
-                            if (session.State == WTS_ACTIVE) {
-                                // Use session id to fetch additional session information
-                                WTS.WTSQuerySessionInformation(Wtsapi32.WTS_CURRENT_SERVER_HANDLE, session.SessionId,
-                                        WTS_CLIENTPROTOCOLTYPE, ppBuffer, pBytes);
-                                Pointer pBuffer = ppBuffer.getValue(); // pointer to USHORT
-                                short protocolType = pBuffer.getShort(0); // 0 = console, 2 = RDP
-                                WTS.WTSFreeMemory(pBuffer);
-                                // We've already got console from registry, only test RDP
-                                if (protocolType > 0) {
-                                    // DEVICE
-                                    String device = session.pWinStationName;
-                                    // USER and LOGIN TIME
-                                    WTS.WTSQuerySessionInformation(Wtsapi32.WTS_CURRENT_SERVER_HANDLE,
-                                            session.SessionId, WTS_SESSIONINFO, ppBuffer, pBytes);
-                                    pBuffer = ppBuffer.getValue(); // returns WTSINFO
-                                    WTSINFO wtsInfo = new WTSINFO(pBuffer);
-                                    // Temporary due to broken LARGE_INTEGER, remove in JNA 5.6.0
-                                    long logonTime = new WinBase.FILETIME(
-                                            new WinNT.LARGE_INTEGER(wtsInfo.LogonTime.getValue())).toTime();
-                                    String userName = wtsInfo.getUserName();
-                                    WTS.WTSFreeMemory(pBuffer);
-                                    // HOST
-                                    WTS.WTSQuerySessionInformation(Wtsapi32.WTS_CURRENT_SERVER_HANDLE,
-                                            session.SessionId, WTS_CLIENTADDRESS, ppBuffer, pBytes);
-                                    pBuffer = ppBuffer.getValue(); // returns WTS_CLIENT_ADDRESS
-                                    WTS_CLIENT_ADDRESS addr = new WTS_CLIENT_ADDRESS(pBuffer);
-                                    WTS.WTSFreeMemory(pBuffer);
-                                    String host = "::";
-                                    if (addr.AddressFamily == IPHlpAPI.AF_INET) {
-                                        try {
-                                            host = InetAddress.getByAddress(Arrays.copyOfRange(addr.Address, 2, 6))
-                                                    .getHostAddress();
-                                        } catch (UnknownHostException e) {
-                                            // If array is not length of 4, shouldn't happen
-                                            host = "Illegal length IP Array";
-                                        }
-                                    } else if (addr.AddressFamily == IPHlpAPI.AF_INET6) {
-                                        // Get ints for address parsing
-                                        int[] ipArray = convertBytesToInts(addr.Address);
-                                        host = ParseUtil.parseUtAddrV6toIP(ipArray);
+                    try {
+                        if (pCount.getValue() > 0) {
+                            WTS_SESSION_INFO sessionInfoRef = new WTS_SESSION_INFO(pSessionInfo);
+                            WTS_SESSION_INFO[] sessionInfo = (WTS_SESSION_INFO[]) sessionInfoRef
+                                    .toArray(pCount.getValue());
+                            for (WTS_SESSION_INFO session : sessionInfo) {
+                                if (session.State == WTS_ACTIVE) {
+                                    // Use session id to fetch additional session information
+                                    if (!WTS.WTSQuerySessionInformation(Wtsapi32.WTS_CURRENT_SERVER_HANDLE,
+                                            session.SessionId, WTS_CLIENTPROTOCOLTYPE, ppBuffer, pBytes)) {
+                                        continue;
                                     }
-                                    sessions.add(new OSSession(userName, device, logonTime, host));
+                                    Pointer pBuffer = ppBuffer.getValue();
+                                    if (pBuffer == null) {
+                                        continue;
+                                    }
+                                    short protocolType;
+                                    try {
+                                        protocolType = pBuffer.getShort(0); // 0 = console, 2 = RDP
+                                    } finally {
+                                        WTS.WTSFreeMemory(pBuffer);
+                                    }
+                                    // We've already got console from registry, only test RDP
+                                    if (protocolType > 0) {
+                                        // DEVICE
+                                        String device = session.pWinStationName;
+                                        // USER and LOGIN TIME
+                                        if (!WTS.WTSQuerySessionInformation(Wtsapi32.WTS_CURRENT_SERVER_HANDLE,
+                                                session.SessionId, WTS_SESSIONINFO, ppBuffer, pBytes)) {
+                                            continue;
+                                        }
+                                        pBuffer = ppBuffer.getValue();
+                                        if (pBuffer == null) {
+                                            continue;
+                                        }
+                                        String userName;
+                                        long logonTime;
+                                        try {
+                                            WTSINFO wtsInfo = new WTSINFO(pBuffer);
+                                            // Temporary due to broken LARGE_INTEGER, remove in JNA 5.6.0
+                                            logonTime = new WinBase.FILETIME(
+                                                    new WinNT.LARGE_INTEGER(wtsInfo.LogonTime.getValue())).toTime();
+                                            userName = wtsInfo.getUserName();
+                                        } finally {
+                                            WTS.WTSFreeMemory(pBuffer);
+                                        }
+                                        // HOST
+                                        if (!WTS.WTSQuerySessionInformation(Wtsapi32.WTS_CURRENT_SERVER_HANDLE,
+                                                session.SessionId, WTS_CLIENTADDRESS, ppBuffer, pBytes)) {
+                                            continue;
+                                        }
+                                        pBuffer = ppBuffer.getValue();
+                                        if (pBuffer == null) {
+                                            continue;
+                                        }
+                                        WTS_CLIENT_ADDRESS addr;
+                                        try {
+                                            addr = new WTS_CLIENT_ADDRESS(pBuffer);
+                                        } finally {
+                                            WTS.WTSFreeMemory(pBuffer);
+                                        }
+                                        String host = "::";
+                                        if (addr.AddressFamily == IPHlpAPI.AF_INET) {
+                                            try {
+                                                host = InetAddress.getByAddress(Arrays.copyOfRange(addr.Address, 2, 6))
+                                                        .getHostAddress();
+                                            } catch (UnknownHostException e) {
+                                                // If array is not length of 4, shouldn't happen
+                                                host = "Illegal length IP Array";
+                                            }
+                                        } else if (addr.AddressFamily == IPHlpAPI.AF_INET6) {
+                                            // Get ints for address parsing
+                                            int[] ipArray = convertBytesToInts(addr.Address);
+                                            host = ParseUtil.parseUtAddrV6toIP(ipArray);
+                                        }
+                                        sessions.add(new OSSession(userName, device, logonTime, host));
+                                    }
                                 }
                             }
                         }
+                    } finally {
+                        WTS.WTSFreeMemory(pSessionInfo);
                     }
-                    WTS.WTSFreeMemory(pSessionInfo);
                 }
             }
         }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
@@ -65,16 +65,19 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
             LOG.error("Unable to open session to DiskArbitration framework.");
             return false;
         }
-        Map<CFKey, CFStringRef> cfKeyMap = mapCFKeys();
-        // Execute the update
-        boolean diskFound = updateDiskStats(session, Fsstat.queryPartitionToMountMap(), cfKeyMap);
-        // Release the session and CFStrings
-        session.release();
-        for (CFTypeRef value : cfKeyMap.values()) {
-            value.release();
+        try {
+            Map<CFKey, CFStringRef> cfKeyMap = mapCFKeys();
+            try {
+                // Execute the update
+                return updateDiskStats(session, Fsstat.queryPartitionToMountMap(), cfKeyMap);
+            } finally {
+                for (CFTypeRef value : cfKeyMap.values()) {
+                    value.release();
+                }
+            }
+        } finally {
+            session.release();
         }
-
-        return diskFound;
     }
 
     private boolean updateDiskStats(DASessionRef session, Map<String, String> mountPointMap,

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsDisplayJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsDisplayJNA.java
@@ -67,23 +67,28 @@ final class WindowsDisplayJNA extends AbstractDisplay {
                 for (int memberIndex = 0; SU.SetupDiEnumDeviceInfo(hDevInfo, memberIndex, info); memberIndex++) {
                     HKEY key = SU.SetupDiOpenDevRegKey(hDevInfo, info, SetupApi.DICS_FLAG_GLOBAL, 0, SetupApi.DIREG_DEV,
                             WinNT.KEY_QUERY_VALUE);
+                    try {
+                        byte[] edid = new byte[1];
 
-                    byte[] edid = new byte[1];
-
-                    try (CloseableIntByReference pType = new CloseableIntByReference();
-                            CloseableIntByReference lpcbData = new CloseableIntByReference()) {
-                        if (ADV.RegQueryValueEx(key, "EDID", 0, pType, edid, lpcbData) == WinError.ERROR_MORE_DATA) {
-                            edid = new byte[lpcbData.getValue()];
-                            if (ADV.RegQueryValueEx(key, "EDID", 0, pType, edid, lpcbData) == WinError.ERROR_SUCCESS) {
-                                Display display = new WindowsDisplayJNA(edid);
-                                displays.add(display);
+                        try (CloseableIntByReference pType = new CloseableIntByReference();
+                                CloseableIntByReference lpcbData = new CloseableIntByReference()) {
+                            if (ADV.RegQueryValueEx(key, "EDID", 0, pType, edid,
+                                    lpcbData) == WinError.ERROR_MORE_DATA) {
+                                edid = new byte[lpcbData.getValue()];
+                                if (ADV.RegQueryValueEx(key, "EDID", 0, pType, edid,
+                                        lpcbData) == WinError.ERROR_SUCCESS) {
+                                    Display display = new WindowsDisplayJNA(edid);
+                                    displays.add(display);
+                                }
                             }
                         }
+                    } finally {
+                        Advapi32.INSTANCE.RegCloseKey(key);
                     }
-                    Advapi32.INSTANCE.RegCloseKey(key);
                 }
+            } finally {
+                SU.SetupDiDestroyDeviceInfoList(hDevInfo);
             }
-            SU.SetupDiDestroyDeviceInfoList(hDevInfo);
         }
         return displays;
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
@@ -104,188 +104,197 @@ public final class WindowsPowerSourceJNA extends WindowsPowerSource {
         HANDLE hdev = SetupApi.INSTANCE.SetupDiGetClassDevs(GUID_DEVCLASS_BATTERY, null, null,
                 SetupApi.DIGCF_PRESENT | SetupApi.DIGCF_DEVICEINTERFACE);
         if (!WinBase.INVALID_HANDLE_VALUE.equals(hdev)) {
-            boolean batteryFound = false;
-            // Limit search to 100 batteries max
-            for (int idev = 0; !batteryFound && idev < 100; idev++) {
-                try (CloseableSpDeviceInterfaceData did = new CloseableSpDeviceInterfaceData();
-                        CloseableIntByReference requiredSize = new CloseableIntByReference();
-                        CloseableIntByReference dwWait = new CloseableIntByReference();
-                        CloseableIntByReference dwTag = new CloseableIntByReference();
-                        CloseableIntByReference dwOut = new CloseableIntByReference()) {
-                    did.cbSize = did.size();
-                    if (SetupApi.INSTANCE.SetupDiEnumDeviceInterfaces(hdev, null, GUID_DEVCLASS_BATTERY, idev, did)) {
-                        SetupApi.INSTANCE.SetupDiGetDeviceInterfaceDetail(hdev, did, null, 0, requiredSize, null);
-                        if (WinError.ERROR_INSUFFICIENT_BUFFER == Kernel32.INSTANCE.GetLastError()) {
-                            // PSP_DEVICE_INTERFACE_DETAIL_DATA: int size + TCHAR array
-                            try (Memory pdidd = new Memory(requiredSize.getValue())) {
-                                // pdidd->cbSize is defined as sizeof(*pdidd)
-                                // On 64 bit, cbSize is 8. On 32-bit it's 5 or 6 based on char size
-                                // This must be set properly for the method to work but is otherwise ignored
-                                pdidd.setInt(0, Integer.BYTES + (X64 ? 4 : CHAR_WIDTH));
-                                // Regardless of this setting the string portion starts after one byte
-                                if (SetupApi.INSTANCE.SetupDiGetDeviceInterfaceDetail(hdev, did, pdidd,
-                                        (int) pdidd.size(), requiredSize, null)) {
-                                    // Enumerated a battery. Ask it for information.
-                                    String devicePath = CHAR_WIDTH > 1 ? pdidd.getWideString(Integer.BYTES)
-                                            : pdidd.getString(Integer.BYTES);
-                                    HANDLE hBattery = Kernel32.INSTANCE.CreateFile(devicePath, // pdidd->DevicePath
-                                            WinNT.GENERIC_READ | WinNT.GENERIC_WRITE,
-                                            WinNT.FILE_SHARE_READ | WinNT.FILE_SHARE_WRITE, null, WinNT.OPEN_EXISTING,
-                                            WinNT.FILE_ATTRIBUTE_NORMAL, null);
-                                    if (!WinBase.INVALID_HANDLE_VALUE.equals(hBattery)) {
-                                        try (BATTERY_QUERY_INFORMATION bqi = new BATTERY_QUERY_INFORMATION();
-                                                BATTERY_INFORMATION bi = new BATTERY_INFORMATION();
-                                                BATTERY_WAIT_STATUS bws = new BATTERY_WAIT_STATUS();
-                                                BATTERY_STATUS bs = new BATTERY_STATUS();
-                                                BATTERY_MANUFACTURE_DATE bmd = new BATTERY_MANUFACTURE_DATE()) {
-                                            // Ask the battery for its tag.
-                                            if (Kernel32.INSTANCE.DeviceIoControl(hBattery, IOCTL_BATTERY_QUERY_TAG,
-                                                    dwWait.getPointer(), Integer.BYTES, dwTag.getPointer(),
-                                                    Integer.BYTES, dwOut, null)) {
-                                                bqi.BatteryTag = dwTag.getValue();
-                                                if (bqi.BatteryTag > 0) {
-                                                    // With the tag, you can query the battery info.
-                                                    bqi.InformationLevel = BATTERY_INFORMATION_LEVEL;
-                                                    bqi.write();
-
-                                                    if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
-                                                            IOCTL_BATTERY_QUERY_INFORMATION, bqi.getPointer(),
-                                                            bqi.size(), bi.getPointer(), bi.size(), dwOut, null)) {
-                                                        // Only non-UPS system batteries count
-                                                        bi.read();
-                                                        int maxCapacitySafe = 1;
-                                                        if (0 != (bi.Capabilities & BATTERY_SYSTEM_BATTERY)
-                                                                && 0 == (bi.Capabilities & BATTERY_IS_SHORT_TERM)) {
-                                                            // Capabilities flags non-mWh units
-                                                            if (0 == (bi.Capabilities & BATTERY_CAPACITY_RELATIVE)) {
-                                                                psCapacityUnits = CapacityUnits.MWH;
-                                                            }
-                                                            psChemistry = Native.toString(bi.Chemistry,
-                                                                    StandardCharsets.US_ASCII);
-                                                            psDesignCapacity = bi.DesignedCapacity;
-                                                            psMaxCapacity = bi.FullChargedCapacity;
-                                                            psCycleCount = bi.CycleCount;
-                                                            maxCapacitySafe = psMaxCapacity > 0 ? psMaxCapacity
-                                                                    : psDesignCapacity > 0 ? psDesignCapacity : 1;
-
-                                                            // Query the battery status.
-                                                            bws.BatteryTag = bqi.BatteryTag;
-                                                            bws.write();
-                                                            if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
-                                                                    IOCTL_BATTERY_QUERY_STATUS, bws.getPointer(),
-                                                                    bws.size(), bs.getPointer(), bs.size(), dwOut,
-                                                                    null)) {
-                                                                bs.read();
-                                                                if (0 != (bs.PowerState & BATTERY_POWER_ON_LINE)) {
-                                                                    psPowerOnLine = true;
-                                                                }
-                                                                if (0 != (bs.PowerState & BATTERY_DISCHARGING)) {
-                                                                    psDischarging = true;
-                                                                }
-                                                                if (0 != (bs.PowerState & BATTERY_CHARGING)) {
-                                                                    psCharging = true;
-                                                                    psTimeRemainingEstimated = -2d;
-                                                                }
-                                                                psCurrentCapacity = bs.Capacity;
-                                                                psVoltage = bs.Voltage > 0 ? bs.Voltage / 1000d
-                                                                        : bs.Voltage;
-                                                                psPowerUsageRate = bs.Rate;
-                                                                if (psVoltage > 0) {
-                                                                    psAmperage = psPowerUsageRate / psVoltage;
-                                                                }
-                                                                psRemainingCapacityPercent = Math.min(1d,
-                                                                        (double) psCurrentCapacity / maxCapacitySafe);
-                                                            }
-                                                        }
-
-                                                        try (Memory nameBuf = new Memory(1024)) {
-                                                            psDeviceName = batteryQueryString(hBattery,
-                                                                    dwTag.getValue(), BATTERY_DEVICE_NAME_LEVEL,
-                                                                    nameBuf);
-                                                            psManufacturer = batteryQueryString(hBattery,
-                                                                    dwTag.getValue(), BATTERY_MANUFACTURE_NAME_LEVEL,
-                                                                    nameBuf);
-                                                            psSerialNumber = batteryQueryString(hBattery,
-                                                                    dwTag.getValue(), BATTERY_SERIAL_NUMBER_LEVEL,
-                                                                    nameBuf);
-                                                        }
-
-                                                        bqi.InformationLevel = BATTERY_MANUFACTURE_DATE_LEVEL;
+            try {
+                boolean batteryFound = false;
+                // Limit search to 100 batteries max
+                for (int idev = 0; !batteryFound && idev < 100; idev++) {
+                    try (CloseableSpDeviceInterfaceData did = new CloseableSpDeviceInterfaceData();
+                            CloseableIntByReference requiredSize = new CloseableIntByReference();
+                            CloseableIntByReference dwWait = new CloseableIntByReference();
+                            CloseableIntByReference dwTag = new CloseableIntByReference();
+                            CloseableIntByReference dwOut = new CloseableIntByReference()) {
+                        did.cbSize = did.size();
+                        if (SetupApi.INSTANCE.SetupDiEnumDeviceInterfaces(hdev, null, GUID_DEVCLASS_BATTERY, idev,
+                                did)) {
+                            SetupApi.INSTANCE.SetupDiGetDeviceInterfaceDetail(hdev, did, null, 0, requiredSize, null);
+                            if (WinError.ERROR_INSUFFICIENT_BUFFER == Kernel32.INSTANCE.GetLastError()) {
+                                // PSP_DEVICE_INTERFACE_DETAIL_DATA: int size + TCHAR array
+                                try (Memory pdidd = new Memory(requiredSize.getValue())) {
+                                    // pdidd->cbSize is defined as sizeof(*pdidd)
+                                    // On 64 bit, cbSize is 8. On 32-bit it's 5 or 6 based on char size
+                                    // This must be set properly for the method to work but is otherwise ignored
+                                    pdidd.setInt(0, Integer.BYTES + (X64 ? 4 : CHAR_WIDTH));
+                                    // Regardless of this setting the string portion starts after one byte
+                                    if (SetupApi.INSTANCE.SetupDiGetDeviceInterfaceDetail(hdev, did, pdidd,
+                                            (int) pdidd.size(), requiredSize, null)) {
+                                        // Enumerated a battery. Ask it for information.
+                                        String devicePath = CHAR_WIDTH > 1 ? pdidd.getWideString(Integer.BYTES)
+                                                : pdidd.getString(Integer.BYTES);
+                                        HANDLE hBattery = Kernel32.INSTANCE.CreateFile(devicePath, // pdidd->DevicePath
+                                                WinNT.GENERIC_READ | WinNT.GENERIC_WRITE,
+                                                WinNT.FILE_SHARE_READ | WinNT.FILE_SHARE_WRITE, null,
+                                                WinNT.OPEN_EXISTING, WinNT.FILE_ATTRIBUTE_NORMAL, null);
+                                        if (!WinBase.INVALID_HANDLE_VALUE.equals(hBattery)) {
+                                            try (BATTERY_QUERY_INFORMATION bqi = new BATTERY_QUERY_INFORMATION();
+                                                    BATTERY_INFORMATION bi = new BATTERY_INFORMATION();
+                                                    BATTERY_WAIT_STATUS bws = new BATTERY_WAIT_STATUS();
+                                                    BATTERY_STATUS bs = new BATTERY_STATUS();
+                                                    BATTERY_MANUFACTURE_DATE bmd = new BATTERY_MANUFACTURE_DATE()) {
+                                                // Ask the battery for its tag.
+                                                if (Kernel32.INSTANCE.DeviceIoControl(hBattery, IOCTL_BATTERY_QUERY_TAG,
+                                                        dwWait.getPointer(), Integer.BYTES, dwTag.getPointer(),
+                                                        Integer.BYTES, dwOut, null)) {
+                                                    bqi.BatteryTag = dwTag.getValue();
+                                                    if (bqi.BatteryTag > 0) {
+                                                        // With the tag, you can query the battery info.
+                                                        bqi.InformationLevel = BATTERY_INFORMATION_LEVEL;
                                                         bqi.write();
 
                                                         if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
                                                                 IOCTL_BATTERY_QUERY_INFORMATION, bqi.getPointer(),
-                                                                bqi.size(), bmd.getPointer(), bmd.size(), dwOut,
-                                                                null)) {
-                                                            bmd.read();
-                                                            // If failed, returns -1 for each field
-                                                            if (bmd.Year > 1900 && bmd.Month >= 1 && bmd.Month <= 12
-                                                                    && bmd.Day >= 1 && bmd.Day <= 31) {
-                                                                try {
-                                                                    psManufactureDate = LocalDate.of(bmd.Year,
-                                                                            bmd.Month, bmd.Day);
-                                                                } catch (DateTimeException ignored) {
-                                                                    // malformed firmware date — leave null
+                                                                bqi.size(), bi.getPointer(), bi.size(), dwOut, null)) {
+                                                            // Only non-UPS system batteries count
+                                                            bi.read();
+                                                            int maxCapacitySafe = 1;
+                                                            if (0 != (bi.Capabilities & BATTERY_SYSTEM_BATTERY)
+                                                                    && 0 == (bi.Capabilities & BATTERY_IS_SHORT_TERM)) {
+                                                                // Capabilities flags non-mWh units
+                                                                if (0 == (bi.Capabilities
+                                                                        & BATTERY_CAPACITY_RELATIVE)) {
+                                                                    psCapacityUnits = CapacityUnits.MWH;
+                                                                }
+                                                                psChemistry = Native.toString(bi.Chemistry,
+                                                                        StandardCharsets.US_ASCII);
+                                                                psDesignCapacity = bi.DesignedCapacity;
+                                                                psMaxCapacity = bi.FullChargedCapacity;
+                                                                psCycleCount = bi.CycleCount;
+                                                                maxCapacitySafe = psMaxCapacity > 0 ? psMaxCapacity
+                                                                        : psDesignCapacity > 0 ? psDesignCapacity : 1;
+
+                                                                // Query the battery status.
+                                                                bws.BatteryTag = bqi.BatteryTag;
+                                                                bws.write();
+                                                                if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
+                                                                        IOCTL_BATTERY_QUERY_STATUS, bws.getPointer(),
+                                                                        bws.size(), bs.getPointer(), bs.size(), dwOut,
+                                                                        null)) {
+                                                                    bs.read();
+                                                                    if (0 != (bs.PowerState & BATTERY_POWER_ON_LINE)) {
+                                                                        psPowerOnLine = true;
+                                                                    }
+                                                                    if (0 != (bs.PowerState & BATTERY_DISCHARGING)) {
+                                                                        psDischarging = true;
+                                                                    }
+                                                                    if (0 != (bs.PowerState & BATTERY_CHARGING)) {
+                                                                        psCharging = true;
+                                                                        psTimeRemainingEstimated = -2d;
+                                                                    }
+                                                                    psCurrentCapacity = bs.Capacity;
+                                                                    psVoltage = bs.Voltage > 0 ? bs.Voltage / 1000d
+                                                                            : bs.Voltage;
+                                                                    psPowerUsageRate = bs.Rate;
+                                                                    if (psVoltage > 0) {
+                                                                        psAmperage = psPowerUsageRate / psVoltage;
+                                                                    }
+                                                                    psRemainingCapacityPercent = Math.min(1d,
+                                                                            (double) psCurrentCapacity
+                                                                                    / maxCapacitySafe);
                                                                 }
                                                             }
-                                                        }
 
-                                                        bqi.InformationLevel = BATTERY_TEMPERATURE_LEVEL;
-                                                        bqi.write();
-                                                        try (CloseableIntByReference tempK = new CloseableIntByReference()) {
-                                                            // 1/10 degree K
-                                                            if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
-                                                                    IOCTL_BATTERY_QUERY_INFORMATION, bqi.getPointer(),
-                                                                    bqi.size(), tempK.getPointer(), Integer.BYTES,
-                                                                    dwOut, null)) {
-                                                                psTemperature = tempK.getValue() / 10d - 273.15;
+                                                            try (Memory nameBuf = new Memory(1024)) {
+                                                                psDeviceName = batteryQueryString(hBattery,
+                                                                        dwTag.getValue(), BATTERY_DEVICE_NAME_LEVEL,
+                                                                        nameBuf);
+                                                                psManufacturer = batteryQueryString(hBattery,
+                                                                        dwTag.getValue(),
+                                                                        BATTERY_MANUFACTURE_NAME_LEVEL, nameBuf);
+                                                                psSerialNumber = batteryQueryString(hBattery,
+                                                                        dwTag.getValue(), BATTERY_SERIAL_NUMBER_LEVEL,
+                                                                        nameBuf);
                                                             }
-                                                        }
 
-                                                        // Put last because we change the AtRate field
-                                                        bqi.InformationLevel = BATTERY_ESTIMATED_TIME_LEVEL;
-                                                        if (psPowerUsageRate != 0) {
-                                                            bqi.AtRate = psPowerUsageRate;
-                                                        }
-                                                        bqi.write();
-                                                        try (CloseableIntByReference tr = new CloseableIntByReference()) {
+                                                            bqi.InformationLevel = BATTERY_MANUFACTURE_DATE_LEVEL;
+                                                            bqi.write();
+
                                                             if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
                                                                     IOCTL_BATTERY_QUERY_INFORMATION, bqi.getPointer(),
-                                                                    bqi.size(), tr.getPointer(), Integer.BYTES, dwOut,
+                                                                    bqi.size(), bmd.getPointer(), bmd.size(), dwOut,
                                                                     null)) {
-                                                                psTimeRemainingInstant = tr.getValue();
+                                                                bmd.read();
+                                                                // If failed, returns -1 for each field
+                                                                if (bmd.Year > 1900 && bmd.Month >= 1 && bmd.Month <= 12
+                                                                        && bmd.Day >= 1 && bmd.Day <= 31) {
+                                                                    try {
+                                                                        psManufactureDate = LocalDate.of(bmd.Year,
+                                                                                bmd.Month, bmd.Day);
+                                                                    } catch (DateTimeException ignored) {
+                                                                        // malformed firmware date — leave null
+                                                                    }
+                                                                }
                                                             }
+
+                                                            bqi.InformationLevel = BATTERY_TEMPERATURE_LEVEL;
+                                                            bqi.write();
+                                                            try (CloseableIntByReference tempK = new CloseableIntByReference()) {
+                                                                // 1/10 degree K
+                                                                if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
+                                                                        IOCTL_BATTERY_QUERY_INFORMATION,
+                                                                        bqi.getPointer(), bqi.size(),
+                                                                        tempK.getPointer(), Integer.BYTES, dwOut,
+                                                                        null)) {
+                                                                    psTemperature = tempK.getValue() / 10d - 273.15;
+                                                                }
+                                                            }
+
+                                                            // Put last because we change the AtRate field
+                                                            bqi.InformationLevel = BATTERY_ESTIMATED_TIME_LEVEL;
+                                                            if (psPowerUsageRate != 0) {
+                                                                bqi.AtRate = psPowerUsageRate;
+                                                            }
+                                                            bqi.write();
+                                                            try (CloseableIntByReference tr = new CloseableIntByReference()) {
+                                                                if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
+                                                                        IOCTL_BATTERY_QUERY_INFORMATION,
+                                                                        bqi.getPointer(), bqi.size(), tr.getPointer(),
+                                                                        Integer.BYTES, dwOut, null)) {
+                                                                    psTimeRemainingInstant = tr.getValue();
+                                                                }
+                                                            }
+                                                            // Fallback if BatteryEstimatedTime query failed
+                                                            if (psTimeRemainingInstant <= 0 && psPowerUsageRate != 0) {
+                                                                psTimeRemainingInstant = psDischarging
+                                                                        ? Math.max(0d,
+                                                                                psCurrentCapacity * 3600d
+                                                                                        / Math.abs(psPowerUsageRate))
+                                                                        : Math.max(0d,
+                                                                                (maxCapacitySafe - psCurrentCapacity)
+                                                                                        * 3600d
+                                                                                        / Math.abs(psPowerUsageRate));
+                                                            }
+                                                            if (psDischarging && psTimeRemainingInstant > 0) {
+                                                                psTimeRemainingEstimated = psTimeRemainingInstant;
+                                                            }
+                                                            // Exit loop
+                                                            batteryFound = true;
                                                         }
-                                                        // Fallback if BatteryEstimatedTime query failed
-                                                        if (psTimeRemainingInstant <= 0 && psPowerUsageRate != 0) {
-                                                            psTimeRemainingInstant = psDischarging
-                                                                    ? Math.max(0d,
-                                                                            psCurrentCapacity * 3600d
-                                                                                    / Math.abs(psPowerUsageRate))
-                                                                    : Math.max(0d, (maxCapacitySafe - psCurrentCapacity)
-                                                                            * 3600d / Math.abs(psPowerUsageRate));
-                                                        }
-                                                        if (psDischarging && psTimeRemainingInstant > 0) {
-                                                            psTimeRemainingEstimated = psTimeRemainingInstant;
-                                                        }
-                                                        // Exit loop
-                                                        batteryFound = true;
                                                     }
                                                 }
+                                            } finally {
+                                                Kernel32.INSTANCE.CloseHandle(hBattery);
                                             }
-                                        } finally {
-                                            Kernel32.INSTANCE.CloseHandle(hBattery);
                                         }
                                     }
                                 }
                             }
+                        } else if (WinError.ERROR_NO_MORE_ITEMS == Kernel32.INSTANCE.GetLastError()) {
+                            break; // Enumeration failed - perhaps we're out of items
                         }
-                    } else if (WinError.ERROR_NO_MORE_ITEMS == Kernel32.INSTANCE.GetLastError()) {
-                        break; // Enumeration failed - perhaps we're out of items
                     }
                 }
+            } finally {
+                SetupApi.INSTANCE.SetupDiDestroyDeviceInfoList(hdev);
             }
-            SetupApi.INSTANCE.SetupDiDestroyDeviceInfoList(hdev);
         }
 
         return new WindowsPowerSourceJNA(psName, psDeviceName, psRemainingCapacityPercent, psTimeRemainingEstimated,

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsJNA.java
@@ -112,23 +112,29 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
             // Get buffer and populate table
             int size = sizePtr.getValue();
             Memory buf = new Memory(size);
-            do {
-                ret = IPHLP.GetExtendedTcpTable(buf, sizePtr, false, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
-                if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
-                    size = sizePtr.getValue();
-                    buf.close();
-                    buf = new Memory(size);
+            try {
+                do {
+                    ret = IPHLP.GetExtendedTcpTable(buf, sizePtr, false, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
+                    if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
+                        size = sizePtr.getValue();
+                        buf.close();
+                        buf = new Memory(size);
+                    }
+                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
+                if (ret == WinError.ERROR_SUCCESS) {
+                    MIB_TCPTABLE_OWNER_PID tcpTable = new MIB_TCPTABLE_OWNER_PID(buf);
+                    for (int i = 0; i < tcpTable.dwNumEntries; i++) {
+                        MIB_TCPROW_OWNER_PID row = tcpTable.table[i];
+                        conns.add(new IPConnection("tcp4", ParseUtil.parseIntToIP(row.dwLocalAddr),
+                                ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort),
+                                ParseUtil.parseIntToIP(row.dwRemoteAddr),
+                                ParseUtil.bigEndian16ToLittleEndian(row.dwRemotePort), stateLookup(row.dwState), 0, 0,
+                                row.dwOwningPid));
+                    }
                 }
-            } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
-            MIB_TCPTABLE_OWNER_PID tcpTable = new MIB_TCPTABLE_OWNER_PID(buf);
-            for (int i = 0; i < tcpTable.dwNumEntries; i++) {
-                MIB_TCPROW_OWNER_PID row = tcpTable.table[i];
-                conns.add(new IPConnection("tcp4", ParseUtil.parseIntToIP(row.dwLocalAddr),
-                        ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort), ParseUtil.parseIntToIP(row.dwRemoteAddr),
-                        ParseUtil.bigEndian16ToLittleEndian(row.dwRemotePort), stateLookup(row.dwState), 0, 0,
-                        row.dwOwningPid));
+            } finally {
+                buf.close();
             }
-            buf.close();
         }
         return conns;
     }
@@ -141,22 +147,28 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
             // Get buffer and populate table
             int size = sizePtr.getValue();
             Memory buf = new Memory(size);
-            do {
-                ret = IPHLP.GetExtendedTcpTable(buf, sizePtr, false, AF_INET6, TCP_TABLE_OWNER_PID_ALL, 0);
-                if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
-                    size = sizePtr.getValue();
-                    buf.close();
-                    buf = new Memory(size);
+            try {
+                do {
+                    ret = IPHLP.GetExtendedTcpTable(buf, sizePtr, false, AF_INET6, TCP_TABLE_OWNER_PID_ALL, 0);
+                    if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
+                        size = sizePtr.getValue();
+                        buf.close();
+                        buf = new Memory(size);
+                    }
+                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
+                if (ret == WinError.ERROR_SUCCESS) {
+                    MIB_TCP6TABLE_OWNER_PID tcpTable = new MIB_TCP6TABLE_OWNER_PID(buf);
+                    for (int i = 0; i < tcpTable.dwNumEntries; i++) {
+                        MIB_TCP6ROW_OWNER_PID row = tcpTable.table[i];
+                        conns.add(new IPConnection("tcp6", row.LocalAddr,
+                                ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort), row.RemoteAddr,
+                                ParseUtil.bigEndian16ToLittleEndian(row.dwRemotePort), stateLookup(row.State), 0, 0,
+                                row.dwOwningPid));
+                    }
                 }
-            } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
-            MIB_TCP6TABLE_OWNER_PID tcpTable = new MIB_TCP6TABLE_OWNER_PID(buf);
-            for (int i = 0; i < tcpTable.dwNumEntries; i++) {
-                MIB_TCP6ROW_OWNER_PID row = tcpTable.table[i];
-                conns.add(new IPConnection("tcp6", row.LocalAddr, ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort),
-                        row.RemoteAddr, ParseUtil.bigEndian16ToLittleEndian(row.dwRemotePort), stateLookup(row.State),
-                        0, 0, row.dwOwningPid));
+            } finally {
+                buf.close();
             }
-            buf.close();
         }
         return conns;
     }
@@ -169,22 +181,27 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
             // Get buffer and populate table
             int size = sizePtr.getValue();
             Memory buf = new Memory(size);
-            do {
-                ret = IPHLP.GetExtendedUdpTable(buf, sizePtr, false, AF_INET, UDP_TABLE_OWNER_PID, 0);
-                if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
-                    size = sizePtr.getValue();
-                    buf.close();
-                    buf = new Memory(size);
+            try {
+                do {
+                    ret = IPHLP.GetExtendedUdpTable(buf, sizePtr, false, AF_INET, UDP_TABLE_OWNER_PID, 0);
+                    if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
+                        size = sizePtr.getValue();
+                        buf.close();
+                        buf = new Memory(size);
+                    }
+                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
+                if (ret == WinError.ERROR_SUCCESS) {
+                    MIB_UDPTABLE_OWNER_PID udpTable = new MIB_UDPTABLE_OWNER_PID(buf);
+                    for (int i = 0; i < udpTable.dwNumEntries; i++) {
+                        MIB_UDPROW_OWNER_PID row = udpTable.table[i];
+                        conns.add(new IPConnection("udp4", ParseUtil.parseIntToIP(row.dwLocalAddr),
+                                ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort), new byte[0], 0, TcpState.NONE, 0,
+                                0, row.dwOwningPid));
+                    }
                 }
-            } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
-            MIB_UDPTABLE_OWNER_PID udpTable = new MIB_UDPTABLE_OWNER_PID(buf);
-            for (int i = 0; i < udpTable.dwNumEntries; i++) {
-                MIB_UDPROW_OWNER_PID row = udpTable.table[i];
-                conns.add(new IPConnection("udp4", ParseUtil.parseIntToIP(row.dwLocalAddr),
-                        ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort), new byte[0], 0, TcpState.NONE, 0, 0,
-                        row.dwOwningPid));
+            } finally {
+                buf.close();
             }
-            buf.close();
         }
         return conns;
     }
@@ -197,20 +214,26 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
             // Get buffer and populate table
             int size = sizePtr.getValue();
             Memory buf = new Memory(size);
-            do {
-                ret = IPHLP.GetExtendedUdpTable(buf, sizePtr, false, AF_INET6, UDP_TABLE_OWNER_PID, 0);
-                if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
-                    size = sizePtr.getValue();
-                    buf.close();
-                    buf = new Memory(size);
+            try {
+                do {
+                    ret = IPHLP.GetExtendedUdpTable(buf, sizePtr, false, AF_INET6, UDP_TABLE_OWNER_PID, 0);
+                    if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
+                        size = sizePtr.getValue();
+                        buf.close();
+                        buf = new Memory(size);
+                    }
+                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
+                if (ret == WinError.ERROR_SUCCESS) {
+                    MIB_UDP6TABLE_OWNER_PID udpTable = new MIB_UDP6TABLE_OWNER_PID(buf);
+                    for (int i = 0; i < udpTable.dwNumEntries; i++) {
+                        MIB_UDP6ROW_OWNER_PID row = udpTable.table[i];
+                        conns.add(new IPConnection("udp6", row.ucLocalAddr,
+                                ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort), new byte[0], 0, TcpState.NONE, 0,
+                                0, row.dwOwningPid));
+                    }
                 }
-            } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
-            MIB_UDP6TABLE_OWNER_PID udpTable = new MIB_UDP6TABLE_OWNER_PID(buf);
-            for (int i = 0; i < udpTable.dwNumEntries; i++) {
-                MIB_UDP6ROW_OWNER_PID row = udpTable.table[i];
-                conns.add(
-                        new IPConnection("udp6", row.ucLocalAddr, ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort),
-                                new byte[0], 0, TcpState.NONE, 0, 0, row.dwOwningPid));
+            } finally {
+                buf.close();
             }
         }
         return conns;


### PR DESCRIPTION
## Summary

Resolves 45 SonarQube blocker findings introduced when `CFTypeRef` was made `AutoCloseable` in #3292.

## Background

PR #3292 correctly made `CFTypeRef` implement `AutoCloseable`, enabling try-with-resources for owned CoreFoundation objects. This uncovered real memory leaks and established clear ownership semantics. However, it also caused SonarQube to flag every place where a `CFTypeRef` subclass is instantiated without being closed — including **borrowed references** that must NOT be released.

## Why these are false positives

CoreFoundation uses reference-counted memory management with two ownership patterns:

- **Owned references** (from `Create`/`Copy` functions) — caller owns the reference and must call `CFRelease`. These should use try-with-resources. ✓
- **Borrowed references** (from `Get` functions like `CFDictionaryGetValue`, `CFArrayGetValueAtIndex`, `IOReportChannelGetGroup`) — caller does NOT own the reference and must NOT call `CFRelease`. Closing these would decrement the ref count on objects still owned by their parent containers, causing use-after-free or double-free bugs.

SonarQube cannot distinguish between these two patterns. It sees `new CFStringRef(segment)` and flags it as an unclosed resource regardless of whether the segment is owned or borrowed.

## Fix strategies

Three patterns are used depending on the context:

### 1. Static value-extraction methods (majority of fixes)

For the common pattern of wrapping a borrowed segment just to extract a value:

```java
// Before — SonarQube flags unclosed CFStringRef
new CFStringRef(groupSeg).stringValue()

// After — no AutoCloseable created
CFStringRef.stringValue(groupSeg)
```

Added static methods to `CFStringRef`, `CFNumberRef`, `CFBooleanRef`, `CFArrayRef`, and `CFDictionaryRef` that operate directly on `MemorySegment` without creating an `AutoCloseable` wrapper.

### 2. Move owned refs directly into try-with-resources

For owned references (DASessionRef, DADiskRef) that had a gap between creation and the try block:

```java
// Before — SonarQube flags potential leak between create and try
DASessionRef session = DASessionRef.create(alloc);
if (session.isNull()) { return; }
try (session) { ... }

// After — no gap
try (DASessionRef session = DASessionRef.create(alloc)) {
    if (session.isNull()) { return; }
    ...
}
```

### 3. @SuppressWarnings for framework-consumed references

For references with complex ownership semantics that cannot be expressed through code structure:

- `CFAllocatorRef` from `CFAllocatorGetDefault()` — a borrowed singleton that must never be released
- `CFMutableDictionaryRef` passed to `IOServiceGetMatchingServices()` — IOKit consumes (releases) the matching dictionary on the caller's behalf

```java
@SuppressWarnings("resource") // consumed by getMatchingServices
CFMutableDictionaryRef matchingDict = ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal memory access patterns across macOS and Windows implementations to reduce object allocations and improve performance.

* **Chores**
  * Enhanced resource cleanup and lifetime management throughout native library interactions to improve stability and prevent resource leaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->