### PR TITLE
OpenBSD FFM port: add sysctl FFM bindings and utility

### DIFF
--- a/oshi-core-ffm/src/main/java/module-info.java
+++ b/oshi-core-ffm/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module com.github.oshi.ffm {
     exports oshi.ffm.util.gpu;
     exports oshi.ffm.util.platform.mac;
     exports oshi.ffm.util.platform.unix.freebsd;
+    exports oshi.ffm.util.platform.unix.openbsd;
     exports oshi.ffm.util.platform.windows;
 
     provides oshi.spi.SystemInfoProvider with oshi.ffm.SystemInfo;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/unix/openbsd/OpenBsdLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/unix/openbsd/OpenBsdLibcFunctions.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.unix.openbsd;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+
+import oshi.ffm.ForeignFunctions;
+
+/**
+ * FFM bindings for OpenBSD libc functions used by OSHI.
+ * <p>
+ * OpenBSD uses {@code sysctl(int *name, u_int namelen, ...)} exclusively (no {@code sysctlbyname}). Additional bindings
+ * ({@code getthrid}, {@code getrlimit}) support process and resource limit queries.
+ */
+public final class OpenBsdLibcFunctions extends ForeignFunctions {
+
+    private OpenBsdLibcFunctions() {
+    }
+
+    /** Layout of the C {@code size_t} type on OpenBSD (8 bytes on all supported 64-bit archs). */
+    public static final ValueLayout.OfLong SIZE_T = ValueLayout.JAVA_LONG;
+
+    /** {@code getrlimit} resource: maximum number of open file descriptors. OpenBSD value (8). */
+    public static final int RLIMIT_NOFILE = 8;
+
+    /**
+     * Layout of OpenBSD's {@code struct rlimit}: two {@code rlim_t} (LP64 long) fields.
+     */
+    public static final StructLayout RLIMIT_LAYOUT = MemoryLayout.structLayout(JAVA_LONG.withName("rlim_cur"),
+            JAVA_LONG.withName("rlim_max"));
+
+    private static final VarHandle RLIMIT_CUR = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_cur"));
+    private static final VarHandle RLIMIT_MAX = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_max"));
+
+    // libc is already loaded into the JVM process; defaultLookup() avoids versioning pitfalls.
+    private static final SymbolLookup LIBC = LINKER.defaultLookup();
+
+    // int sysctl(int *name, u_int namelen, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
+    private static final MethodHandle sysctl = LINKER.downcallHandle(LIBC.findOrThrow("sysctl"),
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, ADDRESS, ADDRESS, SIZE_T), CAPTURE_CALL_STATE);
+
+    /**
+     * Calls {@code sysctl(name, namelen, oldp, oldlenp, newp, newlen)} with errno capture.
+     *
+     * @param callState segment allocated with {@link ForeignFunctions#CAPTURED_STATE_LAYOUT} for errno capture
+     * @param name      MIB array segment (sequence of ints)
+     * @param namelen   number of ints in {@code name}
+     * @param oldp      output buffer for the current value, or {@link MemorySegment#NULL} to query size only
+     * @param oldlenp   pointer to a {@code size_t}: on input, the size of {@code oldp}; on output, the bytes written
+     * @param newp      new value buffer, or {@link MemorySegment#NULL} when reading
+     * @param newlen    size of {@code newp} in bytes, or 0 when reading
+     * @return 0 on success, -1 on error
+     * @throws Throwable on FFM invocation error
+     */
+    public static int sysctl(MemorySegment callState, MemorySegment name, int namelen, MemorySegment oldp,
+            MemorySegment oldlenp, MemorySegment newp, long newlen) throws Throwable {
+        return (int) sysctl.invokeExact(callState, name, namelen, oldp, oldlenp, newp, newlen);
+    }
+
+    // int getthrid(void);
+    private static final MethodHandle getthrid = LINKER.downcallHandle(LIBC.findOrThrow("getthrid"),
+            FunctionDescriptor.of(JAVA_INT));
+
+    /**
+     * Calls {@code getthrid()} — returns the thread ID of the calling thread.
+     *
+     * @return the thread ID of the calling thread
+     * @throws Throwable on FFM invocation error
+     */
+    public static int getthrid() throws Throwable {
+        return (int) getthrid.invokeExact();
+    }
+
+    // int getrlimit(int resource, struct rlimit *rlim);
+    private static final MethodHandle getrlimit = LINKER.downcallHandle(LIBC.findOrThrow("getrlimit"),
+            FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
+
+    /**
+     * Calls {@code getrlimit(resource, rlim)}.
+     *
+     * @param resource resource constant (e.g. {@link #RLIMIT_NOFILE})
+     * @param rlim     segment allocated with {@link #RLIMIT_LAYOUT}
+     * @return 0 on success, -1 on error
+     * @throws Throwable on FFM invocation error
+     */
+    public static int getrlimit(int resource, MemorySegment rlim) throws Throwable {
+        return (int) getrlimit.invokeExact(resource, rlim);
+    }
+
+    /**
+     * Reads {@code rlim_cur} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
+     *
+     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
+     * @return the soft resource limit
+     */
+    public static long rlimitCur(MemorySegment rlim) {
+        return (long) RLIMIT_CUR.get(rlim, 0L);
+    }
+
+    /**
+     * Reads {@code rlim_max} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
+     *
+     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
+     * @return the hard resource limit
+     */
+    public static long rlimitMax(MemorySegment rlim) {
+        return (long) RLIMIT_MAX.get(rlim, 0L);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/ffm/unix/openbsd/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/unix/openbsd/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides FFM access to system libraries for OpenBSD.
+ */
+package oshi.ffm.unix.openbsd;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFM.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.util.platform.unix.openbsd;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
+import static oshi.ffm.ForeignFunctions.getErrno;
+import static oshi.ffm.unix.openbsd.OpenBsdLibcFunctions.SIZE_T;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.unix.openbsd.OpenBsdLibcFunctions;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+/**
+ * Provides access to sysctl calls on OpenBSD via the FFM API.
+ * <p>
+ * Mirrors the API of {@code oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil} (JNA) so per-class FFM concretes can be
+ * swapped in without changing call sites.
+ */
+@ThreadSafe
+public final class OpenBsdSysctlUtilFFM {
+
+    private static final String SYSCTL_N = "sysctl -n ";
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenBsdSysctlUtilFFM.class);
+
+    private static final String SYSCTL_FAIL = "Failed sysctl call: {}, Error code: {}";
+
+    private OpenBsdSysctlUtilFFM() {
+    }
+
+    /**
+     * Executes a sysctl call with an int result.
+     *
+     * @param mib MIB array identifying the sysctl
+     * @param def default int value
+     * @return The int result of the call if successful; the default otherwise
+     */
+    public static int sysctl(int[] mib, int def) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment valueSeg = arena.allocate(JAVA_INT);
+            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_INT.byteSize());
+            if (!sysctlMib(arena, mib, valueSeg, sizeSeg)) {
+                return def;
+            }
+            return valueSeg.get(JAVA_INT, 0);
+        } catch (Throwable e) {
+            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
+            return def;
+        }
+    }
+
+    /**
+     * Executes a sysctl call with a long result.
+     *
+     * @param mib MIB array identifying the sysctl
+     * @param def default long value
+     * @return The long result of the call if successful; the default otherwise
+     */
+    public static long sysctl(int[] mib, long def) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment valueSeg = arena.allocate(JAVA_LONG);
+            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_LONG.byteSize());
+            if (!sysctlMib(arena, mib, valueSeg, sizeSeg)) {
+                return def;
+            }
+            return valueSeg.get(JAVA_LONG, 0);
+        } catch (Throwable e) {
+            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
+            return def;
+        }
+    }
+
+    /**
+     * Executes a sysctl call with a String result.
+     *
+     * @param mib MIB array identifying the sysctl
+     * @param def default String value
+     * @return The String result of the call if successful; the default otherwise
+     */
+    public static String sysctl(int[] mib, String def) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment sizeSeg = arena.allocate(SIZE_T);
+            if (!sysctlMib(arena, mib, MemorySegment.NULL, sizeSeg)) {
+                return def;
+            }
+            long size = sizeSeg.get(SIZE_T, 0);
+            MemorySegment valueSeg = arena.allocate(size + 1);
+            if (!sysctlMib(arena, mib, valueSeg, sizeSeg)) {
+                return def;
+            }
+            return valueSeg.getString(0);
+        } catch (Throwable e) {
+            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
+            return def;
+        }
+    }
+
+    /**
+     * Executes a sysctl call that populates a caller-provided struct segment.
+     *
+     * @param mib    MIB array identifying the sysctl
+     * @param struct segment sized to the expected struct layout
+     * @return {@code true} if the struct was populated, {@code false} otherwise
+     */
+    public static boolean sysctl(int[] mib, MemorySegment struct) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, struct.byteSize());
+            return sysctlMib(arena, mib, struct, sizeSeg);
+        } catch (Throwable e) {
+            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
+            return false;
+        }
+    }
+
+    /**
+     * Executes a sysctl call returning a freshly allocated buffer of the natural size.
+     *
+     * @param mib MIB array identifying the sysctl
+     * @return an auto-arena {@link MemorySegment} containing the result on success; {@code null} otherwise
+     */
+    public static MemorySegment sysctl(int[] mib) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment sizeSeg = arena.allocate(SIZE_T);
+            if (!sysctlMib(arena, mib, MemorySegment.NULL, sizeSeg)) {
+                return null;
+            }
+            long size = sizeSeg.get(SIZE_T, 0);
+            MemorySegment valueSeg = arena.allocate(size);
+            if (!sysctlMib(arena, mib, valueSeg, sizeSeg)) {
+                return null;
+            }
+            MemorySegment returnSeg = Arena.ofAuto().allocate(size);
+            returnSeg.copyFrom(valueSeg);
+            return returnSeg;
+        } catch (Throwable e) {
+            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
+            return null;
+        }
+    }
+
+    /*
+     * Backup versions with command parsing
+     */
+
+    /**
+     * Executes a sysctl call with an int result via command line.
+     *
+     * @param name name of the sysctl
+     * @param def  default int value
+     * @return The int result of the call if successful; the default otherwise
+     */
+    public static int sysctl(String name, int def) {
+        return ParseUtil.parseIntOrDefault(ExecutingCommand.getFirstAnswer(SYSCTL_N + name), def);
+    }
+
+    /**
+     * Executes a sysctl call with a long result via command line.
+     *
+     * @param name name of the sysctl
+     * @param def  default long value
+     * @return The long result of the call if successful; the default otherwise
+     */
+    public static long sysctl(String name, long def) {
+        return ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer(SYSCTL_N + name), def);
+    }
+
+    /**
+     * Executes a sysctl call with a String result via command line.
+     *
+     * @param name name of the sysctl
+     * @param def  default String value
+     * @return The String result of the call if successful; the default otherwise
+     */
+    public static String sysctl(String name, String def) {
+        String v = ExecutingCommand.getFirstAnswer(SYSCTL_N + name);
+        if (null == v || v.isEmpty()) {
+            return def;
+        }
+        return v;
+    }
+
+    private static boolean sysctlMib(Arena arena, int[] mib, MemorySegment oldp, MemorySegment oldlenp)
+            throws Throwable {
+        MemorySegment mibSeg = arena.allocate(JAVA_INT, mib.length);
+        for (int i = 0; i < mib.length; i++) {
+            mibSeg.setAtIndex(JAVA_INT, i, mib[i]);
+        }
+        MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
+        int result = OpenBsdLibcFunctions.sysctl(callState, mibSeg, mib.length, oldp, oldlenp, MemorySegment.NULL, 0L);
+        if (result != 0) {
+            LOG.warn(SYSCTL_FAIL, Arrays.toString(mib), getErrno(callState));
+            return false;
+        }
+        return true;
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides OpenBSD-specific FFM utility classes for sysctl and related operations.
+ */
+package oshi.ffm.util.platform.unix.openbsd;

--- a/oshi-core-ffm/src/test/java/module-info.test
+++ b/oshi-core-ffm/src/test/java/module-info.test
@@ -9,6 +9,8 @@
 --add-opens
   com.github.oshi.ffm/oshi.ffm.util.platform.unix.freebsd=org.junit.platform.commons
 --add-opens
+  com.github.oshi.ffm/oshi.ffm.util.platform.unix.openbsd=org.junit.platform.commons
+--add-opens
   com.github.oshi.ffm/oshi.ffm.windows.com=org.junit.platform.commons
 --add-opens
   com.github.oshi.ffm/oshi.driver.windows.perfmon=org.junit.platform.commons

--- a/oshi-core-ffm/src/test/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFMTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.util.platform.unix.openbsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.ffm.unix.openbsd.OpenBsdLibcFunctions;
+
+@EnabledOnOs(OS.OPENBSD)
+class OpenBsdSysctlUtilFFMTest {
+
+    private static final int CTL_KERN = 1;
+    private static final int CTL_HW = 6;
+    private static final int KERN_OSTYPE = 1;
+    private static final int KERN_OSRELEASE = 2;
+    private static final int HW_MACHINE = 1;
+    private static final int HW_PAGESIZE = 7;
+    private static final int HW_NCPUFOUND = 21;
+
+    @Test
+    void testSysctlIntReturnsDefault() {
+        int[] bogus = { 99, 99, 99 };
+        assertThat(OpenBsdSysctlUtilFFM.sysctl(bogus, -42), is(-42));
+    }
+
+    @Test
+    void testSysctlLongReturnsDefault() {
+        int[] bogus = { 99, 99, 99 };
+        assertThat(OpenBsdSysctlUtilFFM.sysctl(bogus, -123L), is(-123L));
+    }
+
+    @Test
+    void testSysctlStringReturnsDefault() {
+        int[] bogus = { 99, 99, 99 };
+        assertThat(OpenBsdSysctlUtilFFM.sysctl(bogus, "mydefault"), is("mydefault"));
+    }
+
+    @Test
+    void testSysctlIntHwPagesize() {
+        int[] mib = { CTL_HW, HW_PAGESIZE };
+        int pageSize = OpenBsdSysctlUtilFFM.sysctl(mib, 0);
+        assertThat("Page size should be positive", pageSize, greaterThan(0));
+    }
+
+    @Test
+    void testSysctlIntHwNcpufound() {
+        int[] mib = { CTL_HW, HW_NCPUFOUND };
+        int ncpu = OpenBsdSysctlUtilFFM.sysctl(mib, 0);
+        assertThat("CPU count should be at least 1", ncpu, greaterThan(0));
+    }
+
+    @Test
+    void testSysctlStringKernOstype() {
+        int[] mib = { CTL_KERN, KERN_OSTYPE };
+        String osType = OpenBsdSysctlUtilFFM.sysctl(mib, "");
+        assertThat("kern.ostype should be OpenBSD", osType, is("OpenBSD"));
+    }
+
+    @Test
+    void testSysctlStringKernOsrelease() {
+        int[] mib = { CTL_KERN, KERN_OSRELEASE };
+        String release = OpenBsdSysctlUtilFFM.sysctl(mib, "");
+        assertThat("kern.osrelease should not be empty", release, is(not("")));
+    }
+
+    @Test
+    void testSysctlStringHwMachine() {
+        int[] mib = { CTL_HW, HW_MACHINE };
+        String machine = OpenBsdSysctlUtilFFM.sysctl(mib, "");
+        assertThat("hw.machine should not be empty", machine, is(not("")));
+    }
+
+    @Test
+    void testSysctlBufferReturnsNullForBogus() {
+        int[] bogus = { 99, 99, 99 };
+        assertThat(OpenBsdSysctlUtilFFM.sysctl(bogus), is(nullValue()));
+    }
+
+    @Test
+    void testSysctlCommandLineString() {
+        String osType = OpenBsdSysctlUtilFFM.sysctl("kern.ostype", "");
+        assertThat("Command-line kern.ostype should be OpenBSD", osType, is("OpenBSD"));
+    }
+
+    @Test
+    void testSysctlCommandLineInt() {
+        int pageSize = OpenBsdSysctlUtilFFM.sysctl("hw.pagesize", 0);
+        assertThat("Command-line hw.pagesize should be positive", pageSize, greaterThan(0));
+    }
+
+    @Test
+    void testSysctlCommandLineLong() {
+        long physmem = OpenBsdSysctlUtilFFM.sysctl("hw.physmem", 0L);
+        assertThat("Command-line hw.physmem should be positive", physmem, greaterThan(0L));
+    }
+
+    @Test
+    void testGetrlimit() throws Throwable {
+        java.lang.foreign.Arena arena = java.lang.foreign.Arena.ofConfined();
+        java.lang.foreign.MemorySegment rlim = arena.allocate(OpenBsdLibcFunctions.RLIMIT_LAYOUT);
+        int ret = OpenBsdLibcFunctions.getrlimit(OpenBsdLibcFunctions.RLIMIT_NOFILE, rlim);
+        assertThat("getrlimit should succeed", ret, is(0));
+        long cur = OpenBsdLibcFunctions.rlimitCur(rlim);
+        long max = OpenBsdLibcFunctions.rlimitMax(rlim);
+        assertThat("soft limit should be positive", cur, greaterThan(0L));
+        assertThat("hard limit should be >= soft limit", max >= cur, is(true));
+        arena.close();
+    }
+
+    @Test
+    void testGetthrid() throws Throwable {
+        int tid = OpenBsdLibcFunctions.getthrid();
+        assertThat("Thread ID should be positive", tid, greaterThan(0));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `OpenBsdLibcFunctions` with FFM downcall bindings for `sysctl(int[] mib, ...)`, `getthrid()`, and `getrlimit()`
- Add `OpenBsdSysctlUtilFFM` wrapping the raw sysctl binding with convenience methods for int/long/String/struct/buffer results, plus command-line fallbacks
- Tests gated to `@EnabledOnOs(OS.OPENBSD)` covering both native and command-line paths

This is the low-level foundation for the OpenBSD FFM port — no consumers yet, just the bindings and utilities that later PRs will wire into platform classes.

### Key differences from FreeBSD
- No `sysctlbyname` — everything goes through `sysctl(int[] mib, ...)`
- `getthrid()` returns int directly (no out-pointer like FreeBSD's `thr_self`)
- `RLIMIT_NOFILE = 8` (same as FreeBSD)

## Test plan
- [x] CI passes on OpenBSD 7.9 VM (live sysctl + getthrid + getrlimit tests)
- [ ] Tests skipped cleanly on other platforms (`@EnabledOnOs(OS.OPENBSD)`)
- [ ] Full project compiles on all platforms

Refs #3332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenBSD platform support with system utilities for retrieving configuration information (sysctl, resource limits, thread IDs).

* **Tests**
  * Added comprehensive test coverage for OpenBSD system utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->