### PR TITLE
Allow SystemInfoProvider SPI discovery on the class path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ lib/
 release.properties
 *.releaseBackup
 bin/
-META-INF/
 AGENTS.md
 CLAUDE.md
 .kiro/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#3349](https://github.com/oshi/oshi/pull/3349): Fix AIX `Uptime.queryUpTime()` regex to accept the `mins` suffix that appears in the first hour past each day boundary - [@dbwiddis](https://github.com/dbwiddis).
 * [#3358](https://github.com/oshi/oshi/pull/3358): Add macOS 27 (Golden Gate) codename mapping - [@dbwiddis](https://github.com/dbwiddis).
+* [#3365](https://github.com/oshi/oshi/pull/3365): Allow `SystemInfoProvider` SPI discovery on the class path - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.3.0 (2026-06-06)
 

--- a/oshi-common/src/main/resources/META-INF/services/oshi.spi.SystemInfoProvider
+++ b/oshi-common/src/main/resources/META-INF/services/oshi.spi.SystemInfoProvider
@@ -1,0 +1,1 @@
+oshi.nativefree.SystemInfo

--- a/oshi-common/src/test/java/oshi/spi/SystemInfoFactoryTest.java
+++ b/oshi-common/src/test/java/oshi/spi/SystemInfoFactoryTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.spi;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Validates SystemInfoFactory behavior when only oshi-common is on the classpath (no oshi-core or oshi-core-ffm).
+ */
+class SystemInfoFactoryTest {
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void factoryReturnsNativeFreeProviderOnLinux() {
+        SystemInfoProvider provider = SystemInfoFactory.create();
+        assertThat(provider, is(instanceOf(oshi.nativefree.SystemInfo.class)));
+        assertThat(provider.getPriority(), is(0));
+    }
+
+    @Test
+    @DisabledOnOs(OS.LINUX)
+    void factoryThrowsOnNonLinux() {
+        assertThrows(IllegalStateException.class, SystemInfoFactory::create);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
@@ -6,8 +6,6 @@ package oshi.ffm;
 
 import static oshi.util.Memoizer.memoize;
 
-import java.util.EnumSet;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import oshi.annotation.PublicApi;
@@ -92,13 +90,9 @@ public class SystemInfo implements SystemInfoProvider {
         return 20;
     }
 
-    private static final Set<PlatformEnum> SUPPORTED_PLATFORMS = EnumSet.of(PlatformEnum.LINUX, PlatformEnum.MACOS,
-            PlatformEnum.WINDOWS, PlatformEnum.FREEBSD, PlatformEnum.NETBSD, PlatformEnum.OPENBSD,
-            PlatformEnum.DRAGONFLYBSD, PlatformEnum.SOLARIS, PlatformEnum.AIX);
-
     @Override
     public boolean isAvailable() {
-        return SUPPORTED_PLATFORMS.contains(PlatformEnum.getCurrentPlatform()) && Runtime.version().feature() >= 25;
+        return true;
     }
 
     private static OperatingSystem createOperatingSystem() {

--- a/oshi-core-ffm/src/main/resources/META-INF/services/oshi.spi.SystemInfoProvider
+++ b/oshi-core-ffm/src/main/resources/META-INF/services/oshi.spi.SystemInfoProvider
@@ -1,0 +1,1 @@
+oshi.ffm.SystemInfo

--- a/oshi-core/src/main/resources/META-INF/services/oshi.spi.SystemInfoProvider
+++ b/oshi-core/src/main/resources/META-INF/services/oshi.spi.SystemInfoProvider
@@ -1,0 +1,1 @@
+oshi.SystemInfo

--- a/oshi-metrics/pom.xml
+++ b/oshi-metrics/pom.xml
@@ -109,4 +109,20 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>java25</id>
+            <activation>
+                <jdk>[25,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>oshi-core-ffm</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/oshi-metrics/src/test/java/oshi/metrics/SystemInfoFactorySelectionTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/SystemInfoFactorySelectionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.spi.SystemInfoFactory;
+import oshi.spi.SystemInfoProvider;
+
+/**
+ * Validates that SystemInfoFactory selects the correct provider based on JDK version when both oshi-core and
+ * oshi-core-ffm are on the classpath.
+ */
+class SystemInfoFactorySelectionTest {
+
+    @Test
+    void factorySelectsCorrectProvider() {
+        SystemInfoProvider provider = SystemInfoFactory.create();
+        if (Runtime.version().feature() >= 25) {
+            assertEquals("oshi.ffm.SystemInfo", provider.getClass().getName(),
+                    "JDK 25+: Factory should select FFM provider");
+            assertEquals(20, provider.getPriority());
+        } else {
+            assertEquals("oshi.SystemInfo", provider.getClass().getName(),
+                    "JDK < 25: Factory should select JNA provider");
+            assertEquals(10, provider.getPriority());
+        }
+    }
+}


### PR DESCRIPTION
- FFM `SystemInfo.isAvailable()` now returns `true` (class can't load on JDK < 25 anyway, and all platforms are supported — the `SUPPORTED_PLATFORMS` set and version check were redundant)
- Add `oshi-core-ffm` test dependency to oshi-metrics
- Add test validating factory selects FFM (priority 20) on JDK 25+ or JNA (priority 10) on JDK < 25 when both are on classpath
- Add test in oshi-common validating factory returns native-free provider on Linux (or throws on non-Linux) when only oshi-common is available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating provider selection on Linux vs non-Linux.
  * Added tests validating provider selection when multiple implementations are present (JDK 25+ vs earlier).

* **Chores**
  * Enabled an additional test-time dependency for JDK 25+ builds.
  * Updated service registrations to reflect available provider implementations.
  * Updated changelog entry noting improved SPI provider discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->