### PR TITLE
Adopt ExceptionUtil/callInArena in ExecutingCommand and SysctlUtils

### DIFF
--- a/oshi-common/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-common/src/main/java/oshi/util/ExecutingCommand.java
@@ -117,21 +117,9 @@ public final class ExecutingCommand {
         // so we must handle separately
         if (PlatformEnum.getCurrentPlatform() == PlatformEnum.WINDOWS
                 || PlatformEnum.getCurrentPlatform() == PlatformEnum.SOLARIS) {
-            try {
-                p.getOutputStream().close();
-            } catch (IOException e) {
-                // do nothing on failure
-            }
-            try {
-                p.getInputStream().close();
-            } catch (IOException e) {
-                // do nothing on failure
-            }
-            try {
-                p.getErrorStream().close();
-            } catch (IOException e) {
-                // do nothing on failure
-            }
+            ExceptionUtil.runSilently(() -> p.getOutputStream().close());
+            ExceptionUtil.runSilently(() -> p.getInputStream().close());
+            ExceptionUtil.runSilently(() -> p.getErrorStream().close());
         }
         p.destroy();
     }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SysctlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SysctlUtilFFM.java
@@ -7,6 +7,10 @@ package oshi.ffm.util.platform.mac;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
+import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.ForeignFunctions.getErrno;
 import static oshi.ffm.platform.mac.MacSystemFunctions.SIZE_T;
 
@@ -16,6 +20,7 @@ import java.util.Arrays;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.mac.MacSystemFunctions;
@@ -53,7 +58,7 @@ public final class SysctlUtilFFM {
      * @return The int result of the call if successful; the default otherwise
      */
     public static int sysctl(String name, int def, boolean logWarning) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaIntOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment valueSeg = arena.allocate(JAVA_INT);
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_INT.byteSize());
@@ -61,12 +66,7 @@ public final class SysctlUtilFFM {
                 return def;
             }
             return valueSeg.get(JAVA_INT, 0);
-        } catch (Throwable e) {
-            if (logWarning) {
-                LOG.warn("Failed to get sysctl value for {}", name, e);
-            }
-            return def;
-        }
+        }, LOG, logWarning ? Level.WARN : Level.DEBUG, "Failed to get sysctl value for " + name, def);
     }
 
     /**
@@ -77,7 +77,7 @@ public final class SysctlUtilFFM {
      * @return The long result of the call if successful; the default otherwise
      */
     public static long sysctl(String name, long def) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment valueSeg = arena.allocate(JAVA_LONG);
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_LONG.byteSize());
@@ -85,10 +85,7 @@ public final class SysctlUtilFFM {
                 return def;
             }
             return valueSeg.get(JAVA_LONG, 0);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", name, e);
-            return def;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, def);
     }
 
     /**
@@ -111,24 +108,19 @@ public final class SysctlUtilFFM {
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(String name, String def, boolean logWarning) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment sizeSeg = arena.allocate(SIZE_T);
             if (!sysctlbyname(arena, nameSeg, MemorySegment.NULL, sizeSeg, logWarning)) {
                 return def;
             }
             long size = sizeSeg.get(SIZE_T, 0);
-            MemorySegment valueSeg = arena.allocate(size + 1); // +1 for null terminator
+            MemorySegment valueSeg = arena.allocate(size + 1);
             if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg, logWarning)) {
                 return def;
             }
             return valueSeg.getString(0);
-        } catch (Throwable e) {
-            if (logWarning) {
-                LOG.warn("Failed to get sysctl value for {}", name, e);
-            }
-            return def;
-        }
+        }, LOG, logWarning ? Level.WARN : Level.DEBUG, "Failed to get sysctl value for " + name, def);
     }
 
     /**
@@ -139,14 +131,11 @@ public final class SysctlUtilFFM {
      * @return True if structure is successfuly populated, false otherwise
      */
     public static boolean sysctl(String name, MemorySegment struct) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaBooleanOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, struct.byteSize());
             return sysctlbyname(arena, nameSeg, struct, sizeSeg, true);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", name, e);
-            return false;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, false);
     }
 
     /**
@@ -157,7 +146,7 @@ public final class SysctlUtilFFM {
      *         undefined.
      */
     public static MemorySegment sysctl(String name) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment sizeSeg = arena.allocate(SIZE_T);
             if (!sysctlbyname(arena, nameSeg, MemorySegment.NULL, sizeSeg, true)) {
@@ -168,14 +157,10 @@ public final class SysctlUtilFFM {
             if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg, true)) {
                 return null;
             }
