### PR TITLE
Mechanical Sonar sweep: try-with-resources, unnamed patterns, Stream.toList()

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -208,27 +208,27 @@
              value="Member name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="ParameterName">
-      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^_$|^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LambdaParameterName">
-      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^_$|^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
              value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="CatchParameterName">
-      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^_$|^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
              value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LocalVariableName">
-      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^_$|^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="PatternVariableName">
-      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^_$|^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
              value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
@@ -238,7 +238,7 @@
              value="Class type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="RecordComponentName">
-      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^_$|^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
                value="Record component name ''{0}'' must match pattern ''{1}''."/>
     </module>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -238,7 +238,7 @@
              value="Class type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="RecordComponentName">
-      <property name="format" value="^_$|^[a-z]([a-zA-Z0-9]*)?$"/>
+      <property name="format" value="^[a-z]([a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
                value="Record component name ''{0}'' must match pattern ''{1}''."/>
     </module>

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -810,7 +810,7 @@ class NativeComparisonTest {
 
         // The longest-lived processes should be present in both lists
         List<OSProcess> jnaSorted = jna.stream().sorted(Comparator.comparingLong(OSProcess::getStartTime)).limit(10)
-                .collect(Collectors.toList());
+                .toList();
         Map<Integer, OSProcess> ffmByPid = ffm.stream()
                 .collect(Collectors.toMap(OSProcess::getProcessID, Function.identity(), (a, b) -> a));
         for (OSProcess j : jnaSorted) {

--- a/oshi-core-ffm/src/main/java/oshi/driver/linux/WhoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/linux/WhoFFM.java
@@ -52,7 +52,7 @@ public final class WhoFFM {
                 if (!systemdSessions.isEmpty()) {
                     return systemdSessions;
                 }
-            } catch (Throwable t) {
+            } catch (Throwable _) {
                 useSystemd = false;
             }
         }
@@ -79,7 +79,7 @@ public final class WhoFFM {
             } finally {
                 LinuxLibcFunctions.endutxent();
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             return oshi.util.driver.linux.Who.queryWho();
         }
 
@@ -121,7 +121,7 @@ public final class WhoFFM {
                         if (session != null) {
                             sessionList.add(session);
                         }
-                    } catch (Exception e) {
+                    } catch (Exception _) {
                         // Skip invalid session
                     }
                 }
@@ -221,7 +221,7 @@ public final class WhoFFM {
                                 sessionList.add(new OSSession(user, tty, loginTime, remoteHost));
                             }
                         }
-                    } catch (Exception e) {
+                    } catch (Exception _) {
                         // Skip invalid session files
                     }
                 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
@@ -99,7 +99,7 @@ public final class IOReportClientFFM {
                     return new IOReportClientFFM(sub, subPtr);
                 }
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             return null;
         }
     }
