### PR TITLE
Extract BSD OperatingSystem common bases (JNA/FFM)

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOperatingSystem.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.dragonflybsd;
+
+import static oshi.software.os.OSService.State.RUNNING;
+import static oshi.software.os.OSService.State.STOPPED;
+import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
+import static oshi.util.Memoizer.memoize;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OSService;
+import oshi.software.os.OSThread;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+/**
+ * Abstract base shared by the DragonFly BSD OperatingSystem implementations (JNA and FFM). Holds the {@code ps}-based
+ * process enumeration, process/thread counts, services, and system uptime/boot time. The native bits (the
+ * {@link OSProcess}/{@code FileSystem}/{@code NetworkParams}/{@code InternetProtocolStats} factories,
+ * {@code getpid}/{@code lwp_gettid}, sysctl version and boot-time queries, and {@code who} sessions) are provided by
+ * the JNA and FFM subclasses.
+ */
+@ThreadSafe
+public abstract class DragonFlyBsdOperatingSystem extends AbstractOperatingSystem {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOperatingSystem.class);
+
+    private final Supplier<Long> bootTime = memoize(this::queryBootTime);
+
+    @Override
+    public String queryManufacturer() {
+        return "Unix/BSD";
+    }
+
+    @Override
+    protected int queryBitness(int jvmBitness) {
+        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
+            return jvmBitness;
+        }
+        return 64;
+    }
+
+    @Override
+    public List<OSProcess> queryAllProcesses() {
+        return getProcessListFromPS(-1);
+    }
+
+    @Override
+    public List<OSProcess> queryChildProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<OSProcess> queryDescendantProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public OSProcess getProcess(int pid) {
+        List<OSProcess> procs = getProcessListFromPS(pid);
+        if (procs.isEmpty()) {
+            return null;
+        }
+        return procs.get(0);
+    }
+
+    private List<OSProcess> getProcessListFromPS(int pid) {
+        String psCommand = "ps -awwxo " + DragonFlyBsdOSProcess.PS_COMMAND_ARGS;
+        if (pid >= 0) {
+            psCommand += " -p " + pid;
+        }
+
+        Predicate<Map<BsdPsKeyword, String>> hasKeywordCommand = psMap -> psMap.containsKey(BsdPsKeyword.COMMAND);
+        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
+                .map(proc -> ParseUtil
+                        .stringToEnumMap(BsdPsKeyword.class, DragonFlyBsdOSProcess.PS_KEYWORDS, proc.trim(), ' '))
+                .filter(hasKeywordCommand)
+                .map(psMap -> createProcess(pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid,
+                        psMap))
+                // DragonFlyBSD kernel threads report PID -1; filter them out
+                .filter(proc -> proc.getProcessID() > 0).filter(VALID_PROCESS).collect(Collectors.toList());
+    }
+
+    @Override
+    public int getProcessCount() {
+        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
+        if (!procList.isEmpty()) {
+            // Subtract 1 for header
+            return procList.size() - 1;
+        }
+        return 0;
+    }
+
+    @Override
+    public OSThread getCurrentThread() {
+        OSProcess proc = getCurrentProcess();
+        final int tid = getThreadId();
+        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
+                .orElse(new DragonFlyBsdOSThread(proc.getProcessID(), tid));
+    }
+
+    @Override
+    public int getThreadCount() {
+        int threads = 0;
+        for (String proc : ExecutingCommand.runNative("ps -axo nlwp")) {
+            threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
+        }
+        return threads;
+    }
+
+    @Override
+    public long getSystemUptime() {
+        return System.currentTimeMillis() / 1000 - getSystemBootTime();
+    }
+
+    @Override
+    public long getSystemBootTime() {
+        return bootTime.get();
+    }
+
+    @Override
+    public List<OSService> getServices() {
+        // Get running services
+        List<OSService> services = new ArrayList<>();
+        Set<String> running = new HashSet<>();
+        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
+            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
+            services.add(s);
+            running.add(p.getName());
+        }
+        // Get Directories for stopped services
+        File dir = new File("/etc/rc.d");
+        File[] listFiles;
+        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
+            for (File f : listFiles) {
+                String name = f.getName();
+                if (!running.contains(name)) {
+                    OSService s = new OSService(name, 0, STOPPED);
+                    services.add(s);
+                }
+            }
+        } else {
+            LOG.error("Directory: /etc/rc.d does not exist");
+        }
+        return services;
+    }
+
+    /**
+     * Creates a backend-specific {@link OSProcess} from a parsed {@code ps} row.
+     *
+     * @param pid   the process ID
+     * @param psMap the parsed {@code ps} columns for this process
+     * @return a new OSProcess
+     */
+    protected abstract OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap);
+
+    /**
+     * Queries the system boot time in seconds since the epoch via the backend-specific {@code kern.boottime} sysctl.
+     *
+     * @return the boot time in seconds
+     */
+    protected abstract long queryBootTime();
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2016-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.freebsd;
+
+import static oshi.software.os.OSService.State.RUNNING;
+import static oshi.software.os.OSService.State.STOPPED;
+import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
+import static oshi.util.Memoizer.memoize;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OSService;
+import oshi.software.os.OSThread;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+/**
+ * Abstract base shared by the FreeBSD OperatingSystem implementations (JNA and FFM). Holds the {@code ps}-based process
+ * enumeration, process/thread counts, services, and system uptime/boot time. The native bits (the
+ * {@link OSProcess}/{@code FileSystem}/{@code NetworkParams}/{@code InternetProtocolStats} factories,
+ * {@code getpid}/{@code thr_self}, sysctl version and boot-time queries, and {@code who} sessions) are provided by the
+ * JNA and FFM subclasses.
+ */
+@ThreadSafe
+public abstract class FreeBsdOperatingSystem extends AbstractOperatingSystem {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FreeBsdOperatingSystem.class);
+
+    private final Supplier<Long> bootTime = memoize(this::queryBootTime);
+
+    @Override
+    public String queryManufacturer() {
+        return "Unix/BSD";
+    }
+
+    @Override
+    protected int queryBitness(int jvmBitness) {
+        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
+            return jvmBitness;
+        }
+        return 64;
+    }
+
+    @Override
+    public List<OSProcess> queryAllProcesses() {
+        return getProcessListFromPS(-1);
+    }
+
+    @Override
+    public List<OSProcess> queryChildProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<OSProcess> queryDescendantProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public OSProcess getProcess(int pid) {
+        List<OSProcess> procs = getProcessListFromPS(pid);
+        if (procs.isEmpty()) {
+            return null;
+        }
+        return procs.get(0);
+    }
+
+    private List<OSProcess> getProcessListFromPS(int pid) {
+        String psCommand = "ps -awwxo " + FreeBsdOSProcess.PS_COMMAND_ARGS;
+        if (pid >= 0) {
+            psCommand += " -p " + pid;
+        }
+
+        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.ARGS);
+        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
+                .map(proc -> ParseUtil.stringToEnumMap(BsdPsKeyword.class, FreeBsdOSProcess.PS_KEYWORDS, proc.trim(),
+                        ' '))
+                .filter(hasKeywordArgs)
+                .map(psMap -> createProcess(pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid,
+                        psMap))
+                .filter(VALID_PROCESS).collect(Collectors.toList());
+    }
+
+    @Override
+    public int getProcessCount() {
+        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
+        if (!procList.isEmpty()) {
+            // Subtract 1 for header
+            return procList.size() - 1;
+        }
+        return 0;
+    }
+
+    @Override
+    public OSThread getCurrentThread() {
+        OSProcess proc = getCurrentProcess();
+        final int tid = getThreadId();
+        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
+                .orElse(new FreeBsdOSThread(proc.getProcessID(), tid));
+    }
+
+    @Override
+    public int getThreadCount() {
+        int threads = 0;
+        for (String proc : ExecutingCommand.runNative("ps -axo nlwp")) {
+            threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
+        }
+        return threads;
+    }
+
+    @Override
+    public long getSystemUptime() {
+        return System.currentTimeMillis() / 1000 - getSystemBootTime();
+    }
+
+    @Override
+    public long getSystemBootTime() {
+        return bootTime.get();
+    }
+
+    @Override
+    public List<OSService> getServices() {
+        // Get running services
+        List<OSService> services = new ArrayList<>();
+        Set<String> running = new HashSet<>();
+        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
+            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
+            services.add(s);
+            running.add(p.getName());
+        }
+        // Get Directories for stopped services
+        File dir = new File("/etc/rc.d");
+        File[] listFiles;
+        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
+            for (File f : listFiles) {
+                String name = f.getName();
+                if (!running.contains(name)) {
+                    OSService s = new OSService(name, 0, STOPPED);
+                    services.add(s);
+                }
+            }
+        } else {
+            LOG.error("Directory: /etc/rc.d does not exist");
+        }
+        return services;
+    }
+
+    /**
+     * Creates a backend-specific {@link OSProcess} from a parsed {@code ps} row.
+     *
+     * @param pid   the process ID
+     * @param psMap the parsed {@code ps} columns for this process
+     * @return a new OSProcess
+     */
+    protected abstract OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap);
+
+    /**
+     * Queries the system boot time in seconds since the epoch via the backend-specific {@code kern.boottime} sysctl.
+     *
+     * @return the boot time in seconds
+     */
+    protected abstract long queryBootTime();
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2021-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.openbsd;
+
+import static oshi.software.os.OSService.State.RUNNING;
+import static oshi.software.os.OSService.State.STOPPED;
+import static oshi.util.Memoizer.memoize;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.os.InternetProtocolStats;
+import oshi.software.os.NetworkParams;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OSService;
+import oshi.software.os.OSThread;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+/**
+ * Abstract base shared by the OpenBSD OperatingSystem implementations (JNA and FFM). Holds the {@code ps}-based process
+ * enumeration, process/thread counts, services, internet protocol stats, network params, and system uptime/boot time.
+ * The native bits (the {@link OSProcess} and {@code FileSystem} factories, {@code getpid}/{@code getthrid}, and the
+ * sysctl version query) are provided by the JNA and FFM subclasses.
+ */
+@ThreadSafe
+public abstract class OpenBsdOperatingSystem extends AbstractOperatingSystem {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOperatingSystem.class);
+
+    private final Supplier<Long> bootTime = memoize(this::queryBootTime);
+
+    @Override
+    public String queryManufacturer() {
+        return "Unix/BSD";
+    }
+
+    @Override
+    protected int queryBitness(int jvmBitness) {
+        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
+            return jvmBitness;
+        }
+        return 64;
+    }
+
+    @Override
+    public InternetProtocolStats getInternetProtocolStats() {
+        return new OpenBsdInternetProtocolStats();
+    }
+
+    @Override
+    public NetworkParams getNetworkParams() {
+        return new OpenBsdNetworkParams();
+    }
+
+    @Override
+    public List<OSProcess> queryAllProcesses() {
+        return getProcessListFromPS(-1);
+    }
+
+    @Override
+    public List<OSProcess> queryChildProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<OSProcess> queryDescendantProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public OSProcess getProcess(int pid) {
+        List<OSProcess> procs = getProcessListFromPS(pid);
+        if (procs.isEmpty()) {
+            return null;
+        }
+        return procs.get(0);
+    }
+
+    private List<OSProcess> getProcessListFromPS(int pid) {
+        List<OSProcess> procs = new ArrayList<>();
+        // https://man.openbsd.org/ps#KEYWORDS
+        // missing are threadCount and kernelTime which is included in cputime
+        String psCommand = "ps -awwxo " + OpenBsdOSProcess.PS_COMMAND_ARGS;
+        if (pid >= 0) {
+            psCommand += " -p " + pid;
+        }
+        List<String> procList = ExecutingCommand.runNative(psCommand);
+        if (procList.isEmpty() || procList.size() < 2) {
+            return procs;
+        }
+
+        // remove header row
+        procList.remove(0);
+        // Fill list
+        for (String proc : procList) {
+            Map<BsdPsKeyword, String> psMap = ParseUtil.stringToEnumMap(BsdPsKeyword.class,
+                    OpenBsdOSProcess.PS_KEYWORDS, proc.trim(), ' ');
+            // Check if last (thus all) value populated
+            if (psMap.containsKey(BsdPsKeyword.ARGS)) {
+                procs.add(createProcess(pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid,
+                        psMap));
+            }
+        }
+        return procs;
+    }
+
+    @Override
+    public int getProcessCount() {
+        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
+        if (!procList.isEmpty()) {
+            // Subtract 1 for header
+            return procList.size() - 1;
+        }
+        return 0;
+    }
+
+    @Override
+    public OSThread getCurrentThread() {
+        OSProcess proc = getCurrentProcess();
+        final int tid = getThreadId();
+        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
+                .orElse(new OpenBsdOSThread(proc.getProcessID(), tid));
+    }
+
+    @Override
+    public int getThreadCount() {
+        // -H "Also display information about kernel visible threads"
+        // -k "Also display information about kernel threads"
+        // column TID holds thread ID
+        List<String> threadList = ExecutingCommand.runNative("ps -axHo tid");
+        if (!threadList.isEmpty()) {
+            // Subtract 1 for header
+            return threadList.size() - 1;
+        }
+        return 0;
+    }
+
+    @Override
+    public long getSystemUptime() {
+        return System.currentTimeMillis() / 1000 - getSystemBootTime();
+    }
+
+    @Override
+    public long getSystemBootTime() {
+        return bootTime.get();
+    }
+
+    private long queryBootTime() {
+        // Boot time will be the first consecutive string of digits.
+        return ParseUtil.parseLongOrDefault(
+                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
+                System.currentTimeMillis() / 1000);
+    }
+
+    @Override
+    public List<OSService> getServices() {
+        // Get running services
+        List<OSService> services = new ArrayList<>();
+        Set<String> running = new HashSet<>();
+        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
+            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
+            services.add(s);
+            running.add(p.getName());
+        }
+        // Get Directories for stopped services
+        File dir = new File("/etc/rc.d");
+        File[] listFiles;
+        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
+            for (File f : listFiles) {
+                String name = f.getName();
+                if (!running.contains(name)) {
+                    OSService s = new OSService(name, 0, STOPPED);
+                    services.add(s);
+                }
+            }
+        } else {
+            LOG.error("Directory: /etc/rc.d does not exist");
+        }
+        return services;
+    }
+
+    /**
+     * Creates a backend-specific {@link OSProcess} from a parsed {@code ps} row.
+     *
+     * @param pid   the process ID
+     * @param psMap the parsed {@code ps} columns for this process
+     * @return a new OSProcess
+     */
+    protected abstract OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap);
+}

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
@@ -6,20 +6,11 @@ package oshi.software.os.unix.dragonflybsd;
 
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
-import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
 
