### PR TITLE
Extract cross-BSD OperatingSystem super-base

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOperatingSystem.java
@@ -75,6 +75,10 @@ public abstract class BsdOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public OSProcess getProcess(int pid) {
+        if (pid < 0) {
+            // A negative pid is the getProcessListFromPS "all processes" sentinel, not a real process
+            return null;
+        }
         List<OSProcess> procs = getProcessListFromPS(pid);
         if (procs.isEmpty()) {
             return null;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOperatingSystem.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2016-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.bsd;
+
+import static oshi.software.os.OSService.State.RUNNING;
+import static oshi.software.os.OSService.State.STOPPED;
+import static oshi.util.Memoizer.memoize;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OSService;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+/**
+ * Abstract base shared by the BSD-family OperatingSystem implementations (FreeBSD, OpenBSD, DragonFly, NetBSD). Holds
+ * the cross-BSD-identical pieces: the {@code Unix/BSD} manufacturer, the {@code uname}-based bitness, the
+ * process/child/descendant queries, the {@code ps -axo pid} process count, the {@code ps -axo nlwp} thread count, the
+ * {@code /etc/rc.d} services, and the memoized system uptime/boot time. Per-platform work (the {@code ps} process
+ * enumeration, the boot-time source, the current-thread factory, and the native version/file-system/network queries) is
+ * provided by the subclasses.
+ */
+@ThreadSafe
+public abstract class BsdOperatingSystem extends AbstractOperatingSystem {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BsdOperatingSystem.class);
+
+    private final Supplier<Long> bootTime = memoize(this::queryBootTime);
+
+    @Override
+    public String queryManufacturer() {
+        return "Unix/BSD";
+    }
+
+    @Override
+    protected int queryBitness(int jvmBitness) {
+        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
+            return jvmBitness;
+        }
+        return 64;
+    }
+
+    @Override
+    public List<OSProcess> queryAllProcesses() {
+        return getProcessListFromPS(-1);
+    }
+
+    @Override
+    public List<OSProcess> queryChildProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<OSProcess> queryDescendantProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public OSProcess getProcess(int pid) {
+        List<OSProcess> procs = getProcessListFromPS(pid);
+        if (procs.isEmpty()) {
+            return null;
+        }
+        return procs.get(0);
+    }
+
+    @Override
+    public int getProcessCount() {
+        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
+        if (!procList.isEmpty()) {
+            // Subtract 1 for header
+            return procList.size() - 1;
+        }
+        return 0;
+    }
+
+    @Override
+    public int getThreadCount() {
+        // Sum nlwp (number of LWPs) across all processes; the header row parses to 0
+        int threads = 0;
+        for (String proc : ExecutingCommand.runNative("ps -axo nlwp")) {
+            threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
+        }
+        return threads;
+    }
+
+    @Override
+    public long getSystemUptime() {
+        return System.currentTimeMillis() / 1000 - getSystemBootTime();
+    }
+
+    @Override
+    public long getSystemBootTime() {
+        return bootTime.get();
+    }
+
+    @Override
+    public List<OSService> getServices() {
+        // Get running services
+        List<OSService> services = new ArrayList<>();
+        Set<String> running = new HashSet<>();
+        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
+            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
+            services.add(s);
+            running.add(p.getName());
+        }
+        // Get Directories for stopped services
+        File dir = new File("/etc/rc.d");
+        File[] listFiles;
+        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
+            for (File f : listFiles) {
+                String name = f.getName();
+                if (!running.contains(name)) {
+                    OSService s = new OSService(name, 0, STOPPED);
+                    services.add(s);
+                }
+            }
+        } else {
+            LOG.error("Directory: /etc/rc.d does not exist");
+        }
+        return services;
+    }
+
+    /**
+     * Enumerates processes (or a single process when {@code pid >= 0}) via the platform's {@code ps} command.
+     *
+     * @param pid the process ID, or {@code -1} for all processes
+     * @return the process list
+     */
+    protected abstract List<OSProcess> getProcessListFromPS(int pid);
+
+    /**
+     * Queries the system boot time in seconds since the epoch.
+     *
+     * @return the boot time in seconds
+     */
+    protected abstract long queryBootTime();
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOperatingSystem.java
@@ -4,89 +4,34 @@
  */
 package oshi.software.common.os.unix.dragonflybsd;
 
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
 import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