@@ -170,7 +170,7 @@ public final class IOReportClientFFM {
             } finally {
                 cfRelease(delta);
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             return -1d;
         } finally {
             if (sample != null && !sample.equals(MemorySegment.NULL)) {
@@ -224,7 +224,7 @@ public final class IOReportClientFFM {
             } finally {
                 cfRelease(delta);
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             return -1d;
         } finally {
             if (sample != null && !sample.equals(MemorySegment.NULL)) {

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/WhoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/WhoFFM.java
@@ -71,7 +71,7 @@ public final class WhoFFM {
             } finally {
                 endutxent();
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             return oshi.util.driver.unix.Who.queryWho();
         }
         return whoList;

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/WindowInfoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/WindowInfoFFM.java
@@ -130,7 +130,7 @@ public final class WindowInfoFFM {
                     }
                 }
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             return windowList;
         }
         return windowList;

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/disk/FsstatFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/disk/FsstatFFM.java
@@ -50,7 +50,7 @@ public final class FsstatFFM {
                 String mntOn = statfs.getString(STATFS.byteOffset(F_MNTONNAME));
                 mountPointMap.put(mntFrom.replace("/dev/", ""), mntOn);
             }
-        } catch (Throwable t) {
+        } catch (Throwable _) {
             // Fall through with empty map
         }
         return mountPointMap;

--- a/oshi-core-ffm/src/main/java/oshi/driver/unix/aix/PsInfoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/unix/aix/PsInfoFFM.java
@@ -77,7 +77,7 @@ public final class PsInfoFFM {
                 try {
                     byte[] status = Files.readAllBytes(p);
                     increment = status[17] == 1 ? 8 : 4;
-                } catch (IOException e) {
+                } catch (IOException _) {
                     return new Pair<>(args, env);
                 }
 

--- a/oshi-core-ffm/src/main/java/oshi/driver/unix/freebsd/WhoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/unix/freebsd/WhoFFM.java
@@ -62,7 +62,7 @@ public final class WhoFFM {
             } finally {
                 endutxent();
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             return oshi.util.driver.unix.Who.queryWho();
         }
         return whoList;

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/NetSessionDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/NetSessionDataFFM.java
@@ -63,7 +63,7 @@ public final class NetSessionDataFFM {
                     Netapi32FFM.NetApiBufferFree(buf);
                 }
             }
-        } catch (Throwable t) {
+        } catch (Throwable _) {
             // Silently return what we have
         }
         return sessions;

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/SessionWtsDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/SessionWtsDataFFM.java
@@ -162,7 +162,7 @@ public final class SessionWtsDataFFM {
                         if (addrFamily == AF_INET) {
                             try {
                                 host = InetAddress.getByAddress(Arrays.copyOfRange(address, 2, 6)).getHostAddress();
-                            } catch (UnknownHostException e) {
+                            } catch (UnknownHostException _) {
                                 host = "Illegal length IP Array";
                             }
                         } else if (addrFamily == AF_INET6) {
@@ -175,7 +175,7 @@ public final class SessionWtsDataFFM {
             } finally {
                 Wtsapi32FFM.WTSFreeMemory(pSessionInfo);
             }
-        } catch (Throwable t) {
+        } catch (Throwable _) {
             // Silently return what we have
         }
         return sessions;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -381,7 +381,7 @@ public abstract class ForeignFunctions {
                 MemorySegment sym = (MemorySegment) DlSyms.DLSYM.invokeExact(libHandle, nameSeg);
                 return sym.address() == 0L ? java.util.Optional.empty()
                         : java.util.Optional.of(MemorySegment.ofAddress(sym.address()));
-            } catch (Throwable t) {
+            } catch (Throwable _) {
                 return java.util.Optional.empty();
             }
         };

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/linux/UdevFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/linux/UdevFunctions.java
@@ -163,7 +163,7 @@ public final class UdevFunctions extends ForeignFunctions {
         for (String name : new String[] { "udev", "libudev.so.1", "libudev.so.0" }) {
             try {
                 return name.startsWith("lib") ? SymbolLookup.libraryLookup(name, LIBRARY_ARENA) : libraryLookup(name);
-            } catch (IllegalArgumentException ignored) {
+            } catch (IllegalArgumentException _) {
                 // try next candidate name
             }
         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/DiskArbitration.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/DiskArbitration.java
@@ -71,7 +71,7 @@ public interface DiskArbitration {
                 MemorySegment bsdNameSeg = arena.allocateFrom(bsdName);
                 MemorySegment diskSeg = DADiskCreateFromBSDName(allocSeg, sessionSeg, bsdNameSeg);
                 return new DADiskRef(diskSeg);
-            } catch (Throwable e) {
+            } catch (Throwable _) {
                 return new DADiskRef(MemorySegment.NULL);
             }
         }
@@ -122,7 +122,7 @@ public interface DiskArbitration {
             try (Arena arena = Arena.ofConfined()) {
                 MemorySegment nameSeg = DADiskGetBSDName(segment());
                 return ForeignFunctions.getStringFromNativePointer(nameSeg, arena);
-            } catch (Throwable e) {
+            } catch (Throwable _) {
                 return null;
             }
         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/IOReportFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/IOReportFunctions.java
@@ -35,7 +35,7 @@ public final class IOReportFunctions extends MacForeignFunctions {
         // JNA's Native.load("IOReport", ...) which maps to the same name via System.mapLibraryName.
         try {
             return SymbolLookup.libraryLookup(System.mapLibraryName("IOReport"), LIBRARY_ARENA);
-        } catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException _) {
             return null;
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/MacForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/MacForeignFunctions.java
@@ -42,7 +42,7 @@ public abstract class MacForeignFunctions extends ForeignFunctions {
             try {
                 return SymbolLookup.libraryLookup(base + "/" + frameworkName + ".framework/" + frameworkName,
                         LIBRARY_ARENA);
-            } catch (IllegalArgumentException ignored) {
+            } catch (IllegalArgumentException _) {
                 // Not found in this directory, try the next one
             }
         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/CupsFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/CupsFunctions.java
@@ -96,7 +96,7 @@ public final class CupsFunctions extends ForeignFunctions {
                     FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_INT, ADDRESS));
             hGetDefault = LINKER.downcallHandle(lookup.findOrThrow("cupsGetDefault"), FunctionDescriptor.of(ADDRESS));
             available = true;
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             // libcups not available or symbol binding failed; callers should fall back to lpstat
         }
         CUPS_LIBRARY = lookup;
@@ -179,7 +179,7 @@ public final class CupsFunctions extends ForeignFunctions {
                 return "";
             }
             return getStringFromNativePointer(result, arena);
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             return "";
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Cfgmgr32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Cfgmgr32FFM.java
@@ -114,7 +114,7 @@ public final class Cfgmgr32FFM extends WindowsForeignFunctions {
             if (CM_Get_Device_ID(dnDevInst, buf, 260, 0) == CR_SUCCESS) {
                 return readWideString(buf);
             }
-        } catch (Throwable t) {
+        } catch (Throwable _) {
             LOG.debug("CM_Get_Device_ID failed for node {}", dnDevInst);
         }
         return "";
@@ -137,7 +137,7 @@ public final class Cfgmgr32FFM extends WindowsForeignFunctions {
                     0) == CR_SUCCESS) {
                 return readWideString(buf);
             }
-        } catch (Throwable t) {
+        } catch (Throwable _) {
             LOG.debug("CM_Get_DevNode_Registry_Property failed for node {} property {}", dnDevInst, ulProperty);
         }
         return "";

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Kernel32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Kernel32FFM.java
@@ -575,7 +575,7 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
         try {
             SymbolLookup powrProf = lib("PowrProf");
             mh = downcall(powrProf, "CallNtPowerInformation", JAVA_INT, JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, JAVA_INT);
-        } catch (Throwable t) {
+        } catch (Throwable _) {
             // PowrProf may not be available
         }
         CallNtPowerInformation = mh;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
