### PR TITLE
Use ForeignFunctions arena helpers in IOKitUtilFFM and Advapi32UtilFFM

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/IOKitUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/IOKitUtilFFM.java
@@ -6,6 +6,9 @@ package oshi.ffm.util.platform.mac;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.slf4j.event.Level.TRACE;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.mac.IOKitFunctions.IOBSDNameMatching;
 import static oshi.ffm.mac.IOKitFunctions.IOMasterPort;
 import static oshi.ffm.mac.IOKitFunctions.IORegistryGetRootEntry;
@@ -17,8 +20,10 @@ import static oshi.ffm.mac.MacSystemFunctions.mach_task_self;
 import static oshi.util.ExceptionUtil.getOrDefault;
 import static oshi.util.ExceptionUtil.runSilently;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import oshi.ffm.mac.IOKit.IOIterator;
 import oshi.ffm.mac.IOKit.IORegistryEntry;
@@ -28,6 +33,8 @@ import oshi.ffm.mac.IOKit.IOService;
  * FFM-based utility for macOS IOKit registry and service operations.
  */
 public final class IOKitUtilFFM {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IOKitUtilFFM.class);
 
     private IOKitUtilFFM() {
     }
@@ -41,16 +48,14 @@ public final class IOKitUtilFFM {
      *         programming practice to deallocate the port when you are finished with it, using mach_port_deallocate.
      */
     public static int getMasterPort() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaIntOrDefault(arena -> {
             MemorySegment port = arena.allocate(JAVA_INT);
             int result = IOMasterPort(0, port);
             if (result == 0) {
                 return port.get(JAVA_INT, 0);
             }
             return 0;
-        } catch (Throwable e) {
-            return 0;
-        }
+        }, LOG, TRACE, "Failed to get IOKit master port", 0);
     }
 
     /**
@@ -74,16 +79,14 @@ public final class IOKitUtilFFM {
      * @return a handle to an IOService if successful, {@code null} if failed. Callers should release when finished.
      */
     public static IOService getMatchingService(String serviceName) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment nameStr = arena.allocateFrom(serviceName);
             MemorySegment dict = IOServiceMatching(nameStr);
             if (dict != null && !dict.equals(MemorySegment.NULL)) {
                 return getMatchingService(dict);
             }
             return null;
-        } catch (Throwable e) {
-            return null;
-        }
+        }, LOG, TRACE, "Failed to get matching IOService for name", null);
     }
 
     /**
@@ -108,16 +111,14 @@ public final class IOKitUtilFFM {
      * @return a handle to an IOIterator if successful, {@code null} if failed. Callers should release when finished.
      */
     public static IOIterator getMatchingServices(String serviceName) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment nameStr = arena.allocateFrom(serviceName);
             MemorySegment dict = IOServiceMatching(nameStr);
             if (dict != null && !dict.equals(MemorySegment.NULL)) {
                 return getMatchingServices(dict);
             }
             return null;
-        } catch (Throwable e) {
-            return null;
-        }
+        }, LOG, TRACE, "Failed to get matching IOServices for name", null);
     }
 
     /**
@@ -127,7 +128,7 @@ public final class IOKitUtilFFM {
      * @return a handle to an IOIterator if successful, {@code null} if failed. Callers should release when finished.
      */
     public static IOIterator getMatchingServices(MemorySegment matchingDictionary) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             int masterPort = getMasterPort();
             MemorySegment iteratorSeg = arena.allocate(ADDRESS);
 
@@ -141,9 +142,7 @@ public final class IOKitUtilFFM {
                 }
             }
             return null;
-        } catch (Throwable e) {
-            return null;
-        }
+        }, LOG, TRACE, "Failed to get matching IOServices for dictionary", null);
     }
 
     /**
@@ -153,15 +152,13 @@ public final class IOKitUtilFFM {
      * @return The dictionary ref if successful, {@code null} if failed. Callers should release when finished.
      */
     public static MemorySegment getBSDNameMatchingDict(String bsdName) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             int masterPort = getMasterPort();
             MemorySegment bsdNameStr = arena.allocateFrom(bsdName);
             MemorySegment result = IOBSDNameMatching(masterPort, 0, bsdNameStr);
             deallocatePort(masterPort);
             return result;
