### PR TITLE
Remove JNA native library requirement for NetBSD

### DIFF
--- a/.github/workflows/unix.yaml
+++ b/.github/workflows/unix.yaml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - master
-      - netbsd-port
     paths-ignore:
       - '**.md'
       - '**.yml'
@@ -165,9 +164,9 @@ jobs:
             mount -t procfs procfs /proc 2>/dev/null || true
             ./mvnw clean test -B -Djacoco.skip=true
 
-  # Runs on NetBSD 10.1 x86 VM
+  # Runs on NetBSD 10.1 x86 VM without JNA native library
   testnetbsd:
-    name: Test JDK 11, NetBSD
+    name: Test JDK 11, NetBSD (VM)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -180,10 +179,32 @@ jobs:
           prepare: |
             pkg_add curl
             pkg_add openjdk11
-            pkg_add java-jna
           run: |
             export JAVA_HOME=/usr/pkg/java/openjdk11
             export PATH=$JAVA_HOME/bin:$PATH
-            export JAVA_TOOL_OPTIONS="-Djna.boot.library.path=/usr/pkg/lib"
             mount -t procfs procfs /proc 2>/dev/null || true
             ./mvnw clean test -B -Djacoco.skip=true
+
+  # SSH into NetBSD server on GCC Compile Farm and run tests
+  testnetbsd-gcc70:
+    name: Test JDK 11, NetBSD (GCC farm)
+    concurrency: netbsd_gcc70
+    if: github.repository_owner == 'oshi'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Test in NetBSD
+      uses: appleboy/ssh-action@master
+      with:
+        host: gcc70.fsffrance.org
+        username: oshi
+        key: ${{ secrets.AIX_OSHI_KEY }}
+        port: 22
+        command_timeout: 15m
+        script: |
+          set -e
+          cd ~/oshi
+          git reset --hard
+          git checkout master
+          git reset --hard HEAD~2
+          git pull
+          ./mvnw clean test -B -Djacoco.skip=true

