### PR TITLE
Extract a shared BsdOSProcess base to de-duplicate the BSD OSProcess classes

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -62,6 +62,11 @@
     <suppress checks="MemberName" files="(AixCentralProcessor|AixHWDiskStore|AixNetworkIF|AixGlobalMemory)\.java"/>
     <suppress checks="VisibilityModifier" files="(AixCentralProcessor|AixHWDiskStore|AixNetworkIF|AixGlobalMemory)\.java"/>
 
+    <!-- BsdOSProcess is the shared BSD-family OSProcess base; its protected fields are populated by the
+         per-platform updateAttributes() in the subclasses (which read platform-specific ps columns), so
+         they can't be private with accessors. -->
+    <suppress checks="VisibilityModifier" files="BsdOSProcess\.java"/>
+
     <!-- Solaris shared HAL abstract bases use public data POJOs (DiskStats, IfStats, BatteryReadings)
          for the kstat I/O, interface, and battery counters that the JNA and FFM subclasses populate. -->
     <suppress checks="VisibilityModifier" files="(SolarisHWDiskStore|SolarisNetworkIF|SolarisPowerSource)\.java"/>

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -47,6 +47,7 @@ module com.github.oshi.common {
     exports oshi.software.common.os.linux;
     exports oshi.software.common.os.mac;
     exports oshi.software.common.os.unix.aix;
+    exports oshi.software.common.os.unix.bsd;
     exports oshi.software.common.os.unix.dragonflybsd;
     exports oshi.software.common.os.unix.freebsd;
     exports oshi.software.common.os.unix.netbsd;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.bsd;
+
+import static oshi.software.os.OSProcess.State.OTHER;
+import static oshi.software.os.OSProcess.State.RUNNING;
+import static oshi.software.os.OSProcess.State.SLEEPING;
+import static oshi.software.os.OSProcess.State.STOPPED;
+import static oshi.software.os.OSProcess.State.WAITING;
+import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.util.Memoizer.memoize;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractOSProcess;
+import oshi.util.ExecutingCommand;
+import oshi.util.FileUtil;
+import oshi.util.ParseUtil;
+
+/**
+ * Abstract base shared by the BSD-family OSProcess implementations (FreeBSD, OpenBSD, DragonFly, NetBSD). Holds the
+ * field storage, the trivial accessors, command-line/argument/environment/bitness memoization, the {@code ps} state
+ * mapping, the {@code cpuset} affinity lookup, and the {@code /proc/<pid>/limits} fallback. Platform-specific work (the
+ * {@code ps} attribute query, thread enumeration, cwd/open-file lookups, and the native argument/environment and
+ * file-limit reads) is provided by the per-platform subclasses.
+ */
+@ThreadSafe
+public abstract class BsdOSProcess extends AbstractOSProcess {
+
+    private final Supplier<Integer> bitness = memoize(this::queryBitness);
+    private final Supplier<String> commandLine = memoize(this::queryCommandLine);
+    private final Supplier<List<String>> arguments = memoize(this::queryArguments);
+    private final Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
+
+    protected String name;
+    protected String path = "";
+    protected String user;
+    protected String userID;
+    protected String group;
+    protected String groupID;
+    protected State state = State.INVALID;
+    protected int parentProcessID;
+    protected int threadCount;
+    protected int priority;
+    protected long virtualSize;
+    protected long residentSetSize;
+    protected long kernelTime;
+    protected long userTime;
+    protected long startTime;
+    protected long upTime;
+    protected long bytesRead;
+    protected long bytesWritten;
+    protected long minorFaults;
+    protected long majorFaults;
+    protected long voluntaryContextSwitches;
+    protected long involuntaryContextSwitches;
+    protected String commandLineBackup;
+
+    protected BsdOSProcess(int pid) {
+        super(pid);
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getPath() {
+        return this.path;
+    }
+
+    @Override
+    public String getCommandLine() {
+        return this.commandLine.get();
+    }
+
+    private String queryCommandLine() {
+        String cl = String.join(" ", getArguments());
+        return cl.isEmpty() ? this.commandLineBackup : cl;
+    }
+
+    @Override
+    public List<String> getArguments() {
+        return arguments.get();
+    }
+
+    @Override
+    public Map<String, String> getEnvironmentVariables() {
+        return environmentVariables.get();
+    }
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    @Override
+    public String getUserID() {
+        return this.userID;
+    }
+
+    @Override
+    public String getGroup() {
+        return this.group;
+    }
+
+    @Override
+    public String getGroupID() {
+        return this.groupID;
+    }
+
+    @Override
+    public State getState() {
+        return this.state;
+    }
+
+    @Override
+    public int getParentProcessID() {
+        return this.parentProcessID;
+    }
+
+    @Override
+    public int getThreadCount() {
+        return this.threadCount;
+    }
+
+    @Override
+    public int getPriority() {
+        return this.priority;
+    }
+
+    @Override
+    public long getVirtualSize() {
+        return this.virtualSize;
+    }
+
+    @Override
+    public long getResidentMemory() {
+        return this.residentSetSize;
+    }
+
+    @Override
+    public long getKernelTime() {
+        return this.kernelTime;
+    }
+
+    @Override
+    public long getUserTime() {
+        return this.userTime;
+    }
+
+    @Override
+    public long getUpTime() {
+        return this.upTime;
+    }
+
+    @Override
+    public long getStartTime() {
+        return this.startTime;
+    }
+
+    @Override
+    public long getBytesRead() {
+        return this.bytesRead;
+    }
+
+    @Override
+    public long getBytesWritten() {
+        return this.bytesWritten;
+    }
+
+    @Override
+    public long getMinorFaults() {
+        return this.minorFaults;
+    }
+
+    @Override
+    public long getMajorFaults() {
+        return this.majorFaults;
+    }
+
+    @Override
+    public long getVoluntaryContextSwitches() {
+        return this.voluntaryContextSwitches;
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        return this.involuntaryContextSwitches;
+    }
+
+    @Override
+    public int getBitness() {
+        return this.bitness.get();
+    }
+
+    @Override
+    public long getAffinityMask() {
+        long bitMask = 0L;
+        // Would prefer to use native cpuset_getaffinity call but variable sizing is
+        // kernel-dependent and requires C macros, so we use commandline instead.
+        String cpuset = ExecutingCommand.getFirstAnswer("cpuset -gp " + getProcessID());
+        // Sample output:
+        // pid 8 mask: 0, 1
+        // cpuset: getaffinity: No such process
+        String[] split = cpuset.split(":");
+        if (split.length > 1) {
+            String[] bits = split[1].split(",");
+            for (String bit : bits) {
+                int bitToSet = ParseUtil.parseIntOrDefault(bit.trim(), -1);
+                if (bitToSet >= 0 && bitToSet < Long.SIZE) {
+                    bitMask |= 1L << bitToSet;
+                }
+            }
+        }
+        return bitMask;
+    }
+
+    /**
+     * Maps a {@code ps} single-character state to an {@link State}.
+     *
+     * @param stateValue the first character of the {@code ps} STATE column
+     * @return the corresponding process state
+     */
+    protected static State getStateFromOutput(char stateValue) {
+        switch (stateValue) {
+            case 'R':
+                return RUNNING;
+            case 'I':
+            case 'S':
+                return SLEEPING;
+            case 'D':
+            case 'L':
+            case 'U':
+                return WAITING;
+            case 'Z':
+                return ZOMBIE;
+            case 'T':
+                return STOPPED;
+            default:
+                return OTHER;
+        }
+    }
+
+    /**
+     * Parses the soft or hard open-file limit for another process from {@code /proc/<pid>/limits}.
+     *
+     * @param processId the process ID
+     * @param index     {@code 1} for the soft limit, {@code 2} for the hard limit
+     * @return the limit, or {@code -1} if unavailable
+     */
+    protected static long getProcessOpenFileLimit(long processId, int index) {
+        final String limitsPath = String.format(Locale.ROOT, "/proc/%d/limits", processId);
+        if (!Files.exists(Paths.get(limitsPath))) {
+            return -1; // not supported
+        }
+        final List<String> lines = FileUtil.readFile(limitsPath);
+        final Optional<String> maxOpenFilesLine = lines.stream().filter(line -> line.startsWith("Max open files"))
+                .findFirst();
+        if (!maxOpenFilesLine.isPresent()) {
+            return -1;
+        }
+        // Split all non-Digits away -> ["", "{soft-limit}, "{hard-limit}"]
+        final String[] split = maxOpenFilesLine.get().split("\\D+");
+        if (split.length <= index) {
+            return -1;
+        }
+        return ParseUtil.parseLongOrDefault(split[index], -1);
+    }
+
+    /**
+     * Queries this process's argument list.
+     *
+     * @return the arguments, or an empty list if unavailable
+     */
+    protected abstract List<String> queryArguments();
+
+    /**
+     * Queries this process's environment variables.
+     *
+     * @return the environment map, or an empty map if unavailable
+     */
+    protected abstract Map<String, String> queryEnvironmentVariables();
+
+    /**
+     * Queries this process's bitness (32 or 64), or {@code 0} if unknown.
+     *
+     * @return the bitness
+     */
+    protected abstract int queryBitness();
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides shared abstract base classes for the BSD-family operating systems
+ */
+package oshi.software.common.os.unix.bsd;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
@@ -8,9 +8,9 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
-import oshi.software.common.AbstractOSProcess;
+import oshi.software.common.os.unix.bsd.BsdOSProcess;
 
-public abstract class DragonFlyBsdOSProcess extends AbstractOSProcess {
+public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
 
     /**
      * Columns requested from {@code ps -awwxo} when enumerating threads. Shared by DragonFlyBsdOSProcess subclasses and

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSProcess.java
@@ -8,9 +8,9 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
-import oshi.software.common.AbstractOSProcess;
+import oshi.software.common.os.unix.bsd.BsdOSProcess;
 
-public abstract class FreeBsdOSProcess extends AbstractOSProcess {
+public abstract class FreeBsdOSProcess extends BsdOSProcess {
 
     /**
      * Columns requested from {@code ps -awwxo} when enumerating threads. Shared by FreeBsdOSProcess subclasses and

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -5,14 +5,7 @@
 package oshi.software.common.os.unix.netbsd;
 
 import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
 import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
-import static oshi.util.Memoizer.memoize;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,14 +13,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.common.AbstractOSProcess;
+import oshi.software.common.os.unix.bsd.BsdOSProcess;
 import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem.PsKeywords;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
@@ -40,7 +32,7 @@ import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
  * OSProcess implementation
  */
 @ThreadSafe
-public class NetBsdOSProcess extends AbstractOSProcess {
+public class NetBsdOSProcess extends BsdOSProcess {
 
     private static final Logger LOG = LoggerFactory.getLogger(NetBsdOSProcess.class);
 
@@ -58,71 +50,15 @@ public class NetBsdOSProcess extends AbstractOSProcess {
 
     private final NetBsdOperatingSystem os;
 
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<List<String>> arguments = memoize(this::queryArguments);
-    private Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
-
-    private String name;
-    private String path = "";
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
-    private long minorFaults;
-    private long majorFaults;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
-    private int bitness;
-    private String commandLineBackup;
-
     public NetBsdOSProcess(int pid, Map<PsKeywords, String> psMap, NetBsdOperatingSystem os) {
         super(pid);
         this.os = os;
-        // NetBSD does not maintain a compatibility layer.
-        // Process bitness is OS bitness
-        this.bitness = System.getProperty("os.arch", "").contains("64") ? 64 : 32;
         updateThreadCount();
         updateAttributes(psMap);
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        String cl = String.join(" ", getArguments());
-        return cl.isEmpty() ? this.commandLineBackup : cl;
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return arguments.get();
-    }
-
-    private List<String> queryArguments() {
+    protected List<String> queryArguments() {
         // NetBSD provides command line via /proc filesystem
         byte[] cmdBytes = FileUtil.readAllBytes("/proc/" + getProcessID() + "/cmdline", false);
         if (cmdBytes != null && cmdBytes.length > 0) {
@@ -132,11 +68,7 @@ public class NetBsdOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return environmentVariables.get();
-    }
-
-    private Map<String, String> queryEnvironmentVariables() {
+    protected Map<String, String> queryEnvironmentVariables() {
         // For the current process, use Java's System.getenv()
         if (getProcessID() == this.os.getProcessId()) {
             return System.getenv();
@@ -148,86 +80,6 @@ public class NetBsdOSProcess extends AbstractOSProcess {
     @Override
     public String getCurrentWorkingDirectory() {
         return FstatUtil.getCwd(getProcessID());
-    }
-
-    @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
     }
 
     @Override
@@ -257,8 +109,10 @@ public class NetBsdOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public int getBitness() {
-        return this.bitness;
+    protected int queryBitness() {
+        // NetBSD does not maintain a compatibility layer.
+        // Process bitness is OS bitness
+        return System.getProperty("os.arch", "").contains("64") ? 64 : 32;
     }
 
     @Override
@@ -300,26 +154,6 @@ public class NetBsdOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        return this.voluntaryContextSwitches;
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        return this.involuntaryContextSwitches;
-    }
-
-    @Override
     public boolean updateAttributes() {
         // 'ps' does not provide threadCount or kernelTime on NetBSD
         String psCommand = "ps -awwxo " + NetBsdOperatingSystem.PS_COMMAND_ARGS + " -p " + getProcessID();
@@ -339,29 +173,7 @@ public class NetBsdOSProcess extends AbstractOSProcess {
 
     private boolean updateAttributes(Map<PsKeywords, String> psMap) {
         long now = System.currentTimeMillis();
-        switch (psMap.get(PsKeywords.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
+        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
         this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
         this.user = psMap.get(PsKeywords.USER);
         this.userID = psMap.get(PsKeywords.UID);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
@@ -8,9 +8,9 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
-import oshi.software.common.AbstractOSProcess;
+import oshi.software.common.os.unix.bsd.BsdOSProcess;
 
-public abstract class OpenBsdOSProcess extends AbstractOSProcess {
+public abstract class OpenBsdOSProcess extends BsdOSProcess {
 
     /**
      * Columns requested from {@code ps -aHwwxo} when enumerating threads. Shared by OpenBsdOSProcess subclasses and

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
@@ -11,26 +11,14 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
 import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
-import static oshi.util.Memoizer.memoize;
 
 import java.lang.foreign.MemorySegment;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -58,35 +46,6 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
 
     private final DragonFlyBsdOperatingSystemFFM os;
 
-    private Supplier<Integer> bitness = memoize(this::queryBitness);
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<List<String>> arguments = memoize(this::queryArguments);
-    private Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
-
-    private String name;
-    private String path = "";
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
-    private long minorFaults;
-    private long majorFaults;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
-    private String commandLineBackup;
-
     public DragonFlyBsdOSProcessFFM(int pid, Map<PsKeywords, String> psMap, DragonFlyBsdOperatingSystemFFM os) {
         super(pid);
         this.os = os;
@@ -94,31 +53,7 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        String cl = String.join(" ", getArguments());
-        return cl.isEmpty() ? this.commandLineBackup : cl;
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return arguments.get();
-    }
-
-    private List<String> queryArguments() {
+    protected List<String> queryArguments() {
         // DragonFlyBSD provides command line via /proc filesystem
         byte[] cmdBytes = FileUtil.readAllBytes("/proc/" + getProcessID() + "/cmdline", false);
         if (cmdBytes != null && cmdBytes.length > 0) {
@@ -128,11 +63,7 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
     }
 
     @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return environmentVariables.get();
-    }
-
-    private Map<String, String> queryEnvironmentVariables() {
+    protected Map<String, String> queryEnvironmentVariables() {
         // DragonFlyBSD's /proc does not expose environ for other processes.
         // For the current process, use Java's System.getenv().
         int self = callInArenaIntOrDefault(arena -> FreeBsdLibcFunctions.getpid(), LOG, Level.WARN, "getpid failed",
@@ -146,86 +77,6 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
     @Override
     public String getCurrentWorkingDirectory() {
         return ProcstatUtil.getCwd(getProcessID());
-    }
-
-    @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
     }
 
     @Override
@@ -260,33 +111,7 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
     }
 
     @Override
-    public int getBitness() {
-        return this.bitness.get();
-    }
-
-    @Override
-    public long getAffinityMask() {
-        long bitMask = 0L;
-        // Would prefer to use native cpuset_getaffinity call but variable sizing is
-        // kernel-dependent and requires C macros, so we use commandline instead.
-        String cpuset = ExecutingCommand.getFirstAnswer("cpuset -gp " + getProcessID());
-        // Sample output:
-        // pid 8 mask: 0, 1
-        // cpuset: getaffinity: No such process
-        String[] split = cpuset.split(":");
-        if (split.length > 1) {
-            String[] bits = split[1].split(",");
-            for (String bit : bits) {
-                int bitToSet = ParseUtil.parseIntOrDefault(bit.trim(), -1);
-                if (bitToSet >= 0 && bitToSet < Long.SIZE) {
-                    bitMask |= 1L << bitToSet;
-                }
-            }
-        }
-        return bitMask;
-    }
-
-    private int queryBitness() {
+    protected int queryBitness() {
         return callInArenaIntOrDefault(arena -> {
             // CTL_KERN.KERN_PROC.KERN_PROC_SV_NAME.<pid>
             MemorySegment mib = arena.allocateFrom(JAVA_INT, 1, 14, 9, getProcessID());
@@ -323,26 +148,6 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
     }
 
     @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        return this.voluntaryContextSwitches;
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        return this.involuntaryContextSwitches;
-    }
-
-    @Override
     public boolean updateAttributes() {
         String psCommand = "ps -awwxo " + DragonFlyBsdOperatingSystemFFM.PS_COMMAND_ARGS + " -p " + getProcessID();
         List<String> procList = ExecutingCommand.runNative(psCommand);
@@ -360,29 +165,7 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
 
     private boolean updateAttributes(Map<PsKeywords, String> psMap) {
         long now = System.currentTimeMillis();
-        switch (psMap.get(PsKeywords.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
+        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
         this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
         this.user = psMap.get(PsKeywords.USER);
         this.userID = psMap.get(PsKeywords.UID);
@@ -424,25 +207,5 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
             }
         }
         return System.currentTimeMillis();
-    }
-
-    private long getProcessOpenFileLimit(long processId, int index) {
-        final String limitsPath = String.format(Locale.ROOT, "/proc/%d/limits", processId);
-        if (!Files.exists(Paths.get(limitsPath))) {
-            return -1; // not supported
-        }
-        final List<String> lines = FileUtil.readFile(limitsPath);
-        final Optional<String> maxOpenFilesLine = lines.stream().filter(line -> line.startsWith("Max open files"))
-                .findFirst();
-        if (!maxOpenFilesLine.isPresent()) {
-            return -1;
-        }
-
-        // Split all non-Digits away -> ["", "{soft-limit}, "{hard-limit}"]
-        final String[] split = maxOpenFilesLine.get().split("\\D+");
-        if (split.length <= index) {
-            return -1;
-        }
-        return ParseUtil.parseLongOrDefault(split[index], -1);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
@@ -13,26 +13,14 @@ import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.RLIMIT_LAYOUT;
 import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.RLIMIT_NOFILE;
 import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.SIZE_T;
 import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
 import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
-import static oshi.util.Memoizer.memoize;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -46,7 +34,6 @@ import oshi.software.common.os.unix.freebsd.FreeBsdOSThread;
 import oshi.software.os.OSThread;
 import oshi.software.os.unix.freebsd.FreeBsdOperatingSystemFFM.PsKeywords;
 import oshi.util.ExecutingCommand;
-import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.freebsd.ProcstatUtil;
 
@@ -69,35 +56,6 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
 
     private final FreeBsdOperatingSystemFFM os;
 
-    private Supplier<Integer> bitness = memoize(this::queryBitness);
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<List<String>> arguments = memoize(this::queryArguments);
-    private Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
-
-    private String name;
-    private String path = "";
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
-    private long minorFaults;
-    private long majorFaults;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
-    private String commandLineBackup;
-
     public FreeBsdOSProcessFFM(int pid, Map<PsKeywords, String> psMap, FreeBsdOperatingSystemFFM os) {
         super(pid);
         this.os = os;
@@ -105,31 +63,7 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        String cl = String.join(" ", getArguments());
-        return cl.isEmpty() ? this.commandLineBackup : cl;
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return arguments.get();
-    }
-
-    private List<String> queryArguments() {
+    protected List<String> queryArguments() {
         if (ARGMAX <= 0) {
             return Collections.emptyList();
         }
@@ -152,11 +86,7 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
     }
 
     @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return environmentVariables.get();
-    }
-
-    private Map<String, String> queryEnvironmentVariables() {
+    protected Map<String, String> queryEnvironmentVariables() {
         if (ARGMAX <= 0) {
             return Collections.emptyMap();
         }
@@ -181,86 +111,6 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
     @Override
     public String getCurrentWorkingDirectory() {
         return ProcstatUtil.getCwd(getProcessID());
-    }
-
-    @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
     }
 
     @Override
@@ -298,30 +148,7 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
     }
 
     @Override
-    public int getBitness() {
-        return this.bitness.get();
-    }
-
-    @Override
-    public long getAffinityMask() {
-        long bitMask = 0L;
-        // Would prefer to use native cpuset_getaffinity call but variable sizing is
-        // kernel-dependent and requires C macros, so we use commandline instead.
-        String cpuset = ExecutingCommand.getFirstAnswer("cpuset -gp " + getProcessID());
-        String[] split = cpuset.split(":");
-        if (split.length > 1) {
-            String[] bits = split[1].split(",");
-            for (String bit : bits) {
-                int bitToSet = ParseUtil.parseIntOrDefault(bit.trim(), -1);
-                if (bitToSet >= 0 && bitToSet < Long.SIZE) {
-                    bitMask |= 1L << bitToSet;
-                }
-            }
-        }
-        return bitMask;
-    }
-
-    private int queryBitness() {
+    protected int queryBitness() {
         return callInArenaOrDefault(arena -> {
             MemorySegment mib = arena.allocateFrom(JAVA_INT, CTL_KERN, KERN_PROC, KERN_PROC_SV_NAME, getProcessID());
             MemorySegment buf = arena.allocate(32L);
@@ -354,26 +181,6 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
     }
 
     @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        return this.voluntaryContextSwitches;
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        return this.involuntaryContextSwitches;
-    }
-
-    @Override
     public boolean updateAttributes() {
         String psCommand = "ps -awwxo " + FreeBsdOperatingSystemFFM.PS_COMMAND_ARGS + " -p " + getProcessID();
         List<String> procList = ExecutingCommand.runNative(psCommand);
@@ -391,29 +198,7 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
 
     private boolean updateAttributes(Map<PsKeywords, String> psMap) {
         long now = System.currentTimeMillis();
-        switch (psMap.get(PsKeywords.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
+        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
         this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
         this.user = psMap.get(PsKeywords.USER);
         this.userID = psMap.get(PsKeywords.UID);
@@ -434,31 +219,9 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
         this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
         this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
         this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
-        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
-        this.voluntaryContextSwitches = voluntaryContextSwitches;
-        this.involuntaryContextSwitches = nonVoluntaryContextSwitches;
+        this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
+        this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
         this.commandLineBackup = psMap.get(PsKeywords.ARGS);
         return true;
-    }
-
-    private long getProcessOpenFileLimit(long processId, int index) {
-        final String limitsPath = String.format(Locale.ROOT, "/proc/%d/limits", processId);
-        if (!Files.exists(Paths.get(limitsPath))) {
-            return -1; // not supported
-        }
-        final List<String> lines = FileUtil.readFile(limitsPath);
-        final Optional<String> maxOpenFilesLine = lines.stream().filter(line -> line.startsWith("Max open files"))
-                .findFirst();
-        if (!maxOpenFilesLine.isPresent()) {
-            return -1;
-        }
-
-        // Split all non-Digits away -> ["", "{soft-limit}, "{hard-limit}"]
-        final String[] split = maxOpenFilesLine.get().split("\\D+");
-        if (split.length <= index) {
-            return -1;
-        }
-        return ParseUtil.parseLongOrDefault(split[index], -1);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
@@ -16,14 +16,7 @@ import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_PROC_ENV;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.RLIMIT_NOFILE;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.SIZE_T;
 import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
 import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
-import static oshi.util.Memoizer.memoize;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -33,7 +26,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -64,69 +56,20 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
 
     private final OpenBsdOperatingSystemFFM os;
 
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<List<String>> arguments = memoize(this::queryArguments);
-    private Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
-
-    private String name;
-    private String path = "";
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
-    private long minorFaults;
-    private long majorFaults;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
-    private int bitness;
-    private String commandLineBackup;
-
     public OpenBsdOSProcessFFM(int pid, Map<PsKeywords, String> psMap, OpenBsdOperatingSystemFFM os) {
         super(pid);
         this.os = os;
-        this.bitness = (int) (NATIVE_LONG_SIZE * 8);
         updateThreadCount();
         updateAttributes(psMap);
     }
 
     @Override
-    public String getName() {
-        return this.name;
+    protected int queryBitness() {
+        return (int) (NATIVE_LONG_SIZE * 8);
     }
 
     @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        String cl = String.join(" ", getArguments());
-        return cl.isEmpty() ? this.commandLineBackup : cl;
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return arguments.get();
-    }
-
-    private List<String> queryArguments() {
+    protected List<String> queryArguments() {
         if (ARGMAX > 0) {
             int[] mib = { CTL_KERN, KERN_PROC_ARGS, getProcessID(), KERN_PROC_ARGV };
             try (Arena arena = Arena.ofConfined()) {
@@ -160,11 +103,7 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
     }
 
     @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return environmentVariables.get();
-    }
-
-    private Map<String, String> queryEnvironmentVariables() {
+    protected Map<String, String> queryEnvironmentVariables() {
         if (ARGMAX > 0) {
             int[] mib = { CTL_KERN, KERN_PROC_ARGS, getProcessID(), KERN_PROC_ENV };
             try (Arena arena = Arena.ofConfined()) {
@@ -207,86 +146,6 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
     }
 
     @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
-    }
-
-    @Override
     public long getOpenFiles() {
         return FstatUtil.getOpenFiles(getProcessID());
     }
@@ -318,28 +177,6 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
     }
 
     @Override
-    public int getBitness() {
-        return this.bitness;
-    }
-
-    @Override
-    public long getAffinityMask() {
-        long bitMask = 0L;
-        String cpuset = ExecutingCommand.getFirstAnswer("cpuset -gp " + getProcessID());
-        String[] split = cpuset.split(":");
-        if (split.length > 1) {
-            String[] bits = split[1].split(",");
-            for (String bit : bits) {
-                int bitToSet = ParseUtil.parseIntOrDefault(bit.trim(), -1);
-                if (bitToSet >= 0) {
-                    bitMask |= 1L << bitToSet;
-                }
-            }
-        }
-        return bitMask;
-    }
-
-    @Override
     public List<OSThread> getThreadDetails() {
         String psCommand = "ps -aHwwxo " + PS_THREAD_COLUMNS;
         if (getProcessID() >= 0) {
@@ -351,26 +188,6 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
                 .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
                 .filter(hasColumnsArgs).map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap))
                 .filter(VALID_THREAD).collect(Collectors.toList());
-    }
-
-    @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        return this.voluntaryContextSwitches;
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        return this.involuntaryContextSwitches;
     }
 
     @Override
@@ -390,29 +207,7 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
 
     private boolean updateAttributes(Map<PsKeywords, String> psMap) {
         long now = System.currentTimeMillis();
-        switch (psMap.get(PsKeywords.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
+        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
         this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
         this.user = psMap.get(PsKeywords.USER);
         this.userID = psMap.get(PsKeywords.UID);

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
@@ -5,24 +5,12 @@
 package oshi.software.os.unix.dragonflybsd;
 
 import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
 import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
-import static oshi.util.Memoizer.memoize;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -54,35 +42,6 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
 
     private final DragonFlyBsdOperatingSystemJNA os;
 
-    private Supplier<Integer> bitness = memoize(this::queryBitness);
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<List<String>> arguments = memoize(this::queryArguments);
-    private Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
-
-    private String name;
-    private String path = "";
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
-    private long minorFaults;
-    private long majorFaults;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
-    private String commandLineBackup;
-
     public DragonFlyBsdOSProcessJNA(int pid, Map<PsKeywords, String> psMap, DragonFlyBsdOperatingSystemJNA os) {
         super(pid);
         this.os = os;
@@ -90,31 +49,7 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        String cl = String.join(" ", getArguments());
-        return cl.isEmpty() ? this.commandLineBackup : cl;
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return arguments.get();
-    }
-
-    private List<String> queryArguments() {
+    protected List<String> queryArguments() {
         // DragonFlyBSD provides command line via /proc filesystem
         byte[] cmdBytes = FileUtil.readAllBytes("/proc/" + getProcessID() + "/cmdline", false);
         if (cmdBytes != null && cmdBytes.length > 0) {
@@ -124,11 +59,7 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
     }
 
     @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return environmentVariables.get();
-    }
-
-    private Map<String, String> queryEnvironmentVariables() {
+    protected Map<String, String> queryEnvironmentVariables() {
         // DragonFlyBSD's /proc does not expose environ for other processes.
         // For the current process, use Java's System.getenv().
         if (getProcessID() == DragonFlyBsdLibc.INSTANCE.getpid()) {
@@ -140,86 +71,6 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
     @Override
     public String getCurrentWorkingDirectory() {
         return ProcstatUtil.getCwd(getProcessID());
-    }
-
-    @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
     }
 
     @Override
@@ -250,33 +101,7 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
     }
 
     @Override
-    public int getBitness() {
-        return this.bitness.get();
-    }
-
-    @Override
-    public long getAffinityMask() {
-        long bitMask = 0L;
-        // Would prefer to use native cpuset_getaffinity call but variable sizing is
-        // kernel-dependent and requires C macros, so we use commandline instead.
-        String cpuset = ExecutingCommand.getFirstAnswer("cpuset -gp " + getProcessID());
-        // Sample output:
-        // pid 8 mask: 0, 1
-        // cpuset: getaffinity: No such process
-        String[] split = cpuset.split(":");
-        if (split.length > 1) {
-            String[] bits = split[1].split(",");
-            for (String bit : bits) {
-                int bitToSet = ParseUtil.parseIntOrDefault(bit.trim(), -1);
-                if (bitToSet >= 0 && bitToSet < Long.SIZE) {
-                    bitMask |= 1L << bitToSet;
-                }
-            }
-        }
-        return bitMask;
-    }
-
-    private int queryBitness() {
+    protected int queryBitness() {
         // Get process abi vector
         int[] mib = new int[4];
         mib[0] = 1; // CTL_KERN
@@ -312,26 +137,6 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
     }
 
     @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        return this.voluntaryContextSwitches;
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        return this.involuntaryContextSwitches;
-    }
-
-    @Override
     public boolean updateAttributes() {
         String psCommand = "ps -awwxo " + DragonFlyBsdOperatingSystemJNA.PS_COMMAND_ARGS + " -p " + getProcessID();
         List<String> procList = ExecutingCommand.runNative(psCommand);
@@ -349,29 +154,7 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
 
     private boolean updateAttributes(Map<PsKeywords, String> psMap) {
         long now = System.currentTimeMillis();
-        switch (psMap.get(PsKeywords.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
+        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
         this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
         this.user = psMap.get(PsKeywords.USER);
         this.userID = psMap.get(PsKeywords.UID);
@@ -413,25 +196,5 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
             }
         }
         return System.currentTimeMillis();
-    }
-
-    private long getProcessOpenFileLimit(long processId, int index) {
-        final String limitsPath = String.format(Locale.ROOT, "/proc/%d/limits", processId);
-        if (!Files.exists(Paths.get(limitsPath))) {
-            return -1; // not supported
-        }
-        final List<String> lines = FileUtil.readFile(limitsPath);
-        final Optional<String> maxOpenFilesLine = lines.stream().filter(line -> line.startsWith("Max open files"))
-                .findFirst();
-        if (!maxOpenFilesLine.isPresent()) {
-            return -1;
-        }
-
-        // Split all non-Digits away -> ["", "{soft-limit}, "{hard-limit}"]
-        final String[] split = maxOpenFilesLine.get().split("\\D+");
-        if (split.length <= index) {
-            return -1;
-        }
-        return ParseUtil.parseLongOrDefault(split[index], -1);
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessJNA.java
@@ -5,24 +5,12 @@
 package oshi.software.os.unix.freebsd;
 
 import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
 import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
-import static oshi.util.Memoizer.memoize;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -41,13 +29,12 @@ import oshi.software.common.os.unix.freebsd.FreeBsdOSThread;
 import oshi.software.os.OSThread;
 import oshi.software.os.unix.freebsd.FreeBsdOperatingSystemJNA.PsKeywords;
 import oshi.util.ExecutingCommand;
-import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.freebsd.ProcstatUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
 
 /**
- * OSProcess implementation
+ * JNA-backed FreeBSD OSProcess.
  */
 @ThreadSafe
 public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
@@ -58,35 +45,6 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
 
     private final FreeBsdOperatingSystemJNA os;
 
-    private Supplier<Integer> bitness = memoize(this::queryBitness);
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<List<String>> arguments = memoize(this::queryArguments);
-    private Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
-
-    private String name;
-    private String path = "";
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
-    private long minorFaults;
-    private long majorFaults;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
-    private String commandLineBackup;
-
     public FreeBsdOSProcessJNA(int pid, Map<PsKeywords, String> psMap, FreeBsdOperatingSystemJNA os) {
         super(pid);
         this.os = os;
@@ -94,31 +52,7 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        String cl = String.join(" ", getArguments());
-        return cl.isEmpty() ? this.commandLineBackup : cl;
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return arguments.get();
-    }
-
-    private List<String> queryArguments() {
+    protected List<String> queryArguments() {
         if (ARGMAX > 0) {
             // Get arguments via sysctl(3)
             int[] mib = new int[4];
@@ -144,11 +78,7 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
     }
 
     @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return environmentVariables.get();
-    }
-
-    private Map<String, String> queryEnvironmentVariables() {
+    protected Map<String, String> queryEnvironmentVariables() {
         if (ARGMAX > 0) {
             // Get environment variables via sysctl(3)
             int[] mib = new int[4];
@@ -179,86 +109,6 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
     }
 
     @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
-    }
-
-    @Override
     public long getOpenFiles() {
         return ProcstatUtil.getOpenFiles(getProcessID());
     }
@@ -286,33 +136,7 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
     }
 
     @Override
-    public int getBitness() {
-        return this.bitness.get();
-    }
-
-    @Override
-    public long getAffinityMask() {
-        long bitMask = 0L;
-        // Would prefer to use native cpuset_getaffinity call but variable sizing is
-        // kernel-dependent and requires C macros, so we use commandline instead.
-        String cpuset = ExecutingCommand.getFirstAnswer("cpuset -gp " + getProcessID());
-        // Sample output:
-        // pid 8 mask: 0, 1
-        // cpuset: getaffinity: No such process
-        String[] split = cpuset.split(":");
-        if (split.length > 1) {
-            String[] bits = split[1].split(",");
-            for (String bit : bits) {
-                int bitToSet = ParseUtil.parseIntOrDefault(bit.trim(), -1);
-                if (bitToSet >= 0 && bitToSet < Long.SIZE) {
-                    bitMask |= 1L << bitToSet;
-                }
-            }
-        }
-        return bitMask;
-    }
-
-    private int queryBitness() {
+    protected int queryBitness() {
         // Get process abi vector
         int[] mib = new int[4];
         mib[0] = 1; // CTL_KERN
@@ -348,26 +172,6 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
     }
 
     @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        return this.voluntaryContextSwitches;
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        return this.involuntaryContextSwitches;
-    }
-
-    @Override
     public boolean updateAttributes() {
         String psCommand = "ps -awwxo " + FreeBsdOperatingSystemJNA.PS_COMMAND_ARGS + " -p " + getProcessID();
         List<String> procList = ExecutingCommand.runNative(psCommand);
@@ -385,29 +189,7 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
 
     private boolean updateAttributes(Map<PsKeywords, String> psMap) {
         long now = System.currentTimeMillis();
-        switch (psMap.get(PsKeywords.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
+        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
         this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
         this.user = psMap.get(PsKeywords.USER);
         this.userID = psMap.get(PsKeywords.UID);
@@ -428,31 +210,9 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
         this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
         this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
         this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
-        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
-        this.voluntaryContextSwitches = voluntaryContextSwitches;
-        this.involuntaryContextSwitches = nonVoluntaryContextSwitches;
+        this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
+        this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
         this.commandLineBackup = psMap.get(PsKeywords.ARGS);
         return true;
-    }
-
-    private long getProcessOpenFileLimit(long processId, int index) {
-        final String limitsPath = String.format(Locale.ROOT, "/proc/%d/limits", processId);
-        if (!Files.exists(Paths.get(limitsPath))) {
-            return -1; // not supported
-        }
-        final List<String> lines = FileUtil.readFile(limitsPath);
-        final Optional<String> maxOpenFilesLine = lines.stream().filter(line -> line.startsWith("Max open files"))
-                .findFirst();
-        if (!maxOpenFilesLine.isPresent()) {
-            return -1;
-        }
-
-        // Split all non-Digits away -> ["", "{soft-limit}, "{hard-limit}"]
-        final String[] split = maxOpenFilesLine.get().split("\\D+");
-        if (split.length <= index) {
-            return -1;
-        }
-        return ParseUtil.parseLongOrDefault(split[index], -1);
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessJNA.java
@@ -5,14 +5,7 @@
 package oshi.software.os.unix.openbsd;
 
 import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
 import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
-import static oshi.util.Memoizer.memoize;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,7 +13,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -71,71 +63,22 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
 
     private final OpenBsdOperatingSystemJNA os;
 
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<List<String>> arguments = memoize(this::queryArguments);
-    private Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
-
-    private String name;
-    private String path = "";
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
-    private long minorFaults;
-    private long majorFaults;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
-    private int bitness;
-    private String commandLineBackup;
-
     public OpenBsdOSProcessJNA(int pid, Map<PsKeywords, String> psMap, OpenBsdOperatingSystemJNA os) {
         super(pid);
         this.os = os;
-        // OpenBSD does not maintain a compatibility layer.
-        // Process bitness is OS bitness
-        this.bitness = Native.LONG_SIZE * 8;
         updateThreadCount();
         updateAttributes(psMap);
     }
 
     @Override
-    public String getName() {
-        return this.name;
+    protected int queryBitness() {
+        // OpenBSD does not maintain a compatibility layer.
+        // Process bitness is OS bitness
+        return Native.LONG_SIZE * 8;
     }
 
     @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        String cl = String.join(" ", getArguments());
-        return cl.isEmpty() ? this.commandLineBackup : cl;
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return arguments.get();
-    }
-
-    private List<String> queryArguments() {
+    protected List<String> queryArguments() {
         if (ARGMAX > 0) {
             // Get arguments via sysctl(3)
             int[] mib = new int[4];
@@ -170,11 +113,7 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
     }
 
     @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return environmentVariables.get();
-    }
-
-    private Map<String, String> queryEnvironmentVariables() {
+    protected Map<String, String> queryEnvironmentVariables() {
         // Get environment variables via sysctl(3)
         int[] mib = new int[4];
         mib[0] = 1; // CTL_KERN
@@ -215,86 +154,6 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
     }
 
     @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
-    }
-
-    @Override
     public long getOpenFiles() {
         return FstatUtil.getOpenFiles(getProcessID());
     }
@@ -322,33 +181,6 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
     }
 
     @Override
-    public int getBitness() {
-        return this.bitness;
-    }
-
-    @Override
-    public long getAffinityMask() {
-        long bitMask = 0L;
-        // Would prefer to use native cpuset_getaffinity call but variable sizing is
-        // kernel-dependent and requires C macros, so we use commandline instead.
-        String cpuset = ExecutingCommand.getFirstAnswer("cpuset -gp " + getProcessID());
-        // Sample output:
-        // pid 8 mask: 0, 1
-        // cpuset: getaffinity: No such process
-        String[] split = cpuset.split(":");
-        if (split.length > 1) {
-            String[] bits = split[1].split(",");
-            for (String bit : bits) {
-                int bitToSet = ParseUtil.parseIntOrDefault(bit.trim(), -1);
-                if (bitToSet >= 0) {
-                    bitMask |= 1L << bitToSet;
-                }
-            }
-        }
-        return bitMask;
-    }
-
-    @Override
     public List<OSThread> getThreadDetails() {
         String psCommand = "ps -aHwwxo " + PS_THREAD_COLUMNS;
         if (getProcessID() >= 0) {
@@ -360,26 +192,6 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
                 .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
                 .filter(hasColumnsArgs).map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap))
                 .filter(VALID_THREAD).collect(Collectors.toList());
-    }
-
-    @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        return this.voluntaryContextSwitches;
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        return this.involuntaryContextSwitches;
     }
 
     @Override
@@ -402,29 +214,7 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
 
     private boolean updateAttributes(Map<PsKeywords, String> psMap) {
         long now = System.currentTimeMillis();
-        switch (psMap.get(PsKeywords.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
+        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
         this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
         this.user = psMap.get(PsKeywords.USER);
         this.userID = psMap.get(PsKeywords.UID);
@@ -459,6 +249,5 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
             // Subtract 1 for header
             this.threadCount = threadList.size() - 1;
         }
-        this.threadCount = 1;
     }
 }


### PR DESCRIPTION
Eliminates the largest remaining duplication cluster in the codebase. A SonarCloud duplication query showed the BSD `OSProcess` classes dominating the top of the list: when FreeBSD/OpenBSD/DragonFly were FFM-ported they were given near-empty bases, leaving ~450 lines of process logic duplicated in each JNA and FFM concrete — and again across the platforms (DragonFly is a FreeBSD fork). This applies the same base-extraction approach used for the Solaris series (#3367/#3368/#3369), but shared across the whole BSD family.

## What changed

- New abstract `oshi.software.common.os.unix.bsd.BsdOSProcess` holds the cross-BSD-identical, non-native logic: the field storage and all trivial accessors, the command-line/argument/environment/bitness memoization, the `ps` state mapping, the `cpuset` affinity lookup, and the `/proc/<pid>/limits` fallback.
- The per-platform bases (`FreeBsdOSProcess`, `OpenBsdOSProcess`, `DragonFlyBsdOSProcess`) now extend it and keep only their `PsThreadColumns` enum; the JNA/FFM concretes keep only the platform-specific work — the native `sysctl` argument/environment/bitness reads, `getrlimit`, `procstat`/`fstat` cwd/open-file lookups, `ps` thread enumeration, and the `ps` attribute parsing.
- `NetBsdOSProcess` (a single no-native class) folds in too: its argument/environment/bitness hooks are pure Java, and it overrides `getAffinityMask` for its `schedctl`-based lookup.

The JNA/FFM concretes drop from ~458 to ~200-250 lines each; NetBSD from 402 to 214. The shared `updateAttributes` is left per-platform because it reads each OS's own `PsKeywords` enum (which lives in the operating-system classes, not shared).

## Incidental fix

Removes a dead, unreachable `this.threadCount = 1;` in the OpenBSD JNA `updateThreadCount()` that unconditionally overwrote the computed `ps` thread count.

## Validation

Full clean reactor build plus spotless/checkstyle/forbiddenapis/javadoc pass locally. The Unix CI (FreeBSD, OpenBSD, DragonFly, NetBSD, and OpenIndiana VMs) was run on the branch and is green, so the per-platform behavior is verified unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated common BSD operating system process handling logic into a shared abstract base class, enabling code reuse across FreeBSD, OpenBSD, NetBSD, and DragonFly BSD implementations while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->