### PR TITLE
Move NetBSD to oshi-common; wire NetBSD into FFM SystemInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ##### New Features
 
 * [#3350](https://github.com/oshi/oshi/pull/3350): Add AIX support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
-* Add NetBSD support to the FFM (`oshi-core-ffm`) implementation. The NetBSD implementation has no native dependencies, so the classes live in `oshi-common` and are used by both `oshi-core` and `oshi-core-ffm` - [@dbwiddis](https://github.com/dbwiddis).
+* [#3360](https://github.com/oshi/oshi/pull/3360): Add NetBSD support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug Fixes and Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### New Features
 
 * [#3350](https://github.com/oshi/oshi/pull/3350): Add AIX support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
+* Add NetBSD support to the FFM (`oshi-core-ffm`) implementation. The NetBSD implementation has no native dependencies, so the classes live in `oshi-common` and are used by both `oshi-core` and `oshi-core-ffm` - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug Fixes and Improvements
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -100,7 +100,7 @@ OSHI has been implemented and tested on the following systems.  Some features ma
 * AIX 7.1 (POWER4)
 * Android 7.0 and higher
 
-The FFM implementation (`oshi-core-ffm`) supports Windows, macOS, Linux, FreeBSD, OpenBSD, and Solaris (illumos), and assumes a 64-bit operating system.
+The FFM implementation (`oshi-core-ffm`) supports Windows, macOS, Linux, FreeBSD, NetBSD, OpenBSD, Solaris (illumos), and AIX, and assumes a 64-bit operating system.
 
 ## How can I get reliable sensor information on Windows?
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ SystemInfoProvider si = SystemInfoFactory.create();
 | Classpath | JDK | Platform | Selected implementation |
 |-----------|-----|----------|------------------------|
 | `oshi-core` only | 8+ | Any | JNA (`oshi.SystemInfo`) |
-| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows, FreeBSD, OpenBSD, Solaris (illumos), AIX | FFM (`oshi.ffm.SystemInfo`) |
-| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows, FreeBSD, OpenBSD, Solaris (illumos), AIX | FFM (higher priority) |
-| Both `oshi-core` and `oshi-core-ffm` | &lt;25 or unsupported platform (DragonFly BSD, NetBSD) | Any | JNA (FFM unavailable) |
+| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows, FreeBSD, NetBSD, OpenBSD, Solaris (illumos), AIX | FFM (`oshi.ffm.SystemInfo`) |
+| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows, FreeBSD, NetBSD, OpenBSD, Solaris (illumos), AIX | FFM (higher priority) |
+| Both `oshi-core` and `oshi-core-ffm` | &lt;25 or unsupported platform (DragonFly BSD) | Any | JNA (FFM unavailable) |
 | `oshi-common` only | 8+ | Linux | No `--enable-native-access` required (`oshi.nativefree.SystemInfo`) |
 
 You can also instantiate directly:

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -68,5 +68,6 @@ module com.github.oshi.common {
     provides oshi.spi.SystemInfoProvider with oshi.nativefree.SystemInfo;
 
     requires transitive java.desktop;
+    requires java.management;
     requires org.slf4j;
 }

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -37,6 +37,7 @@ module com.github.oshi.common {
     exports oshi.hardware.common.platform.unix;
     exports oshi.hardware.common.platform.unix.aix;
     exports oshi.hardware.common.platform.unix.freebsd;
+    exports oshi.hardware.common.platform.unix.netbsd;
     exports oshi.hardware.common.platform.unix.openbsd;
     exports oshi.hardware.common.platform.unix.solaris;
     exports oshi.hardware.common.platform.windows;
@@ -46,6 +47,7 @@ module com.github.oshi.common {
     exports oshi.software.common.os.mac;
     exports oshi.software.common.os.unix.aix;
     exports oshi.software.common.os.unix.freebsd;
+    exports oshi.software.common.os.unix.netbsd;
     exports oshi.software.common.os.unix.openbsd;
     exports oshi.software.common.os.unix.solaris;
     exports oshi.software.common.os.windows;
@@ -53,6 +55,7 @@ module com.github.oshi.common {
     exports oshi.spi;
     exports oshi.util;
     exports oshi.util.common.platform.unix.freebsd;
+    exports oshi.util.common.platform.unix.netbsd;
     exports oshi.util.common.platform.unix.openbsd;
     exports oshi.util.driver.linux;
     exports oshi.util.driver.linux.proc;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/LpstatPrinter.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/LpstatPrinter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix;
+
+import java.util.List;
+
+import oshi.annotation.concurrent.Immutable;
+import oshi.hardware.Printer;
+
+/**
+ * Native-free CUPS printer implementation. Queries printers via the {@code lpstat} command rather than libcups, so it
+ * works without JNA or FFM native access. Used by platforms whose hardware abstraction layer lives entirely in
+ * {@code oshi-common} (currently NetBSD).
+ */
+@Immutable
+public final class LpstatPrinter extends CupsPrinter {
+
+    LpstatPrinter(String name, String driverName, String description, PrinterStatus status, String statusReason,
+            boolean isDefault, boolean isLocal, String portName) {
+        super(name, driverName, description, status, statusReason, isDefault, isLocal, portName);
+    }
+
+    /**
+     * Gets the list of printers known to CUPS by parsing {@code lpstat -p} output.
+     *
+     * @return list of printers, or an empty list if {@code lpstat} is unavailable.
+     */
+    public static List<Printer> getPrinters() {
+        return getPrintersFromLpstat(LpstatPrinter::new);
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
@@ -24,7 +24,7 @@ import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Quartet;
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdComputerSystem.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import static oshi.util.Memoizer.memoize;
 
@@ -14,7 +14,7 @@ import oshi.hardware.Firmware;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.hardware.common.platform.unix.UnixBaseboard;
 import oshi.util.Constants;
-import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
 
 /**
  * NetBSD ComputerSystem implementation

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdFirmware.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import static oshi.util.Memoizer.memoize;
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdGlobalMemory.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
@@ -14,7 +14,7 @@ import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.AbstractGlobalMemory;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
 
 /**
  * Memory obtained by sysctl and vmstat

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdGraphicsCard.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
@@ -20,7 +20,7 @@ import oshi.hardware.HWPartition;
 import oshi.hardware.common.AbstractHWDiskStore;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
 import oshi.util.tuples.Quartet;
 
 /**

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHardwareAbstractionLayer.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import java.util.List;
 
@@ -20,8 +20,8 @@ import oshi.hardware.Sensors;
 import oshi.hardware.SoundCard;
 import oshi.hardware.UsbDevice;
 import oshi.hardware.common.AbstractHardwareAbstractionLayer;
+import oshi.hardware.common.platform.unix.LpstatPrinter;
 import oshi.hardware.common.platform.unix.UnixDisplay;
-import oshi.hardware.platform.unix.CupsPrinterJNA;
 
 /**
  * NetBsdHardwareAbstractionLayer class.
@@ -86,6 +86,6 @@ public final class NetBsdHardwareAbstractionLayer extends AbstractHardwareAbstra
 
     @Override
     public List<Printer> getPrinters() {
-        return CupsPrinterJNA.getPrinters();
+        return LpstatPrinter.getPrinters();
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import java.net.NetworkInterface;
 import java.util.ArrayList;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdPowerSource.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import java.time.LocalDate;
 import java.util.ArrayList;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdSensors.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdSoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdSoundCard.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdUsbDevice.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import static java.util.Collections.sort;
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdVirtualMemory.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;
 
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/package-info.java
@@ -5,4 +5,4 @@
 /**
  * Provides information about hardware such as Memory, Power Sources, and Processor on NetBSD systems
  */
-package oshi.hardware.platform.unix.netbsd;
+package oshi.hardware.common.platform.unix.netbsd;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.unix.netbsd;
+package oshi.software.common.os.unix.netbsd;
 
 import java.io.File;
 import java.nio.file.PathMatcher;
@@ -17,7 +17,7 @@ import oshi.software.os.OSFileStore;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileSystemUtil;
 import oshi.util.ParseUtil;
-import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
 
 /**
  * The NetBSD File System contains {@link oshi.software.os.OSFileStore}s which are a storage pool, device, partition,

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdInternetProtocolStats.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.unix.netbsd;
+package oshi.software.common.os.unix.netbsd;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractInternetProtocolStats;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdNetworkParams.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.unix.netbsd;
+package oshi.software.common.os.unix.netbsd;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractNetworkParams;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSFileStore.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.unix.netbsd;
+package oshi.software.common.os.unix.netbsd;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOSFileStore;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.unix.netbsd;
+package oshi.software.common.os.unix.netbsd;
 
 import static oshi.software.os.OSProcess.State.INVALID;
 import static oshi.software.os.OSProcess.State.OTHER;
@@ -28,13 +28,13 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOSProcess;
+import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem.PsKeywords;
 import oshi.software.os.OSThread;
-import oshi.software.os.unix.netbsd.NetBsdOperatingSystem.PsKeywords;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
-import oshi.util.platform.unix.netbsd.FstatUtil;
-import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.netbsd.FstatUtil;
+import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
 
 /**
  * OSProcess implementation

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSThread.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.unix.netbsd;
+package oshi.software.common.os.unix.netbsd;
 
 import static oshi.software.os.OSProcess.State.INVALID;
 import static oshi.software.os.OSProcess.State.OTHER;
@@ -17,8 +17,8 @@ import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOSThread;
+import oshi.software.common.os.unix.netbsd.NetBsdOSProcess.PsThreadColumns;
 import oshi.software.os.OSProcess;
-import oshi.software.os.unix.netbsd.NetBsdOSProcess.PsThreadColumns;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
@@ -2,7 +2,7 @@
  * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.unix.netbsd;
+package oshi.software.common.os.unix.netbsd;
 
 import static oshi.software.os.OSService.State.RUNNING;
 import static oshi.software.os.OSService.State.STOPPED;
@@ -30,7 +30,7 @@ import oshi.software.os.OSService;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
 import oshi.util.tuples.Pair;
 
 /**

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/package-info.java
@@ -5,4 +5,4 @@
 /**
  * Provides information about Software and OS on NetBSD
  */
-package oshi.software.os.unix.netbsd;
+package oshi.software.common.os.unix.netbsd;

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/FstatUtil.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/FstatUtil.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.util.platform.unix.netbsd;
+package oshi.util.common.platform.unix.netbsd;
 
 import java.util.List;
 

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/NetBsdSysctlUtil.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/NetBsdSysctlUtil.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.util.platform.unix.netbsd;
+package oshi.util.common.platform.unix.netbsd;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/package-info.java
@@ -5,4 +5,4 @@
 /**
  * Provides utilities for NetBSD
  */
-package oshi.util.platform.unix.netbsd;
+package oshi.util.common.platform.unix.netbsd;

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -59,6 +59,12 @@
 --add-opens
   com.github.oshi.common/oshi.util.common.platform.unix.freebsd=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.hardware.common.platform.unix.netbsd=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.software.common.os.unix.netbsd=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.util.common.platform.unix.netbsd=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.hardware.common.platform.unix.openbsd=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.software.common.os.unix.openbsd=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/netbsd/FstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/netbsd/FstatUtilTest.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.util.platform.unix.netbsd;
+package oshi.util.common.platform.unix.netbsd;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
@@ -14,10 +14,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import java.lang.management.ManagementFactory;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-import oshi.SystemInfo;
+import oshi.util.ParseUtil;
 
 /**
  * Tests for {@link FstatUtil}. Pure parsing methods are covered with sample {@code fstat} output; the integration test
@@ -66,7 +68,9 @@ class FstatUtilTest {
     @Test
     @EnabledIfSystemProperty(named = "os.name", matches = "(?i)netbsd")
     void testFstatLive() {
-        int pid = new SystemInfo().getOperatingSystem().getProcessId();
+        // RuntimeMXBean#getName() returns "<pid>@<host>" — use it to avoid pulling oshi-core's SystemInfo into a
+        // oshi-common test. Mirrors the pattern used in the FreeBSD ProcstatUtilTest.
+        int pid = ParseUtil.parseIntOrDefault(ManagementFactory.getRuntimeMXBean().getName().split("@", 2)[0], -1);
         assertThat("Number of open files must be nonnegative", FstatUtil.getOpenFiles(pid),
                 is(greaterThanOrEqualTo(0L)));
         assertThat("Cwd should not be empty", FstatUtil.getCwd(pid), is(not(emptyString())));

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/netbsd/FstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/netbsd/FstatUtilTest.java
@@ -10,11 +10,10 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import java.lang.management.ManagementFactory;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;

--- a/oshi-core-ffm/src/main/java/module-info.java
+++ b/oshi-core-ffm/src/main/java/module-info.java
@@ -2,8 +2,8 @@
  * FFM-based native implementation of the OSHI API for JDK 25+.
  * <p>
  * This module uses the Foreign Function and Memory (FFM) API for native access and currently supports Windows, macOS,
- * Linux, FreeBSD, OpenBSD, and Solaris (illumos). For broader platform support (DragonFly BSD, NetBSD, AIX), use the
- * JNA-based {@code com.github.oshi} module.
+ * Linux, FreeBSD, NetBSD, OpenBSD, Solaris (illumos), and AIX. For DragonFly BSD support, use the JNA-based
+ * {@code com.github.oshi} module.
  * <p>
  * Usage:
  *

--- a/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
@@ -12,6 +12,7 @@ import java.util.function.Supplier;
 
 import oshi.annotation.PublicApi;
 import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.common.platform.unix.netbsd.NetBsdHardwareAbstractionLayer;
 import oshi.hardware.platform.linux.LinuxHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.mac.MacHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.unix.aix.AixHardwareAbstractionLayerFFM;
@@ -19,6 +20,7 @@ import oshi.hardware.platform.unix.freebsd.FreeBsdHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.unix.openbsd.OpenBsdHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.unix.solaris.SolarisHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.windows.WindowsHardwareAbstractionLayerFFM;
+import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem;
 import oshi.software.os.OperatingSystem;
 import oshi.software.os.linux.LinuxOperatingSystemFFM;
 import oshi.software.os.mac.MacOperatingSystemFFM;
@@ -56,9 +58,9 @@ import oshi.util.PlatformEnum;
  * instance. To conserve memory at the cost of additional processing time, create a new SystemInfo for subsequent calls.
  * To conserve processing time at the cost of additional memory usage, re-use the same instance.
  * <p>
- * This implementation requires JDK 25+ and currently supports Windows, macOS, Linux, FreeBSD, OpenBSD, Solaris
+ * This implementation requires JDK 25+ and currently supports Windows, macOS, Linux, FreeBSD, NetBSD, OpenBSD, Solaris
  * (illumos), and AIX. It uses the FFM API in place of JNA for native access, which may offer better performance. For
- * broader platform support (DragonFly BSD, NetBSD), use the JNA-based entry point ({@code oshi.SystemInfo}) in the
+ * platforms not yet covered by FFM (DragonFly BSD), use the JNA-based entry point ({@code oshi.SystemInfo}) in the
  * {@code oshi-core} module.
  * <p>
  * Both this class and the JNA entry point require native access. Starting with
@@ -91,7 +93,8 @@ public class SystemInfo implements SystemInfoProvider {
     }
 
     private static final Set<PlatformEnum> SUPPORTED_PLATFORMS = EnumSet.of(PlatformEnum.LINUX, PlatformEnum.MACOS,
-            PlatformEnum.WINDOWS, PlatformEnum.FREEBSD, PlatformEnum.OPENBSD, PlatformEnum.SOLARIS, PlatformEnum.AIX);
+            PlatformEnum.WINDOWS, PlatformEnum.FREEBSD, PlatformEnum.NETBSD, PlatformEnum.OPENBSD, PlatformEnum.SOLARIS,
+            PlatformEnum.AIX);
 
     @Override
     public boolean isAvailable() {
@@ -108,6 +111,8 @@ public class SystemInfo implements SystemInfoProvider {
                 return new WindowsOperatingSystemFFM();
             case FREEBSD:
                 return new FreeBsdOperatingSystemFFM();
+            case NETBSD:
+                return new NetBsdOperatingSystem();
             case OPENBSD:
                 return new OpenBsdOperatingSystemFFM();
             case SOLARIS:
@@ -129,6 +134,8 @@ public class SystemInfo implements SystemInfoProvider {
                 return new WindowsHardwareAbstractionLayerFFM();
             case FREEBSD:
                 return new FreeBsdHardwareAbstractionLayerFFM();
+            case NETBSD:
+                return new NetBsdHardwareAbstractionLayer();
             case OPENBSD:
                 return new OpenBsdHardwareAbstractionLayerFFM();
             case SOLARIS:

--- a/oshi-core/src/main/java/module-info.java
+++ b/oshi-core/src/main/java/module-info.java
@@ -43,6 +43,5 @@ module com.github.oshi {
     requires transitive com.sun.jna;
     requires transitive com.sun.jna.platform;
     requires transitive java.desktop;
-    requires java.management;
     requires org.slf4j;
 }

--- a/oshi-core/src/main/java/module-info.java
+++ b/oshi-core/src/main/java/module-info.java
@@ -24,7 +24,6 @@ module com.github.oshi {
     exports oshi.util.platform.mac;
     exports oshi.util.platform.unix.freebsd;
     exports oshi.util.platform.unix.dragonflybsd;
-    exports oshi.util.platform.unix.netbsd;
     exports oshi.util.platform.unix.openbsd;
     exports oshi.util.platform.unix.solaris;
     exports oshi.util.platform.windows;

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -10,22 +10,22 @@ import java.util.function.Supplier;
 
 import oshi.annotation.PublicApi;
 import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.common.platform.unix.netbsd.NetBsdHardwareAbstractionLayer;
 import oshi.hardware.platform.linux.LinuxHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.mac.MacHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.aix.AixHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.dragonflybsd.DragonFlyBsdHardwareAbstractionLayer;
 import oshi.hardware.platform.unix.freebsd.FreeBsdHardwareAbstractionLayerJNA;
-import oshi.hardware.platform.unix.netbsd.NetBsdHardwareAbstractionLayer;
 import oshi.hardware.platform.unix.openbsd.OpenBsdHardwareAbstractionLayer;
 import oshi.hardware.platform.unix.solaris.SolarisHardwareAbstractionLayer;
 import oshi.hardware.platform.windows.WindowsHardwareAbstractionLayerJNA;
+import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem;
 import oshi.software.os.OperatingSystem;
 import oshi.software.os.linux.LinuxOperatingSystemJNA;
 import oshi.software.os.mac.MacOperatingSystemJNA;
 import oshi.software.os.unix.aix.AixOperatingSystemJNA;
 import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystem;
 import oshi.software.os.unix.freebsd.FreeBsdOperatingSystemJNA;
-import oshi.software.os.unix.netbsd.NetBsdOperatingSystem;
 import oshi.software.os.unix.openbsd.OpenBsdOperatingSystem;
 import oshi.software.os.unix.solaris.SolarisOperatingSystem;
 import oshi.software.os.windows.WindowsOperatingSystemJNA;
@@ -61,7 +61,8 @@ import oshi.util.PlatformEnum;
  * all OSHI platforms (Windows, macOS, Linux, Android, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, Solaris, AIX). Android
  * is routed through the Linux implementations. For JDK 25+, the {@code oshi-core-ffm} module provides an alternative
  * entry point ({@code oshi.ffm.SystemInfo}) that uses the Foreign Function and Memory (FFM) API for potentially better
- * performance on supported platforms (currently Windows, macOS, Linux, FreeBSD, OpenBSD, and Solaris (illumos)).
+ * performance on supported platforms (currently Windows, macOS, Linux, FreeBSD, NetBSD, OpenBSD, Solaris (illumos), and
+ * AIX).
  * <p>
  * Both this class and the FFM entry point require native access. Starting with <a href="https://openjdk.org/jeps/472">
  * JEP 472</a> (JDK 24), the JVM warns when native code is loaded, and a future JDK release will require


### PR DESCRIPTION
## Summary

NetBSD's implementation has no native dependencies — it's all command-line parsing and file reads — so its platform classes belong next to oshi-common's other "no JNA / no FFM" code (FreeBSD bases, OpenBSD bases, Solaris bases, AIX bases) rather than over in oshi-core. This move + a small wiring change lets `oshi-core-ffm` cover NetBSD too, closing the only remaining FFM platform gap that wasn't a JDK-25-availability problem.

Companion to [#3357](https://github.com/oshi/oshi/pull/3357) / [#3359](https://github.com/oshi/oshi/pull/3359) — once this lands, the only platform `oshi-core-ffm` doesn't claim is DragonFly BSD (tracked separately by #3346, which adds a real FFM port mirroring the FreeBSD pattern).

## What changed

- **All 25 NetBSD classes move from oshi-core to oshi-common** (8 software/os + 13 hardware + 2 util + 2 package-info), under the canonical `oshi.{software,hardware,util}.common.{os,platform}.unix.netbsd` packages. Mirrors the layout already used for the other Unix platforms. Renames preserve git history.
- **`oshi-core-ffm/SystemInfo.java`** gains `case NETBSD:` entries in `createOperatingSystem()` and `createHardware()` (instantiating the shared oshi-common classes), and `NETBSD` is added to `SUPPORTED_PLATFORMS`. JDK 25 on NetBSD is currently aspirational (no community port yet), but when one lands FFM mode just works.
- **New `LpstatPrinter` class in oshi-common** (`oshi.hardware.common.platform.unix.LpstatPrinter`) — a concrete `CupsPrinter` subclass that uses `lpstat` shell output only, no libcups via JNA. `NetBsdHardwareAbstractionLayer` now calls `LpstatPrinter.getPrinters()` instead of `CupsPrinterJNA.getPrinters()`. Printer enumeration behavior on NetBSD is functionally unchanged; it's just no longer coupled to `oshi-core`.
- **`FstatUtilTest`** switches from `oshi.SystemInfo` to `ManagementFactory.getRuntimeMXBean().getName()` for the live-NetBSD PID, mirroring the FreeBSD `ProcstatUtilTest` pattern, so the test can live in `oshi-common` without depending on `oshi-core`.
- **Docs swept** for stale "FFM doesn't support …" caveats:
  - `README.md` selection-matrix: NetBSD removed from the "unsupported platform" row; added to the FFM-supported rows.
  - `FAQ.md` FFM platform list: NetBSD and AIX added (AIX had been missing since the AIX-FFM port landed in 7.3.1-rc).
  - `oshi-core-ffm/module-info.java`: same list update.
  - `oshi-core/SystemInfo.java` javadoc: same list update.
- **`CHANGELOG.md`** entry under 7.3.1 New Features.
- **`module-info.test`** (oshi-common): adds `--add-opens` lines for the three new NetBSD packages so JUnit Jupiter can reflectively access the test class.

## Issues

- Does not close #3347 (restore JNA-with-fallback for NetBSD oshi-core) or #3348 (FFM-native bindings for NetBSD) — those stay open as future *performance* improvements layered on top of the no-native baseline. With this PR landed they're nice-to-haves, not missing features.

## Test plan

- [x] `./mvnw clean install` from repo root passes (all 788 tests).
- [x] Spotless / Checkstyle / Forbidden APIs / Javadoc clean on `oshi-common`, `oshi-core`, `oshi-core-ffm`.
- [x] JPMS module-info updates verified: oshi-core no longer exports the moved package, oshi-common exports the three new ones.
- [ ] CI runs (this PR) — Linux/macOS/Windows matrix should be unchanged. FreeBSD/OpenBSD/OpenIndiana paths should be unchanged. NetBSD VM job exercises `oshi-core` SystemInfo against the moved classes (the actual functional regression check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FFM now supports NetBSD (no native dependencies) and AIX; FFM coverage expanded across BSD/Unix platforms.
  * Added native-free printer discovery using lpstat for Unix platforms where available.

* **Chores**
  * Reorganized NetBSD implementation packages and updated fallback behavior (DragonFly BSD still falls back to JNA).
  * Updated CHANGELOG, README and FAQ to reflect platform compatibility changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->