### PR TITLE
OpenBSD: add JNA suffix to oshi-core HAL/OS/etc classes

### DIFF
--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -16,7 +16,7 @@ import oshi.hardware.platform.mac.MacHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.aix.AixHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.dragonflybsd.DragonFlyBsdHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.freebsd.FreeBsdHardwareAbstractionLayerJNA;
-import oshi.hardware.platform.unix.openbsd.OpenBsdHardwareAbstractionLayer;
+import oshi.hardware.platform.unix.openbsd.OpenBsdHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.solaris.SolarisHardwareAbstractionLayer;
 import oshi.hardware.platform.windows.WindowsHardwareAbstractionLayerJNA;
 import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem;
@@ -26,7 +26,7 @@ import oshi.software.os.mac.MacOperatingSystemJNA;
 import oshi.software.os.unix.aix.AixOperatingSystemJNA;
 import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystemJNA;
 import oshi.software.os.unix.freebsd.FreeBsdOperatingSystemJNA;
-import oshi.software.os.unix.openbsd.OpenBsdOperatingSystem;
+import oshi.software.os.unix.openbsd.OpenBsdOperatingSystemJNA;
 import oshi.software.os.unix.solaris.SolarisOperatingSystem;
 import oshi.software.os.windows.WindowsOperatingSystemJNA;
 import oshi.spi.SystemInfoProvider;
