### PR TITLE
Unify BSD OSThread parsing into a shared BsdOSThread base

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -62,10 +62,10 @@
     <suppress checks="MemberName" files="(AixCentralProcessor|AixHWDiskStore|AixNetworkIF|AixGlobalMemory)\.java"/>
     <suppress checks="VisibilityModifier" files="(AixCentralProcessor|AixHWDiskStore|AixNetworkIF|AixGlobalMemory)\.java"/>
 
-    <!-- BsdOSProcess is the shared BSD-family OSProcess base; its protected fields are populated by the
-         per-platform updateAttributes() in the subclasses (which read platform-specific ps columns), so
-         they can't be private with accessors. -->
-    <suppress checks="VisibilityModifier" files="BsdOSProcess\.java"/>
+    <!-- BsdOSProcess/BsdOSThread are the shared BSD-family OSProcess/OSThread bases; their protected fields
+         are populated by the shared updateAttributes() against platform-specific ps columns (and the thread
+         id is set by the per-platform OSThread constructors), so they can't be private with accessors. -->
+    <suppress checks="VisibilityModifier" files="(BsdOSProcess|BsdOSThread)\.java"/>
 
     <!-- Solaris shared HAL abstract bases use public data POJOs (DiskStats, IfStats, BatteryReadings)
          for the kstat I/O, interface, and battery counters that the JNA and FFM subclasses populate. -->

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSThread.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.bsd;
+
+import java.util.List;
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractOSThread;
+import oshi.software.os.OSProcess;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+/**
+ * Abstract base shared by the BSD-family OSThread implementations (FreeBSD, OpenBSD, DragonFly, NetBSD). Holds the
+ * field storage, the trivial accessors, and the shared {@code ps} thread-row parsing. Differences in the available
+ * columns (thread-id keyword, name, elapsed/cpu time, thread address) are handled by checking which keys are present.
+ * Platform-specific work (the ordered column list and the {@code ps} command used to refresh a single thread) is
+ * provided by the per-platform subclasses.
+ */
+@ThreadSafe
+public abstract class BsdOSThread extends AbstractOSThread {
+
+    protected int threadId;
+    protected String name = "";
+    protected OSProcess.State state = OSProcess.State.INVALID;
+    protected long minorFaults;
+    protected long majorFaults;
+    protected long startMemoryAddress;
+    protected long contextSwitches;
+    protected long kernelTime;
+    protected long userTime;
+    protected long startTime;
+    protected long upTime;
+    protected int priority;
+
+    protected BsdOSThread(int processId) {
+        super(processId);
+    }
+
+    @Override
+    public int getThreadId() {
+        return this.threadId;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public OSProcess.State getState() {
+        return this.state;
+    }
+
+    @Override
+    public long getStartMemoryAddress() {
+        return this.startMemoryAddress;
+    }
+
+    @Override
+    public long getContextSwitches() {
+        return this.contextSwitches;
+    }
+
+    @Override
+    public long getMinorFaults() {
+        return this.minorFaults;
+    }
+
+    @Override
+    public long getMajorFaults() {
+        return this.majorFaults;
+    }
+
+    @Override
+    public long getKernelTime() {
+        return this.kernelTime;
+    }
+
+    @Override
+    public long getUserTime() {
+        return this.userTime;
+    }
+
+    @Override
+    public long getUpTime() {
+        return this.upTime;
+    }
+
+    @Override
+    public long getStartTime() {
+        return this.startTime;
+    }
+
+    @Override
+    public int getPriority() {
+        return this.priority;
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        List<BsdPsThreadKeyword> cols = psThreadKeywords();
+        BsdPsThreadKeyword idKey = threadIdKeyword(cols);
+        BsdPsThreadKeyword lastKey = cols.get(cols.size() - 1);
+        // There is no -p switch for a single thread, so refresh the owning process's thread rows and filter to ours.
+        String idStr = Integer.toString(this.threadId);
+        for (String psOutput : ExecutingCommand.runNative(psThreadCommand() + " -p " + getOwningProcessId())) {
+            Map<BsdPsThreadKeyword, String> threadMap = ParseUtil.stringToEnumMap(BsdPsThreadKeyword.class, cols,
+                    psOutput.trim(), ' ');
+            if (threadMap.containsKey(lastKey) && idStr.equals(threadMap.get(idKey))) {
+                return updateAttributes(threadMap);
+            }
+        }
+        this.state = OSProcess.State.INVALID;
+        return false;
+    }
+
+    /**
+     * Populates this thread's attributes from a parsed {@code ps} thread row. Shared by every BSD platform; differences
+     * in the available columns are handled by checking which keys are present in the map.
+     *
+     * @param threadMap the parsed {@code ps} columns for this thread
+     * @return {@code true} once the attributes are populated
+     */
+    protected boolean updateAttributes(Map<BsdPsThreadKeyword, String> threadMap) {
+        // Thread id: lwp (FreeBSD), tid (OpenBSD/DragonFly), or lid (NetBSD)
+        this.threadId = ParseUtil.parseIntOrDefault(threadIdValue(threadMap), 0);
+        this.state = BsdOSProcess.getStateFromOutput(threadMap.get(BsdPsThreadKeyword.STATE).charAt(0));
+        // Name: tdname (FreeBSD), args (OpenBSD/NetBSD), or absent (DragonFly leaves the default empty string)
+        if (threadMap.containsKey(BsdPsThreadKeyword.TDNAME)) {
+            this.name = threadMap.get(BsdPsThreadKeyword.TDNAME);
+        } else if (threadMap.containsKey(BsdPsThreadKeyword.ARGS)) {
+            this.name = threadMap.get(BsdPsThreadKeyword.ARGS);
+        }
+        // Kernel/user time: FreeBSD reports systime separately (time is user+sys); the others fold kernel time into a
+        // single cputime/time column.
+        if (threadMap.containsKey(BsdPsThreadKeyword.SYSTIME)) {
+            this.kernelTime = ParseUtil.parseDHMSOrDefault(threadMap.get(BsdPsThreadKeyword.SYSTIME), 0L);
+            this.userTime = ParseUtil.parseDHMSOrDefault(threadMap.get(BsdPsThreadKeyword.TIME), 0L) - this.kernelTime;
+        } else if (threadMap.containsKey(BsdPsThreadKeyword.CPUTIME)) {
+            this.kernelTime = 0L;
+            this.userTime = ParseUtil.parseDHMSOrDefault(threadMap.get(BsdPsThreadKeyword.CPUTIME), 0L);
+        } else {
+            this.kernelTime = 0L;
+            this.userTime = ParseUtil.parseDHMSOrDefault(threadMap.get(BsdPsThreadKeyword.TIME), 0L);
+        }
+        // Start/up time: derived from the ps elapsed-time column where present; DragonFly's thread ps has none.
+        long now = System.currentTimeMillis();
+        if (threadMap.containsKey(BsdPsThreadKeyword.ETIMES) || threadMap.containsKey(BsdPsThreadKeyword.ETIME)) {
+            BsdPsThreadKeyword elapsedKey = threadMap.containsKey(BsdPsThreadKeyword.ETIMES) ? BsdPsThreadKeyword.ETIMES
+                    : BsdPsThreadKeyword.ETIME;
+            long elapsedTime = ParseUtil.parseDHMSOrDefault(threadMap.get(elapsedKey), 0L);
+            this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
+            this.startTime = now - this.upTime;
+        } else {
+            this.startTime = now;
+            this.upTime = 1L;
+        }
+        this.startMemoryAddress = threadMap.containsKey(BsdPsThreadKeyword.TDADDR)
+                ? ParseUtil.hexStringToLong(threadMap.get(BsdPsThreadKeyword.TDADDR), 0L)
+                : 0L;
+        this.contextSwitches = ParseUtil.parseLongOrDefault(threadMap.get(BsdPsThreadKeyword.NVCSW), 0L)
+                + ParseUtil.parseLongOrDefault(threadMap.get(BsdPsThreadKeyword.NIVCSW), 0L);
+        this.majorFaults = ParseUtil.parseLongOrDefault(threadMap.get(BsdPsThreadKeyword.MAJFLT), 0L);
+        this.minorFaults = ParseUtil.parseLongOrDefault(threadMap.get(BsdPsThreadKeyword.MINFLT), 0L);
+        this.priority = ParseUtil.parseIntOrDefault(threadMap.get(BsdPsThreadKeyword.PRI), 0);
+        return true;
+    }
+
+    private static String threadIdValue(Map<BsdPsThreadKeyword, String> threadMap) {
+        if (threadMap.containsKey(BsdPsThreadKeyword.LWP)) {
+            return threadMap.get(BsdPsThreadKeyword.LWP);
+        }
+        if (threadMap.containsKey(BsdPsThreadKeyword.TID)) {
+            return threadMap.get(BsdPsThreadKeyword.TID);
+        }
+        return threadMap.get(BsdPsThreadKeyword.LID);
+    }
+
+    private static BsdPsThreadKeyword threadIdKeyword(List<BsdPsThreadKeyword> cols) {
+        if (cols.contains(BsdPsThreadKeyword.LWP)) {
+            return BsdPsThreadKeyword.LWP;
+        }
+        if (cols.contains(BsdPsThreadKeyword.TID)) {
+            return BsdPsThreadKeyword.TID;
+        }
+        return BsdPsThreadKeyword.LID;
+    }
+
+    /**
+     * Returns this platform's ordered {@code ps} thread column keys, used to parse thread rows positionally.
+     *
+     * @return the ordered thread column keys
+     */
+    protected abstract List<BsdPsThreadKeyword> psThreadKeywords();
+
+    /**
+     * Returns the {@code ps} command (without the trailing {@code -p <pid>}) used to enumerate this process's threads
+     * when refreshing a single thread.
+     *
+     * @return the {@code ps} command prefix
+     */
+    protected abstract String psThreadCommand();
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdPsThreadKeyword.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdPsThreadKeyword.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.bsd;
+
+/**
+ * The union of {@code ps} thread (per-LWP) output columns used by the BSD-family {@code OSThread} implementations
+ * (FreeBSD, OpenBSD, DragonFly, NetBSD). Each platform declares its own ordered subset (see {@code PS_THREAD_KEYWORDS}
+ * on the per-platform {@code OSProcess} base) and parses {@code ps} output positionally against that subset. The
+ * constant order here is not significant; only the per-platform subset order is.
+ */
+public enum BsdPsThreadKeyword {
+    TDNAME, LWP, TID, LID, STATE, ETIME, ETIMES, CPUTIME, SYSTIME, TIME, TDADDR, NIVCSW, NVCSW, MAJFLT, MINFLT, PRI,
+    ARGS;
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import oshi.software.common.os.unix.bsd.BsdOSProcess;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.common.os.unix.bsd.BsdPsThreadKeyword;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
@@ -49,17 +50,6 @@ public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
             USER, UID, RGID, NLWP, PRI, VSZ, RSS, TIME, MAJFLT, MINFLT, NVCSW, NIVCSW, UCOMM, COMMAND));
 
     public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
-
-    /**
-     * Columns requested from {@code ps -awwxo} when enumerating threads. Shared by DragonFlyBsdOSProcess subclasses and
-     * DragonFlyBsdOSThread so the column list and parsing enum stay in lockstep.
-     */
-    public enum PsThreadColumns {
-        TID, STATE, TIME, MAJFLT, MINFLT, NVCSW, NIVCSW, PRI;
-    }
-
-    public static final String PS_THREAD_COLUMNS = Arrays.stream(PsThreadColumns.values()).map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     protected DragonFlyBsdOSProcess(int pid) {
@@ -100,13 +90,15 @@ public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        String psCommand = "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
+        String psCommand = "ps -awwxo " + DragonFlyBsdOSThread.PS_THREAD_COLUMNS + " -H";
         if (getProcessID() >= 0) {
             psCommand += " -p " + getProcessID();
         }
-        Predicate<Map<PsThreadColumns, String>> hasColumnsPri = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
+        Predicate<Map<BsdPsThreadKeyword, String>> hasColumnsPri = threadMap -> threadMap
+                .containsKey(BsdPsThreadKeyword.PRI);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .map(thread -> ParseUtil.stringToEnumMap(BsdPsThreadKeyword.class,
+                        DragonFlyBsdOSThread.PS_THREAD_KEYWORDS, thread.trim(), ' '))
                 .filter(hasColumnsPri).map(threadMap -> new DragonFlyBsdOSThread(getProcessID(), threadMap))
                 .filter(VALID_THREAD).collect(Collectors.toList());
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSThread.java
@@ -4,44 +4,43 @@
  */
 package oshi.software.common.os.unix.dragonflybsd;
 
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.MAJFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.MINFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.NIVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.NVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.PRI;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.STATE;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.TID;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.TIME;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.common.AbstractOSThread;
-import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess.PsThreadColumns;
-import oshi.software.os.OSProcess;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+import oshi.software.common.os.unix.bsd.BsdOSThread;
+import oshi.software.common.os.unix.bsd.BsdPsThreadKeyword;
 
 /**
  * OSThread implementation
  */
 @ThreadSafe
-public class DragonFlyBsdOSThread extends AbstractOSThread {
+public class DragonFlyBsdOSThread extends BsdOSThread {
 
-    private int threadId;
-    private String name = "";
-    private OSProcess.State state = INVALID;
-    private long minorFaults;
-    private long majorFaults;
-    private long startMemoryAddress;
-    private long contextSwitches;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private int priority;
+    /**
+     * Ordered {@code ps} thread columns. Shared with DragonFlyBsdOSProcess's thread enumeration so the column list and
+     * parsing stay in lockstep. {@code PRI} must remain last (the row-complete sentinel).
+     */
+    public static final List<BsdPsThreadKeyword> PS_THREAD_KEYWORDS = Collections
+            .unmodifiableList(Arrays.asList(TID, STATE, TIME, MAJFLT, MINFLT, NVCSW, NIVCSW, PRI));
 
-    public DragonFlyBsdOSThread(int processId, Map<PsThreadColumns, String> threadMap) {
+    public static final String PS_THREAD_COLUMNS = PS_THREAD_KEYWORDS.stream().map(Enum::name)
+            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
+
+    public DragonFlyBsdOSThread(int processId, Map<BsdPsThreadKeyword, String> threadMap) {
         super(processId);
         updateAttributes(threadMap);
     }
@@ -53,118 +52,12 @@ public class DragonFlyBsdOSThread extends AbstractOSThread {
     }
 
     @Override
-    public int getThreadId() {
-        return this.threadId;
+    protected List<BsdPsThreadKeyword> psThreadKeywords() {
+        return PS_THREAD_KEYWORDS;
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public OSProcess.State getState() {
-        return this.state;
-    }
-
-    @Override
-    public long getStartMemoryAddress() {
-        return this.startMemoryAddress;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
-    }
-
-    @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        List<String> threadList = ExecutingCommand
-                .runNative("ps -awwxo " + DragonFlyBsdOSProcess.PS_THREAD_COLUMNS + " -H -p " + getOwningProcessId());
-        // DragonFlyBsdOSProcess (oshi-common abstract base) provides PS_THREAD_COLUMNS + the PsThreadColumns enum.
-        // there is no switch for thread in ps command, hence filtering.
-        String lwpStr = Integer.toString(this.threadId);
-        for (String psOutput : threadList) {
-            Map<PsThreadColumns, String> threadMap = ParseUtil.stringToEnumMap(PsThreadColumns.class, psOutput.trim(),
-                    ' ');
-            if (threadMap.containsKey(PsThreadColumns.PRI) && lwpStr.equals(threadMap.get(PsThreadColumns.TID))) {
-                return updateAttributes(threadMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsThreadColumns, String> threadMap) {
-        this.threadId = ParseUtil.parseIntOrDefault(threadMap.get(PsThreadColumns.TID), 0);
-        switch (threadMap.get(PsThreadColumns.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
-        long now = System.currentTimeMillis();
-        this.startTime = now;
-        this.upTime = 1L;
-        this.userTime = ParseUtil.parseDHMSOrDefault(threadMap.get(PsThreadColumns.TIME), 0L);
-        this.majorFaults = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.MAJFLT), 0L);
-        this.minorFaults = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.MINFLT), 0L);
-        long nvcsw = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.NVCSW), 0L);
-        long nivcsw = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.NIVCSW), 0L);
-        this.contextSwitches = nvcsw + nivcsw;
-        this.priority = ParseUtil.parseIntOrDefault(threadMap.get(PsThreadColumns.PRI), 0);
-        return true;
+    protected String psThreadCommand() {
+        return "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSProcess.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 
 import oshi.software.common.os.unix.bsd.BsdOSProcess;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.common.os.unix.bsd.BsdPsThreadKeyword;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -51,17 +52,6 @@ public abstract class FreeBsdOSProcess extends BsdOSProcess {
                     SYSTIME, TIME, COMM, MAJFLT, MINFLT, NVCSW, NIVCSW, ARGS));
 
     public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
-
-    /**
-     * Columns requested from {@code ps -awwxo} when enumerating threads. Shared by FreeBsdOSProcess subclasses and
-     * FreeBsdOSThread so the column list and parsing enum stay in lockstep.
-     */
-    public enum PsThreadColumns {
-        TDNAME, LWP, STATE, ETIMES, SYSTIME, TIME, TDADDR, NIVCSW, NVCSW, MAJFLT, MINFLT, PRI;
-    }
-
-    public static final String PS_THREAD_COLUMNS = Arrays.stream(PsThreadColumns.values()).map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     protected FreeBsdOSProcess(int pid) {
@@ -80,13 +70,15 @@ public abstract class FreeBsdOSProcess extends BsdOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        String psCommand = "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
+        String psCommand = "ps -awwxo " + FreeBsdOSThread.PS_THREAD_COLUMNS + " -H";
         if (getProcessID() >= 0) {
             psCommand += " -p " + getProcessID();
         }
-        Predicate<Map<PsThreadColumns, String>> hasColumnsPri = threadMap -> threadMap.containsKey(PsThreadColumns.PRI);
+        Predicate<Map<BsdPsThreadKeyword, String>> hasColumnsPri = threadMap -> threadMap
+                .containsKey(BsdPsThreadKeyword.PRI);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .map(thread -> ParseUtil.stringToEnumMap(BsdPsThreadKeyword.class, FreeBsdOSThread.PS_THREAD_KEYWORDS,
+                        thread.trim(), ' '))
                 .filter(hasColumnsPri).map(threadMap -> new FreeBsdOSThread(getProcessID(), threadMap))
                 .filter(VALID_THREAD).collect(Collectors.toList());
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSThread.java
@@ -4,45 +4,47 @@
  */
 package oshi.software.common.os.unix.freebsd;
 
-import static oshi.software.common.os.unix.freebsd.FreeBsdOSProcess.PS_THREAD_COLUMNS;
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.ETIMES;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.LWP;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.MAJFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.MINFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.NIVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.NVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.PRI;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.STATE;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.SYSTIME;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.TDADDR;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.TDNAME;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.TIME;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.common.AbstractOSThread;
-import oshi.software.common.os.unix.freebsd.FreeBsdOSProcess.PsThreadColumns;
-import oshi.software.os.OSProcess;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+import oshi.software.common.os.unix.bsd.BsdOSThread;
+import oshi.software.common.os.unix.bsd.BsdPsThreadKeyword;
 
 /**
  * OSThread implementation
  */
 @ThreadSafe
-public class FreeBsdOSThread extends AbstractOSThread {
+public class FreeBsdOSThread extends BsdOSThread {
 
-    private int threadId;
-    private String name = "";
-    private OSProcess.State state = INVALID;
-    private long minorFaults;
-    private long majorFaults;
-    private long startMemoryAddress;
-    private long contextSwitches;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private int priority;
+    /**
+     * Ordered {@code ps} thread columns. Shared with FreeBsdOSProcess's thread enumeration so the column list and
+     * parsing stay in lockstep. {@code PRI} must remain last (the row-complete sentinel).
+     */
+    public static final List<BsdPsThreadKeyword> PS_THREAD_KEYWORDS = Collections.unmodifiableList(
+            Arrays.asList(TDNAME, LWP, STATE, ETIMES, SYSTIME, TIME, TDADDR, NIVCSW, NVCSW, MAJFLT, MINFLT, PRI));
 
-    public FreeBsdOSThread(int processId, Map<PsThreadColumns, String> threadMap) {
+    public static final String PS_THREAD_COLUMNS = PS_THREAD_KEYWORDS.stream().map(Enum::name)
+            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
+
+    public FreeBsdOSThread(int processId, Map<BsdPsThreadKeyword, String> threadMap) {
         super(processId);
         updateAttributes(threadMap);
     }
@@ -54,122 +56,12 @@ public class FreeBsdOSThread extends AbstractOSThread {
     }
 
     @Override
-    public int getThreadId() {
-        return this.threadId;
+    protected List<BsdPsThreadKeyword> psThreadKeywords() {
+        return PS_THREAD_KEYWORDS;
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public OSProcess.State getState() {
-        return this.state;
-    }
-
-    @Override
-    public long getStartMemoryAddress() {
-        return this.startMemoryAddress;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
-    }
-
-    @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        List<String> threadList = ExecutingCommand
-                .runNative("ps -awwxo " + PS_THREAD_COLUMNS + " -H -p " + getOwningProcessId());
-        // there is no switch for thread in ps command, hence filtering.
-        String lwpStr = Integer.toString(this.threadId);
-        for (String psOutput : threadList) {
-            Map<PsThreadColumns, String> threadMap = ParseUtil.stringToEnumMap(PsThreadColumns.class, psOutput.trim(),
-                    ' ');
-            if (threadMap.containsKey(PsThreadColumns.PRI) && lwpStr.equals(threadMap.get(PsThreadColumns.LWP))) {
-                return updateAttributes(threadMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsThreadColumns, String> threadMap) {
-        this.name = threadMap.get(PsThreadColumns.TDNAME);
-        this.threadId = ParseUtil.parseIntOrDefault(threadMap.get(PsThreadColumns.LWP), 0);
-        switch (threadMap.get(PsThreadColumns.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
-        long elapsedTime = ParseUtil.parseDHMSOrDefault(threadMap.get(PsThreadColumns.ETIMES), 0L);
-        // Avoid divide by zero for processes up less than a second
-        this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
-        long now = System.currentTimeMillis();
-        this.startTime = now - this.upTime;
-        this.kernelTime = ParseUtil.parseDHMSOrDefault(threadMap.get(PsThreadColumns.SYSTIME), 0L);
-        this.userTime = ParseUtil.parseDHMSOrDefault(threadMap.get(PsThreadColumns.TIME), 0L) - this.kernelTime;
-        this.startMemoryAddress = ParseUtil.hexStringToLong(threadMap.get(PsThreadColumns.TDADDR), 0L);
-        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.NIVCSW), 0L);
-        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.NVCSW), 0L);
-        this.contextSwitches = voluntaryContextSwitches + nonVoluntaryContextSwitches;
-        this.majorFaults = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.MAJFLT), 0L);
-        this.minorFaults = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.MINFLT), 0L);
-        this.priority = ParseUtil.parseIntOrDefault(threadMap.get(PsThreadColumns.PRI), 0);
-        return true;
+    protected String psThreadCommand() {
+        return "ps -awwxo " + PS_THREAD_COLUMNS + " -H";
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.os.unix.bsd.BsdOSProcess;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.common.os.unix.bsd.BsdPsThreadKeyword;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
@@ -56,16 +57,6 @@ public class NetBsdOSProcess extends BsdOSProcess {
             USER, UID, GROUP, GID, PRI, VSZ, RSS, ETIME, CPUTIME, COMM, MAJFLT, MINFLT, NVCSW, NIVCSW, ARGS));
 
     public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
-
-    /*
-     * Package-private for use by NetBsdOSThread
-     */
-    enum PsThreadColumns {
-        LID, STATE, ETIME, CPUTIME, NIVCSW, NVCSW, MAJFLT, MINFLT, PRI, ARGS;
-    }
-
-    static final String PS_THREAD_COLUMNS = Arrays.stream(PsThreadColumns.values()).map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     private final NetBsdOperatingSystem os;
@@ -170,14 +161,15 @@ public class NetBsdOSProcess extends BsdOSProcess {
     @Override
     public List<OSThread> getThreadDetails() {
         // NetBSD ps shows per-LWP rows when lid is in the format specifier
-        String psCommand = "ps -awwxo " + PS_THREAD_COLUMNS;
+        String psCommand = "ps -awwxo " + NetBsdOSThread.PS_THREAD_COLUMNS;
         if (getProcessID() >= 0) {
             psCommand += " -p " + getProcessID();
         }
-        Predicate<Map<PsThreadColumns, String>> hasColumnsArgs = threadMap -> threadMap
-                .containsKey(PsThreadColumns.ARGS);
+        Predicate<Map<BsdPsThreadKeyword, String>> hasColumnsArgs = threadMap -> threadMap
+                .containsKey(BsdPsThreadKeyword.ARGS);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .map(thread -> ParseUtil.stringToEnumMap(BsdPsThreadKeyword.class, NetBsdOSThread.PS_THREAD_KEYWORDS,
+                        thread.trim(), ' '))
                 .filter(hasColumnsArgs).map(threadMap -> new NetBsdOSThread(getProcessID(), threadMap))
                 .filter(VALID_THREAD).collect(Collectors.toList());
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSThread.java
@@ -4,44 +4,45 @@
  */
 package oshi.software.common.os.unix.netbsd;
 
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.ARGS;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.CPUTIME;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.ETIME;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.LID;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.MAJFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.MINFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.NIVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.NVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.PRI;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.STATE;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.common.AbstractOSThread;
-import oshi.software.common.os.unix.netbsd.NetBsdOSProcess.PsThreadColumns;
-import oshi.software.os.OSProcess;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+import oshi.software.common.os.unix.bsd.BsdOSThread;
+import oshi.software.common.os.unix.bsd.BsdPsThreadKeyword;
 
 /**
  * OSThread implementation
  */
 @ThreadSafe
-public class NetBsdOSThread extends AbstractOSThread {
+public class NetBsdOSThread extends BsdOSThread {
 
-    private int threadId;
-    private String name = "";
-    private OSProcess.State state = INVALID;
-    private long minorFaults;
-    private long majorFaults;
-    private long startMemoryAddress;
-    private long contextSwitches;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private int priority;
+    /**
+     * Ordered {@code ps} thread columns. Shared with NetBsdOSProcess's thread enumeration so the column list and
+     * parsing stay in lockstep. {@code ARGS} must remain last (the row-complete sentinel).
+     */
+    public static final List<BsdPsThreadKeyword> PS_THREAD_KEYWORDS = Collections
+            .unmodifiableList(Arrays.asList(LID, STATE, ETIME, CPUTIME, NIVCSW, NVCSW, MAJFLT, MINFLT, PRI, ARGS));
 
-    public NetBsdOSThread(int processId, Map<PsThreadColumns, String> threadMap) {
+    public static final String PS_THREAD_COLUMNS = PS_THREAD_KEYWORDS.stream().map(Enum::name)
+            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
+
+    public NetBsdOSThread(int processId, Map<BsdPsThreadKeyword, String> threadMap) {
         super(processId);
         updateAttributes(threadMap);
     }
@@ -53,123 +54,13 @@ public class NetBsdOSThread extends AbstractOSThread {
     }
 
     @Override
-    public int getThreadId() {
-        return this.threadId;
+    protected List<BsdPsThreadKeyword> psThreadKeywords() {
+        return PS_THREAD_KEYWORDS;
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public OSProcess.State getState() {
-        return this.state;
-    }
-
-    @Override
-    public long getStartMemoryAddress() {
-        return this.startMemoryAddress;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
-    }
-
-    @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        String psCommand = "ps -awwxo " + NetBsdOSProcess.PS_THREAD_COLUMNS + " -p " + getOwningProcessId();
-        // there is no switch for thread in ps command, hence filtering.
-        List<String> threadList = ExecutingCommand.runNative(psCommand);
-        String tidStr = Integer.toString(this.threadId);
-        for (String psOutput : threadList) {
-            Map<PsThreadColumns, String> threadMap = ParseUtil.stringToEnumMap(PsThreadColumns.class, psOutput.trim(),
-                    ' ');
-            if (threadMap.containsKey(PsThreadColumns.ARGS) && tidStr.equals(threadMap.get(PsThreadColumns.LID))) {
-                return updateAttributes(threadMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsThreadColumns, String> threadMap) {
-        this.threadId = ParseUtil.parseIntOrDefault(threadMap.get(PsThreadColumns.LID), 0);
-        switch (threadMap.get(PsThreadColumns.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
-        // Avoid divide by zero for processes up less than a second
-        long elapsedTime = ParseUtil.parseDHMSOrDefault(threadMap.get(PsThreadColumns.ETIME), 0L);
-        this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
-        long now = System.currentTimeMillis();
-        this.startTime = now - this.upTime;
-        // ps does not provide kerneltime on NetBSD
-        this.kernelTime = 0L;
-        this.userTime = ParseUtil.parseDHMSOrDefault(threadMap.get(PsThreadColumns.CPUTIME), 0L);
-        this.startMemoryAddress = 0L;
-        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.NIVCSW), 0L);
-        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.NVCSW), 0L);
-        this.contextSwitches = voluntaryContextSwitches + nonVoluntaryContextSwitches;
-        this.majorFaults = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.MAJFLT), 0L);
-        this.minorFaults = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.MINFLT), 0L);
-        this.priority = ParseUtil.parseIntOrDefault(threadMap.get(PsThreadColumns.PRI), 0);
-        this.name = threadMap.get(PsThreadColumns.ARGS);
-        return true;
+    protected String psThreadCommand() {
+        // NetBSD ps shows per-LWP rows when lid is in the format specifier; no -H needed
+        return "ps -awwxo " + PS_THREAD_COLUMNS;
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 
 import oshi.software.common.os.unix.bsd.BsdOSProcess;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.common.os.unix.bsd.BsdPsThreadKeyword;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -48,17 +49,6 @@ public abstract class OpenBsdOSProcess extends BsdOSProcess {
             USER, UID, GROUP, GID, PRI, VSZ, RSS, ETIME, CPUTIME, COMM, MAJFLT, MINFLT, NVCSW, NIVCSW, ARGS));
 
     public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
-            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
-
-    /**
-     * Columns requested from {@code ps -aHwwxo} when enumerating threads. Shared by OpenBsdOSProcess subclasses and
-     * OpenBsdOSThread so the column list and parsing enum stay in lockstep.
-     */
-    public enum PsThreadColumns {
-        TID, STATE, ETIME, CPUTIME, NIVCSW, NVCSW, MAJFLT, MINFLT, PRI, ARGS;
-    }
-
-    public static final String PS_THREAD_COLUMNS = Arrays.stream(PsThreadColumns.values()).map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
     protected OpenBsdOSProcess(int pid) {
@@ -88,14 +78,15 @@ public abstract class OpenBsdOSProcess extends BsdOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        String psCommand = "ps -aHwwxo " + PS_THREAD_COLUMNS;
+        String psCommand = "ps -aHwwxo " + OpenBsdOSThread.PS_THREAD_COLUMNS;
         if (getProcessID() >= 0) {
             psCommand += " -p " + getProcessID();
         }
-        Predicate<Map<PsThreadColumns, String>> hasColumnsArgs = threadMap -> threadMap
-                .containsKey(PsThreadColumns.ARGS);
+        Predicate<Map<BsdPsThreadKeyword, String>> hasColumnsArgs = threadMap -> threadMap
+                .containsKey(BsdPsThreadKeyword.ARGS);
         return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(thread -> ParseUtil.stringToEnumMap(PsThreadColumns.class, thread.trim(), ' '))
+                .map(thread -> ParseUtil.stringToEnumMap(BsdPsThreadKeyword.class, OpenBsdOSThread.PS_THREAD_KEYWORDS,
+                        thread.trim(), ' '))
                 .filter(hasColumnsArgs).map(threadMap -> new OpenBsdOSThread(getProcessID(), threadMap))
                 .filter(VALID_THREAD).collect(Collectors.toList());
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSThread.java
@@ -4,45 +4,45 @@
  */
 package oshi.software.common.os.unix.openbsd;
 
-import static oshi.software.common.os.unix.openbsd.OpenBsdOSProcess.PS_THREAD_COLUMNS;
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.ARGS;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.CPUTIME;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.ETIME;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.MAJFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.MINFLT;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.NIVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.NVCSW;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.PRI;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.STATE;
+import static oshi.software.common.os.unix.bsd.BsdPsThreadKeyword.TID;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.common.AbstractOSThread;
-import oshi.software.common.os.unix.openbsd.OpenBsdOSProcess.PsThreadColumns;
-import oshi.software.os.OSProcess;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+import oshi.software.common.os.unix.bsd.BsdOSThread;
+import oshi.software.common.os.unix.bsd.BsdPsThreadKeyword;
 
 /**
  * OSThread implementation
  */
 @ThreadSafe
-public class OpenBsdOSThread extends AbstractOSThread {
+public class OpenBsdOSThread extends BsdOSThread {
 
-    private int threadId;
-    private String name = "";
-    private OSProcess.State state = INVALID;
-    private long minorFaults;
-    private long majorFaults;
-    private long startMemoryAddress;
-    private long contextSwitches;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private int priority;
+    /**
+     * Ordered {@code ps} thread columns. Shared with OpenBsdOSProcess's thread enumeration so the column list and
+     * parsing stay in lockstep. {@code ARGS} must remain last (the row-complete sentinel).
+     */
+    public static final List<BsdPsThreadKeyword> PS_THREAD_KEYWORDS = Collections
+            .unmodifiableList(Arrays.asList(TID, STATE, ETIME, CPUTIME, NIVCSW, NVCSW, MAJFLT, MINFLT, PRI, ARGS));
 
-    public OpenBsdOSThread(int processId, Map<PsThreadColumns, String> threadMap) {
+    public static final String PS_THREAD_COLUMNS = PS_THREAD_KEYWORDS.stream().map(Enum::name)
+            .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
+
+    public OpenBsdOSThread(int processId, Map<BsdPsThreadKeyword, String> threadMap) {
         super(processId);
         updateAttributes(threadMap);
     }
@@ -54,123 +54,12 @@ public class OpenBsdOSThread extends AbstractOSThread {
     }
 
     @Override
-    public int getThreadId() {
-        return this.threadId;
+    protected List<BsdPsThreadKeyword> psThreadKeywords() {
+        return PS_THREAD_KEYWORDS;
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public OSProcess.State getState() {
-        return this.state;
-    }
-
-    @Override
-    public long getStartMemoryAddress() {
-        return this.startMemoryAddress;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
-    }
-
-    @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        String psCommand = "ps -aHwwxo " + PS_THREAD_COLUMNS + " -p " + getOwningProcessId();
-        // there is no switch for thread in ps command, hence filtering.
-        List<String> threadList = ExecutingCommand.runNative(psCommand);
-        String tidStr = Integer.toString(this.threadId);
-        for (String psOutput : threadList) {
-            Map<PsThreadColumns, String> threadMap = ParseUtil.stringToEnumMap(PsThreadColumns.class, psOutput.trim(),
-                    ' ');
-            if (threadMap.containsKey(PsThreadColumns.ARGS) && tidStr.equals(threadMap.get(PsThreadColumns.TID))) {
-                return updateAttributes(threadMap);
-            }
-        }
-        this.state = INVALID;
-        return false;
-    }
-
-    private boolean updateAttributes(Map<PsThreadColumns, String> threadMap) {
-        this.threadId = ParseUtil.parseIntOrDefault(threadMap.get(PsThreadColumns.TID), 0);
-        switch (threadMap.get(PsThreadColumns.STATE).charAt(0)) {
-            case 'R':
-                this.state = RUNNING;
-                break;
-            case 'I':
-            case 'S':
-                this.state = SLEEPING;
-                break;
-            case 'D':
-            case 'L':
-            case 'U':
-                this.state = WAITING;
-                break;
-            case 'Z':
-                this.state = ZOMBIE;
-                break;
-            case 'T':
-                this.state = STOPPED;
-                break;
-            default:
-                this.state = OTHER;
-                break;
-        }
-        // Avoid divide by zero for processes up less than a second
-        long elapsedTime = ParseUtil.parseDHMSOrDefault(threadMap.get(PsThreadColumns.ETIME), 0L);
-        this.upTime = elapsedTime < 1L ? 1L : elapsedTime;
-        long now = System.currentTimeMillis();
-        this.startTime = now - this.upTime;
-        // ps does not provide kerneltime on OpenBSD
-        this.kernelTime = 0L;
-        this.userTime = ParseUtil.parseDHMSOrDefault(threadMap.get(PsThreadColumns.CPUTIME), 0L);
-        this.startMemoryAddress = 0L;
-        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.NIVCSW), 0L);
-        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.NVCSW), 0L);
-        this.contextSwitches = voluntaryContextSwitches + nonVoluntaryContextSwitches;
-        this.majorFaults = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.MAJFLT), 0L);
-        this.minorFaults = ParseUtil.parseLongOrDefault(threadMap.get(PsThreadColumns.MINFLT), 0L);
-        this.priority = ParseUtil.parseIntOrDefault(threadMap.get(PsThreadColumns.PRI), 0);
-        this.name = threadMap.get(PsThreadColumns.ARGS);
-        return true;
+    protected String psThreadCommand() {
+        return "ps -aHwwxo " + PS_THREAD_COLUMNS;
     }
 }


### PR DESCRIPTION
## Summary

Builds on the BSD `OSProcess` dedup (#3370/#3372) by applying the same pattern one level down to the BSD `OSThread` implementations. The FreeBSD, OpenBSD, DragonFly, and NetBSD `OSThread` classes each duplicated the same ~175-line body: identical field storage and accessors, an identical `ps` STATE-char mapping, and a nearly identical `updateAttributes(map)` that parsed per-platform `ps` thread columns.

- A single `BsdPsThreadKeyword` master enum (union of all BSD `ps` thread columns).
- A `BsdOSThread` base holding the field storage, the trivial accessors, the single-thread refresh, and one shared `updateAttributes(map)`. Per-platform differences are handled by checking which keys are present: thread-id keyword (`lwp`/`tid`/`lid`), name (`tdname`/`args`/absent on DragonFly), kernel/user time (`systime`+`time` vs `cputime` vs `time`), thread address (`tdaddr` or none), and the missing elapsed column on DragonFly. State mapping reuses `BsdOSProcess.getStateFromOutput`.
- Each platform's `OSThread` declares its ordered `PS_THREAD_KEYWORDS` subset (the row-complete sentinel is the last column) plus the `ps` command; the `OSProcess` base `getThreadDetails()` references those and parses with the list-driven `ParseUtil.stringToEnumMap`. The per-platform `PsThreadColumns` enums are removed.

The `OSThread` subclasses shrink from ~175 lines to ~20 (two constructors + two hooks). Net **−245 lines**. Behavior is unchanged — the per-platform column lists and `ps` invocations are identical to before.

The thread column constants live on the `OSThread` class (not the `OSProcess` base) to avoid a static-import name collision between `BsdPsKeyword` and `BsdPsThreadKeyword`, which share many constant names.

## Testing

All five `unix.yaml` VM jobs pass, exercising the refactored code on real FreeBSD, OpenBSD, DragonFly, and NetBSD systems (plus OpenIndiana). Local spotless / checkstyle / forbidden-APIs / javadoc and a clean full-reactor build also pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified thread management logic across BSD operating system implementations for improved code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->