### PR TITLE
Adopt callInArenaOrDefault in IPHlpAPIUtilFFM and PerfDataUtilFFM

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
@@ -9,6 +9,7 @@ import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.windows.IPHlpAPIFFM.AF_INET;
 import static oshi.ffm.platform.windows.IPHlpAPIFFM.AF_INET6;
 import static oshi.ffm.platform.windows.IPHlpAPIFFM.FIXED_INFO_LAYOUT;
@@ -44,7 +45,6 @@ import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
 import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
 import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,6 +52,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import oshi.ffm.platform.windows.Win32Exception;
 import oshi.software.os.InternetProtocolStats.IPConnection;
@@ -75,7 +76,7 @@ public final class IPHlpAPIUtilFFM {
      * @return an array of DNS server IP address strings, or an empty array on failure
      */
     public static String[] getDnsServers() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment sizeSegment = arena.allocate(JAVA_INT);
             int ret = GetNetworkParams(NULL, sizeSegment);
             if (ret != ERROR_BUFFER_OVERFLOW) {
@@ -115,10 +116,7 @@ public final class IPHlpAPIUtilFFM {
             }
 
             return dnsServers.toArray(new String[0]);
-        } catch (Throwable t) {
-            LOG.error("GetNetworkParams failed: {}", t.getMessage());
-            return new String[0];
-        }
+        }, LOG, Level.ERROR, "GetNetworkParams failed", new String[0]);
     }
 
     /**
@@ -128,7 +126,7 @@ public final class IPHlpAPIUtilFFM {
      * @return TCP statistics, or null on failure
      */
     public static TcpStats getTcpStats(int family) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment stats = arena.allocate(MIB_TCPSTATS_LAYOUT);
 
             int rc = GetTcpStatisticsEx(stats, family);
@@ -157,10 +155,7 @@ public final class IPHlpAPIUtilFFM {
 
             return new TcpStats(connectionsEstablished, connectionsActive, connectionsPassive, connectionFailures,
                     connectionsReset, segmentsSent, segmentsReceived, segmentsRetransmitted, inErrors, outResets);
-        } catch (Throwable t) {
-            LOG.debug("getTcpStats failed: {}", t.getMessage());
-            return null;
-        }
+        }, LOG, Level.DEBUG, "getTcpStats failed", null);
     }
 
     /**
@@ -170,7 +165,7 @@ public final class IPHlpAPIUtilFFM {
      * @return UDP statistics, or null on failure
      */
     public static UdpStats getUdpStats(int family) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment stats = arena.allocate(MIB_UDPSTATS_LAYOUT);
 
             int rc = GetUdpStatisticsEx(stats, family);