-import java.io.File;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,16 +21,13 @@ import oshi.driver.unix.freebsd.WhoFFM;
 import oshi.ffm.platform.unix.dragonflybsd.DragonFlyBsdLibcFunctions;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
-import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
-import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
+import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
 import oshi.software.os.OSSession;
-import oshi.software.os.OSThread;
 import oshi.software.os.unix.freebsd.FreeBsdFileSystemFFM;
 import oshi.software.os.unix.freebsd.FreeBsdInternetProtocolStatsFFM;
 import oshi.software.os.unix.freebsd.FreeBsdNetworkParamsFFM;
@@ -51,16 +39,9 @@ import oshi.util.tuples.Pair;
  * FFM-backed DragonFly BSD operating system.
  */
 @ThreadSafe
-public class DragonFlyBsdOperatingSystemFFM extends AbstractOperatingSystem {
+public class DragonFlyBsdOperatingSystemFFM extends DragonFlyBsdOperatingSystem {
 
     private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOperatingSystemFFM.class);
-
-    private static final long BOOTTIME = querySystemBootTime();
-
-    @Override
-    public String queryManufacturer() {
-        return "Unix/BSD";
-    }
 
     @Override
     public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
@@ -74,14 +55,6 @@ public class DragonFlyBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
-            return jvmBitness;
-        }
-        return 64;
-    }
-
-    @Override
     public FileSystem getFileSystem() {
         return new FreeBsdFileSystemFFM();
     }
