### PR TITLE
Export oshi package from oshi-core OSGi bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#3349](https://github.com/oshi/oshi/pull/3349): Fix AIX `Uptime.queryUpTime()` regex to accept the `mins` suffix that appears in the first hour past each day boundary - [@dbwiddis](https://github.com/dbwiddis).
 * [#3358](https://github.com/oshi/oshi/pull/3358): Add macOS 27 (Golden Gate) codename mapping - [@dbwiddis](https://github.com/dbwiddis).
 * [#3365](https://github.com/oshi/oshi/pull/3365): Allow `SystemInfoProvider` SPI discovery on the class path - [@dbwiddis](https://github.com/dbwiddis).
+* [#3373](https://github.com/oshi/oshi/pull/3373): Export the `oshi` package from `oshi-core` in the OSGi bundle so the documented `new oshi.SystemInfo()` entry point is usable in OSGi environments - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.3.0 (2026-06-06)
 

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -154,7 +154,7 @@
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
                 <configuration>
-                    <bnd><![CDATA[Export-Package: oshi.jna.*,!oshi.driver.common.*,!oshi.driver.unix.bsd.*,!oshi.driver.unix.freebsd.disk.*,!oshi.driver.unix.solaris.disk.*,oshi.driver.*,oshi.hardware.platform.*,!oshi.software.common.*,oshi.software.os.linux.*,oshi.software.os.mac.*,oshi.software.os.unix.*,oshi.software.os.windows.*,oshi.util.gpu.*,oshi.util.platform.*;-noimport:=true
+                    <bnd><![CDATA[Export-Package: oshi,oshi.jna.*,!oshi.driver.common.*,!oshi.driver.unix.bsd.*,!oshi.driver.unix.freebsd.disk.*,!oshi.driver.unix.solaris.disk.*,oshi.driver.*,oshi.hardware.platform.*,!oshi.software.common.*,oshi.software.os.linux.*,oshi.software.os.mac.*,oshi.software.os.unix.*,oshi.software.os.windows.*,oshi.util.gpu.*,oshi.util.platform.*;-noimport:=true
                     Import-Package: io.github.pandalxb.jlibrehardwaremonitor.*;resolution:=optional, ${osgi.slf4j.import.packages}, *
                     Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                     -snapshot: SNAPSHOT]]></bnd>


### PR DESCRIPTION
## Summary

`oshi-core`'s bnd `Export-Package` enumerated subpackages (`oshi.jna.*`, `oshi.driver.*`, `oshi.hardware.platform.*`, …) but never included the root `oshi` package, so bnd emitted `Private-Package: oshi`. As a result the entry point documented in the README — `SystemInfoProvider si = new oshi.SystemInfo();` — was unreachable in OSGi environments, even though the JPMS `module-info` already declares `exports oshi;`.

This adds the bare `oshi` package to `oshi-core`'s `Export-Package`, aligning the OSGi manifest with the module descriptor.

## Why this is safe

- The `oshi` package in `oshi-core` contains only the public `SystemInfo` class (plus `package-info`) — no implementation classes are inadvertently exposed.
- No split-package: only `oshi-core` ships classes in the bare `oshi` package (`oshi-common` and `oshi-core-ffm` have classes only in subpackages such as `oshi.nativefree` / `oshi.ffm`, which are already exported).
- Verified against the built jar: the manifest now contains `Export-Package: oshi;version="7.3.1";uses:="oshi.annotation,…"`.

The sibling providers were already reachable (`oshi.ffm.SystemInfo` via `oshi.ffm.*`, `oshi.nativefree.SystemInfo` via `oshi.*`); this brings `oshi-core` to parity.

## Scope

This restores the documented direct-instantiation fallback under OSGi. Making `SystemInfoFactory.create()` (which uses `ServiceLoader`) resolve natively under OSGi is a separate, larger change (an `osgi.serviceloader` Provide/Require-Capability requiring an SPI-mediator such as Apache Aries SPI Fly in the consumer runtime) and is best handled as its own tested follow-up.

Resolves #3371


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OSGi bundle export configuration to properly expose the `oshi` package, enabling `SystemInfo` functionality in OSGi environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->