### PR TITLE
Add macOS 27 (Golden Gate) codename mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ##### Bug Fixes and Improvements
 
 * [#3349](https://github.com/oshi/oshi/pull/3349): Fix AIX `Uptime.queryUpTime()` regex to accept the `mins` suffix that appears in the first hour past each day boundary - [@dbwiddis](https://github.com/dbwiddis).
+* [#3358](https://github.com/oshi/oshi/pull/3358): Add macOS 27 (Golden Gate) codename mapping - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.3.0 (2026-06-06)
 

--- a/oshi-common/src/main/resources/oshi.macos.versions.properties
+++ b/oshi-common/src/main/resources/oshi.macos.versions.properties
@@ -1,4 +1,5 @@
 # Mapping of macOS version numbers to names
+27=Golden Gate
 26=Tahoe
 # Early betas of Tahoe used 16
 16=Tahoe


### PR DESCRIPTION
Add macOS 27 (Golden Gate) to the version-to-codename properties file, announced at WWDC 2026.