@@ -92,68 +65,18 @@ public class DragonFlyBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     @Override
+    public NetworkParams getNetworkParams() {
+        return new FreeBsdNetworkParamsFFM();
+    }
+
+    @Override
     public List<OSSession> getSessions() {
         return USE_WHO_COMMAND ? super.getSessions() : WhoFFM.queryUtxent();
     }
 
     @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromPS(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromPS(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromPS(int pid) {
-        String psCommand = "ps -awwxo " + DragonFlyBsdOSProcess.PS_COMMAND_ARGS;
-        if (pid >= 0) {
-            psCommand += " -p " + pid;
-        }
-
-        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.COMMAND);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(proc -> ParseUtil
-                        .stringToEnumMap(BsdPsKeyword.class, DragonFlyBsdOSProcess.PS_KEYWORDS, proc.trim(), ' '))
-                .filter(hasKeywordArgs)
-                .map(psMap -> new DragonFlyBsdOSProcessFFM(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this))
-                // DragonFlyBSD kernel threads report PID -1; filter them out
-                .filter(proc -> proc.getProcessID() > 0).filter(VALID_PROCESS).collect(Collectors.toList());
-    }
-
-    @Override
     public int getProcessId() {
         return callInArenaIntOrDefault(arena -> FreeBsdLibcFunctions.getpid(), LOG, Level.WARN, "getpid failed", 0);
-    }
-
-    @Override
-    public int getProcessCount() {
-        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
-        if (!procList.isEmpty()) {
-            // Subtract 1 for header
-            return procList.size() - 1;
-        }
-        return 0;
     }
 
     @Override
@@ -164,33 +87,12 @@ public class DragonFlyBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     @Override
-    public OSThread getCurrentThread() {
-        OSProcess proc = getCurrentProcess();
-        final int tid = getThreadId();
-        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
-                .orElse(new oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSThread(proc.getProcessID(), tid));
+    protected OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap) {
+        return new DragonFlyBsdOSProcessFFM(pid, psMap, this);
     }
 
     @Override
-    public int getThreadCount() {
-        int threads = 0;
-        for (String proc : ExecutingCommand.runNative("ps -axo nlwp")) {
-            threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
-        }
-        return threads;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000 - BOOTTIME;
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return BOOTTIME;
-    }
-
-    private static long querySystemBootTime() {
+    protected long queryBootTime() {
         try (Arena arena = Arena.ofConfined()) {
             // struct timeval: two longs (tv_sec, tv_usec) = 16 bytes on LP64 BSD.
             MemorySegment tv = arena.allocate(JAVA_LONG.byteSize() * 2);
@@ -202,37 +104,5 @@ public class DragonFlyBsdOperatingSystemFFM extends AbstractOperatingSystem {
         return ParseUtil.parseLongOrDefault(
                 ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
                 System.currentTimeMillis() / 1000);
-    }
-
-    @Override
-    public NetworkParams getNetworkParams() {
-        return new FreeBsdNetworkParamsFFM();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        // Get running services
-        List<OSService> services = new ArrayList<>();
-        Set<String> running = new HashSet<>();
-        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
-            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
-            services.add(s);
-            running.add(p.getName());
-        }
-        // Get Directories for stopped services
-        File dir = new File("/etc/rc.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File f : listFiles) {
-                String name = f.getName();
-                if (!running.contains(name)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
-                }
-            }
-        } else {
-            LOG.error("Directory: /etc/rc.d does not exist");
-        }
-        return services;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemFFM.java
@@ -6,20 +6,11 @@ package oshi.software.os.unix.freebsd;
 
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
-import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
 
-import java.io.File;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,17 +20,13 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.freebsd.WhoFFM;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
-import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
-import oshi.software.common.os.unix.freebsd.FreeBsdOSProcess;
-import oshi.software.common.os.unix.freebsd.FreeBsdOSThread;
+import oshi.software.common.os.unix.freebsd.FreeBsdOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
 import oshi.software.os.OSSession;
-import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
@@ -48,16 +35,9 @@ import oshi.util.tuples.Pair;
  * FFM-backed FreeBSD operating system.
  */
 @ThreadSafe
-public class FreeBsdOperatingSystemFFM extends AbstractOperatingSystem {
+public class FreeBsdOperatingSystemFFM extends FreeBsdOperatingSystem {
 
     private static final Logger LOG = LoggerFactory.getLogger(FreeBsdOperatingSystemFFM.class);
-
-    private static final long BOOTTIME = querySystemBootTime();
-
-    @Override
-    public String queryManufacturer() {
-        return "Unix/BSD";
-    }
 
     @Override
     public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
@@ -71,14 +51,6 @@ public class FreeBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
-            return jvmBitness;
-        }
-        return 64;
-    }
-
-    @Override
     public FileSystem getFileSystem() {
         return new FreeBsdFileSystemFFM();
     }
@@ -89,67 +61,18 @@ public class FreeBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     @Override
+    public NetworkParams getNetworkParams() {
+        return new FreeBsdNetworkParamsFFM();
+    }
+
+    @Override
     public List<OSSession> getSessions() {
         return USE_WHO_COMMAND ? super.getSessions() : WhoFFM.queryUtxent();
     }
 
     @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromPS(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromPS(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromPS(int pid) {
-        String psCommand = "ps -awwxo " + FreeBsdOSProcess.PS_COMMAND_ARGS;
-        if (pid >= 0) {
-            psCommand += " -p " + pid;
-        }
-
-        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.ARGS);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(proc -> ParseUtil
-                        .stringToEnumMap(BsdPsKeyword.class, FreeBsdOSProcess.PS_KEYWORDS, proc.trim(), ' '))
-                .filter(hasKeywordArgs)
-                .map(psMap -> new FreeBsdOSProcessFFM(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this))
-                .filter(VALID_PROCESS).collect(Collectors.toList());
-    }
-
-    @Override
     public int getProcessId() {
         return callInArenaIntOrDefault(arena -> FreeBsdLibcFunctions.getpid(), LOG, Level.WARN, "getpid failed", 0);
-    }
-
-    @Override
-    public int getProcessCount() {
-        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
-        if (!procList.isEmpty()) {
-            // Subtract 1 for header
-            return procList.size() - 1;
-        }
-        return 0;
     }
 
     @Override
@@ -164,33 +87,12 @@ public class FreeBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     @Override
-    public OSThread getCurrentThread() {
-        OSProcess proc = getCurrentProcess();
-        final int tid = getThreadId();
-        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
-                .orElse(new FreeBsdOSThread(proc.getProcessID(), tid));
+    protected OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap) {
+        return new FreeBsdOSProcessFFM(pid, psMap, this);
     }
 
     @Override
-    public int getThreadCount() {
-        int threads = 0;
-        for (String proc : ExecutingCommand.runNative("ps -axo nlwp")) {
-            threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
-        }
-        return threads;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000 - BOOTTIME;
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return BOOTTIME;
-    }
-
-    private static long querySystemBootTime() {
+    protected long queryBootTime() {
         try (Arena arena = Arena.ofConfined()) {
             // struct timeval: two longs (tv_sec, tv_usec) = 16 bytes on LP64 FreeBSD.
             MemorySegment tv = arena.allocate(JAVA_LONG.byteSize() * 2);
@@ -202,37 +104,5 @@ public class FreeBsdOperatingSystemFFM extends AbstractOperatingSystem {
         return ParseUtil.parseLongOrDefault(
                 ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
                 System.currentTimeMillis() / 1000);
-    }
-
-    @Override
-    public NetworkParams getNetworkParams() {
-        return new FreeBsdNetworkParamsFFM();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        // Get running services
-        List<OSService> services = new ArrayList<>();
-        Set<String> running = new HashSet<>();
-        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
-            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
-            services.add(s);
-            running.add(p.getName());
-        }
-        // Get Directories for stopped services
-        File dir = new File("/etc/rc.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File f : listFiles) {
-                String name = f.getName();
-                if (!running.contains(name)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
-                }
-            }
-        } else {
-            LOG.error("Directory: /etc/rc.d does not exist");
-        }
-        return services;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
@@ -8,16 +8,8 @@ import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CTL_KERN;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_OSRELEASE;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_OSTYPE;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_VERSION;
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,33 +19,19 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.ForeignFunctions;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
-import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
-import oshi.software.common.os.unix.openbsd.OpenBsdInternetProtocolStats;
-import oshi.software.common.os.unix.openbsd.OpenBsdNetworkParams;
-import oshi.software.common.os.unix.openbsd.OpenBsdOSProcess;
-import oshi.software.common.os.unix.openbsd.OpenBsdOSThread;
+import oshi.software.common.os.unix.openbsd.OpenBsdOperatingSystem;
 import oshi.software.os.FileSystem;
-import oshi.software.os.InternetProtocolStats;
-import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
-import oshi.software.os.OSThread;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 
+/**
+ * FFM-backed OpenBSD operating system.
+ */
 @ThreadSafe
-public class OpenBsdOperatingSystemFFM extends AbstractOperatingSystem {
+public class OpenBsdOperatingSystemFFM extends OpenBsdOperatingSystem {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOperatingSystemFFM.class);
-
-    private static final long BOOTTIME = querySystemBootTime();
-
-    @Override
-    public String queryManufacturer() {
-        return "Unix/BSD";
-    }
 
     @Override
     public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
@@ -71,72 +49,8 @@ public class OpenBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
-            return jvmBitness;
-        }
-        return 64;
-    }
-
-    @Override
     public FileSystem getFileSystem() {
         return new OpenBsdFileSystemFFM();
-    }
-
-    @Override
-    public InternetProtocolStats getInternetProtocolStats() {
-        return new OpenBsdInternetProtocolStats();
-    }
-
-    @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromPS(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromPS(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromPS(int pid) {
-        String psCommand = "ps -awwxo " + OpenBsdOSProcess.PS_COMMAND_ARGS;
-        if (pid >= 0) {
-            psCommand += " -p " + pid;
-        }
-        List<String> procList = ExecutingCommand.runNative(psCommand);
-        if (procList.size() < 2) {
-            return new ArrayList<>();
-        }
-        procList.remove(0);
-        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.ARGS);
-        List<OSProcess> procs = new ArrayList<>();
-        for (String proc : procList) {
-            Map<BsdPsKeyword, String> psMap = ParseUtil.stringToEnumMap(BsdPsKeyword.class,
-                    OpenBsdOSProcess.PS_KEYWORDS, proc.trim(), ' ');
-            if (hasKeywordArgs.test(psMap)) {
-                procs.add(new OpenBsdOSProcessFFM(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this));
-            }
-        }
-        return procs;
     }
 
     @Override
@@ -146,80 +60,13 @@ public class OpenBsdOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     @Override
-    public int getProcessCount() {
-        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
-        if (!procList.isEmpty()) {
-            return procList.size() - 1;
-        }
-        return 0;
-    }
-
-    @Override
     public int getThreadId() {
         return ForeignFunctions.callInArenaIntOrDefault(arena -> OpenBsdLibcFunctions.getthrid(), LOG, Level.WARN,
                 "getthrid failed", 0);
     }
 
     @Override
-    public OSThread getCurrentThread() {
-        OSProcess proc = getCurrentProcess();
-        final int tid = getThreadId();
-        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
-                .orElse(new OpenBsdOSThread(proc.getProcessID(), tid));
-    }
-
-    @Override
-    public int getThreadCount() {
-        List<String> threadList = ExecutingCommand.runNative("ps -axHo tid");
-        if (!threadList.isEmpty()) {
-            return threadList.size() - 1;
-        }
-        return 0;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000 - BOOTTIME;
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return BOOTTIME;
-    }
-
-    private static long querySystemBootTime() {
-        return ParseUtil.parseLongOrDefault(
-                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
-                System.currentTimeMillis() / 1000);
-    }
-
-    @Override
-    public NetworkParams getNetworkParams() {
-        return new OpenBsdNetworkParams();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        List<OSService> services = new ArrayList<>();
-        Set<String> running = new HashSet<>();
-        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
-            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
-            services.add(s);
-            running.add(p.getName());
-        }
-        File dir = new File("/etc/rc.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File f : listFiles) {
-                String name = f.getName();
-                if (!running.contains(name)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
-                }
-            }
-        } else {
-            LOG.error("Directory: /etc/rc.d does not exist");
-        }
-        return services;
+    protected OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap) {
+        return new OpenBsdOSProcessFFM(pid, psMap, this);
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemJNA.java
@@ -4,37 +4,20 @@
  */
 package oshi.software.os.unix.dragonflybsd;
 
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
-import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.freebsd.Who;
 import oshi.jna.platform.unix.DragonFlyBsdLibc;
 import oshi.jna.platform.unix.FreeBsdLibc;
-import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
-import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
-import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSThread;
+import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
 import oshi.software.os.OSSession;
-import oshi.software.os.OSThread;
 import oshi.software.os.unix.freebsd.FreeBsdFileSystemJNA;
 import oshi.software.os.unix.freebsd.FreeBsdInternetProtocolStatsJNA;
 import oshi.software.os.unix.freebsd.FreeBsdNetworkParamsJNA;
@@ -44,20 +27,10 @@ import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
 import oshi.util.tuples.Pair;
 
 /**
- * DragonFly BSD is a free and open-source Unix-like operating system forked from FreeBSD 4.8 in 2003. It features the
- * HAMMER2 filesystem and a unique approach to SMP with its lightweight kernel threads (LWKT) subsystem.
+ * JNA-backed DragonFly BSD operating system.
  */
 @ThreadSafe
-public class DragonFlyBsdOperatingSystemJNA extends AbstractOperatingSystem {
-
-    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOperatingSystemJNA.class);
-
-    private static final long BOOTTIME = querySystemBootTime();
-
-    @Override
-    public String queryManufacturer() {
-        return "Unix/BSD";
-    }
+public class DragonFlyBsdOperatingSystemJNA extends DragonFlyBsdOperatingSystem {
 
     @Override
     public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
@@ -71,14 +44,6 @@ public class DragonFlyBsdOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
-            return jvmBitness;
-        }
-        return 64;
-    }
-
-    @Override
     public FileSystem getFileSystem() {
         return new FreeBsdFileSystemJNA();
     }
@@ -89,68 +54,18 @@ public class DragonFlyBsdOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     @Override
+    public NetworkParams getNetworkParams() {
+        return new FreeBsdNetworkParamsJNA();
+    }
+
+    @Override
     public List<OSSession> getSessions() {
         return USE_WHO_COMMAND ? super.getSessions() : Who.queryUtxent();
     }
 
     @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromPS(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromPS(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromPS(int pid) {
-        String psCommand = "ps -awwxo " + DragonFlyBsdOSProcess.PS_COMMAND_ARGS;
-        if (pid >= 0) {
-            psCommand += " -p " + pid;
-        }
-
-        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.COMMAND);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(proc -> ParseUtil
-                        .stringToEnumMap(BsdPsKeyword.class, DragonFlyBsdOSProcess.PS_KEYWORDS, proc.trim(), ' '))
-                .filter(hasKeywordArgs)
-                .map(psMap -> new DragonFlyBsdOSProcessJNA(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this))
-                // DragonFlyBSD kernel threads report PID -1; filter them out
-                .filter(proc -> proc.getProcessID() > 0).filter(VALID_PROCESS).collect(Collectors.toList());
-    }
-
-    @Override
     public int getProcessId() {
         return DragonFlyBsdLibc.INSTANCE.getpid();
-    }
-
-    @Override
-    public int getProcessCount() {
-        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
-        if (!procList.isEmpty()) {
-            // Subtract 1 for header
-            return procList.size() - 1;
-        }
-        return 0;
     }
 
     @Override
@@ -160,33 +75,12 @@ public class DragonFlyBsdOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     @Override
-    public OSThread getCurrentThread() {
-        OSProcess proc = getCurrentProcess();
-        final int tid = getThreadId();
-        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
-                .orElse(new DragonFlyBsdOSThread(proc.getProcessID(), tid));
+    protected OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap) {
+        return new DragonFlyBsdOSProcessJNA(pid, psMap, this);
     }
 
     @Override
-    public int getThreadCount() {
-        int threads = 0;
-        for (String proc : ExecutingCommand.runNative("ps -axo nlwp")) {
-            threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
-        }
-        return threads;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000 - BOOTTIME;
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return BOOTTIME;
-    }
-
-    private static long querySystemBootTime() {
+    protected long queryBootTime() {
         FreeBsdLibc.Timeval tv = new FreeBsdLibc.Timeval();
         if (!BsdSysctlUtil.sysctl("kern.boottime", tv) || tv.tv_sec == 0) {
             // Fall back to text parsing: "{ sec = 1779823319, nsec = 0 } ..."
@@ -195,37 +89,5 @@ public class DragonFlyBsdOperatingSystemJNA extends AbstractOperatingSystem {
                     System.currentTimeMillis() / 1000);
         }
         return tv.tv_sec;
-    }
-
-    @Override
-    public NetworkParams getNetworkParams() {
-        return new FreeBsdNetworkParamsJNA();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        // Get running services
-        List<OSService> services = new ArrayList<>();
-        Set<String> running = new HashSet<>();
-        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
-            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
-            services.add(s);
-            running.add(p.getName());
-        }
-        // Get Directories for stopped services
-        File dir = new File("/etc/rc.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File f : listFiles) {
-                String name = f.getName();
-                if (!running.contains(name)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
-                }
-            }
-        } else {
-            LOG.error("Directory: /etc/rc.d does not exist");
-        }
-        return services;
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemJNA.java
@@ -4,21 +4,8 @@
  */
 package oshi.software.os.unix.freebsd;
 
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
-import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.sun.jna.ptr.NativeLongByReference;
 
@@ -26,39 +13,23 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.freebsd.Who;
 import oshi.jna.platform.unix.FreeBsdLibc;
 import oshi.jna.platform.unix.FreeBsdLibc.Timeval;
-import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
-import oshi.software.common.os.unix.freebsd.FreeBsdOSProcess;
-import oshi.software.common.os.unix.freebsd.FreeBsdOSThread;
+import oshi.software.common.os.unix.freebsd.FreeBsdOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
 import oshi.software.os.OSSession;
-import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
 import oshi.util.tuples.Pair;
 
 /**
- * FreeBSD is a free and open-source Unix-like operating system descended from the Berkeley Software Distribution (BSD),
- * which was based on Research Unix. The first version of FreeBSD was released in 1993. In 2005, FreeBSD was the most
- * popular open-source BSD operating system, accounting for more than three-quarters of all installed simply,
- * permissively licensed BSD systems.
+ * JNA-backed FreeBSD operating system.
  */
 @ThreadSafe
-public class FreeBsdOperatingSystemJNA extends AbstractOperatingSystem {
-
-    private static final Logger LOG = LoggerFactory.getLogger(FreeBsdOperatingSystemJNA.class);
-
-    private static final long BOOTTIME = querySystemBootTime();
-
-    @Override
-    public String queryManufacturer() {
-        return "Unix/BSD";
-    }
+public class FreeBsdOperatingSystemJNA extends FreeBsdOperatingSystem {
 
     @Override
     public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
@@ -72,14 +43,6 @@ public class FreeBsdOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
-            return jvmBitness;
-        }
-        return 64;
-    }
-
-    @Override
     public FileSystem getFileSystem() {
         return new FreeBsdFileSystemJNA();
     }
@@ -90,67 +53,18 @@ public class FreeBsdOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     @Override
+    public NetworkParams getNetworkParams() {
+        return new FreeBsdNetworkParamsJNA();
+    }
+
+    @Override
     public List<OSSession> getSessions() {
         return USE_WHO_COMMAND ? super.getSessions() : Who.queryUtxent();
     }
 
     @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromPS(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromPS(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromPS(int pid) {
-        String psCommand = "ps -awwxo " + FreeBsdOSProcess.PS_COMMAND_ARGS;
-        if (pid >= 0) {
-            psCommand += " -p " + pid;
-        }
-
-        Predicate<Map<BsdPsKeyword, String>> hasKeywordArgs = psMap -> psMap.containsKey(BsdPsKeyword.ARGS);
-        return ExecutingCommand.runNative(psCommand).stream().skip(1).parallel()
-                .map(proc -> ParseUtil
-                        .stringToEnumMap(BsdPsKeyword.class, FreeBsdOSProcess.PS_KEYWORDS, proc.trim(), ' '))
-                .filter(hasKeywordArgs)
-                .map(psMap -> new FreeBsdOSProcessJNA(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this))
-                .filter(VALID_PROCESS).collect(Collectors.toList());
-    }
-
-    @Override
     public int getProcessId() {
         return FreeBsdLibc.INSTANCE.getpid();
-    }
-
-    @Override
-    public int getProcessCount() {
-        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
-        if (!procList.isEmpty()) {
-            // Subtract 1 for header
-            return procList.size() - 1;
-        }
-        return 0;
     }
 
     @Override
@@ -163,33 +77,12 @@ public class FreeBsdOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     @Override
-    public OSThread getCurrentThread() {
-        OSProcess proc = getCurrentProcess();
-        final int tid = getThreadId();
-        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
-                .orElse(new FreeBsdOSThread(proc.getProcessID(), tid));
+    protected OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap) {
+        return new FreeBsdOSProcessJNA(pid, psMap, this);
     }
 
     @Override
-    public int getThreadCount() {
-        int threads = 0;
-        for (String proc : ExecutingCommand.runNative("ps -axo nlwp")) {
-            threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
-        }
-        return threads;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000 - BOOTTIME;
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return BOOTTIME;
-    }
-
-    private static long querySystemBootTime() {
+    protected long queryBootTime() {
         Timeval tv = new Timeval();
         if (!BsdSysctlUtil.sysctl("kern.boottime", tv) || tv.tv_sec == 0) {
             // Usually this works. If it doesn't, fall back to text parsing.
@@ -201,37 +94,5 @@ public class FreeBsdOperatingSystemJNA extends AbstractOperatingSystem {
         // tv now points to a 128-bit timeval structure for boot time.
         // First 8 bytes are seconds, second 8 bytes are microseconds (we ignore)
         return tv.tv_sec;
-    }
-
-    @Override
-    public NetworkParams getNetworkParams() {
-        return new FreeBsdNetworkParamsJNA();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        // Get running services
-        List<OSService> services = new ArrayList<>();
-        Set<String> running = new HashSet<>();
-        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
-            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
-            services.add(s);
-            running.add(p.getName());
-        }
-        // Get Directories for stopped services
-        File dir = new File("/etc/rc.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File f : listFiles) {
-                String name = f.getName();
-                if (!running.contains(name)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
-                }
-            }
-        } else {
-            LOG.error("Directory: /etc/rc.d does not exist");
-        }
-        return services;
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemJNA.java
@@ -8,54 +8,23 @@ import static oshi.jna.platform.unix.OpenBsdLibc.CTL_KERN;
 import static oshi.jna.platform.unix.OpenBsdLibc.KERN_OSRELEASE;
 import static oshi.jna.platform.unix.OpenBsdLibc.KERN_OSTYPE;
 import static oshi.jna.platform.unix.OpenBsdLibc.KERN_VERSION;
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.platform.unix.OpenBsdLibc;
-import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
-import oshi.software.common.os.unix.openbsd.OpenBsdInternetProtocolStats;
-import oshi.software.common.os.unix.openbsd.OpenBsdNetworkParams;
-import oshi.software.common.os.unix.openbsd.OpenBsdOSProcess;
-import oshi.software.common.os.unix.openbsd.OpenBsdOSThread;
+import oshi.software.common.os.unix.openbsd.OpenBsdOperatingSystem;
 import oshi.software.os.FileSystem;
-import oshi.software.os.InternetProtocolStats;
-import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
-import oshi.software.os.OSThread;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
 import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
 import oshi.util.tuples.Pair;
 
 /**
- * OpenBsd is a free and open-source Unix-like operating system descended from the Berkeley Software Distribution (BSD),
- * which was based on Research Unix.
+ * JNA-backed OpenBSD operating system.
  */
 @ThreadSafe
-public class OpenBsdOperatingSystemJNA extends AbstractOperatingSystem {
-
-    private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOperatingSystemJNA.class);
-
-    private static final long BOOTTIME = querySystemBootTime();
-
-    @Override
-    public String queryManufacturer() {
-        return "Unix/BSD";
-    }
+public class OpenBsdOperatingSystemJNA extends OpenBsdOperatingSystem {
 
     @Override
     public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
@@ -73,77 +42,8 @@ public class OpenBsdOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
-            return jvmBitness;
-        }
-        return 64;
-    }
-
-    @Override
     public FileSystem getFileSystem() {
         return new OpenBsdFileSystemJNA();
-    }
-
-    @Override
-    public InternetProtocolStats getInternetProtocolStats() {
-        return new OpenBsdInternetProtocolStats();
-    }
-
-    @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromPS(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromPS(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromPS(int pid) {
-        List<OSProcess> procs = new ArrayList<>();
-        // https://man.openbsd.org/ps#KEYWORDS
-        // missing are threadCount and kernelTime which is included in cputime
-        String psCommand = "ps -awwxo " + OpenBsdOSProcess.PS_COMMAND_ARGS;
-        if (pid >= 0) {
-            psCommand += " -p " + pid;
-        }
-        List<String> procList = ExecutingCommand.runNative(psCommand);
-        if (procList.isEmpty() || procList.size() < 2) {
-            return procs;
-        }
-
-        // remove header row
-        procList.remove(0);
-        // Fill list
-        for (String proc : procList) {
-            Map<BsdPsKeyword, String> psMap = ParseUtil.stringToEnumMap(BsdPsKeyword.class,
-                    OpenBsdOSProcess.PS_KEYWORDS, proc.trim(), ' ');
-            // Check if last (thus all) value populated
-            if (psMap.containsKey(BsdPsKeyword.ARGS)) {
-                procs.add(new OpenBsdOSProcessJNA(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this));
-            }
-        }
-        return procs;
     }
 
     @Override
@@ -152,87 +52,12 @@ public class OpenBsdOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     @Override
-    public int getProcessCount() {
-        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
-        if (!procList.isEmpty()) {
-            // Subtract 1 for header
-            return procList.size() - 1;
-        }
-        return 0;
-    }
-
-    @Override
     public int getThreadId() {
         return OpenBsdLibc.INSTANCE.getthrid();
     }
 
     @Override
-    public OSThread getCurrentThread() {
-        OSProcess proc = getCurrentProcess();
-        final int tid = getThreadId();
-        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
-                .orElse(new OpenBsdOSThread(proc.getProcessID(), tid));
-    }
-
-    @Override
-    public int getThreadCount() {
-        // -H "Also display information about kernel visible threads"
-        // -k "Also display information about kernel threads"
-        // column TID holds thread ID
-        List<String> threadList = ExecutingCommand.runNative("ps -axHo tid");
-        if (!threadList.isEmpty()) {
-            // Subtract 1 for header
-            return threadList.size() - 1;
-        }
-        return 0;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000 - BOOTTIME;
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return BOOTTIME;
-    }
-
-    private static long querySystemBootTime() {
-        // Boot time will be the first consecutive string of digits.
-        return ParseUtil.parseLongOrDefault(
-                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
-                System.currentTimeMillis() / 1000);
-    }
-
-    @Override
-    public NetworkParams getNetworkParams() {
-        return new OpenBsdNetworkParams();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        // Get running services
-        List<OSService> services = new ArrayList<>();
-        Set<String> running = new HashSet<>();
-        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
-            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
-            services.add(s);
-            running.add(p.getName());
-        }
-        // Get Directories for stopped services
-        File dir = new File("/etc/rc.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File f : listFiles) {
-                String name = f.getName();
-                if (!running.contains(name)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
-                }
-            }
-        } else {
-            LOG.error("Directory: /etc/rc.d does not exist");
-        }
-        return services;
+    protected OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap) {
+        return new OpenBsdOSProcessJNA(pid, psMap, this);
     }
 }


### PR DESCRIPTION
## Summary

Completes the BSD `OperatingSystem` deduplication (after the `OSProcess` #3372 and `OSThread` #3374 work). The FreeBSD, OpenBSD, and DragonFly `OperatingSystem` classes each duplicated their *entire* body between the JNA and FFM backends — the method signatures were identical; only the native calls and backend factory types differed.

Following the Solaris #3367 template, this extracts an abstract per-platform base in `oshi-common` holding the shared, non-native logic (ps-based process enumeration, process/thread counts, services, system uptime/boot time). The JNA and FFM subclasses are reduced to the genuinely backend-specific bits: the `OSProcess` factory (a new `createProcess` hook), the `FileSystem`/`NetworkParams`/`InternetProtocolStats` factories, `getpid`/thread-id, the sysctl version query, and `who` sessions.

Per-platform notes:
- **Boot time:** FreeBSD/DragonFly read it from a native sysctl struct, so their base declares an abstract `queryBootTime()` hook (memoized via `getSystemBootTime()`); OpenBSD text-parses it, so its base implements `queryBootTime()` concretely.
- **OpenBSD** `InternetProtocolStats` and `NetworkParams` are common (non-native) classes, so they move into its base; FreeBSD/DragonFly keep their JNA/FFM factory overrides.
- **DragonFly** reuses FreeBSD's filesystem/IP/network impls and keeps its kernel-thread (`pid <= 0`) filter in the shared enumeration.
- **NetBSD** already has a single common `OperatingSystem` class and is unchanged.

The JNA/FFM subclasses shrink from ~225–238 lines each to ~55–90. Net **−287 lines**. Behavior is unchanged — the per-platform `ps` commands and column lists are identical to before.

Cross-platform commonality between the three new bases (e.g. `getProcessCount`/`getServices`) remains; collapsing that into a shared `BsdOperatingSystem` super-base is a possible follow-up but was kept out to keep this change a clean JNA↔FFM dedup mirroring the Solaris template.

## Testing

All five `unix.yaml` VM jobs pass, exercising the refactored code on real FreeBSD, OpenBSD, DragonFly, and NetBSD systems (plus OpenIndiana). Local spotless / checkstyle / forbidden-APIs / javadoc and a clean full-reactor build also pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated BSD operating system implementations for DragonFly BSD, FreeBSD, and OpenBSD. Process enumeration, thread counting, system uptime/boot time queries, and service discovery are now handled through shared base class methods, with platform-specific implementations providing only native-code bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->