### PR TITLE
Unify ps-based BSD OSProcess parsing onto a shared BsdOSProcess base

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
@@ -226,6 +226,94 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
         return bitMask;
     }
 
+    @Override
+    public boolean updateAttributes() {
+        List<BsdPsKeyword> cols = psKeywords();
+        String psCommand = "ps -awwxo " + psCommandArgs() + " -p " + getProcessID();
+        List<String> procList = ExecutingCommand.runNative(psCommand);
+        if (procList.size() > 1) {
+            // Skip the header row and parse the first data row against this platform's columns
+            Map<BsdPsKeyword, String> psMap = ParseUtil.stringToEnumMap(BsdPsKeyword.class, cols,
+                    procList.get(1).trim(), ' ');
+            // Check if the last (thus all) value populated
+            if (psMap.containsKey(cols.get(cols.size() - 1))) {
+                return updateAttributes(psMap);
+            }
+        }
+        this.state = State.INVALID;
+        return false;
+    }
+
+    /**
+     * Populates this process's attributes from a parsed {@code ps} row. Shared by every BSD platform; differences in
+     * the available columns are handled by checking which keys are present in the map.
+     *
+     * @param psMap the parsed {@code ps} columns for this process
+     * @return {@code true} once the attributes are populated
+     */
+    protected boolean updateAttributes(Map<BsdPsKeyword, String> psMap) {
+        long now = System.currentTimeMillis();
+        this.state = getStateFromOutput(psMap.get(BsdPsKeyword.STATE).charAt(0));
+        this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PPID), 0);
+        this.user = psMap.get(BsdPsKeyword.USER);
+        this.userID = psMap.get(BsdPsKeyword.UID);
+        // Most platforms report a group name and gid. DragonFly's ps has no group column, so fall
+        // back to the user name and the real group id.
+        if (psMap.containsKey(BsdPsKeyword.GROUP)) {
+            this.group = psMap.get(BsdPsKeyword.GROUP);
+            this.groupID = psMap.get(BsdPsKeyword.GID);
+        } else {
+            this.group = this.user;
+            this.groupID = psMap.get(BsdPsKeyword.RGID);
+        }
+        this.priority = ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PRI), 0);
+        // These are in KB, multiply
+        this.virtualSize = ParseUtil.parseLongOrDefault(psMap.get(BsdPsKeyword.VSZ), 0) * 1024;
+        this.residentSetSize = ParseUtil.parseLongOrDefault(psMap.get(BsdPsKeyword.RSS), 0) * 1024;
+        // Thread count comes from the nlwp column where present; platforms that omit it (OpenBSD,
+        // NetBSD) populate it via a separate ps query.
+        if (psMap.containsKey(BsdPsKeyword.NLWP)) {
+            this.threadCount = ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.NLWP), 0);
+        } else {
+            updateThreadCount();
+        }
+        // Kernel/user time: FreeBSD reports systime separately (time is user+sys); the others fold
+        // kernel time into a single cputime/time column.
+        if (psMap.containsKey(BsdPsKeyword.SYSTIME)) {
+            this.kernelTime = ParseUtil.parseDHMSOrDefault(psMap.get(BsdPsKeyword.SYSTIME), 0L);
+            this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(BsdPsKeyword.TIME), 0L) - this.kernelTime;
+        } else if (psMap.containsKey(BsdPsKeyword.CPUTIME)) {
+            this.kernelTime = 0L;
+            this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(BsdPsKeyword.CPUTIME), 0L);
+        } else {
+            this.kernelTime = 0L;
+            this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(BsdPsKeyword.TIME), 0L);
+        }
+        // Start/up time: DragonFly resolves an absolute start time from /proc; the others derive it
+        // from the ps elapsed-time column.
+        long startMillis = queryStartTimeMillis();
+        if (startMillis > 0L) {
+            this.startTime = startMillis;
+            this.upTime = Math.max(1L, now - startMillis);
+        } else {
+            BsdPsKeyword elapsedKey = psMap.containsKey(BsdPsKeyword.ETIMES) ? BsdPsKeyword.ETIMES : BsdPsKeyword.ETIME;
+            long elapsedTime = ParseUtil.parseDHMSOrDefault(psMap.get(elapsedKey), 0L);
+            this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
+            this.startTime = now - this.upTime;
+        }
+        // Path/name come from comm (ucomm on DragonFly)
+        this.path = psMap.get(psMap.containsKey(BsdPsKeyword.UCOMM) ? BsdPsKeyword.UCOMM : BsdPsKeyword.COMM);
+        this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
+        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(BsdPsKeyword.MINFLT), 0L);
+        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(BsdPsKeyword.MAJFLT), 0L);
+        this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(BsdPsKeyword.NVCSW), 0L);
+        this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(BsdPsKeyword.NIVCSW), 0L);
+        // Command-line fallback: the full args column (named "command" on DragonFly)
+        this.commandLineBackup = psMap
+                .get(psMap.containsKey(BsdPsKeyword.COMMAND) ? BsdPsKeyword.COMMAND : BsdPsKeyword.ARGS);
+        return true;
+    }
+
     /**
      * Maps a {@code ps} single-character state to an {@link State}.
      *
@@ -276,6 +364,41 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
             return -1;
         }
         return ParseUtil.parseLongOrDefault(split[index], -1);
+    }
+
+    /**
+     * Returns this platform's ordered {@code ps} column keys, used both to build the {@code ps} command and to parse
+     * its output positionally.
+     *
+     * @return the ordered column keys
+     */
+    protected abstract List<BsdPsKeyword> psKeywords();
+
+    /**
+     * Returns the comma-separated {@code ps -o} column list for this platform, derived from {@link #psKeywords()}.
+     *
+     * @return the {@code ps} column argument
+     */
+    protected abstract String psCommandArgs();
+
+    /**
+     * Returns this process's start time in epoch milliseconds, or {@code -1} to derive it from the {@code ps}
+     * elapsed-time column. The default derives from elapsed time; platforms with an absolute source (DragonFly's
+     * {@code /proc}) override this.
+     *
+     * @return the start time in epoch milliseconds, or {@code -1} to derive from elapsed time
+     */
+    protected long queryStartTimeMillis() {
+        return -1L;
+    }
+
+    /**
+     * Populates {@link #threadCount} for platforms whose {@code ps} output lacks an {@code nlwp} column. The default is
+     * a no-op (the count is taken from the {@code nlwp} column); OpenBSD and NetBSD override this with a separate
+     * {@code ps} query.
+     */
+    protected void updateThreadCount() {
+        // Default no-op; overridden where ps lacks an nlwp column
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdPsKeyword.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdPsKeyword.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.bsd;
+
+/**
+ * The union of {@code ps} output columns used by the BSD-family {@code OSProcess} implementations (FreeBSD, OpenBSD,
+ * DragonFly, NetBSD). Each platform declares its own ordered subset (see {@code PS_KEYWORDS} on the per-platform
+ * {@code OSProcess} base) and parses {@code ps} output positionally against that subset. The constant order here is not
+ * significant; only the per-platform subset order is.
+ */
+public enum BsdPsKeyword {
+    STATE, PID, PPID, USER, UID, GROUP, GID, RGID, NLWP, PRI, VSZ, RSS, ETIME, ETIMES, CPUTIME, SYSTIME, TIME, COMM,
+    UCOMM, MAJFLT, MINFLT, NVCSW, NIVCSW, ARGS, COMMAND;
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
@@ -4,13 +4,52 @@
  */
 package oshi.software.common.os.unix.dragonflybsd;
 
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.COMMAND;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.MAJFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.MINFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.NIVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.NLWP;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.NVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PPID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PRI;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.RGID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.RSS;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.STATE;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.TIME;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.UCOMM;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.UID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.USER;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.VSZ;
+import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
+
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import oshi.software.common.os.unix.bsd.BsdOSProcess;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.os.OSThread;
+import oshi.util.ExecutingCommand;
+import oshi.util.FileUtil;
+import oshi.util.ParseUtil;
 
 public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
+
+    /**
+     * Ordered {@code ps} columns queried for each process. Shared by the DragonFlyBsdOSProcess subclasses (JNA/FFM) and
+     * the DragonFly OperatingSystem classes so the column list and parsing stay in lockstep. {@code COMMAND} must
+     * remain last.
+     */
+    public static final List<BsdPsKeyword> PS_KEYWORDS = Collections.unmodifiableList(Arrays.asList(STATE, PID, PPID,
+            USER, UID, RGID, NLWP, PRI, VSZ, RSS, TIME, MAJFLT, MINFLT, NVCSW, NIVCSW, UCOMM, COMMAND));
+
+    public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
+            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     /**
      * Columns requested from {@code ps -awwxo} when enumerating threads. Shared by DragonFlyBsdOSProcess subclasses and
@@ -25,5 +64,49 @@ public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
 
     protected DragonFlyBsdOSProcess(int pid) {
         super(pid);
+    }
+
+    @Override
+    protected List<BsdPsKeyword> psKeywords() {
+        return PS_KEYWORDS;
+    }
+
+    @Override
+    protected String psCommandArgs() {
+        return PS_COMMAND_ARGS;
+    }
+
+    @Override
+    protected long queryStartTimeMillis() {
+        return queryStartTimeFromProc(getProcessID());
+    }
+
+    private static long queryStartTimeFromProc(int pid) {
+        List<String> status = FileUtil.readFile("/proc/" + pid + "/status", false);
+        if (!status.isEmpty()) {
+            // Format: name pid ... startSec,startUsec ...
+            String[] split = ParseUtil.whitespaces.split(status.get(0).trim());
+            if (split.length >= 8) {
+                String[] timeParts = split[7].split(",");
+                long seconds = ParseUtil.parseLongOrDefault(timeParts[0], 0L);
+                if (seconds > 0) {
+                    return seconds * 1000L;
+                }
+            }
+        }
+        return System.currentTimeMillis();
+    }
+
+    @Override
+    public List<OSThread> getThreadDetails() {
+        String psCommand = "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
+        if (getProcessID() >= 0) {
+            psCommand += " -p " + getProcessID();
+        }
+        Predicate<Map<PsThreadColumns, String>> hasColumnsPri = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
+        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
+                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .filter(hasColumnsPri).map(threadMap -> new DragonFlyBsdOSThread(getProcessID(), threadMap))
+                .filter(VALID_THREAD).collect(Collectors.toList());
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
@@ -94,7 +94,8 @@ public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
                 }
             }
         }
-        return System.currentTimeMillis();
+        // Unknown start time: return the sentinel so updateAttributes() falls back to elapsed time
+        return -1L;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSProcess.java
@@ -4,13 +4,54 @@
  */
 package oshi.software.common.os.unix.freebsd;
 
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.ARGS;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.COMM;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.ETIMES;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.GID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.GROUP;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.MAJFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.MINFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.NIVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.NLWP;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.NVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PPID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PRI;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.RSS;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.STATE;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.SYSTIME;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.TIME;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.UID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.USER;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.VSZ;
+import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
+
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import oshi.software.common.os.unix.bsd.BsdOSProcess;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.os.OSThread;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
 
 public abstract class FreeBsdOSProcess extends BsdOSProcess {
+
+    /**
+     * Ordered {@code ps} columns queried for each process. Shared by the FreeBsdOSProcess subclasses (JNA/FFM) and the
+     * FreeBSD OperatingSystem classes so the column list and parsing stay in lockstep. {@code ARGS} must remain last.
+     */
+    public static final List<BsdPsKeyword> PS_KEYWORDS = Collections
+            .unmodifiableList(Arrays.asList(STATE, PID, PPID, USER, UID, GROUP, GID, NLWP, PRI, VSZ, RSS, ETIMES,
+                    SYSTIME, TIME, COMM, MAJFLT, MINFLT, NVCSW, NIVCSW, ARGS));
+
+    public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
+            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     /**
      * Columns requested from {@code ps -awwxo} when enumerating threads. Shared by FreeBsdOSProcess subclasses and
@@ -25,5 +66,28 @@ public abstract class FreeBsdOSProcess extends BsdOSProcess {
 
     protected FreeBsdOSProcess(int pid) {
         super(pid);
+    }
+
+    @Override
+    protected List<BsdPsKeyword> psKeywords() {
+        return PS_KEYWORDS;
+    }
+
+    @Override
+    protected String psCommandArgs() {
+        return PS_COMMAND_ARGS;
+    }
+
+    @Override
+    public List<OSThread> getThreadDetails() {
+        String psCommand = "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
+        if (getProcessID() >= 0) {
+            psCommand += " -p " + getProcessID();
+        }
+        Predicate<Map<PsThreadColumns, String>> hasColumnsPri = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
+        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
+                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .filter(hasColumnsPri).map(threadMap -> new FreeBsdOSThread(getProcessID(), threadMap))
+                .filter(VALID_THREAD).collect(Collectors.toList());
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -4,7 +4,24 @@
  */
 package oshi.software.common.os.unix.netbsd;
 
-import static oshi.software.os.OSProcess.State.INVALID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.ARGS;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.COMM;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.CPUTIME;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.ETIME;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.GID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.GROUP;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.MAJFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.MINFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.NIVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.NVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PPID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PRI;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.RSS;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.STATE;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.UID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.USER;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.VSZ;
 import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 
 import java.util.Arrays;
@@ -15,12 +32,9 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.os.unix.bsd.BsdOSProcess;
-import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem.PsKeywords;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
@@ -34,7 +48,15 @@ import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
 @ThreadSafe
 public class NetBsdOSProcess extends BsdOSProcess {
 
-    private static final Logger LOG = LoggerFactory.getLogger(NetBsdOSProcess.class);
+    /**
+     * Ordered {@code ps} columns queried for each process. Shared by NetBsdOSProcess and the NetBSD OperatingSystem so
+     * the column list and parsing stay in lockstep. {@code ARGS} must remain last.
+     */
+    public static final List<BsdPsKeyword> PS_KEYWORDS = Collections.unmodifiableList(Arrays.asList(STATE, PID, PPID,
+            USER, UID, GROUP, GID, PRI, VSZ, RSS, ETIME, CPUTIME, COMM, MAJFLT, MINFLT, NVCSW, NIVCSW, ARGS));
+
+    public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
+            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     /*
      * Package-private for use by NetBsdOSThread
@@ -46,15 +68,22 @@ public class NetBsdOSProcess extends BsdOSProcess {
     static final String PS_THREAD_COLUMNS = Arrays.stream(PsThreadColumns.values()).map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
-    private static final int ARGMAX = NetBsdSysctlUtil.sysctl("kern.argmax", 0);
-
     private final NetBsdOperatingSystem os;
 
-    public NetBsdOSProcess(int pid, Map<PsKeywords, String> psMap, NetBsdOperatingSystem os) {
+    public NetBsdOSProcess(int pid, Map<BsdPsKeyword, String> psMap, NetBsdOperatingSystem os) {
         super(pid);
         this.os = os;
-        updateThreadCount();
         updateAttributes(psMap);
+    }
+
+    @Override
+    protected List<BsdPsKeyword> psKeywords() {
+        return PS_KEYWORDS;
+    }
+
+    @Override
+    protected String psCommandArgs() {
+        return PS_COMMAND_ARGS;
     }
 
     @Override
@@ -154,55 +183,7 @@ public class NetBsdOSProcess extends BsdOSProcess {
     }
 
     @Override
-    public boolean updateAttributes() {
-        // 'ps' does not provide threadCount or kernelTime on NetBSD
-        String psCommand = "ps -awwxo " + NetBsdOperatingSystem.PS_COMMAND_ARGS + " -p " + getProcessID();
-        List<String> procList = ExecutingCommand.runNative(psCommand);
-        if (procList.size() > 1) {
-            // skip header row
-            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, procList.get(1).trim(), ' ');
-            // Check if last (thus all) value populated
-            if (psMap.containsKey(PsKeywords.ARGS)) {
-                updateThreadCount();
-                return updateAttributes(psMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsKeywords, String> psMap) {
-        long now = System.currentTimeMillis();
-        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
-        this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
-        this.user = psMap.get(PsKeywords.USER);
-        this.userID = psMap.get(PsKeywords.UID);
-        this.group = psMap.get(PsKeywords.GROUP);
-        this.groupID = psMap.get(PsKeywords.GID);
-        this.priority = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PRI), 0);
-        // These are in KB, multiply
-        this.virtualSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.VSZ), 0) * 1024;
-        this.residentSetSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.RSS), 0) * 1024;
-        // Avoid divide by zero for processes up less than a second
-        long elapsedTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.ETIME), 0L);
-        this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
-        this.startTime = now - this.upTime;
-        this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.CPUTIME), 0L);
-        // kernel time is included in user time
-        this.kernelTime = 0L;
-        this.path = psMap.get(PsKeywords.COMM);
-        this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
-        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
-        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
-        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
-        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        this.voluntaryContextSwitches = voluntaryContextSwitches;
-        this.involuntaryContextSwitches = nonVoluntaryContextSwitches;
-        this.commandLineBackup = psMap.get(PsKeywords.ARGS);
-        return true;
-    }
-
-    private void updateThreadCount() {
+    protected void updateThreadCount() {
         // Use nlwp keyword to get LWP count for this process
         List<String> nlwpList = ExecutingCommand.runNative("ps -o nlwp -p " + getProcessID());
         if (nlwpList.size() > 1) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -176,7 +176,7 @@ public class NetBsdOSProcess extends BsdOSProcess {
         }
         Predicate<Map<PsThreadColumns, String>> hasColumnsArgs = threadMap -> threadMap
                 .containsKey(PsThreadColumns.ARGS);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1)
+        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
                 .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
                 .filter(hasColumnsArgs).map(threadMap -> new NetBsdOSThread(getProcessID(), threadMap))
                 .filter(VALID_THREAD).collect(Collectors.toList());

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
@@ -9,10 +9,8 @@ import static oshi.software.os.OSService.State.STOPPED;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -22,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
@@ -43,17 +42,6 @@ public class NetBsdOperatingSystem extends AbstractOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(NetBsdOperatingSystem.class);
 
     private static final long BOOTTIME = querySystemBootTime();
-
-    /*
-     * Package-private for use by NetBsdOSProcess
-     */
-    enum PsKeywords {
-        STATE, PID, PPID, USER, UID, GROUP, GID, PRI, VSZ, RSS, ETIME, CPUTIME, COMM, MAJFLT, MINFLT, NVCSW, NIVCSW,
-        ARGS; // ARGS must always be last
-    }
-
-    static final String PS_COMMAND_ARGS = Arrays.stream(PsKeywords.values()).map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     @Override
     public String queryManufacturer() {
@@ -120,7 +108,7 @@ public class NetBsdOperatingSystem extends AbstractOperatingSystem {
         List<OSProcess> procs = new ArrayList<>();
         // https://man.netbsd.org/ps#KEYWORDS
         // missing are threadCount and kernelTime which is included in cputime
-        String psCommand = "ps -awwxo " + PS_COMMAND_ARGS;
+        String psCommand = "ps -awwxo " + NetBsdOSProcess.PS_COMMAND_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
         }
@@ -133,11 +121,12 @@ public class NetBsdOperatingSystem extends AbstractOperatingSystem {
         procList.remove(0);
         // Fill list
         for (String proc : procList) {
-            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ');
+            Map<BsdPsKeyword, String> psMap = ParseUtil.stringToEnumMap(BsdPsKeyword.class, NetBsdOSProcess.PS_KEYWORDS,
+                    proc.trim(), ' ');
             // Check if last (thus all) value populated
-            if (psMap.containsKey(PsKeywords.ARGS)) {
-                procs.add(new NetBsdOSProcess(pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid,
-                        psMap, this));
+            if (psMap.containsKey(BsdPsKeyword.ARGS)) {
+                procs.add(new NetBsdOSProcess(
+                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this));
             }
         }
         return procs;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
@@ -4,13 +4,51 @@
  */
 package oshi.software.common.os.unix.openbsd;
 
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.ARGS;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.COMM;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.CPUTIME;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.ETIME;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.GID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.GROUP;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.MAJFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.MINFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.NIVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.NVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PPID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.PRI;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.RSS;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.STATE;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.UID;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.USER;
+import static oshi.software.common.os.unix.bsd.BsdPsKeyword.VSZ;
+import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
+
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import oshi.software.common.os.unix.bsd.BsdOSProcess;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.os.OSThread;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
 
 public abstract class OpenBsdOSProcess extends BsdOSProcess {
+
+    /**
+     * Ordered {@code ps} columns queried for each process. Shared by the OpenBsdOSProcess subclasses (JNA/FFM) and the
+     * OpenBSD OperatingSystem classes so the column list and parsing stay in lockstep. {@code ARGS} must remain last.
+     */
+    public static final List<BsdPsKeyword> PS_KEYWORDS = Collections.unmodifiableList(Arrays.asList(STATE, PID, PPID,
+            USER, UID, GROUP, GID, PRI, VSZ, RSS, ETIME, CPUTIME, COMM, MAJFLT, MINFLT, NVCSW, NIVCSW, ARGS));
+
+    public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
+            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     /**
      * Columns requested from {@code ps -aHwwxo} when enumerating threads. Shared by OpenBsdOSProcess subclasses and
@@ -25,5 +63,40 @@ public abstract class OpenBsdOSProcess extends BsdOSProcess {
 
     protected OpenBsdOSProcess(int pid) {
         super(pid);
+    }
+
+    @Override
+    protected List<BsdPsKeyword> psKeywords() {
+        return PS_KEYWORDS;
+    }
+
+    @Override
+    protected String psCommandArgs() {
+        return PS_COMMAND_ARGS;
+    }
+
+    @Override
+    protected void updateThreadCount() {
+        List<String> threadList = ExecutingCommand.runNative("ps -axHo tid -p " + getProcessID());
+        if (!threadList.isEmpty()) {
+            // Subtract 1 for header
+            this.threadCount = threadList.size() - 1;
+        }
+        // A live process always has at least one thread
+        this.threadCount = Math.max(this.threadCount, 1);
+    }
+
+    @Override
+    public List<OSThread> getThreadDetails() {
+        String psCommand = "ps -aHwwxo " + PS_THREAD_COLUMNS;
+        if (getProcessID() >= 0) {
+            psCommand += " -p " + getProcessID();
+        }
+        Predicate<Map<PsThreadColumns, String>> hasColumnsArgs = threadMap -> threadMap
+                .containsKey(PsThreadColumns.ARGS);
+        return ExecutingCommand.runNative(psCommand).stream().skip(1)
+                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .filter(hasColumnsArgs).map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap))
+                .filter(VALID_THREAD).collect(Collectors.toList());
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
@@ -94,7 +94,7 @@ public abstract class OpenBsdOSProcess extends BsdOSProcess {
         }
         Predicate<Map<PsThreadColumns, String>> hasColumnsArgs = threadMap -> threadMap
                 .containsKey(PsThreadColumns.ARGS);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1)
+        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
                 .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
                 .filter(hasColumnsArgs).map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap))
                 .filter(VALID_THREAD).collect(Collectors.toList());

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -1393,10 +1393,29 @@ public final class ParseUtil {
      *         String, including excess delimiters.
      */
     public static <K extends Enum<K>> Map<K, String> stringToEnumMap(Class<K> clazz, String values, char delim) {
+        return stringToEnumMap(clazz, new ArrayList<>(EnumSet.allOf(clazz)), values, delim);
+    }
+
+    /**
+     * Parses a delimited String into an enum map using an explicit, ordered subset of enum keys. Multiple consecutive
+     * delimiters are treated as one. Unlike {@link #stringToEnumMap(Class, String, char)}, which maps every enum
+     * constant in ordinal order, this overload maps only the supplied {@code keys} in the order given, so callers can
+     * share a single enum across columns that vary by platform.
+     *
+     * @param <K>    a type extending Enum
+     * @param clazz  The enum class (used to construct the backing {@link EnumMap})
+     * @param keys   The ordered enum keys to map, one per delimited field
+     * @param values A delimited String to be parsed into the map
+     * @param delim  the delimiter to use
+     * @return An EnumMap populated in order using the delimited String values. If there are fewer String values than
+     *         keys, the later keys are not mapped. The final key will contain the remainder of the String, including
+     *         excess delimiters.
+     */
+    public static <K extends Enum<K>> Map<K, String> stringToEnumMap(Class<K> clazz, List<K> keys, String values,
+            char delim) {
         EnumMap<K, String> map = new EnumMap<>(clazz);
         int start = 0;
         int len = values.length();
-        EnumSet<K> keys = EnumSet.allOf(clazz);
         int keySize = keys.size();
         for (K key : keys) {
             // If this is the last enum, put the index at the end of the string, otherwise

--- a/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
@@ -924,6 +924,28 @@ class ParseUtilTest {
     }
 
     @Test
+    void teststringToEnumMapWithKeys() {
+        // Explicit key order independent of ordinal order; last key slurps the remainder
+        List<TestEnum> keys = Arrays.asList(TestEnum.BAZ, TestEnum.FOO);
+        Map<TestEnum, String> map = ParseUtil.stringToEnumMap(TestEnum.class, keys, "one two,three four", ' ');
+        assertThat(map.get(TestEnum.BAZ), is("one"));
+        assertThat(map.get(TestEnum.FOO), is("two,three four"));
+        assertThat(map.containsKey(TestEnum.BAR), is(false));
+
+        // Fewer values than keys: later keys are not mapped
+        map = ParseUtil.stringToEnumMap(TestEnum.class, keys, "only", ' ');
+        assertThat(map.get(TestEnum.BAZ), is("only"));
+        assertThat(map.containsKey(TestEnum.FOO), is(false));
+
+        // Consecutive delimiters are treated as one
+        List<TestEnum> three = Arrays.asList(TestEnum.FOO, TestEnum.BAR, TestEnum.BAZ);
+        map = ParseUtil.stringToEnumMap(TestEnum.class, three, "one,,two,three", ',');
+        assertThat(map.get(TestEnum.FOO), is("one"));
+        assertThat(map.get(TestEnum.BAR), is("two"));
+        assertThat(map.get(TestEnum.BAZ), is("three"));
+    }
+
+    @Test
     void testgetValueOrUnknown() {
         String key = "key";
         Map<String, String> map = new HashMap<>();

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
@@ -4,10 +4,10 @@
  */
 package oshi.software.os.unix.dragonflybsd;
 
-import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
 import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 
@@ -111,7 +111,7 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
             MemorySegment buf = arena.allocate(32);
             MemorySegment size = arena.allocate(JAVA_LONG);
             size.set(JAVA_LONG, 0, 32L);
-            MemorySegment callState = arena.allocate(ADDRESS);
+            MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
             int rc = FreeBsdLibcFunctions.sysctl(callState, mib, 4, buf, size, MemorySegment.NULL, 0L);
             if (rc != 0) {
                 return 0;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
@@ -10,16 +10,12 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 
 import java.lang.foreign.MemorySegment;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,11 +23,8 @@ import org.slf4j.event.Level;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
-import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSThread;
-import oshi.software.os.OSThread;
-import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystemFFM.PsKeywords;
-import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.dragonflybsd.ProcstatUtil;
@@ -46,7 +39,7 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
 
     private final DragonFlyBsdOperatingSystemFFM os;
 
-    public DragonFlyBsdOSProcessFFM(int pid, Map<PsKeywords, String> psMap, DragonFlyBsdOperatingSystemFFM os) {
+    public DragonFlyBsdOSProcessFFM(int pid, Map<BsdPsKeyword, String> psMap, DragonFlyBsdOperatingSystemFFM os) {
         super(pid);
         this.os = os;
         updateAttributes(psMap);
@@ -134,78 +127,4 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
         }, LOG, Level.WARN, "queryBitness failed", 0);
     }
 
-    @Override
-    public List<OSThread> getThreadDetails() {
-        String psCommand = "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
-        if (getProcessID() >= 0) {
-            psCommand += " -p " + getProcessID();
-        }
-        Predicate<Map<PsThreadColumns, String>> hasColumnsPri = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-                .filter(hasColumnsPri).map(threadMap -> new DragonFlyBsdOSThread(getProcessID(), threadMap))
-                .filter(VALID_THREAD).collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        String psCommand = "ps -awwxo " + DragonFlyBsdOperatingSystemFFM.PS_COMMAND_ARGS + " -p " + getProcessID();
-        List<String> procList = ExecutingCommand.runNative(psCommand);
-        if (procList.size() > 1) {
-            // skip header row
-            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, procList.get(1).trim(), ' ');
-            // Check if last (thus all) value populated
-            if (psMap.containsKey(PsKeywords.COMMAND)) {
-                return updateAttributes(psMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsKeywords, String> psMap) {
-        long now = System.currentTimeMillis();
-        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
-        this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
-        this.user = psMap.get(PsKeywords.USER);
-        this.userID = psMap.get(PsKeywords.UID);
-        this.group = this.user; // DragonFly ps lacks group keyword
-        this.groupID = psMap.get(PsKeywords.RGID);
-        this.threadCount = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.NLWP), 0);
-        this.priority = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PRI), 0);
-        // These are in KB, multiply
-        this.virtualSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.VSZ), 0) * 1024;
-        this.residentSetSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.RSS), 0) * 1024;
-        // Get start time from /proc/<pid>/status (field 8: sec,usec)
-        this.startTime = queryStartTimeFromProc(getProcessID());
-        this.upTime = now - this.startTime;
-        if (this.upTime < 1L) {
-            this.upTime = 1L;
-        }
-        this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.TIME), 0L);
-        this.path = psMap.get(PsKeywords.UCOMM);
-        this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
-        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
-        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
-        this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
-        this.commandLineBackup = psMap.get(PsKeywords.COMMAND);
-        return true;
-    }
-
-    private static long queryStartTimeFromProc(int pid) {
-        List<String> status = FileUtil.readFile("/proc/" + pid + "/status", false);
-        if (!status.isEmpty()) {
-            // Format: name pid ... startSec,startUsec ...
-            String[] split = ParseUtil.whitespaces.split(status.get(0).trim());
-            if (split.length >= 8) {
-                String[] timeParts = split[7].split(",");
-                long seconds = ParseUtil.parseLongOrDefault(timeParts[0], 0L);
-                if (seconds > 0) {
-                    return seconds * 1000L;
-                }
-            }
-        }
-        return System.currentTimeMillis();
-    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
@@ -14,10 +14,8 @@ import java.io.File;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -33,6 +31,8 @@ import oshi.ffm.platform.unix.dragonflybsd.DragonFlyBsdLibcFunctions;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
@@ -56,20 +56,6 @@ public class DragonFlyBsdOperatingSystemFFM extends AbstractOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOperatingSystemFFM.class);
 
     private static final long BOOTTIME = querySystemBootTime();
-
-    /*
-     * Package-private for use by DragonFlyBsdOSProcessFFM
-     */
-    enum PsKeywords {
-        STATE, PID, PPID, USER, UID, RGID, NLWP, PRI, VSZ, RSS, TIME, MAJFLT, MINFLT, NVCSW, NIVCSW, UCOMM, COMMAND; // COMMAND
-                                                                                                                     // must
-                                                                                                                     // always
-                                                                                                                     // be
-                                                                                                                     // last
-    }
-
-    static final String PS_COMMAND_ARGS = Arrays.stream(PsKeywords.values()).map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     @Override
     public String queryManufacturer() {
@@ -139,16 +125,18 @@ public class DragonFlyBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     private List<OSProcess> getProcessListFromPS(int pid) {
-        String psCommand = "ps -awwxo " + PS_COMMAND_ARGS;
+        String psCommand = "ps -awwxo " + DragonFlyBsdOSProcess.PS_COMMAND_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
         }
 
-        Predicate<Map<PsKeywords, String>> hasKeywordArgs = psMap -> psMap.containsKey(PsKeywords.COMMAND);
+        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.COMMAND);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ')).filter(hasKeywordArgs)
+                .map(proc -> ParseUtil
+                        .stringToEnumMap(BsdPsKeyword.class, DragonFlyBsdOSProcess.PS_KEYWORDS, proc.trim(), ' '))
+                .filter(hasKeywordArgs)
                 .map(psMap -> new DragonFlyBsdOSProcessFFM(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap, this))
+                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this))
                 // DragonFlyBSD kernel threads report PID -1; filter them out
                 .filter(proc -> proc.getProcessID() > 0).filter(VALID_PROCESS).collect(Collectors.toList());
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
@@ -12,16 +12,12 @@ import static oshi.ffm.ForeignFunctions.getErrno;
 import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.RLIMIT_LAYOUT;
 import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.RLIMIT_NOFILE;
 import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.SIZE_T;
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,11 +25,8 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.freebsd.FreeBsdOSProcess;
-import oshi.software.common.os.unix.freebsd.FreeBsdOSThread;
-import oshi.software.os.OSThread;
-import oshi.software.os.unix.freebsd.FreeBsdOperatingSystemFFM.PsKeywords;
-import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.freebsd.ProcstatUtil;
 
@@ -56,7 +49,7 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
 
     private final FreeBsdOperatingSystemFFM os;
 
-    public FreeBsdOSProcessFFM(int pid, Map<PsKeywords, String> psMap, FreeBsdOperatingSystemFFM os) {
+    public FreeBsdOSProcessFFM(int pid, Map<BsdPsKeyword, String> psMap, FreeBsdOperatingSystemFFM os) {
         super(pid);
         this.os = os;
         updateAttributes(psMap);
@@ -165,63 +158,5 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
             }
             return 0;
         }, LOG, org.slf4j.event.Level.WARN, "queryBitness failed", 0);
