### PR TITLE
FreeBSD FFM port: docs + coverage cleanup, CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 * [#3303](https://github.com/oshi/oshi/pull/3303): Add DragonFly BSD platform support - [@dbwiddis](https://github.com/dbwiddis).
 * [#3307](https://github.com/oshi/oshi/pull/3307): Add NetBSD platform support - [@dbwiddis](https://github.com/dbwiddis).
+* [#3316](https://github.com/oshi/oshi/pull/3316),
+  [#3319](https://github.com/oshi/oshi/pull/3319),
+  [#3322](https://github.com/oshi/oshi/pull/3322),
+  [#3328](https://github.com/oshi/oshi/pull/3328),
+  [#3330](https://github.com/oshi/oshi/pull/3330): Add FreeBSD support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug Fixes and Improvements
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -99,7 +99,7 @@ OSHI has been implemented and tested on the following systems.  Some features ma
 * AIX 7.1 (POWER4)
 * Android 7.0 and higher
 
-The FFM implementation (`oshi-core-ffm`) supports Windows, macOS, and Linux only, and assumes a 64-bit operating system.
+The FFM implementation (`oshi-core-ffm`) supports Windows, macOS, Linux, and FreeBSD only, and assumes a 64-bit operating system.
 
 ## How can I get reliable sensor information on Windows?
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -6,7 +6,7 @@
 OSHI provides two native access implementations:
 
 - **JNA** (`oshi-core`): Supports JDK 8+ and all platforms OSHI targets. JNA uses reflection-based marshalling for native calls, which adds overhead per invocation.
-- **FFM** (`oshi-core-ffm`): Requires JDK 25+ and currently supports Linux, macOS, and Windows. FFM (Foreign Function & Memory API) uses compiler-optimized stubs for native calls, reducing per-call overhead.
+- **FFM** (`oshi-core-ffm`): Requires JDK 25+ and currently supports Linux, macOS, Windows, and FreeBSD. FFM (Foreign Function & Memory API) uses compiler-optimized stubs for native calls, reducing per-call overhead.
 
 The tables below show approximate average times from JMH benchmarks (1 warmup iteration, 3 measurement iterations) run on GitHub Actions CI runners.
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ SystemInfoProvider si = SystemInfoFactory.create();
 | Classpath | JDK | Platform | Selected implementation |
 |-----------|-----|----------|------------------------|
 | `oshi-core` only | 8+ | Any | JNA (`oshi.SystemInfo`) |
-| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows | FFM (`oshi.ffm.SystemInfo`) |
-| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows | FFM (higher priority) |
+| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows, FreeBSD | FFM (`oshi.ffm.SystemInfo`) |
+| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows, FreeBSD | FFM (higher priority) |
 | Both `oshi-core` and `oshi-core-ffm` | &lt;25 or unsupported platform | Any | JNA (FFM unavailable) |
 | `oshi-common` only | 8+ | Linux | No `--enable-native-access` required (`oshi.nativefree.SystemInfo`) |
 

--- a/oshi-core-ffm/src/main/java/module-info.java
+++ b/oshi-core-ffm/src/main/java/module-info.java
@@ -2,7 +2,8 @@
  * FFM-based native implementation of the OSHI API for JDK 25+.
  * <p>
  * This module uses the Foreign Function and Memory (FFM) API for native access and currently supports Windows, macOS,
- * and Linux. For broader platform support, use the JNA-based {@code com.github.oshi} module.
+ * Linux, and FreeBSD. For broader platform support (OpenBSD, Solaris, AIX), use the JNA-based {@code com.github.oshi}
+ * module.
  * <p>
  * Usage:
  *

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -61,7 +61,7 @@ import oshi.util.PlatformEnum;
  * all OSHI platforms (Windows, macOS, Linux, Android, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, Solaris, AIX). Android
  * is routed through the Linux implementations. For JDK 25+, the {@code oshi-core-ffm} module provides an alternative
  * entry point ({@code oshi.ffm.SystemInfo}) that uses the Foreign Function and Memory (FFM) API for potentially better
- * performance on supported platforms (currently Windows, macOS, and Linux).
+ * performance on supported platforms (currently Windows, macOS, Linux, and FreeBSD).
  * <p>
  * Both this class and the FFM entry point require native access. Starting with <a href="https://openjdk.org/jeps/472">
  * JEP 472</a> (JDK 24), the JVM warns when native code is loaded, and a future JDK release will require

--- a/oshi-core/src/main/java/oshi/package-info.java
+++ b/oshi-core/src/main/java/oshi/package-info.java
@@ -34,7 +34,7 @@
  * <a href="https://github.com/java-native-access/jna">JNA</a> for native access. Supports all platforms (Windows,
  * macOS, Linux, DragonFly BSD, FreeBSD, OpenBSD, Solaris, AIX). Entry point: {@link oshi.SystemInfo}.</li>
  * <li><b>{@code oshi-core-ffm}</b> - Alternative implementation using the Foreign Function and Memory (FFM) API (JDK
- * 25+). Currently supports Windows, macOS, and Linux. Entry point: {@code oshi.ffm.SystemInfo}.</li>
+ * 25+). Currently supports Windows, macOS, Linux, and FreeBSD. Entry point: {@code oshi.ffm.SystemInfo}.</li>
  * </ul>
  *
  * <h2>Native Access and JEP 472</h2>

--- a/pom.xml
+++ b/pom.xml
@@ -824,14 +824,14 @@
                         <exclude>**/unix/solaris/**</exclude>
                         <!-- Narrow these `**/unix/<Name>*` patterns — JaCoCo agent globs let `*`
                              cross path separators, so `**/unix/*Bsd*` etc. would also exclude
-                             `**/unix/<bsd-subpkg>/Free**Bsd**...`. -->
+                             `**/unix/<bsd-subpkg>/Free**Bsd**...`. BsdNetworkIF and UnixBaseboard
+                             are no longer excluded: they're now exercised on the permanent FreeBSD
+                             CI job that landed with the FreeBSD FFM port. -->
                         <exclude>**/unix/*Aix*</exclude>
-                        <exclude>**/unix/BsdNetworkIF*</exclude>
                         <exclude>**/unix/*DragonFlyBsd*</exclude>
                         <exclude>**/unix/*NetBsd*</exclude>
                         <exclude>**/unix/*OpenBsd*</exclude>
                         <exclude>**/unix/*Solaris*</exclude>
-                        <exclude>**/unix/UnixBaseboard*</exclude>
                         <!-- Hardware-dependent: no GPU/sensors/battery on CI runners -->
                         <exclude>**/gpu/NvmlUtil*</exclude>
                         <exclude>**/gpu/AdlUtil*</exclude>
@@ -846,6 +846,7 @@
                         <exclude>**/MacPowerSource*</exclude>
                         <exclude>**/WindowsPowerSource*</exclude>
                         <exclude>**/LinuxPowerSource*</exclude>
+                        <exclude>**/FreeBsdPowerSource*</exclude>
                         <!-- Systemd/utmp fallback paths: CI always succeeds on first path -->
                         <exclude>**/driver/linux/WhoJNA*</exclude>
                         <exclude>**/driver/linux/WhoFFM*</exclude>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -75,8 +75,8 @@ SystemInfoProvider si = SystemInfoFactory.create();
 | Classpath | JDK | Platform | Selected implementation |
 |-----------|-----|----------|------------------------|
 | `oshi-core` only | 8+ | Any | JNA (`oshi.SystemInfo`) |
-| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows | FFM (`oshi.ffm.SystemInfo`) |
-| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows | FFM (higher priority) |
+| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows, FreeBSD | FFM (`oshi.ffm.SystemInfo`) |
+| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows, FreeBSD | FFM (higher priority) |
 | Both `oshi-core` and `oshi-core-ffm` | &lt;25 or unsupported platform | Any | JNA (FFM unavailable) |
 | `oshi-common` only | 8+ | Linux | No `--enable-native-access` required (`oshi.nativefree.SystemInfo`) |
 


### PR DESCRIPTION
## Summary

Follow-up to the five FreeBSD FFM port PRs (#3316, #3319, #3322,
#3328, #3330). Bundles the loose ends that didn't fit any individual
port commit: codecov exclude cleanup, supported-platforms doc
updates, and the CHANGELOG entry summarizing the series.

## Changes

### JaCoCo agent excludes (`pom.xml`)

* Remove `**/unix/BsdNetworkIF*` and `**/unix/UnixBaseboard*`. Both
  classes were hoisted to `oshi-common` during the port (#3316 moved
  `UnixBaseboard`; #3328 moved `BsdNetworkIF`) and are now exercised
  on the permanent FreeBSD CI job — `NativeComparisonTest.networkInterfaces()`
  hits `BsdNetworkIF`, and `ComputerSystem.getBaseboard()` hits
  `UnixBaseboard`. The excludes were silently dropping that coverage
  from the `freebsd` codecov flag.
* Add `**/FreeBsdPowerSource*` alongside the existing
  `**/{Mac,Windows,Linux}PowerSource*` entries. No battery on the
  FreeBSD CI VM, same hardware-conditional pattern as the other
  platforms.

### Documentation

Update the supported-platforms statement from "Windows, macOS, and
Linux" to "Windows, macOS, Linux, and FreeBSD" in:

* `README.md` (selector table)
* `src/site/markdown/index.md` (mirror of README)
* `FAQ.md` ("The FFM implementation supports…")
* `PERFORMANCE.md` (FFM vs JNA bullet)
* `oshi-core-ffm/src/main/java/module-info.java` (module Javadoc)
* `oshi-core/src/main/java/oshi/SystemInfo.java` (class Javadoc that
  pointed at FFM as an alternative)
* `oshi-core/src/main/java/oshi/package-info.java` (module listing)

### `CHANGELOG.md`

New Features bullet under 7.2.2 (in progress) linking all five
FreeBSD FFM port PRs in the same multi-column format used for
earlier multi-PR series in the file.

## Test plan

- [x] `./mvnw spotless:check checkstyle:check` clean across the
      three touched modules
- [x] `grep` swept for any remaining "Windows, macOS, and Linux" /
      "OS.LINUX, OS.MAC, OS.WINDOWS" patterns — none missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated platform support documentation to include FreeBSD as a supported operating system for the FFM implementation.

* **Chores**
  * Updated code coverage configuration to reflect FreeBSD support adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->