--- a/oshi-core/src/main/java/module-info.java
+++ b/oshi-core/src/main/java/module-info.java
@@ -44,5 +44,6 @@ module com.github.oshi {
     requires transitive com.sun.jna;
     requires transitive com.sun.jna.platform;
     requires transitive java.desktop;
+    requires java.management;
     requires org.slf4j;
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -4,17 +4,6 @@
  */
 package oshi.hardware.platform.unix.netbsd;
 
-import static oshi.jna.platform.unix.NetBsdLibc.CPUSTATES;
-import static oshi.jna.platform.unix.NetBsdLibc.CP_IDLE;
-import static oshi.jna.platform.unix.NetBsdLibc.CP_INTR;
-import static oshi.jna.platform.unix.NetBsdLibc.CP_NICE;
-import static oshi.jna.platform.unix.NetBsdLibc.CP_SYS;
-import static oshi.jna.platform.unix.NetBsdLibc.CP_USER;
-import static oshi.jna.platform.unix.NetBsdLibc.CTL_HW;
-import static oshi.jna.platform.unix.NetBsdLibc.CTL_KERN;
-import static oshi.jna.platform.unix.NetBsdLibc.HW_MACHINE;
-import static oshi.jna.platform.unix.NetBsdLibc.HW_MODEL;
-import static oshi.jna.platform.unix.NetBsdLibc.KERN_CP_TIME;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
@@ -30,12 +19,9 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.sun.jna.Memory;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
-import oshi.jna.platform.unix.NetBsdLibc;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
@@ -47,6 +33,14 @@ import oshi.util.tuples.Quartet;
  */
 @ThreadSafe
 public class NetBsdCentralProcessor extends AbstractCentralProcessor {
+
+    private static final int CPUSTATES = 5;
+    private static final int CP_USER = 0;
+    private static final int CP_NICE = 1;
+    private static final int CP_SYS = 2;
+    private static final int CP_INTR = 3;
+    private static final int CP_IDLE = 4;
+
     private final Supplier<Pair<Long, Long>> vmStats = memoize(NetBsdCentralProcessor::queryVmStats,
             defaultExpiration());
     private static final Pattern DMESG_CPU = Pattern.compile("cpu(\\d+): smt (\\d+), core (\\d+), package (\\d+)");
@@ -59,10 +53,7 @@ public class NetBsdCentralProcessor extends AbstractCentralProcessor {
         }
         String cpuName = NetBsdSysctlUtil.sysctl("machdep.cpu_brand", "");
         if (cpuName.isEmpty()) {
-            int[] mib = new int[2];
-            mib[0] = CTL_HW;
-            mib[1] = HW_MODEL;
-            cpuName = NetBsdSysctlUtil.sysctl(mib, "");
+            cpuName = NetBsdSysctlUtil.sysctl("hw.model", "");
         }
         // NetBSD provides family/model/stepping via dmesg
         // e.g., "cpu0: Intel(R) ... 06-7a-01" or from machdep
@@ -94,10 +85,7 @@ public class NetBsdCentralProcessor extends AbstractCentralProcessor {
                 cpuFreq = queryMaxFreq();
             }
         }
-        int[] mib = new int[2];
-        mib[0] = CTL_HW;
-        mib[1] = HW_MACHINE;
-        String machine = NetBsdSysctlUtil.sysctl(mib, "");
+        String machine = NetBsdSysctlUtil.sysctl("hw.machine", "");
         boolean cpu64bit = machine != null && machine.contains("64")
                 || ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
 
@@ -269,20 +257,14 @@ public class NetBsdCentralProcessor extends AbstractCentralProcessor {
     @Override
     protected long[] querySystemCpuLoadTicks() {
         long[] ticks = new long[TickType.values().length];
-        int[] mib = new int[2];
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_CP_TIME;
-        try (Memory m = NetBsdSysctlUtil.sysctl(mib)) {
-            if (m != null) {
-                long[] cpuTicks = cpTimeToTicks(m);
-                if (cpuTicks.length >= CPUSTATES) {
-                    ticks[TickType.USER.getIndex()] = cpuTicks[CP_USER];
-                    ticks[TickType.NICE.getIndex()] = cpuTicks[CP_NICE];
-                    ticks[TickType.SYSTEM.getIndex()] = cpuTicks[CP_SYS];
-                    ticks[TickType.IRQ.getIndex()] = cpuTicks[CP_INTR];
-                    ticks[TickType.IDLE.getIndex()] = cpuTicks[CP_IDLE];
-                }
-            }
+        // Parse "kern.cp_time: user = N, nice = N, sys = N, intr = N, idle = N"
+        long[] cpuTicks = parseCpTime(ExecutingCommand.getFirstAnswer("sysctl kern.cp_time"));
+        if (cpuTicks.length >= CPUSTATES) {
+            ticks[TickType.USER.getIndex()] = cpuTicks[CP_USER];
+            ticks[TickType.NICE.getIndex()] = cpuTicks[CP_NICE];
+            ticks[TickType.SYSTEM.getIndex()] = cpuTicks[CP_SYS];
+            ticks[TickType.IRQ.getIndex()] = cpuTicks[CP_INTR];
+            ticks[TickType.IDLE.getIndex()] = cpuTicks[CP_IDLE];
         }
         return ticks;
     }
@@ -295,37 +277,65 @@ public class NetBsdCentralProcessor extends AbstractCentralProcessor {
     @Override
     protected long[][] queryProcessorCpuLoadTicks() {
         long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
-        // On NetBSD, kern.cp_time with a third MIB element gives per-CPU data
-        int[] mib = new int[3];
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_CP_TIME;
         for (int cpu = 0; cpu < getLogicalProcessorCount(); cpu++) {
-            mib[2] = cpu;
-            try (Memory m = NetBsdSysctlUtil.sysctl(mib)) {
-                if (m != null) {
-                    long[] cpuTicks = cpTimeToTicks(m);
-                    if (cpuTicks.length >= CPUSTATES) {
-                        ticks[cpu][TickType.USER.getIndex()] = cpuTicks[CP_USER];
-                        ticks[cpu][TickType.NICE.getIndex()] = cpuTicks[CP_NICE];
-                        ticks[cpu][TickType.SYSTEM.getIndex()] = cpuTicks[CP_SYS];
-                        ticks[cpu][TickType.IRQ.getIndex()] = cpuTicks[CP_INTR];
-                        ticks[cpu][TickType.IDLE.getIndex()] = cpuTicks[CP_IDLE];
-                    }
-                }
+            // Per-CPU: "kern.cp_time.N: user = ..., nice = ..., sys = ..., intr = ..., idle = ..."
+            long[] cpuTicks = parseCpTime(ExecutingCommand.getFirstAnswer("sysctl kern.cp_time." + cpu));
+            if (cpuTicks.length >= CPUSTATES) {
+                ticks[cpu][TickType.USER.getIndex()] = cpuTicks[CP_USER];
+                ticks[cpu][TickType.NICE.getIndex()] = cpuTicks[CP_NICE];
+                ticks[cpu][TickType.SYSTEM.getIndex()] = cpuTicks[CP_SYS];
+                ticks[cpu][TickType.IRQ.getIndex()] = cpuTicks[CP_INTR];
+                ticks[cpu][TickType.IDLE.getIndex()] = cpuTicks[CP_IDLE];
             }
         }
         return ticks;
     }
 
     /**
-     * Parse memory buffer returned from sysctl kern.cp_time to an array of longs representing CPU states.
+     * Parse sysctl kern.cp_time output to an array of tick values.
+     * <p>
+     * Input format: "kern.cp_time: user = 2930, nice = 42, sys = 1334, intr = 1877, idle = 46354"
      *
-     * @param m A buffer containing the array of 64-bit values.
-     * @return The array
+     * @param cpTimeStr the sysctl output string
+     * @return array of [user, nice, sys, intr, idle] tick values
      */
-    private static long[] cpTimeToTicks(Memory m) {
-        int arraySize = (int) (m.size() / 8L);
-        return m.getLongArray(0, arraySize);
+    private static long[] parseCpTime(String cpTimeStr) {
+        long[] ticks = new long[CPUSTATES];
+        if (cpTimeStr == null || cpTimeStr.isEmpty()) {
+            return ticks;
+        }
+        // Extract the values after the colon
+        int colonIdx = cpTimeStr.indexOf(':');
+        if (colonIdx < 0) {
+            return ticks;
+        }
+        String[] pairs = cpTimeStr.substring(colonIdx + 1).split(",");
+        for (String pair : pairs) {
+            String[] kv = pair.trim().split("\\s*=\\s*");
+            if (kv.length == 2) {
+                long val = ParseUtil.parseLongOrDefault(kv[1].trim(), 0L);
+                switch (kv[0].trim()) {
+                    case "user":
+                        ticks[CP_USER] = val;
+                        break;
+                    case "nice":
+                        ticks[CP_NICE] = val;
+                        break;
+                    case "sys":
+                        ticks[CP_SYS] = val;
+                        break;
+                    case "intr":
+                        ticks[CP_INTR] = val;
+                        break;
+                    case "idle":
+                        ticks[CP_IDLE] = val;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+        return ticks;
     }
 
     /**
@@ -349,9 +359,14 @@ public class NetBsdCentralProcessor extends AbstractCentralProcessor {
             throw new IllegalArgumentException("Must include from one to three elements.");
         }
         double[] average = new double[nelem];
-        int retval = NetBsdLibc.INSTANCE.getloadavg(average, nelem);
-        if (retval < nelem) {
-            Arrays.fill(average, -1d);
+        Arrays.fill(average, -1d);
+        // Parse "vm.loadavg: 1.59 0.47 0.18"
+        String loadavg = ExecutingCommand.getFirstAnswer("sysctl -n vm.loadavg");
+        if (!loadavg.isEmpty()) {
+            String[] loads = ParseUtil.whitespaces.split(loadavg.trim());
+            for (int i = 0; i < nelem && i < loads.length; i++) {
+                average[i] = ParseUtil.parseDoubleOrDefault(loads[i], -1d);
+            }
         }
         return average;
     }

--- a/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdOSProcess.java
@@ -16,7 +16,6 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -27,14 +26,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.Memory;
-import com.sun.jna.Native;
-import com.sun.jna.platform.unix.LibCAPI.size_t;
-import com.sun.jna.platform.unix.Resource;
-
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.jna.ByRef.CloseableSizeTByReference;
-import oshi.jna.platform.unix.NetBsdLibc;
 import oshi.software.common.AbstractOSProcess;
 import oshi.software.os.OSThread;
 import oshi.software.os.unix.netbsd.NetBsdOperatingSystem.PsKeywords;
@@ -62,23 +54,7 @@ public class NetBsdOSProcess extends AbstractOSProcess {
     static final String PS_THREAD_COLUMNS = Arrays.stream(PsThreadColumns.values()).map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
-    private static final int ARGMAX;
-
-    static {
-        int[] mib = new int[2];
-        mib[0] = 1; // CTL_KERN
-        mib[1] = 8; // KERN_ARGMAX
-        try (Memory m = new Memory(Integer.BYTES);
-                CloseableSizeTByReference size = new CloseableSizeTByReference(Integer.BYTES)) {
-            if (NetBsdLibc.INSTANCE.sysctl(mib, mib.length, m, size, null, size_t.ZERO) == 0) {
-                ARGMAX = m.getInt(0);
-            } else {
-                LOG.warn("Failed sysctl call for process arguments max size (kern.argmax). Error code: {}",
-                        Native.getLastError());
-                ARGMAX = 0;
-            }
-        }
-    }
+    private static final int ARGMAX = NetBsdSysctlUtil.sysctl("kern.argmax", 0);
 
     private final NetBsdOperatingSystem os;
 
@@ -116,7 +92,7 @@ public class NetBsdOSProcess extends AbstractOSProcess {
         this.os = os;
         // NetBSD does not maintain a compatibility layer.
         // Process bitness is OS bitness
-        this.bitness = Native.LONG_SIZE * 8;
+        this.bitness = System.getProperty("os.arch", "").contains("64") ? 64 : 32;
         updateThreadCount();
         updateAttributes(psMap);
     }
@@ -165,36 +141,7 @@ public class NetBsdOSProcess extends AbstractOSProcess {
         if (getProcessID() == this.os.getProcessId()) {
             return System.getenv();
         }
-        // For other processes, try sysctl KERN_PROC_ARGS with KERN_PROC_ENV
-        if (ARGMAX <= 0) {
-            return Collections.emptyMap();
-        }
-        int[] mib = new int[4];
-        mib[0] = 1; // CTL_KERN
-        mib[1] = 48; // KERN_PROC_ARGS
-        mib[2] = getProcessID();
-        mib[3] = 3; // KERN_PROC_ENV
-        try (Memory m = new Memory(ARGMAX); CloseableSizeTByReference size = new CloseableSizeTByReference(ARGMAX)) {
-            if (NetBsdLibc.INSTANCE.sysctl(mib, mib.length, m, size, null, size_t.ZERO) == 0) {
-                Map<String, String> env = new LinkedHashMap<>();
-                long bytesReturned = size.getValue().longValue();
-                long offset = 0;
-                while (offset < bytesReturned) {
-                    String envStr = m.getString(offset);
-                    if (envStr.isEmpty()) {
-                        break;
-                    }
-                    int idx = envStr.indexOf('=');
-                    if (idx > 0) {
-                        env.put(envStr.substring(0, idx), envStr.substring(idx + 1));
-                    }
-                    offset += envStr.length() + 1;
-                }
-                if (!env.isEmpty()) {
-                    return Collections.unmodifiableMap(env);
-                }
-            }
-        }
+        // Environment of other processes is not accessible without JNA on NetBSD
         return Collections.emptyMap();
     }
 
@@ -291,23 +238,22 @@ public class NetBsdOSProcess extends AbstractOSProcess {
     @Override
     public long getSoftOpenFileLimit() {
         if (getProcessID() == this.os.getProcessId()) {
-            final Resource.Rlimit rlimit = new Resource.Rlimit();
-            NetBsdLibc.INSTANCE.getrlimit(NetBsdLibc.RLIMIT_NOFILE, rlimit);
-            return rlimit.rlim_cur;
-        } else {
-            return -1L; // not supported
+            long limit = NetBsdSysctlUtil.sysctl("kern.maxfilesperproc", 0L);
+            if (limit <= 0) {
+                limit = NetBsdSysctlUtil.sysctl("kern.maxfiles", 0L);
+            }
+            return limit > 0 ? limit : -1L;
         }
+        return -1L;
     }
 
     @Override
     public long getHardOpenFileLimit() {
         if (getProcessID() == this.os.getProcessId()) {
-            final Resource.Rlimit rlimit = new Resource.Rlimit();
-            NetBsdLibc.INSTANCE.getrlimit(NetBsdLibc.RLIMIT_NOFILE, rlimit);
-            return rlimit.rlim_max;
-        } else {
-            return -1L; // not supported
+            long limit = NetBsdSysctlUtil.sysctl("kern.maxfiles", 0L);
+            return limit > 0 ? limit : -1L;
         }
+        return -1L;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdOperatingSystem.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdOperatingSystem.java
@@ -4,10 +4,6 @@
  */
 package oshi.software.os.unix.netbsd;
 
-import static oshi.jna.platform.unix.NetBsdLibc.CTL_KERN;
-import static oshi.jna.platform.unix.NetBsdLibc.KERN_OSRELEASE;
-import static oshi.jna.platform.unix.NetBsdLibc.KERN_OSTYPE;
-import static oshi.jna.platform.unix.NetBsdLibc.KERN_VERSION;
 import static oshi.software.os.OSService.State.RUNNING;
 import static oshi.software.os.OSService.State.STOPPED;
 
@@ -25,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.jna.platform.unix.NetBsdLibc;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
@@ -67,14 +62,9 @@ public class NetBsdOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        int[] mib = new int[2];
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_OSTYPE;
-        String family = NetBsdSysctlUtil.sysctl(mib, "NetBSD");
-        mib[1] = KERN_OSRELEASE;
-        String version = NetBsdSysctlUtil.sysctl(mib, "");
-        mib[1] = KERN_VERSION;
-        String versionInfo = NetBsdSysctlUtil.sysctl(mib, "");
+        String family = NetBsdSysctlUtil.sysctl("kern.ostype", "NetBSD");
+        String version = NetBsdSysctlUtil.sysctl("kern.osrelease", "");
+        String versionInfo = NetBsdSysctlUtil.sysctl("kern.version", "");
         String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
 
         return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
@@ -155,7 +145,9 @@ public class NetBsdOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public int getProcessId() {
-        return NetBsdLibc.INSTANCE.getpid();
+        // RuntimeMXBean name format is "pid@hostname"
+        String name = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
+        return ParseUtil.parseIntOrDefault(name.split("@")[0], -1);
     }
 
     @Override
@@ -170,7 +162,7 @@ public class NetBsdOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public int getThreadId() {
-        return NetBsdLibc.INSTANCE._lwp_self();
+        return (int) Thread.currentThread().getId();
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/FstatUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/FstatUtil.java
@@ -24,10 +24,17 @@ public final class FstatUtil {
      * @return the current working directory for that process.
      */
     public static String getCwd(int pid) {
-        // NetBSD: use sysctl or /proc if mounted
+        // NetBSD: try /proc if mounted
         List<String> ls = ExecutingCommand.runNative("readlink /proc/" + pid + "/cwd");
         if (!ls.isEmpty() && !ls.get(0).isEmpty()) {
             return ls.get(0);
+        }
+        // Fallback: parse from fstat output (field after 'wd')
+        for (String line : ExecutingCommand.runNative("fstat -p " + pid)) {
+            String[] split = line.trim().split("\\s+");
+            if (split.length > 4 && "wd".equals(split[3])) {
+                return split[4];
+            }
         }
         return "";
     }

--- a/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/NetBsdSysctlUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/NetBsdSysctlUtil.java
@@ -1,144 +1,24 @@
 /*
- * Copyright 2021-2026 The OSHI Project Contributors
+ * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.unix.netbsd;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.sun.jna.Memory;
-import com.sun.jna.Native;
-import com.sun.jna.Structure;
-import com.sun.jna.platform.unix.LibCAPI.size_t;
-
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.jna.ByRef.CloseableSizeTByReference;
-import oshi.jna.platform.unix.NetBsdLibc;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 /**
- * Provides access to sysctl calls on NetBSD
+ * Provides access to sysctl calls on NetBSD via command-line execution. This implementation does not require JNA native
+ * library support.
  */
 @ThreadSafe
 public final class NetBsdSysctlUtil {
 
     private static final String SYSCTL_N = "sysctl -n ";
 
-    private static final Logger LOG = LoggerFactory.getLogger(NetBsdSysctlUtil.class);
-
-    private static final String SYSCTL_FAIL = "Failed sysctl call: {}, Error code: {}";
-
     private NetBsdSysctlUtil() {
     }
-
-    /**
-     * Executes a sysctl call with an int result
-     *
-     * @param name name of the sysctl
-     * @param def  default int value
-     * @return The int result of the call if successful; the default otherwise
-     */
-    public static int sysctl(int[] name, int def) {
-        int intSize = NetBsdLibc.INT_SIZE;
-        try (Memory p = new Memory(intSize); CloseableSizeTByReference size = new CloseableSizeTByReference(intSize)) {
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            return p.getInt(0);
-        }
-    }
-
-    /**
-     * Executes a sysctl call with a long result
-     *
-     * @param name name of the sysctl
-     * @param def  default long value
-     * @return The long result of the call if successful; the default otherwise
-     */
-    public static long sysctl(int[] name, long def) {
-        int uint64Size = NetBsdLibc.UINT64_SIZE;
-        try (Memory p = new Memory(uint64Size);
-                CloseableSizeTByReference size = new CloseableSizeTByReference(uint64Size)) {
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            return p.getLong(0);
-        }
-    }
-
-    /**
-     * Executes a sysctl call with a String result
-     *
-     * @param name name of the sysctl
-     * @param def  default String value
-     * @return The String result of the call if successful; the default otherwise
-     */
-    public static String sysctl(int[] name, String def) {
-        // Call first time with null pointer to get value of size
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, null, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            // Add 1 to size for null terminated string
-            try (Memory p = new Memory(size.longValue() + 1L)) {
-                if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
-                    LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                    return def;
-                }
-                return p.getString(0);
-            }
-        }
-    }
-
-    /**
-     * Executes a sysctl call with a Structure result
-     *
-     * @param name   name of the sysctl
-     * @param struct structure for the result
-     * @return True if structure is successfuly populated, false otherwise
-     */
-    public static boolean sysctl(int[] name, Structure struct) {
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference(struct.size())) {
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, struct.getPointer(), size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                return false;
-            }
-        }
-        struct.read();
-        return true;
-    }
-
-    /**
-     * Executes a sysctl call with a Pointer result
-     *
-     * @param name name of the sysctl
-     * @return An allocated memory buffer containing the result on success, null otherwise. Its value on failure is
-     *         undefined.
-     */
-    public static Memory sysctl(int[] name) {
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, null, size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                return null;
-            }
-            Memory m = new Memory(size.longValue());
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, m, size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                m.close();
-                return null;
-            }
-            return m;
-        }
-    }
-
-    /*
-     * Backup versions with command parsing
-     */
 
     /**
      * Executes a sysctl call with an int result

--- a/oshi-core/src/test/java/oshi/jna/util/FileUtilJNATest.java
+++ b/oshi-core/src/test/java/oshi/jna/util/FileUtilJNATest.java
@@ -11,12 +11,14 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import com.sun.jna.Native;
 
 /**
  * Tests JNA-specific buffer read methods in {@link FileUtilJNA}.
  */
+@DisabledIfSystemProperty(named = "os.name", matches = "(?i)netbsd")
 class FileUtilJNATest {
 
     @Test


### PR DESCRIPTION
## Summary

Remove all JNA native library dependencies from the NetBSD platform implementation, making NetBSD the first oshi-core platform that works entirely without native library support.  (Necessary to stay true to the "no native libraries" promise as JNA does not distribute its binary build for NetBSD: it's available as a package, but its use is minimal so an all-command-line port makes sense.)

- Replace JNA sysctl/getpid/getloadavg/getrlimit calls with command-line alternatives
- NetBSD no longer requires the pkgsrc `java-jna` package
- Add gcc70 (GCC Compile Farm) NetBSD physical hardware test to unix.yaml
- Update NetBSD VM test to verify the no-native path (java-jna not installed)
- Remove stale `netbsd-port` branch trigger from unix.yaml

Passing tests (no JNA installed): https://github.com/dbwiddis/oshi/actions/runs/26703084248

## Test plan

- [x] NetBSD VM without java-jna: 0 test failures (77 passing, 91 skipped)
- [x] NetBSD gcc70 physical hardware with JNA: 0 test failures
- [x] Compiles cleanly with spotless, checkstyle, forbiddenapis
- [ ] Verify gcc70 job works from upstream (requires AIX_OSHI_KEY secret)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NetBSD system info: more reliable CPU ticks, per-CPU loads, and load averages; better process metrics and working-directory resolution with fallbacks.

* **Refactor**
  * Simplified NetBSD system utilities to use command-line sysctl paths, reducing native/JNA reliance.

* **Tests**
  * NetBSD-specific test adjustments to avoid incompatible native-dependent tests.

* **Chores**
  * CI updates for NetBSD test jobs and added Java management support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->