-    }
-
-    @Override
-    public List<OSThread> getThreadDetails() {
-        String psCommand = "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
-        if (getProcessID() >= 0) {
-            psCommand += " -p " + getProcessID();
-        }
-        Predicate<Map<PsThreadColumns, String>> hasColumnsPri = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-                .filter(hasColumnsPri).map(threadMap -> new FreeBsdOSThread(getProcessID(), threadMap))
-                .filter(VALID_THREAD).collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        String psCommand = "ps -awwxo " + FreeBsdOperatingSystemFFM.PS_COMMAND_ARGS + " -p " + getProcessID();
-        List<String> procList = ExecutingCommand.runNative(psCommand);
-        if (procList.size() > 1) {
-            // skip header row
-            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, procList.get(1).trim(), ' ');
-            // Check if last (thus all) value populated
-            if (psMap.containsKey(PsKeywords.ARGS)) {
-                return updateAttributes(psMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsKeywords, String> psMap) {
-        long now = System.currentTimeMillis();
-        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
-        this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
-        this.user = psMap.get(PsKeywords.USER);
-        this.userID = psMap.get(PsKeywords.UID);
-        this.group = psMap.get(PsKeywords.GROUP);
-        this.groupID = psMap.get(PsKeywords.GID);
-        this.threadCount = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.NLWP), 0);
-        this.priority = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PRI), 0);
-        // These are in KB, multiply
-        this.virtualSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.VSZ), 0) * 1024;
-        this.residentSetSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.RSS), 0) * 1024;
-        // Avoid divide by zero for processes up less than a second
-        long elapsedTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.ETIMES), 0L);
-        this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
-        this.startTime = now - this.upTime;
-        this.kernelTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.SYSTIME), 0L);
-        this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.TIME), 0L) - this.kernelTime;
-        this.path = psMap.get(PsKeywords.COMM);
-        this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
-        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
-        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
-        this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
-        this.commandLineBackup = psMap.get(PsKeywords.ARGS);
-        return true;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemFFM.java
@@ -14,10 +14,8 @@ import java.io.File;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -32,6 +30,8 @@ import oshi.driver.unix.freebsd.WhoFFM;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.common.os.unix.freebsd.FreeBsdOSProcess;
 import oshi.software.common.os.unix.freebsd.FreeBsdOSThread;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
