### PR TITLE
Fix WrongMethodTypeException for void invokeExact in expression lambdas

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/BStrFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/BStrFFM.java
@@ -69,7 +69,9 @@ public final class BStrFFM extends WindowsForeignFunctions {
         if (bstr == null || bstr.equals(MemorySegment.NULL)) {
             return;
         }
-        runOrLog(() -> SysFreeString.invokeExact(bstr), LOG, "BStrFFM.free failed");
+        runOrLog(() -> {
+            SysFreeString.invokeExact(bstr);
+        }, LOG, "BStrFFM.free failed");
     }
 
     // SysStringLen

--- a/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/Ole32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/windows/com/Ole32FFM.java
@@ -95,7 +95,9 @@ public final class Ole32FFM extends WindowsForeignFunctions {
      * Closes the COM library on the current thread.
      */
     public static void CoUninitialize() {
-        runOrLog(() -> CoUninitialize.invokeExact(), LOG, "Ole32FFM.CoUninitialize failed");
+        runOrLog(() -> {
+            CoUninitialize.invokeExact();
+        }, LOG, "Ole32FFM.CoUninitialize failed");
     }
 
     // CoInitializeSecurity


### PR DESCRIPTION
## Summary

`MethodHandle.invokeExact()` is signature-polymorphic: its return type is inferred from the call-site context. In an expression lambda passed to a void-returning functional interface (`ThrowingRunnable`), the compiler infers `Object` as the return type instead of `void`, causing a `WrongMethodTypeException` at runtime.

## Fix

Convert expression lambdas to block lambdas so `invokeExact()` is in a statement context where its return type is correctly inferred as `void`.

## Affected methods

- `Ole32FFM.CoUninitialize()` — reported in #3301
- `BStrFFM.free()` — same latent bug

## Why CI didn't catch it

The `runOrLog()` helper catches `Throwable` and logs at DEBUG level, so the test passed silently while the COM cleanup actually failed.

Fixes #3301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting in internal COM interop utilities for better readability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oshi/oshi/pull/3302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->