@@ -186,10 +181,7 @@ public final class IPHlpAPIUtilFFM {
             int inErrors = stats.get(JAVA_INT, MIB_UDPSTATS_LAYOUT.byteOffset(PathElement.groupElement("dwInErrors")));
 
             return new UdpStats(outDatagrams, inDatagrams, noPorts, inErrors);
-        } catch (Throwable t) {
-            LOG.debug("GetUdpStats failed: {}", t.getMessage());
-            return null;
-        }
+        }, LOG, Level.DEBUG, "getUdpStats failed", null);
     }
 
     /**
@@ -198,9 +190,7 @@ public final class IPHlpAPIUtilFFM {
      * @return list of TCP IPv4 connections
      */
     public static List<IPConnection> queryTCPv4Connections() {
-        List<IPConnection> conns = new ArrayList<>();
-        try (Arena arena = Arena.ofConfined()) {
-
+        return callInArenaOrDefault(arena -> {
             MemorySegment sizeSegment = arena.allocate(JAVA_INT);
             int ret = GetExtendedTcpTable(NULL, sizeSegment, 0, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
 
@@ -218,6 +208,7 @@ public final class IPHlpAPIUtilFFM {
 
             int numEntries = buffer.get(JAVA_INT, 0);
             long entryOffset = JAVA_INT.byteSize();
+            List<IPConnection> conns = new ArrayList<>();
 
             for (int i = 0; i < numEntries; i++) {
                 MemorySegment rowSeg = buffer.asSlice(entryOffset + i * MIB_TCPROW_OWNER_PID_LAYOUT.byteSize(),
@@ -241,10 +232,7 @@ public final class IPHlpAPIUtilFFM {
                         ParseUtil.bigEndian16ToLittleEndian(remotePortBE), stateLookup(state), 0, 0, pid));
             }
             return conns;
-        } catch (Throwable t) {
-            LOG.debug("queryTCPv4Connections failed: {}", t.getMessage());
-            return Collections.emptyList();
-        }
+        }, LOG, Level.DEBUG, "queryTCPv4Connections failed", Collections.emptyList());
     }
 
     /**
@@ -253,9 +241,7 @@ public final class IPHlpAPIUtilFFM {
      * @return list of TCP IPv6 connections
      */
     public static List<IPConnection> queryTCPv6Connections() {
-        List<IPConnection> conns = new ArrayList<>();
-        try (Arena arena = Arena.ofConfined()) {
-
+        return callInArenaOrDefault(arena -> {
             MemorySegment sizeSegment = arena.allocate(JAVA_INT);
             int ret = GetExtendedTcpTable(NULL, sizeSegment, 0, AF_INET6, TCP_TABLE_OWNER_PID_ALL, 0);
 
@@ -273,6 +259,7 @@ public final class IPHlpAPIUtilFFM {
 
             int numEntries = buffer.get(JAVA_INT, 0);
             long entryOffset = JAVA_INT.byteSize();
+            List<IPConnection> conns = new ArrayList<>();
 
             for (int i = 0; i < numEntries; i++) {
                 MemorySegment rowSeg = buffer.asSlice(entryOffset + i * MIB_TCP6ROW_OWNER_PID_LAYOUT.byteSize(),
@@ -303,10 +290,7 @@ public final class IPHlpAPIUtilFFM {
                         remoteAddr, ParseUtil.bigEndian16ToLittleEndian(remotePortBE), stateLookup(state), 0, 0, pid));
             }
             return conns;
-        } catch (Throwable t) {
-            LOG.debug("queryTCPv6Connections failed: {}", t.getMessage());
-            return Collections.emptyList();
-        }
+        }, LOG, Level.DEBUG, "queryTCPv6Connections failed", Collections.emptyList());
     }
 
     /**
@@ -315,8 +299,7 @@ public final class IPHlpAPIUtilFFM {
      * @return list of UDP IPv4 connections
      */
     public static List<IPConnection> queryUDPv4Connections() {
-        List<IPConnection> conns = new ArrayList<>();
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment sizeSegment = arena.allocate(JAVA_INT);
             int ret = GetExtendedUdpTable(NULL, sizeSegment, 0, AF_INET, UDP_TABLE_OWNER_PID, 0);
 
@@ -334,6 +317,7 @@ public final class IPHlpAPIUtilFFM {
 
             int numEntries = buffer.get(JAVA_INT, 0);
             long entryOffset = JAVA_INT.byteSize();
+            List<IPConnection> conns = new ArrayList<>();
 
             for (int i = 0; i < numEntries; i++) {
                 MemorySegment rowSeg = buffer.asSlice(entryOffset + i * MIB_UDPROW_OWNER_PID_LAYOUT.byteSize(),
@@ -350,10 +334,7 @@ public final class IPHlpAPIUtilFFM {
                         ParseUtil.bigEndian16ToLittleEndian(localPortBE), new byte[0], 0, TcpState.NONE, 0, 0, pid));
             }
             return conns;
-        } catch (Throwable t) {
-            LOG.debug("queryUDPv4Connections failed: {}", t.getMessage());
-            return Collections.emptyList();
-        }
+        }, LOG, Level.DEBUG, "queryUDPv4Connections failed", Collections.emptyList());
     }
 
     /**
@@ -362,8 +343,7 @@ public final class IPHlpAPIUtilFFM {
      * @return list of UDP IPv6 connections
      */
     public static List<IPConnection> queryUDPv6Connections() {
-        List<IPConnection> conns = new ArrayList<>();
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment sizeSegment = arena.allocate(JAVA_INT);
             int ret = GetExtendedUdpTable(NULL, sizeSegment, 0, AF_INET6, UDP_TABLE_OWNER_PID, 0);
 
@@ -381,6 +361,7 @@ public final class IPHlpAPIUtilFFM {
 
             int numEntries = buffer.get(JAVA_INT, 0);
             long entryOffset = JAVA_INT.byteSize();
+            List<IPConnection> conns = new ArrayList<>();
 
             for (int i = 0; i < numEntries; i++) {
                 MemorySegment rowSeg = buffer.asSlice(entryOffset + i * MIB_UDP6ROW_OWNER_PID_LAYOUT.byteSize(),
@@ -401,10 +382,7 @@ public final class IPHlpAPIUtilFFM {
                         new byte[0], 0, TcpState.NONE, 0, 0, pid));
             }
             return conns;
-        } catch (Throwable t) {
-            LOG.debug("queryUDPv6Connections failed: {}", t.getMessage());
-            return Collections.emptyList();
-        }
+        }, LOG, Level.DEBUG, "queryUDPv6Connections failed", Collections.emptyList());
     }
 
     private static TcpState stateLookup(int state) {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfDataUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfDataUtilFFM.java
@@ -9,6 +9,7 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.windows.PdhFFM.PDH_CSTATUS_NEW_DATA;
 import static oshi.ffm.platform.windows.PdhFFM.PDH_CSTATUS_VALID_DATA;
 import static oshi.ffm.platform.windows.PdhFFM.PDH_MORE_DATA;
@@ -37,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import oshi.driver.common.windows.perfmon.PdhCounterProperty;
 import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
@@ -171,9 +173,8 @@ public final class PerfDataUtilFFM {
      * @return A list of matching instance names, or an empty list on failure
      */
     static List<String> enumInstances(String perfObject, String instanceFilter) {
-        // PdhEnumObjectItemsW requires the localized object name
         String localizedObject = localizeObjectName(perfObject);
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment objectName = toWideString(arena, localizedObject);
             MemorySegment counterLen = arena.allocate(JAVA_INT);
             MemorySegment instanceLen = arena.allocate(JAVA_INT);
@@ -185,7 +186,7 @@ public final class PerfDataUtilFFM {
                     counterLen, MemorySegment.NULL, instanceLen, 100, 0);
             if (result != ERROR_SUCCESS && result != PDH_MORE_DATA) {
                 LOG.warn("Failed to enumerate instances for {}: 0x{}", perfObject, Integer.toHexString(result));
-                return Collections.emptyList();
+                return Collections.<String>emptyList();
             }
 
             // Retry loop for race conditions (e.g., process/thread list changes)
@@ -200,8 +201,6 @@ public final class PerfDataUtilFFM {
 
                 result = PdhEnumObjectItemsW(MemorySegment.NULL, MemorySegment.NULL, objectName, counterBuf, counterLen,
                         instanceBuf, instanceLen, 100, 0);
-                // On PDH_MORE_DATA, counterLen/instanceLen are updated with required sizes;
-                // add headroom for race conditions where instances change between calls
                 if (result == PDH_MORE_DATA) {
                     counterLen.set(JAVA_INT, 0, counterLen.get(JAVA_INT, 0) + 1024);
                     instanceLen.set(JAVA_INT, 0, instanceLen.get(JAVA_INT, 0) + 1024);
@@ -210,17 +209,13 @@ public final class PerfDataUtilFFM {
 
             if (result != ERROR_SUCCESS) {
                 LOG.warn("Failed to enumerate instances for {}: 0x{}", localizedObject, Integer.toHexString(result));
-                return Collections.emptyList();
+                return Collections.<String>emptyList();
             }
 
-            // Parse multi-sz instance list and filter
             List<String> instances = parseMultiSz(instanceBuf);
             instances.removeIf(i -> !Util.wildcardMatch(i.toLowerCase(Locale.ROOT), instanceFilter));
             return instances;
-        } catch (Throwable t) {
-            LOG.warn("Failed to enumerate instances for {}: {}", localizedObject, t.getMessage());
-            return Collections.emptyList();
-        }
+        }, LOG, Level.WARN, "Failed to enumerate instances for " + localizedObject, Collections.emptyList());
     }
 
     /**
@@ -388,7 +383,7 @@ public final class PerfDataUtilFFM {
     }
 
     private static String lookupPerfNameByIndex(int index) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment bufSize = arena.allocate(JAVA_INT);
             bufSize.set(JAVA_INT, 0, 0);
             int result = PdhLookupPerfNameByIndexW(MemorySegment.NULL, index, MemorySegment.NULL, bufSize);
@@ -405,9 +400,6 @@ public final class PerfDataUtilFFM {
                 return "";
             }
             return readWideString(nameBuf);
-        } catch (Throwable t) {
-            LOG.debug("Failed to lookup perf name by index {}: {}", index, t.getMessage());
-            return "";
-        }
+        }, LOG, Level.DEBUG, "Failed to lookup perf name by index " + index, "");
     }
 }


### PR DESCRIPTION
## Summary
- Replace manual `try(Arena arena = Arena.ofConfined()) { ... } catch(Throwable)` blocks with the centralized `callInArenaOrDefault` helper from `ForeignFunctions`
- **IPHlpAPIUtilFFM**: 7 methods converted (`getDnsServers`, `getTcpStats`, `getUdpStats`, `queryTCPv4Connections`, `queryTCPv6Connections`, `queryUDPv4Connections`, `queryUDPv6Connections`)
- **PerfDataUtilFFM**: 2 methods converted (`enumInstances`, `lookupPerfNameByIndex`)
- Arena lifecycle and error logging are now handled by the tested helper infrastructure
- Net reduction of ~30 lines

## Test plan
- [x] All pre-commit checks pass locally (spotless, checkstyle, forbiddenapis, javadoc)
- [x] Windows CI green: JDK 21/25/26 on windows-2022 and windows-2025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal consistency and error handling for Windows system utility operations. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->