@@ -53,17 +53,6 @@ public class FreeBsdOperatingSystemFFM extends AbstractOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(FreeBsdOperatingSystemFFM.class);
 
     private static final long BOOTTIME = querySystemBootTime();
-
-    /*
-     * Package-private for use by FreeBsdOSProcessFFM
-     */
-    enum PsKeywords {
-        STATE, PID, PPID, USER, UID, GROUP, GID, NLWP, PRI, VSZ, RSS, ETIMES, SYSTIME, TIME, COMM, MAJFLT, MINFLT,
-        NVCSW, NIVCSW, ARGS; // ARGS must always be last
-    }
-
-    static final String PS_COMMAND_ARGS = Arrays.stream(PsKeywords.values()).map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     @Override
     public String queryManufacturer() {
@@ -133,16 +122,18 @@ public class FreeBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     private List<OSProcess> getProcessListFromPS(int pid) {
-        String psCommand = "ps -awwxo " + PS_COMMAND_ARGS;
+        String psCommand = "ps -awwxo " + FreeBsdOSProcess.PS_COMMAND_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
         }
 
-        Predicate<Map<PsKeywords, String>> hasKeywordArgs = psMap -> psMap.containsKey(PsKeywords.ARGS);
+        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.ARGS);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ')).filter(hasKeywordArgs)
+                .map(proc -> ParseUtil
+                        .stringToEnumMap(BsdPsKeyword.class, FreeBsdOSProcess.PS_KEYWORDS, proc.trim(), ' '))
+                .filter(hasKeywordArgs)
                 .map(psMap -> new FreeBsdOSProcessFFM(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap, this))