-            // Need to copy to a segment that will be released on GC
             MemorySegment returnSeg = Arena.ofAuto().allocate(size);
             returnSeg.copyFrom(valueSeg);
             return returnSeg;
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", name, e);
-            return null;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, null);
     }
 
     /**
@@ -186,7 +171,7 @@ public final class SysctlUtilFFM {
      * @return The size of data written to the buffer, or -1 if the call failed
      */
     public static long sysctl(int[] mib, MemorySegment buffer) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment mibSeg = arena.allocateFrom(JAVA_INT, mib);
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, buffer.byteSize());
             MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
@@ -195,13 +180,10 @@ public final class SysctlUtilFFM {
 
             if (result != 0) {
                 LOG.warn(SYSCTL_FAIL, Arrays.toString(mib), getErrno(callState));
-                return -1;
+                return -1L;
             }
             return sizeSeg.get(SIZE_T, 0);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
-            return -1;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), -1L);
     }
 
     private static boolean sysctlbyname(Arena arena, MemorySegment name, MemorySegment oldp, MemorySegment oldlenp,

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/freebsd/BsdSysctlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/freebsd/BsdSysctlUtilFFM.java
@@ -7,6 +7,10 @@ package oshi.ffm.util.platform.unix.freebsd;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
+import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.ForeignFunctions.getErrno;
 import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.SIZE_T;
 
@@ -15,6 +19,7 @@ import java.lang.foreign.MemorySegment;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
@@ -43,7 +48,7 @@ public final class BsdSysctlUtilFFM {
      * @return The int result of the call if successful; the default otherwise
      */
     public static int sysctl(String name, int def) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaIntOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment valueSeg = arena.allocate(JAVA_INT);
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_INT.byteSize());
@@ -51,10 +56,7 @@ public final class BsdSysctlUtilFFM {
                 return def;
             }
             return valueSeg.get(JAVA_INT, 0);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", name, e);
-            return def;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, def);
     }
 
     /**
@@ -65,7 +67,7 @@ public final class BsdSysctlUtilFFM {
      * @return The long result of the call if successful; the default otherwise
      */
     public static long sysctl(String name, long def) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment valueSeg = arena.allocate(JAVA_LONG);
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_LONG.byteSize());
@@ -73,10 +75,7 @@ public final class BsdSysctlUtilFFM {
                 return def;
             }
             return valueSeg.get(JAVA_LONG, 0);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", name, e);
-            return def;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, def);
     }
 
     /**
@@ -87,23 +86,19 @@ public final class BsdSysctlUtilFFM {
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(String name, String def) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment sizeSeg = arena.allocate(SIZE_T);
             if (!sysctlbyname(arena, nameSeg, MemorySegment.NULL, sizeSeg)) {
                 return def;
             }
             long size = sizeSeg.get(SIZE_T, 0);
-            // +1 for null terminator
             MemorySegment valueSeg = arena.allocate(size + 1);
             if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg)) {
                 return def;
             }
             return valueSeg.getString(0);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", name, e);
-            return def;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, def);
     }
 
     /**
@@ -114,14 +109,11 @@ public final class BsdSysctlUtilFFM {
      * @return {@code true} if the struct was populated, {@code false} otherwise
      */
     public static boolean sysctl(String name, MemorySegment struct) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaBooleanOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, struct.byteSize());
             return sysctlbyname(arena, nameSeg, struct, sizeSeg);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", name, e);
-            return false;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, false);
     }
 
     /**
@@ -131,7 +123,7 @@ public final class BsdSysctlUtilFFM {
      * @return an auto-arena {@link MemorySegment} containing the result on success; {@code null} otherwise
      */
     public static MemorySegment sysctl(String name) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment sizeSeg = arena.allocate(SIZE_T);
             if (!sysctlbyname(arena, nameSeg, MemorySegment.NULL, sizeSeg)) {
@@ -142,14 +134,10 @@ public final class BsdSysctlUtilFFM {
             if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg)) {
                 return null;
             }
-            // Copy to an auto-arena segment so it outlives this confined arena
             MemorySegment returnSeg = Arena.ofAuto().allocate(size);
             returnSeg.copyFrom(valueSeg);
             return returnSeg;
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", name, e);
-            return null;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, null);
     }
 
     private static boolean sysctlbyname(Arena arena, MemorySegment name, MemorySegment oldp, MemorySegment oldlenp)

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFM.java
@@ -7,6 +7,10 @@ package oshi.ffm.util.platform.unix.openbsd;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
+import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.ForeignFunctions.getErrno;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.SIZE_T;
 
