### PR TITLE
GHA: default-deny perms + persist-credentials:false on checkouts

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -14,15 +14,20 @@ name: Benchmarks (manual)
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Default-deny at the workflow level; each checkout-using job re-grants only
+# what it needs. benchaix is SSH-only and gets no grants.
+permissions: {}
 
 jobs:
   benchlinux:
     name: JMH benchmarks, Linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
@@ -37,8 +42,12 @@ jobs:
   benchmacos:
     name: JMH benchmarks, macOS
     runs-on: macos-26
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
@@ -53,8 +62,12 @@ jobs:
   benchwindows:
     name: JMH benchmarks, Windows
     runs-on: windows-2025
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
@@ -69,8 +82,12 @@ jobs:
   benchfreebsd:
     name: JMH benchmarks, FreeBSD
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Benchmark on FreeBSD
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1
         with:
@@ -87,8 +104,12 @@ jobs:
   benchopenbsd:
     name: JMH benchmarks, OpenBSD
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Benchmark on OpenBSD
         uses: vmactions/openbsd-vm@fcf799d7ce9c305ad89eabef1fb2fa5c1c42d0ee # v1
         with:
@@ -178,8 +199,12 @@ jobs:
   benchopenindiana:
     name: JMH benchmarks, OpenIndiana
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Benchmark on OpenIndiana
         uses: vmactions/openindiana-vm@3248e8c61485588528c034a4285242f77efd8b97 # v1
         with:

--- a/.github/workflows/cfarm.yaml
+++ b/.github/workflows/cfarm.yaml
@@ -11,8 +11,9 @@ on:
       - '**.yml'
       - '**.yaml'
 
-permissions:
-  contents: read
+# Default-deny at the workflow level. Both jobs SSH into cfarm hosts and never
+# touch GITHUB_TOKEN, so no per-job grants are needed.
+permissions: {}
 
 jobs:
   # Runs current branch on Solaris 11.4 on SPARC

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
@@ -56,6 +57,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
@@ -85,6 +88,8 @@ jobs:
     name: Container Cgroup Test
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
@@ -55,6 +56,8 @@ jobs:
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}${{ contains(matrix.java, '25') && ' (+ JNA==FFM)' || '' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
@@ -84,6 +87,8 @@ jobs:
     name: Test JDK 25, FreeBSD (+ JNA==FFM)
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Test in FreeBSD with aggregate coverage
         id: test-freebsd
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1
@@ -111,6 +116,8 @@ jobs:
     name: Test JDK 25, OpenBSD (+ JNA==FFM)
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Test on OpenBSD with aggregate coverage
         id: test-openbsd
         uses: vmactions/openbsd-vm@fcf799d7ce9c305ad89eabef1fb2fa5c1c42d0ee # v1
@@ -141,6 +148,8 @@ jobs:
     name: Test JDK 25, OpenIndiana (+ JNA==FFM)
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Test on OpenIndiana with aggregate coverage
         id: test-openindiana
         uses: vmactions/openindiana-vm@3248e8c61485588528c034a4285242f77efd8b97 # v1
@@ -180,6 +189,8 @@ jobs:
     name: JMH Benchmarks, ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
@@ -30,7 +31,10 @@ jobs:
       - name: Set SONAR_SCANNER_JAVA_OPTS
         run: echo "SONAR_SCANNER_JAVA_OPTS=-Xmx512m" >> $GITHUB_ENV
       - name: Analyze with SonarCloud
-        run: ./mvnw verify sonar:sonar -B -D"sonar.projectKey=oshi_oshi" -D"sonar.organization=oshi-oshi" -D"sonar.host.url=https://sonarcloud.io" -D"sonar.token=$SONAR_TOKEN"
+        # sonar-maven-plugin reads SONAR_TOKEN from the env, so it does not
+        # need to appear on the command line (and shouldn't, to keep it out
+        # of process argv).
+        run: ./mvnw verify sonar:sonar -B -D"sonar.projectKey=oshi_oshi" -D"sonar.organization=oshi-oshi" -D"sonar.host.url=https://sonarcloud.io"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonatype.yaml
+++ b/.github/workflows/sonatype.yaml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:

--- a/.github/workflows/unix.yaml
+++ b/.github/workflows/unix.yaml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Test in FreeBSD
         id: test-freebsd
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1
@@ -51,6 +53,8 @@ jobs:
     name: Test JDK 25, OpenBSD
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Test on OpenBSD
         id: test-openbsd
         uses: vmactions/openbsd-vm@fcf799d7ce9c305ad89eabef1fb2fa5c1c42d0ee # v1
@@ -80,6 +84,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Test on OpenIndiana
         id: test-openindiana
         uses: vmactions/openindiana-vm@3248e8c61485588528c034a4285242f77efd8b97 # v1
@@ -120,6 +126,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Test in DragonFly BSD
         id: test-dragonflybsd
         uses: vmactions/dragonflybsd-vm@4ba8127bd95c94b66fc4b885e37c99955ba308ea # v1
@@ -141,6 +149,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Test in NetBSD
         id: test-netbsd
         uses: vmactions/netbsd-vm@99816dccf75edf233ed6cd00a159e3a5b85ea373 # v1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:


### PR DESCRIPTION
## Summary
- **`cfarm.yaml`, `benchmarks.yaml`**: switch from workflow-level `contents: read` to `permissions: {}` plus per-job grants on the jobs that actually need them. Adopts the `codeql-analysis.yml` pattern; addresses Sonar S8264. cfarm jobs are SSH-only and get no grants; `benchaix` in `benchmarks.yaml` is also SSH-only, so only the six checkout-using bench jobs re-grant `contents: read`.
- **All `actions/checkout` uses outside `site.yaml`**: add `persist-credentials: false` so `GITHUB_TOKEN` isn't written into `.git/config` and inherited by later steps. `site.yaml` is excluded because the gh-pages deploy action relies on those persisted credentials. (27 checkout sites updated across 10 files.)
- **`sonar.yaml`**: drop `-Dsonar.token=\$SONAR_TOKEN` from the Maven command line. `sonar-maven-plugin` reads `SONAR_TOKEN` from the env, so the explicit `-D` is redundant and only serves to expose the token briefly in process argv.

## Test plan
- [ ] All workflow YAML parses (validated locally with PyYAML `safe_load`).
- [ ] This PR's own `Pull Request CI` jobs (in `pr.yaml`) all succeed — confirms `persist-credentials: false` doesn't break any non-deploy checkout.
- [ ] On merge to master: `Linux CI`, `macOS CI`, `Windows CI`, `Unix CI` all succeed.
- [ ] On merge: `SonarCloud` analysis still succeeds (confirms `SONAR_TOKEN` env var is picked up without the `-D` flag).
- [ ] On merge: `Sonatype Snapshot Deployment` still succeeds.
- [ ] Next scheduled `Coverity Scan` succeeds.
- [ ] Next manual `Benchmarks (manual)` dispatch succeeds (incl. `benchaix` SSH-only job under `permissions: {}`).
- [ ] Sonar's S8264 finding clears on next analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened GitHub Actions workflow security by implementing a default-deny permissions model across all CI/CD jobs.
  * Disabled credential persistence in repository checkout steps to prevent git credentials from lingering in runner environments.
  * Enhanced secure credential handling for automated deployments and code analysis tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->