+                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this))
                 .filter(VALID_PROCESS).collect(Collectors.toList());
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
@@ -15,8 +15,6 @@ import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_PROC_ARGV
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_PROC_ENV;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.RLIMIT_NOFILE;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.SIZE_T;
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -25,8 +23,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,11 +31,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.ForeignFunctions;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
-import oshi.software.common.os.unix.openbsd.OpenBsdOSThread;
-import oshi.software.os.OSThread;
-import oshi.software.os.unix.openbsd.OpenBsdOperatingSystemFFM.PsKeywords;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.util.common.platform.unix.openbsd.FstatUtil;
 
 @ThreadSafe
@@ -56,10 +48,9 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
 
     private final OpenBsdOperatingSystemFFM os;
 
-    public OpenBsdOSProcessFFM(int pid, Map<PsKeywords, String> psMap, OpenBsdOperatingSystemFFM os) {
+    public OpenBsdOSProcessFFM(int pid, Map<BsdPsKeyword, String> psMap, OpenBsdOperatingSystemFFM os) {
         super(pid);
         this.os = os;
-        updateThreadCount();
         updateAttributes(psMap);
     }
 
@@ -176,66 +167,4 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
         }, LOG, org.slf4j.event.Level.WARN, "Failed getrlimit", -1L);
     }
 
