### PR TITLE
Extract OpenBsd/FreeBsd HWDiskStore common bases (JNA/FFM dedup)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
@@ -1,14 +1,113 @@
 /*
- * Copyright 2026 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.common.platform.unix.freebsd;
 
-import oshi.hardware.common.AbstractHWDiskStore;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
 
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.unix.freebsd.disk.GeomDiskList;
+import oshi.driver.common.unix.freebsd.disk.GeomPartList;
+import oshi.hardware.HWDiskStore;
+import oshi.hardware.HWPartition;
+import oshi.hardware.common.AbstractHWDiskStore;
+import oshi.util.Constants;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Triplet;
+
+/**
+ * Shared FreeBSD HWDiskStore logic. Subclasses provide the sysctl backend (JNA or FFM).
+ */
+@ThreadSafe
 public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
 
     protected FreeBsdHWDiskStore(String name, String model, String serial, long size) {
         super(name, model, serial, size);
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        List<String> output = ExecutingCommand.runNative("iostat -Ix " + getName());
+        long now = System.currentTimeMillis();
+        boolean diskFound = false;
+        for (String line : output) {
+            String[] split = ParseUtil.whitespaces.split(line);
+            if (split.length < 7 || !split[0].equals(getName())) {
+                continue;
+            }
+            diskFound = true;
+            setReads((long) ParseUtil.parseDoubleOrDefault(split[1], 0d));
+            setWrites((long) ParseUtil.parseDoubleOrDefault(split[2], 0d));
+            setReadBytes((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024));
+            setWriteBytes((long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024));
+            setCurrentQueueLength(ParseUtil.parseLongOrDefault(split[5], 0L));
+            setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
+            setTimeStamp(now);
+        }
+        return diskFound;
+    }
+
+    /**
+     * Gets the disks on this machine using the provided sysctl accessor.
+     *
+     * @param <T>       the concrete disk store type
+     * @param sysctlStr reads a string sysctl given (name, default)
+     * @param factory   constructs the platform-specific instance
+     * @return a list of {@link HWDiskStore} objects representing the disks
+     */
+    protected static <T extends FreeBsdHWDiskStore> List<HWDiskStore> getDisks(
+            BiFunction<String, String, String> sysctlStr, DiskStoreFactory<T> factory) {
+        List<HWDiskStore> diskList = new ArrayList<>();
+
+        Map<String, List<HWPartition>> partitionMap = GeomPartList.queryPartitions();
+        Map<String, Triplet<String, String, Long>> diskInfoMap = GeomDiskList.queryDisks();
+
+        String kernDisks = sysctlStr.apply("kern.disks", "");
+        if (kernDisks.isEmpty()) {
+            return diskList;
+        }
+        List<String> devices = Arrays.asList(ParseUtil.whitespaces.split(kernDisks));
+
+        List<String> iostat = ExecutingCommand.runNative("iostat -Ix");
+        long now = System.currentTimeMillis();
+        for (String line : iostat) {
+            String[] split = ParseUtil.whitespaces.split(line);
+            if (split.length > 6 && devices.contains(split[0])) {
+                Triplet<String, String, Long> storeInfo = diskInfoMap.get(split[0]);
+                T store = (storeInfo == null) ? factory.create(split[0], Constants.UNKNOWN, Constants.UNKNOWN, 0L)
+                        : factory.create(split[0], storeInfo.getA(), storeInfo.getB(), storeInfo.getC());
+                store.setReads((long) ParseUtil.parseDoubleOrDefault(split[1], 0d));
+                store.setWrites((long) ParseUtil.parseDoubleOrDefault(split[2], 0d));
+                store.setReadBytes((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024));
+                store.setWriteBytes((long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024));
+                store.setCurrentQueueLength(ParseUtil.parseLongOrDefault(split[5], 0L));
+                store.setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
+                store.setPartitionList(
+                        Collections.unmodifiableList(partitionMap.getOrDefault(split[0], Collections.emptyList())
+                                .stream().sorted(Comparator.comparing(HWPartition::getName))
+                                .collect(java.util.stream.Collectors.toList())));
+                store.setTimeStamp(now);
+                diskList.add(store);
+            }
+        }
+        return diskList;
+    }
+
+    /**
+     * Factory for creating platform-specific FreeBsdHWDiskStore instances.
+     *
+     * @param <T> the concrete disk store type
+     */
+    @FunctionalInterface
+    protected interface DiskStoreFactory<T extends FreeBsdHWDiskStore> {
+        T create(String name, String model, String serial, long size);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2021-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.openbsd;
+
+import static oshi.util.Memoizer.defaultExpiration;
+import static oshi.util.Memoizer.memoize;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.unix.bsd.disk.Disklabel;
+import oshi.hardware.HWDiskStore;
+import oshi.hardware.HWPartition;
+import oshi.hardware.common.AbstractHWDiskStore;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Quartet;
+
+/**
+ * Shared OpenBSD HWDiskStore logic. Subclasses provide the sysctl backend (JNA or FFM).
+ */
+@ThreadSafe
+public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
+
+    private final Supplier<List<String>> iostat = memoize(OpenBsdHWDiskStore::querySystatIostat, defaultExpiration());
+
+    protected OpenBsdHWDiskStore(String name, String model, String serial, long size) {
+        super(name, model, serial, size);
+    }
+
+    /**
+     * Gets the disks on this machine using the provided sysctl accessor.
+     *
+     * @param <T>       the concrete disk store type
+     * @param sysctlStr reads a string sysctl given (name, default)
+     * @param factory   constructs the platform-specific instance
+     * @return a list of {@link HWDiskStore} objects representing the disks
+     */
+    protected static <T extends OpenBsdHWDiskStore> List<HWDiskStore> getDisks(
+            BiFunction<String, String, String> sysctlStr, DiskStoreFactory<T> factory) {
+        List<HWDiskStore> diskList = new ArrayList<>();
+        List<String> dmesg = null;
+
+        String disknames = sysctlStr.apply("hw.disknames", "");
+        if (disknames.isEmpty()) {
+            return diskList;
+        }
+        String[] devices = disknames.split(",");
+        T store;
+        String diskName;
+        for (String device : devices) {
+            diskName = device.split(":")[0];
+            if (diskName.isEmpty()) {
+                continue;
+            }
+            Quartet<String, String, Long, List<HWPartition>> diskdata = Disklabel.getDiskParams(diskName);
+            String model = diskdata.getA();
+            long size = diskdata.getC();
+            if (size <= 1) {
+                if (dmesg == null) {
+                    dmesg = ExecutingCommand.runNative("dmesg");
+                }
+                Pattern diskAt = Pattern.compile(diskName + " at .*<(.+)>.*");
+                Pattern diskMB = Pattern
+                        .compile(diskName + ":.* (\\d+)MB, (?:(\\d+) bytes\\/sector, )?(?:(\\d+) sectors).*");
+                for (String line : dmesg) {
+                    Matcher m = diskAt.matcher(line);
+                    if (m.matches()) {
+                        model = m.group(1);
+                    }
+                    m = diskMB.matcher(line);
+                    if (m.matches()) {
+                        long sectors = ParseUtil.parseLongOrDefault(m.group(3), 0L);
+                        long bytesPerSector = ParseUtil.parseLongOrDefault(m.group(2), 0L);
+                        if (bytesPerSector == 0 && sectors > 0) {
+                            size = ParseUtil.parseLongOrDefault(m.group(1), 0L) << 20;
+                            bytesPerSector = size / sectors;
+                            bytesPerSector = Long.highestOneBit(bytesPerSector + (bytesPerSector >> 1));
+                        }
+                        size = bytesPerSector * sectors;
+                        break;
+                    }
+                }
+            }
+            store = factory.create(diskName, model, diskdata.getB(), size);
+            store.setPartitionList(diskdata.getD());
+            store.updateAttributes();
+
+            diskList.add(store);
+        }
+        return diskList;
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        long now = System.currentTimeMillis();
+        boolean diskFound = false;
+        for (String line : iostat.get()) {
+            String[] split = ParseUtil.whitespaces.split(line);
+            if (split.length >= 6 && split[0].equals(getName())) {
+                diskFound = true;
+                setReadBytes(ParseUtil.parseMultipliedToLongs(split[1]));
+                setWriteBytes(ParseUtil.parseMultipliedToLongs(split[2]));
+                setReads((long) ParseUtil.parseDoubleOrDefault(split[3], 0d));
+                setWrites((long) ParseUtil.parseDoubleOrDefault(split[4], 0d));
+                setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[5], 0d) * 1000));
+                setTimeStamp(now);
+            }
+        }
+        return diskFound;
+    }
+
+    private static List<String> querySystatIostat() {
+        return ExecutingCommand.runNative("systat -ab iostat");
+    }
+
+    /**
+     * Factory for creating platform-specific OpenBsdHWDiskStore instances.
+     *
+     * @param <T> the concrete disk store type
+     */
+    @FunctionalInterface
+    protected interface DiskStoreFactory<T extends OpenBsdHWDiskStore> {
+        T create(String name, String model, String serial, long size);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHWDiskStoreFFM.java
@@ -4,28 +4,15 @@
  */
 package oshi.hardware.platform.unix.freebsd;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.common.unix.freebsd.disk.GeomDiskList;
-import oshi.driver.common.unix.freebsd.disk.GeomPartList;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
 import oshi.hardware.HWDiskStore;
-import oshi.hardware.HWPartition;
 import oshi.hardware.common.platform.unix.freebsd.FreeBsdHWDiskStore;
-import oshi.util.Constants;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
-import oshi.util.tuples.Triplet;
 
 /**
- * FFM-backed FreeBSD hard disk implementation. Disk enumeration uses {@code kern.disks} via {@link BsdSysctlUtilFFM};
- * the rest (iostat parsing, geom-based partition/disk-info maps) is pure Java shared with the JNA sibling.
+ * FFM-backed FreeBSD hard disk implementation.
  */
 @ThreadSafe
 public final class FreeBsdHWDiskStoreFFM extends FreeBsdHWDiskStore {
@@ -34,75 +21,12 @@ public final class FreeBsdHWDiskStoreFFM extends FreeBsdHWDiskStore {
         super(name, model, serial, size);
     }
 
-    @Override
-    public boolean updateAttributes() {
-        List<String> output = ExecutingCommand.runNative("iostat -Ix " + getName());
-        long now = System.currentTimeMillis();
-        boolean diskFound = false;
-        for (String line : output) {
-            String[] split = ParseUtil.whitespaces.split(line);
-            if (split.length < 7 || !split[0].equals(getName())) {
-                continue;
-            }
-            diskFound = true;
-            setReads((long) ParseUtil.parseDoubleOrDefault(split[1], 0d));
-            setWrites((long) ParseUtil.parseDoubleOrDefault(split[2], 0d));
-            // In KB
-            setReadBytes((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024));
-            setWriteBytes((long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024));
-            // # transactions
-            setCurrentQueueLength(ParseUtil.parseLongOrDefault(split[5], 0L));
-            // In seconds, multiply for ms
-            setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
-            setTimeStamp(now);
-        }
-        return diskFound;
-    }
-
     /**
-     * Gets the disks on this machine
+     * Gets the disks on this machine.
      *
      * @return a list of {@link HWDiskStore} objects representing the disks
      */
     public static List<HWDiskStore> getDisks() {
-        // Result
-        List<HWDiskStore> diskList = new ArrayList<>();
-
-        // Get map of disk names to partitions
-        Map<String, List<HWPartition>> partitionMap = GeomPartList.queryPartitions();
-
-        // Get map of disk names to disk info
-        Map<String, Triplet<String, String, Long>> diskInfoMap = GeomDiskList.queryDisks();
-
-        // Get list of disks from sysctl
-        List<String> devices = Arrays.asList(ParseUtil.whitespaces.split(BsdSysctlUtilFFM.sysctl("kern.disks", "")));
-
-        // Run iostat -Ix to enumerate disks by name and get kb r/w
-        List<String> iostat = ExecutingCommand.runNative("iostat -Ix");
-        long now = System.currentTimeMillis();
-        for (String line : iostat) {
-            String[] split = ParseUtil.whitespaces.split(line);
-            if (split.length > 6 && devices.contains(split[0])) {
-                Triplet<String, String, Long> storeInfo = diskInfoMap.get(split[0]);
-                FreeBsdHWDiskStoreFFM store = (storeInfo == null)
-                        ? new FreeBsdHWDiskStoreFFM(split[0], Constants.UNKNOWN, Constants.UNKNOWN, 0L)
-                        : new FreeBsdHWDiskStoreFFM(split[0], storeInfo.getA(), storeInfo.getB(), storeInfo.getC());
-                store.setReads((long) ParseUtil.parseDoubleOrDefault(split[1], 0d));
-                store.setWrites((long) ParseUtil.parseDoubleOrDefault(split[2], 0d));
-                // In KB
-                store.setReadBytes((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024));
-                store.setWriteBytes((long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024));
-                // # transactions
-                store.setCurrentQueueLength(ParseUtil.parseLongOrDefault(split[5], 0L));
-                // In seconds, multiply for ms
-                store.setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
-                store.setPartitionList(
-                        Collections.unmodifiableList(partitionMap.getOrDefault(split[0], Collections.emptyList())
-                                .stream().sorted(Comparator.comparing(HWPartition::getName)).toList()));
-                store.setTimeStamp(now);
-                diskList.add(store);
-            }
-        }
-        return diskList;
+        return FreeBsdHWDiskStore.getDisks(BsdSysctlUtilFFM::sysctl, FreeBsdHWDiskStoreFFM::new);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreFFM.java
@@ -4,33 +4,18 @@
  */
 package oshi.hardware.platform.unix.openbsd;
 
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
-
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.common.unix.bsd.disk.Disklabel;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.hardware.HWDiskStore;
-import oshi.hardware.HWPartition;
-import oshi.hardware.common.AbstractHWDiskStore;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
-import oshi.util.tuples.Quartet;
+import oshi.hardware.common.platform.unix.openbsd.OpenBsdHWDiskStore;
 
 /**
  * FFM-backed OpenBSD hard disk implementation.
  */
 @ThreadSafe
-public final class OpenBsdHWDiskStoreFFM extends AbstractHWDiskStore {
-
-    private final Supplier<List<String>> iostat = memoize(OpenBsdHWDiskStoreFFM::querySystatIostat,
-            defaultExpiration());
+public final class OpenBsdHWDiskStoreFFM extends OpenBsdHWDiskStore {
 
     private OpenBsdHWDiskStoreFFM(String name, String model, String serial, long size) {
         super(name, model, serial, size);
@@ -42,72 +27,6 @@ public final class OpenBsdHWDiskStoreFFM extends AbstractHWDiskStore {
      * @return a list of {@link HWDiskStore} objects representing the disks
      */
     public static List<HWDiskStore> getDisks() {
-        List<HWDiskStore> diskList = new ArrayList<>();
-        List<String> dmesg = null;
-
-        String[] devices = OpenBsdSysctlUtilFFM.sysctl("hw.disknames", "").split(",");
-        OpenBsdHWDiskStoreFFM store;
-        String diskName;
-        for (String device : devices) {
-            diskName = device.split(":")[0];
-            Quartet<String, String, Long, List<HWPartition>> diskdata = Disklabel.getDiskParams(diskName);
-            String model = diskdata.getA();
-            long size = diskdata.getC();
-            if (size <= 1) {
-                if (dmesg == null) {
-                    dmesg = ExecutingCommand.runNative("dmesg");
-                }
-                Pattern diskAt = Pattern.compile(diskName + " at .*<(.+)>.*");
-                Pattern diskMB = Pattern
-                        .compile(diskName + ":.* (\\d+)MB, (?:(\\d+) bytes\\/sector, )?(?:(\\d+) sectors).*");
-                for (String line : dmesg) {
-                    Matcher m = diskAt.matcher(line);
-                    if (m.matches()) {
-                        model = m.group(1);
-                    }
-                    m = diskMB.matcher(line);
-                    if (m.matches()) {
-                        long sectors = ParseUtil.parseLongOrDefault(m.group(3), 0L);
-                        long bytesPerSector = ParseUtil.parseLongOrDefault(m.group(2), 0L);
-                        if (bytesPerSector == 0 && sectors > 0) {
-                            size = ParseUtil.parseLongOrDefault(m.group(1), 0L) << 20;
-                            bytesPerSector = size / sectors;
-                            bytesPerSector = Long.highestOneBit(bytesPerSector + (bytesPerSector >> 1));
-                        }
-                        size = bytesPerSector * sectors;
-                        break;
-                    }
-                }
-            }
-            store = new OpenBsdHWDiskStoreFFM(diskName, model, diskdata.getB(), size);
-            store.setPartitionList(diskdata.getD());
-            store.updateAttributes();
-
-            diskList.add(store);
-        }
-        return diskList;
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        long now = System.currentTimeMillis();
-        boolean diskFound = false;
-        for (String line : iostat.get()) {
-            String[] split = ParseUtil.whitespaces.split(line);
-            if (split.length >= 6 && split[0].equals(getName())) {
-                diskFound = true;
-                setReadBytes(ParseUtil.parseMultipliedToLongs(split[1]));
-                setWriteBytes(ParseUtil.parseMultipliedToLongs(split[2]));
-                setReads((long) ParseUtil.parseDoubleOrDefault(split[3], 0d));
-                setWrites((long) ParseUtil.parseDoubleOrDefault(split[4], 0d));
-                setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[5], 0d) * 1000));
-                setTimeStamp(now);
-            }
-        }
-        return diskFound;
-    }
-
-    private static List<String> querySystatIostat() {
-        return ExecutingCommand.runNative("systat -ab iostat");
+        return OpenBsdHWDiskStore.getDisks(OpenBsdSysctlUtilFFM::sysctl, OpenBsdHWDiskStoreFFM::new);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHWDiskStoreJNA.java
@@ -4,25 +4,12 @@
  */
 package oshi.hardware.platform.unix.freebsd;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.common.unix.freebsd.disk.GeomDiskList;
-import oshi.driver.common.unix.freebsd.disk.GeomPartList;
 import oshi.hardware.HWDiskStore;
-import oshi.hardware.HWPartition;
 import oshi.hardware.common.platform.unix.freebsd.FreeBsdHWDiskStore;
-import oshi.util.Constants;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
-import oshi.util.tuples.Triplet;
 
 /**
  * FreeBSD hard disk implementation.
@@ -34,75 +21,12 @@ public final class FreeBsdHWDiskStoreJNA extends FreeBsdHWDiskStore {
         super(name, model, serial, size);
     }
 
-    @Override
-    public boolean updateAttributes() {
-        List<String> output = ExecutingCommand.runNative("iostat -Ix " + getName());
-        long now = System.currentTimeMillis();
-        boolean diskFound = false;
-        for (String line : output) {
-            String[] split = ParseUtil.whitespaces.split(line);
-            if (split.length < 7 || !split[0].equals(getName())) {
-                continue;
-            }
-            diskFound = true;
-            setReads((long) ParseUtil.parseDoubleOrDefault(split[1], 0d));
-            setWrites((long) ParseUtil.parseDoubleOrDefault(split[2], 0d));
-            // In KB
-            setReadBytes((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024));
-            setWriteBytes((long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024));
-            // # transactions
-            setCurrentQueueLength(ParseUtil.parseLongOrDefault(split[5], 0L));
-            // In seconds, multiply for ms
-            setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
-            setTimeStamp(now);
-        }
-        return diskFound;
-    }
-
     /**
-     * Gets the disks on this machine
+     * Gets the disks on this machine.
      *
      * @return a list of {@link HWDiskStore} objects representing the disks
      */
     public static List<HWDiskStore> getDisks() {
-        // Result
-        List<HWDiskStore> diskList = new ArrayList<>();
-
-        // Get map of disk names to partitions
-        Map<String, List<HWPartition>> partitionMap = GeomPartList.queryPartitions();
-
-        // Get map of disk names to disk info
-        Map<String, Triplet<String, String, Long>> diskInfoMap = GeomDiskList.queryDisks();
-
-        // Get list of disks from sysctl
-        List<String> devices = Arrays.asList(ParseUtil.whitespaces.split(BsdSysctlUtil.sysctl("kern.disks", "")));
-
-        // Run iostat -Ix to enumerate disks by name and get kb r/w
-        List<String> iostat = ExecutingCommand.runNative("iostat -Ix");
-        long now = System.currentTimeMillis();
-        for (String line : iostat) {
-            String[] split = ParseUtil.whitespaces.split(line);
-            if (split.length > 6 && devices.contains(split[0])) {
-                Triplet<String, String, Long> storeInfo = diskInfoMap.get(split[0]);
-                FreeBsdHWDiskStoreJNA store = (storeInfo == null)
-                        ? new FreeBsdHWDiskStoreJNA(split[0], Constants.UNKNOWN, Constants.UNKNOWN, 0L)
-                        : new FreeBsdHWDiskStoreJNA(split[0], storeInfo.getA(), storeInfo.getB(), storeInfo.getC());
-                store.setReads((long) ParseUtil.parseDoubleOrDefault(split[1], 0d));
-                store.setWrites((long) ParseUtil.parseDoubleOrDefault(split[2], 0d));
-                // In KB
-                store.setReadBytes((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024));
-                store.setWriteBytes((long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024));
-                // # transactions
-                store.setCurrentQueueLength(ParseUtil.parseLongOrDefault(split[5], 0L));
-                // In seconds, multiply for ms
-                store.setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
-                store.setPartitionList(Collections
-                        .unmodifiableList(partitionMap.getOrDefault(split[0], Collections.emptyList()).stream()
-                                .sorted(Comparator.comparing(HWPartition::getName)).collect(Collectors.toList())));
-                store.setTimeStamp(now);
-                diskList.add(store);
-            }
-        }
-        return diskList;
+        return FreeBsdHWDiskStore.getDisks(BsdSysctlUtil::sysctl, FreeBsdHWDiskStoreJNA::new);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreJNA.java
@@ -4,33 +4,18 @@
  */
 package oshi.hardware.platform.unix.openbsd;
 
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
-
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.common.unix.bsd.disk.Disklabel;
 import oshi.hardware.HWDiskStore;
-import oshi.hardware.HWPartition;
-import oshi.hardware.common.AbstractHWDiskStore;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+import oshi.hardware.common.platform.unix.openbsd.OpenBsdHWDiskStore;
 import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
-import oshi.util.tuples.Quartet;
 
 /**
  * OpenBSD hard disk implementation.
  */
 @ThreadSafe
-public final class OpenBsdHWDiskStoreJNA extends AbstractHWDiskStore {
-
-    private final Supplier<List<String>> iostat = memoize(OpenBsdHWDiskStoreJNA::querySystatIostat,
-            defaultExpiration());
+public final class OpenBsdHWDiskStoreJNA extends OpenBsdHWDiskStore {
 
     private OpenBsdHWDiskStoreJNA(String name, String model, String serial, long size) {
         super(name, model, serial, size);
@@ -42,83 +27,6 @@ public final class OpenBsdHWDiskStoreJNA extends AbstractHWDiskStore {
      * @return a list of {@link HWDiskStore} objects representing the disks
      */
     public static List<HWDiskStore> getDisks() {
-        List<HWDiskStore> diskList = new ArrayList<>();
-        List<String> dmesg = null; // Lazily fetch in loop if needed
-
-        // Get list of disks from sysctl
-        // hw.disknames=sd0:2cf69345d371cd82,cd0:,sd1:
-        String[] devices = OpenBsdSysctlUtil.sysctl("hw.disknames", "").split(",");
-        OpenBsdHWDiskStoreJNA store;
-        String diskName;
-        for (String device : devices) {
-            diskName = device.split(":")[0];
-            // get partitions using disklabel command (requires root)
-            Quartet<String, String, Long, List<HWPartition>> diskdata = Disklabel.getDiskParams(diskName);
-            String model = diskdata.getA();
-            long size = diskdata.getC();
-            if (size <= 1) {
-                if (dmesg == null) {
-                    dmesg = ExecutingCommand.runNative("dmesg");
-                }
-                Pattern diskAt = Pattern.compile(diskName + " at .*<(.+)>.*");
-                Pattern diskMB = Pattern
-                        .compile(diskName + ":.* (\\d+)MB, (?:(\\d+) bytes\\/sector, )?(?:(\\d+) sectors).*");
-                for (String line : dmesg) {
-                    Matcher m = diskAt.matcher(line);
-                    if (m.matches()) {
-                        model = m.group(1);
-                    }
-                    m = diskMB.matcher(line);
-                    if (m.matches()) {
-                        // Group 3 is sectors
-                        long sectors = ParseUtil.parseLongOrDefault(m.group(3), 0L);
-                        // Group 2 is optional capture of bytes per sector
-                        long bytesPerSector = ParseUtil.parseLongOrDefault(m.group(2), 0L);
-                        if (bytesPerSector == 0 && sectors > 0) {
-                            // if we don't have bytes per sector guess at it based on total size and number
-                            // of sectors
-                            // Group 1 is size in MB, which may round
-                            size = ParseUtil.parseLongOrDefault(m.group(1), 0L) << 20;
-                            // Estimate bytes per sector. Should be "near" a power of 2
-                            bytesPerSector = size / sectors;
-                            // Multiply by 1.5 and round down to nearest power of 2:
-                            bytesPerSector = Long.highestOneBit(bytesPerSector + (bytesPerSector >> 1));
-                        }
-                        size = bytesPerSector * sectors;
-                        break;
-                    }
-                }
-            }
-            store = new OpenBsdHWDiskStoreJNA(diskName, model, diskdata.getB(), size);
-            store.setPartitionList(diskdata.getD());
-            store.updateAttributes();
-
-            diskList.add(store);
-        }
-        return diskList;
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        long now = System.currentTimeMillis();
-        boolean diskFound = false;
-        for (String line : iostat.get()) {
-            String[] split = ParseUtil.whitespaces.split(line);
-            if (split.length >= 6 && split[0].equals(getName())) {
-                diskFound = true;
-                setReadBytes(ParseUtil.parseMultipliedToLongs(split[1]));
-                setWriteBytes(ParseUtil.parseMultipliedToLongs(split[2]));
-                setReads((long) ParseUtil.parseDoubleOrDefault(split[3], 0d));
-                setWrites((long) ParseUtil.parseDoubleOrDefault(split[4], 0d));
-                // In seconds, multiply for ms
-                setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[5], 0d) * 1000));
-                setTimeStamp(now);
-            }
-        }
-        return diskFound;
-    }
-
-    private static List<String> querySystatIostat() {
-        return ExecutingCommand.runNative("systat -ab iostat");
+        return OpenBsdHWDiskStore.getDisks(OpenBsdSysctlUtil::sysctl, OpenBsdHWDiskStoreJNA::new);
     }
 }


### PR DESCRIPTION
## Summary
- Create `OpenBsdHWDiskStore` superclass in oshi-common with all shared disk enumeration logic (disklabel, dmesg parsing, iostat update). JNA/FFM subclasses become ~30-line shells providing only the sysctl method reference.
- Expand the existing empty `FreeBsdHWDiskStore` superclass with all shared logic (geom partition/disk maps, iostat parsing, updateAttributes). Same pattern — subclasses supply only the sysctl accessor.
- Eliminates ~104 duplicated lines across the 4 subclass files.

## Test plan
- [x] All pre-commit checks pass locally (spotless, checkstyle, forbiddenapis, javadoc)
- [x] Unix CI: OpenBSD, NetBSD, DragonFly BSD, OpenIndiana all green
- [x] FreeBSD: flaky pre-existing test failure (`NativeComparisonTest.currentThreadUpdateAttributes` FFM thread userTime assertion) — unrelated to disk store changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More accurate and timely disk metrics on FreeBSD (reads/writes, bytes, queue length, transfer time).
  * Shared OpenBSD disk store with improved discovery and corrected size/model detection.

* **Refactor**
  * Consolidated disk enumeration and attribute updating across BSD implementations for consistent, maintainable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->