-import static oshi.util.Memoizer.memoize;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 /**
- * Abstract base shared by the DragonFly BSD OperatingSystem implementations (JNA and FFM). Holds the {@code ps}-based
- * process enumeration, process/thread counts, services, and system uptime/boot time. The native bits (the
+ * Abstract base shared by the DragonFly BSD OperatingSystem implementations (JNA and FFM). The cross-BSD-common pieces
+ * live in {@link BsdOperatingSystem}; this layer adds the DragonFly {@code ps} process enumeration (which filters out
+ * the kernel threads that report a negative PID) and the current-thread factory. The native bits (the
  * {@link OSProcess}/{@code FileSystem}/{@code NetworkParams}/{@code InternetProtocolStats} factories,
  * {@code getpid}/{@code lwp_gettid}, sysctl version and boot-time queries, and {@code who} sessions) are provided by
  * the JNA and FFM subclasses.
  */
 @ThreadSafe
-public abstract class DragonFlyBsdOperatingSystem extends AbstractOperatingSystem {
-
-    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOperatingSystem.class);
-
-    private final Supplier<Long> bootTime = memoize(this::queryBootTime);
+public abstract class DragonFlyBsdOperatingSystem extends BsdOperatingSystem {
 
     @Override
-    public String queryManufacturer() {
-        return "Unix/BSD";
-    }
-
-    @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
-            return jvmBitness;
-        }
-        return 64;
-    }
-
-    @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromPS(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromPS(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromPS(int pid) {
+    protected List<OSProcess> getProcessListFromPS(int pid) {
         String psCommand = "ps -awwxo " + DragonFlyBsdOSProcess.PS_COMMAND_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
@@ -104,67 +49,11 @@ public abstract class DragonFlyBsdOperatingSystem extends AbstractOperatingSyste
     }
 
     @Override
-    public int getProcessCount() {
-        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
-        if (!procList.isEmpty()) {
-            // Subtract 1 for header
-            return procList.size() - 1;
-        }
-        return 0;
-    }
-
-    @Override
     public OSThread getCurrentThread() {
         OSProcess proc = getCurrentProcess();
         final int tid = getThreadId();
         return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
                 .orElse(new DragonFlyBsdOSThread(proc.getProcessID(), tid));
-    }
-
-    @Override
-    public int getThreadCount() {
-        int threads = 0;
-        for (String proc : ExecutingCommand.runNative("ps -axo nlwp")) {
-            threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
-        }
-        return threads;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000 - getSystemBootTime();
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return bootTime.get();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        // Get running services
-        List<OSService> services = new ArrayList<>();
-        Set<String> running = new HashSet<>();
-        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
-            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
-            services.add(s);
-            running.add(p.getName());
-        }
-        // Get Directories for stopped services
-        File dir = new File("/etc/rc.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File f : listFiles) {
-                String name = f.getName();
-                if (!running.contains(name)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
-                }
-            }
-        } else {
-            LOG.error("Directory: /etc/rc.d does not exist");
-        }
-        return services;
     }
 
     /**
@@ -175,11 +64,4 @@ public abstract class DragonFlyBsdOperatingSystem extends AbstractOperatingSyste
      * @return a new OSProcess
      */
     protected abstract OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap);
-
-    /**
-     * Queries the system boot time in seconds since the epoch via the backend-specific {@code kern.boottime} sysctl.
-     *
-     * @return the boot time in seconds
-     */
-    protected abstract long queryBootTime();
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -4,89 +4,33 @@
  */
 package oshi.software.common.os.unix.freebsd;
 
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
 import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
-import static oshi.util.Memoizer.memoize;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 /**
- * Abstract base shared by the FreeBSD OperatingSystem implementations (JNA and FFM). Holds the {@code ps}-based process
- * enumeration, process/thread counts, services, and system uptime/boot time. The native bits (the
- * {@link OSProcess}/{@code FileSystem}/{@code NetworkParams}/{@code InternetProtocolStats} factories,
- * {@code getpid}/{@code thr_self}, sysctl version and boot-time queries, and {@code who} sessions) are provided by the
- * JNA and FFM subclasses.
+ * Abstract base shared by the FreeBSD OperatingSystem implementations (JNA and FFM). The cross-BSD-common pieces live
+ * in {@link BsdOperatingSystem}; this layer adds the FreeBSD {@code ps} process enumeration and current-thread factory.
+ * The native bits (the {@link OSProcess}/{@code FileSystem}/{@code NetworkParams}/{@code InternetProtocolStats}
+ * factories, {@code getpid}/{@code thr_self}, sysctl version and boot-time queries, and {@code who} sessions) are
+ * provided by the JNA and FFM subclasses.
  */
 @ThreadSafe