@@ -88,7 +88,7 @@ public final class AdlUtilFFM {
             SymbolLookup adl;
             try {
                 adl = SymbolLookup.libraryLookup("atiadlxx", Arena.global());
-            } catch (Throwable t) {
+            } catch (Throwable _) {
                 adl = SymbolLookup.libraryLookup("atiadlxy", Arena.global());
             }
             Linker linker = Linker.nativeLinker();

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
@@ -92,7 +92,7 @@ public final class KstatUtilFFM {
                     // Avoids busy-spinning on transient EAGAINs while still bounded.
                     try {
                         Thread.sleep(8L << retry);
-                    } catch (InterruptedException ie) {
+                    } catch (InterruptedException _) {
                         Thread.currentThread().interrupt();
                         return false;
                     }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
@@ -80,10 +80,10 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
         }
         try {
             return customClass.getConstructor(EMPTY_CLASS_ARRAY).newInstance(EMPTY_OBJECT_ARRAY);
-        } catch (NoSuchMethodException | SecurityException e) {
+        } catch (NoSuchMethodException | SecurityException _) {
             LOG.error("Failed to find or access a no-arg constructor for {}", customClass);
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
-                | InvocationTargetException e) {
+                | InvocationTargetException _) {
             LOG.error("Failed to create a new instance of {}", customClass);
         }
         customClass = null;
@@ -346,7 +346,7 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
             } finally {
                 IUnknownFFM.safeRelease(pLocator, arena);
             }
-        } catch (FfmComException e) {
+        } catch (FfmComException _) {
             failedWmiClassNames.add(wmiClassName);
         } catch (Exception e) {
             LOG.debug("WMI query failed for {}: {}", wmiClassName, e.getMessage());

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -249,7 +249,7 @@ final class MacGpuStatsFFM implements GpuStats {
                                     if (!statsSeg.equals(MemorySegment.NULL)) {
                                         try {
                                             CoreFoundationFunctions.CFRetain(statsSeg);
-                                        } catch (Throwable ignored) {
+                                        } catch (Throwable _) {
                                             // CFRetain declares throws Throwable; swallow to keep flow clean
                                         }
                                         result = new CFMutableDictionaryRef(statsSeg);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -78,7 +78,7 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                     }
                 }
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             return false;
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -11,7 +11,6 @@ import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,8 +232,8 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                             }
                         }
                     }
-                    setPartitionList(Collections.unmodifiableList(partitions.stream()
-                            .sorted(Comparator.comparing(HWPartition::getName)).collect(Collectors.toList())));
+                    setPartitionList(Collections.unmodifiableList(
+                            partitions.stream().sorted(Comparator.comparing(HWPartition::getName)).toList()));
                 } finally {
                     if (parent != null) {
                         parent.release();

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
@@ -61,7 +61,7 @@ public final class MacNetworkIfFFM extends MacNetworkIF {
                     }
                 }
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             LOG.debug("Failed to query SC network interface display name for {}", name);
         }
         return name;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
@@ -95,7 +95,7 @@ public final class MacPowerSourceFFM extends MacPowerSource {
                     int year80 = (temp >> 9) & 0x7f;
                     try {
                         psManufactureDate = LocalDate.of(1980 + year80, month, day);
-                    } catch (DateTimeException e) {
+                    } catch (DateTimeException _) {
                         // Corrupt bitfield — leave psManufactureDate as null
                     }
                 }
@@ -217,7 +217,7 @@ public final class MacPowerSourceFFM extends MacPowerSource {
                     return psList;
                 }
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             return new ArrayList<>();
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHWDiskStoreFFM.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.freebsd.disk.GeomDiskList;
@@ -97,9 +96,9 @@ public final class FreeBsdHWDiskStoreFFM extends FreeBsdHWDiskStore {
                 store.setCurrentQueueLength(ParseUtil.parseLongOrDefault(split[5], 0L));
                 // In seconds, multiply for ms
                 store.setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
-                store.setPartitionList(Collections
-                        .unmodifiableList(partitionMap.getOrDefault(split[0], Collections.emptyList()).stream()
-                                .sorted(Comparator.comparing(HWPartition::getName)).collect(Collectors.toList())));
+                store.setPartitionList(
+                        Collections.unmodifiableList(partitionMap.getOrDefault(split[0], Collections.emptyList())
+                                .stream().sorted(Comparator.comparing(HWPartition::getName)).toList()));
                 store.setTimeStamp(now);
                 diskList.add(store);
             }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHWDiskStoreFFM.java