@@ -125,7 +125,7 @@ public class SystemInfo implements SystemInfoProvider {
             case AIX:
                 return new AixOperatingSystemJNA();
             case OPENBSD:
-                return new OpenBsdOperatingSystem();
+                return new OpenBsdOperatingSystemJNA();
             case DRAGONFLYBSD:
                 return new DragonFlyBsdOperatingSystemJNA();
             case NETBSD:
@@ -160,7 +160,7 @@ public class SystemInfo implements SystemInfoProvider {
             case AIX:
                 return new AixHardwareAbstractionLayerJNA();
             case OPENBSD:
-                return new OpenBsdHardwareAbstractionLayer();
+                return new OpenBsdHardwareAbstractionLayerJNA();
             case DRAGONFLYBSD:
                 return new DragonFlyBsdHardwareAbstractionLayerJNA();
             case NETBSD:

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorJNA.java
@@ -50,8 +50,8 @@ import oshi.util.tuples.Triplet;
  * OpenBSD Central Processor implementation
  */
 @ThreadSafe
-public class OpenBsdCentralProcessor extends AbstractCentralProcessor {
-    private final Supplier<Pair<Long, Long>> vmStats = memoize(OpenBsdCentralProcessor::queryVmStats,
+public class OpenBsdCentralProcessorJNA extends AbstractCentralProcessor {
+    private final Supplier<Pair<Long, Long>> vmStats = memoize(OpenBsdCentralProcessorJNA::queryVmStats,
             defaultExpiration());
     private static final Pattern DMESG_CPU = Pattern.compile("cpu(\\d+): smt (\\d+), core (\\d+), package (\\d+)");
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdComputerSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdComputerSystemJNA.java
@@ -21,15 +21,15 @@ import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
  * OpenBSD ComputerSystem implementation
  */
 @Immutable
-public class OpenBsdComputerSystem extends AbstractComputerSystem {
+public class OpenBsdComputerSystemJNA extends AbstractComputerSystem {
 
-    private final Supplier<String> manufacturer = memoize(OpenBsdComputerSystem::queryManufacturer);
+    private final Supplier<String> manufacturer = memoize(OpenBsdComputerSystemJNA::queryManufacturer);
 
-    private final Supplier<String> model = memoize(OpenBsdComputerSystem::queryModel);
+    private final Supplier<String> model = memoize(OpenBsdComputerSystemJNA::queryModel);
 
-    private final Supplier<String> serialNumber = memoize(OpenBsdComputerSystem::querySerialNumber);
+    private final Supplier<String> serialNumber = memoize(OpenBsdComputerSystemJNA::querySerialNumber);
 
-    private final Supplier<String> uuid = memoize(OpenBsdComputerSystem::queryUUID);
+    private final Supplier<String> uuid = memoize(OpenBsdComputerSystemJNA::queryUUID);
 
     @Override
     public String getManufacturer() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdGlobalMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdGlobalMemoryJNA.java
@@ -12,6 +12,7 @@ import com.sun.jna.Memory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.VirtualMemory;
+import oshi.hardware.common.platform.unix.openbsd.OpenBsdGlobalMemory;
 import oshi.hardware.common.platform.unix.openbsd.OpenBsdVirtualMemory;
 import oshi.jna.platform.unix.OpenBsdLibc.Bcachestats;
 import oshi.util.ExecutingCommand;
@@ -22,7 +23,7 @@ import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
  * Memory obtained by sysctl vm.stats
  */
 @ThreadSafe
-final class OpenBsdGlobalMemory extends oshi.hardware.common.platform.unix.openbsd.OpenBsdGlobalMemory {
+final class OpenBsdGlobalMemoryJNA extends OpenBsdGlobalMemory {
 
     @Override
     protected long queryAvailable() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreJNA.java
@@ -27,11 +27,12 @@ import oshi.util.tuples.Quartet;
  * OpenBSD hard disk implementation.
  */
 @ThreadSafe
-public final class OpenBsdHWDiskStore extends AbstractHWDiskStore {
+public final class OpenBsdHWDiskStoreJNA extends AbstractHWDiskStore {
 
-    private final Supplier<List<String>> iostat = memoize(OpenBsdHWDiskStore::querySystatIostat, defaultExpiration());
+    private final Supplier<List<String>> iostat = memoize(OpenBsdHWDiskStoreJNA::querySystatIostat,
+            defaultExpiration());
 
-    private OpenBsdHWDiskStore(String name, String model, String serial, long size) {
+    private OpenBsdHWDiskStoreJNA(String name, String model, String serial, long size) {
         super(name, model, serial, size);
     }
 
@@ -47,7 +48,7 @@ public final class OpenBsdHWDiskStore extends AbstractHWDiskStore {
         // Get list of disks from sysctl
         // hw.disknames=sd0:2cf69345d371cd82,cd0:,sd1:
         String[] devices = OpenBsdSysctlUtil.sysctl("hw.disknames", "").split(",");
-        OpenBsdHWDiskStore store;
+        OpenBsdHWDiskStoreJNA store;
         String diskName;
         for (String device : devices) {
             diskName = device.split(":")[0];
@@ -88,7 +89,7 @@ public final class OpenBsdHWDiskStore extends AbstractHWDiskStore {
                     }
                 }
             }
-            store = new OpenBsdHWDiskStore(diskName, model, diskdata.getB(), size);
+            store = new OpenBsdHWDiskStoreJNA(diskName, model, diskdata.getB(), size);
             store.setPartitionList(diskdata.getD());
             store.updateAttributes();
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHardwareAbstractionLayerJNA.java
@@ -30,24 +30,24 @@ import oshi.hardware.common.platform.unix.openbsd.OpenBsdUsbDevice;
 import oshi.hardware.platform.unix.CupsPrinterJNA;
 
 /**
- * OpenBsdHardwareAbstractionLayer class.
+ * OpenBsdHardwareAbstractionLayerJNA class.
  */
 @ThreadSafe
-public final class OpenBsdHardwareAbstractionLayer extends AbstractHardwareAbstractionLayer {
+public final class OpenBsdHardwareAbstractionLayerJNA extends AbstractHardwareAbstractionLayer {
 
     @Override
     public ComputerSystem createComputerSystem() {
-        return new OpenBsdComputerSystem();
+        return new OpenBsdComputerSystemJNA();
     }
 
     @Override
     public GlobalMemory createMemory() {
-        return new OpenBsdGlobalMemory();
+        return new OpenBsdGlobalMemoryJNA();
     }
 
     @Override
     public CentralProcessor createProcessor() {
-        return new OpenBsdCentralProcessor();
+        return new OpenBsdCentralProcessorJNA();
     }
 
     @Override
@@ -62,7 +62,7 @@ public final class OpenBsdHardwareAbstractionLayer extends AbstractHardwareAbstr
 
     @Override
     public List<HWDiskStore> getDiskStores() {
-        return OpenBsdHWDiskStore.getDisks();
+        return OpenBsdHWDiskStoreJNA.getDisks();
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdFileSystemJNA.java
@@ -5,6 +5,7 @@
 package oshi.software.os.unix.openbsd;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.os.unix.openbsd.OpenBsdFileSystem;
 import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
 
 /**
@@ -12,7 +13,7 @@ import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
  * volume, concrete file system or other implementation specific means of file storage.
  */
 @ThreadSafe
-public class OpenBsdFileSystem extends oshi.software.common.os.unix.openbsd.OpenBsdFileSystem {
+public class OpenBsdFileSystemJNA extends OpenBsdFileSystem {
 
     @Override
     public long getOpenFileDescriptors() {

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessJNA.java
@@ -35,9 +35,10 @@ import com.sun.jna.platform.unix.Resource;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.OpenBsdLibc;
+import oshi.software.common.os.unix.openbsd.OpenBsdOSProcess;
 import oshi.software.common.os.unix.openbsd.OpenBsdOSThread;
 import oshi.software.os.OSThread;
-import oshi.software.os.unix.openbsd.OpenBsdOperatingSystem.PsKeywords;
+import oshi.software.os.unix.openbsd.OpenBsdOperatingSystemJNA.PsKeywords;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.openbsd.FstatUtil;
@@ -46,9 +47,9 @@ import oshi.util.common.platform.unix.openbsd.FstatUtil;
  * OSProcess implementation
  */
 @ThreadSafe
-public class OpenBsdOSProcess extends oshi.software.common.os.unix.openbsd.OpenBsdOSProcess {
+public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
 
-    private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOSProcess.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOSProcessJNA.class);
 
     private static final int ARGMAX;
 
@@ -68,7 +69,7 @@ public class OpenBsdOSProcess extends oshi.software.common.os.unix.openbsd.OpenB
         }
     }
 
-    private final OpenBsdOperatingSystem os;
+    private final OpenBsdOperatingSystemJNA os;
 
     private Supplier<String> commandLine = memoize(this::queryCommandLine);
     private Supplier<List<String>> arguments = memoize(this::queryArguments);
@@ -99,7 +100,7 @@ public class OpenBsdOSProcess extends oshi.software.common.os.unix.openbsd.OpenB
     private int bitness;
     private String commandLineBackup;
 
-    public OpenBsdOSProcess(int pid, Map<PsKeywords, String> psMap, OpenBsdOperatingSystem os) {
+    public OpenBsdOSProcessJNA(int pid, Map<PsKeywords, String> psMap, OpenBsdOperatingSystemJNA os) {
         super(pid);
         this.os = os;
         // OpenBSD does not maintain a compatibility layer.
@@ -384,7 +385,7 @@ public class OpenBsdOSProcess extends oshi.software.common.os.unix.openbsd.OpenB
     @Override
     public boolean updateAttributes() {
         // 'ps' does not provide threadCount or kernelTime on OpenBSD
-        String psCommand = "ps -awwxo " + OpenBsdOperatingSystem.PS_COMMAND_ARGS + " -p " + getProcessID();
+        String psCommand = "ps -awwxo " + OpenBsdOperatingSystemJNA.PS_COMMAND_ARGS + " -p " + getProcessID();
         List<String> procList = ExecutingCommand.runNative(psCommand);
         if (procList.size() > 1) {
             // skip header row

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemJNA.java
@@ -46,14 +46,14 @@ import oshi.util.tuples.Pair;
  * which was based on Research Unix.
  */
 @ThreadSafe
-public class OpenBsdOperatingSystem extends AbstractOperatingSystem {
+public class OpenBsdOperatingSystemJNA extends AbstractOperatingSystem {
 
-    private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOperatingSystem.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOperatingSystemJNA.class);
 
     private static final long BOOTTIME = querySystemBootTime();
 
     /*
-     * Package-private for use by OpenBsdOSProcess
+     * Package-private for use by OpenBsdOSProcessJNA
      */
     enum PsKeywords {
         STATE, PID, PPID, USER, UID, GROUP, GID, PRI, VSZ, RSS, ETIME, CPUTIME, COMM, MAJFLT, MINFLT, NVCSW, NIVCSW,
@@ -93,7 +93,7 @@ public class OpenBsdOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public FileSystem getFileSystem() {
-        return new OpenBsdFileSystem();
+        return new OpenBsdFileSystemJNA();
     }
 
     @Override
@@ -149,7 +149,7 @@ public class OpenBsdOperatingSystem extends AbstractOperatingSystem {
             Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ');
             // Check if last (thus all) value populated
             if (psMap.containsKey(PsKeywords.ARGS)) {
-                procs.add(new OpenBsdOSProcess(
+                procs.add(new OpenBsdOSProcessJNA(
                         pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap, this));
             }
         }


### PR DESCRIPTION
## Summary

Mechanical naming-consistency cleanup. The 8 OpenBSD classes in `oshi-core` (5 hardware, 3 software/os) get a `JNA` suffix to match the convention already used for AIX (#3350), FreeBSD, and (as of #3362) DragonFly. The 6 abstract bases in `oshi-common` keep their unsuffixed names; the FFM classes in `oshi-core-ffm` already have the `FFM` suffix.

OpenBSD is the last Unix platform that was inconsistent on this. Solaris is the other holdout but needs architectural work (extracting common bases to `oshi-common` first), so it stays a separate task.

## What changed

- Renames in `oshi-core/.../openbsd/`:
  - `OpenBsdComputerSystem` → `OpenBsdComputerSystemJNA`
  - `OpenBsdHardwareAbstractionLayer` → `OpenBsdHardwareAbstractionLayerJNA`
  - `OpenBsdCentralProcessor` → `OpenBsdCentralProcessorJNA`
  - `OpenBsdGlobalMemory` → `OpenBsdGlobalMemoryJNA`
  - `OpenBsdHWDiskStore` → `OpenBsdHWDiskStoreJNA`
  - `OpenBsdFileSystem` → `OpenBsdFileSystemJNA`
  - `OpenBsdOperatingSystem` → `OpenBsdOperatingSystemJNA`
  - `OpenBsdOSProcess` → `OpenBsdOSProcessJNA`
- Three classes (`OpenBsdGlobalMemory`, `OpenBsdFileSystem`, `OpenBsdOSProcess`) previously used `extends oshi.<...>.<unqualified-same-name>` to disambiguate from the common base of the same name. With the suffix in place, those become regular `extends OpenBsdFoo` with a normal import — cleaner and matches every other platform.
- `oshi-core/SystemInfo.java` updated for the two renamed entry-point classes.
- `OpenBsdSysctlUtil` stays unsuffixed in `oshi-core` (matches the `BsdSysctlUtil` precedent — the FFM counterpart `OpenBsdSysctlUtilFFM` carries the suffix on the FFM side only).

## Test plan

- [x] `./mvnw clean install` from repo root passes (all tests).
- [x] Spotless / Checkstyle / Forbidden APIs / Javadoc clean.
- [x] No external module references to the renamed classes besides `oshi-core/SystemInfo` (`oshi-core-ffm/SystemInfo` already references the FFM versions which kept their existing names).
- [ ] PR CI matrix passes. OpenBSD-specific code path exercised by the OpenBSD VM job in `pr.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * OpenBSD platform implementations refactored to standardize on JNA-based classes across operating system, hardware, file system, and process management components, improving internal consistency while maintaining full backward compatibility with existing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->