### PR TITLE
Extract MacOSProcess common base (JNA/FFM dedup)

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -62,10 +62,10 @@
     <suppress checks="MemberName" files="(AixCentralProcessor|AixHWDiskStore|AixNetworkIF|AixGlobalMemory)\.java"/>
     <suppress checks="VisibilityModifier" files="(AixCentralProcessor|AixHWDiskStore|AixNetworkIF|AixGlobalMemory)\.java"/>
 
-    <!-- BsdOSProcess/BsdOSThread are the shared BSD-family OSProcess/OSThread bases; their protected fields
-         are populated by the shared updateAttributes() against platform-specific ps columns (and the thread
-         id is set by the per-platform OSThread constructors), so they can't be private with accessors. -->
-    <suppress checks="VisibilityModifier" files="(BsdOSProcess|BsdOSThread)\.java"/>
+    <!-- BsdOSProcess/BsdOSThread/MacOSProcess are shared OSProcess/OSThread bases; their protected fields are
+         populated by the per-backend native updateAttributes() in the subclasses (and the thread id / version are
+         set by the per-platform constructors), so they can't be private with accessors. -->
+    <suppress checks="VisibilityModifier" files="(BsdOSProcess|BsdOSThread|MacOSProcess)\.java"/>
 
     <!-- Solaris shared HAL abstract bases use public data POJOs (DiskStats, IfStats, BatteryReadings)
          for the kstat I/O, interface, and battery counters that the JNA and FFM subclasses populate. -->

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSProcess.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.mac;
+
+import static oshi.software.os.OSProcess.State.INVALID;
+import static oshi.software.os.OSProcess.State.NEW;
+import static oshi.software.os.OSProcess.State.OTHER;
+import static oshi.software.os.OSProcess.State.RUNNING;
+import static oshi.software.os.OSProcess.State.SLEEPING;
+import static oshi.software.os.OSProcess.State.STOPPED;
+import static oshi.software.os.OSProcess.State.WAITING;
+import static oshi.software.os.OSProcess.State.ZOMBIE;
+import static oshi.util.Memoizer.memoize;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.mac.ThreadInfo;
+import oshi.software.common.AbstractOSProcess;
+import oshi.software.os.OSThread;
+import oshi.util.GlobalConfig;
+import oshi.util.tuples.Pair;
+
+/**
+ * Abstract base shared by the macOS OSProcess implementations (JNA and FFM). Holds the field storage, the trivial
+ * accessors, the command-line/argument/environment memoization, thread enumeration, affinity mask, and the {@code
+ * pbi_status} state mapping. The native attribute reads ({@code proc_pidinfo}, the {@code KERN_PROCARGS2} sysctl, the
+ * {@code getrlimit} file limits, and the logical-processor sysctl) are provided by the per-backend subclasses.
+ */
+@ThreadSafe
+public abstract class MacOSProcess extends AbstractOSProcess {
+
+    protected static final boolean LOG_MAC_SYSCTL_WARNING = GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SYSCTL_LOGWARNING,
+            false);
+
+    protected static final int MAC_RLIMIT_NOFILE = 8;
+
+    // 64-bit flag
+    protected static final int P_LP64 = 0x4;
+
+    /*
+     * macOS process states
+     */
+    private static final int SSLEEP = 1; // sleeping on high priority
+    private static final int SWAIT = 2; // sleeping on low priority
+    private static final int SRUN = 3; // running
+    private static final int SIDL = 4; // intermediate state in process creation
+    private static final int SZOMB = 5; // intermediate state in process termination
+    private static final int SSTOP = 6; // process being traced
+
+    protected final int majorVersion;
+    protected final int minorVersion;
+    protected final MacOperatingSystem os;
+
+    private final Supplier<String> commandLine = memoize(this::queryCommandLine);
+    private final Supplier<Pair<List<String>, Map<String, String>>> argsEnviron = memoize(
+            this::queryArgsAndEnvironment);
+
+    protected String name = "";
+    protected String path = "";
+    protected String currentWorkingDirectory;
+    protected String user;
+    protected String userID;
+    protected String group;
+    protected String groupID;
+    protected State state = INVALID;
+    protected int parentProcessID;
+    protected int threadCount;
+    protected int priority;
+    protected long virtualSize;
+    protected long residentSetSize;
+    protected long memoryFootprint;
+    protected long kernelTime;
+    protected long userTime;
+    protected long startTime;
+    protected long upTime;
+    protected long bytesRead;
+    protected long bytesWritten;
+    protected long openFiles;
+    protected int bitness;
+    protected long minorFaults;
+    protected long majorFaults;
+    protected long contextSwitches;
+    protected long voluntaryContextSwitches;
+    protected long involuntaryContextSwitches;
+
+    protected MacOSProcess(int pid, int major, int minor, MacOperatingSystem os) {
+        super(pid);
+        this.majorVersion = major;
+        this.minorVersion = minor;
+        this.os = os;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getPath() {
+        return this.path;
+    }
+
+    @Override
+    public String getCommandLine() {
+        return this.commandLine.get();
+    }
+
+    private String queryCommandLine() {
+        return String.join(" ", getArguments());
+    }
+
+    @Override
+    public List<String> getArguments() {
+        return argsEnviron.get().getA();
+    }
+
+    @Override
+    public Map<String, String> getEnvironmentVariables() {
+        return argsEnviron.get().getB();
+    }
+
+    @Override
+    public String getCurrentWorkingDirectory() {
+        return this.currentWorkingDirectory;
+    }
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    @Override
+    public String getUserID() {
+        return this.userID;
+    }
+
+    @Override
+    public String getGroup() {
+        return this.group;
+    }
+
+    @Override
+    public String getGroupID() {
+        return this.groupID;
+    }
+
+    @Override
+    public State getState() {
+        return this.state;
+    }
+
+    @Override
+    public int getParentProcessID() {
+        return this.parentProcessID;
+    }
+
+    @Override
+    public int getThreadCount() {
+        return this.threadCount;
+    }
+
+    @Override
+    public List<OSThread> getThreadDetails() {
+        long now = System.currentTimeMillis();
+        return ThreadInfo.queryTaskThreads(getProcessID()).stream().parallel().map(stat -> {
+            // For long running threads the start time calculation can overestimate
+            long start = Math.max(now - stat.getUpTime(), getStartTime());
+            return new MacOSThread(getProcessID(), stat.getThreadId(), stat.getState(), stat.getSystemTime(),
+                    stat.getUserTime(), start, now - start, stat.getPriority());
+        }).collect(Collectors.toList());
+    }
+
+    @Override
+    public int getPriority() {
+        return this.priority;
+    }
+
+    @Override
+    public long getVirtualSize() {
+        return this.virtualSize;
+    }
+
+    @Override
+    public long getResidentMemory() {
+        return this.residentSetSize;
+    }
+
+    @Override
+    public long getPrivateResidentMemory() {
+        return this.memoryFootprint;
+    }
+
+    @Override
+    public long getKernelTime() {
+        return this.kernelTime;
+    }
+
+    @Override
+    public long getUserTime() {
+        return this.userTime;
+    }
+
+    @Override
+    public long getUpTime() {
+        return this.upTime;
+    }
+
+    @Override
+    public long getStartTime() {
+        return this.startTime;
+    }
+
+    @Override
+    public long getBytesRead() {
+        return this.bytesRead;
+    }
+
+    @Override
+    public long getBytesWritten() {
+        return this.bytesWritten;
+    }
+
+    @Override
+    public long getOpenFiles() {
+        return this.openFiles;
+    }
+
+    @Override
+    public int getBitness() {
+        return this.bitness;
+    }
+
+    @Override
+    public long getAffinityMask() {
+        // macOS doesn't do affinity. Return a bitmask of the current processors.
+        int logicalProcessorCount = queryLogicalProcessorCount();
+        return logicalProcessorCount < 64 ? (1L << logicalProcessorCount) - 1 : -1L;
+    }
+
+    @Override
+    public long getMinorFaults() {
+        return this.minorFaults;
+    }
+
+    @Override
+    public long getMajorFaults() {
+        return this.majorFaults;
+    }
+
+    @Override
+    public long getContextSwitches() {
+        return this.contextSwitches;
+    }
+
+    @Override
+    public long getVoluntaryContextSwitches() {
+        return this.voluntaryContextSwitches;
+    }
+
+    @Override
+    public long getInvoluntaryContextSwitches() {
+        return this.involuntaryContextSwitches;
+    }
+
+    /**
+     * Maps a macOS {@code pbi_status} value to an {@link State}.
+     *
+     * @param status the {@code pbi_status} value
+     * @return the corresponding process state
+     */
+    protected static State stateFromStatus(int status) {
+        switch (status) {
+            case SSLEEP:
+                return SLEEPING;
+            case SWAIT:
+                return WAITING;
+            case SRUN:
+                return RUNNING;
+            case SIDL:
+                return NEW;
+            case SZOMB:
+                return ZOMBIE;
+            case SSTOP:
+                return STOPPED;
+            default:
+                return OTHER;
+        }
+    }
+
+    /**
+     * Queries this process's arguments and environment via the backend-specific {@code KERN_PROCARGS2} sysctl.
+     *
+     * @return a pair of the argument list and the environment map
+     */
+    protected abstract Pair<List<String>, Map<String, String>> queryArgsAndEnvironment();
+
+    /**
+     * Returns the number of logical processors via the backend-specific {@code hw.logicalcpu} sysctl.
+     *
+     * @return the logical processor count
+     */
+    protected abstract int queryLogicalProcessorCount();
+}

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
@@ -63,14 +63,6 @@ import static oshi.ffm.platform.mac.MacSystemFunctions.proc_pidinfo;
 import static oshi.ffm.platform.mac.MacSystemFunctions.proc_pidpath;
 import static oshi.ffm.util.platform.mac.SysctlUtilFFM.sysctl;
 import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.NEW;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
