### PR TITLE
Post-3339 audit pass + consolidated manual benchmark workflow

### DIFF
--- a/.github/workflows/benchmarks-unix.yaml
+++ b/.github/workflows/benchmarks-unix.yaml
@@ -1,0 +1,78 @@
+# One-shot JMH benchmark capture for FreeBSD / OpenBSD / OpenIndiana.
+#
+# Runs only on workflow_dispatch so it doesn't burn CI time on every push/PR.
+# Intended for occasional re-capture of the numbers reported in PERFORMANCE.md
+# (e.g. when adding a new platform or making a perf-relevant change).
+#
+# Numbers are noisier than the native-runner platforms (macOS/Windows/Linux)
+# because these all run inside a nested VM on an Ubuntu GitHub Actions runner;
+# only the relative JNA-vs-FFM comparison within a single run is meaningful.
+name: Unix Benchmarks (manual)
+
+on:
+  workflow_dispatch:
+  # Temporary: trigger on push to this branch so the numbers can be captured
+  # before the branch is merged. Remove this `push:` block before opening the PR.
+  push:
+    branches:
+      - docs-and-audit-pass
+
+jobs:
+  benchfreebsd:
+    name: JMH benchmarks, FreeBSD
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Benchmark on FreeBSD
+        uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1
+        with:
+          usesh: true
+          prepare: |
+            pkg install -y curl
+            pkg install -y openjdk25
+          run: |
+            export JAVA_HOME=/usr/local/openjdk25
+            export PATH=$JAVA_HOME/bin:$PATH
+            ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q -B
+            java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+
+  benchopenbsd:
+    name: JMH benchmarks, OpenBSD
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Benchmark on OpenBSD
+        uses: vmactions/openbsd-vm@fcf799d7ce9c305ad89eabef1fb2fa5c1c42d0ee # v1
+        with:
+          release: "7.9"
+          usesh: false
+          mem: 4096
+          prepare: |
+            pkg_add curl
+            pkg_add jdk%25
+            pkg_add maven
+          run: |
+            mvn package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q -B
+            java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+
+  benchopenindiana:
+    name: JMH benchmarks, OpenIndiana
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Benchmark on OpenIndiana
+        uses: vmactions/openindiana-vm@5ecd04945b8ac6c9b82248324912326a4d065094 # v1
+        with:
+          # Bumped above the 8 GB used by the regular CI job because JMH forks
+          # a fresh JVM per benchmark and illumos's native malloc pool is the
+          # OOM bottleneck under back-to-back forks.
+          mem: 12288
+          prepare: |
+            pkg install openjdk25
+          run: |
+            export JAVA_HOME=/usr/jdk/openjdk25
+            export PATH=$JAVA_HOME/bin:$PATH
+            export MAVEN_OPTS="-Xmx1g"
+            export _JAVA_OPTIONS="-Xmx1g"
+            ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q -B -Dmaven.gitcommitid.skip=true
+            java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,13 +1,15 @@
-# One-shot JMH benchmark capture for FreeBSD / OpenBSD / OpenIndiana.
+# Manual JMH benchmark capture across every platform OSHI runs JMH on.
 #
 # Runs only on workflow_dispatch so it doesn't burn CI time on every push/PR.
 # Intended for occasional re-capture of the numbers reported in PERFORMANCE.md
 # (e.g. when adding a new platform or making a perf-relevant change).
 #
-# Numbers are noisier than the native-runner platforms (macOS/Windows/Linux)
-# because these all run inside a nested VM on an Ubuntu GitHub Actions runner;
-# only the relative JNA-vs-FFM comparison within a single run is meaningful.
-name: Unix Benchmarks (manual)
+# Native runners (Linux/macOS/Windows) produce stable numbers; FreeBSD,
+# OpenBSD and OpenIndiana all run inside a nested QEMU VM on an Ubuntu runner,
+# so absolute numbers are noisier and only the relative JNA-vs-FFM comparison
+# within a single run is meaningful. illumos is especially fragile under
+# back-to-back JMH JVM forks (native malloc pool), so its VM mem is bumped.
+name: Benchmarks (manual)
 
 on:
   workflow_dispatch:
@@ -18,6 +20,54 @@ on:
       - docs-and-audit-pass
 
 jobs:
