### PR TITLE
Fix macOS FFM open file limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#3281](https://github.com/oshi/oshi/pull/3281): Fix AIX processor count detection to use LPAR vcpu and SMT configuration instead of frame-level physical processor count - [@dbwiddis](https://github.com/dbwiddis).
 * [#3283](https://github.com/oshi/oshi/pull/3283): Fix macOS JNA system CPU ticks overflowing to negative values after long uptimes - [@dbwiddis](https://github.com/dbwiddis).
 * [#3299](https://github.com/oshi/oshi/pull/3299): Handle Linux LUKS device-mapper disks without LVM volume names and avoid synthetic `null` paths - [@dbwiddis](https://github.com/dbwiddis).
+* [#3300](https://github.com/oshi/oshi/pull/3300): Fix macOS FFM open file limits and strengthen current-process limit coverage - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.1.0 (2026-05-06)
 

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -394,6 +394,8 @@ class NativeComparisonTest {
                 .isLessThanOrEqualTo(Math.max(jna.getUpTime() / 10, 300L));
         assertThat(ffm.getStartTime()).isEqualTo(jna.getStartTime());
         assertThat(ffm.getCommandLine()).isEqualTo(jna.getCommandLine());
+        assertThat(ffm.getSoftOpenFileLimit()).as("process.softOpenFileLimit").isEqualTo(jna.getSoftOpenFileLimit());
+        assertThat(ffm.getHardOpenFileLimit()).as("process.hardOpenFileLimit").isEqualTo(jna.getHardOpenFileLimit());
         // Context switches: both use getrusage, snapshots taken at different times
         assertWithinRatio(ffm.getContextSwitches(), jna.getContextSwitches(), 0.2, "process.contextSwitches");
         assertWithinRatio(ffm.getVoluntaryContextSwitches(), jna.getVoluntaryContextSwitches(), 0.2,

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
@@ -403,7 +403,7 @@ public class MacOSProcessFFM extends AbstractOSProcess {
             return callInArenaLongOrDefault(arena -> {
                 MemorySegment buffer = arena.allocate(RLIMIT);
                 int result = getrlimit(MAC_RLIMIT_NOFILE, buffer);
-                if (result > 0) {
+                if (result == 0) {
                     return buffer.get(JAVA_LONG, RLIMIT.byteOffset(RLIM_CUR));
                 }
                 return 0L;
@@ -418,7 +418,7 @@ public class MacOSProcessFFM extends AbstractOSProcess {
             return callInArenaLongOrDefault(arena -> {
                 MemorySegment buffer = arena.allocate(RLIMIT);
                 int result = getrlimit(MAC_RLIMIT_NOFILE, buffer);
-                if (result > 0) {
+                if (result == 0) {
                     return buffer.get(JAVA_LONG, RLIMIT.byteOffset(RLIM_MAX));
                 }
                 return 0L;

--- a/oshi-core-ffm/src/test/java/oshi/ffm/OperatingSystemFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/OperatingSystemFFMTest.java
@@ -7,6 +7,7 @@ package oshi.ffm;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
+import oshi.software.os.OSProcess;
 import oshi.software.os.OperatingSystem;
 import oshi.software.os.mac.MacOperatingSystemFFM;
 
@@ -35,6 +37,18 @@ public class OperatingSystemFFMTest {
         assertThat("OS should have 1 or more currently running processes", os.getProcessCount(), is(greaterThan(0)));
         assertThat("OS should have at least 1 currently running process", os.getProcesses(null, null, 0),
                 is(not(empty())));
+    }
+
+    @Test
+    void testCurrentProcessOpenFileLimits() {
+        OperatingSystem os = new SystemInfo().getOperatingSystem();
+        OSProcess process = os.getProcess(os.getProcessId());
+        assertThat("Current process shouldn't be null", process, is(notNullValue()));
+        long softLimit = process.getSoftOpenFileLimit();
+        long hardLimit = process.getHardOpenFileLimit();
+        assertThat("Soft open file limit for current process should be positive", softLimit, is(greaterThan(0L)));
+        assertThat("Hard open file limit for current process should be at least the soft limit", hardLimit,
+                is(greaterThanOrEqualTo(softLimit)));
     }
 
     @EnabledOnOs(OS.MAC)

--- a/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
@@ -169,10 +169,12 @@ class OperatingSystemTest {
         assertThat("Bitness must be 0, 32 or 64", proc.getBitness(), is(oneOf(0, 32, 64)));
         assertThat("Current process open file handles should be -1 or higher", proc.getOpenFiles(),
                 is(greaterThanOrEqualTo(0L)));
-        assertThat("Soft open file limit for process should be -1 or higher", proc.getSoftOpenFileLimit(),
-                is(greaterThanOrEqualTo(-1L)));
-        assertThat("Hard open file limit for process should be -1 or higher", proc.getHardOpenFileLimit(),
-                is(greaterThanOrEqualTo(-1L)));
+        long softOpenFileLimit = proc.getSoftOpenFileLimit();
+        long hardOpenFileLimit = proc.getHardOpenFileLimit();
+        assertThat("Soft open file limit for current process should be positive", softOpenFileLimit,
+                is(greaterThan(0L)));
+        assertThat("Hard open file limit for current process should be at least the soft limit", hardOpenFileLimit,
+                is(greaterThanOrEqualTo(softOpenFileLimit)));
         // updateAttributes should succeed and kernel/user time should be nondecreasing
         long kernelBefore = proc.getKernelTime();
         long userBefore = proc.getUserTime();


### PR DESCRIPTION
## Summary
- Fix macOS FFM open file limit queries to treat getrlimit() return value 0 as success.
- Strengthen current-process open file limit smoke coverage for JNA and FFM paths.

Fixes #3286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected macOS handling of process open-file limits so soft and hard limits are retrieved reliably.

* **Tests**
  * Strengthened tests to validate current process soft/hard open-file limits and to compare limits across implementations.

* **Chore**
  * Updated changelog entry for the upcoming 7.2.0 release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->