-import static oshi.util.Memoizer.memoize;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -80,31 +72,26 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.common.mac.ThreadInfo;
 import oshi.ffm.ForeignFunctions;
 import oshi.ffm.platform.mac.IOKit.IOIterator;
 import oshi.ffm.platform.mac.IOKit.IORegistryEntry;
 import oshi.ffm.platform.mac.MacSystemFunctions;
 import oshi.ffm.util.platform.mac.IOKitUtilFFM;
-import oshi.software.common.AbstractOSProcess;
-import oshi.software.common.os.mac.MacOSThread;
-import oshi.software.os.OSThread;
-import oshi.util.GlobalConfig;
+import oshi.software.common.os.mac.MacOSProcess;
+import oshi.software.common.os.mac.MacOperatingSystem;
 import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 
 /**
- * OSProcess implementation
+ * FFM-backed macOS OSProcess.
  */
 @ThreadSafe
-public class MacOSProcessFFM extends AbstractOSProcess {
+public class MacOSProcessFFM extends MacOSProcess {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacOSProcessFFM.class);
 
@@ -136,96 +123,13 @@ public class MacOSProcessFFM extends AbstractOSProcess {
         TICKS_PER_MS = ticksPerSec / 1000L;
     }
 
-    private static final boolean LOG_MAC_SYSCTL_WARNING = GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SYSCTL_LOGWARNING,
-            false);
-
-    private static final int MAC_RLIMIT_NOFILE = 8;
-
-    // 64-bit flag
-    private static final int P_LP64 = 0x4;
-    /*
-     * macOS States:
-     */
-    private static final int SSLEEP = 1; // sleeping on high priority
-    private static final int SWAIT = 2; // sleeping on low priority
-    private static final int SRUN = 3; // running
-    private static final int SIDL = 4; // intermediate state in process creation
-    private static final int SZOMB = 5; // intermediate state in process termination
-    private static final int SSTOP = 6; // process being traced
-
-    private int majorVersion;
-    private int minorVersion;
-    private final MacOperatingSystemFFM os;
-
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<Pair<List<String>, Map<String, String>>> argsEnviron = memoize(this::queryArgsAndEnvironment);
-
-    private String name = "";
-    private String path = "";
-    private String currentWorkingDirectory;
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long memoryFootprint;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
-    private long openFiles;
-    private int bitness;
-    private long minorFaults;
-    private long majorFaults;
-    private long contextSwitches;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
-
-    public MacOSProcessFFM(int pid, int major, int minor, MacOperatingSystemFFM os) {
-        super(pid);
-        this.majorVersion = major;
-        this.minorVersion = minor;
-        this.os = os;
+    public MacOSProcessFFM(int pid, int major, int minor, MacOperatingSystem os) {
+        super(pid, major, minor, os);
         updateAttributes();
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        return String.join(" ", getArguments());
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return argsEnviron.get().getA();
-    }
-
-    @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return argsEnviron.get().getB();
-    }
-
-    private Pair<List<String>, Map<String, String>> queryArgsAndEnvironment() {
+    protected Pair<List<String>, Map<String, String>> queryArgsAndEnvironment() {
         int pid = getProcessID();
         // Set up return objects
         List<String> args = new ArrayList<>();
@@ -294,109 +198,8 @@ public class MacOSProcessFFM extends AbstractOSProcess {
     }
 
     @Override
-    public String getCurrentWorkingDirectory() {
-        return this.currentWorkingDirectory;
-    }
-
-    @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public List<OSThread> getThreadDetails() {
-        long now = System.currentTimeMillis();
-        return ThreadInfo.queryTaskThreads(getProcessID()).stream().parallel().map(stat -> {
-            // For long running threads the start time calculation can overestimate
-            long start = Math.max(now - stat.getUpTime(), getStartTime());
-            return new MacOSThread(getProcessID(), stat.getThreadId(), stat.getState(), stat.getSystemTime(),
-                    stat.getUserTime(), start, now - start, stat.getPriority());
-        }).collect(Collectors.toList());
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getPrivateResidentMemory() {
-        return this.memoryFootprint;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
-    }
-
-    @Override
-    public long getOpenFiles() {
-        return this.openFiles;
+    protected int queryLogicalProcessorCount() {
+        return sysctl("hw.logicalcpu", 1);
     }
 
     @Override
@@ -427,43 +230,6 @@ public class MacOSProcessFFM extends AbstractOSProcess {
             }, LOG, DEBUG, "Failed to query hard open file limit", 0L);
         }
         return -1L; // not supported
-    }
-
-    @Override
-    public int getBitness() {
-        return this.bitness;
-    }
-
-    @Override
-    public long getAffinityMask() {
-        // macOS doesn't do affinity. Return a bitmask of the current processors.
-        int logicalProcessorCount = sysctl("hw.logicalcpu", 1);
-        return logicalProcessorCount < 64 ? (1L << logicalProcessorCount) - 1 : -1L;
-    }
-
-    @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        return this.voluntaryContextSwitches;
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        return this.involuntaryContextSwitches;
     }
 
     @Override