+  benchlinux:
+    name: JMH benchmarks, Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: 25
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Build benchmark jar
+        run: ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
+      - name: Run JMH benchmarks
+        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+
+  benchmacos:
+    name: JMH benchmarks, macOS
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: 25
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Build benchmark jar
+        run: ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
+      - name: Run JMH benchmarks
+        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+
+  benchwindows:
+    name: JMH benchmarks, Windows
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: 25
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Build benchmark jar
+        run: ./mvnw package -pl oshi-benchmark -am "-DskipTests" "-Dshade.phase=package" -q
+      - name: Run JMH benchmarks
+        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+
   benchfreebsd:
     name: JMH benchmarks, FreeBSD
     runs-on: ubuntu-24.04
@@ -52,6 +102,10 @@ jobs:
             pkg_add jdk%25
             pkg_add maven
           run: |
+            # `pkg_add maven` wraps mvn with its own JAVA_HOME shim, but a bare
+            # `java` invocation needs PATH/JAVA_HOME set explicitly.
+            export JAVA_HOME=/usr/local/jdk-25
+            export PATH=$JAVA_HOME/bin:$PATH
             mvn package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q -B
             java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
 

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -13,11 +13,6 @@ name: Benchmarks (manual)
 
 on:
   workflow_dispatch:
-  # Temporary: trigger on push to this branch so the numbers can be captured
-  # before the branch is merged. Remove this `push:` block before opening the PR.
-  push:
-    branches:
-      - docs-and-audit-pass
 
 jobs:
   benchlinux:

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -102,20 +102,3 @@ jobs:
             -w /workspace \
             eclipse-temurin:21-jdk \
             ./mvnw test -pl oshi-common -am -B