-    @Override
-    public List<OSThread> getThreadDetails() {
-        String psCommand = "ps -aHwwxo " + PS_THREAD_COLUMNS;
-        if (getProcessID() >= 0) {
-            psCommand += " -p " + getProcessID();
-        }
-        Predicate<Map<PsThreadColumns, String>> hasColumnsArgs = threadMap -> threadMap
-                .containsKey(PsThreadColumns.ARGS);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1)
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-                .filter(hasColumnsArgs).map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap))
-                .filter(VALID_THREAD).collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        String psCommand = "ps -awwxo " + OpenBsdOperatingSystemFFM.PS_COMMAND_ARGS + " -p " + getProcessID();
-        List<String> procList = ExecutingCommand.runNative(psCommand);
-        if (procList.size() > 1) {
-            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, procList.get(1).trim(), ' ');
-            if (psMap.containsKey(PsKeywords.ARGS)) {
-                updateThreadCount();
-                return updateAttributes(psMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsKeywords, String> psMap) {
-        long now = System.currentTimeMillis();
-        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
-        this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
-        this.user = psMap.get(PsKeywords.USER);
-        this.userID = psMap.get(PsKeywords.UID);
-        this.group = psMap.get(PsKeywords.GROUP);
-        this.groupID = psMap.get(PsKeywords.GID);
-        this.priority = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PRI), 0);
-        this.virtualSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.VSZ), 0) * 1024;
-        this.residentSetSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.RSS), 0) * 1024;
-        long elapsedTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.ETIME), 0L);
-        this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
-        this.startTime = now - this.upTime;
-        this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.CPUTIME), 0L);
-        this.kernelTime = 0L;
-        this.path = psMap.get(PsKeywords.COMM);
-        this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
-        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
-        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
-        this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
-        this.commandLineBackup = psMap.get(PsKeywords.ARGS);
-        return true;
-    }
-
-    private void updateThreadCount() {
-        List<String> threadList = ExecutingCommand.runNative("ps -axHo tid -p " + getProcessID());
-        if (!threadList.isEmpty()) {
-            this.threadCount = threadList.size() - 1;
-        }
-        this.threadCount = Math.max(this.threadCount, 1);
-    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
@@ -13,14 +13,11 @@ import static oshi.software.os.OSService.State.STOPPED;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,8 +28,10 @@ import oshi.ffm.ForeignFunctions;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.openbsd.OpenBsdInternetProtocolStats;
 import oshi.software.common.os.unix.openbsd.OpenBsdNetworkParams;
+import oshi.software.common.os.unix.openbsd.OpenBsdOSProcess;
 import oshi.software.common.os.unix.openbsd.OpenBsdOSThread;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
@@ -50,14 +49,6 @@ public class OpenBsdOperatingSystemFFM extends AbstractOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOperatingSystemFFM.class);
 
     private static final long BOOTTIME = querySystemBootTime();