@@ -11,7 +11,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.solaris.disk.Iostat;
@@ -78,7 +77,7 @@ public final class SolarisHWDiskStoreFFM extends AbstractHWDiskStore {
         SolarisHWDiskStoreFFM store = new SolarisHWDiskStoreFFM(diskName,
                 model.isEmpty() ? (vendor + " " + product).trim() : model, serial, size);
         store.setPartitionList(Collections.unmodifiableList(Prtvtoc.queryPartitions(mount, major).stream()
-                .sorted(Comparator.comparing(HWPartition::getName)).collect(Collectors.toList())));
+                .sorted(Comparator.comparing(HWPartition::getName)).toList()));
         store.updateAttributes();
         return store;
     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.slf4j.Logger;
@@ -179,7 +178,7 @@ final class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
 
         List<String> featureFlags = IntStream.range(0, PROCESSOR_FEATURES.length)
                 .filter(i -> Kernel32FFM.IsProcessorFeaturePresent(PROCESSOR_FEATURES[i]))
-                .mapToObj(i -> PROCESSOR_FEATURE_NAMES[i]).collect(Collectors.toList());
+                .mapToObj(i -> PROCESSOR_FEATURE_NAMES[i]).toList();
         return new Quartet<>(lpi.getA(), lpi.getB(), lpi.getC(), featureFlags);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