-
-  # JMH performance benchmarks — separate job to avoid slowing down test+coverage
-  benchmarks:
-    runs-on: ubuntu-latest
-    name: JMH Benchmarks
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          java-version: 25
-          distribution: 'zulu'
-          cache: 'maven'
-      - name: Build benchmark jar
-        run: ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
-      - name: Run JMH Benchmarks (JNA vs FFM)
-        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -51,20 +51,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: macos
-
-  # JMH performance benchmarks — separate job to avoid slowing down test+coverage
-  benchmarks:
-    runs-on: macos-26
-    name: JMH Benchmarks
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          java-version: 25
-          distribution: 'zulu'
-          cache: 'maven'
-      - name: Build benchmark jar
-        run: ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
-      - name: Run JMH Benchmarks (JNA vs FFM)
-        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -47,20 +47,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: windows
-
-  # JMH performance benchmarks — separate job to avoid slowing down test+coverage
-  benchmarks:
-    runs-on: windows-2025
-    name: JMH Benchmarks
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          java-version: 25
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Build benchmark jar
-        run: ./mvnw package -pl oshi-benchmark -am "-DskipTests" "-Dshade.phase=package" -q
-      - name: Run JMH Benchmarks (JNA vs FFM)
-        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [#3333](https://github.com/oshi/oshi/pull/3333),
   [#3334](https://github.com/oshi/oshi/pull/3334),
   [#3335](https://github.com/oshi/oshi/pull/3335): Add OpenBSD support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
-* Add Solaris/illumos support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
+* [#3339](https://github.com/oshi/oshi/pull/3339): Add Solaris/illumos support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug Fixes and Improvements
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -92,10 +92,11 @@ OSHI has been implemented and tested on the following systems.  Some features ma
 * Windows 7 and higher.  (Nearly all features work on Vista and most work on Windows XP.)
 * macOS version 10.6 (Snow Leopard) and higher.
 * Linux (Most major distributions) Kernel 2.6 and higher
+* DragonFly BSD 6.4
 * FreeBSD 10
 * NetBSD 10.1
 * OpenBSD 6.8
-* Solaris 11 (SunOS 5.11)
+* Solaris 11 / illumos (SunOS 5.11)
 * AIX 7.1 (POWER4)
 * Android 7.0 and higher
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -8,7 +8,7 @@ OSHI provides two native access implementations:
 - **JNA** (`oshi-core`): Supports JDK 8+ and all platforms OSHI targets. JNA uses reflection-based marshalling for native calls, which adds overhead per invocation.
 - **FFM** (`oshi-core-ffm`): Requires JDK 25+ and currently supports Linux, macOS, Windows, FreeBSD, OpenBSD, and Solaris (illumos). FFM (Foreign Function & Memory API) uses compiler-optimized stubs for native calls, reducing per-call overhead.
 
-The tables below show approximate average times from JMH benchmarks (1 warmup iteration, 3 measurement iterations) run on GitHub Actions CI runners.
+The tables below show approximate average times from JMH benchmarks (1 warmup iteration, 3 measurement iterations) captured by the manually-triggered `Benchmarks (manual)` workflow (`.github/workflows/benchmarks.yaml`) on GitHub Actions runners. The workflow is `workflow_dispatch`-only so it doesn't burn CI time on every push/PR; re-run it when adding a platform or making a perf-relevant change.
 
 ### macOS
 
@@ -46,9 +46,33 @@ Windows benefits from FFM across all benchmarks.
 
 Linux shows minimal difference between FFM and JNA for most benchmarks. This is because Linux exposes most system information through the `/proc` and `/sys` pseudo-filesystems, which OSHI reads as plain files without native calls. The FileStore benchmark is the exception, where FFM's direct `statvfs` call avoids JNA marshalling overhead.
 
-### FreeBSD / OpenBSD / Solaris (illumos)
+### FreeBSD
 
-_Numbers will be populated from a manual run of the `Unix Benchmarks (manual)` workflow (`.github/workflows/benchmarks-unix.yaml`). These platforms run inside a nested QEMU VM on an Ubuntu GitHub Actions runner; absolute numbers are noisier than the native-runner platforms above and the benchmark is gated to a one-off `workflow_dispatch` trigger rather than every push (especially on illumos, where back-to-back JMH JVM forks easily exhaust the VM's native malloc pool). The relative JNA-vs-FFM comparison within a single run is still meaningful._
+| Benchmark  | FFM     | JNA     |
+|------------|---------|---------|
+| CpuTicks   | ~3 µs   | ~3 µs   |
+| FileStore  | ~52 ms  | ~51 ms  |
+| Memory     | ~1.3 ms | ~1.3 ms |
+| NetworkIF  | ~8 ms   | ~9 ms   |
+| Processes  | ~2.3 ms | ~2.3 ms |
+
+FreeBSD, OpenBSD and Solaris all run inside a nested QEMU VM on an Ubuntu runner, so absolute numbers are noisier than the native-runner platforms above; only the relative JNA-vs-FFM comparison within a single run is meaningful. FreeBSD shows essentially no FFM/JNA gap because most data comes from `/proc`-style or `sysctl` reads that don't bottleneck on per-call overhead.
+
+### OpenBSD
+
+_TODO: populate from a future `Benchmarks (manual)` run — OpenBSD failed in the first capture pass (`java` not on PATH after `pkg_add jdk%25`)._
+
+### Solaris (illumos)
+
+| Benchmark  | FFM      | JNA      |
+|------------|----------|----------|
+| CpuTicks   | ~16 µs   | ~1.4 ms  |
+| FileStore  | ~89 ms   | ~91 ms   |
+| Memory     | ~9.9 ms  | ~10 ms   |
+| NetworkIF  | ~317 µs  | ~427 µs  |
+| Processes  | ~376 ms  | ~378 ms  |
+
+Solaris (illumos) shows the most dramatic FFM advantage on `CpuTicks` (~85x faster) because every CPU-tick read crosses a `libkstat`/`kstat2` boundary, and JNA's per-call marshalling cost dominates the workload. Same nested-VM caveat as FreeBSD applies.
 
 ### Running benchmarks locally
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -46,6 +46,10 @@ Windows benefits from FFM across all benchmarks.
 
 Linux shows minimal difference between FFM and JNA for most benchmarks. This is because Linux exposes most system information through the `/proc` and `/sys` pseudo-filesystems, which OSHI reads as plain files without native calls. The FileStore benchmark is the exception, where FFM's direct `statvfs` call avoids JNA marshalling overhead.
 
+### FreeBSD / OpenBSD / Solaris (illumos)
+
+_Numbers will be populated from a manual run of the `Unix Benchmarks (manual)` workflow (`.github/workflows/benchmarks-unix.yaml`). These platforms run inside a nested QEMU VM on an Ubuntu GitHub Actions runner; absolute numbers are noisier than the native-runner platforms above and the benchmark is gated to a one-off `workflow_dispatch` trigger rather than every push (especially on illumos, where back-to-back JMH JVM forks easily exhaust the VM's native malloc pool). The relative JNA-vs-FFM comparison within a single run is still meaningful._
+
 ### Running benchmarks locally
 
 The numbers above were collected on GitHub Actions CI runners, which may differ significantly from your hardware and workload (e.g., number of running processes, mounted file stores, or network interfaces). The `oshi-benchmark` module contains JMH benchmarks that can be built and run with JDK 25+:

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -14,23 +14,23 @@ The tables below show approximate average times from JMH benchmarks (1 warmup it
 
 | Benchmark  | FFM     | JNA      |
 |------------|---------|----------|
-| CpuTicks   | ~6 µs   | ~7 µs    |
-| FileStore  | ~42 µs  | ~99 µs   |
+| CpuTicks   | ~5 µs   | ~9 µs    |
+| FileStore  | ~45 µs  | ~104 µs  |
 | Memory     | ~4 µs   | ~8 µs    |
-| NetworkIF  | ~20 µs  | ~127 µs  |
-| Processes  | ~1.4 ms | ~9.6 ms  |
+| NetworkIF  | ~20 µs  | ~128 µs  |
+| Processes  | ~1.6 ms | ~11 ms   |
 
 macOS shows the largest FFM advantage because most system information requires native syscalls (`sysctl`, `proc_pidinfo`, etc.) where FFM's lower per-call overhead compounds across many invocations.
 
 ### Windows
 
-| Benchmark  | FFM      | JNA       |
-|------------|----------|-----------|
-| CpuTicks   | ~0.25 ms | ~0.43 ms  |
-| FileStore  | ~35 µs   | ~136 µs   |
-| Memory     | ~77 µs   | ~113 µs   |
-| NetworkIF  | ~613 µs  | ~1238 µs  |
-| Processes  | ~2.9 ms  | ~9.9 ms   |
+| Benchmark  | FFM      | JNA      |
+|------------|----------|----------|
+| CpuTicks   | ~0.22 ms | ~0.40 ms |
+| FileStore  | ~26 µs   | ~101 µs  |
+| Memory     | ~59 µs   | ~89 µs   |
+| NetworkIF  | ~479 µs  | ~862 µs  |
+| Processes  | ~6.0 ms  | ~7.6 ms  |
 
 Windows benefits from FFM across all benchmarks.
 
@@ -38,11 +38,11 @@ Windows benefits from FFM across all benchmarks.
 
 | Benchmark  | FFM      | JNA      |
 |------------|----------|----------|
-| CpuTicks   | ~24 µs   | ~24 µs   |
+| CpuTicks   | ~25 µs   | ~24 µs   |
 | FileStore  | ~4 µs    | ~31 µs   |
-| Memory     | ~81 µs   | ~81 µs   |
-| NetworkIF  | ~820 µs  | ~805 µs  |
-| Processes  | ~9.7 ms  | ~9.7 ms  |
+| Memory     | ~85 µs   | ~86 µs   |
+| NetworkIF  | ~833 µs  | ~842 µs  |
+| Processes  | ~11 ms   | ~11 ms   |
 
 Linux shows minimal difference between FFM and JNA for most benchmarks. This is because Linux exposes most system information through the `/proc` and `/sys` pseudo-filesystems, which OSHI reads as plain files without native calls. The FileStore benchmark is the exception, where FFM's direct `statvfs` call avoids JNA marshalling overhead.
 
@@ -50,29 +50,37 @@ Linux shows minimal difference between FFM and JNA for most benchmarks. This is 
 
 | Benchmark  | FFM     | JNA     |
 |------------|---------|---------|
-| CpuTicks   | ~3 µs   | ~3 µs   |
-| FileStore  | ~52 ms  | ~51 ms  |
-| Memory     | ~1.3 ms | ~1.3 ms |
-| NetworkIF  | ~8 ms   | ~9 ms   |
-| Processes  | ~2.3 ms | ~2.3 ms |
+| CpuTicks   | ~3 µs   | ~4 µs   |
+| FileStore  | ~68 ms  | ~68 ms  |
+| Memory     | ~1.7 ms | ~1.7 ms |
+| NetworkIF  | ~7 ms   | ~8 ms   |
+| Processes  | ~3.1 ms | ~3.0 ms |
 
-FreeBSD, OpenBSD and Solaris all run inside a nested QEMU VM on an Ubuntu runner, so absolute numbers are noisier than the native-runner platforms above; only the relative JNA-vs-FFM comparison within a single run is meaningful. FreeBSD shows essentially no FFM/JNA gap because most data comes from `/proc`-style or `sysctl` reads that don't bottleneck on per-call overhead.
+FreeBSD, OpenBSD and Solaris all run inside a nested QEMU VM on an Ubuntu runner, so absolute numbers are noisier than the native-runner platforms above; only the relative JNA-vs-FFM comparison within a single run is meaningful. FreeBSD shows essentially no FFM/JNA gap because most data comes from `sysctl` reads that don't bottleneck on per-call overhead.
 
 ### OpenBSD
 
-_TODO: populate from a future `Benchmarks (manual)` run — OpenBSD failed in the first capture pass (`java` not on PATH after `pkg_add jdk%25`)._
+| Benchmark  | FFM     | JNA     |
+|------------|---------|---------|
+| CpuTicks   | ~12 µs  | ~22 µs  |
+| FileStore  | ~182 ms | ~179 ms |
+| Memory     | ~28 ms  | ~30 ms  |
+| NetworkIF  | ~13 ms  | ~14 ms  |
+| Processes  | ~366 ms | ~350 ms |
+
+OpenBSD's `FileStore` and `Processes` numbers carry very wide error bars in the nested VM; treat them as order-of-magnitude only. Same nested-VM caveat as FreeBSD.
 
 ### Solaris (illumos)
 
 | Benchmark  | FFM      | JNA      |
 |------------|----------|----------|
 | CpuTicks   | ~16 µs   | ~1.4 ms  |
-| FileStore  | ~89 ms   | ~91 ms   |
-| Memory     | ~9.9 ms  | ~10 ms   |
-| NetworkIF  | ~317 µs  | ~427 µs  |
-| Processes  | ~376 ms  | ~378 ms  |
+| FileStore  | ~85 ms   | ~83 ms   |
+| Memory     | ~10 ms   | ~10 ms   |
+| NetworkIF  | ~308 µs  | ~415 µs  |
+| Processes  | ~384 ms  | ~381 ms  |
 
-Solaris (illumos) shows the most dramatic FFM advantage on `CpuTicks` (~85x faster) because every CPU-tick read crosses a `libkstat`/`kstat2` boundary, and JNA's per-call marshalling cost dominates the workload. Same nested-VM caveat as FreeBSD applies.
+Solaris (illumos) shows the most dramatic FFM advantage on `CpuTicks` (~85x faster) because every CPU-tick read crosses a `libkstat`/`kstat2` boundary, and JNA's per-call marshalling cost dominates the workload. Same nested-VM caveat as FreeBSD.
 
 ### Running benchmarks locally
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supported Platforms
 - Windows
 - macOS
 - Linux (Android)
-- UNIX (AIX, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, Solaris)
+- UNIX (AIX, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, Solaris (illumos))
 
 Supported Features
 ------------------
@@ -76,9 +76,9 @@ SystemInfoProvider si = SystemInfoFactory.create();
 | Classpath | JDK | Platform | Selected implementation |
 |-----------|-----|----------|------------------------|
 | `oshi-core` only | 8+ | Any | JNA (`oshi.SystemInfo`) |
-| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows, FreeBSD | FFM (`oshi.ffm.SystemInfo`) |
-| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows, FreeBSD | FFM (higher priority) |
-| Both `oshi-core` and `oshi-core-ffm` | &lt;25 or unsupported platform | Any | JNA (FFM unavailable) |
+| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows, FreeBSD, OpenBSD, Solaris (illumos) | FFM (`oshi.ffm.SystemInfo`) |
+| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows, FreeBSD, OpenBSD, Solaris (illumos) | FFM (higher priority) |
+| Both `oshi-core` and `oshi-core-ffm` | &lt;25 or unsupported platform (AIX, DragonFly BSD, NetBSD) | Any | JNA (FFM unavailable) |
 | `oshi-common` only | 8+ | Linux | No `--enable-native-access` required (`oshi.nativefree.SystemInfo`) |
 
 You can also instantiate directly:

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisPowerSourceFFM.java
@@ -112,9 +112,16 @@ public final class SolarisPowerSourceFFM extends AbstractPowerSource {
                     if (powerNow == 0xFFFFFFFFL) {
                         powerNow = 0L;
                     }
-                    boolean isCharging = (KstatUtilFFM.dataLookupLong(ksp, "bst_state") & 0x10) > 0;
+                    psPowerUsageRate = powerNow;
+                    // Battery State:
+                    // bit 0 = discharging
+                    // bit 1 = charging
+                    // bit 2 = critical energy state
+                    long bstState = KstatUtilFFM.dataLookupLong(ksp, "bst_state");
+                    psDischarging = (bstState & 0x1) > 0;
+                    psCharging = (bstState & 0x2) > 0;
 
-                    if (!isCharging) {
+                    if (psDischarging) {
                         psTimeRemainingEstimated = powerNow > 0 ? 3600d * energyNow / powerNow : -1d;
                     }
 

--- a/oshi-core-ffm/src/test/java/module-info.test
+++ b/oshi-core-ffm/src/test/java/module-info.test
@@ -20,12 +20,6 @@
   com.github.oshi.ffm/oshi.driver.windows.registry=org.junit.platform.commons
 --add-opens
   com.github.oshi.ffm/oshi.driver.windows.wmi=org.junit.platform.commons
---add-opens
-  com.github.oshi.ffm/oshi.driver.mac=org.junit.platform.commons
---add-opens
-  com.github.oshi.ffm/oshi.driver.mac.disk=org.junit.platform.commons
---add-opens
-  com.github.oshi.ffm/oshi.driver.mac.net=org.junit.platform.commons
 
 --enable-native-access
   com.github.oshi.ffm

--- a/oshi-core-ffm/src/test/java/oshi/ffm/ForeignFunctionsTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/ForeignFunctionsTest.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * Tests for {@link ForeignFunctions} helper methods.
  */
 @EnabledForJreRange(min = JRE.JAVA_25)
-@EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD })
+@EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD, OS.SOLARIS })
 class ForeignFunctionsTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(ForeignFunctionsTest.class);

--- a/oshi-core-ffm/src/test/java/oshi/ffm/GlobalMemoryFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/GlobalMemoryFFMTest.java
@@ -28,7 +28,7 @@ import oshi.hardware.GlobalMemory;
 import oshi.hardware.PhysicalMemory;
 
 @EnabledForJreRange(min = JRE.JAVA_25)
-@EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD })
+@EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD, OS.SOLARIS })
 @TestInstance(Lifecycle.PER_CLASS)
 public class GlobalMemoryFFMTest {
 

--- a/oshi-core-ffm/src/test/java/oshi/ffm/OperatingSystemFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/OperatingSystemFFMTest.java
@@ -26,7 +26,7 @@ import oshi.software.os.OperatingSystem;
 import oshi.software.os.mac.MacOperatingSystemFFM;
 
 @EnabledForJreRange(min = JRE.JAVA_25)
-@EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD })
+@EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD, OS.SOLARIS })
 @TestInstance(Lifecycle.PER_CLASS)
 public class OperatingSystemFFMTest {
 

--- a/oshi-core-ffm/src/test/java/oshi/ffm/SystemInfoTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/SystemInfoTest.java
@@ -51,7 +51,7 @@ import oshi.util.PlatformEnum;
 
 @Execution(ExecutionMode.SAME_THREAD)
 @EnabledForJreRange(min = JRE.JAVA_25)
-@EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD })
+@EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD, OS.SOLARIS })
 public class SystemInfoTest {
 
     private static final Logger logger = LoggerFactory.getLogger(SystemInfoTest.class);

--- a/oshi-core-ffm/src/test/java/oshi/ffm/VirtualMemoryFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/VirtualMemoryFFMTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.condition.OS;
 import oshi.hardware.VirtualMemory;
 
 @EnabledForJreRange(min = JRE.JAVA_25)
-@EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD })
+@EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD, OS.SOLARIS })
 public class VirtualMemoryFFMTest {
 
     @Test

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -61,7 +61,7 @@ import oshi.util.PlatformEnum;
  * all OSHI platforms (Windows, macOS, Linux, Android, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, Solaris, AIX). Android
  * is routed through the Linux implementations. For JDK 25+, the {@code oshi-core-ffm} module provides an alternative
  * entry point ({@code oshi.ffm.SystemInfo}) that uses the Foreign Function and Memory (FFM) API for potentially better
- * performance on supported platforms (currently Windows, macOS, Linux, and FreeBSD).
+ * performance on supported platforms (currently Windows, macOS, Linux, FreeBSD, OpenBSD, and Solaris (illumos)).
  * <p>
  * Both this class and the FFM entry point require native access. Starting with <a href="https://openjdk.org/jeps/472">
  * JEP 472</a> (JDK 24), the JVM warns when native code is loaded, and a future JDK release will require

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisPowerSource.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisPowerSource.java
@@ -128,13 +128,16 @@ public final class SolarisPowerSource extends AbstractPowerSource {
                     if (powerNow == 0xFFFFFFFF) {
                         powerNow = 0L;
                     }
+                    psPowerUsageRate = powerNow;
                     // Battery State:
                     // bit 0 = discharging
                     // bit 1 = charging
                     // bit 2 = critical energy state
-                    boolean isCharging = (KstatUtil.dataLookupLong(ksp, "bst_state") & 0x10) > 0;
+                    long bstState = KstatUtil.dataLookupLong(ksp, "bst_state");
+                    psDischarging = (bstState & 0x1) > 0;
+                    psCharging = (bstState & 0x2) > 0;
 
-                    if (!isCharging) {
+                    if (psDischarging) {
                         psTimeRemainingEstimated = powerNow > 0 ? 3600d * energyNow / powerNow : -1d;
                     }
 

--- a/oshi-core/src/main/java/oshi/package-info.java
+++ b/oshi-core/src/main/java/oshi/package-info.java
@@ -32,9 +32,11 @@
  * utilities. This module contains <i>no native code</i> and requires no native access permissions.</li>
  * <li><b>{@code oshi-core}</b> (this module) - Full OSHI implementation using
  * <a href="https://github.com/java-native-access/jna">JNA</a> for native access. Supports all platforms (Windows,
- * macOS, Linux, DragonFly BSD, FreeBSD, OpenBSD, Solaris, AIX). Entry point: {@link oshi.SystemInfo}.</li>
+ * macOS, Linux, Android, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, Solaris, AIX). Entry point:
+ * {@link oshi.SystemInfo}.</li>
  * <li><b>{@code oshi-core-ffm}</b> - Alternative implementation using the Foreign Function and Memory (FFM) API (JDK
- * 25+). Currently supports Windows, macOS, Linux, and FreeBSD. Entry point: {@code oshi.ffm.SystemInfo}.</li>
+ * 25+). Currently supports Windows, macOS, Linux, FreeBSD, OpenBSD, and Solaris (illumos). Entry point:
+ * {@code oshi.ffm.SystemInfo}.</li>
  * </ul>
  *
  * <h2>Native Access and JEP 472</h2>

--- a/pom.xml
+++ b/pom.xml
@@ -842,6 +842,8 @@
                         <exclude>**/WindowsPowerSource*</exclude>
                         <exclude>**/LinuxPowerSource*</exclude>
                         <exclude>**/FreeBsdPowerSource*</exclude>
+                        <exclude>**/OpenBsdPowerSource*</exclude>
+                        <exclude>**/SolarisPowerSource*</exclude>
                         <!-- Systemd/utmp fallback paths: CI always succeeds on first path -->
                         <exclude>**/driver/linux/WhoJNA*</exclude>
                         <exclude>**/driver/linux/WhoFFM*</exclude>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -16,7 +16,7 @@ Supported Platforms
 - Windows
 - macOS
 - Linux (Android)
-- UNIX (AIX, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, Solaris)
+- UNIX (AIX, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, Solaris (illumos))
 
 Supported Features
 ------------------
@@ -75,9 +75,9 @@ SystemInfoProvider si = SystemInfoFactory.create();
 | Classpath | JDK | Platform | Selected implementation |
 |-----------|-----|----------|------------------------|
 | `oshi-core` only | 8+ | Any | JNA (`oshi.SystemInfo`) |
-| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows, FreeBSD | FFM (`oshi.ffm.SystemInfo`) |
-| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows, FreeBSD | FFM (higher priority) |
-| Both `oshi-core` and `oshi-core-ffm` | &lt;25 or unsupported platform | Any | JNA (FFM unavailable) |
+| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows, FreeBSD, OpenBSD, Solaris (illumos) | FFM (`oshi.ffm.SystemInfo`) |
+| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows, FreeBSD, OpenBSD, Solaris (illumos) | FFM (higher priority) |
+| Both `oshi-core` and `oshi-core-ffm` | &lt;25 or unsupported platform (AIX, DragonFly BSD, NetBSD) | Any | JNA (FFM unavailable) |
 | `oshi-common` only | 8+ | Linux | No `--enable-native-access` required (`oshi.nativefree.SystemInfo`) |
 
 You can also instantiate directly:


### PR DESCRIPTION
## Summary

Audit pass after the Solaris/illumos FFM port (#3339) merged, plus consolidation of the JMH benchmark jobs that were sprinkled across the per-OS workflows.

### Docs / cross-platform consistency
- `CHANGELOG.md` — entry for #3339.
- `README.md`, `src/site/markdown/index.md`, `FAQ.md`, `PERFORMANCE.md`, `oshi-core/src/main/java/oshi/SystemInfo.java`, `oshi-core/src/main/java/oshi/package-info.java` — supported-platform lists are now consistent (JNA covers everything OSHI has ever targeted; FFM lists Linux/macOS/Windows/FreeBSD/OpenBSD/Solaris (illumos)), with the `(illumos)` parenthetical and an OpenBSD/Solaris row in the README factory table.

### Coverage / module config
- `pom.xml` — adds `OpenBsdPowerSource*` and `SolarisPowerSource*` to the JaCoCo excludes for parity with the other platforms.
- `oshi-core-ffm/src/test/java/module-info.test` — drops three stale `--add-opens` for `oshi.driver.mac{,.disk,.net}` (no tests exist in those packages).

### Tests
- Five FFM smoke tests (`SystemInfoTest`, `VirtualMemoryFFMTest`, `OperatingSystemFFMTest`, `GlobalMemoryFFMTest`, `ForeignFunctionsTest`) gained `OS.SOLARIS` in their `@EnabledOnOs` annotation so the Solaris CI run actually exercises them.

### Benchmarks
- New `.github/workflows/benchmarks.yaml` — single `workflow_dispatch`-only workflow that runs the JMH suite on **all six** supported platforms (Linux, macOS, Windows, FreeBSD, OpenBSD, OpenIndiana). OpenIndiana mem is bumped to 12288 MB because back-to-back JMH JVM forks otherwise exhaust illumos's native malloc pool. OpenBSD step sets `JAVA_HOME=/usr/local/jdk-25` explicitly because `pkg_add maven` wraps `mvn` with its own JDK shim but a bare `java` invocation does not inherit it.
- `linux.yaml`, `macos.yaml`, `windows.yaml` — drop the per-OS `benchmarks:` job; numbers are captured ad-hoc now instead of on every push.
- `PERFORMANCE.md` — refresh all six platform tables from a single consistent run for clean apples-to-apples comparison.

### Pre-existing JNA bug fix (Solaris PowerSource)
- `oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisPowerSource.java` and `oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisPowerSourceFFM.java` — `psPowerUsageRate` was declared `0d` and never assigned, which also forced `psAmperage` to 0 via the downstream `psAmperage = psPowerUsageRate * 1000 / voltageNow` calc. `psCharging` / `psDischarging` were never written from `bst_state` (only a local `isCharging` was read). And the bit mask was `0x10` despite the inline ACPI comment naming bit 1 (= `0x02`) as the charging bit. Now assigns `psPowerUsageRate = bst_rate`, masks `0x01` for discharging and `0x02` for charging per ACPI BST spec, and gates the time-remaining calc on `psDischarging`. The other platforms (Mac/Windows/Linux/FreeBSD/OpenBSD) were audited and confirmed correct — Solaris was the lone outlier.

## Test plan

- [x] Pre-commit gate passes on `oshi-core` + `oshi-core-ffm`: `spotless:apply`, `checkstyle:check`, `install`, `forbiddenapis:check`, `javadoc:javadoc`
- [x] Manual `Benchmarks (manual)` workflow run captured a clean snapshot for all six platforms before refreshing the tables in `PERFORMANCE.md` — https://github.com/dbwiddis/oshi/actions/runs/27004570481
- [ ] Existing per-OS CI workflows continue to pass on this PR (Linux/macOS/Windows/FreeBSD/OpenBSD/OpenIndiana test+coverage jobs; no behavioral change there)
- [ ] Solaris PowerSource fix can't be exercised in CI (the OpenIndiana VM has no battery) — reviewers, please eyeball the diff against the ACPI BST spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Solaris (illumos), OpenBSD, and FreeBSD with the FFM implementation for improved performance.

* **Bug Fixes**
  * Improved battery state detection in Solaris power source handling.

* **Documentation**
  * Updated platform support documentation, FAQ, and performance benchmarks to reflect expanded compatibility.
  * Expanded supported platform list to include Solaris (illumos) and DragonFly BSD.

* **Tests**
  * Extended test coverage to run on newly supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->