### PR TITLE
GHA: add explicit "permissions: contents: read" to all read-only workflows

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -14,6 +14,9 @@ name: Benchmarks (manual)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   benchlinux:
     name: JMH benchmarks, Linux

--- a/.github/workflows/cfarm.yaml
+++ b/.github/workflows/cfarm.yaml
@@ -11,6 +11,9 @@ on:
       - '**.yml'
       - '**.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   # Runs current branch on Solaris 11.4 on SPARC
   # Retries flaky test once, possible junit-platform-maven-test issue

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 9 */4 * *" # every 4 days at 09:00 UTC
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository_owner == 'oshi'

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -11,6 +11,9 @@ on:
       - '**.yml'
       - '**.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   # Static analysis: formatting, style, API restrictions, and javadoc link validity.
   # Runs once on ubuntu/JDK 25 (javadoc for oshi-core-ffm requires JDK 25).

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -11,6 +11,9 @@ on:
       - '**.yml'
       - '**.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   # Runs full project on multiple JDKs
   testmatrix:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,9 @@ on:
       - '**.yml'
       - '**.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   # Static analysis: formatting, style, API restrictions, and javadoc link validity.
   # Runs once on ubuntu/JDK 25 (javadoc for oshi-core-ffm requires JDK 25).

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -9,6 +9,9 @@ on:
       - '**.yml'
       - '**.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository_owner == 'oshi'

--- a/.github/workflows/sonatype.yaml
+++ b/.github/workflows/sonatype.yaml
@@ -9,6 +9,9 @@ on:
       - '**.yml'
       - '**.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository_owner == 'oshi' && ! contains(toJSON(github.event.head_commit.message), '[maven-release-plugin] prepare release')

--- a/.github/workflows/unix.yaml
+++ b/.github/workflows/unix.yaml
@@ -11,6 +11,9 @@ on:
       - '**.yml'
       - '**.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   # Runs current branch on FreeBSD in a VM, with aggregate-coverage uploaded
   # to Codecov under the `freebsd` flag (no other CI job exercises the

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,6 +11,9 @@ on:
       - '**.yml'
       - '**.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   # Runs current branch with multiple JDKs
   testmatrix:


### PR DESCRIPTION
## Summary

GitHub's default `GITHUB_TOKEN` permissions are wide-open (write to most scopes) unless a workflow explicitly narrows them. This PR adds a workflow-level `permissions: contents: read` block to all 10 OSHI workflows that only need to clone the repo and run tests / external-service uploads.

None of these workflows push to GitHub (no PR comments, no labels, no releases, no security events). Third-party uploads (Codecov, Sonar, Coverity, Sonatype) all use their own dedicated tokens, not `GITHUB_TOKEN`. So `contents: read` is the tightest minimum that still lets every job clone the repo.

**Files changed (10):** `benchmarks.yaml`, `cfarm.yaml`, `coverity.yaml`, `linux.yaml`, `macos.yaml`, `pr.yaml`, `sonar.yaml`, `sonatype.yaml`, `unix.yaml`, `windows.yaml`.

**Unchanged (intentionally):**

* `codeql-analysis.yml` — already has per-job permissions including `security-events: write` for the CodeQL upload.
* `site.yaml` — already has workflow-level `contents: write` for the gh-pages publish.

## Why

GitHub treats the default `GITHUB_TOKEN` generously to keep onboarding easy, which means any compromised third-party action could write to the repo even when it didn't need to. Tightening per-workflow `permissions:` limits the blast radius. CodeRabbit flagged this on PR #3350's benchmark AIX job — this PR closes the broader gap.

## Test plan

- [x] All workflows still parse (Spotless / actionlint would catch syntax issues; the structure follows the existing `site.yaml` pattern).
- [x] No workflow actually performs GitHub writes — verified by `grep` for `gh pr/issue/release`, PR-commenter actions, label-bot actions, artifact uploads, and release-action uses.
- [ ] CI green on this PR (the workflows themselves are exercised here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configurations across all CI/CD workflows by implementing explicit, minimal-privilege permission scopes for automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->