### PR TITLE
DragonFly BSD: add FFM port; refactor to mirror FreeBSD split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#3350](https://github.com/oshi/oshi/pull/3350): Add AIX support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
 * [#3360](https://github.com/oshi/oshi/pull/3360): Add NetBSD support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
+* Add DragonFly BSD support to the FFM (`oshi-core-ffm`) implementation. With this, FFM and JNA implementations cover the same set of supported platforms - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug Fixes and Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#3350](https://github.com/oshi/oshi/pull/3350): Add AIX support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
 * [#3360](https://github.com/oshi/oshi/pull/3360): Add NetBSD support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
-* Add DragonFly BSD support to the FFM (`oshi-core-ffm`) implementation. With this, FFM and JNA implementations cover the same set of supported platforms - [@dbwiddis](https://github.com/dbwiddis).
+* [#3362](https://github.com/oshi/oshi/pull/3362): Add DragonFly BSD support to the FFM (`oshi-core-ffm`) implementation - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug Fixes and Improvements
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -100,7 +100,7 @@ OSHI has been implemented and tested on the following systems.  Some features ma
 * AIX 7.1 (POWER4)
 * Android 7.0 and higher
 
-The FFM implementation (`oshi-core-ffm`) supports Windows, macOS, Linux, FreeBSD, NetBSD, OpenBSD, Solaris (illumos), and AIX, and assumes a 64-bit operating system.
+The FFM implementation (`oshi-core-ffm`) supports the same platforms as the JNA implementation and assumes a 64-bit operating system.
 
 ## How can I get reliable sensor information on Windows?
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ SystemInfoProvider si = SystemInfoFactory.create();
 | Classpath | JDK | Platform | Selected implementation |
 |-----------|-----|----------|------------------------|
 | `oshi-core` only | 8+ | Any | JNA (`oshi.SystemInfo`) |
-| `oshi-core-ffm` only | 25+ | Linux, macOS, Windows, FreeBSD, NetBSD, OpenBSD, Solaris (illumos), AIX | FFM (`oshi.ffm.SystemInfo`) |
-| Both `oshi-core` and `oshi-core-ffm` | 25+ | Linux, macOS, Windows, FreeBSD, NetBSD, OpenBSD, Solaris (illumos), AIX | FFM (higher priority) |
-| Both `oshi-core` and `oshi-core-ffm` | &lt;25 or unsupported platform (DragonFly BSD) | Any | JNA (FFM unavailable) |
+| `oshi-core-ffm` only | 25+ | All supported platforms | FFM (`oshi.ffm.SystemInfo`) |
+| Both `oshi-core` and `oshi-core-ffm` | 25+ | All supported platforms | FFM (higher priority) |
+| Both `oshi-core` and `oshi-core-ffm` | &lt;25 | Any | JNA (FFM unavailable) |
 | `oshi-common` only | 8+ | Linux | No `--enable-native-access` required (`oshi.nativefree.SystemInfo`) |
 
 You can also instantiate directly:

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -46,6 +46,7 @@ module com.github.oshi.common {
     exports oshi.software.common.os.linux;
     exports oshi.software.common.os.mac;
     exports oshi.software.common.os.unix.aix;
+    exports oshi.software.common.os.unix.dragonflybsd;
     exports oshi.software.common.os.unix.freebsd;
     exports oshi.software.common.os.unix.netbsd;
     exports oshi.software.common.os.unix.openbsd;
@@ -54,6 +55,7 @@ module com.github.oshi.common {
     exports oshi.software.os;
     exports oshi.spi;
     exports oshi.util;
+    exports oshi.util.common.platform.unix.dragonflybsd;
     exports oshi.util.common.platform.unix.freebsd;
     exports oshi.util.common.platform.unix.netbsd;
     exports oshi.util.common.platform.unix.openbsd;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.dragonflybsd;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import oshi.software.common.AbstractOSProcess;
+
+public abstract class DragonFlyBsdOSProcess extends AbstractOSProcess {
+
+    /**
+     * Columns requested from {@code ps -awwxo} when enumerating threads. Shared by DragonFlyBsdOSProcess subclasses and
+     * DragonFlyBsdOSThread so the column list and parsing enum stay in lockstep.
+     */
+    public enum PsThreadColumns {
+        TID, STATE, TIME, MAJFLT, MINFLT, NVCSW, NIVCSW, PRI;
+    }
+
+    public static final String PS_THREAD_COLUMNS = Arrays.stream(PsThreadColumns.values()).map(Enum::name)
+            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
+
+    protected DragonFlyBsdOSProcess(int pid) {
+        super(pid);
+    }
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSThread.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.software.os.unix.dragonflybsd;
+package oshi.software.common.os.unix.dragonflybsd;
 
 import static oshi.software.os.OSProcess.State.INVALID;
 import static oshi.software.os.OSProcess.State.OTHER;
@@ -17,8 +17,8 @@ import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOSThread;
+import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess.PsThreadColumns;
 import oshi.software.os.OSProcess;
-import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOSProcess.PsThreadColumns;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
@@ -116,6 +116,7 @@ public class DragonFlyBsdOSThread extends AbstractOSThread {
     public boolean updateAttributes() {
         List<String> threadList = ExecutingCommand
                 .runNative("ps -awwxo " + DragonFlyBsdOSProcess.PS_THREAD_COLUMNS + " -H -p " + getOwningProcessId());
+        // DragonFlyBsdOSProcess (oshi-common abstract base) provides PS_THREAD_COLUMNS + the PsThreadColumns enum.
         // there is no switch for thread in ps command, hence filtering.
         String lwpStr = Integer.toString(this.threadId);
         for (String psOutput : threadList) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides DragonFly BSD-specific shared software OS classes (abstract bases and no-native concrete implementations).
+ */
+package oshi.software.common.os.unix.dragonflybsd;

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtil.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtil.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.util.platform.unix.dragonflybsd;
+package oshi.util.common.platform.unix.dragonflybsd;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/dragonflybsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/dragonflybsd/package-info.java
@@ -5,4 +5,4 @@
 /**
  * Provides utilities for DragonFly BSD
  */
-package oshi.util.platform.unix.dragonflybsd;
+package oshi.util.common.platform.unix.dragonflybsd;

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -53,6 +53,10 @@
 --add-opens
   com.github.oshi.common/oshi.driver.common.unix.freebsd.disk=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.software.common.os.unix.dragonflybsd=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.util.common.platform.unix.dragonflybsd=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.driver.common.unix.solaris.disk=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.hardware.common.platform.unix.freebsd=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtilTest.java
@@ -6,6 +6,7 @@ package oshi.util.common.platform.unix.dragonflybsd;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -89,6 +90,7 @@ class ProcstatUtilTest {
         // RuntimeMXBean#getName() returns "<pid>@<host>" — use it to avoid pulling oshi-core's SystemInfo into a
         // oshi-common test. Mirrors the pattern used in the FreeBSD ProcstatUtilTest and NetBSD FstatUtilTest.
         int pid = ParseUtil.parseIntOrDefault(ManagementFactory.getRuntimeMXBean().getName().split("@", 2)[0], -1);
+        assertThat("RuntimeMXBean#getName() should yield a positive PID, got " + pid, pid, is(greaterThan(0)));
         assertThat("Open files must be nonnegative", ProcstatUtil.getOpenFiles(pid), is(greaterThanOrEqualTo(0L)));
         assertThat("Cwd should be nonempty", ProcstatUtil.getCwd(pid), is(not(emptyString())));
     }

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtilTest.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.util.platform.unix.dragonflybsd;
+package oshi.util.common.platform.unix.dragonflybsd;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-import oshi.SystemInfo;
+import oshi.util.ParseUtil;
 
 /**
  * Tests for {@link ProcstatUtil}. Pure parsing methods are covered with sample {@code fstat} output; the integration
@@ -85,7 +86,9 @@ class ProcstatUtilTest {
     @Test
     @EnabledIfSystemProperty(named = "os.name", matches = "(?i)dragonfly")
     void testProcstatLive() {
-        int pid = new SystemInfo().getOperatingSystem().getProcessId();
+        // RuntimeMXBean#getName() returns "<pid>@<host>" — use it to avoid pulling oshi-core's SystemInfo into a
+        // oshi-common test. Mirrors the pattern used in the FreeBSD ProcstatUtilTest and NetBSD FstatUtilTest.
+        int pid = ParseUtil.parseIntOrDefault(ManagementFactory.getRuntimeMXBean().getName().split("@", 2)[0], -1);
         assertThat("Open files must be nonnegative", ProcstatUtil.getOpenFiles(pid), is(greaterThanOrEqualTo(0L)));
         assertThat("Cwd should be nonempty", ProcstatUtil.getCwd(pid), is(not(emptyString())));
     }

--- a/oshi-core-ffm/src/main/java/module-info.java
+++ b/oshi-core-ffm/src/main/java/module-info.java
@@ -1,9 +1,8 @@
 /**
  * FFM-based native implementation of the OSHI API for JDK 25+.
  * <p>
- * This module uses the Foreign Function and Memory (FFM) API for native access and currently supports Windows, macOS,
- * Linux, FreeBSD, NetBSD, OpenBSD, Solaris (illumos), and AIX. For DragonFly BSD support, use the JNA-based
- * {@code com.github.oshi} module.
+ * This module uses the Foreign Function and Memory (FFM) API for native access and supports the same platforms as the
+ * JNA-based {@code com.github.oshi} module.
  * <p>
  * Usage:
  *
@@ -24,6 +23,7 @@ module com.github.oshi.ffm {
     exports oshi.ffm.util;
     exports oshi.ffm.util.gpu;
     exports oshi.ffm.util.platform.mac;
+    exports oshi.ffm.platform.unix.dragonflybsd;
     exports oshi.ffm.util.platform.unix.freebsd;
     exports oshi.ffm.util.platform.unix.openbsd;
     exports oshi.ffm.util.platform.unix.solaris;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
@@ -16,6 +16,7 @@ import oshi.hardware.common.platform.unix.netbsd.NetBsdHardwareAbstractionLayer;
 import oshi.hardware.platform.linux.LinuxHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.mac.MacHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.unix.aix.AixHardwareAbstractionLayerFFM;
+import oshi.hardware.platform.unix.dragonflybsd.DragonFlyBsdHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.unix.freebsd.FreeBsdHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.unix.openbsd.OpenBsdHardwareAbstractionLayerFFM;
 import oshi.hardware.platform.unix.solaris.SolarisHardwareAbstractionLayerFFM;
@@ -25,6 +26,7 @@ import oshi.software.os.OperatingSystem;
 import oshi.software.os.linux.LinuxOperatingSystemFFM;
 import oshi.software.os.mac.MacOperatingSystemFFM;
 import oshi.software.os.unix.aix.AixOperatingSystemFFM;
+import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystemFFM;
 import oshi.software.os.unix.freebsd.FreeBsdOperatingSystemFFM;
 import oshi.software.os.unix.openbsd.OpenBsdOperatingSystemFFM;
 import oshi.software.os.unix.solaris.SolarisOperatingSystemFFM;
@@ -58,10 +60,8 @@ import oshi.util.PlatformEnum;
  * instance. To conserve memory at the cost of additional processing time, create a new SystemInfo for subsequent calls.
  * To conserve processing time at the cost of additional memory usage, re-use the same instance.
  * <p>
- * This implementation requires JDK 25+ and currently supports Windows, macOS, Linux, FreeBSD, NetBSD, OpenBSD, Solaris
- * (illumos), and AIX. It uses the FFM API in place of JNA for native access, which may offer better performance. For
- * platforms not yet covered by FFM (DragonFly BSD), use the JNA-based entry point ({@code oshi.SystemInfo}) in the
- * {@code oshi-core} module.
+ * This implementation requires JDK 25+ and supports the same platforms as the JNA-based entry point. It uses the FFM
+ * API in place of JNA for native access, which may offer better performance.
  * <p>
  * Both this class and the JNA entry point require native access. Starting with
  * <a href="https://openjdk.org/jeps/472">JEP 472</a> (JDK 24), the JVM warns when native code is loaded, and a future
@@ -93,8 +93,8 @@ public class SystemInfo implements SystemInfoProvider {
     }
 
     private static final Set<PlatformEnum> SUPPORTED_PLATFORMS = EnumSet.of(PlatformEnum.LINUX, PlatformEnum.MACOS,
-            PlatformEnum.WINDOWS, PlatformEnum.FREEBSD, PlatformEnum.NETBSD, PlatformEnum.OPENBSD, PlatformEnum.SOLARIS,
-            PlatformEnum.AIX);
+            PlatformEnum.WINDOWS, PlatformEnum.FREEBSD, PlatformEnum.NETBSD, PlatformEnum.OPENBSD,
+            PlatformEnum.DRAGONFLYBSD, PlatformEnum.SOLARIS, PlatformEnum.AIX);
 
     @Override
     public boolean isAvailable() {
@@ -115,6 +115,8 @@ public class SystemInfo implements SystemInfoProvider {
                 return new NetBsdOperatingSystem();
             case OPENBSD:
                 return new OpenBsdOperatingSystemFFM();
+            case DRAGONFLYBSD:
+                return new DragonFlyBsdOperatingSystemFFM();
             case SOLARIS:
                 return new SolarisOperatingSystemFFM();
             case AIX:
@@ -138,6 +140,8 @@ public class SystemInfo implements SystemInfoProvider {
                 return new NetBsdHardwareAbstractionLayer();
             case OPENBSD:
                 return new OpenBsdHardwareAbstractionLayerFFM();
+            case DRAGONFLYBSD:
+                return new DragonFlyBsdHardwareAbstractionLayerFFM();
             case SOLARIS:
                 return new SolarisHardwareAbstractionLayerFFM();
             case AIX:

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/dragonflybsd/DragonFlyBsdLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/dragonflybsd/DragonFlyBsdLibcFunctions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.platform.unix.dragonflybsd;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+
+import oshi.ffm.ForeignFunctions;
+
+/**
+ * FFM bindings for DragonFly BSD-specific libc functions. DragonFly shares most of its libc surface with FreeBSD, so
+ * shared functions ({@code sysctlbyname}, {@code sysctl}, {@code getpid}, {@code getrlimit}, etc.) are called via
+ * {@link oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions}. This class adds only the DragonFly-specific
+ * {@code lwp_gettid()} (FreeBSD uses {@code thr_self} instead).
+ */
+public final class DragonFlyBsdLibcFunctions extends ForeignFunctions {
+
+    private DragonFlyBsdLibcFunctions() {
+    }
+
+    private static final SymbolLookup LIBC = LINKER.defaultLookup();
+
+    // int lwp_gettid(void);
+    private static final MethodHandle lwp_gettid = LINKER.downcallHandle(LIBC.findOrThrow("lwp_gettid"),
+            FunctionDescriptor.of(JAVA_INT));
+
+    /**
+     * Calls {@code lwp_gettid()} — returns the kernel thread ID of the calling LWP.
+     *
+     * @return the kernel thread ID, or -1 on error
+     * @throws Throwable on FFM invocation error
+     */
+    public static int lwp_gettid() throws Throwable {
+        return (int) lwp_gettid.invokeExact();
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/dragonflybsd/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/dragonflybsd/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * FFM bindings for DragonFly BSD-specific libc functions.
+ */
+package oshi.ffm.platform.unix.dragonflybsd;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdCentralProcessorFFM.java
@@ -41,6 +41,11 @@ public class DragonFlyBsdCentralProcessorFFM extends FreeBsdCentralProcessorFFM 
             return ticks;
         }
         long structSize = arraySize / cpus;
+        // Guard: kern.cputime's per-CPU struct must hold at least the 5 tick fields we read (CP_IDLE is the highest
+        // index). A short return — e.g. a stub sysctl on a non-DragonFly kernel — would otherwise IOBE in buf.get().
+        if (structSize < (CP_IDLE + 1) * UINT64_SIZE) {
+            return ticks;
+        }
         for (int cpu = 0; cpu < cpus; cpu++) {
             long base = structSize * cpu;
             ticks[cpu][TickType.USER.getIndex()] = buf.get(JAVA_LONG, base + CP_USER * UINT64_SIZE);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdCentralProcessorFFM.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.dragonflybsd;
+
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+
+import java.lang.foreign.MemorySegment;
+
+import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.platform.unix.freebsd.FreeBsdCentralProcessorFFM;
+
+/**
+ * DragonFly BSD Central Processor (FFM). Inherits {@code kern.cp_time} system tick logic from
+ * {@link FreeBsdCentralProcessorFFM} and overrides per-CPU tick retrieval to use DragonFly's {@code kern.cputime}
+ * sysctl (FreeBSD uses {@code kern.cp_times}).
+ */
+public class DragonFlyBsdCentralProcessorFFM extends FreeBsdCentralProcessorFFM {
+
+    private static final int CP_USER = 0;
+    private static final int CP_NICE = 1;
+    private static final int CP_SYS = 2;
+    private static final int CP_INTR = 3;
+    private static final int CP_IDLE = 4;
+    private static final long UINT64_SIZE = Long.BYTES;
+
+    @Override
+    public long[][] queryProcessorCpuLoadTicks() {
+        int cpus = getLogicalProcessorCount();
+        long[][] ticks = new long[cpus][CentralProcessor.TickType.values().length];
+        // DragonFly's kern.cputime returns a packed per-CPU array; the struct size per CPU is the total length
+        // divided by CPU count (the trailing fields can vary by DragonFly version).
+        MemorySegment buf = BsdSysctlUtilFFM.sysctl("kern.cputime");
+        if (buf == null) {
+            return ticks;
+        }
+        long arraySize = buf.byteSize();
+        if (arraySize <= 0) {
+            return ticks;
+        }
+        long structSize = arraySize / cpus;
+        for (int cpu = 0; cpu < cpus; cpu++) {
+            long base = structSize * cpu;
+            ticks[cpu][TickType.USER.getIndex()] = buf.get(JAVA_LONG, base + CP_USER * UINT64_SIZE);
+            ticks[cpu][TickType.NICE.getIndex()] = buf.get(JAVA_LONG, base + CP_NICE * UINT64_SIZE);
+            ticks[cpu][TickType.SYSTEM.getIndex()] = buf.get(JAVA_LONG, base + CP_SYS * UINT64_SIZE);
+            ticks[cpu][TickType.IRQ.getIndex()] = buf.get(JAVA_LONG, base + CP_INTR * UINT64_SIZE);
+            ticks[cpu][TickType.IDLE.getIndex()] = buf.get(JAVA_LONG, base + CP_IDLE * UINT64_SIZE);
+        }
+        return ticks;
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerFFM.java
@@ -25,47 +25,48 @@ import oshi.hardware.common.platform.unix.UnixDisplay;
 import oshi.hardware.common.platform.unix.freebsd.FreeBsdGraphicsCard;
 import oshi.hardware.common.platform.unix.freebsd.FreeBsdSoundCard;
 import oshi.hardware.common.platform.unix.freebsd.FreeBsdUsbDevice;
-import oshi.hardware.platform.unix.CupsPrinterJNA;
-import oshi.hardware.platform.unix.freebsd.FreeBsdComputerSystemJNA;
-import oshi.hardware.platform.unix.freebsd.FreeBsdGlobalMemoryJNA;
-import oshi.hardware.platform.unix.freebsd.FreeBsdHWDiskStoreJNA;
-import oshi.hardware.platform.unix.freebsd.FreeBsdPowerSourceJNA;
-import oshi.hardware.platform.unix.freebsd.FreeBsdSensorsJNA;
+import oshi.hardware.platform.unix.CupsPrinterFFM;
+import oshi.hardware.platform.unix.freebsd.FreeBsdComputerSystemFFM;
+import oshi.hardware.platform.unix.freebsd.FreeBsdGlobalMemoryFFM;
+import oshi.hardware.platform.unix.freebsd.FreeBsdHWDiskStoreFFM;
+import oshi.hardware.platform.unix.freebsd.FreeBsdPowerSourceFFM;
+import oshi.hardware.platform.unix.freebsd.FreeBsdSensorsFFM;
 
 /**
- * DragonFlyBsdHardwareAbstractionLayer class. Uses FreeBSD implementations where behavior is identical.
+ * FFM-backed DragonFly BSD HAL. Uses FreeBSD FFM implementations where behavior is identical; overrides
+ * {@link #createProcessor()} to return the DragonFly-specific CPU implementation.
  */
 @ThreadSafe
-public final class DragonFlyBsdHardwareAbstractionLayer extends AbstractHardwareAbstractionLayer {
+public final class DragonFlyBsdHardwareAbstractionLayerFFM extends AbstractHardwareAbstractionLayer {
 
     @Override
     public ComputerSystem createComputerSystem() {
-        return new FreeBsdComputerSystemJNA();
+        return new FreeBsdComputerSystemFFM();
     }
 
     @Override
     public GlobalMemory createMemory() {
-        return new FreeBsdGlobalMemoryJNA();
+        return new FreeBsdGlobalMemoryFFM();
     }
 
     @Override
     public CentralProcessor createProcessor() {
-        return new DragonFlyBsdCentralProcessor();
+        return new DragonFlyBsdCentralProcessorFFM();
     }
 
     @Override
     public Sensors createSensors() {
-        return new FreeBsdSensorsJNA();
+        return new FreeBsdSensorsFFM();
     }
 
     @Override
     public List<PowerSource> getPowerSources() {
-        return FreeBsdPowerSourceJNA.getPowerSources();
+        return FreeBsdPowerSourceFFM.getPowerSources();
     }
 
     @Override
     public List<HWDiskStore> getDiskStores() {
-        return FreeBsdHWDiskStoreJNA.getDisks();
+        return FreeBsdHWDiskStoreFFM.getDisks();
     }
 
     @Override
@@ -95,6 +96,6 @@ public final class DragonFlyBsdHardwareAbstractionLayer extends AbstractHardware
 
     @Override
     public List<Printer> getPrinters() {
-        return CupsPrinterJNA.getPrinters();
+        return CupsPrinterFFM.getPrinters();
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.unix.dragonflybsd;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+import static oshi.software.os.OSProcess.State.INVALID;
+import static oshi.software.os.OSProcess.State.OTHER;
+import static oshi.software.os.OSProcess.State.RUNNING;
+import static oshi.software.os.OSProcess.State.SLEEPING;
+import static oshi.software.os.OSProcess.State.STOPPED;
+import static oshi.software.os.OSProcess.State.WAITING;
+import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
+import static oshi.util.Memoizer.memoize;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
+import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
+import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSThread;
+import oshi.software.os.OSThread;
+import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystemFFM.PsKeywords;
+import oshi.util.ExecutingCommand;
+import oshi.util.FileUtil;
+import oshi.util.ParseUtil;
+import oshi.util.common.platform.unix.dragonflybsd.ProcstatUtil;
+
+/**
+ * FFM-backed DragonFly BSD OS process.
+ */
+@ThreadSafe
+public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOSProcessFFM.class);
+
+    private final DragonFlyBsdOperatingSystemFFM os;
+
+    private Supplier<Integer> bitness = memoize(this::queryBitness);
+    private Supplier<String> commandLine = memoize(this::queryCommandLine);
+    private Supplier<List<String>> arguments = memoize(this::queryArguments);
+    private Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
+
+    private String name;
+    private String path = "";
+    private String user;
+    private String userID;
+    private String group;
+    private String groupID;
+    private State state = INVALID;
+    private int parentProcessID;
+    private int threadCount;
+    private int priority;
+    private long virtualSize;
+    private long residentSetSize;
+    private long kernelTime;
+    private long userTime;
+    private long startTime;
+    private long upTime;
+    private long bytesRead;
+    private long bytesWritten;
+    private long minorFaults;
+    private long majorFaults;
+    private long voluntaryContextSwitches;
+    private long involuntaryContextSwitches;
+    private String commandLineBackup;
+
+    public DragonFlyBsdOSProcessFFM(int pid, Map<PsKeywords, String> psMap, DragonFlyBsdOperatingSystemFFM os) {
+        super(pid);
+        this.os = os;
+        updateAttributes(psMap);
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getPath() {
+        return this.path;
+    }
+
+    @Override
+    public String getCommandLine() {
+        return this.commandLine.get();
+    }
+
+    private String queryCommandLine() {
+        String cl = String.join(" ", getArguments());
+        return cl.isEmpty() ? this.commandLineBackup : cl;
+    }
+
+    @Override
+    public List<String> getArguments() {
+        return arguments.get();
+    }
+
+    private List<String> queryArguments() {
+        // DragonFlyBSD provides command line via /proc filesystem
+        byte[] cmdBytes = FileUtil.readAllBytes("/proc/" + getProcessID() + "/cmdline", false);
+        if (cmdBytes != null && cmdBytes.length > 0) {
+            return Collections.unmodifiableList(ParseUtil.parseByteArrayToStrings(cmdBytes));
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Map<String, String> getEnvironmentVariables() {
+        return environmentVariables.get();
+    }
+
+    private Map<String, String> queryEnvironmentVariables() {
+        // DragonFlyBSD's /proc does not expose environ for other processes.
+        // For the current process, use Java's System.getenv().
+        int self = callInArenaIntOrDefault(arena -> FreeBsdLibcFunctions.getpid(), LOG, Level.WARN, "getpid failed",
+                -1);
+        if (getProcessID() == self) {
+            return System.getenv();
+        }
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public String getCurrentWorkingDirectory() {
+        return ProcstatUtil.getCwd(getProcessID());
+    }
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    @Override
+    public String getUserID() {
+        return this.userID;
+    }
+
+    @Override
+    public String getGroup() {
+        return this.group;
+    }
+
+    @Override
+    public String getGroupID() {
+        return this.groupID;
+    }
+
+    @Override
+    public State getState() {
+        return this.state;
+    }
+
+    @Override
+    public int getParentProcessID() {
+        return this.parentProcessID;
+    }
+
+    @Override
+    public int getThreadCount() {
+        return this.threadCount;
+    }
+
+    @Override
+    public int getPriority() {
+        return this.priority;
+    }
+
+    @Override
+    public long getVirtualSize() {
+        return this.virtualSize;
+    }
+
+    @Override
+    public long getResidentMemory() {
+        return this.residentSetSize;
+    }
+
+    @Override
+    public long getKernelTime() {
+        return this.kernelTime;
+    }
+
+    @Override
+    public long getUserTime() {
+        return this.userTime;
+    }
+
+    @Override
+    public long getUpTime() {
+        return this.upTime;
+    }
+
+    @Override
+    public long getStartTime() {
+        return this.startTime;
+    }
+
+    @Override
+    public long getBytesRead() {
+        return this.bytesRead;
+    }
+
+    @Override
+    public long getBytesWritten() {
+        return this.bytesWritten;
+    }
+
+    @Override
+    public long getOpenFiles() {
+        return ProcstatUtil.getOpenFiles(getProcessID());
+    }
+
+    @Override
+    public long getSoftOpenFileLimit() {
+        if (getProcessID() == this.os.getProcessId()) {
+            return queryRlimitNofile(true);
+        }
+        return getProcessOpenFileLimit(getProcessID(), 1);
+    }
+
+    @Override
+    public long getHardOpenFileLimit() {
+        if (getProcessID() == this.os.getProcessId()) {
+            return queryRlimitNofile(false);
+        }
+        return getProcessOpenFileLimit(getProcessID(), 2);
+    }
+
+    private long queryRlimitNofile(boolean soft) {
+        return callInArenaOrDefault(arena -> {
+            MemorySegment rlim = arena.allocate(FreeBsdLibcFunctions.RLIMIT_LAYOUT);
+            if (FreeBsdLibcFunctions.getrlimit(FreeBsdLibcFunctions.RLIMIT_NOFILE, rlim) != 0) {
+                return -1L;
+            }
+            return rlim.get(JAVA_LONG, soft ? 0 : Long.BYTES);
+        }, LOG, Level.WARN, "getrlimit(RLIMIT_NOFILE) failed", -1L);
+    }
+
+    @Override
+    public int getBitness() {
+        return this.bitness.get();
+    }
+
+    @Override
+    public long getAffinityMask() {
+        long bitMask = 0L;
+        // Would prefer to use native cpuset_getaffinity call but variable sizing is
+        // kernel-dependent and requires C macros, so we use commandline instead.
+        String cpuset = ExecutingCommand.getFirstAnswer("cpuset -gp " + getProcessID());
+        // Sample output:
+        // pid 8 mask: 0, 1
+        // cpuset: getaffinity: No such process
+        String[] split = cpuset.split(":");
+        if (split.length > 1) {
+            String[] bits = split[1].split(",");
+            for (String bit : bits) {
+                int bitToSet = ParseUtil.parseIntOrDefault(bit.trim(), -1);
+                if (bitToSet >= 0 && bitToSet < Long.SIZE) {
+                    bitMask |= 1L << bitToSet;
+                }
+            }
+        }
+        return bitMask;
+    }
+
+    private int queryBitness() {
+        return callInArenaIntOrDefault(arena -> {
+            // CTL_KERN.KERN_PROC.KERN_PROC_SV_NAME.<pid>
+            MemorySegment mib = arena.allocateFrom(JAVA_INT, 1, 14, 9, getProcessID());
+            MemorySegment buf = arena.allocate(32);
+            MemorySegment size = arena.allocate(JAVA_LONG);
+            size.set(JAVA_LONG, 0, 32L);
+            MemorySegment callState = arena.allocate(ADDRESS);
+            int rc = FreeBsdLibcFunctions.sysctl(callState, mib, 4, buf, size, MemorySegment.NULL, 0L);
+            if (rc != 0) {
+                return 0;
+            }
+            byte[] bytes = buf.asSlice(0, Math.min(size.get(JAVA_LONG, 0), 32L)).toArray(JAVA_BYTE);
+            String elf = new String(bytes, StandardCharsets.UTF_8).trim();
+            if (elf.contains("ELF32")) {
+                return 32;
+            } else if (elf.contains("ELF64")) {
+                return 64;
+            }
+            return 0;
+        }, LOG, Level.WARN, "queryBitness failed", 0);
+    }
+
+    @Override
+    public List<OSThread> getThreadDetails() {
+        String psCommand = "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
+        if (getProcessID() >= 0) {
+            psCommand += " -p " + getProcessID();
+        }
+        Predicate<Map<PsThreadColumns, String>> hasColumnsPri = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
+        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
+                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .filter(hasColumnsPri).map(threadMap -> new DragonFlyBsdOSThread(getProcessID(), threadMap))
+                .filter(VALID_THREAD).collect(Collectors.toList());
+    }
+
+    @Override
+    public long getMinorFaults() {
+        return this.minorFaults;
+    }
+
+    @Override
+    public long getMajorFaults() {
+        return this.majorFaults;
+    }
+
+    @Override
+    public long getVoluntaryContextSwitches() {
+        return this.voluntaryContextSwitches;
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        return this.involuntaryContextSwitches;
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        String psCommand = "ps -awwxo " + DragonFlyBsdOperatingSystemFFM.PS_COMMAND_ARGS + " -p " + getProcessID();
+        List<String> procList = ExecutingCommand.runNative(psCommand);
+        if (procList.size() > 1) {
+            // skip header row
+            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, procList.get(1).trim(), ' ');
+            // Check if last (thus all) value populated
+            if (psMap.containsKey(PsKeywords.COMMAND)) {
+                return updateAttributes(psMap);
+            }
+        }
+        this.state = INVALID;
+        return false;
+    }
+
+    private boolean updateAttributes(Map<PsKeywords, String> psMap) {
+        long now = System.currentTimeMillis();
+        switch (psMap.get(PsKeywords.STATE).charAt(0)) {
+            case 'R':
+                this.state = RUNNING;
+                break;
+            case 'I':
+            case 'S':
+                this.state = SLEEPING;
+                break;
+            case 'D':
+            case 'L':
+            case 'U':
+                this.state = WAITING;
+                break;
+            case 'Z':
+                this.state = ZOMBIE;
+                break;
+            case 'T':
+                this.state = STOPPED;
+                break;
+            default:
+                this.state = OTHER;
+                break;
+        }
+        this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
+        this.user = psMap.get(PsKeywords.USER);
+        this.userID = psMap.get(PsKeywords.UID);
+        this.group = this.user; // DragonFly ps lacks group keyword
+        this.groupID = psMap.get(PsKeywords.RGID);
+        this.threadCount = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.NLWP), 0);
+        this.priority = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PRI), 0);
+        // These are in KB, multiply
+        this.virtualSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.VSZ), 0) * 1024;
+        this.residentSetSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.RSS), 0) * 1024;
+        // Get start time from /proc/<pid>/status (field 8: sec,usec)
+        this.startTime = queryStartTimeFromProc(getProcessID());
+        this.upTime = now - this.startTime;
+        if (this.upTime < 1L) {
+            this.upTime = 1L;
+        }
+        this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.TIME), 0L);
+        this.path = psMap.get(PsKeywords.UCOMM);
+        this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
+        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
+        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
+        this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
+        this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
+        this.commandLineBackup = psMap.get(PsKeywords.COMMAND);
+        return true;
+    }
+
+    private static long queryStartTimeFromProc(int pid) {
+        List<String> status = FileUtil.readFile("/proc/" + pid + "/status", false);
+        if (!status.isEmpty()) {
+            // Format: name pid ... startSec,startUsec ...
+            String[] split = ParseUtil.whitespaces.split(status.get(0).trim());
+            if (split.length >= 8) {
+                String[] timeParts = split[7].split(",");
+                long seconds = ParseUtil.parseLongOrDefault(timeParts[0], 0L);
+                if (seconds > 0) {
+                    return seconds * 1000L;
+                }
+            }
+        }
+        return System.currentTimeMillis();
+    }
+
+    private long getProcessOpenFileLimit(long processId, int index) {
+        final String limitsPath = String.format(Locale.ROOT, "/proc/%d/limits", processId);
+        if (!Files.exists(Paths.get(limitsPath))) {
+            return -1; // not supported
+        }
+        final List<String> lines = FileUtil.readFile(limitsPath);
+        final Optional<String> maxOpenFilesLine = lines.stream().filter(line -> line.startsWith("Max open files"))
+                .findFirst();
+        if (!maxOpenFilesLine.isPresent()) {
+            return -1;
+        }
+
+        // Split all non-Digits away -> ["", "{soft-limit}, "{hard-limit}"]
+        final String[] split = maxOpenFilesLine.get().split("\\D+");
+        if (split.length <= index) {
+            return -1;
+        }
+        return ParseUtil.parseLongOrDefault(split[index], -1);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.unix.dragonflybsd;
+
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.software.os.OSService.State.RUNNING;
+import static oshi.software.os.OSService.State.STOPPED;
+import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
+
+import java.io.File;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.unix.freebsd.WhoFFM;
+import oshi.ffm.platform.unix.dragonflybsd.DragonFlyBsdLibcFunctions;
+import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
+import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
+import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.os.FileSystem;
+import oshi.software.os.InternetProtocolStats;
+import oshi.software.os.NetworkParams;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OSService;
+import oshi.software.os.OSSession;
+import oshi.software.os.OSThread;
+import oshi.software.os.unix.freebsd.FreeBsdFileSystemFFM;
+import oshi.software.os.unix.freebsd.FreeBsdInternetProtocolStatsFFM;
+import oshi.software.os.unix.freebsd.FreeBsdNetworkParamsFFM;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
+
+/**
+ * FFM-backed DragonFly BSD operating system.
+ */
+@ThreadSafe
+public class DragonFlyBsdOperatingSystemFFM extends AbstractOperatingSystem {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOperatingSystemFFM.class);
+
+    private static final long BOOTTIME = querySystemBootTime();
+
+    /*
+     * Package-private for use by DragonFlyBsdOSProcessFFM
+     */
+    enum PsKeywords {
+        STATE, PID, PPID, USER, UID, RGID, NLWP, PRI, VSZ, RSS, TIME, MAJFLT, MINFLT, NVCSW, NIVCSW, UCOMM, COMMAND; // COMMAND
+                                                                                                                     // must
+                                                                                                                     // always
+                                                                                                                     // be
+                                                                                                                     // last
+    }
+
+    static final String PS_COMMAND_ARGS = Arrays.stream(PsKeywords.values()).map(Enum::name)
+            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
+
+    @Override
+    public String queryManufacturer() {
+        return "Unix/BSD";
+    }
+
+    @Override
+    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
+        String family = BsdSysctlUtilFFM.sysctl("kern.ostype", "DragonFly");
+
+        String version = BsdSysctlUtilFFM.sysctl("kern.osrelease", "");
+        String versionInfo = BsdSysctlUtilFFM.sysctl("kern.version", "");
+        String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
+
+        return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
+    }
+
+    @Override
+    protected int queryBitness(int jvmBitness) {
+        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
+            return jvmBitness;
+        }
+        return 64;
+    }
+
+    @Override
+    public FileSystem getFileSystem() {
+        return new FreeBsdFileSystemFFM();
+    }
+
+    @Override
+    public InternetProtocolStats getInternetProtocolStats() {
+        return new FreeBsdInternetProtocolStatsFFM();
+    }
+
+    @Override
+    public List<OSSession> getSessions() {
+        return USE_WHO_COMMAND ? super.getSessions() : WhoFFM.queryUtxent();
+    }
+
+    @Override
+    public List<OSProcess> queryAllProcesses() {
+        return getProcessListFromPS(-1);
+    }
+
+    @Override
+    public List<OSProcess> queryChildProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<OSProcess> queryDescendantProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public OSProcess getProcess(int pid) {
+        List<OSProcess> procs = getProcessListFromPS(pid);
+        if (procs.isEmpty()) {
+            return null;
+        }
+        return procs.get(0);
+    }
+
+    private List<OSProcess> getProcessListFromPS(int pid) {
+        String psCommand = "ps -awwxo " + PS_COMMAND_ARGS;
+        if (pid >= 0) {
+            psCommand += " -p " + pid;
+        }
+
+        Predicate<Map<PsKeywords, String>> hasKeywordArgs = psMap -> psMap.containsKey(PsKeywords.COMMAND);
+        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
+                .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ')).filter(hasKeywordArgs)
+                .map(psMap -> new DragonFlyBsdOSProcessFFM(
+                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap, this))
+                // DragonFlyBSD kernel threads report PID -1; filter them out
+                .filter(proc -> proc.getProcessID() > 0).filter(VALID_PROCESS).collect(Collectors.toList());
+    }
+
+    @Override
+    public int getProcessId() {
+        return callInArenaIntOrDefault(arena -> FreeBsdLibcFunctions.getpid(), LOG, Level.WARN, "getpid failed", 0);
+    }
+
+    @Override
+    public int getProcessCount() {
+        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
+        if (!procList.isEmpty()) {
+            // Subtract 1 for header
+            return procList.size() - 1;
+        }
+        return 0;
+    }
+
+    @Override
+    public int getThreadId() {
+        int tid = callInArenaIntOrDefault(arena -> DragonFlyBsdLibcFunctions.lwp_gettid(), LOG, Level.WARN,
+                "lwp_gettid failed", -1);
+        return tid < 0 ? 0 : tid;
+    }
+
+    @Override
+    public OSThread getCurrentThread() {
+        OSProcess proc = getCurrentProcess();
+        final int tid = getThreadId();
+        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
+                .orElse(new oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSThread(proc.getProcessID(), tid));
+    }
+
+    @Override
+    public int getThreadCount() {
+        int threads = 0;
+        for (String proc : ExecutingCommand.runNative("ps -axo nlwp")) {
+            threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
+        }
+        return threads;
+    }
+
+    @Override
+    public long getSystemUptime() {
+        return System.currentTimeMillis() / 1000 - BOOTTIME;
+    }
+
+    @Override
+    public long getSystemBootTime() {
+        return BOOTTIME;
+    }
+
+    private static long querySystemBootTime() {
+        try (Arena arena = Arena.ofConfined()) {
+            // struct timeval: two longs (tv_sec, tv_usec) = 16 bytes on LP64 BSD.
+            MemorySegment tv = arena.allocate(JAVA_LONG.byteSize() * 2);
+            if (BsdSysctlUtilFFM.sysctl("kern.boottime", tv) && tv.get(JAVA_LONG, 0) != 0L) {
+                return tv.get(JAVA_LONG, 0);
+            }
+        }
+        // Fall back to text parsing: "{ sec = 1779823319, nsec = 0 } ..."
+        return ParseUtil.parseLongOrDefault(
+                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
+                System.currentTimeMillis() / 1000);
+    }
+
+    @Override
+    public NetworkParams getNetworkParams() {
+        return new FreeBsdNetworkParamsFFM();
+    }
+
+    @Override
+    public List<OSService> getServices() {
+        // Get running services
+        List<OSService> services = new ArrayList<>();
+        Set<String> running = new HashSet<>();
+        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
+            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
+            services.add(s);
+            running.add(p.getName());
+        }
+        // Get Directories for stopped services
+        File dir = new File("/etc/rc.d");
+        File[] listFiles;
+        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
+            for (File f : listFiles) {
+                String name = f.getName();
+                if (!running.contains(name)) {
+                    OSService s = new OSService(name, 0, STOPPED);
+                    services.add(s);
+                }
+            }
+        } else {
+            LOG.error("Directory: /etc/rc.d does not exist");
+        }
+        return services;
+    }
+}

--- a/oshi-core/src/main/java/module-info.java
+++ b/oshi-core/src/main/java/module-info.java
@@ -2,7 +2,7 @@
  * JNA-based native implementation of the OSHI API for JDK 8+.
  * <p>
  * This module uses <a href="https://github.com/java-native-access/jna">JNA</a> for native access and supports all OSHI
- * platforms (Windows, macOS, Linux, Android, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, Solaris, AIX).
+ * platforms.
  * <p>
  * Usage:
  *
@@ -23,7 +23,6 @@ module com.github.oshi {
     exports oshi.util.gpu;
     exports oshi.util.platform.mac;
     exports oshi.util.platform.unix.freebsd;
-    exports oshi.util.platform.unix.dragonflybsd;
     exports oshi.util.platform.unix.openbsd;
     exports oshi.util.platform.unix.solaris;
     exports oshi.util.platform.windows;

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -14,7 +14,7 @@ import oshi.hardware.common.platform.unix.netbsd.NetBsdHardwareAbstractionLayer;
 import oshi.hardware.platform.linux.LinuxHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.mac.MacHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.aix.AixHardwareAbstractionLayerJNA;
-import oshi.hardware.platform.unix.dragonflybsd.DragonFlyBsdHardwareAbstractionLayer;
+import oshi.hardware.platform.unix.dragonflybsd.DragonFlyBsdHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.freebsd.FreeBsdHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.openbsd.OpenBsdHardwareAbstractionLayer;
 import oshi.hardware.platform.unix.solaris.SolarisHardwareAbstractionLayer;
@@ -24,7 +24,7 @@ import oshi.software.os.OperatingSystem;
 import oshi.software.os.linux.LinuxOperatingSystemJNA;
 import oshi.software.os.mac.MacOperatingSystemJNA;
 import oshi.software.os.unix.aix.AixOperatingSystemJNA;
-import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystem;
+import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystemJNA;
 import oshi.software.os.unix.freebsd.FreeBsdOperatingSystemJNA;
 import oshi.software.os.unix.openbsd.OpenBsdOperatingSystem;
 import oshi.software.os.unix.solaris.SolarisOperatingSystem;
@@ -58,11 +58,9 @@ import oshi.util.PlatformEnum;
  * To conserve processing time at the cost of additional memory usage, re-use the same instance.
  * <p>
  * This implementation uses <a href="https://github.com/java-native-access/jna">JNA</a> for native access and supports
- * all OSHI platforms (Windows, macOS, Linux, Android, DragonFly BSD, FreeBSD, NetBSD, OpenBSD, Solaris, AIX). Android
- * is routed through the Linux implementations. For JDK 25+, the {@code oshi-core-ffm} module provides an alternative
- * entry point ({@code oshi.ffm.SystemInfo}) that uses the Foreign Function and Memory (FFM) API for potentially better
- * performance on supported platforms (currently Windows, macOS, Linux, FreeBSD, NetBSD, OpenBSD, Solaris (illumos), and
- * AIX).
+ * all OSHI platforms. Android is routed through the Linux implementations. For JDK 25+, the {@code oshi-core-ffm}
+ * module provides an alternative entry point ({@code oshi.ffm.SystemInfo}) that uses the Foreign Function and Memory
+ * (FFM) API for potentially better performance.
  * <p>
  * Both this class and the FFM entry point require native access. Starting with <a href="https://openjdk.org/jeps/472">
  * JEP 472</a> (JDK 24), the JVM warns when native code is loaded, and a future JDK release will require
@@ -129,7 +127,7 @@ public class SystemInfo implements SystemInfoProvider {
             case OPENBSD:
                 return new OpenBsdOperatingSystem();
             case DRAGONFLYBSD:
-                return new DragonFlyBsdOperatingSystem();
+                return new DragonFlyBsdOperatingSystemJNA();
             case NETBSD:
                 return new NetBsdOperatingSystem();
             default:
@@ -164,7 +162,7 @@ public class SystemInfo implements SystemInfoProvider {
             case OPENBSD:
                 return new OpenBsdHardwareAbstractionLayer();
             case DRAGONFLYBSD:
-                return new DragonFlyBsdHardwareAbstractionLayer();
+                return new DragonFlyBsdHardwareAbstractionLayerJNA();
             case NETBSD:
                 return new NetBsdHardwareAbstractionLayer();
             default:

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdCentralProcessorJNA.java
@@ -21,9 +21,9 @@ import oshi.jna.platform.unix.FreeBsdLibc;
  * DragonFly BSD Central Processor. Overrides CPU tick retrieval to use DragonFly's kern.cputime sysctl via
  * {@link DragonFlyBsdLibc#INSTANCE}.
  */
-public class DragonFlyBsdCentralProcessor extends FreeBsdCentralProcessorJNA {
+public class DragonFlyBsdCentralProcessorJNA extends FreeBsdCentralProcessorJNA {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdCentralProcessor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdCentralProcessorJNA.class);
 
     @Override
     public long[] querySystemCpuLoadTicks() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerJNA.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.dragonflybsd;
+
+import java.util.List;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.ComputerSystem;
+import oshi.hardware.Display;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.GraphicsCard;
+import oshi.hardware.HWDiskStore;
+import oshi.hardware.NetworkIF;
+import oshi.hardware.PowerSource;
+import oshi.hardware.Printer;
+import oshi.hardware.Sensors;
+import oshi.hardware.SoundCard;
+import oshi.hardware.UsbDevice;
+import oshi.hardware.common.AbstractHardwareAbstractionLayer;
+import oshi.hardware.common.platform.unix.BsdNetworkIF;
+import oshi.hardware.common.platform.unix.UnixDisplay;
+import oshi.hardware.common.platform.unix.freebsd.FreeBsdGraphicsCard;
+import oshi.hardware.common.platform.unix.freebsd.FreeBsdSoundCard;
+import oshi.hardware.common.platform.unix.freebsd.FreeBsdUsbDevice;
+import oshi.hardware.platform.unix.CupsPrinterJNA;
+import oshi.hardware.platform.unix.freebsd.FreeBsdComputerSystemJNA;
+import oshi.hardware.platform.unix.freebsd.FreeBsdGlobalMemoryJNA;
+import oshi.hardware.platform.unix.freebsd.FreeBsdHWDiskStoreJNA;
+import oshi.hardware.platform.unix.freebsd.FreeBsdPowerSourceJNA;
+import oshi.hardware.platform.unix.freebsd.FreeBsdSensorsJNA;
+
+/**
+ * DragonFlyBsdHardwareAbstractionLayerJNA class. Uses FreeBSD implementations where behavior is identical.
+ */
+@ThreadSafe
+public final class DragonFlyBsdHardwareAbstractionLayerJNA extends AbstractHardwareAbstractionLayer {
+
+    @Override
+    public ComputerSystem createComputerSystem() {
+        return new FreeBsdComputerSystemJNA();
+    }
+
+    @Override
+    public GlobalMemory createMemory() {
+        return new FreeBsdGlobalMemoryJNA();
+    }
+
+    @Override
+    public CentralProcessor createProcessor() {
+        return new DragonFlyBsdCentralProcessorJNA();
+    }
+
+    @Override
+    public Sensors createSensors() {
+        return new FreeBsdSensorsJNA();
+    }
+
+    @Override
+    public List<PowerSource> getPowerSources() {
+        return FreeBsdPowerSourceJNA.getPowerSources();
+    }
+
+    @Override
+    public List<HWDiskStore> getDiskStores() {
+        return FreeBsdHWDiskStoreJNA.getDisks();
+    }
+
+    @Override
+    public List<Display> getDisplays() {
+        return UnixDisplay.getDisplays();
+    }
+
+    @Override
+    public List<NetworkIF> getNetworkIFs(boolean includeLocalInterfaces) {
+        return BsdNetworkIF.getNetworks(includeLocalInterfaces);
+    }
+
+    @Override
+    public List<UsbDevice> getUsbDevices(boolean tree) {
+        return FreeBsdUsbDevice.getUsbDevices(tree);
+    }
+
+    @Override
+    public List<SoundCard> getSoundCards() {
+        return FreeBsdSoundCard.getSoundCards();
+    }
+
+    @Override
+    public List<GraphicsCard> getGraphicsCards() {
+        return FreeBsdGraphicsCard.getGraphicsCards();
+    }
+
+    @Override
+    public List<Printer> getPrinters() {
+        return CupsPrinterJNA.getPrinters();
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
@@ -16,7 +16,6 @@ import static oshi.util.Memoizer.memoize;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -36,33 +35,24 @@ import com.sun.jna.platform.unix.Resource;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.DragonFlyBsdLibc;
-import oshi.software.common.AbstractOSProcess;
+import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
+import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSThread;
 import oshi.software.os.OSThread;
-import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystem.PsKeywords;
+import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystemJNA.PsKeywords;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
-import oshi.util.platform.unix.dragonflybsd.ProcstatUtil;
+import oshi.util.common.platform.unix.dragonflybsd.ProcstatUtil;
 
 /**
  * OSProcess implementation
  */
 @ThreadSafe
-public class DragonFlyBsdOSProcess extends AbstractOSProcess {
+public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOSProcess.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOSProcessJNA.class);
 
-    private final DragonFlyBsdOperatingSystem os;
-
-    /*
-     * Package-private for use by DragonFlyBsdOSThread
-     */
-    enum PsThreadColumns {
-        TID, STATE, TIME, MAJFLT, MINFLT, NVCSW, NIVCSW, PRI;
-    }
-
-    static final String PS_THREAD_COLUMNS = Arrays.stream(PsThreadColumns.values()).map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
+    private final DragonFlyBsdOperatingSystemJNA os;
 
     private Supplier<Integer> bitness = memoize(this::queryBitness);
     private Supplier<String> commandLine = memoize(this::queryCommandLine);
@@ -93,7 +83,7 @@ public class DragonFlyBsdOSProcess extends AbstractOSProcess {
     private long involuntaryContextSwitches;
     private String commandLineBackup;
 
-    public DragonFlyBsdOSProcess(int pid, Map<PsKeywords, String> psMap, DragonFlyBsdOperatingSystem os) {
+    public DragonFlyBsdOSProcessJNA(int pid, Map<PsKeywords, String> psMap, DragonFlyBsdOperatingSystemJNA os) {
         super(pid);
         this.os = os;
         updateAttributes(psMap);
@@ -343,7 +333,7 @@ public class DragonFlyBsdOSProcess extends AbstractOSProcess {
 
     @Override
     public boolean updateAttributes() {
-        String psCommand = "ps -awwxo " + DragonFlyBsdOperatingSystem.PS_COMMAND_ARGS + " -p " + getProcessID();
+        String psCommand = "ps -awwxo " + DragonFlyBsdOperatingSystemJNA.PS_COMMAND_ARGS + " -p " + getProcessID();
         List<String> procList = ExecutingCommand.runNative(psCommand);
         if (procList.size() > 1) {
             // skip header row

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemJNA.java
@@ -27,6 +27,7 @@ import oshi.driver.unix.freebsd.Who;
 import oshi.jna.platform.unix.DragonFlyBsdLibc;
 import oshi.jna.platform.unix.FreeBsdLibc;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSThread;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
@@ -47,14 +48,14 @@ import oshi.util.tuples.Pair;
  * HAMMER2 filesystem and a unique approach to SMP with its lightweight kernel threads (LWKT) subsystem.
  */
 @ThreadSafe
-public class DragonFlyBsdOperatingSystem extends AbstractOperatingSystem {
+public class DragonFlyBsdOperatingSystemJNA extends AbstractOperatingSystem {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOperatingSystem.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOperatingSystemJNA.class);
 
     private static final long BOOTTIME = querySystemBootTime();
 
     /*
-     * Package-private for use by DragonFlyBsdOSProcess
+     * Package-private for use by DragonFlyBsdOSProcessJNA
      */
     enum PsKeywords {
         STATE, PID, PPID, USER, UID, RGID, NLWP, PRI, VSZ, RSS, TIME, MAJFLT, MINFLT, NVCSW, NIVCSW, UCOMM, COMMAND; // COMMAND
@@ -143,7 +144,7 @@ public class DragonFlyBsdOperatingSystem extends AbstractOperatingSystem {
         Predicate<Map<PsKeywords, String>> hasKeywordArgs = psMap -> psMap.containsKey(PsKeywords.COMMAND);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
                 .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ')).filter(hasKeywordArgs)
-                .map(psMap -> new DragonFlyBsdOSProcess(
+                .map(psMap -> new DragonFlyBsdOSProcessJNA(
                         pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap, this))
                 // DragonFlyBSD kernel threads report PID -1; filter them out
                 .filter(proc -> proc.getProcessID() > 0).filter(VALID_PROCESS).collect(Collectors.toList());


### PR DESCRIPTION
## Summary

Closes #3346. Adds DragonFly BSD support to `oshi-core-ffm`, refactoring the existing JNA implementation along the way to match the abstract-base / JNA-subclass / FFM-subclass split used by FreeBSD/AIX.

With this PR, `oshi-core-ffm` covers the same set of platforms as `oshi-core` (JNA). The user-facing story is now simple: OSHI has JNA and FFM implementations; both cover all supported platforms; pick whichever fits your deployment.

## What changed

### Refactor (mirror FreeBSD pattern)

- **Move no-native DragonFly code to oshi-common**: `DragonFlyBsdOSThread` and `ProcstatUtil` (with its test) are pure shell/file-parsing; they live next to the other Unix `oshi-common` classes.
- **Extract `DragonFlyBsdOSProcess` abstract base into oshi-common**, holding the shared `PsThreadColumns` enum + `PS_THREAD_COLUMNS` constant used by both OSProcess and OSThread (same pattern as `FreeBsdOSProcess`).
- **Rename JNA classes with `JNA` suffix** in `oshi-core`: `DragonFlyBsd{OperatingSystem,OSProcess,CentralProcessor,HardwareAbstractionLayer}JNA`. Matches FreeBSD/AIX.

### New FFM implementations (`oshi-core-ffm`)

- **`DragonFlyBsdLibcFunctions`** — adds only the DragonFly-specific `lwp_gettid()` downcall. Shared libc surface (`getpid`, `sysctl`, `getrlimit`, `sysctlbyname`) is reused from `FreeBsdLibcFunctions`.
- **`DragonFlyBsdCentralProcessorFFM extends FreeBsdCentralProcessorFFM`** — inherits `kern.cp_time` system-tick logic from FreeBSD; overrides `queryProcessorCpuLoadTicks` to use DragonFly's `kern.cputime` sysctl (FreeBSD uses `kern.cp_times`).
- **`DragonFlyBsdHardwareAbstractionLayerFFM`** — uses FreeBSD FFM implementations where behavior is identical (computer system, memory, sensors, power, disks, USB, sound, graphics, displays, network); overrides `createProcessor` for the DragonFly-specific CP; uses `CupsPrinterFFM` for printers.
- **`DragonFlyBsdOperatingSystemFFM`** — full FFM implementation mirroring the JNA structure; uses `FreeBsdLibcFunctions.getpid`, `DragonFlyBsdLibcFunctions.lwp_gettid`, `BsdSysctlUtilFFM` for `kern.boottime`, and FreeBSD FFM file system / IP stats / network params.
- **`DragonFlyBsdOSProcessFFM`** — full FFM implementation; uses `FreeBsdLibcFunctions.getrlimit` for file-descriptor limits and `FreeBsdLibcFunctions.sysctl(int MIB)` for bitness detection.

### Wiring + docs

- `oshi.ffm.SystemInfo` gains `case DRAGONFLYBSD` in `createOperatingSystem` and `createHardware`; `DRAGONFLYBSD` added to `SUPPORTED_PLATFORMS`.
- `oshi-common/module-info.java` and `oshi-core-ffm/module-info.java` get the new package exports; `oshi-core/module-info.java` drops the moved-out `oshi.util.platform.unix.dragonflybsd` export.
- `module-info.test` adds `--add-opens` entries for the new DragonFly packages in `oshi-common`.
- `ProcstatUtilTest` switches from `oshi.SystemInfo` to `ManagementFactory` for its live-DragonFly PID (matches the FreeBSD/NetBSD test pattern, avoiding a oshi-common-to-oshi-core dependency).
- **Docs simplification** — README selection-matrix, FAQ FFM platform list, `oshi-core-ffm/module-info` javadoc, and `oshi-core/SystemInfo` + `oshi-core-ffm/SystemInfo` javadoc all drop the "currently supports these specific OSes" lists, since FFM and JNA now cover the same platforms. The selection matrix in README just says "all supported platforms" for both columns.

## Test plan

- [x] `./mvnw clean install` from repo root passes (all 788 tests).
- [x] Spotless / Checkstyle / Forbidden APIs / Javadoc clean on `oshi-common`, `oshi-core`, `oshi-core-ffm`.
- [x] `oshi-core` SystemInfo references the new JNA-suffixed class names.
- [x] `oshi-core-ffm` SystemInfo now supports DragonFly; throws only for genuinely unsupported platforms.
- [x] PR CI matrix passes (Linux/macOS/Windows + FreeBSD/OpenBSD/OpenIndiana). DragonFly VM job runs only in `unix.yaml` push-to-master, so the FFM path is not exercised by PR CI today — same gap we've worked around for NetBSD.
- [x] Post-merge `Unix CI` validates the JNA-suffixed DragonFly classes still work on the actual DragonFly VM (the no-FFM portion).

## Caveats / notes

- The DragonFly FFM code path is untested in CI today (DragonFly's `pkg install openjdk25` is still failing per #3346's blocker — no published binary on the vmactions DF VM image). When that clears, `unix.yaml` can be bumped to JDK 25 for DragonFly and FFM will be exercised. The FFM code is structured to closely mirror the FreeBSD FFM bindings, so confidence is high.
- Behavior on JDK < 25 is unchanged: `oshi.SystemInfo` (JNA) instantiates the renamed `DragonFlyBsd*JNA` classes from `oshi-core`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FFM backend now supports DragonFly BSD, adding DragonFly-specific OS and hardware coverage.

* **Documentation**
  * Platform compatibility and implementation-selection docs updated to reflect FFM parity with the JNA implementation and standardized eligibility wording.

* **Tests**
  * Test configuration and live tests updated to include DragonFly BSD package access and runtime PID acquisition for DragonFly-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->