-public abstract class FreeBsdOperatingSystem extends AbstractOperatingSystem {
-
-    private static final Logger LOG = LoggerFactory.getLogger(FreeBsdOperatingSystem.class);
-
-    private final Supplier<Long> bootTime = memoize(this::queryBootTime);
+public abstract class FreeBsdOperatingSystem extends BsdOperatingSystem {
 
     @Override
-    public String queryManufacturer() {
-        return "Unix/BSD";
-    }
-
-    @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
-            return jvmBitness;
-        }
-        return 64;
-    }
-
-    @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromPS(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromPS(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromPS(int pid) {
+    protected List<OSProcess> getProcessListFromPS(int pid) {
         String psCommand = "ps -awwxo " + FreeBsdOSProcess.PS_COMMAND_ARGS;
         if (pid >= 0) {
             psCommand += " -p " + pid;
@@ -103,67 +47,11 @@ public abstract class FreeBsdOperatingSystem extends AbstractOperatingSystem {
     }
 
     @Override
-    public int getProcessCount() {
-        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
-        if (!procList.isEmpty()) {
-            // Subtract 1 for header
-            return procList.size() - 1;
-        }
-        return 0;
-    }
-
-    @Override
     public OSThread getCurrentThread() {
         OSProcess proc = getCurrentProcess();
         final int tid = getThreadId();
         return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
                 .orElse(new FreeBsdOSThread(proc.getProcessID(), tid));
-    }
-
-    @Override
-    public int getThreadCount() {
-        int threads = 0;
-        for (String proc : ExecutingCommand.runNative("ps -axo nlwp")) {
-            threads += ParseUtil.parseIntOrDefault(proc.trim(), 0);
-        }
-        return threads;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000 - getSystemBootTime();
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return bootTime.get();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        // Get running services
-        List<OSService> services = new ArrayList<>();
-        Set<String> running = new HashSet<>();
-        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
-            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
-            services.add(s);
-            running.add(p.getName());
-        }
-        // Get Directories for stopped services
-        File dir = new File("/etc/rc.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File f : listFiles) {
-                String name = f.getName();
-                if (!running.contains(name)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
-                }
-            }
-        } else {
-            LOG.error("Directory: /etc/rc.d does not exist");
-        }
-        return services;
     }
 
     /**
@@ -174,11 +62,4 @@ public abstract class FreeBsdOperatingSystem extends AbstractOperatingSystem {
      * @return a new OSProcess
      */
     protected abstract OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap);
-
-    /**
-     * Queries the system boot time in seconds since the epoch via the backend-specific {@code kern.boottime} sysctl.
-     *
-     * @return the boot time in seconds
-     */
-    protected abstract long queryBootTime();
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
@@ -4,28 +4,18 @@
  */
 package oshi.software.common.os.unix.netbsd;
 
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
-
-import java.io.File;
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.os.FileSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -35,18 +25,13 @@ import oshi.util.tuples.Pair;
 /**
  * NetBsd is a free and open-source Unix-like operating system descended from the Berkeley Software Distribution (BSD),
  * which was based on Research Unix.
+ * <p>
+ * The cross-BSD-common pieces live in {@link BsdOperatingSystem}; NetBSD has no native-access split, so this single
+ * class also provides the {@code ps} process enumeration, the text-parsed boot time, the current-thread factory, and
+ * the sysctl version / file-system / network queries.
  */
 @ThreadSafe
-public class NetBsdOperatingSystem extends AbstractOperatingSystem {
-
-    private static final Logger LOG = LoggerFactory.getLogger(NetBsdOperatingSystem.class);
-
-    private static final long BOOTTIME = querySystemBootTime();
-
-    @Override
-    public String queryManufacturer() {
-        return "Unix/BSD";
-    }
+public class NetBsdOperatingSystem extends BsdOperatingSystem {
 
     @Override
     public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
@@ -56,14 +41,6 @@ public class NetBsdOperatingSystem extends AbstractOperatingSystem {
         String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
 
         return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
-    }
-
-    @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
-            return jvmBitness;
-        }
-        return 64;
     }
 
     @Override
@@ -77,34 +54,12 @@ public class NetBsdOperatingSystem extends AbstractOperatingSystem {
     }
 
     @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromPS(-1);
+    public NetworkParams getNetworkParams() {
+        return new NetBsdNetworkParams();
     }
 
     @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromPS(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromPS(int pid) {
+    protected List<OSProcess> getProcessListFromPS(int pid) {
         List<OSProcess> procs = new ArrayList<>();
         // https://man.netbsd.org/ps#KEYWORDS
         // missing are threadCount and kernelTime which is included in cputime
@@ -135,18 +90,8 @@ public class NetBsdOperatingSystem extends AbstractOperatingSystem {
     @Override
     public int getProcessId() {
         // RuntimeMXBean name format is "pid@hostname"
-        String name = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
+        String name = ManagementFactory.getRuntimeMXBean().getName();
         return ParseUtil.parseIntOrDefault(name.split("@")[0], -1);
-    }
-
-    @Override
-    public int getProcessCount() {
-        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
-        if (!procList.isEmpty()) {
-            // Subtract 1 for header
-            return procList.size() - 1;
-        }
-        return 0;
     }
 
     @Override
@@ -163,62 +108,10 @@ public class NetBsdOperatingSystem extends AbstractOperatingSystem {
     }
 
     @Override
-    public int getThreadCount() {
-        int threads = 0;
-        // Sum nlwp (number of LWPs) across all processes
-        List<String> nlwpList = ExecutingCommand.runNative("ps -axo nlwp");
-        for (String line : nlwpList) {
-            threads += ParseUtil.parseIntOrDefault(line.trim(), 0);
-        }
-        return threads;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000 - BOOTTIME;
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return BOOTTIME;
-    }
-
-    private static long querySystemBootTime() {
+    protected long queryBootTime() {
         // Boot time will be the first consecutive string of digits.
         return ParseUtil.parseLongOrDefault(
                 ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
                 System.currentTimeMillis() / 1000);
-    }
-
-    @Override
-    public NetworkParams getNetworkParams() {
-        return new NetBsdNetworkParams();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        // Get running services
-        List<OSService> services = new ArrayList<>();
-        Set<String> running = new HashSet<>();
-        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
-            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
-            services.add(s);
-            running.add(p.getName());
-        }
-        // Get Directories for stopped services
-        File dir = new File("/etc/rc.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File f : listFiles) {
-                String name = f.getName();
-                if (!running.contains(name)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
-                }
-            }
-        } else {
-            LOG.error("Directory: /etc/rc.d does not exist");
-        }
-        return services;
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
@@ -4,58 +4,29 @@
  */
 package oshi.software.common.os.unix.openbsd;
 
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
-import static oshi.util.Memoizer.memoize;
-
-import java.io.File;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.common.os.unix.bsd.BsdOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 /**
- * Abstract base shared by the OpenBSD OperatingSystem implementations (JNA and FFM). Holds the {@code ps}-based process
- * enumeration, process/thread counts, services, internet protocol stats, network params, and system uptime/boot time.
- * The native bits (the {@link OSProcess} and {@code FileSystem} factories, {@code getpid}/{@code getthrid}, and the
- * sysctl version query) are provided by the JNA and FFM subclasses.
+ * Abstract base shared by the OpenBSD OperatingSystem implementations (JNA and FFM). The cross-BSD-common pieces live
+ * in {@link BsdOperatingSystem}; this layer adds the OpenBSD {@code ps} process enumeration, the {@code ps -axHo tid}
+ * thread count, the text-parsed boot time, and the (non-native) internet protocol stats and network params. The native
+ * bits (the {@link OSProcess} and {@code FileSystem} factories, {@code getpid}/{@code getthrid}, and the sysctl version
+ * query) are provided by the JNA and FFM subclasses.
  */
 @ThreadSafe
-public abstract class OpenBsdOperatingSystem extends AbstractOperatingSystem {
-
-    private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOperatingSystem.class);
-
-    private final Supplier<Long> bootTime = memoize(this::queryBootTime);
-
-    @Override
-    public String queryManufacturer() {
-        return "Unix/BSD";
-    }
-
-    @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness < 64 && ExecutingCommand.getFirstAnswer("uname -m").indexOf("64") == -1) {
-            return jvmBitness;
-        }
-        return 64;
-    }
+public abstract class OpenBsdOperatingSystem extends BsdOperatingSystem {
 
     @Override
     public InternetProtocolStats getInternetProtocolStats() {
@@ -68,34 +39,7 @@ public abstract class OpenBsdOperatingSystem extends AbstractOperatingSystem {
     }
 
     @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromPS(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromPS(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromPS(int pid) {
+    protected List<OSProcess> getProcessListFromPS(int pid) {
         List<OSProcess> procs = new ArrayList<>();
         // https://man.openbsd.org/ps#KEYWORDS
         // missing are threadCount and kernelTime which is included in cputime
@@ -124,16 +68,6 @@ public abstract class OpenBsdOperatingSystem extends AbstractOperatingSystem {
     }
 
     @Override
-    public int getProcessCount() {
-        List<String> procList = ExecutingCommand.runNative("ps -axo pid");
-        if (!procList.isEmpty()) {
-            // Subtract 1 for header
-            return procList.size() - 1;
-        }
-        return 0;
-    }
-
-    @Override
     public OSThread getCurrentThread() {
         OSProcess proc = getCurrentProcess();
         final int tid = getThreadId();
@@ -155,47 +89,11 @@ public abstract class OpenBsdOperatingSystem extends AbstractOperatingSystem {
     }
 
     @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000 - getSystemBootTime();
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return bootTime.get();
-    }
-
-    private long queryBootTime() {
+    protected long queryBootTime() {
         // Boot time will be the first consecutive string of digits.
         return ParseUtil.parseLongOrDefault(
                 ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
                 System.currentTimeMillis() / 1000);
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        // Get running services
-        List<OSService> services = new ArrayList<>();
-        Set<String> running = new HashSet<>();
-        for (OSProcess p : getChildProcesses(1, ProcessFiltering.ALL_PROCESSES, ProcessSorting.PID_ASC, 0)) {
-            OSService s = new OSService(p.getName(), p.getProcessID(), RUNNING);
-            services.add(s);
-            running.add(p.getName());
-        }
-        // Get Directories for stopped services
-        File dir = new File("/etc/rc.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File f : listFiles) {
-                String name = f.getName();
-                if (!running.contains(name)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
-                }
-            }
-        } else {
-            LOG.error("Directory: /etc/rc.d does not exist");
-        }
-        return services;
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to #3375 (which extracted per-platform BSD `OperatingSystem` bases to kill the JNA↔FFM duplication). With those bases in place, the cross-*platform* duplication became visible: FreeBSD, OpenBSD, DragonFly, and NetBSD each carried identical copies of the cross-BSD-common methods.

This lifts those into a shared `BsdOperatingSystem` super-base (`extends AbstractOperatingSystem`):
- `queryManufacturer` (`Unix/BSD`) and `uname`-based `queryBitness`
- `queryAllProcesses` / `queryChildProcesses` / `queryDescendantProcesses` / `getProcess`
- `getProcessCount` (`ps -axo pid`)
- `getThreadCount` (`ps -axo nlwp` sum — the default)
- `getServices` (`/etc/rc.d`)
- `getSystemUptime` / `getSystemBootTime` (memoized)

The four platforms now extend it and override only what genuinely differs:
- **`getProcessListFromPS(int)`** (abstract hook) — FreeBSD/DragonFly stream + `VALID_PROCESS` (DragonFly also drops kernel threads reporting `pid <= 0`); OpenBSD/NetBSD use the for-loop form.
- **`queryBootTime()`** (abstract hook) — FreeBSD/DragonFly read a native `kern.boottime` sysctl struct (kept abstract through to the JNA/FFM subclasses); OpenBSD/NetBSD text-parse it.
- **`getThreadCount()`** — OpenBSD overrides with `ps -axHo tid`.
- **`getCurrentThread()`** and the native version/file-system/network/sysctl methods stay per-platform.

NetBSD has no native-access split, so its single class extends the super-base directly. The JNA/FFM subclasses are unchanged (they extend the per-platform bases transitively). Net **−290 lines**.

## Testing

All five `unix.yaml` VM jobs pass, exercising the refactored code on real FreeBSD, OpenBSD, DragonFly, and NetBSD systems (plus OpenIndiana). Local spotless / checkstyle / forbidden-APIs / javadoc and a clean full-reactor build also pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated BSD-specific OS behavior into a shared BSD base used by DragonFly, FreeBSD, NetBSD, and OpenBSD to provide more consistent process listing, thread/process counts, uptime/boot-time reporting, and service discovery.
* **Behavior**
  * Uniform reporting for BSD systems (manufacturer/bitness detection and service status) with improved reliability across variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->