### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,18 +32,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
       with:
         languages: ${{ matrix.language }}
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           cache: maven
           java-version: 21

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint (Spotless, Checkstyle, ForbiddenAPIs, Javadoc)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 25
           distribution: 'zulu'
@@ -52,9 +52,9 @@ jobs:
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -70,7 +70,7 @@ jobs:
         run: ./mvnw test -Paggregate-coverage -B
       - name: Upload Coverage
         if: always() && contains(matrix.java, '25')
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
@@ -81,9 +81,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Container Cgroup Test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 17
           distribution: 'zulu'
@@ -108,9 +108,9 @@ jobs:
     runs-on: ubuntu-latest
     name: JMH Benchmarks
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 25
           distribution: 'zulu'

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -27,9 +27,9 @@ jobs:
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Coverage
         if: always() && contains(matrix.java, '25') && contains(matrix.os, 'macos-15')
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
@@ -57,9 +57,9 @@ jobs:
     runs-on: macos-26
     name: JMH Benchmarks
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 25
           distribution: 'zulu'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint (Spotless, Checkstyle, ForbiddenAPIs, Javadoc)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 25
           distribution: 'zulu'
@@ -51,9 +51,9 @@ jobs:
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}${{ contains(matrix.java, '25') && ' (+ JNA==FFM)' || '' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -66,7 +66,7 @@ jobs:
         run: ./mvnw test -Paggregate-coverage -B
       - name: Upload Coverage
         if: always() && contains(matrix.java, '25')
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
@@ -81,9 +81,9 @@ jobs:
       fail-fast: false
     name: JMH Benchmarks, ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 25
           distribution: 'zulu'

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -18,15 +18,15 @@ jobs:
     if: github.repository_owner == 'oshi'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           cache: maven
           distribution: temurin
           java-version: 25
       - name: Cache NVD database
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.2.0
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
           key: nvd-db
@@ -36,7 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       - name: Deploy Site to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
         with:
           branch: gh-pages
           folder: target/staging

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -14,12 +14,12 @@ jobs:
     if: github.repository_owner == 'oshi'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           cache: maven
           distribution: temurin

--- a/.github/workflows/sonatype.yaml
+++ b/.github/workflows/sonatype.yaml
@@ -18,9 +18,9 @@ jobs:
       CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
       NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           cache: maven
           distribution: temurin

--- a/.github/workflows/unix.yaml
+++ b/.github/workflows/unix.yaml
@@ -19,10 +19,10 @@ jobs:
     if: github.repository_owner == 'oshi'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Test in FreeBSD
         id: test-freebsd
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1
         with:
           usesh: true
           prepare: |
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-24.04
     name: Test JDK 11, OpenBSD vm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Test on OpenBSD
         id: test-openbsd
-        uses: vmactions/openbsd-vm@v1
+        uses: vmactions/openbsd-vm@6fac4962055fe9952d29930942445739e509fecd # v1
         with:
           release: "7.7"
           usesh: false
@@ -59,10 +59,10 @@ jobs:
     if: github.repository_owner == 'oshi'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Test on Solaris
         id: test-solaris
-        uses: vmactions/solaris-vm@v1
+        uses: vmactions/solaris-vm@3702ccf20b84c7f7c0a9bb68894aba7623f8301d # v1
         with:
           run: |
             wget https://download.bell-sw.com/java/11.0.15.1+2/bellsoft-jdk11.0.15.1+2-solaris-x64-lite.tar.gz -nv
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Test in Solaris SPARC
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
       with:
         host: gcc211.fsffrance.org
         username: oshi
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Test in AIX
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
       with:
         host: gcc119.fsffrance.org
         username: oshi
@@ -148,10 +148,10 @@ jobs:
     name: Test JDK 11, DragonFly BSD
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Test in DragonFly BSD
         id: test-dragonflybsd
-        uses: vmactions/dragonflybsd-vm@v1
+        uses: vmactions/dragonflybsd-vm@b4468429bb9ab60b14600c6eeeb6464427f29391 # v1
         with:
           release: "6.4.2"
           usesh: true
@@ -169,10 +169,10 @@ jobs:
     name: Test JDK 11, NetBSD (VM)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Test in NetBSD
         id: test-netbsd
-        uses: vmactions/netbsd-vm@v1
+        uses: vmactions/netbsd-vm@ad31081832386a0ba569aee243e6edf9524f3f80 # v1
         with:
           release: "10.1"
           usesh: true
@@ -193,7 +193,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Test in NetBSD
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
       with:
         host: gcc70.fsffrance.org
         username: oshi

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -23,9 +23,9 @@ jobs:
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -42,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Coverage
         if: always() && contains(matrix.java, '25') && contains(matrix.os, 'windows-2022')
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
@@ -53,9 +53,9 @@ jobs:
     runs-on: windows-2025
     name: JMH Benchmarks
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 25
           distribution: 'temurin'


### PR DESCRIPTION
## Summary

Pin all GitHub Actions dependencies to their current release commit SHAs to mitigate supply-chain risk from mutable tags.

## Actions pinned

| Action | Version | SHA |
|--------|---------|-----|
| actions/checkout | v6 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| actions/setup-java | v5 | `be666c2fcd27ec809703dec50e508c2fdc7f6654` |
| actions/cache | v5 | `27d5ce7f107fe9357f9df03efb73ab90386fccae` |
| codecov/codecov-action | v6 | `e79a6962e0d4c0c17b229090214935d2e33f8354` |
| appleboy/ssh-action | v1.2.5 | `0ff4204d59e8e51228ff73bce53f80d53301dee2` |
| github/codeql-action | v4 | `7211b7c8077ea37d8641b6271f6a365a22a5fbfa` |
| JamesIves/github-pages-deploy-action | v4 | `d92aa235d04922e8f08b40ce78cc5442fcfbfa2f` |
| vmactions/freebsd-vm | v1 | `a6de9343ef5747433d9c25784c90e84998b9d69a` |
| vmactions/openbsd-vm | v1 | `6fac4962055fe9952d29930942445739e509fecd` |
| vmactions/solaris-vm | v1 | `3702ccf20b84c7f7c0a9bb68894aba7623f8301d` |
| vmactions/dragonflybsd-vm | v1 | `b4468429bb9ab60b14600c6eeeb6464427f29391` |
| vmactions/netbsd-vm | v1 | `ad31081832386a0ba569aee243e6edf9524f3f80` |

All SHAs verified as pointing to the current latest release for each action.

## Test plan

- [x] No functional changes — only `uses:` references updated
- [x] Version comments preserved for readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations across all CI pipelines to use pinned commit references, improving build consistency and reproducibility across multiple platforms and deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->