-        } catch (Throwable e) {
-            return null;
-        }
+        }, LOG, TRACE, "Failed to get BSD name matching dictionary", null);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
@@ -7,6 +7,9 @@ package oshi.ffm.util.platform.windows;
 import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.slf4j.event.Level.TRACE;
+import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.windows.Advapi32FFM.GetTokenInformation;
 import static oshi.ffm.windows.Advapi32FFM.OpenProcessToken;
 import static oshi.ffm.windows.Advapi32FFM.RegCloseKey;
@@ -255,7 +258,7 @@ public final class Advapi32UtilFFM {
      * @return The value object (Integer for REG_DWORD, String for REG_SZ/REG_EXPAND_SZ), or null on failure
      */
     public static Object registryGetValue(MemorySegment rootKey, String keyPath, String valueName) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment phkResult = arena.allocate(ADDRESS);
             int rc = RegOpenKeyEx(rootKey, toWideString(arena, keyPath), 0, KEY_READ, phkResult);
             if (rc != ERROR_SUCCESS) {
@@ -270,9 +273,7 @@ public final class Advapi32UtilFFM {
                     LOG.debug("Failed to close registry key {}: error {}", keyPath, closeRc);
                 }
             }
-        } catch (Throwable t) {
-            return null;
-        }
+        }, LOG, TRACE, "Failed to read registry value", null);
     }
 
     /**
@@ -284,7 +285,7 @@ public final class Advapi32UtilFFM {
      * @return true if the value exists, false otherwise
      */
     public static boolean registryValueExists(MemorySegment rootKey, String keyPath, String valueName) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaBooleanOrDefault(arena -> {
             MemorySegment phkResult = arena.allocate(ADDRESS);
             int rc = RegOpenKeyEx(rootKey, toWideString(arena, keyPath), 0, KEY_READ, phkResult);
             if (rc != ERROR_SUCCESS) {
@@ -302,9 +303,7 @@ public final class Advapi32UtilFFM {
                     LOG.debug("Failed to close registry key {}: error {}", keyPath, closeRc);
                 }
             }
-        } catch (Throwable t) {
-            return false;
-        }
+        }, LOG, TRACE, "Failed to check registry value exists", false);
     }
 
     /**


### PR DESCRIPTION
## Summary

Replaces seven hand-rolled `try (Arena = Arena.ofConfined()) … catch (Throwable) { return default; }` blocks across `IOKitUtilFFM` (5) and `Advapi32UtilFFM` (2) with the existing `callInArenaOrDefault` / `callInArenaIntOrDefault` / `callInArenaBooleanOrDefault` helpers in `ForeignFunctions`. Centralises the swallow-and-return pattern so the catch-default convention lives in one place, matching how `Mac*FFM`, `LinuxUsbDeviceFFM`, and the `*CentralProcessorFFM` family already do it.

* Logged at TRACE with static-literal messages. When TRACE is not configured the call collapses to a single `isTraceEnabled()` check that the JIT inlines and the branch predictor pegs — the runtime cost on the success path is effectively zero. The benefit is a debug signal that previously did not exist: enabling TRACE on the offending utility class surfaces the swallowed throwable when chasing an unexpected null/0/false return.
* `IOKitUtilFFM` picks up a `private static final Logger LOG` field; `Advapi32UtilFFM` already had one.

Sites intentionally left alone after closer reading: `IOReportClientFFM` (outer catches cover CFString/CFType allocations beyond the Arena, or `try (CFTypeRef)` resources with `finally { cfRelease }` cleanup that must run after the catch), `MacInternetProtocolStatsFFM` and `HkeyUserDataFFM` (Arena passed in as a parameter), and `MacOSProcessFFM` L600 (inner catch inside a larger Arena scope).

## Test plan

- [x] `./mvnw -pl oshi-core-ffm -am spotless:apply checkstyle:check install javadoc:javadoc -DskipTests` — all gates pass locally
- [x] `./mvnw -pl oshi-core-ffm -am test` — full FFM test suite green on macOS arm64
- [x] CI green across all platforms (mac, windows, linux, freebsd, openbsd, solaris, aix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated macOS IOKit utility to use centralized error-handling wrappers with trace-level logging.
  * Updated Windows registry utility to use shared wrapper functions for consistent error handling and logging across helper methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->