### PR TITLE
Fix Linux device-mapper disk paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   [#3280](https://github.com/oshi/oshi/pull/3280): Add `SystemInfoProvider` convenience overloads to `OshiMetrics` constructor, `bindTo`, and `builder` methods - [@dbwiddis](https://github.com/dbwiddis).
 * [#3281](https://github.com/oshi/oshi/pull/3281): Fix AIX processor count detection to use LPAR vcpu and SMT configuration instead of frame-level physical processor count - [@dbwiddis](https://github.com/dbwiddis).
 * [#3283](https://github.com/oshi/oshi/pull/3283): Fix macOS JNA system CPU ticks overflowing to negative values after long uptimes - [@dbwiddis](https://github.com/dbwiddis).
+* [#3299](https://github.com/oshi/oshi/pull/3299): Handle Linux LUKS device-mapper disks without LVM volume names and avoid synthetic `null` paths - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.1.0 (2026-05-06)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
@@ -19,6 +19,7 @@ import oshi.hardware.HWPartition;
 import oshi.hardware.common.AbstractHWDiskStore;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.Util;
 import oshi.util.linux.DevPath;
 import oshi.util.linux.ProcPath;
 
@@ -57,12 +58,18 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
 
     /** Device-mapper UUID property. */
     protected static final String DM_UUID = "DM_UUID";
+    /** Device-mapper name property. */
+    protected static final String DM_NAME = "DM_NAME";
     /** Device-mapper volume group name property. */
     protected static final String DM_VG_NAME = "DM_VG_NAME";
     /** Device-mapper logical volume name property. */
     protected static final String DM_LV_NAME = "DM_LV_NAME";
     /** Logical volume group description string. */
     protected static final String LOGICAL_VOLUME_GROUP = "Logical Volume Group";
+    /** Encrypted volume description string. */
+    protected static final String ENCRYPTED_VOLUME = "Encrypted Volume";
+    /** Device-mapper description string. */
+    protected static final String DEVICE_MAPPER = "Device Mapper";
 
     /** Sector size in bytes. */
     protected static final int SECTORSIZE = 512;
@@ -175,6 +182,112 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
      */
     protected static String getMountPointOfDmDevice(String vgName, String lvName) {
         return DevPath.MAPPER + vgName + '-' + lvName;
+    }
+
+    /**
+     * Gets the model description for a device-mapper device.
+     *
+     * @param dmUuid the device-mapper UUID
+     * @return the model description
+     */
+    protected static String getModelForDmDevice(String dmUuid) {
+        if (isLogicalVolume(dmUuid)) {
+            return LOGICAL_VOLUME_GROUP;
+        } else if (isEncryptedVolume(dmUuid)) {
+            return ENCRYPTED_VOLUME;
+        }
+        return DEVICE_MAPPER;
+    }
+
+    /**
+     * Checks whether a device-mapper UUID identifies an LVM logical volume.
+     *
+     * @param dmUuid the device-mapper UUID
+     * @return whether the UUID identifies an LVM logical volume
+     */
+    protected static boolean isLogicalVolume(String dmUuid) {
+        return dmUuid != null && dmUuid.startsWith("LVM-");
+    }
+
+    /**
+     * Checks whether a device-mapper UUID identifies an encrypted volume.
+     *
+     * @param dmUuid the device-mapper UUID
+     * @return whether the UUID identifies an encrypted volume
+     */
+    protected static boolean isEncryptedVolume(String dmUuid) {
+        return dmUuid != null && dmUuid.startsWith("CRYPT-");
+    }
+
+    /**
+     * Gets the preferred path for a device-mapper device.
+     *
+     * @param dmName  the device-mapper name
+     * @param devnode the device node path
+     * @return the device path
+     */
+    protected static String getDmDevicePath(String dmName, String devnode) {
+        return Util.isBlank(dmName) ? devnode : DevPath.MAPPER + dmName;
+    }
+
+    /**
+     * Gets the mount point for a device-mapper device.
+     *
+     * @param mountsMap the map of device paths to mount points
+     * @param dmName    the device-mapper name
+     * @param devnode   the device node path
+     * @param sysPath   the sysfs path for the device
+     * @return the mount point or dependent device names
+     */
+    protected static String getMountPointForDmDevice(Map<String, String> mountsMap, String dmName, String devnode,
+            String sysPath) {
+        String devicePath = getDmDevicePath(dmName, devnode);
+        String mountPoint = mountsMap.get(devicePath);
+        if (mountPoint != null) {
+            return mountPoint;
+        }
+        if (!devicePath.equals(devnode)) {
+            mountPoint = mountsMap.get(devnode);
+            if (mountPoint != null) {
+                return mountPoint;
+            }
+        }
+        return getDependentNamesFromHoldersDirectory(sysPath);
+    }
+
+    /**
+     * Adds a partition entry for a supported device-mapper device.
+     *
+     * @param store     the disk store to update
+     * @param mountsMap the map of device paths to mount points
+     * @param dmUuid    the device-mapper UUID
+     * @param vgName    the LVM volume group name
+     * @param lvName    the LVM logical volume name
+     * @param dmName    the device-mapper name
+     * @param devnode   the device node path
+     * @param sysname   the sysfs device name
+     * @param sysPath   the sysfs path for the device
+     * @param fsType    the filesystem type
+     * @param fsUuid    the filesystem UUID
+     * @param fsLabel   the filesystem label
+     * @param size      the partition size in bytes
+     * @param major     the major device ID
+     * @param minor     the minor device ID
+     */
+    protected static void addDeviceMapperPartition(LinuxHWDiskStore store, Map<String, String> mountsMap, String dmUuid,
+            String vgName, String lvName, String dmName, String devnode, String sysname, String sysPath, String fsType,
+            String fsUuid, String fsLabel, long size, int major, int minor) {
+        if (isLogicalVolume(dmUuid) && !Util.isBlank(vgName) && !Util.isBlank(lvName)) {
+            store.getMutablePartitionList().add(new HWPartition(getPartitionNameForDmDevice(vgName, lvName), sysname,
+                    fsType == null ? PARTITION : fsType, fsUuid == null ? "" : fsUuid, fsLabel == null ? "" : fsLabel,
+                    size, major, minor, getMountPointOfDmDevice(vgName, lvName)));
+        } else if (isEncryptedVolume(dmUuid)) {
+            String name = getDmDevicePath(dmName, devnode);
+            store.getMutablePartitionList()
+                    .add(new HWPartition(name, sysname, fsType == null ? PARTITION : fsType,
+                            fsUuid == null ? "" : fsUuid, fsLabel == null ? "" : fsLabel, size, major, minor,
+                            getMountPointForDmDevice(mountsMap, dmName, devnode, sysPath)));
+        }
     }
 
     /**

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxHWDiskStoreTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxHWDiskStoreTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import oshi.hardware.HWPartition;
+
+@EnabledOnOs(OS.LINUX)
+class LinuxHWDiskStoreTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void testGetModelForDmDevice() {
+        assertThat(LinuxHWDiskStore.getModelForDmDevice("LVM-test"), is(LinuxHWDiskStore.LOGICAL_VOLUME_GROUP));
+        assertThat(LinuxHWDiskStore.getModelForDmDevice("CRYPT-LUKS2-test"), is(LinuxHWDiskStore.ENCRYPTED_VOLUME));
+        assertThat(LinuxHWDiskStore.getModelForDmDevice("DMRAID-test"), is(LinuxHWDiskStore.DEVICE_MAPPER));
+        assertThat(LinuxHWDiskStore.getModelForDmDevice(null), is(LinuxHWDiskStore.DEVICE_MAPPER));
+    }
+
+    @Test
+    void testDeviceMapperUuidTypeChecks() {
+        assertThat(LinuxHWDiskStore.isLogicalVolume("LVM-test"), is(true));
+        assertThat(LinuxHWDiskStore.isLogicalVolume("CRYPT-LUKS2-test"), is(false));
+        assertThat(LinuxHWDiskStore.isLogicalVolume(null), is(false));
+
+        assertThat(LinuxHWDiskStore.isEncryptedVolume("CRYPT-LUKS2-test"), is(true));
+        assertThat(LinuxHWDiskStore.isEncryptedVolume("LVM-test"), is(false));
+        assertThat(LinuxHWDiskStore.isEncryptedVolume(null), is(false));
+    }
+
+    @Test
+    void testGetDmDevicePath() {
+        assertThat(LinuxHWDiskStore.getDmDevicePath("cryptroot", "/dev/dm-0"), is("/dev/mapper/cryptroot"));
+        assertThat(LinuxHWDiskStore.getDmDevicePath(null, "/dev/dm-0"), is("/dev/dm-0"));
+        assertThat(LinuxHWDiskStore.getDmDevicePath("", "/dev/dm-0"), is("/dev/dm-0"));
+    }
+
+    @Test
+    void testGetMountPointForDmDevice() {
+        Map<String, String> mountsMap = new HashMap<>();
+        mountsMap.put("/dev/mapper/cryptroot", "/");
+        mountsMap.put("/dev/dm-0", "/mnt/fallback");
+
+        assertThat(LinuxHWDiskStore.getMountPointForDmDevice(mountsMap, "cryptroot", "/dev/dm-0", "/sys/block/dm-0"),
+                is("/"));
+        assertThat(LinuxHWDiskStore.getMountPointForDmDevice(mountsMap, "missing", "/dev/dm-0", "/sys/block/dm-0"),
+                is("/mnt/fallback"));
+    }
+
+    @Test
+    void testGetMountPointForDmDeviceFallsBackToHoldersDirectory() throws IOException {
+        Map<String, String> mountsMap = new HashMap<>();
+        Path sysPath = tempDir.resolve("sys/block/dm-0");
+        Files.createDirectories(sysPath.resolve("holders"));
+        Files.createFile(sysPath.resolve("holders/dm-1"));
+
+        assertThat(LinuxHWDiskStore.getMountPointForDmDevice(mountsMap, "missing", "/dev/dm-0", sysPath.toString()),
+                is("dm-1"));
+    }
+
+    @Test
+    void testAddDeviceMapperPartitionForLogicalVolume() {
+        TestLinuxHWDiskStore store = new TestLinuxHWDiskStore();
+
+        LinuxHWDiskStore.addDeviceMapperPartition(store, new HashMap<>(), "LVM-test", "vg", "lv", null, "/dev/dm-0",
+                "dm-0", "/sys/block/dm-0", "ext4", "uuid", "label", 1024L, 253, 0);
+
+        HWPartition partition = store.getPartitions().get(0);
+        assertThat(store.getPartitions().size(), is(1));
+        assertThat(partition.getIdentification(), is("/dev/vg/lv"));
+        assertThat(partition.getName(), is("dm-0"));
+        assertThat(partition.getType(), is("ext4"));
+        assertThat(partition.getUuid(), is("uuid"));
+        assertThat(partition.getLabel(), is("label"));
+        assertThat(partition.getSize(), is(1024L));
+        assertThat(partition.getMajor(), is(253));
+        assertThat(partition.getMinor(), is(0));
+        assertThat(partition.getMountPoint(), is("/dev/mapper/vg-lv"));
+    }
+
+    @Test
+    void testAddDeviceMapperPartitionSkipsLogicalVolumeWithoutNames() {
+        TestLinuxHWDiskStore store = new TestLinuxHWDiskStore();
+
+        LinuxHWDiskStore.addDeviceMapperPartition(store, new HashMap<>(), "LVM-test", null, "lv", null, "/dev/dm-0",
+                "dm-0", "/sys/block/dm-0", null, null, null, 1024L, 253, 0);
+
+        assertThat(store.getPartitions().isEmpty(), is(true));
+    }
+
+    @Test
+    void testAddDeviceMapperPartitionForEncryptedVolumeWithMapperName() {
+        TestLinuxHWDiskStore store = new TestLinuxHWDiskStore();
+        Map<String, String> mountsMap = new HashMap<>();
+        mountsMap.put("/dev/mapper/cryptroot", "/");
+
+        LinuxHWDiskStore.addDeviceMapperPartition(store, mountsMap, "CRYPT-LUKS2-test", null, null, "cryptroot",
+                "/dev/dm-0", "dm-0", "/sys/block/dm-0", null, null, null, 2048L, 253, 1);
+
+        HWPartition partition = store.getPartitions().get(0);
+        assertThat(store.getPartitions().size(), is(1));
+        assertThat(partition.getIdentification(), is("/dev/mapper/cryptroot"));
+        assertThat(partition.getType(), is("partition"));
+        assertThat(partition.getUuid(), is(""));
+        assertThat(partition.getLabel(), is(""));
+        assertThat(partition.getMountPoint(), is("/"));
+    }
+
+    @Test
+    void testAddDeviceMapperPartitionForEncryptedVolumeFallsBackToDevnode() {
+        TestLinuxHWDiskStore store = new TestLinuxHWDiskStore();
+        Map<String, String> mountsMap = new HashMap<>();
+        mountsMap.put("/dev/dm-0", "/mnt/crypt");
+
+        LinuxHWDiskStore.addDeviceMapperPartition(store, mountsMap, "CRYPT-LUKS2-test", null, null, null, "/dev/dm-0",
+                "dm-0", "/sys/block/dm-0", "xfs", "uuid", "label", 2048L, 253, 1);
+
+        HWPartition partition = store.getPartitions().get(0);
+        assertThat(store.getPartitions().size(), is(1));
+        assertThat(partition.getIdentification(), is("/dev/dm-0"));
+        assertThat(partition.getType(), is("xfs"));
+        assertThat(partition.getMountPoint(), is("/mnt/crypt"));
+    }
+
+    @Test
+    void testAddDeviceMapperPartitionSkipsGenericDeviceMapper() {
+        TestLinuxHWDiskStore store = new TestLinuxHWDiskStore();
+
+        LinuxHWDiskStore.addDeviceMapperPartition(store, new HashMap<>(), "DMRAID-test", null, null, "dmraid",
+                "/dev/dm-0", "dm-0", "/sys/block/dm-0", null, null, null, 1024L, 253, 0);
+
+        assertThat(store.getPartitions().isEmpty(), is(true));
+    }
+
+    private static final class TestLinuxHWDiskStore extends LinuxHWDiskStore {
+        private TestLinuxHWDiskStore() {
+            super("/dev/dm-0", "model", "serial", 4096L, "Virtual");
+        }
+
+        @Override
+        public boolean updateAttributes() {
+            return false;
+        }
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
@@ -99,31 +99,26 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
                                     long devSize = ParseUtil.parseLongOrDefault(
                                             UdevFunctions.getSysattrValue(device, SIZE, arena), 0L) * SECTORSIZE;
                                     if (devnode.startsWith(DevPath.DM)) {
-                                        devModel = LOGICAL_VOLUME_GROUP;
                                         devSerial = UdevFunctions.getPropertyValue(device, DM_UUID, arena);
+                                        devModel = getModelForDmDevice(devSerial);
                                         store = new LinuxHWDiskStoreFFM(devnode, devModel,
                                                 devSerial == null ? Constants.UNKNOWN : devSerial, devSize, "Virtual");
-                                        if (devSerial != null && devSerial.startsWith("LVM-")) {
-                                            String vgName = UdevFunctions.getPropertyValue(device, DM_VG_NAME, arena);
-                                            String lvName = UdevFunctions.getPropertyValue(device, DM_LV_NAME, arena);
-                                            String fsType = UdevFunctions.getPropertyValue(device, ID_FS_TYPE, arena);
-                                            String fsUuid = UdevFunctions.getPropertyValue(device, ID_FS_UUID, arena);
-                                            String fsLabel = UdevFunctions.getPropertyValue(device, ID_FS_LABEL, arena);
-                                            String sysname = UdevFunctions
-                                                    .getString(UdevFunctions.udev_device_get_sysname(device), arena);
-                                            store.getMutablePartitionList().add(new HWPartition(
-                                                    getPartitionNameForDmDevice(vgName, lvName), sysname,
-                                                    fsType == null ? PARTITION : fsType, fsUuid == null ? "" : fsUuid,
-                                                    fsLabel == null ? "" : fsLabel,
-                                                    ParseUtil.parseLongOrDefault(
-                                                            UdevFunctions.getSysattrValue(device, SIZE, arena), 0L)
-                                                            * SECTORSIZE,
-                                                    ParseUtil.parseIntOrDefault(
-                                                            UdevFunctions.getPropertyValue(device, MAJOR, arena), 0),
-                                                    ParseUtil.parseIntOrDefault(
-                                                            UdevFunctions.getPropertyValue(device, MINOR, arena), 0),
-                                                    getMountPointOfDmDevice(vgName, lvName)));
-                                        }
+                                        addDeviceMapperPartition(store, mountsMap, devSerial,
+                                                UdevFunctions.getPropertyValue(device, DM_VG_NAME, arena),
+                                                UdevFunctions.getPropertyValue(device, DM_LV_NAME, arena),
+                                                UdevFunctions.getPropertyValue(device, DM_NAME, arena), devnode,
+                                                UdevFunctions.getString(UdevFunctions.udev_device_get_sysname(device),
+                                                        arena),
+                                                syspath, UdevFunctions.getPropertyValue(device, ID_FS_TYPE, arena),
+                                                UdevFunctions.getPropertyValue(device, ID_FS_UUID, arena),
+                                                UdevFunctions.getPropertyValue(device, ID_FS_LABEL, arena),
+                                                ParseUtil.parseLongOrDefault(
+                                                        UdevFunctions.getSysattrValue(device, SIZE, arena), 0L)
+                                                        * SECTORSIZE,
+                                                ParseUtil.parseIntOrDefault(
+                                                        UdevFunctions.getPropertyValue(device, MAJOR, arena), 0),
+                                                ParseUtil.parseIntOrDefault(
+                                                        UdevFunctions.getPropertyValue(device, MINOR, arena), 0));
                                     } else {
                                         store = new LinuxHWDiskStoreFFM(devnode,
                                                 devModel == null ? Constants.UNKNOWN : devModel,

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
@@ -85,28 +85,21 @@ public final class LinuxHWDiskStoreJNA extends LinuxHWDiskStore {
                                     long devSize = ParseUtil.parseLongOrDefault(device.getSysattrValue(SIZE), 0L)
                                             * SECTORSIZE;
                                     if (devnode.startsWith(DevPath.DM)) {
-                                        devModel = LOGICAL_VOLUME_GROUP;
                                         devSerial = device.getPropertyValue(DM_UUID);
+                                        devModel = getModelForDmDevice(devSerial);
                                         store = new LinuxHWDiskStoreJNA(devnode, devModel,
                                                 devSerial == null ? Constants.UNKNOWN : devSerial, devSize, "Virtual");
                                         String vgName = device.getPropertyValue(DM_VG_NAME);
                                         String lvName = device.getPropertyValue(DM_LV_NAME);
-                                        if (vgName != null && lvName != null && devSerial != null
-                                                && devSerial.startsWith("LVM-")) {
-                                            store.getMutablePartitionList().add(new HWPartition(
-                                                    getPartitionNameForDmDevice(vgName, lvName), device.getSysname(),
-                                                    device.getPropertyValue(ID_FS_TYPE) == null ? PARTITION
-                                                            : device.getPropertyValue(ID_FS_TYPE),
-                                                    device.getPropertyValue(ID_FS_UUID) == null ? ""
-                                                            : device.getPropertyValue(ID_FS_UUID),
-                                                    device.getPropertyValue(ID_FS_LABEL) == null ? ""
-                                                            : device.getPropertyValue(ID_FS_LABEL),
-                                                    ParseUtil.parseLongOrDefault(device.getSysattrValue(SIZE), 0L)
-                                                            * SECTORSIZE,
-                                                    ParseUtil.parseIntOrDefault(device.getPropertyValue(MAJOR), 0),
-                                                    ParseUtil.parseIntOrDefault(device.getPropertyValue(MINOR), 0),
-                                                    getMountPointOfDmDevice(vgName, lvName)));
-                                        }
+                                        addDeviceMapperPartition(store, mountsMap, devSerial, vgName, lvName,
+                                                device.getPropertyValue(DM_NAME), devnode, device.getSysname(),
+                                                device.getSyspath(), device.getPropertyValue(ID_FS_TYPE),
+                                                device.getPropertyValue(ID_FS_UUID),
+                                                device.getPropertyValue(ID_FS_LABEL),
+                                                ParseUtil.parseLongOrDefault(device.getSysattrValue(SIZE), 0L)
+                                                        * SECTORSIZE,
+                                                ParseUtil.parseIntOrDefault(device.getPropertyValue(MAJOR), 0),
+                                                ParseUtil.parseIntOrDefault(device.getPropertyValue(MINOR), 0));
                                     } else {
                                         store = new LinuxHWDiskStoreJNA(devnode,
                                                 devModel == null ? Constants.UNKNOWN : devModel,


### PR DESCRIPTION
## Description
- Gate LVM-specific device-mapper partition paths on nonblank LVM volume group/logical volume names
- Handle CRYPT device-mapper disks separately as encrypted volumes using DM_NAME with a /dev/dm-N fallback
- Extract common device-mapper classification/path helpers so the hardware-dependent branches have unit coverage
- Add Linux-only tests for LVM/CRYPT classification, mapper path selection, devnode fallback, and holders-directory fallback
- Add changelog entry for #3299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Linux device-mapper disks (LVM and encrypted), more reliable device naming and mount-point resolution, and removal of synthetic null paths.

* **Tests**
  * Added Linux-focused tests for device-mapper type detection, device-path selection, mount-point fallback behavior, and partition-creation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->