### PR TITLE
Move shared Unix drivers to oshi.driver.common.unix.*

### DIFF
--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -22,14 +22,14 @@ module com.github.oshi.common {
     exports oshi.annotation.concurrent;
     exports oshi.driver.common.mac;
     exports oshi.driver.common.unix.aix;
+    exports oshi.driver.common.unix.bsd;
+    exports oshi.driver.common.unix.bsd.disk;
+    exports oshi.driver.common.unix.freebsd.disk;
+    exports oshi.driver.common.unix.solaris.disk;
     exports oshi.driver.common.windows.perfmon;
     exports oshi.driver.common.windows.registry;
     exports oshi.driver.common.windows.gpu;
     exports oshi.driver.common.windows.wmi;
-    exports oshi.driver.unix.bsd;
-    exports oshi.driver.unix.bsd.disk;
-    exports oshi.driver.unix.freebsd.disk;
-    exports oshi.driver.unix.solaris.disk;
     exports oshi.hardware;
     exports oshi.hardware.common;
     exports oshi.hardware.common.platform.linux;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/bsd/Systat.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/bsd/Systat.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.bsd;
+package oshi.driver.common.unix.bsd;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/bsd/disk/Disklabel.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/bsd/disk/Disklabel.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.bsd.disk;
+package oshi.driver.common.unix.bsd.disk;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/bsd/disk/package-info.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/bsd/disk/package-info.java
@@ -5,4 +5,4 @@
 /**
  * Provides parsing utilities for BSD disk-related commands (e.g. {@code disklabel}) shared by OpenBSD and NetBSD.
  */
-package oshi.driver.unix.bsd.disk;
+package oshi.driver.common.unix.bsd.disk;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/bsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/bsd/package-info.java
@@ -5,4 +5,4 @@
 /**
  * Provides parsing utilities for commands shared by BSD-derived platforms (e.g. OpenBSD and NetBSD).
  */
-package oshi.driver.unix.bsd;
+package oshi.driver.common.unix.bsd;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/GeomDiskList.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/GeomDiskList.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.freebsd.disk;
+package oshi.driver.common.unix.freebsd.disk;
 
 import java.util.HashMap;
 import java.util.List;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/GeomPartList.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/GeomPartList.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.freebsd.disk;
+package oshi.driver.common.unix.freebsd.disk;
 
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/Mount.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/Mount.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.freebsd.disk;
+package oshi.driver.common.unix.freebsd.disk;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/package-info.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/package-info.java
@@ -5,4 +5,4 @@
 /**
  * Provides functions to query FreeBSD disk information
  */
-package oshi.driver.unix.freebsd.disk;
+package oshi.driver.common.unix.freebsd.disk;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Iostat.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Iostat.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.solaris.disk;
+package oshi.driver.common.unix.solaris.disk;
 
 import java.util.HashMap;
 import java.util.List;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Lshal.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Lshal.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.solaris.disk;
+package oshi.driver.common.unix.solaris.disk;
 
 import java.util.HashMap;
 import java.util.List;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Prtvtoc.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Prtvtoc.java
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.solaris.disk;
+package oshi.driver.common.unix.solaris.disk;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/package-info.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/package-info.java
@@ -1,4 +1,4 @@
 /**
  * Provides functions to query Solaris disk information.
  */
-package oshi.driver.unix.solaris.disk;
+package oshi.driver.common.unix.solaris.disk;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdPowerSource.java
@@ -9,8 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.bsd.Systat;
-import oshi.driver.unix.bsd.Systat.BatteryFields;
+import oshi.driver.common.unix.bsd.Systat;
+import oshi.driver.common.unix.bsd.Systat.BatteryFields;
 import oshi.hardware.PowerSource;
 import oshi.hardware.common.AbstractPowerSource;
 import oshi.util.Constants;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdSensors.java
@@ -10,7 +10,7 @@ import static oshi.util.Memoizer.memoize;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.bsd.Systat;
+import oshi.driver.common.unix.bsd.Systat;
 import oshi.hardware.common.AbstractSensors;
 import oshi.util.tuples.Triplet;
 

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -47,13 +47,13 @@
 --add-opens
   com.github.oshi.common/oshi.driver.common.windows.gpu=org.junit.platform.commons
 --add-opens
-  com.github.oshi.common/oshi.driver.unix.bsd=org.junit.platform.commons
+  com.github.oshi.common/oshi.driver.common.unix.bsd=org.junit.platform.commons
 --add-opens
-  com.github.oshi.common/oshi.driver.unix.bsd.disk=org.junit.platform.commons
+  com.github.oshi.common/oshi.driver.common.unix.bsd.disk=org.junit.platform.commons
 --add-opens
-  com.github.oshi.common/oshi.driver.unix.freebsd.disk=org.junit.platform.commons
+  com.github.oshi.common/oshi.driver.common.unix.freebsd.disk=org.junit.platform.commons
 --add-opens
-  com.github.oshi.common/oshi.driver.unix.solaris.disk=org.junit.platform.commons
+  com.github.oshi.common/oshi.driver.common.unix.solaris.disk=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.hardware.common.platform.unix.freebsd=org.junit.platform.commons
 --add-opens

--- a/oshi-common/src/test/java/oshi/driver/common/unix/bsd/SystatTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/bsd/SystatTest.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.bsd;
+package oshi.driver.common.unix.bsd;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import oshi.driver.unix.bsd.Systat.BatteryFields;
+import oshi.driver.common.unix.bsd.Systat.BatteryFields;
 import oshi.hardware.PowerSource.CapacityUnits;
 import oshi.util.tuples.Triplet;
 

--- a/oshi-common/src/test/java/oshi/driver/common/unix/bsd/disk/DisklabelTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/bsd/disk/DisklabelTest.java
@@ -2,7 +2,7 @@
  * Copyright 2022-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.bsd.disk;
+package oshi.driver.common.unix.bsd.disk;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;

--- a/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/DiskDriversTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/DiskDriversTest.java
@@ -2,7 +2,7 @@
  * Copyright 2022-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.freebsd.disk;
+package oshi.driver.common.unix.freebsd.disk;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;

--- a/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/DiskDriversTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/DiskDriversTest.java
@@ -2,7 +2,7 @@
  * Copyright 2022-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.driver.unix.solaris.disk;
+package oshi.driver.common.unix.solaris.disk;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHWDiskStoreFFM.java
@@ -13,8 +13,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.freebsd.disk.GeomDiskList;
-import oshi.driver.unix.freebsd.disk.GeomPartList;
+import oshi.driver.common.unix.freebsd.disk.GeomDiskList;
+import oshi.driver.common.unix.freebsd.disk.GeomPartList;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreFFM.java
@@ -14,7 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.bsd.disk.Disklabel;
+import oshi.driver.common.unix.bsd.disk.Disklabel;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHWDiskStoreFFM.java
@@ -14,9 +14,9 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.solaris.disk.Iostat;
-import oshi.driver.unix.solaris.disk.Lshal;
-import oshi.driver.unix.solaris.disk.Prtvtoc;
+import oshi.driver.common.unix.solaris.disk.Iostat;
+import oshi.driver.common.unix.solaris.disk.Lshal;
+import oshi.driver.common.unix.solaris.disk.Prtvtoc;
 import oshi.ffm.util.platform.unix.solaris.KstatUtilFFM;
 import oshi.ffm.util.platform.unix.solaris.KstatUtilFFM.KstatChain;
 import oshi.ffm.util.platform.unix.solaris.LibKstatFunctions;

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHWDiskStoreJNA.java
@@ -13,8 +13,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.freebsd.disk.GeomDiskList;
-import oshi.driver.unix.freebsd.disk.GeomPartList;
+import oshi.driver.common.unix.freebsd.disk.GeomDiskList;
+import oshi.driver.common.unix.freebsd.disk.GeomPartList;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
 import oshi.hardware.common.platform.unix.freebsd.FreeBsdHWDiskStore;

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdHWDiskStore.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdHWDiskStore.java
@@ -14,7 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.bsd.disk.Disklabel;
+import oshi.driver.common.unix.bsd.disk.Disklabel;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
 import oshi.hardware.common.AbstractHWDiskStore;

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdPowerSource.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdPowerSource.java
@@ -9,8 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.bsd.Systat;
-import oshi.driver.unix.bsd.Systat.BatteryFields;
+import oshi.driver.common.unix.bsd.Systat;
+import oshi.driver.common.unix.bsd.Systat.BatteryFields;
 import oshi.hardware.PowerSource;
 import oshi.hardware.common.AbstractPowerSource;
 import oshi.util.Constants;

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdSensors.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdSensors.java
@@ -10,7 +10,7 @@ import static oshi.util.Memoizer.memoize;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.bsd.Systat;
+import oshi.driver.common.unix.bsd.Systat;
 import oshi.hardware.common.AbstractSensors;
 import oshi.util.tuples.Triplet;
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStore.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStore.java
@@ -14,7 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.bsd.disk.Disklabel;
+import oshi.driver.common.unix.bsd.disk.Disklabel;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
 import oshi.hardware.common.AbstractHWDiskStore;

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHWDiskStore.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHWDiskStore.java
@@ -18,9 +18,9 @@ import com.sun.jna.platform.unix.solaris.LibKstat.Kstat;
 import com.sun.jna.platform.unix.solaris.LibKstat.KstatIO;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.unix.solaris.disk.Iostat;
-import oshi.driver.unix.solaris.disk.Lshal;
-import oshi.driver.unix.solaris.disk.Prtvtoc;
+import oshi.driver.common.unix.solaris.disk.Iostat;
+import oshi.driver.common.unix.solaris.disk.Lshal;
+import oshi.driver.common.unix.solaris.disk.Prtvtoc;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
 import oshi.hardware.common.AbstractHWDiskStore;


### PR DESCRIPTION
## Summary

Sweeps the older Unix ports to match the AIX convention established in #3350. The shared (`oshi-common`) drivers for BSD, FreeBSD, and Solaris were sitting at the top-level `oshi.driver.unix.<os>` namespace, which worked only because the JNA-only drivers in `oshi-core` happened to live in disjoint sub-packages (e.g. `oshi-core`'s `oshi.driver.unix.solaris` holds `PsInfo`/`Who`, `oshi-common`'s `oshi.driver.unix.solaris.disk` holds `Iostat`/`Lshal`/`Prtvtoc` — different Java packages, no split). The new convention puts every `oshi-common` driver under `oshi.driver.common.unix.<os>[.sub]`, mirroring `oshi.driver.common.mac` and `oshi.driver.common.windows.*` and avoiding the top-level-namespace-shared-across-modules fragility.

## Moves

In `oshi-common/src/main/java`:

* `oshi.driver.unix.bsd.Systat` → `oshi.driver.common.unix.bsd.Systat`
* `oshi.driver.unix.bsd.disk.Disklabel` → `oshi.driver.common.unix.bsd.disk.Disklabel`
* `oshi.driver.unix.freebsd.disk.{GeomDiskList,GeomPartList,Mount}` → `oshi.driver.common.unix.freebsd.disk.*`
* `oshi.driver.unix.solaris.disk.{Iostat,Lshal,Prtvtoc}` → `oshi.driver.common.unix.solaris.disk.*`

Tests follow their drivers under `oshi-common/src/test/java/oshi/driver/common/unix/...`.

## Updated

* **Consumer imports** in 8 hardware classes across `oshi-common`, `oshi-core`, and `oshi-core-ffm` (the FreeBSD/OpenBSD/NetBSD/Solaris `HWDiskStore` / `Sensors` / `PowerSource` peers, both JNA and FFM).
* `oshi-common/src/main/java/module-info.java` exports: the four old `oshi.driver.unix.*` entries replaced by their `oshi.driver.common.unix.*` equivalents, sorted alphabetically.
* `oshi-common/src/test/java/module-info.test` `--add-opens` directives: matching package renames so JUnit Platform can still introspect each test class.
* `oshi-core/pom.xml` and `oshi-core-ffm/pom.xml` bnd `Export-Package` globs: the moved packages are now covered by the existing `!oshi.driver.common.*` exclude, so the explicit `!oshi.driver.unix.{bsd,freebsd.disk,solaris.disk}.*` overrides drop out.

## Notes

* **Pure refactor** — no public API surface changes (everything in the moved packages was already shared between `oshi-common` consumers; the exported package names change but the class names don't).
* No `oshi-core` packages move. The `oshi.driver.unix.aix` JNA-only package (`PsInfoJNA` + the `perfstat/Perfstat*JNA` drivers) stays put, as do `oshi.driver.unix.freebsd.Who` and `oshi.driver.unix.solaris.{PsInfo,Who,kstat.SystemPages}`.

## Test plan

- [x] `./mvnw clean install -Djacoco.skip=true` green through `oshi-dist` (where bnd conflicts typically surface)
- [x] Inspected the resulting bnd manifests — `oshi-common` exports the four new paths, no `oshi.driver.unix.{bsd,freebsd,solaris}` leaks from any module
- [x] All `oshi-common` tests pass under `mvn clean install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal Unix/BSD/Solaris driver utilities package structure for improved code organization and maintainability. All functionality remains unchanged and there is no impact on end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->