@@ -501,15 +267,7 @@ public class MacOSProcessFFM extends AbstractOSProcess {
 
             // Get Process state based on status
             int status = pbsd.get(JAVA_INT, PROC_BSD_INFO.byteOffset(PBI_STATUS));
-            this.state = switch (status) {
-                case SSLEEP -> SLEEPING;
-                case SWAIT -> WAITING;
-                case SRUN -> RUNNING;
-                case SIDL -> NEW;
-                case SZOMB -> ZOMBIE;
-                case SSTOP -> STOPPED;
-                default -> OTHER;
-            };
+            this.state = stateFromStatus(status);
 
             // User and group info
             this.parentProcessID = pbsd.get(JAVA_INT, PROC_BSD_INFO.byteOffset(PBI_PPID));

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
@@ -5,14 +5,6 @@
 package oshi.software.os.mac;
 
 import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSProcess.State.NEW;
-import static oshi.software.os.OSProcess.State.OTHER;
-import static oshi.software.os.OSProcess.State.RUNNING;
-import static oshi.software.os.OSProcess.State.SLEEPING;
-import static oshi.software.os.OSProcess.State.STOPPED;
-import static oshi.software.os.OSProcess.State.WAITING;
-import static oshi.software.os.OSProcess.State.ZOMBIE;
-import static oshi.util.Memoizer.memoize;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -21,8 +13,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,25 +28,21 @@ import com.sun.jna.platform.unix.LibCAPI.size_t;
 import com.sun.jna.platform.unix.Resource;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.common.mac.ThreadInfo;
 import oshi.jna.Struct.CloseableProcTaskAllInfo;
 import oshi.jna.Struct.CloseableRUsageInfoV2;
 import oshi.jna.Struct.CloseableVnodePathInfo;
 import oshi.jna.platform.mac.SystemB;
-import oshi.software.common.AbstractOSProcess;
-import oshi.software.common.os.mac.MacOSThread;
+import oshi.software.common.os.mac.MacOSProcess;
 import oshi.software.common.os.mac.MacOperatingSystem;
-import oshi.software.os.OSThread;
-import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
 import oshi.util.platform.mac.SysctlUtil;
 import oshi.util.tuples.Pair;
 
 /**
- * OSProcess implementation
+ * JNA-backed macOS OSProcess.
  */
 @ThreadSafe
-public class MacOSProcessJNA extends AbstractOSProcess {
+public class MacOSProcessJNA extends MacOSProcess {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacOSProcessJNA.class);
 
@@ -89,96 +75,13 @@ public class MacOSProcessJNA extends AbstractOSProcess {
         TICKS_PER_MS = ticksPerSec / 1000L;
     }
 
-    private static final boolean LOG_MAC_SYSCTL_WARNING = GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SYSCTL_LOGWARNING,
-            false);
-
-    private static final int MAC_RLIMIT_NOFILE = 8;
-
-    // 64-bit flag
-    private static final int P_LP64 = 0x4;
-    /*
-     * macOS States:
-     */
-    private static final int SSLEEP = 1; // sleeping on high priority
-    private static final int SWAIT = 2; // sleeping on low priority
-    private static final int SRUN = 3; // running
-    private static final int SIDL = 4; // intermediate state in process creation
-    private static final int SZOMB = 5; // intermediate state in process termination
-    private static final int SSTOP = 6; // process being traced
-
-    private int majorVersion;
-    private int minorVersion;
-    private final MacOperatingSystem os;
-
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<Pair<List<String>, Map<String, String>>> argsEnviron = memoize(this::queryArgsAndEnvironment);
-
-    private String name = "";
-    private String path = "";
-    private String currentWorkingDirectory;
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long memoryFootprint;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
-    private long openFiles;
-    private int bitness;
-    private long minorFaults;
-    private long majorFaults;
-    private long contextSwitches;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
-
     public MacOSProcessJNA(int pid, int major, int minor, MacOperatingSystem os) {
-        super(pid);
-        this.majorVersion = major;
-        this.minorVersion = minor;
-        this.os = os;
+        super(pid, major, minor, os);
         updateAttributes();
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        return String.join(" ", getArguments());
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return argsEnviron.get().getA();
-    }
-
-    @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return argsEnviron.get().getB();
-    }
-
-    private Pair<List<String>, Map<String, String>> queryArgsAndEnvironment() {
+    protected Pair<List<String>, Map<String, String>> queryArgsAndEnvironment() {
         int pid = getProcessID();
         // Set up return objects
         List<String> args = new ArrayList<>();
@@ -248,109 +151,8 @@ public class MacOSProcessJNA extends AbstractOSProcess {
     }
 
     @Override
-    public String getCurrentWorkingDirectory() {
-        return this.currentWorkingDirectory;
-    }
-
-    @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public List<OSThread> getThreadDetails() {
-        long now = System.currentTimeMillis();
-        return ThreadInfo.queryTaskThreads(getProcessID()).stream().parallel().map(stat -> {
-            // For long running threads the start time calculation can overestimate
-            long start = Math.max(now - stat.getUpTime(), getStartTime());
-            return new MacOSThread(getProcessID(), stat.getThreadId(), stat.getState(), stat.getSystemTime(),
-                    stat.getUserTime(), start, now - start, stat.getPriority());
-        }).collect(Collectors.toList());
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getPrivateResidentMemory() {
-        return this.memoryFootprint;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
-    }
-
-    @Override
-    public long getOpenFiles() {
-        return this.openFiles;
+    protected int queryLogicalProcessorCount() {
+        return SysctlUtil.sysctl("hw.logicalcpu", 1);
     }
 
     @Override
@@ -373,43 +175,6 @@ public class MacOSProcessJNA extends AbstractOSProcess {
         } else {
             return -1L; // not supported
         }
-    }
-
-    @Override
-    public int getBitness() {
-        return this.bitness;
-    }
-
-    @Override
-    public long getAffinityMask() {
-        // macOS doesn't do affinity. Return a bitmask of the current processors.
-        int logicalProcessorCount = SysctlUtil.sysctl("hw.logicalcpu", 1);
-        return logicalProcessorCount < 64 ? (1L << logicalProcessorCount) - 1 : -1L;
-    }
-
-    @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        return this.voluntaryContextSwitches;
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        return this.involuntaryContextSwitches;
     }
 
     @Override
@@ -436,29 +201,7 @@ public class MacOSProcessJNA extends AbstractOSProcess {
                 this.name = Native.toString(taskAllInfo.pbsd.pbi_comm, StandardCharsets.UTF_8);
             }
 
-            switch (taskAllInfo.pbsd.pbi_status) {
-                case SSLEEP:
-                    this.state = SLEEPING;
-                    break;
-                case SWAIT:
-                    this.state = WAITING;
-                    break;
-                case SRUN:
-                    this.state = RUNNING;
-                    break;
-                case SIDL:
-                    this.state = NEW;
-                    break;
-                case SZOMB:
-                    this.state = ZOMBIE;
-                    break;
-                case SSTOP:
-                    this.state = STOPPED;
-                    break;
-                default:
-                    this.state = OTHER;
-                    break;
-            }
+            this.state = stateFromStatus(taskAllInfo.pbsd.pbi_status);
             this.parentProcessID = taskAllInfo.pbsd.pbi_ppid;
             this.userID = Integer.toString(taskAllInfo.pbsd.pbi_uid);
             Passwd pwuid = SystemB.INSTANCE.getpwuid(taskAllInfo.pbsd.pbi_uid);


### PR DESCRIPTION
## Summary

Extends the OSProcess deduplication to macOS (after the BSD #3370/#3372 and Solaris #3367 work). The JNA and FFM macOS `OSProcess` implementations duplicated their field storage, all the trivial accessors, the command-line/argument/environment memoization, thread enumeration, the affinity mask, and the `pbi_status` state mapping (~243 duplicated lines each per Sonar — the #2/#3 files on the project).

This extracts an abstract `MacOSProcess` base in `oshi-common` holding that shared surface, with the macOS state mapping pulled into a shared `stateFromStatus()` helper. The native attribute reads stay in the JNA and FFM subclasses behind hooks:
- `updateAttributes()` — `proc_pidinfo` (PROC_PIDTASKALLINFO / vnode / rusage)
- `queryArgsAndEnvironment()` — `KERN_PROCARGS2` sysctl
- `getSoftOpenFileLimit()` / `getHardOpenFileLimit()` — `getrlimit`
- `queryLogicalProcessorCount()` — `hw.logicalcpu` sysctl (for `getAffinityMask`)

The `os` field is typed as the `MacOperatingSystem` base, so the FFM subclass constructor widens its parameter to match (the OS classes pass `this`, which already IS-A `MacOperatingSystem`, so no call-site change is needed).

`MacOSThread` (single common class) and `MacOperatingSystem` (base + JNA/FFM) already followed this pattern; `MacOSProcess` was the last Mac class lacking a common base. The subclasses keep their (genuinely divergent) native struct reads. Net **−190 lines**.

## Testing

Validated on macOS by the full test suite **including `NativeComparisonTest`, which asserts JNA and FFM produce identical results** — the strongest parity check available. Local spotless / checkstyle / forbidden-APIs / javadoc and a clean full-reactor build also pass. (A checkstyle `VisibilityModifier` suppression was extended to cover `MacOSProcess`, consistent with the existing `BsdOSProcess`/`BsdOSThread` shared-base entries.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated macOS process handling logic into a shared base class, improving code organization and reducing duplication across different implementation backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->