-
-    enum PsKeywords {
-        STATE, PID, PPID, USER, UID, GROUP, GID, PRI, VSZ, RSS, ETIME, CPUTIME, COMM, MAJFLT, MINFLT, NVCSW, NIVCSW,
-        ARGS;
-    }
-
-    static final String PS_COMMAND_ARGS = Arrays.stream(PsKeywords.values()).map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     @Override
     public String queryManufacturer() {
@@ -126,7 +117,7 @@ public class OpenBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     private List<OSProcess> getProcessListFromPS(int pid) {
-        String psCommand = "ps -awwxo " + PS_COMMAND_ARGS;
+        String psCommand = "ps -awwxo " + OpenBsdOSProcess.PS_COMMAND_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
         }
@@ -135,13 +126,14 @@ public class OpenBsdOperatingSystemFFM extends AbstractOperatingSystem {
             return new ArrayList<>();
         }
         procList.remove(0);
-        Predicate<Map<PsKeywords, String>> hasKeywordArgs = psMap -> psMap.containsKey(PsKeywords.ARGS);
+        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.ARGS);
         List<OSProcess> procs = new ArrayList<>();
         for (String proc : procList) {
-            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ');
+            Map<BsdPsKeyword, String> psMap = ParseUtil.stringToEnumMap(BsdPsKeyword.class,
+                    OpenBsdOSProcess.PS_KEYWORDS, proc.trim(), ' ');
             if (hasKeywordArgs.test(psMap)) {
                 procs.add(new OpenBsdOSProcessFFM(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap, this));
+                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this));
             }
         }
         return procs;

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
@@ -4,14 +4,9 @@
  */
 package oshi.software.os.unix.dragonflybsd;
 
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,11 +18,8 @@ import com.sun.jna.platform.unix.Resource;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.DragonFlyBsdLibc;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
-import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSThread;
-import oshi.software.os.OSThread;
-import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystemJNA.PsKeywords;
-import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.dragonflybsd.ProcstatUtil;
@@ -42,7 +34,7 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
 
     private final DragonFlyBsdOperatingSystemJNA os;
 
-    public DragonFlyBsdOSProcessJNA(int pid, Map<PsKeywords, String> psMap, DragonFlyBsdOperatingSystemJNA os) {
+    public DragonFlyBsdOSProcessJNA(int pid, Map<BsdPsKeyword, String> psMap, DragonFlyBsdOperatingSystemJNA os) {
         super(pid);
         this.os = os;
         updateAttributes(psMap);
@@ -123,78 +115,4 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
         return 0;
     }
 
-    @Override
-    public List<OSThread> getThreadDetails() {
-        String psCommand = "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
-        if (getProcessID() >= 0) {
-            psCommand += " -p " + getProcessID();
-        }
-        Predicate<Map<PsThreadColumns, String>> hasColumnsPri = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-                .filter(hasColumnsPri).map(threadMap -> new DragonFlyBsdOSThread(getProcessID(), threadMap))
-                .filter(VALID_THREAD).collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        String psCommand = "ps -awwxo " + DragonFlyBsdOperatingSystemJNA.PS_COMMAND_ARGS + " -p " + getProcessID();
-        List<String> procList = ExecutingCommand.runNative(psCommand);
-        if (procList.size() > 1) {
-            // skip header row
-            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, procList.get(1).trim(), ' ');
-            // Check if last (thus all) value populated
-            if (psMap.containsKey(PsKeywords.COMMAND)) {
-                return updateAttributes(psMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsKeywords, String> psMap) {
-        long now = System.currentTimeMillis();
-        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
-        this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
-        this.user = psMap.get(PsKeywords.USER);
-        this.userID = psMap.get(PsKeywords.UID);
-        this.group = this.user; // DragonFly ps lacks group keyword
-        this.groupID = psMap.get(PsKeywords.RGID);
-        this.threadCount = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.NLWP), 0);
-        this.priority = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PRI), 0);
-        // These are in KB, multiply
-        this.virtualSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.VSZ), 0) * 1024;
-        this.residentSetSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.RSS), 0) * 1024;
-        // Get start time from /proc/<pid>/status (field 8: sec,usec)
-        this.startTime = queryStartTimeFromProc(getProcessID());
-        this.upTime = now - this.startTime;
-        if (this.upTime < 1L) {
-            this.upTime = 1L;
-        }
-        this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.TIME), 0L);
-        this.path = psMap.get(PsKeywords.UCOMM);
-        this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
-        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
-        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
-        this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
-        this.commandLineBackup = psMap.get(PsKeywords.COMMAND);
-        return true;
-    }
-
-    private static long queryStartTimeFromProc(int pid) {
-        List<String> status = FileUtil.readFile("/proc/" + pid + "/status", false);
-        if (!status.isEmpty()) {
-            // Format: name pid ... startSec,startUsec ...
-            String[] split = ParseUtil.whitespaces.split(status.get(0).trim());
-            if (split.length >= 8) {
-                String[] timeParts = split[7].split(",");
-                long seconds = ParseUtil.parseLongOrDefault(timeParts[0], 0L);
-                if (seconds > 0) {
-                    return seconds * 1000L;
-                }
-            }
-        }
-        return System.currentTimeMillis();
-    }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemJNA.java
@@ -10,10 +10,8 @@ import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -27,6 +25,8 @@ import oshi.driver.unix.freebsd.Who;
 import oshi.jna.platform.unix.DragonFlyBsdLibc;
 import oshi.jna.platform.unix.FreeBsdLibc;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
 import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSThread;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
@@ -53,20 +53,6 @@ public class DragonFlyBsdOperatingSystemJNA extends AbstractOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOperatingSystemJNA.class);
 
     private static final long BOOTTIME = querySystemBootTime();
-
-    /*
-     * Package-private for use by DragonFlyBsdOSProcessJNA
-     */
-    enum PsKeywords {
-        STATE, PID, PPID, USER, UID, RGID, NLWP, PRI, VSZ, RSS, TIME, MAJFLT, MINFLT, NVCSW, NIVCSW, UCOMM, COMMAND; // COMMAND
-                                                                                                                     // must
-                                                                                                                     // always
-                                                                                                                     // be
-                                                                                                                     // last
-    }
-
-    static final String PS_COMMAND_ARGS = Arrays.stream(PsKeywords.values()).map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     @Override
     public String queryManufacturer() {
@@ -136,16 +122,18 @@ public class DragonFlyBsdOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     private List<OSProcess> getProcessListFromPS(int pid) {
-        String psCommand = "ps -awwxo " + PS_COMMAND_ARGS;
+        String psCommand = "ps -awwxo " + DragonFlyBsdOSProcess.PS_COMMAND_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
         }
 
-        Predicate<Map<PsKeywords, String>> hasKeywordArgs = psMap -> psMap.containsKey(PsKeywords.COMMAND);
+        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.COMMAND);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ')).filter(hasKeywordArgs)
+                .map(proc -> ParseUtil
+                        .stringToEnumMap(BsdPsKeyword.class, DragonFlyBsdOSProcess.PS_KEYWORDS, proc.trim(), ' '))
+                .filter(hasKeywordArgs)
                 .map(psMap -> new DragonFlyBsdOSProcessJNA(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap, this))
+                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this))
                 // DragonFlyBSD kernel threads report PID -1; filter them out
                 .filter(proc -> proc.getProcessID() > 0).filter(VALID_PROCESS).collect(Collectors.toList());
     }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessJNA.java
