### PR TITLE
FreeBSD Port: FFM concretes for Memory/Sensors/Network/CPU

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/unix/freebsd/FreeBsdLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/unix/freebsd/FreeBsdLibcFunctions.java
@@ -25,10 +25,10 @@ import oshi.ffm.ForeignFunctions;
 /**
  * FFM bindings for FreeBSD libc functions used by OSHI.
  * <p>
- * Phase 3 scope covers {@code sysctlbyname}, {@code getloadavg}, and the {@code utmpx} family
- * ({@code setutxent}/{@code getutxent}/{@code endutxent}) plus the matching {@link #UTMPX_LAYOUT} so a session driver
- * can walk the database. Additional libc bindings ({@code sysctl} with int MIB, {@code getpid}, {@code thr_self},
- * {@code getrlimit}) are added in later phases alongside their first FFM consumer.
+ * Covers {@code sysctlbyname}, {@code getloadavg}, the {@code utmpx} family, and the
+ * {@code gethostname}/{@code getaddrinfo}/{@code freeaddrinfo}/{@code gai_strerror} surface used by network params.
+ * Additional libc bindings ({@code sysctl} with int MIB, {@code getpid}, {@code thr_self}, {@code getrlimit}) are added
+ * in later phases alongside their first FFM consumer.
  */
 public final class FreeBsdLibcFunctions extends ForeignFunctions {
 
@@ -37,6 +37,36 @@ public final class FreeBsdLibcFunctions extends ForeignFunctions {
 
     /** Layout of the C {@code size_t} type on FreeBSD (8 bytes on all supported 64-bit archs). */
     public static final ValueLayout.OfLong SIZE_T = ValueLayout.JAVA_LONG;
+
+    /** {@code getaddrinfo} hint flag: return the canonical name in {@code ai_canonname}. */
+    public static final int AI_CANONNAME = 2;
+
+    /** POSIX maximum length of a host name, excluding the null terminator. Buffers should be allocated as +1. */
+    public static final int HOST_NAME_MAX = 255;
+
+    /**
+     * Layout of FreeBSD's {@code struct addrinfo} ({@code <netdb.h>}).
+     *
+     * <pre>
+     *   int    ai_flags      (4) @ 0
+     *   int    ai_family     (4) @ 4
+     *   int    ai_socktype   (4) @ 8
+     *   int    ai_protocol   (4) @ 12
+     *   int    ai_addrlen    (4) @ 16   -- socklen_t (uint32_t on FreeBSD)
+     *   pad                  (4) @ 20
+     *   ptr    ai_canonname  (8) @ 24   -- note: canonname BEFORE addr, unlike Linux glibc
+     *   ptr    ai_addr       (8) @ 32
+     *   ptr    ai_next       (8) @ 40
+     *   total = 48 bytes
+     * </pre>
+     */
+    public static final StructLayout ADDRINFO_LAYOUT = MemoryLayout.structLayout(JAVA_INT.withName("ai_flags"),
+            JAVA_INT.withName("ai_family"), JAVA_INT.withName("ai_socktype"), JAVA_INT.withName("ai_protocol"),
+            JAVA_INT.withName("ai_addrlen"), MemoryLayout.paddingLayout(4), ADDRESS.withName("ai_canonname"),
+            ADDRESS.withName("ai_addr"), ADDRESS.withName("ai_next"));
+
+    private static final VarHandle ADDRINFO_CANONNAME = ADDRINFO_LAYOUT
+            .varHandle(PathElement.groupElement("ai_canonname"));
 
     // ---- utmpx constants (FreeBSD <utmpx.h>) ----
 
@@ -208,5 +238,88 @@ public final class FreeBsdLibcFunctions extends ForeignFunctions {
         long tvSec = (long) UTMPX_TV_SEC.get(ut, 0L);
         long tvUsec = (long) UTMPX_TV_USEC.get(ut, 0L);
         return tvSec * 1000L + tvUsec / 1000L;
+    }
+
+    // int gethostname(char *name, size_t namelen);
+    private static final MethodHandle gethostname = LINKER.downcallHandle(LIBC.findOrThrow("gethostname"),
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, SIZE_T));
+
+    /**
+     * Calls {@code gethostname(name, namelen)}.
+     *
+     * @param buf segment of at least {@code len} bytes
+     * @param len buffer length
+     * @return 0 on success, -1 on error
+     * @throws Throwable on FFM invocation error
+     */
+    public static int gethostname(MemorySegment buf, long len) throws Throwable {
+        return (int) gethostname.invokeExact(buf, len);
+    }
+
+    // int getaddrinfo(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res);
+    private static final MethodHandle getaddrinfo = LINKER.downcallHandle(LIBC.findOrThrow("getaddrinfo"),
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
+
+    /**
+     * Calls {@code getaddrinfo(node, service, hints, res)}.
+     *
+     * @param node    hostname segment (null-terminated UTF-8)
+     * @param service NULL segment or service name
+     * @param hints   segment allocated with {@link #ADDRINFO_LAYOUT}, or NULL
+     * @param res     pointer-to-pointer output segment (ADDRESS-sized)
+     * @return 0 on success, non-zero error code on failure
+     * @throws Throwable on FFM invocation error
+     */
+    public static int getaddrinfo(MemorySegment node, MemorySegment service, MemorySegment hints, MemorySegment res)
+            throws Throwable {
+        return (int) getaddrinfo.invokeExact(node, service, hints, res);
+    }
+
+    // void freeaddrinfo(struct addrinfo *res);
+    private static final MethodHandle freeaddrinfo = LINKER.downcallHandle(LIBC.findOrThrow("freeaddrinfo"),
+            FunctionDescriptor.ofVoid(ADDRESS));
+
+    /**
+     * Calls {@code freeaddrinfo(res)}.
+     *
+     * @param res the addrinfo pointer returned by {@link #getaddrinfo}
+     * @throws Throwable on FFM invocation error
+     */
+    public static void freeaddrinfo(MemorySegment res) throws Throwable {
+        freeaddrinfo.invokeExact(res);
+    }
+
+    // const char *gai_strerror(int ecode);
+    private static final MethodHandle gai_strerror = LINKER.downcallHandle(LIBC.findOrThrow("gai_strerror"),
+            FunctionDescriptor.of(ADDRESS, JAVA_INT));
+
+    /**
+     * Calls {@code gai_strerror(ecode)} and returns the error string.
+     *
+     * @param errcode error code from {@link #getaddrinfo}
+     * @param arena   arena to scope the string reinterpret
+     * @return human-readable error string
+     * @throws Throwable on FFM invocation error
+     */
+    public static String gaiStrerror(int errcode, java.lang.foreign.Arena arena) throws Throwable {
+        MemorySegment ptr = (MemorySegment) gai_strerror.invokeExact(errcode);
+        return getStringFromNativePointer(ptr, arena);
+    }
+
+    /**
+     * Reads {@code ai_canonname} from the first addrinfo result pointer.
+     *
+     * @param resPtr the raw pointer value stored in the output segment after {@link #getaddrinfo}
+     * @param arena  arena to scope the reinterpret
+     * @return the canonical name string, or {@code null} if the pointer is NULL
+     */
+    public static String addrinfoCanonname(MemorySegment resPtr, java.lang.foreign.Arena arena) {
+        if (resPtr == null || MemorySegment.NULL.equals(resPtr)) {
+            return null;
+        }
+        MemorySegment addrinfo = MemorySegment.ofAddress(resPtr.address()).reinterpret(ADDRINFO_LAYOUT.byteSize(),
+                arena, null);
+        MemorySegment canonPtr = (MemorySegment) ADDRINFO_CANONNAME.get(addrinfo, 0L);
+        return getStringFromNativePointer(canonPtr, arena);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorFFM.java
@@ -334,7 +334,7 @@ public class FreeBsdCentralProcessorFFM extends FreeBsdCentralProcessor {
     private static String getProcessorIDfromDmiDecode(long processorID) {
         boolean procInfo = false;
         String marker = "Processor Information";
-        for (String checkLine : ExecutingCommand.runNative("dmidecode -t system")) {
+        for (String checkLine : ExecutingCommand.runNative("dmidecode -t processor")) {
             if (!procInfo && checkLine.contains(marker)) {
                 marker = "ID:";
                 procInfo = true;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorFFM.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.freebsd;
+
+import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.unix.freebsd.FreeBsdLibcFunctions;
+import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
+import oshi.hardware.CentralProcessor.ProcessorCache.Type;
+import oshi.hardware.common.platform.unix.freebsd.FreeBsdCentralProcessor;
+import oshi.util.ExecutingCommand;
+import oshi.util.FileUtil;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Quartet;
+
+/**
+ * FFM-backed FreeBSD central processor.
+ */
+@ThreadSafe
+public class FreeBsdCentralProcessorFFM extends FreeBsdCentralProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FreeBsdCentralProcessorFFM.class);
+
+    // Capture the CSV of hex values as group(1), clients should split on ','
+    private static final Pattern CPUMASK = Pattern
+            .compile(".*<cpu\\s.*mask=\"(\\p{XDigit}+(,\\p{XDigit}+)*)\".*>.*</cpu>.*");
+
+    // FreeBSD CPU state indices into kern.cp_time / kern.cp_times arrays
+    private static final int CP_USER = 0;
+    private static final int CP_NICE = 1;
+    private static final int CP_SYS = 2;
+    private static final int CP_INTR = 3;
+    private static final int CP_IDLE = 4;
+    private static final int CPUSTATES = 5;
+    private static final long UINT64_SIZE = Long.BYTES;
+    private static final long CPTIME_SIZE = CPUSTATES * UINT64_SIZE;
+
+    @Override
+    protected ProcessorIdentifier queryProcessorId() {
+        final Pattern identifierPattern = Pattern
+                .compile("Origin=\"([^\"]*)\".*Id=(\\S+).*Family=(\\S+).*Model=(\\S+).*Stepping=(\\S+).*");
+        final Pattern featuresPattern = Pattern.compile("Features=(\\S+)<.*");
+
+        String cpuVendor = "";
+        String cpuName = BsdSysctlUtilFFM.sysctl("hw.model", "");
+        String cpuFamily = "";
+        String cpuModel = "";
+        String cpuStepping = "";
+        String processorID;
+        long cpuFreq = BsdSysctlUtilFFM.sysctl("hw.clockrate", 0L) * 1_000_000L;
+
+        boolean cpu64bit;
+
+        // Parsing dmesg.boot is apparently the only reliable source for processor
+        // identification in FreeBSD
+        long processorIdBits = 0L;
+        List<String> cpuInfo = FileUtil.readFile("/var/run/dmesg.boot");
+        for (String line : cpuInfo) {
+            line = line.trim();
+            // Prefer hw.model to this one
+            if (line.startsWith("CPU:") && cpuName.isEmpty()) {
+                cpuName = line.replace("CPU:", "").trim();
+            } else if (line.startsWith("Origin=")) {
+                Matcher m = identifierPattern.matcher(line);
+                if (m.matches()) {
+                    cpuVendor = m.group(1);
+                    processorIdBits |= Long.decode(m.group(2));
+                    cpuFamily = Integer.decode(m.group(3)).toString();
+                    cpuModel = Integer.decode(m.group(4)).toString();
+                    cpuStepping = Integer.decode(m.group(5)).toString();
+                }
+            } else if (line.startsWith("Features=")) {
+                Matcher m = featuresPattern.matcher(line);
+                if (m.matches()) {
+                    processorIdBits |= Long.decode(m.group(1)) << 32;
+                }
+                // No further interest in this file
+                break;
+            }
+        }
+        cpu64bit = ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
+        processorID = getProcessorIDfromDmiDecode(processorIdBits);
+
+        return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,
+                cpuFreq);
+    }
+
+    @Override
+    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+        List<LogicalProcessor> logProcs = parseTopology();
+        // Force at least one processor
+        if (logProcs.isEmpty()) {
+            logProcs.add(new LogicalProcessor(0, 0, 0));
+        }
+        Map<Integer, String> dmesg = new HashMap<>();
+        // cpu0: <Open Firmware CPU> on cpulist0
+        Pattern normal = Pattern.compile("cpu(\\d+): (.+) on .*");
+        // CPU 0: ARM Cortex-A53 r0p4 affinity: 0 0
+        Pattern hybrid = Pattern.compile("CPU\\s*(\\d+): (.+) affinity:.*");
+        List<String> featureFlags = new ArrayList<>();
+        boolean readingFlags = false;
+        for (String s : FileUtil.readFile("/var/run/dmesg.boot")) {
+            Matcher h = hybrid.matcher(s);
+            if (h.matches()) {
+                int coreId = ParseUtil.parseIntOrDefault(h.group(1), 0);
+                // This always takes priority, overwrite if needed
+                dmesg.put(coreId, h.group(2).trim());
+            } else {
+                Matcher n = normal.matcher(s);
+                if (n.matches()) {
+                    int coreId = ParseUtil.parseIntOrDefault(n.group(1), 0);
+                    // Don't overwrite if h matched earlier
+                    dmesg.putIfAbsent(coreId, n.group(2).trim());
+                }
+            }
+            if (s.contains("Origin=")) {
+                readingFlags = true;
+            } else if (readingFlags) {
+                if (s.startsWith("  ")) {
+                    featureFlags.add(s.trim());
+                } else {
+                    readingFlags = false;
+                }
+            }
+        }
+        List<PhysicalProcessor> physProcs = dmesg.isEmpty() ? null : createProcListFromDmesg(logProcs, dmesg);
+        List<ProcessorCache> caches = getCacheInfoFromLscpu();
+        return new Quartet<>(logProcs, physProcs, caches, featureFlags);
+    }
+
+    private List<ProcessorCache> getCacheInfoFromLscpu() {
+        Set<ProcessorCache> caches = new HashSet<>();
+        for (String checkLine : ExecutingCommand.runNative("lscpu")) {
+            if (checkLine.contains("L1d cache:")) {
+                caches.add(new ProcessorCache(1, 0, 0,
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.DATA));
+            } else if (checkLine.contains("L1i cache:")) {
+                caches.add(new ProcessorCache(1, 0, 0,
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.INSTRUCTION));
+            } else if (checkLine.contains("L2 cache:")) {
+                caches.add(new ProcessorCache(2, 0, 0,
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.UNIFIED));
+            } else if (checkLine.contains("L3 cache:")) {
+                caches.add(new ProcessorCache(3, 0, 0,
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.UNIFIED));
+            }
+        }
+        return orderedProcCaches(caches);
+    }
+
+    private static List<LogicalProcessor> parseTopology() {
+        String[] topology = BsdSysctlUtilFFM.sysctl("kern.sched.topology_spec", "").split("[\\n\\r]");
+        // See FreeBsdCentralProcessorJNA for sample output and the layered <group> semantics.
+        long group1 = 1L;
+        List<Long> group2 = new ArrayList<>();
+        List<Long> group3 = new ArrayList<>();
+        int groupLevel = 0;
+        for (String topo : topology) {
+            if (topo.contains("<group level=")) {
+                groupLevel++;
+            } else if (topo.contains("</group>")) {
+                groupLevel--;
+            } else if (topo.contains("<cpu")) {
+                Matcher m = CPUMASK.matcher(topo);
+                if (m.matches()) {
+                    String csvMatch = m.group(1);
+                    String[] csvTokens = csvMatch.split(",");
+                    String firstVal = csvTokens[0];
+                    long parsedVal = ParseUtil.hexStringToLong(firstVal, 0);
+                    switch (groupLevel) {
+                        case 1:
+                            group1 = parsedVal;
+                            break;
+                        case 2:
+                            group2.add(parsedVal);
+                            break;
+                        case 3:
+                            group3.add(parsedVal);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+        return matchBitmasks(group1, group2, group3);
+    }
+
+    private static List<LogicalProcessor> matchBitmasks(long group1, List<Long> group2, List<Long> group3) {
+        List<LogicalProcessor> logProcs = new ArrayList<>();
+        int lowBit = Long.numberOfTrailingZeros(group1);
+        int hiBit = 63 - Long.numberOfLeadingZeros(group1);
+        for (int i = lowBit; i <= hiBit; i++) {
+            if ((group1 & (1L << i)) > 0) {
+                int numaNode = 0;
+                LogicalProcessor logProc = new LogicalProcessor(i, getMatchingBitmask(group3, i),
+                        getMatchingBitmask(group2, i), numaNode);
+                logProcs.add(logProc);
+            }
+        }
+        return logProcs;
+    }
+
+    private static int getMatchingBitmask(List<Long> bitmasks, int lp) {
+        for (int j = 0; j < bitmasks.size(); j++) {
+            if ((bitmasks.get(j).longValue() & (1L << lp)) != 0) {
+                return j;
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public long[] querySystemCpuLoadTicks() {
+        long[] ticks = new long[TickType.values().length];
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment cpTime = arena.allocate(CPTIME_SIZE);
+            if (BsdSysctlUtilFFM.sysctl("kern.cp_time", cpTime)) {
+                ticks[TickType.USER.getIndex()] = cpTime.getAtIndex(JAVA_LONG, CP_USER);
+                ticks[TickType.NICE.getIndex()] = cpTime.getAtIndex(JAVA_LONG, CP_NICE);
+                ticks[TickType.SYSTEM.getIndex()] = cpTime.getAtIndex(JAVA_LONG, CP_SYS);
+                ticks[TickType.IRQ.getIndex()] = cpTime.getAtIndex(JAVA_LONG, CP_INTR);
+                ticks[TickType.IDLE.getIndex()] = cpTime.getAtIndex(JAVA_LONG, CP_IDLE);
+            }
+        }
+        return ticks;
+    }
+
+    @Override
+    public long[] queryCurrentFreq() {
+        long[] freq = new long[1];
+        freq[0] = BsdSysctlUtilFFM.sysctl("dev.cpu.0.freq", -1L);
+        if (freq[0] > 0) {
+            // If success, value is in MHz
+            freq[0] *= 1_000_000L;
+        } else {
+            freq[0] = BsdSysctlUtilFFM.sysctl("machdep.tsc_freq", -1L);
+        }
+        return freq;
+    }
+
+    @Override
+    public long queryMaxFreq() {
+        long max = -1L;
+        String freqLevels = BsdSysctlUtilFFM.sysctl("dev.cpu.0.freq_levels", "");
+        // MHz/Watts pairs like: 2501/32000 2187/27125 2000/24000
+        for (String s : ParseUtil.whitespaces.split(freqLevels)) {
+            long freq = ParseUtil.parseLongOrDefault(s.split("/")[0], -1L);
+            if (max < freq) {
+                max = freq;
+            }
+        }
+        if (max > 0) {
+            // If success, value is in MHz
+            max *= 1_000_000;
+        } else {
+            max = BsdSysctlUtilFFM.sysctl("machdep.tsc_freq", -1L);
+        }
+        return max;
+    }
+
+    @Override
+    public double[] getSystemLoadAverage(int nelem) {
+        if (nelem < 1 || nelem > 3) {
+            throw new IllegalArgumentException("Must include from one to three elements.");
+        }
+        final int n = nelem;
+        return callInArenaOrDefault(arena -> {
+            MemorySegment avg = arena.allocate(JAVA_DOUBLE, n);
+            int retval = FreeBsdLibcFunctions.getloadavg(avg, n);
+            double[] result = new double[n];
+            for (int i = 0; i < n; i++) {
+                result[i] = (i < retval) ? avg.getAtIndex(JAVA_DOUBLE, i) : -1d;
+            }
+            return result;
+        }, LOG, Level.WARN, "Failed to read load average", fillNegative(nelem));
+    }
+
+    private static double[] fillNegative(int nelem) {
+        double[] arr = new double[nelem];
+        for (int i = 0; i < nelem; i++) {
+            arr[i] = -1d;
+        }
+        return arr;
+    }
+
+    @Override
+    public long[][] queryProcessorCpuLoadTicks() {
+        int cpus = getLogicalProcessorCount();
+        long[][] ticks = new long[cpus][TickType.values().length];
+        MemorySegment buf = BsdSysctlUtilFFM.sysctl("kern.cp_times");
+        if (buf == null) {
+            return ticks;
+        }
+        for (int cpu = 0; cpu < cpus; cpu++) {
+            long base = CPTIME_SIZE * cpu;
+            ticks[cpu][TickType.USER.getIndex()] = buf.get(JAVA_LONG, base + CP_USER * UINT64_SIZE);
+            ticks[cpu][TickType.NICE.getIndex()] = buf.get(JAVA_LONG, base + CP_NICE * UINT64_SIZE);
+            ticks[cpu][TickType.SYSTEM.getIndex()] = buf.get(JAVA_LONG, base + CP_SYS * UINT64_SIZE);
+            ticks[cpu][TickType.IRQ.getIndex()] = buf.get(JAVA_LONG, base + CP_INTR * UINT64_SIZE);
+            ticks[cpu][TickType.IDLE.getIndex()] = buf.get(JAVA_LONG, base + CP_IDLE * UINT64_SIZE);
+        }
+        return ticks;
+    }
+
+    /**
+     * Fetches the ProcessorID from dmidecode (if possible with root permissions), otherwise uses the values from
+     * /var/run/dmesg.boot
+     *
+     * @param processorID The processorID as a long
+     * @return The ProcessorID string
+     */
+    private static String getProcessorIDfromDmiDecode(long processorID) {
+        boolean procInfo = false;
+        String marker = "Processor Information";
+        for (String checkLine : ExecutingCommand.runNative("dmidecode -t system")) {
+            if (!procInfo && checkLine.contains(marker)) {
+                marker = "ID:";
+                procInfo = true;
+            } else if (procInfo && checkLine.contains(marker)) {
+                return checkLine.split(marker)[1].trim();
+            }
+        }
+        // If we've gotten this far, dmidecode failed. Used the passed-in values
+        return String.format(Locale.ROOT, "%016X", processorID);
+    }
+
+    @Override
+    public long queryContextSwitches() {
+        return ParseUtil.unsignedIntToLong(BsdSysctlUtilFFM.sysctl("vm.stats.sys.v_swtch", 0));
+    }
+
+    @Override
+    public long queryInterrupts() {
+        return ParseUtil.unsignedIntToLong(BsdSysctlUtilFFM.sysctl("vm.stats.sys.v_intr", 0));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdComputerSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdComputerSystemFFM.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.freebsd;
+
+import oshi.annotation.concurrent.Immutable;
+import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
+import oshi.hardware.common.platform.unix.freebsd.FreeBsdComputerSystem;
+import oshi.util.Constants;
+
+/**
+ * FFM-backed FreeBSD computer system. {@code dmidecode} and {@code lshal} parsing live on
+ * {@link FreeBsdComputerSystem}; only the {@code kern.hostuuid} sysctl fallback is FFM-specific.
+ */
+@Immutable
+public class FreeBsdComputerSystemFFM extends FreeBsdComputerSystem {
+
+    @Override
+    protected String queryHostUuid() {
+        return BsdSysctlUtilFFM.sysctl("kern.hostuuid", Constants.UNKNOWN);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdGlobalMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdGlobalMemoryFFM.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.freebsd;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
+import oshi.hardware.VirtualMemory;
+import oshi.hardware.common.platform.unix.freebsd.FreeBsdGlobalMemory;
+
+/**
+ * FFM-backed FreeBSD global memory. Native reads use {@link BsdSysctlUtilFFM}; shared parsing and the public API live
+ * on {@link FreeBsdGlobalMemory}.
+ */
+@ThreadSafe
+public class FreeBsdGlobalMemoryFFM extends FreeBsdGlobalMemory {
+
+    @Override
+    protected long queryVmStats() {
+        // cached removed in FreeBSD 12 but was always set to 0
+        int inactive = BsdSysctlUtilFFM.sysctl("vm.stats.vm.v_inactive_count", 0);
+        int free = BsdSysctlUtilFFM.sysctl("vm.stats.vm.v_free_count", 0);
+        return (inactive + free) * getPageSize();
+    }
+
+    @Override
+    protected long queryPhysMem() {
+        return BsdSysctlUtilFFM.sysctl("hw.physmem", 0L);
+    }
+
+    @Override
+    protected VirtualMemory createVirtualMemory() {
+        return new FreeBsdVirtualMemoryFFM(this);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdGlobalMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdGlobalMemoryFFM.java
@@ -18,9 +18,11 @@ public class FreeBsdGlobalMemoryFFM extends FreeBsdGlobalMemory {
 
     @Override
     protected long queryVmStats() {
-        // cached removed in FreeBSD 12 but was always set to 0
-        int inactive = BsdSysctlUtilFFM.sysctl("vm.stats.vm.v_inactive_count", 0);
-        int free = BsdSysctlUtilFFM.sysctl("vm.stats.vm.v_free_count", 0);
+        // cached removed in FreeBSD 12 but was always set to 0.
+        // Counters are uint32 from the kernel; widen to long before adding so the sum and the page-size multiply
+        // don't truncate or sign-extend if either counter exceeds 2^31.
+        long inactive = Integer.toUnsignedLong(BsdSysctlUtilFFM.sysctl("vm.stats.vm.v_inactive_count", 0));
+        long free = Integer.toUnsignedLong(BsdSysctlUtilFFM.sysctl("vm.stats.vm.v_free_count", 0));
         return (inactive + free) * getPageSize();
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdSensorsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdSensorsFFM.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.freebsd;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
+import static oshi.ffm.ForeignFunctions.callInArenaDoubleOrDefault;
+import static oshi.ffm.unix.freebsd.FreeBsdLibcFunctions.SIZE_T;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Locale;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.unix.freebsd.FreeBsdLibcFunctions;
+import oshi.hardware.common.platform.unix.freebsd.FreeBsdSensors;
+
+/**
+ * FFM-backed FreeBSD sensors. The only native read is the per-CPU temperature from the {@code coretemp} kld module via
+ * {@code sysctlbyname("dev.cpu.%d.temperature")}. Fan speeds and CPU voltage have no FreeBSD-supported source and
+ * return the empty/zero defaults inherited from {@link FreeBsdSensors}.
+ */
+@ThreadSafe
+public class FreeBsdSensorsFFM extends FreeBsdSensors {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FreeBsdSensorsFFM.class);
+
+    @Override
+    public double queryCpuTemperature() {
+        return queryKldloadCoretemp();
+    }
+
+    /*
+     * If user has loaded coretemp module via kldload coretemp, sysctl call will return temperature
+     *
+     * @return Temperature if successful, otherwise NaN
+     */
+    private static double queryKldloadCoretemp() {
+        return callInArenaDoubleOrDefault(arena -> {
+            MemorySegment p = arena.allocate(JAVA_INT);
+            MemorySegment size = arena.allocateFrom(SIZE_T, JAVA_INT.byteSize());
+            MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
+            int cpu = 0;
+            double sumTemp = 0d;
+            while (true) {
+                MemorySegment name = arena.allocateFrom(String.format(Locale.ROOT, "dev.cpu.%d.temperature", cpu));
+                if (0 != FreeBsdLibcFunctions.sysctlbyname(callState, name, p, size, MemorySegment.NULL, 0L)) {
+                    break;
+                }
+                sumTemp += p.get(JAVA_INT, 0) / 10d - 273.15;
+                cpu++;
+            }
+            return cpu > 0 ? sumTemp / cpu : Double.NaN;
+        }, LOG, Level.WARN, "Failed reading CPU temperature", Double.NaN);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdVirtualMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdVirtualMemoryFFM.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.freebsd;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
+import oshi.hardware.common.platform.unix.freebsd.FreeBsdGlobalMemory;
+import oshi.hardware.common.platform.unix.freebsd.FreeBsdVirtualMemory;
+
+/**
+ * FFM-backed FreeBSD virtual memory. Native sysctl reads use {@link BsdSysctlUtilFFM}; the public API and the swapinfo
+ * command-line parsing live on {@link FreeBsdVirtualMemory}.
+ */
+@ThreadSafe
+final class FreeBsdVirtualMemoryFFM extends FreeBsdVirtualMemory {
+
+    FreeBsdVirtualMemoryFFM(FreeBsdGlobalMemory global) {
+        super(global);
+    }
+
+    @Override
+    protected long querySwapTotal() {
+        return BsdSysctlUtilFFM.sysctl("vm.swap_total", 0L);
+    }
+
+    @Override
+    protected long queryPagesIn() {
+        return BsdSysctlUtilFFM.sysctl("vm.stats.vm.v_swappgsin", 0L);
+    }
+
+    @Override
+    protected long queryPagesOut() {
+        return BsdSysctlUtilFFM.sysctl("vm.stats.vm.v_swappgsout", 0L);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParamsFFM.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.unix.freebsd;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+import static oshi.ffm.unix.freebsd.FreeBsdLibcFunctions.ADDRINFO_LAYOUT;
+import static oshi.ffm.unix.freebsd.FreeBsdLibcFunctions.AI_CANONNAME;
+import static oshi.ffm.unix.freebsd.FreeBsdLibcFunctions.HOST_NAME_MAX;
+
+import java.lang.foreign.MemorySegment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.unix.freebsd.FreeBsdLibcFunctions;
+import oshi.software.common.os.unix.freebsd.FreeBsdNetworkParams;
+
+/**
+ * FFM-backed FreeBSD network params. Command-line gateway lookup and the {@code getHostName} fallback live on
+ * {@link FreeBsdNetworkParams}; only the libc bindings ({@code getaddrinfo}, {@code gethostname}) are FFM-specific.
+ */
+@ThreadSafe
+public class FreeBsdNetworkParamsFFM extends FreeBsdNetworkParams {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FreeBsdNetworkParamsFFM.class);
+
+    @Override
+    protected String queryDomainName() {
+        String hostname = getHostName();
+        if (hostname == null || hostname.isEmpty()) {
+            return "";
+        }
+        return callInArenaOrDefault(arena -> {
+            MemorySegment hint = arena.allocate(ADDRINFO_LAYOUT);
+            hint.set(JAVA_INT, 0, AI_CANONNAME);
+            MemorySegment node = arena.allocateFrom(hostname);
+            MemorySegment resPtr = arena.allocate(ADDRESS);
+            int rc = FreeBsdLibcFunctions.getaddrinfo(node, MemorySegment.NULL, hint, resPtr);
+            if (rc != 0) {
+                if (LOG.isWarnEnabled()) {
+                    LOG.warn("Failed getaddrinfo(): {}", FreeBsdLibcFunctions.gaiStrerror(rc, arena));
+                }
+                return "";
+            }
+            MemorySegment res = resPtr.get(ADDRESS, 0);
+            try {
+                String canonname = FreeBsdLibcFunctions.addrinfoCanonname(res, arena);
+                return canonname == null ? "" : canonname.trim();
+            } finally {
+                FreeBsdLibcFunctions.freeaddrinfo(res);
+            }
+        }, LOG, Level.WARN, "Failed to query domain name", "");
+    }
+
+    @Override
+    protected String queryHostName() {
+        return callInArenaOrDefault(arena -> {
+            MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1);
+            if (0 != FreeBsdLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
+                return null;
+            }
+            return buf.getString(0);
+        }, LOG, Level.WARN, "Failed to get hostname", null);
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorJNA.java
@@ -367,7 +367,7 @@ public class FreeBsdCentralProcessorJNA extends FreeBsdCentralProcessor {
     private static String getProcessorIDfromDmiDecode(long processorID) {
         boolean procInfo = false;
         String marker = "Processor Information";
-        for (String checkLine : ExecutingCommand.runNative("dmidecode -t system")) {
+        for (String checkLine : ExecutingCommand.runNative("dmidecode -t processor")) {
             if (!procInfo && checkLine.contains(marker)) {
                 marker = "ID:";
                 procInfo = true;

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdGlobalMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdGlobalMemoryJNA.java
@@ -18,9 +18,11 @@ public class FreeBsdGlobalMemoryJNA extends FreeBsdGlobalMemory {
 
     @Override
     protected long queryVmStats() {
-        // cached removed in FreeBSD 12 but was always set to 0
-        int inactive = BsdSysctlUtil.sysctl("vm.stats.vm.v_inactive_count", 0);
-        int free = BsdSysctlUtil.sysctl("vm.stats.vm.v_free_count", 0);
+        // cached removed in FreeBSD 12 but was always set to 0.
+        // Counters are uint32 from the kernel; widen to long before adding so the sum and the page-size multiply
+        // don't truncate or sign-extend if either counter exceeds 2^31.
+        long inactive = Integer.toUnsignedLong(BsdSysctlUtil.sysctl("vm.stats.vm.v_inactive_count", 0));
+        long free = Integer.toUnsignedLong(BsdSysctlUtil.sysctl("vm.stats.vm.v_free_count", 0));
         return (inactive + free) * getPageSize();
     }
 


### PR DESCRIPTION
## Summary

Phase 4 of the FreeBSD FFM port (tracking #3315). Ports the
sysctl-friendly FreeBSD HAL/OS concretes onto the Phase 3 bindings:
six new `FreeBsd*FFM` siblings (ComputerSystem, GlobalMemory,
VirtualMemory, Sensors, NetworkParams, CentralProcessor) plus the
libc surface NetworkParams needs (`gethostname`, `getaddrinfo` family).
FFM `SystemInfo` still reports FreeBSD as unsupported — wiring stays
for Phase 6 so we never expose half-built state.

## Per-commit walk

1. **Phase 4 commit 1** — `FreeBsdComputerSystemFFM`,
   `FreeBsdGlobalMemoryFFM`, `FreeBsdVirtualMemoryFFM`. Each is a
   mechanical mirror of its `*JNA` sibling: same abstract parent in
   `oshi-common`, same overrides, `BsdSysctlUtil` swapped for
   `BsdSysctlUtilFFM`. ~100 lines total.
2. **Phase 4 commit 2** — `FreeBsdSensorsFFM`. Per-CPU
   `dev.cpu.%d.temperature` loop via raw
   `FreeBsdLibcFunctions.sysctlbyname` (the MIB is formatted at each
   iteration so going through the util would just add indirection).
   Uses `callInArenaDoubleOrDefault` to scope the arena.
3. **Phase 4 commit 3** — `FreeBsdNetworkParamsFFM` plus the libc
   surface it needs. Extends `FreeBsdLibcFunctions` with
   `gethostname`, `getaddrinfo`, `freeaddrinfo`, `gai_strerror` —
   mirroring `LinuxLibcFunctions` but with FreeBSD's actual
   `struct addrinfo` layout (`ai_canonname` comes BEFORE `ai_addr` on
   FreeBSD, the opposite of glibc).
4. **Phase 4 commit 4** — `FreeBsdCentralProcessorFFM`. Largest of
   the batch. Native reads all go through `BsdSysctlUtilFFM` (sysctl,
   sysctlbyname struct/raw variants) or `FreeBsdLibcFunctions.getloadavg`:
   `kern.cp_time` → 40-byte segment; `kern.cp_times` → variable-sized
   buffer indexed by `CP_USER`/`CP_NICE`/`CP_SYS`/`CP_INTR`/`CP_IDLE`;
   `hw.model`, `hw.clockrate`, `dev.cpu.0.freq*`, `machdep.tsc_freq`,
   `kern.sched.topology_spec` via the util; `vm.stats.sys.v_swtch` /
   `v_intr` via int sysctl + `ParseUtil.unsignedIntToLong`. Private
   parsing helpers (`parseTopology`, `matchBitmasks`,
   `getCacheInfoFromLscpu`, `getProcessorIDfromDmiDecode`) are
   duplicated from the JNA sibling — Phase 2 explicitly deferred this
   class's abstract API design, and the duplication keeps Phase 4
   scope tight.

## Intentionally deferred

* **FFM `SystemInfo` factory wiring** — Phase 6, so `isAvailable()`
  doesn't return true while the rest of the HAL/OS is still being
  built. `NativeComparisonTest` stays gated to
  `{LINUX, MAC, WINDOWS}`.
* **Remaining `FreeBsd*FFM` concretes** — `PowerSource`,
  `InternetProtocolStats`, `HWDiskStore`, `OSProcess`,
  `OperatingSystem`. These are the Phase 2 deferrals (too JNA-heavy /
  struct-tangled to pre-design the abstract API at hoist time). They
  land in Phase 5 alongside the libc bindings they need
  (`sysctl(int*…)` for kproc info, `getpid`, `thr_self`, `getrlimit`).
* **Hoisting CentralProcessor's pure-Java parsing helpers to
  `oshi-common`** — `parseTopology`/`matchBitmasks`/`getProcessorIDfromDmiDecode`
  could move to the abstract super and be shared by both JNA and FFM
  siblings. Doing it now would require redesigning the abstract API
  Phase 2 deferred; leaving the duplication keeps this PR small and
  reviewable.
* **Tests** — none committed for the new concretes. Per the testing
  pattern established in #3319 commit 3, Phase 6's
  `NativeComparisonTest` HAL/OS traversal will cover them
  transitively. The existing `GlobalMemoryFFMTest` /
  `VirtualMemoryFFMTest` etc. in `oshi-core-ffm` are likewise gated
  to `{LINUX, MAC, WINDOWS}` until then.

## Test plan

- [x] `./mvnw -pl oshi-core-ffm compile` clean on each commit
- [x] `./mvnw -pl oshi-core-ffm test` — 68 successful on Mac (the
      FreeBSD-only Phase 3 smoke tests skip as expected)
- [x] `./mvnw spotless:check checkstyle:check -pl oshi-core-ffm` clean
- [x] Temporary FreeBSD CI green on all 4 commits in succession
- [x] PR CI: existing `testfreebsd` job in `pr.yaml` will exercise
      the codebase under `flags: freebsd`

Tracks #3315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced FreeBSD CPU monitoring (topology, frequencies, per‑CPU ticks, load averages)
  * Improved physical and virtual memory reporting and swap metrics
  * CPU temperature sensing via coretemp
  * Hostname and domain name resolution improvements
  * System UUID discovery for FreeBSD

* **Bug Fixes**
  * More robust kernel counter handling to avoid integer truncation
  * More accurate processor info extraction from system DMI data
<!-- end of auto-generated comment: release notes by coderabbit.ai -->