@@ -16,6 +20,7 @@ import java.util.Arrays;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
@@ -48,17 +53,14 @@ public final class OpenBsdSysctlUtilFFM {
      * @return The int result of the call if successful; the default otherwise
      */
     public static int sysctl(int[] mib, int def) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaIntOrDefault(arena -> {
             MemorySegment valueSeg = arena.allocate(JAVA_INT);
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_INT.byteSize());
             if (!sysctlMib(arena, mib, valueSeg, sizeSeg)) {
                 return def;
             }
             return valueSeg.get(JAVA_INT, 0);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
-            return def;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), def);
     }
 
     /**
@@ -69,17 +71,14 @@ public final class OpenBsdSysctlUtilFFM {
      * @return The long result of the call if successful; the default otherwise
      */
     public static long sysctl(int[] mib, long def) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment valueSeg = arena.allocate(JAVA_LONG);
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_LONG.byteSize());
             if (!sysctlMib(arena, mib, valueSeg, sizeSeg)) {
                 return def;
             }
             return valueSeg.get(JAVA_LONG, 0);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
-            return def;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), def);
     }
 
     /**
@@ -90,7 +89,7 @@ public final class OpenBsdSysctlUtilFFM {
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(int[] mib, String def) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment sizeSeg = arena.allocate(SIZE_T);
             if (!sysctlMib(arena, mib, MemorySegment.NULL, sizeSeg)) {
                 return def;
@@ -101,10 +100,7 @@ public final class OpenBsdSysctlUtilFFM {
                 return def;
             }
             return valueSeg.getString(0);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
-            return def;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), def);
     }
 
     /**
@@ -115,13 +111,10 @@ public final class OpenBsdSysctlUtilFFM {
      * @return {@code true} if the struct was populated, {@code false} otherwise
      */
     public static boolean sysctl(int[] mib, MemorySegment struct) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaBooleanOrDefault(arena -> {
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, struct.byteSize());
             return sysctlMib(arena, mib, struct, sizeSeg);
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
-            return false;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), false);
     }
 
     /**
@@ -131,7 +124,7 @@ public final class OpenBsdSysctlUtilFFM {
      * @return an auto-arena {@link MemorySegment} containing the result on success; {@code null} otherwise
      */
     public static MemorySegment sysctl(int[] mib) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment sizeSeg = arena.allocate(SIZE_T);
             if (!sysctlMib(arena, mib, MemorySegment.NULL, sizeSeg)) {
                 return null;
@@ -144,10 +137,7 @@ public final class OpenBsdSysctlUtilFFM {
             MemorySegment returnSeg = Arena.ofAuto().allocate(size);
             returnSeg.copyFrom(valueSeg);
             return returnSeg;
-        } catch (Throwable e) {
-            LOG.warn("Failed to get sysctl value for {}", Arrays.toString(mib), e);
-            return null;
-        }
+        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), null);
     }
 
     /*


### PR DESCRIPTION
## Summary
- **ExecutingCommand.destroyProcess**: Replace 3 sequential `try { stream.close() } catch (IOException) {}` blocks with `ExceptionUtil.runSilently()`
- **BsdSysctlUtilFFM**: Replace 5 `try(Arena)/catch(Throwable)` blocks with `callInArenaIntOrDefault`, `callInArenaLongOrDefault`, `callInArenaBooleanOrDefault`, `callInArenaOrDefault`
- **OpenBsdSysctlUtilFFM**: Replace 5 `try(Arena)/catch(Throwable)` blocks with the same helpers
- **SysctlUtilFFM (Mac)**: Replace 6 `try(Arena)/catch(Throwable)` blocks, using the `logWarning` flag to select between `Level.WARN` and `Level.DEBUG`

Net reduction of ~52 lines. Exception handling centralized into tested helper infrastructure.

## Test plan
- [x] All pre-commit checks pass locally (spotless, checkstyle, forbiddenapis, javadoc)
- [x] Unix CI green: NetBSD, FreeBSD, OpenBSD, DragonFly BSD, OpenIndiana
- [x] macOS CI green: JDK 21/25/26 on macos-14, macos-15, macos-26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved error handling and code consolidation in system utility functions across Windows, Solaris, macOS, BSD, and OpenBSD platforms for better maintainability and consistency. No behavioral changes or API modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->