### PR TITLE
Extract FreeBsdCentralProcessor common base (JNA/FFM dedup)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -1,10 +1,320 @@
 /*
- * Copyright 2026 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.common.platform.unix.freebsd;
 
-import oshi.hardware.common.AbstractCentralProcessor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import oshi.hardware.CentralProcessor.ProcessorCache.Type;
+import oshi.hardware.common.AbstractCentralProcessor;
+import oshi.util.ExecutingCommand;
+import oshi.util.FileUtil;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Quartet;
+
+/**
+ * Shared FreeBSD CentralProcessor logic. Subclasses provide the sysctl and native-call backends (JNA or FFM).
+ */
 public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
+
+    // Capture the CSV of hex values as group(1), clients should split on ','
+    private static final Pattern CPUMASK = Pattern
+            .compile(".*<cpu\\s.*mask=\"(\\p{XDigit}+(,\\p{XDigit}+)*)\".*>.*</cpu>.*");
+
+    /**
+     * Reads a string sysctl value.
+     *
+     * @param name the sysctl name
+     * @param def  the default value
+     * @return the sysctl string value or the default
+     */
+    protected abstract String sysctlString(String name, String def);
+
+    /**
+     * Reads a long sysctl value.
+     *
+     * @param name the sysctl name
+     * @param def  the default value
+     * @return the sysctl long value or the default
+     */
+    protected abstract long sysctlLong(String name, long def);
+
+    @Override
+    protected ProcessorIdentifier queryProcessorId() {
+        final Pattern identifierPattern = Pattern
+                .compile("Origin=\"([^\"]*)\".*Id=(\\S+).*Family=(\\S+).*Model=(\\S+).*Stepping=(\\S+).*");
+        final Pattern featuresPattern = Pattern.compile("Features=(\\S+)<.*");
+
+        String cpuVendor = "";
+        String cpuName = sysctlString("hw.model", "");
+        String cpuFamily = "";
+        String cpuModel = "";
+        String cpuStepping = "";
+        String processorID;
+        long cpuFreq = sysctlLong("hw.clockrate", 0L) * 1_000_000L;
+
+        boolean cpu64bit;
+
+        // Parsing dmesg.boot is apparently the only reliable source for processor
+        // identification in FreeBSD
+        long processorIdBits = 0L;
+        List<String> cpuInfo = FileUtil.readFile("/var/run/dmesg.boot");
+        for (String line : cpuInfo) {
+            line = line.trim();
+            // Prefer hw.model to this one
+            if (line.startsWith("CPU:") && cpuName.isEmpty()) {
+                cpuName = line.replace("CPU:", "").trim();
+            } else if (line.startsWith("Origin=")) {
+                Matcher m = identifierPattern.matcher(line);
+                if (m.matches()) {
+                    cpuVendor = m.group(1);
+                    processorIdBits |= Long.decode(m.group(2));
+                    cpuFamily = Integer.decode(m.group(3)).toString();
+                    cpuModel = Integer.decode(m.group(4)).toString();
+                    cpuStepping = Integer.decode(m.group(5)).toString();
+                }
+            } else if (line.startsWith("Features=")) {
+                Matcher m = featuresPattern.matcher(line);
+                if (m.matches()) {
+                    processorIdBits |= Long.decode(m.group(1)) << 32;
+                }
+                // No further interest in this file
+                break;
+            }
+        }
+        cpu64bit = ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
+        processorID = getProcessorIDfromDmiDecode(processorIdBits);
+
+        return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,
+                cpuFreq);
+    }
+
+    @Override
+    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+        List<LogicalProcessor> logProcs = parseTopology();
+        // Force at least one processor
+        if (logProcs.isEmpty()) {
+            logProcs.add(new LogicalProcessor(0, 0, 0));
+        }
+        Map<Integer, String> dmesg = new HashMap<>();
+        // cpu0: <Open Firmware CPU> on cpulist0
+        Pattern normal = Pattern.compile("cpu(\\d+): (.+) on .*");
+        // CPU 0: ARM Cortex-A53 r0p4 affinity: 0 0
+        Pattern hybrid = Pattern.compile("CPU\\s*(\\d+): (.+) affinity:.*");
+        List<String> featureFlags = new ArrayList<>();
+        boolean readingFlags = false;
+        for (String s : FileUtil.readFile("/var/run/dmesg.boot")) {
+            Matcher h = hybrid.matcher(s);
+            if (h.matches()) {
+                int coreId = ParseUtil.parseIntOrDefault(h.group(1), 0);
+                // This always takes priority, overwrite if needed
+                dmesg.put(coreId, h.group(2).trim());
+            } else {
+                Matcher n = normal.matcher(s);
+                if (n.matches()) {
+                    int coreId = ParseUtil.parseIntOrDefault(n.group(1), 0);
+                    // Don't overwrite if h matched earlier
+                    dmesg.putIfAbsent(coreId, n.group(2).trim());
+                }
+            }
+            if (s.contains("Origin=")) {
+                readingFlags = true;
+            } else if (readingFlags) {
+                if (s.startsWith("  ")) {
+                    featureFlags.add(s.trim());
+                } else {
+                    readingFlags = false;
+                }
+            }
+        }
+        List<PhysicalProcessor> physProcs = dmesg.isEmpty() ? null : createProcListFromDmesg(logProcs, dmesg);
+        List<ProcessorCache> caches = getCacheInfoFromLscpu();
+        return new Quartet<>(logProcs, physProcs, caches, featureFlags);
+    }
+
+    private List<ProcessorCache> getCacheInfoFromLscpu() {
+        Set<ProcessorCache> caches = new HashSet<>();
+        for (String checkLine : ExecutingCommand.runNative("lscpu")) {
+            if (checkLine.contains("L1d cache:")) {
+                caches.add(new ProcessorCache(1, 0, 0,
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.DATA));
+            } else if (checkLine.contains("L1i cache:")) {
+                caches.add(new ProcessorCache(1, 0, 0,
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.INSTRUCTION));
+            } else if (checkLine.contains("L2 cache:")) {
+                caches.add(new ProcessorCache(2, 0, 0,
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.UNIFIED));
+            } else if (checkLine.contains("L3 cache:")) {
+                caches.add(new ProcessorCache(3, 0, 0,
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.UNIFIED));
+            }
+        }
+        return orderedProcCaches(caches);
+    }
+
+    private List<LogicalProcessor> parseTopology() {
+        String[] topology = sysctlString("kern.sched.topology_spec", "").split("[\\n\\r]");
+        /*-
+         * Sample output:
+         *
+        <groups>
+        <group level="1" cache-level="0">
+         <cpu count="24" mask="ffffff">0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23</cpu>
+         <children>
+          <group level="2" cache-level="2">
+           <cpu count="12" mask="fff">0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11</cpu>
+           <children>
+            <group level="3" cache-level="1">
+             <cpu count="2" mask="3">0, 1</cpu>
+             <flags><flag name="THREAD">THREAD group</flag><flag name="SMT">SMT group</flag></flags>
+            </group>
+            ...
+        * On FreeBSD 13.1, the output may contain a csv value for the mask:
+        <groups>
+         <group level="1" cache-level="3">
+          <cpu count="8" mask="ff,0,0,0">0, 1, 2, 3, 4, 5, 6, 7</cpu>
+          <children>
+           <group level="2" cache-level="2">
+            <cpu count="2" mask="3,0,0,0">0, 1</cpu>
+            ...
+        *
+        * Opens with <groups>
+        * <group> level 1 identifies all the processors via bitmask, should only be one
+        * <group> level 2 separates by physical package
+        * <group> level 3 puts hyperthreads together: if THREAD or SMT or HTT all the CPUs are one physical
+        * If there is no level 3, then all logical processors are physical
+        */
+        // Create lists of the group bitmasks
+        long group1 = 1L;
+        List<Long> group2 = new ArrayList<>();
+        List<Long> group3 = new ArrayList<>();
+        int groupLevel = 0;
+        for (String topo : topology) {
+            if (topo.contains("<group level=")) {
+                groupLevel++;
+            } else if (topo.contains("</group>")) {
+                groupLevel--;
+            } else if (topo.contains("<cpu")) {
+                // Find <cpu> tag and extract bits
+                Matcher m = CPUMASK.matcher(topo);
+                if (m.matches()) {
+                    // If csv of hex values like "f,0,0,0", parse the first value
+                    String csvMatch = m.group(1);
+                    String[] csvTokens = csvMatch.split(",");
+                    String firstVal = csvTokens[0];
+
+                    // Regex guarantees parsing digits so we won't get a
+                    // NumberFormatException
+                    long parsedVal = ParseUtil.hexStringToLong(firstVal, 0);
+                    switch (groupLevel) {
+                        case 1:
+                            group1 = parsedVal;
+                            break;
+                        case 2:
+                            group2.add(parsedVal);
+                            break;
+                        case 3:
+                            group3.add(parsedVal);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+        return matchBitmasks(group1, group2, group3);
+    }
+
+    private static List<LogicalProcessor> matchBitmasks(long group1, List<Long> group2, List<Long> group3) {
+        List<LogicalProcessor> logProcs = new ArrayList<>();
+        // Lowest and Highest set bits, indexing from 0
+        int lowBit = Long.numberOfTrailingZeros(group1);
+        int hiBit = 63 - Long.numberOfLeadingZeros(group1);
+        // Create logical processors for this core
+        for (int i = lowBit; i <= hiBit; i++) {
+            if ((group1 & (1L << i)) > 0) {
+                int numaNode = 0;
+                LogicalProcessor logProc = new LogicalProcessor(i, getMatchingBitmask(group3, i),
+                        getMatchingBitmask(group2, i), numaNode);
+                logProcs.add(logProc);
+            }
+        }
+        return logProcs;
+    }
+
+    private static int getMatchingBitmask(List<Long> bitmasks, int lp) {
+        for (int j = 0; j < bitmasks.size(); j++) {
+            if ((bitmasks.get(j).longValue() & (1L << lp)) != 0) {
+                return j;
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public long[] queryCurrentFreq() {
+        long[] freq = new long[1];
+        freq[0] = sysctlLong("dev.cpu.0.freq", -1L);
+        if (freq[0] > 0) {
+            // If success, value is in MHz
+            freq[0] *= 1_000_000L;
+        } else {
+            freq[0] = sysctlLong("machdep.tsc_freq", -1L);
+        }
+        return freq;
+    }
+
+    @Override
+    public long queryMaxFreq() {
+        long max = -1L;
+        String freqLevels = sysctlString("dev.cpu.0.freq_levels", "");
+        // MHz/Watts pairs like: 2501/32000 2187/27125 2000/24000
+        for (String s : ParseUtil.whitespaces.split(freqLevels)) {
+            long freq = ParseUtil.parseLongOrDefault(s.split("/")[0], -1L);
+            if (max < freq) {
+                max = freq;
+            }
+        }
+        if (max > 0) {
+            // If success, value is in MHz
+            max *= 1_000_000;
+        } else {
+            max = sysctlLong("machdep.tsc_freq", -1L);
+        }
+        return max;
+    }
+
+    /**
+     * Fetches the ProcessorID from dmidecode (if possible with root permissions), otherwise uses the values from
+     * /var/run/dmesg.boot
+     *
+     * @param processorID The processorID as a long
+     * @return The ProcessorID string
+     */
+    protected static String getProcessorIDfromDmiDecode(long processorID) {
+        boolean procInfo = false;
+        String marker = "Processor Information";
+        for (String checkLine : ExecutingCommand.runNative("dmidecode -t processor")) {
+            if (!procInfo && checkLine.contains(marker)) {
+                marker = "ID:";
+                procInfo = true;
+            } else if (procInfo && checkLine.contains(marker)) {
+                String[] parts = checkLine.split(marker);
+                if (parts.length > 1) {
+                    return parts[1].trim();
+                }
+            }
+        }
+        // If we've gotten this far, dmidecode failed. Used the passed-in values
+        return String.format(Locale.ROOT, "%016X", processorID);
+    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorFFM.java
@@ -10,15 +10,6 @@ import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,12 +18,8 @@ import org.slf4j.event.Level;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.platform.unix.freebsd.FreeBsdCentralProcessor;
-import oshi.util.ExecutingCommand;
-import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
-import oshi.util.tuples.Quartet;
 
 /**
  * FFM-backed FreeBSD central processor.
@@ -41,10 +28,6 @@ import oshi.util.tuples.Quartet;
 public class FreeBsdCentralProcessorFFM extends FreeBsdCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(FreeBsdCentralProcessorFFM.class);
-
-    // Capture the CSV of hex values as group(1), clients should split on ','
-    private static final Pattern CPUMASK = Pattern
-            .compile(".*<cpu\\s.*mask=\"(\\p{XDigit}+(,\\p{XDigit}+)*)\".*>.*</cpu>.*");
 
     // FreeBSD CPU state indices into kern.cp_time / kern.cp_times arrays
     private static final int CP_USER = 0;
@@ -57,178 +40,13 @@ public class FreeBsdCentralProcessorFFM extends FreeBsdCentralProcessor {
     private static final long CPTIME_SIZE = CPUSTATES * UINT64_SIZE;
 
     @Override
-    protected ProcessorIdentifier queryProcessorId() {
-        final Pattern identifierPattern = Pattern
-                .compile("Origin=\"([^\"]*)\".*Id=(\\S+).*Family=(\\S+).*Model=(\\S+).*Stepping=(\\S+).*");
-        final Pattern featuresPattern = Pattern.compile("Features=(\\S+)<.*");
-
-        String cpuVendor = "";
-        String cpuName = BsdSysctlUtilFFM.sysctl("hw.model", "");
-        String cpuFamily = "";
-        String cpuModel = "";
-        String cpuStepping = "";
-        String processorID;
-        long cpuFreq = BsdSysctlUtilFFM.sysctl("hw.clockrate", 0L) * 1_000_000L;
-
-        boolean cpu64bit;
-
-        // Parsing dmesg.boot is apparently the only reliable source for processor
-        // identification in FreeBSD
-        long processorIdBits = 0L;
-        List<String> cpuInfo = FileUtil.readFile("/var/run/dmesg.boot");
-        for (String line : cpuInfo) {
-            line = line.trim();
-            // Prefer hw.model to this one
-            if (line.startsWith("CPU:") && cpuName.isEmpty()) {
-                cpuName = line.replace("CPU:", "").trim();
-            } else if (line.startsWith("Origin=")) {
-                Matcher m = identifierPattern.matcher(line);
-                if (m.matches()) {
-                    cpuVendor = m.group(1);
-                    processorIdBits |= Long.decode(m.group(2));
-                    cpuFamily = Integer.decode(m.group(3)).toString();
-                    cpuModel = Integer.decode(m.group(4)).toString();
-                    cpuStepping = Integer.decode(m.group(5)).toString();
-                }
-            } else if (line.startsWith("Features=")) {
-                Matcher m = featuresPattern.matcher(line);
-                if (m.matches()) {
-                    processorIdBits |= Long.decode(m.group(1)) << 32;
-                }
-                // No further interest in this file
-                break;
-            }
-        }
-        cpu64bit = ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
-        processorID = getProcessorIDfromDmiDecode(processorIdBits);
-
-        return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,
-                cpuFreq);
+    protected String sysctlString(String name, String def) {
+        return BsdSysctlUtilFFM.sysctl(name, def);
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
-        List<LogicalProcessor> logProcs = parseTopology();
-        // Force at least one processor
-        if (logProcs.isEmpty()) {
-            logProcs.add(new LogicalProcessor(0, 0, 0));
-        }
-        Map<Integer, String> dmesg = new HashMap<>();
-        // cpu0: <Open Firmware CPU> on cpulist0
-        Pattern normal = Pattern.compile("cpu(\\d+): (.+) on .*");
-        // CPU 0: ARM Cortex-A53 r0p4 affinity: 0 0
-        Pattern hybrid = Pattern.compile("CPU\\s*(\\d+): (.+) affinity:.*");
-        List<String> featureFlags = new ArrayList<>();
-        boolean readingFlags = false;
-        for (String s : FileUtil.readFile("/var/run/dmesg.boot")) {
-            Matcher h = hybrid.matcher(s);
-            if (h.matches()) {
-                int coreId = ParseUtil.parseIntOrDefault(h.group(1), 0);
-                // This always takes priority, overwrite if needed
-                dmesg.put(coreId, h.group(2).trim());
-            } else {
-                Matcher n = normal.matcher(s);
-                if (n.matches()) {
-                    int coreId = ParseUtil.parseIntOrDefault(n.group(1), 0);
-                    // Don't overwrite if h matched earlier
-                    dmesg.putIfAbsent(coreId, n.group(2).trim());
-                }
-            }
-            if (s.contains("Origin=")) {
-                readingFlags = true;
-            } else if (readingFlags) {
-                if (s.startsWith("  ")) {
-                    featureFlags.add(s.trim());
-                } else {
-                    readingFlags = false;
-                }
-            }
-        }
-        List<PhysicalProcessor> physProcs = dmesg.isEmpty() ? null : createProcListFromDmesg(logProcs, dmesg);
-        List<ProcessorCache> caches = getCacheInfoFromLscpu();
-        return new Quartet<>(logProcs, physProcs, caches, featureFlags);
-    }
-
-    private List<ProcessorCache> getCacheInfoFromLscpu() {
-        Set<ProcessorCache> caches = new HashSet<>();
-        for (String checkLine : ExecutingCommand.runNative("lscpu")) {
-            if (checkLine.contains("L1d cache:")) {
-                caches.add(new ProcessorCache(1, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.DATA));
-            } else if (checkLine.contains("L1i cache:")) {
-                caches.add(new ProcessorCache(1, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.INSTRUCTION));
-            } else if (checkLine.contains("L2 cache:")) {
-                caches.add(new ProcessorCache(2, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.UNIFIED));
-            } else if (checkLine.contains("L3 cache:")) {
-                caches.add(new ProcessorCache(3, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.UNIFIED));
-            }
-        }
-        return orderedProcCaches(caches);
-    }
-
-    private static List<LogicalProcessor> parseTopology() {
-        String[] topology = BsdSysctlUtilFFM.sysctl("kern.sched.topology_spec", "").split("[\\n\\r]");
-        // See FreeBsdCentralProcessorJNA for sample output and the layered <group> semantics.
-        long group1 = 1L;
-        List<Long> group2 = new ArrayList<>();
-        List<Long> group3 = new ArrayList<>();
-        int groupLevel = 0;
-        for (String topo : topology) {
-            if (topo.contains("<group level=")) {
-                groupLevel++;
-            } else if (topo.contains("</group>")) {
-                groupLevel--;
-            } else if (topo.contains("<cpu")) {
-                Matcher m = CPUMASK.matcher(topo);
-                if (m.matches()) {
-                    String csvMatch = m.group(1);
-                    String[] csvTokens = csvMatch.split(",");
-                    String firstVal = csvTokens[0];
-                    long parsedVal = ParseUtil.hexStringToLong(firstVal, 0);
-                    switch (groupLevel) {
-                        case 1:
-                            group1 = parsedVal;
-                            break;
-                        case 2:
-                            group2.add(parsedVal);
-                            break;
-                        case 3:
-                            group3.add(parsedVal);
-                            break;
-                        default:
-                            break;
-                    }
-                }
-            }
-        }
-        return matchBitmasks(group1, group2, group3);
-    }
-
-    private static List<LogicalProcessor> matchBitmasks(long group1, List<Long> group2, List<Long> group3) {
-        List<LogicalProcessor> logProcs = new ArrayList<>();
-        int lowBit = Long.numberOfTrailingZeros(group1);
-        int hiBit = 63 - Long.numberOfLeadingZeros(group1);
-        for (int i = lowBit; i <= hiBit; i++) {
-            if ((group1 & (1L << i)) > 0) {
-                int numaNode = 0;
-                LogicalProcessor logProc = new LogicalProcessor(i, getMatchingBitmask(group3, i),
-                        getMatchingBitmask(group2, i), numaNode);
-                logProcs.add(logProc);
-            }
-        }
-        return logProcs;
-    }
-
-    private static int getMatchingBitmask(List<Long> bitmasks, int lp) {
-        for (int j = 0; j < bitmasks.size(); j++) {
-            if ((bitmasks.get(j).longValue() & (1L << lp)) != 0) {
-                return j;
-            }
-        }
-        return 0;
+    protected long sysctlLong(String name, long def) {
+        return BsdSysctlUtilFFM.sysctl(name, def);
     }
 
     @Override
@@ -245,39 +63,6 @@ public class FreeBsdCentralProcessorFFM extends FreeBsdCentralProcessor {
             }
         }
         return ticks;
-    }
-
-    @Override
-    public long[] queryCurrentFreq() {
-        long[] freq = new long[1];
-        freq[0] = BsdSysctlUtilFFM.sysctl("dev.cpu.0.freq", -1L);
-        if (freq[0] > 0) {
-            // If success, value is in MHz
-            freq[0] *= 1_000_000L;
-        } else {
-            freq[0] = BsdSysctlUtilFFM.sysctl("machdep.tsc_freq", -1L);
-        }
-        return freq;
-    }
-
-    @Override
-    public long queryMaxFreq() {
-        long max = -1L;
-        String freqLevels = BsdSysctlUtilFFM.sysctl("dev.cpu.0.freq_levels", "");
-        // MHz/Watts pairs like: 2501/32000 2187/27125 2000/24000
-        for (String s : ParseUtil.whitespaces.split(freqLevels)) {
-            long freq = ParseUtil.parseLongOrDefault(s.split("/")[0], -1L);
-            if (max < freq) {
-                max = freq;
-            }
-        }
-        if (max > 0) {
-            // If success, value is in MHz
-            max *= 1_000_000;
-        } else {
-            max = BsdSysctlUtilFFM.sysctl("machdep.tsc_freq", -1L);
-        }
-        return max;
     }
 
     @Override
@@ -322,28 +107,6 @@ public class FreeBsdCentralProcessorFFM extends FreeBsdCentralProcessor {
             ticks[cpu][TickType.IDLE.getIndex()] = buf.get(JAVA_LONG, base + CP_IDLE * UINT64_SIZE);
         }
         return ticks;
-    }
-
-    /**
-     * Fetches the ProcessorID from dmidecode (if possible with root permissions), otherwise uses the values from
-     * /var/run/dmesg.boot
-     *
-     * @param processorID The processorID as a long
-     * @return The ProcessorID string
-     */
-    private static String getProcessorIDfromDmiDecode(long processorID) {
-        boolean procInfo = false;
-        String marker = "Processor Information";
-        for (String checkLine : ExecutingCommand.runNative("dmidecode -t processor")) {
-            if (!procInfo && checkLine.contains(marker)) {
-                marker = "ID:";
-                procInfo = true;
-            } else if (procInfo && checkLine.contains(marker)) {
-                return checkLine.split(marker)[1].trim();
-            }
-        }
-        // If we've gotten this far, dmidecode failed. Used the passed-in values
-        return String.format(Locale.ROOT, "%016X", processorID);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorJNA.java
@@ -4,16 +4,6 @@
  */
 package oshi.hardware.platform.unix.freebsd;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,16 +12,12 @@ import com.sun.jna.Native;
 import com.sun.jna.platform.unix.LibCAPI.size_t;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.platform.unix.freebsd.FreeBsdCentralProcessor;
 import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.FreeBsdLibc;
 import oshi.jna.platform.unix.FreeBsdLibc.CpTime;
-import oshi.util.ExecutingCommand;
-import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
-import oshi.util.tuples.Quartet;
 
 /**
  * A CPU
@@ -41,10 +27,6 @@ public class FreeBsdCentralProcessorJNA extends FreeBsdCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(FreeBsdCentralProcessorJNA.class);
 
-    // Capture the CSV of hex values as group(1), clients should split on ','
-    private static final Pattern CPUMASK = Pattern
-            .compile(".*<cpu\\s.*mask=\"(\\p{XDigit}+(,\\p{XDigit}+)*)\".*>.*</cpu>.*");
-
     private static final long CPTIME_SIZE;
     static {
         try (CpTime cpTime = new CpTime()) {
@@ -53,215 +35,13 @@ public class FreeBsdCentralProcessorJNA extends FreeBsdCentralProcessor {
     }
 
     @Override
-    protected ProcessorIdentifier queryProcessorId() {
-        final Pattern identifierPattern = Pattern
-                .compile("Origin=\"([^\"]*)\".*Id=(\\S+).*Family=(\\S+).*Model=(\\S+).*Stepping=(\\S+).*");
-        final Pattern featuresPattern = Pattern.compile("Features=(\\S+)<.*");
-
-        String cpuVendor = "";
-        String cpuName = BsdSysctlUtil.sysctl("hw.model", "");
-        String cpuFamily = "";
-        String cpuModel = "";
-        String cpuStepping = "";
-        String processorID;
-        long cpuFreq = BsdSysctlUtil.sysctl("hw.clockrate", 0L) * 1_000_000L;
-
-        boolean cpu64bit;
-
-        // Parsing dmesg.boot is apparently the only reliable source for processor
-        // identification in FreeBSD
-        long processorIdBits = 0L;
-        List<String> cpuInfo = FileUtil.readFile("/var/run/dmesg.boot");
-        for (String line : cpuInfo) {
-            line = line.trim();
-            // Prefer hw.model to this one
-            if (line.startsWith("CPU:") && cpuName.isEmpty()) {
-                cpuName = line.replace("CPU:", "").trim();
-            } else if (line.startsWith("Origin=")) {
-                Matcher m = identifierPattern.matcher(line);
-                if (m.matches()) {
-                    cpuVendor = m.group(1);
-                    processorIdBits |= Long.decode(m.group(2));
-                    cpuFamily = Integer.decode(m.group(3)).toString();
-                    cpuModel = Integer.decode(m.group(4)).toString();
-                    cpuStepping = Integer.decode(m.group(5)).toString();
-                }
-            } else if (line.startsWith("Features=")) {
-                Matcher m = featuresPattern.matcher(line);
-                if (m.matches()) {
-                    processorIdBits |= Long.decode(m.group(1)) << 32;
-                }
-                // No further interest in this file
-                break;
-            }
-        }
-        cpu64bit = ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
-        processorID = getProcessorIDfromDmiDecode(processorIdBits);
-
-        return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,
-                cpuFreq);
+    protected String sysctlString(String name, String def) {
+        return BsdSysctlUtil.sysctl(name, def);
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
-        List<LogicalProcessor> logProcs = parseTopology();
-        // Force at least one processor
-        if (logProcs.isEmpty()) {
-            logProcs.add(new LogicalProcessor(0, 0, 0));
-        }
-        Map<Integer, String> dmesg = new HashMap<>();
-        // cpu0: <Open Firmware CPU> on cpulist0
-        Pattern normal = Pattern.compile("cpu(\\d+): (.+) on .*");
-        // CPU 0: ARM Cortex-A53 r0p4 affinity: 0 0
-        Pattern hybrid = Pattern.compile("CPU\\s*(\\d+): (.+) affinity:.*");
-        List<String> featureFlags = new ArrayList<>();
-        boolean readingFlags = false;
-        for (String s : FileUtil.readFile("/var/run/dmesg.boot")) {
-            Matcher h = hybrid.matcher(s);
-            if (h.matches()) {
-                int coreId = ParseUtil.parseIntOrDefault(h.group(1), 0);
-                // This always takes priority, overwrite if needed
-                dmesg.put(coreId, h.group(2).trim());
-            } else {
-                Matcher n = normal.matcher(s);
-                if (n.matches()) {
-                    int coreId = ParseUtil.parseIntOrDefault(n.group(1), 0);
-                    // Don't overwrite if h matched earlier
-                    dmesg.putIfAbsent(coreId, n.group(2).trim());
-                }
-            }
-            if (s.contains("Origin=")) {
-                readingFlags = true;
-            } else if (readingFlags) {
-                if (s.startsWith("  ")) {
-                    featureFlags.add(s.trim());
-                } else {
-                    readingFlags = false;
-                }
-            }
-        }
-        List<PhysicalProcessor> physProcs = dmesg.isEmpty() ? null : createProcListFromDmesg(logProcs, dmesg);
-        List<ProcessorCache> caches = getCacheInfoFromLscpu();
-        return new Quartet<>(logProcs, physProcs, caches, featureFlags);
-    }
-
-    private List<ProcessorCache> getCacheInfoFromLscpu() {
-        Set<ProcessorCache> caches = new HashSet<>();
-        for (String checkLine : ExecutingCommand.runNative("lscpu")) {
-            if (checkLine.contains("L1d cache:")) {
-                caches.add(new ProcessorCache(1, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.DATA));
-            } else if (checkLine.contains("L1i cache:")) {
-                caches.add(new ProcessorCache(1, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.INSTRUCTION));
-            } else if (checkLine.contains("L2 cache:")) {
-                caches.add(new ProcessorCache(2, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.UNIFIED));
-            } else if (checkLine.contains("L3 cache:")) {
-                caches.add(new ProcessorCache(3, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.UNIFIED));
-            }
-        }
-        return orderedProcCaches(caches);
-    }
-
-    private static List<LogicalProcessor> parseTopology() {
-        String[] topology = BsdSysctlUtil.sysctl("kern.sched.topology_spec", "").split("[\\n\\r]");
-        /*-
-         * Sample output:
-         *
-        <groups>
-        <group level="1" cache-level="0">
-         <cpu count="24" mask="ffffff">0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23</cpu>
-         <children>
-          <group level="2" cache-level="2">
-           <cpu count="12" mask="fff">0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11</cpu>
-           <children>
-            <group level="3" cache-level="1">
-             <cpu count="2" mask="3">0, 1</cpu>
-             <flags><flag name="THREAD">THREAD group</flag><flag name="SMT">SMT group</flag></flags>
-            </group>
-            ...
-        * On FreeBSD 13.1, the output may contain a csv value for the mask:
-        <groups>
-         <group level="1" cache-level="3">
-          <cpu count="8" mask="ff,0,0,0">0, 1, 2, 3, 4, 5, 6, 7</cpu>
-          <children>
-           <group level="2" cache-level="2">
-            <cpu count="2" mask="3,0,0,0">0, 1</cpu>
-            ...
-        *
-        * Opens with <groups>
-        * <group> level 1 identifies all the processors via bitmask, should only be one
-        * <group> level 2 separates by physical package
-        * <group> level 3 puts hyperthreads together: if THREAD or SMT or HTT all the CPUs are one physical
-        * If there is no level 3, then all logical processors are physical
-        */
-        // Create lists of the group bitmasks
-        long group1 = 1L;
-        List<Long> group2 = new ArrayList<>();
-        List<Long> group3 = new ArrayList<>();
-        int groupLevel = 0;
-        for (String topo : topology) {
-            if (topo.contains("<group level=")) {
-                groupLevel++;
-            } else if (topo.contains("</group>")) {
-                groupLevel--;
-            } else if (topo.contains("<cpu")) {
-                // Find <cpu> tag and extract bits
-                Matcher m = CPUMASK.matcher(topo);
-                if (m.matches()) {
-                    // If csv of hex values like "f,0,0,0", parse the first value
-                    String csvMatch = m.group(1);
-                    String[] csvTokens = csvMatch.split(",");
-                    String firstVal = csvTokens[0];
-
-                    // Regex guarantees parsing digits so we won't get a
-                    // NumberFormatException
-                    long parsedVal = ParseUtil.hexStringToLong(firstVal, 0);
-                    switch (groupLevel) {
-                        case 1:
-                            group1 = parsedVal;
-                            break;
-                        case 2:
-                            group2.add(parsedVal);
-                            break;
-                        case 3:
-                            group3.add(parsedVal);
-                            break;
-                        default:
-                            break;
-                    }
-                }
-            }
-        }
-        return matchBitmasks(group1, group2, group3);
-    }
-
-    private static List<LogicalProcessor> matchBitmasks(long group1, List<Long> group2, List<Long> group3) {
-        List<LogicalProcessor> logProcs = new ArrayList<>();
-        // Lowest and Highest set bits, indexing from 0
-        int lowBit = Long.numberOfTrailingZeros(group1);
-        int hiBit = 63 - Long.numberOfLeadingZeros(group1);
-        // Create logical processors for this core
-        for (int i = lowBit; i <= hiBit; i++) {
-            if ((group1 & (1L << i)) > 0) {
-                int numaNode = 0;
-                LogicalProcessor logProc = new LogicalProcessor(i, getMatchingBitmask(group3, i),
-                        getMatchingBitmask(group2, i), numaNode);
-                logProcs.add(logProc);
-            }
-        }
-        return logProcs;
-    }
-
-    private static int getMatchingBitmask(List<Long> bitmasks, int lp) {
-        for (int j = 0; j < bitmasks.size(); j++) {
-            if ((bitmasks.get(j).longValue() & (1L << lp)) != 0) {
-                return j;
-            }
-        }
-        return 0;
+    protected long sysctlLong(String name, long def) {
+        return BsdSysctlUtil.sysctl(name, def);
     }
 
     @Override
@@ -276,39 +56,6 @@ public class FreeBsdCentralProcessorJNA extends FreeBsdCentralProcessor {
             ticks[TickType.IDLE.getIndex()] = cpTime.cpu_ticks[FreeBsdLibc.CP_IDLE];
         }
         return ticks;
-    }
-
-    @Override
-    public long[] queryCurrentFreq() {
-        long[] freq = new long[1];
-        freq[0] = BsdSysctlUtil.sysctl("dev.cpu.0.freq", -1L);
-        if (freq[0] > 0) {
-            // If success, value is in MHz
-            freq[0] *= 1_000_000L;
-        } else {
-            freq[0] = BsdSysctlUtil.sysctl("machdep.tsc_freq", -1L);
-        }
-        return freq;
-    }
-
-    @Override
-    public long queryMaxFreq() {
-        long max = -1L;
-        String freqLevels = BsdSysctlUtil.sysctl("dev.cpu.0.freq_levels", "");
-        // MHz/Watts pairs like: 2501/32000 2187/27125 2000/24000
-        for (String s : ParseUtil.whitespaces.split(freqLevels)) {
-            long freq = ParseUtil.parseLongOrDefault(s.split("/")[0], -1L);
-            if (max < freq) {
-                max = freq;
-            }
-        }
-        if (max > 0) {
-            // If success, value is in MHz
-            max *= 1_000_000;
-        } else {
-            max = BsdSysctlUtil.sysctl("machdep.tsc_freq", -1L);
-        }
-        return max;
     }
 
     @Override
@@ -355,28 +102,6 @@ public class FreeBsdCentralProcessorJNA extends FreeBsdCentralProcessor {
             }
         }
         return ticks;
-    }
-
-    /**
-     * Fetches the ProcessorID from dmidecode (if possible with root permissions), otherwise uses the values from
-     * /var/run/dmesg.boot
-     *
-     * @param processorID The processorID as a long
-     * @return The ProcessorID string
-     */
-    private static String getProcessorIDfromDmiDecode(long processorID) {
-        boolean procInfo = false;
-        String marker = "Processor Information";
-        for (String checkLine : ExecutingCommand.runNative("dmidecode -t processor")) {
-            if (!procInfo && checkLine.contains(marker)) {
-                marker = "ID:";
-                procInfo = true;
-            } else if (procInfo && checkLine.contains(marker)) {
-                return checkLine.split(marker)[1].trim();
-            }
-        }
-        // If we've gotten this far, dmidecode failed. Used the passed-in values
-        return String.format(Locale.ROOT, "%016X", processorID);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Move shared processor logic (`queryProcessorId`, `initProcessorCounts`, topology parsing, cache info from lscpu, frequency queries, `getProcessorIDfromDmiDecode`) into the `FreeBsdCentralProcessor` superclass
- Abstract `sysctlString`/`sysctlLong` methods let JNA and FFM subclasses provide their sysctl backend
- JNA/FFM subclasses now only contain native-specific code: CPU load ticks, load average, context switches, and interrupts
- Eliminates ~189 duplicated lines between the two implementations

## Test plan
- [x] All pre-commit checks pass locally (spotless, checkstyle, forbiddenapis, javadoc)
- [x] Unix CI green: NetBSD, FreeBSD, OpenBSD, DragonFly BSD, OpenIndiana

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded and unified FreeBSD CPU detection for more accurate processor identification and reporting.
  * Improved frequency querying with stronger fallbacks for current and max clock speeds.
  * Enhanced CPU topology and cache discovery for more reliable logical/physical core and cache size reporting across FreeBSD builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->