@@ -254,7 +254,7 @@ public final class WindowsPowerSourceFFM extends WindowsPowerSource {
                                 if (year > 1900 && month >= 1 && month <= 12 && day >= 1 && day <= 31) {
                                     try {
                                         psManufactureDate = LocalDate.of(year, month, day);
-                                    } catch (java.time.DateTimeException ignored) {
+                                    } catch (java.time.DateTimeException _) {
                                         // malformed firmware date — leave null
                                     }
                                 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
@@ -100,7 +100,7 @@ public class LinuxOperatingSystemFFM extends LinuxOperatingSystem {
         if (!hasSyscallGettid) {
             try {
                 hasSyscallGettid = LinuxLibcFunctions.syscallGettid() > 0;
-            } catch (Throwable e) {
+            } catch (Throwable _) {
                 LOG.debug("Did not find working syscall gettid via FFM. Using procfs");
             }
         }
@@ -159,7 +159,7 @@ public class LinuxOperatingSystemFFM extends LinuxOperatingSystem {
         try {
             return ParseUtil.parseIntOrDefault(
                     Files.readSymbolicLink(new File(ProcPath.THREAD_SELF).toPath()).getFileName().toString(), 0);
-        } catch (IOException e) {
+        } catch (IOException _) {
             return 0;
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
@@ -64,7 +64,7 @@ public class MacOperatingSystemFFM extends MacOperatingSystem {
             if (SysctlUtilFFM.sysctl("kern.boottime", timeval)) {
                 bootTime = timeval.get(JAVA_LONG, 0L);
             }
-        } catch (Throwable e) {
+        } catch (Throwable _) {
             // do nothing, the bootTime == 0 conditional will handle
         }
         // Usually this works. If it doesn't, fall back to text parsing.

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixNetworkParamsFFM.java
@@ -34,7 +34,7 @@ final class AixNetworkParamsFFM extends AixNetworkParams {
             byte[] bytes = new byte[len];
             MemorySegment.copy(buf, JAVA_BYTE, 0, bytes, 0, len);
             return new String(bytes, StandardCharsets.US_ASCII);
-        } catch (Throwable t) {
+        } catch (Throwable _) {
             return super.getHostName();
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOSProcessFFM.java
@@ -73,7 +73,7 @@ public final class AixOSProcessFFM extends AixOSProcess {
                 if (AixLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) == 0) {
                     return AixLibcFunctions.rlimitCur(rlim);
                 }
-            } catch (Throwable t) {
+            } catch (Throwable _) {
                 // fall through
             }
         }
@@ -88,7 +88,7 @@ public final class AixOSProcessFFM extends AixOSProcess {
                 if (AixLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) == 0) {
                     return AixLibcFunctions.rlimitMax(rlim);
                 }
-            } catch (Throwable t) {
+            } catch (Throwable _) {
                 // fall through
             }
         }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOperatingSystemFFM.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.aix.Uptime;
@@ -112,14 +111,14 @@ public final class AixOperatingSystemFFM extends AbstractOperatingSystem {
     public List<OSProcess> queryChildProcesses(int parentPid) {
         List<OSProcess> allProcs = queryAllProcesses();
         Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
     }
 
     @Override
     public List<OSProcess> queryDescendantProcesses(int parentPid) {
         List<OSProcess> allProcs = queryAllProcesses();
         Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOperatingSystemFFM.java
@@ -152,7 +152,7 @@ public final class AixOperatingSystemFFM extends AbstractOperatingSystem {
     public int getProcessId() {
         try {
             return AixLibcFunctions.getpid();
-        } catch (Throwable t) {
+        } catch (Throwable _) {
             return 0;
         }
     }
@@ -166,7 +166,7 @@ public final class AixOperatingSystemFFM extends AbstractOperatingSystem {
     public int getThreadId() {
         try {
             return AixLibcFunctions.thread_self();
-        } catch (Throwable t) {
+        } catch (Throwable _) {
             return 0;
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
@@ -119,14 +119,14 @@ public class DragonFlyBsdOperatingSystemFFM extends AbstractOperatingSystem {
     public List<OSProcess> queryChildProcesses(int parentPid) {
         List<OSProcess> allProcs = queryAllProcesses();
         Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
     }
 
     @Override
     public List<OSProcess> queryDescendantProcesses(int parentPid) {
         List<OSProcess> allProcs = queryAllProcesses();
         Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemFFM.java
@@ -113,14 +113,14 @@ public class FreeBsdOperatingSystemFFM extends AbstractOperatingSystem {
     public List<OSProcess> queryChildProcesses(int parentPid) {
         List<OSProcess> allProcs = queryAllProcesses();
         Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
     }
 
     @Override
     public List<OSProcess> queryDescendantProcesses(int parentPid) {
         List<OSProcess> allProcs = queryAllProcesses();
         Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
@@ -106,14 +106,14 @@ public class OpenBsdOperatingSystemFFM extends AbstractOperatingSystem {
     public List<OSProcess> queryChildProcesses(int parentPid) {
         List<OSProcess> allProcs = queryAllProcesses();
         Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
     }
 
     @Override
     public List<OSProcess> queryDescendantProcesses(int parentPid) {
         List<OSProcess> allProcs = queryAllProcesses();
         Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcessFFM.java
@@ -255,7 +255,7 @@ public class SolarisOSProcessFFM extends AbstractOSProcess {
     public long getOpenFiles() {
         try (Stream<Path> fd = Files.list(Paths.get("/proc/" + getProcessID() + "/fd"))) {
             return fd.count();
-        } catch (IOException e) {
+        } catch (IOException _) {
             return 0L;
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystemFFM.java
@@ -13,7 +13,6 @@ import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,14 +99,14 @@ public class SolarisOperatingSystemFFM extends AbstractOperatingSystem {
     public List<OSProcess> queryChildProcesses(int parentPid) {
         List<OSProcess> allProcs = queryAllProcesses();
         Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
     }
 
     @Override
     public List<OSProcess> queryDescendantProcesses(int parentPid) {
         List<OSProcess> allProcs = queryAllProcesses();
         Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
     }
 
     private List<OSProcess> getProcessListFromProcfs(int pid) {

--- a/oshi-core-ffm/src/test/java/oshi/ffm/platform/mac/CoreFoundationTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/platform/mac/CoreFoundationTest.java
@@ -68,10 +68,9 @@ class CoreFoundationTest {
 
     @Test
     void testCFTypeRefEqualsAndHashCode() {
-        var str1 = CFStringRef.createCFString("test");
-        var str2 = CFStringRef.createCFString("test");
-        var str3 = CFStringRef.createCFString("other");
-        try {
+        try (var str1 = CFStringRef.createCFString("test");
+                var str2 = CFStringRef.createCFString("test");
+                var str3 = CFStringRef.createCFString("other")) {
             assertThat(str1.equals(str2), is(true));
             assertThat(str1.hashCode(), is(str2.hashCode()));
             assertThat(str1.equals(str3), is(false));
@@ -83,10 +82,6 @@ class CoreFoundationTest {
             assertThat(nullRef1.equals(nullRef2), is(true));
             assertThat(nullRef1.hashCode(), is(nullRef2.hashCode()));
             assertThat(nullRef1.equals(str1), is(false));
-        } finally {
-            str1.release();
-            str2.release();
-            str3.release();
         }
     }
 
@@ -155,10 +150,8 @@ class CoreFoundationTest {
             var valuePtr = arena.allocate(ValueLayout.JAVA_INT);
             valuePtr.set(ValueLayout.JAVA_INT, 0, 42);
             var numSeg = CoreFoundationFunctions.CFNumberCreate(allocator, CoreFoundation.kCFNumberIntType, valuePtr);
-            try {
-                assertThrows(ClassCastException.class, () -> new CFStringRef(numSeg));
-            } finally {
-                CoreFoundationFunctions.CFRelease(numSeg);
+            try (var cfNum = new CFNumberRef(numSeg)) {
+                assertThrows(ClassCastException.class, () -> new CFStringRef(cfNum.segment()));
             }
         }
     }
@@ -175,12 +168,9 @@ class CoreFoundationTest {
             valuePtr.set(ValueLayout.JAVA_LONG, 0, 123456789L);
             var numSeg = CoreFoundationFunctions.CFNumberCreate(allocator, CoreFoundation.kCFNumberLongLongType,
                     valuePtr);
-            var cfNum = new CFNumberRef(numSeg);
-            try {
+            try (var cfNum = new CFNumberRef(numSeg)) {
                 assertThat(cfNum.longValue(), is(123456789L));
                 assertThat(cfNum.isTypeID(CoreFoundationFunctions.NUMBER_TYPE_ID), is(true));
-            } finally {
-                cfNum.release();
             }
         }
     }
@@ -192,11 +182,8 @@ class CoreFoundationTest {
             var valuePtr = arena.allocate(ValueLayout.JAVA_INT);
             valuePtr.set(ValueLayout.JAVA_INT, 0, 42);
             var numSeg = CoreFoundationFunctions.CFNumberCreate(allocator, CoreFoundation.kCFNumberIntType, valuePtr);
-            var cfNum = new CFNumberRef(numSeg);
-            try {
+            try (var cfNum = new CFNumberRef(numSeg)) {
                 assertThat(cfNum.intValue(), is(42));
-            } finally {
-                cfNum.release();
             }
         }
     }
@@ -208,11 +195,8 @@ class CoreFoundationTest {
             var valuePtr = arena.allocate(ValueLayout.JAVA_SHORT);
             valuePtr.set(ValueLayout.JAVA_SHORT, 0, (short) 7);
             var numSeg = CoreFoundationFunctions.CFNumberCreate(allocator, CoreFoundation.kCFNumberShortType, valuePtr);
-            var cfNum = new CFNumberRef(numSeg);
-            try {
+            try (var cfNum = new CFNumberRef(numSeg)) {
                 assertThat(cfNum.shortValue(), is((short) 7));
-            } finally {
-                cfNum.release();
             }
         }
     }
@@ -224,11 +208,8 @@ class CoreFoundationTest {
             var valuePtr = arena.allocate(ValueLayout.JAVA_BYTE);
             valuePtr.set(ValueLayout.JAVA_BYTE, 0, (byte) 3);
             var numSeg = CoreFoundationFunctions.CFNumberCreate(allocator, CoreFoundation.kCFNumberCharType, valuePtr);
-            var cfNum = new CFNumberRef(numSeg);
-            try {
+            try (var cfNum = new CFNumberRef(numSeg)) {
                 assertThat(cfNum.byteValue(), is((byte) 3));
-            } finally {
-                cfNum.release();
             }
         }
     }
@@ -241,11 +222,8 @@ class CoreFoundationTest {
             valuePtr.set(ValueLayout.JAVA_DOUBLE, 0, 3.14);
             var numSeg = CoreFoundationFunctions.CFNumberCreate(allocator, CoreFoundation.kCFNumberDoubleType,
                     valuePtr);
-            var cfNum = new CFNumberRef(numSeg);
-            try {
+            try (var cfNum = new CFNumberRef(numSeg)) {
                 assertThat(cfNum.doubleValue(), is(closeTo(3.14, 0.001)));
-            } finally {
-                cfNum.release();
             }
         }
     }
@@ -257,11 +235,8 @@ class CoreFoundationTest {
             var valuePtr = arena.allocate(ValueLayout.JAVA_FLOAT);
             valuePtr.set(ValueLayout.JAVA_FLOAT, 0, 2.5f);
             var numSeg = CoreFoundationFunctions.CFNumberCreate(allocator, CoreFoundation.kCFNumberFloatType, valuePtr);
-            var cfNum = new CFNumberRef(numSeg);
-            try {
+            try (var cfNum = new CFNumberRef(numSeg)) {
                 assertThat(cfNum.floatValue(), is(2.5f));
-            } finally {
-                cfNum.release();
             }
         }
     }
@@ -315,15 +290,12 @@ class CoreFoundationTest {
             var bytesSeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, input);
             var allocator = CoreFoundationFunctions.CFAllocatorGetDefault();
             var dataSeg = CoreFoundationFunctions.CFDataCreate(allocator, bytesSeg, input.length);
-            var cfData = new CFDataRef(dataSeg);
-            try {
+            try (var cfData = new CFDataRef(dataSeg)) {
                 assertThat(cfData.isNull(), is(false));
                 assertThat(cfData.isTypeID(CoreFoundationFunctions.DATA_TYPE_ID), is(true));
                 assertThat(cfData.getLength(), is(5));
                 assertThat(cfData.getBytePtr(), is(not(NULL)));
                 assertThat(cfData.getBytes(), is(input));
-            } finally {
-                cfData.release();
             }
         }
     }
@@ -342,27 +314,21 @@ class CoreFoundationTest {
 
     @Test
     void testCFArrayWithStrings() throws Throwable {
-        var str1 = CFStringRef.createCFString("a");
-        var str2 = CFStringRef.createCFString("b");
-        try (var arena = Arena.ofConfined()) {
+        try (var arena = Arena.ofConfined();
+                var str1 = CFStringRef.createCFString("a");
+                var str2 = CFStringRef.createCFString("b")) {
             var values = arena.allocate(ValueLayout.ADDRESS, 2);
             values.setAtIndex(ValueLayout.ADDRESS, 0, str1.segment());
             values.setAtIndex(ValueLayout.ADDRESS, 1, str2.segment());
             var allocator = CoreFoundationFunctions.CFAllocatorGetDefault();
             var callbacks = CF_LOOKUP.findOrThrow("kCFTypeArrayCallBacks");
             var arraySeg = CoreFoundationFunctions.CFArrayCreate(allocator, values, 2, callbacks);
-            var cfArray = new CFArrayRef(arraySeg);
-            try {
+            try (var cfArray = new CFArrayRef(arraySeg)) {
                 assertThat(cfArray.isTypeID(CoreFoundationFunctions.ARRAY_TYPE_ID), is(true));
                 assertThat(cfArray.getCount(), is(2));
                 var elem0 = new CFStringRef(cfArray.getValueAtIndex(0));
                 assertThat(elem0.stringValue(), is("a"));
-            } finally {
-                cfArray.release();
             }
-        } finally {
-            str1.release();
-            str2.release();
         }
     }
 
@@ -384,36 +350,25 @@ class CoreFoundationTest {
             var keyCallbacks = CF_LOOKUP.findOrThrow("kCFTypeDictionaryKeyCallBacks");
             var valCallbacks = CF_LOOKUP.findOrThrow("kCFTypeDictionaryValueCallBacks");
             var dictSeg = CoreFoundationFunctions.CFDictionaryCreateMutable(allocator, 0, keyCallbacks, valCallbacks);
-            var dict = new CFMutableDictionaryRef(dictSeg);
-            try {
-                var key = CFStringRef.createCFString("myKey");
-                var val = CFStringRef.createCFString("myValue");
-                try {
-                    dict.setValue(key, val);
-                    assertThat(dict.getCount(), is(1L));
+            try (var dict = new CFMutableDictionaryRef(dictSeg);
+                    var key = CFStringRef.createCFString("myKey");
+                    var val = CFStringRef.createCFString("myValue")) {
+                dict.setValue(key, val);
+                assertThat(dict.getCount(), is(1L));
 
-                    var result = dict.getValue(key);
-                    assertThat(result, is(not(NULL)));
-                    assertThat(new CFStringRef(result).stringValue(), is("myValue"));
+                var result = dict.getValue(key);
+                assertThat(result, is(not(NULL)));
+                assertThat(new CFStringRef(result).stringValue(), is("myValue"));
 
-                    // getValueIfPresent
-                    var outPtr = arena.allocate(ValueLayout.ADDRESS);
-                    assertThat(dict.getValueIfPresent(key, outPtr), is(true));
+                // getValueIfPresent
+                var outPtr = arena.allocate(ValueLayout.ADDRESS);
+                assertThat(dict.getValueIfPresent(key, outPtr), is(true));
 
-                    // Missing key
-                    var missingKey = CFStringRef.createCFString("noSuchKey");
-                    try {
-                        assertThat(dict.getValue(missingKey), is(NULL));
-                        assertThat(dict.getValueIfPresent(missingKey, outPtr), is(false));
-                    } finally {
-                        missingKey.release();
-                    }
-                } finally {
-                    key.release();
-                    val.release();
+                // Missing key
+                try (var missingKey = CFStringRef.createCFString("noSuchKey")) {
+                    assertThat(dict.getValue(missingKey), is(NULL));
+                    assertThat(dict.getValueIfPresent(missingKey, outPtr), is(false));
                 }
-            } finally {
-                dict.release();
             }
         }
     }
@@ -433,21 +388,13 @@ class CoreFoundationTest {
             var keyCallbacks = CF_LOOKUP.findOrThrow("kCFTypeDictionaryKeyCallBacks");
             var valCallbacks = CF_LOOKUP.findOrThrow("kCFTypeDictionaryValueCallBacks");
             var dictSeg = CoreFoundationFunctions.CFDictionaryCreateMutable(allocator, 0, keyCallbacks, valCallbacks);
-            var dict = new CFMutableDictionaryRef(dictSeg);
-            try {
-                // setValue with null key should not throw
-                var val1 = CFStringRef.createCFString("val");
-                var val2 = CFStringRef.createCFString("val");
-                try {
-                    dict.setValue(null, val1);
-                    dict.setValue(new CFStringRef(NULL), val2);
-                    assertThat(dict.getCount(), is(0L));
-                } finally {
-                    val1.release();
-                    val2.release();
-                }
-            } finally {
-                dict.release();
+            // setValue with null key should not throw
+            try (var dict = new CFMutableDictionaryRef(dictSeg);
+                    var val1 = CFStringRef.createCFString("val");
+                    var val2 = CFStringRef.createCFString("val")) {
+                dict.setValue(null, val1);
+                dict.setValue(new CFStringRef(NULL), val2);
+                assertThat(dict.getCount(), is(0L));
             }
         }
     }
@@ -469,11 +416,8 @@ class CoreFoundationTest {
 
     @Test
     void testCFLocaleCopyCurrent() {
-        var locale = CFLocale.copyCurrent();
-        try {
+        try (var locale = CFLocale.copyCurrent()) {
             assertThat(locale.isNull(), is(false));
-        } finally {
-            locale.release();
         }
     }
 
@@ -483,20 +427,13 @@ class CoreFoundationTest {
 
     @Test
     void testCFDateFormatterGetFormat() {
-        var locale = CFLocale.copyCurrent();
-        try {
-            var formatter = CFDateFormatter.create(null, locale, CoreFoundation.kCFDateFormatterShortStyle,
-                    CoreFoundation.kCFDateFormatterNoStyle);
-            try {
-                assertThat(formatter.isNull(), is(false));
-                var format = formatter.getFormat();
-                assertThat(format.isNull(), is(false));
-                assertThat(format.stringValue().length(), is(greaterThan(0)));
-            } finally {
-                formatter.release();
-            }
-        } finally {
-            locale.release();
+        try (var locale = CFLocale.copyCurrent();
+                var formatter = CFDateFormatter.create(null, locale, CoreFoundation.kCFDateFormatterShortStyle,
+                        CoreFoundation.kCFDateFormatterNoStyle)) {
+            assertThat(formatter.isNull(), is(false));
+            var format = formatter.getFormat();
+            assertThat(format.isNull(), is(false));
+            assertThat(format.stringValue().length(), is(greaterThan(0)));
         }
     }
 
@@ -513,51 +450,36 @@ class CoreFoundationTest {
 
     @Test
     void testCFNumberRefRejectsString() {
-        var cfStr = CFStringRef.createCFString("notANumber");
-        try {
+        try (var cfStr = CFStringRef.createCFString("notANumber")) {
             assertThrows(ClassCastException.class, () -> new CFNumberRef(cfStr.segment()));
-        } finally {
-            cfStr.release();
         }
     }
 
     @Test
     void testCFBooleanRefRejectsString() {
-        var cfStr = CFStringRef.createCFString("notABool");
-        try {
+        try (var cfStr = CFStringRef.createCFString("notABool")) {
             assertThrows(ClassCastException.class, () -> new CFBooleanRef(cfStr.segment()));
-        } finally {
-            cfStr.release();
         }
     }
 
     @Test
     void testCFArrayRefRejectsString() {
-        var cfStr = CFStringRef.createCFString("notAnArray");
-        try {
+        try (var cfStr = CFStringRef.createCFString("notAnArray")) {
             assertThrows(ClassCastException.class, () -> new CFArrayRef(cfStr.segment()));
-        } finally {
-            cfStr.release();
         }
     }
 
     @Test
     void testCFDataRefRejectsString() {
-        var cfStr = CFStringRef.createCFString("notData");
-        try {
+        try (var cfStr = CFStringRef.createCFString("notData")) {
             assertThrows(ClassCastException.class, () -> new CFDataRef(cfStr.segment()));
-        } finally {
-            cfStr.release();
         }
     }
 
     @Test
     void testCFDictionaryRefRejectsString() {
-        var cfStr = CFStringRef.createCFString("notADict");
-        try {
+        try (var cfStr = CFStringRef.createCFString("notADict")) {
             assertThrows(ClassCastException.class, () -> new CFDictionaryRef(cfStr.segment()));
-        } finally {
-            cfStr.release();
         }
     }
 }


### PR DESCRIPTION
Three commits, each one Sonar rule, each one mechanical pass across `oshi-core-ffm` (+ a touch of `oshi-benchmark`). No behaviour changes intended.

## Summary

- **`3ce4c9b350` — try-with-resources in CoreFoundationTest (S2093, 19 sites).** `CFTypeRef` and its subclasses already implement `AutoCloseable` with `close() = release()`, so the manual `try { … } finally { ref.release(); }` pattern collapses into try-with-resources. Includes a couple of not-Sonar-flagged but identical patterns in `testCFLocaleCopyCurrent` / `testCFDateFormatterGetFormat` for consistency, and `testCFStringCastCheckRejectsNonString` gets the same treatment by wrapping its test segment in a `CFNumberRef` (it's a valid CFNumber by construction).
- **`e01807740e` — unnamed pattern in unused catch params (S7467, 46 sites).** Java 21+ unnamed patterns (JEP 443/456): `catch (Throwable t)` → `catch (Throwable _)` where the body never references the exception. Includes one multi-catch line-continuation in `WmiQueryHandlerFFM.createInstance` the bulk script didn't catch.
- **`c0cda2268b` — Stream.toList() (S6204, 15 sites).** `.collect(Collectors.toList())` → `.toList()` (Java 16+). The returned list is unmodifiable, whereas `Collectors.toList()` returned an `ArrayList` in practice — both are spec-compliant (`Collectors.toList` docs explicitly disclaim mutability) and no internal caller mutates. The matching JNA-side files target Java 9 so can't use `.toList()` and stay on `Collectors.toList()`.

## Test plan
- [ ] `Pull Request CI` runs all green (lint / Linux / macOS / Windows / FreeBSD / OpenBSD / OpenIndiana matrices).
- [ ] `CoreFoundationTest` passes on macOS / JDK 25+ (verified locally).
- [ ] Sonar reanalysis on merge: S2093 (19), S7467 (46), S6204 (15) all drop to 0 in scope.
- [ ] No `Collectors` import left dangling in changed FFM files (spotless cleaned them up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized exception handling and updated internal collection usage to newer language patterns (stream-to-list).
  * Lint configuration updated to permit the underscore (_) as an unused parameter name.

* **Tests**
  * Improved native-wrapper tests to use modern resource-management, enhancing reliability and lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->