@@ -4,14 +4,9 @@
  */
 package oshi.software.os.unix.freebsd;
 
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,11 +19,8 @@ import com.sun.jna.platform.unix.Resource;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.FreeBsdLibc;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.freebsd.FreeBsdOSProcess;
-import oshi.software.common.os.unix.freebsd.FreeBsdOSThread;
-import oshi.software.os.OSThread;
-import oshi.software.os.unix.freebsd.FreeBsdOperatingSystemJNA.PsKeywords;
-import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.freebsd.ProcstatUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
@@ -45,7 +37,7 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
 
     private final FreeBsdOperatingSystemJNA os;
 
-    public FreeBsdOSProcessJNA(int pid, Map<PsKeywords, String> psMap, FreeBsdOperatingSystemJNA os) {
+    public FreeBsdOSProcessJNA(int pid, Map<BsdPsKeyword, String> psMap, FreeBsdOperatingSystemJNA os) {
         super(pid);
         this.os = os;
         updateAttributes(psMap);
@@ -156,63 +148,5 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
             }
         }
         return 0;
-    }
-
-    @Override
-    public List<OSThread> getThreadDetails() {
-        String psCommand = "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
-        if (getProcessID() >= 0) {
-            psCommand += " -p " + getProcessID();
-        }
-        Predicate<Map<PsThreadColumns, String>> hasColumnsPri = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-                .filter(hasColumnsPri).map(threadMap -> new FreeBsdOSThread(getProcessID(), threadMap))
-                .filter(VALID_THREAD).collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        String psCommand = "ps -awwxo " + FreeBsdOperatingSystemJNA.PS_COMMAND_ARGS + " -p " + getProcessID();
-        List<String> procList = ExecutingCommand.runNative(psCommand);
-        if (procList.size() > 1) {
-            // skip header row
-            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, procList.get(1).trim(), ' ');
-            // Check if last (thus all) value populated
-            if (psMap.containsKey(PsKeywords.ARGS)) {
-                return updateAttributes(psMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsKeywords, String> psMap) {
-        long now = System.currentTimeMillis();
-        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
-        this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
-        this.user = psMap.get(PsKeywords.USER);
-        this.userID = psMap.get(PsKeywords.UID);
-        this.group = psMap.get(PsKeywords.GROUP);
-        this.groupID = psMap.get(PsKeywords.GID);
-        this.threadCount = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.NLWP), 0);
-        this.priority = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PRI), 0);
-        // These are in KB, multiply
-        this.virtualSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.VSZ), 0) * 1024;
-        this.residentSetSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.RSS), 0) * 1024;
-        // Avoid divide by zero for processes up less than a second
-        long elapsedTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.ETIMES), 0L);
-        this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
-        this.startTime = now - this.upTime;
-        this.kernelTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.SYSTIME), 0L);
-        this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.TIME), 0L) - this.kernelTime;
-        this.path = psMap.get(PsKeywords.COMM);
-        this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
-        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
-        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
-        this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
-        this.commandLineBackup = psMap.get(PsKeywords.ARGS);
-        return true;
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemJNA.java
@@ -10,10 +10,8 @@ import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -29,6 +27,8 @@ import oshi.driver.unix.freebsd.Who;
 import oshi.jna.platform.unix.FreeBsdLibc;
 import oshi.jna.platform.unix.FreeBsdLibc.Timeval;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.common.os.unix.freebsd.FreeBsdOSProcess;
 import oshi.software.common.os.unix.freebsd.FreeBsdOSThread;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
@@ -54,17 +54,6 @@ public class FreeBsdOperatingSystemJNA extends AbstractOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(FreeBsdOperatingSystemJNA.class);
 
     private static final long BOOTTIME = querySystemBootTime();
-
-    /*
-     * Package-private for use by FreeBsdOSProcessJNA
-     */
-    enum PsKeywords {
-        STATE, PID, PPID, USER, UID, GROUP, GID, NLWP, PRI, VSZ, RSS, ETIMES, SYSTIME, TIME, COMM, MAJFLT, MINFLT,
-        NVCSW, NIVCSW, ARGS; // ARGS must always be last
-    }
-
-    static final String PS_COMMAND_ARGS = Arrays.stream(PsKeywords.values()).map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     @Override
     public String queryManufacturer() {
@@ -134,16 +123,18 @@ public class FreeBsdOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     private List<OSProcess> getProcessListFromPS(int pid) {
-        String psCommand = "ps -awwxo " + PS_COMMAND_ARGS;
+        String psCommand = "ps -awwxo " + FreeBsdOSProcess.PS_COMMAND_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
         }
 
-        Predicate<Map<PsKeywords, String>> hasKeywordArgs = psMap -> psMap.containsKey(PsKeywords.ARGS);
+        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.ARGS);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(proc -> ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ')).filter(hasKeywordArgs)
+                .map(proc -> ParseUtil
+                        .stringToEnumMap(BsdPsKeyword.class, FreeBsdOSProcess.PS_KEYWORDS, proc.trim(), ' '))
+                .filter(hasKeywordArgs)
                 .map(psMap -> new FreeBsdOSProcessJNA(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap, this))
+                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this))
                 .filter(VALID_PROCESS).collect(Collectors.toList());
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessJNA.java
@@ -104,6 +104,9 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
 
     @Override
     protected Map<String, String> queryEnvironmentVariables() {
+        if (ARGMAX <= 0) {
+            return Collections.emptyMap();
+        }
         // Get environment variables via sysctl(3)
         int[] mib = new int[4];
         mib[0] = 1; // CTL_KERN

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessJNA.java
@@ -4,16 +4,11 @@
  */
 package oshi.software.os.unix.openbsd;
 
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,12 +22,8 @@ import com.sun.jna.platform.unix.Resource;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.OpenBsdLibc;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.openbsd.OpenBsdOSProcess;
-import oshi.software.common.os.unix.openbsd.OpenBsdOSThread;
-import oshi.software.os.OSThread;
-import oshi.software.os.unix.openbsd.OpenBsdOperatingSystemJNA.PsKeywords;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.openbsd.FstatUtil;
 
 /**
@@ -63,10 +54,9 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
 
     private final OpenBsdOperatingSystemJNA os;
 
-    public OpenBsdOSProcessJNA(int pid, Map<PsKeywords, String> psMap, OpenBsdOperatingSystemJNA os) {
+    public OpenBsdOSProcessJNA(int pid, Map<BsdPsKeyword, String> psMap, OpenBsdOperatingSystemJNA os) {
         super(pid);
         this.os = os;
-        updateThreadCount();
         updateAttributes(psMap);
     }
 
@@ -180,74 +170,4 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
         }
     }
 
-    @Override
-    public List<OSThread> getThreadDetails() {
-        String psCommand = "ps -aHwwxo " + PS_THREAD_COLUMNS;
-        if (getProcessID() >= 0) {
-            psCommand += " -p " + getProcessID();
-        }
-        Predicate<Map<PsThreadColumns, String>> hasColumnsArgs = threadMap -> threadMap
-                .containsKey(PsThreadColumns.ARGS);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1)
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
-                .filter(hasColumnsArgs).map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap))
-                .filter(VALID_THREAD).collect(Collectors.toList());
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        // 'ps' does not provide threadCount or kernelTime on OpenBSD
-        String psCommand = "ps -awwxo " + OpenBsdOperatingSystemJNA.PS_COMMAND_ARGS + " -p " + getProcessID();
-        List<String> procList = ExecutingCommand.runNative(psCommand);
-        if (procList.size() > 1) {
-            // skip header row
-            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, procList.get(1).trim(), ' ');
-            // Check if last (thus all) value populated
-            if (psMap.containsKey(PsKeywords.ARGS)) {
-                updateThreadCount();
-                return updateAttributes(psMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsKeywords, String> psMap) {
-        long now = System.currentTimeMillis();
-        this.state = getStateFromOutput(psMap.get(PsKeywords.STATE).charAt(0));
-        this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PPID), 0);
-        this.user = psMap.get(PsKeywords.USER);
-        this.userID = psMap.get(PsKeywords.UID);
-        this.group = psMap.get(PsKeywords.GROUP);
-        this.groupID = psMap.get(PsKeywords.GID);
-        this.priority = ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PRI), 0);
-        // These are in KB, multiply
-        this.virtualSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.VSZ), 0) * 1024;
-        this.residentSetSize = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.RSS), 0) * 1024;
-        // Avoid divide by zero for processes up less than a second
-        long elapsedTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.ETIME), 0L);
-        this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
-        this.startTime = now - this.upTime;
-        this.userTime = ParseUtil.parseDHMSOrDefault(psMap.get(PsKeywords.CPUTIME), 0L);
-        // kernel time is included in user time
-        this.kernelTime = 0L;
-        this.path = psMap.get(PsKeywords.COMM);
-        this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
-        this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MINFLT), 0L);
-        this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.MAJFLT), 0L);
-        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NIVCSW), 0L);
-        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(PsKeywords.NVCSW), 0L);
-        this.voluntaryContextSwitches = voluntaryContextSwitches;
-        this.involuntaryContextSwitches = nonVoluntaryContextSwitches;
-        this.commandLineBackup = psMap.get(PsKeywords.ARGS);
-        return true;
-    }
-
-    private void updateThreadCount() {
-        List<String> threadList = ExecutingCommand.runNative("ps -axHo tid -p " + getProcessID());
-        if (!threadList.isEmpty()) {
-            // Subtract 1 for header
-            this.threadCount = threadList.size() - 1;
-        }
-    }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemJNA.java
@@ -13,10 +13,8 @@ import static oshi.software.os.OSService.State.STOPPED;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,8 +25,10 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.platform.unix.OpenBsdLibc;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.openbsd.OpenBsdInternetProtocolStats;
 import oshi.software.common.os.unix.openbsd.OpenBsdNetworkParams;
+import oshi.software.common.os.unix.openbsd.OpenBsdOSProcess;
 import oshi.software.common.os.unix.openbsd.OpenBsdOSThread;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
@@ -51,17 +51,6 @@ public class OpenBsdOperatingSystemJNA extends AbstractOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOperatingSystemJNA.class);
 
     private static final long BOOTTIME = querySystemBootTime();
-
-    /*
-     * Package-private for use by OpenBsdOSProcessJNA
-     */
-    enum PsKeywords {
-        STATE, PID, PPID, USER, UID, GROUP, GID, PRI, VSZ, RSS, ETIME, CPUTIME, COMM, MAJFLT, MINFLT, NVCSW, NIVCSW,
-        ARGS; // ARGS must always be last
-    }
-
-    static final String PS_COMMAND_ARGS = Arrays.stream(PsKeywords.values()).map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     @Override
     public String queryManufacturer() {
@@ -133,7 +122,7 @@ public class OpenBsdOperatingSystemJNA extends AbstractOperatingSystem {
         List<OSProcess> procs = new ArrayList<>();
         // https://man.openbsd.org/ps#KEYWORDS
         // missing are threadCount and kernelTime which is included in cputime
-        String psCommand = "ps -awwxo " + PS_COMMAND_ARGS;
+        String psCommand = "ps -awwxo " + OpenBsdOSProcess.PS_COMMAND_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
         }
@@ -146,11 +135,12 @@ public class OpenBsdOperatingSystemJNA extends AbstractOperatingSystem {
         procList.remove(0);
         // Fill list
         for (String proc : procList) {
-            Map<PsKeywords, String> psMap = ParseUtil.stringToEnumMap(PsKeywords.class, proc.trim(), ' ');
+            Map<BsdPsKeyword, String> psMap = ParseUtil.stringToEnumMap(BsdPsKeyword.class,
+                    OpenBsdOSProcess.PS_KEYWORDS, proc.trim(), ' ');
             // Check if last (thus all) value populated
-            if (psMap.containsKey(PsKeywords.ARGS)) {
+            if (psMap.containsKey(BsdPsKeyword.ARGS)) {
                 procs.add(new OpenBsdOSProcessJNA(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(PsKeywords.PID), 0) : pid, psMap, this));
+                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this));
             }
         }
         return procs;

--- a/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
@@ -209,8 +209,12 @@ class OperatingSystemTest {
         if (currentThread.updateAttributes()) {
             assertThat("Thread kernel time should be nondecreasing after update", currentThread.getKernelTime(),
                     is(greaterThanOrEqualTo(preKernel)));
-            assertThat("Thread user time should be nondecreasing after update", currentThread.getUserTime(),
-                    is(greaterThanOrEqualTo(preUser)));
+            // The user-time component alone can dip between two back-to-back reads on platforms that derive it as
+            // (total - kernel) from coarse-resolution ps columns: the ps syscall itself bumps kernel time while the
+            // total rounds unchanged. Assert the total CPU time (which maps to the monotonic ps TIME) is nondecreasing.
+            assertThat("Thread total CPU time should be nondecreasing after update",
+                    currentThread.getUserTime() + currentThread.getKernelTime(),
+                    is(greaterThanOrEqualTo(preUser + preKernel)));
         }
     }
 


### PR DESCRIPTION
## Summary

Builds on #3370 (which extracted the shared `BsdOSProcess` base holding the BSD-family field storage and accessors). This PR unifies the remaining duplication: the `ps`-output **parsing**.

Before this change, each platform's `updateAttributes(psMap)` was byte-identical between the JNA and FFM backends and ~85% similar across FreeBSD/OpenBSD/DragonFly/NetBSD, while each `OperatingSystem` class carried its own copy of the `PsKeywords` enum + `PS_COMMAND_ARGS`.

- A single `BsdPsKeyword` master enum (union of all BSD `ps` columns). Each platform's `OSProcess` base declares its ordered `PS_KEYWORDS` subset and derives `PS_COMMAND_ARGS` from it; the `OperatingSystem` classes reference those instead of per-backend copies.
- A new `ParseUtil.stringToEnumMap(Class, List<K> keys, values, delim)` overload that maps an explicit ordered subset (the last key slurps the line remainder). The existing all-values method delegates to it. This is needed because `stringToEnumMap` is positional by enum ordinal, so a single master enum can't be parsed with the all-values form — each platform requests a different column subset/order.
- One shared `updateAttributes(Map<BsdPsKeyword,String>)` and no-arg `updateAttributes()` in `BsdOSProcess`, reading defensively by present key. Per-platform differences are handled by two protected hooks: `queryStartTimeMillis()` (DragonFly overrides to read `/proc`) and `updateThreadCount()` (OpenBSD/NetBSD override).
- The identical-across-backends `getThreadDetails()` moves into each platform's `OSProcess` base.

The JNA/FFM `OSProcess` classes now hold only their native code (arguments, environment, bitness, rlimit, cwd, open files). Derived `PS_COMMAND_ARGS` strings are byte-identical to before, so the `ps` invocations are unchanged.

Solaris and AIX source process data from `/proc` psinfo structs and perfstat rather than `ps`, so they are out of scope.

## Notes

- Folds in one pre-existing JNA/FFM divergence: OpenBSD's FFM `updateThreadCount` clamped the count to at least 1 while JNA did not; the shared version keeps the clamp (a live process always has at least one thread), matching NetBSD.
- `OperatingSystemTest.testThreads` was pre-existing flaky: it asserted a thread's user-time *component* was nondecreasing, but platforms that derive it as `TIME - SYSTIME` from coarse-resolution `ps` columns can see it dip between two back-to-back reads (the `ps` syscall bumps kernel time while the total rounds unchanged). It now asserts total CPU time (user + kernel, which maps to the monotonic `ps` `TIME`) is nondecreasing.

## Testing

All five `unix.yaml` VM jobs pass, exercising the refactored code on real FreeBSD, OpenBSD, DragonFly, and NetBSD systems (plus OpenIndiana). Local spotless / checkstyle / forbidden-APIs / javadoc and a clean full-reactor build also pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured process CPU time is measured as total CPU time (user + kernel) to remain monotonic across BSD platforms.

* **New Features**
  * More reliable BSD process attribute refreshes (state, memory, start time, command/args, thread counts) for FreeBSD, OpenBSD, DragonFly, and NetBSD.

* **Refactor**
  * Unified BSD ps column handling and shared parsing logic to reduce duplication.

* **Tests**
  * Added test coverage for ordered enum-based parsing utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->