### PR TITLE
Extract OpenBSD/NetBSD CentralProcessor common bases (BSD dedup)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2021-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix;
+
+import static oshi.util.Memoizer.defaultExpiration;
+import static oshi.util.Memoizer.memoize;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import oshi.hardware.CentralProcessor.ProcessorCache.Type;
+import oshi.hardware.common.AbstractCentralProcessor;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
+import oshi.util.tuples.Quartet;
+
+/**
+ * Shared CentralProcessor logic for the {@code dmesg}-parsing BSDs (OpenBSD and NetBSD). Both enumerate processors,
+ * caches, and feature flags from {@code dmesg} output and read counters from {@code vmstat}; the platform-specific
+ * sysctl backend and the {@code vmstat} parsing are supplied by the subclasses.
+ */
+public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
+
+    private final Supplier<Pair<Long, Long>> vmStats = memoize(this::queryVmStats, defaultExpiration());
+
+    private static final Pattern DMESG_CPU = Pattern.compile("cpu(\\d+): smt (\\d+), core (\\d+), package (\\d+)");
+
+    /**
+     * Reads an integer sysctl value by name.
+     *
+     * @param name the sysctl name
+     * @param def  the default value
+     * @return the sysctl integer value or the default
+     */
+    protected abstract int sysctl(String name, int def);
+
+    /**
+     * Reads the number of context switches and interrupts from {@code vmstat}. The label text and parsing differ
+     * between OpenBSD and NetBSD, so each subclass supplies its own implementation.
+     *
+     * @return a {@link Pair} of (context switches, interrupts)
+     */
+    protected abstract Pair<Long, Long> queryVmStats();
+
+    @Override
+    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+        // Iterate dmesg, look for lines:
+        // cpu0: smt 0, core 0, package 0
+        // cpu1: smt 0, core 1, package 0
+        Map<Integer, Integer> coreMap = new HashMap<>();
+        Map<Integer, Integer> packageMap = new HashMap<>();
+        for (String line : ExecutingCommand.runNative("dmesg")) {
+            Matcher m = DMESG_CPU.matcher(line);
+            if (m.matches()) {
+                int cpu = ParseUtil.parseIntOrDefault(m.group(1), 0);
+                coreMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(3), 0));
+                packageMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(4), 0));
+            }
+        }
+        // native call seems to fail here, use fallback
+        int logicalProcessorCount = sysctl("hw.ncpuonline", 1);
+        // If we found more procs in dmesg, update
+        if (logicalProcessorCount < coreMap.keySet().size()) {
+            logicalProcessorCount = coreMap.keySet().size();
+        }
+        List<LogicalProcessor> logProcs = new ArrayList<>(logicalProcessorCount);
+        for (int i = 0; i < logicalProcessorCount; i++) {
+            logProcs.add(new LogicalProcessor(i, coreMap.getOrDefault(i, 0), packageMap.getOrDefault(i, 0)));
+        }
+        Map<Integer, String> cpuMap = new HashMap<>();
+        // cpu0 at mainbus0 mpidr 0: ARM Cortex-A7 r0p5
+        // but NOT: cpu0 at mainbus0: apid 0 (boot processor)
+        // cpu0: AMD GX-412TC SOC, 998.28 MHz, 16-30-01
+        // cpu0: AMD EPYC 7313P 16-Core Processor, 2994.74 MHz, 19-01-01
+        // cpu0: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01
+        Pattern p = Pattern.compile("cpu(\\d+).*: ((ARM|AMD|Intel|Apple).+)");
+
+        Set<ProcessorCache> caches = new HashSet<>();
+        // cpu0: 48KB 64b/line 12-way D-cache, 32KB 64b/line 8-way I-cache,
+        // ... 1MB 64b/line 10-way L2 cache, 24MB 64b/line 12-way L3 cache
+        // cpu0: 32KB 64b/line 8-way D-cache, 64KB 64b/line 4-way I-cache,
+        // ... 512KB 64b/line 8-way L2 cache, 4MB 64b/line 16-way L3 cache
+        // cpu0: 32KB 64b/line 2-way I-cache, 32KB 64b/line 8-way D-cache,
+        // ... 2MB 64b/line 16-way L2 cache
+        // cpu0: 32KB 64b/line 8-way I-cache, 32KB 64b/line 8-way D-cache,
+        // ... 512KB 64b/line 8-way L2 cache
+        // cpu0: 256KB 64b/line disabled L2 cache
+        // cpu0: 1MB 64b/line 16-way L2 cache
+        // --- Mac M1 example ---
+        // shows different for icestorm/firestrorm and multiple lines for L1 vs. L2
+        // cpu0 at mainbus0 mpidr 0: Apple Icestorm Pro r2p0
+        // cpu0: 128KB 64b/line 8-way L1 VIPT I-cache, 64KB 64b/line 8-way L1 D-cache
+        // cpu0: 4096KB 128b/line 16-way L2 cache
+        // cpu2 at mainbus0 mpidr 10100: Apple Firestorm Pro r2p0
+        // cpu2: 192KB 64b/line 6-way L1 VIPT I-cache, 128KB 64b/line 8-way L1 D-cache
+        // cpu2: 12288KB 128b/line 12-way L2 cache
+        // --- BIG:little example ---
+        // shows different for A53/A72 and multiple lines for L1 vs. L2
+        // cpu0 at mainbus0 mpidr 0: ARM Cortex-A53 r0p4
+        // cpu0: 32KB 64b/line 2-way L1 VIPT I-cache, 32KB 64b/line 4-way L1 D-cache
+        // cpu0: 512KB 64b/line 16-way L2 cache
+        // cpu4 at mainbus0 mpidr 100: ARM Cortex-A72 r0p2
+        // cpu4: 48KB 64b/line 3-way L1 PIPT I-cache, 32KB 64b/line 2-way L1 D-cache
+        // cpu4: 1024KB 64b/line 16-way L2 cache
+        Pattern q = Pattern.compile("cpu(\\d+).*: (.+(I-|D-|L\\d+\\s)cache)");
+        Set<String> featureFlags = new LinkedHashSet<>();
+        for (String s : ExecutingCommand.runNative("dmesg")) {
+            Matcher m = p.matcher(s);
+            if (m.matches()) {
+                int coreId = ParseUtil.parseIntOrDefault(m.group(1), 0);
+                cpuMap.put(coreId, m.group(2).trim());
+            } else {
+                Matcher n = q.matcher(s);
+                if (n.matches()) {
+                    for (String cacheStr : n.group(2).split(",")) {
+                        ProcessorCache cache = parseCacheStr(cacheStr);
+                        if (cache != null) {
+                            caches.add(cache);
+                        }
+                    }
+                }
+            }
+            if (s.startsWith("cpu")) {
+                String[] ss = s.trim().split(": ");
+                if (ss.length == 2 && ss[1].split(",").length > 3) {
+                    featureFlags.add(ss[1]);
+                }
+            }
+        }
+        List<PhysicalProcessor> physProcs = cpuMap.isEmpty() ? null : createProcListFromDmesg(logProcs, cpuMap);
+        return new Quartet<>(logProcs, physProcs, orderedProcCaches(caches), new ArrayList<>(featureFlags));
+    }
+
+    private ProcessorCache parseCacheStr(String cacheStr) {
+        String[] split = ParseUtil.whitespaces.split(cacheStr.trim());
+        if (split.length > 3) {
+            switch (split[split.length - 1]) {
+                case "I-cache":
+                    return new ProcessorCache(1, ParseUtil.getFirstIntValue(split[2]),
+                            ParseUtil.getFirstIntValue(split[1]), ParseUtil.parseDecimalMemorySizeToBinary(split[0]),
+                            Type.INSTRUCTION);
+                case "D-cache":
+                    return new ProcessorCache(1, ParseUtil.getFirstIntValue(split[2]),
+                            ParseUtil.getFirstIntValue(split[1]), ParseUtil.parseDecimalMemorySizeToBinary(split[0]),
+                            Type.DATA);
+                default:
+                    return new ProcessorCache(ParseUtil.getFirstIntValue(split[3]),
+                            ParseUtil.getFirstIntValue(split[2]), ParseUtil.getFirstIntValue(split[1]),
+                            ParseUtil.parseDecimalMemorySizeToBinary(split[0]), Type.UNIFIED);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get number of context switches
+     *
+     * @return The context switches
+     */
+    @Override
+    protected long queryContextSwitches() {
+        return vmStats.get().getA();
+    }
+
+    /**
+     * Get number of interrupts
+     *
+     * @return The interrupts
+     */
+    @Override
+    protected long queryInterrupts() {
+        return vmStats.get().getB();
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -4,35 +4,23 @@
  */
 package oshi.hardware.common.platform.unix.netbsd;
 
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
-
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
-import oshi.hardware.common.AbstractCentralProcessor;
+import oshi.hardware.common.platform.unix.BsdCentralProcessor;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
 import oshi.util.tuples.Pair;
-import oshi.util.tuples.Quartet;
 
 /**
- * NetBSD Central Processor implementation
+ * NetBSD Central Processor implementation. Shares the {@code dmesg}-based topology and cache parsing with the other
+ * BSDs via {@link BsdCentralProcessor}; the processor identification, frequency, CPU ticks, and load average are read
+ * from command output and name-based sysctls specific to NetBSD.
  */
 @ThreadSafe
-public class NetBsdCentralProcessor extends AbstractCentralProcessor {
+public class NetBsdCentralProcessor extends BsdCentralProcessor {
 
     private static final int CPUSTATES = 5;
     private static final int CP_USER = 0;
@@ -41,9 +29,10 @@ public class NetBsdCentralProcessor extends AbstractCentralProcessor {
     private static final int CP_INTR = 3;
     private static final int CP_IDLE = 4;
 
-    private final Supplier<Pair<Long, Long>> vmStats = memoize(NetBsdCentralProcessor::queryVmStats,
-            defaultExpiration());
-    private static final Pattern DMESG_CPU = Pattern.compile("cpu(\\d+): smt (\\d+), core (\\d+), package (\\d+)");
+    @Override
+    protected int sysctl(String name, int def) {
+        return NetBsdSysctlUtil.sysctl(name, def);
+    }
 
     @Override
     protected ProcessorIdentifier queryProcessorId() {
@@ -106,136 +95,7 @@ public class NetBsdCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
-        // Iterate dmesg, look for lines:
-        // cpu0: smt 0, core 0, package 0
-        // cpu1: smt 0, core 1, package 0
-        Map<Integer, Integer> coreMap = new HashMap<>();
-        Map<Integer, Integer> packageMap = new HashMap<>();
-        for (String line : ExecutingCommand.runNative("dmesg")) {
-            Matcher m = DMESG_CPU.matcher(line);
-            if (m.matches()) {
-                int cpu = ParseUtil.parseIntOrDefault(m.group(1), 0);
-                coreMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(3), 0));
-                packageMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(4), 0));
-            }
-        }
-        // native call seems to fail here, use fallback
-        int logicalProcessorCount = NetBsdSysctlUtil.sysctl("hw.ncpuonline", 1);
-        // If we found more procs in dmesg, update
-        if (logicalProcessorCount < coreMap.keySet().size()) {
-            logicalProcessorCount = coreMap.keySet().size();
-        }
-        List<LogicalProcessor> logProcs = new ArrayList<>(logicalProcessorCount);
-        for (int i = 0; i < logicalProcessorCount; i++) {
-            logProcs.add(new LogicalProcessor(i, coreMap.getOrDefault(i, 0), packageMap.getOrDefault(i, 0)));
-        }
-        Map<Integer, String> cpuMap = new HashMap<>();
-        // cpu0 at mainbus0 mpidr 0: ARM Cortex-A7 r0p5
-        // but NOT: cpu0 at mainbus0: apid 0 (boot processor)
-        // cpu0: AMD GX-412TC SOC, 998.28 MHz, 16-30-01
-        // cpu0: AMD EPYC 7313P 16-Core Processor, 2994.74 MHz, 19-01-01
-        // cpu0: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01
-        Pattern p = Pattern.compile("cpu(\\d+).*: ((ARM|AMD|Intel|Apple).+)");
-
-        Set<ProcessorCache> caches = new HashSet<>();
-        // cpu0: 48KB 64b/line 12-way D-cache, 32KB 64b/line 8-way I-cache,
-        // ... 1MB 64b/line 10-way L2 cache, 24MB 64b/line 12-way L3 cache
-        // cpu0: 32KB 64b/line 8-way D-cache, 64KB 64b/line 4-way I-cache,
-        // ... 512KB 64b/line 8-way L2 cache, 4MB 64b/line 16-way L3 cache
-        // cpu0: 32KB 64b/line 2-way I-cache, 32KB 64b/line 8-way D-cache,
-        // ... 2MB 64b/line 16-way L2 cache
-        // cpu0: 32KB 64b/line 8-way I-cache, 32KB 64b/line 8-way D-cache,
-        // ... 512KB 64b/line 8-way L2 cache
-        // cpu0: 256KB 64b/line disabled L2 cache
-        // cpu0: 1MB 64b/line 16-way L2 cache
-        // --- Mac M1 example ---
-        // shows different for icestorm/firestrorm and multiple lines for L1 vs. L2
-        // cpu0 at mainbus0 mpidr 0: Apple Icestorm Pro r2p0
-        // cpu0: 128KB 64b/line 8-way L1 VIPT I-cache, 64KB 64b/line 8-way L1 D-cache
-        // cpu0: 4096KB 128b/line 16-way L2 cache
-        // cpu2 at mainbus0 mpidr 10100: Apple Firestorm Pro r2p0
-        // cpu2: 192KB 64b/line 6-way L1 VIPT I-cache, 128KB 64b/line 8-way L1 D-cache
-        // cpu2: 12288KB 128b/line 12-way L2 cache
-        // --- BIG:little example ---
-        // shows different for A53/A72 and multiple lines for L1 vs. L2
-        // cpu0 at mainbus0 mpidr 0: ARM Cortex-A53 r0p4
-        // cpu0: 32KB 64b/line 2-way L1 VIPT I-cache, 32KB 64b/line 4-way L1 D-cache
-        // cpu0: 512KB 64b/line 16-way L2 cache
-        // cpu4 at mainbus0 mpidr 100: ARM Cortex-A72 r0p2
-        // cpu4: 48KB 64b/line 3-way L1 PIPT I-cache, 32KB 64b/line 2-way L1 D-cache
-        // cpu4: 1024KB 64b/line 16-way L2 cache
-        Pattern q = Pattern.compile("cpu(\\d+).*: (.+(I-|D-|L\\d+\\s)cache)");
-        Set<String> featureFlags = new LinkedHashSet<>();
-        for (String s : ExecutingCommand.runNative("dmesg")) {
-            Matcher m = p.matcher(s);
-            if (m.matches()) {
-                int coreId = ParseUtil.parseIntOrDefault(m.group(1), 0);
-                cpuMap.put(coreId, m.group(2).trim());
-            } else {
-                Matcher n = q.matcher(s);
-                if (n.matches()) {
-                    for (String cacheStr : n.group(1).split(",")) {
-                        ProcessorCache cache = parseCacheStr(cacheStr);
-                        if (cache != null) {
-                            caches.add(cache);
-                        }
-                    }
-                }
-            }
-            if (s.startsWith("cpu")) {
-                String[] ss = s.trim().split(": ");
-                if (ss.length == 2 && ss[1].split(",").length > 3) {
-                    featureFlags.add(ss[1]);
-                }
-            }
-        }
-        List<PhysicalProcessor> physProcs = cpuMap.isEmpty() ? null : createProcListFromDmesg(logProcs, cpuMap);
-        return new Quartet<>(logProcs, physProcs, orderedProcCaches(caches), new ArrayList<>(featureFlags));
-    }
-
-    private ProcessorCache parseCacheStr(String cacheStr) {
-        String[] split = ParseUtil.whitespaces.split(cacheStr);
-        if (split.length > 3) {
-            switch (split[split.length - 1]) {
-                case "I-cache":
-                    return new ProcessorCache(1, ParseUtil.getFirstIntValue(split[2]),
-                            ParseUtil.getFirstIntValue(split[1]), ParseUtil.parseDecimalMemorySizeToBinary(split[0]),
-                            Type.INSTRUCTION);
-                case "D-cache":
-                    return new ProcessorCache(1, ParseUtil.getFirstIntValue(split[2]),
-                            ParseUtil.getFirstIntValue(split[1]), ParseUtil.parseDecimalMemorySizeToBinary(split[0]),
-                            Type.DATA);
-                default:
-                    return new ProcessorCache(ParseUtil.getFirstIntValue(split[3]),
-                            ParseUtil.getFirstIntValue(split[2]), ParseUtil.getFirstIntValue(split[1]),
-                            ParseUtil.parseDecimalMemorySizeToBinary(split[0]), Type.UNIFIED);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Get number of context switches
-     *
-     * @return The context switches
-     */
-    @Override
-    protected long queryContextSwitches() {
-        return vmStats.get().getA();
-    }
-
-    /**
-     * Get number of interrupts
-     *
-     * @return The interrupts
-     */
-    @Override
-    protected long queryInterrupts() {
-        return vmStats.get().getB();
-    }
-
-    private static Pair<Long, Long> queryVmStats() {
+    protected Pair<Long, Long> queryVmStats() {
         long contextSwitches = 0L;
         long interrupts = 0L;
         List<String> vmstat = ExecutingCommand.runNative("vmstat -s");

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.openbsd;
+
+import java.util.List;
+import java.util.Locale;
+
+import oshi.hardware.common.platform.unix.BsdCentralProcessor;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
+import oshi.util.tuples.Triplet;
+
+/**
+ * Shared OpenBSD CentralProcessor logic. The processor identification, frequency, and {@code vmstat} parsing are common
+ * to the JNA and FFM backends; subclasses supply only the sysctl reads (mib- and name-based) and the native CPU-tick
+ * and load-average calls.
+ */
+public abstract class OpenBsdCentralProcessor extends BsdCentralProcessor {
+
+    // OpenBSD sysctl(3) ABI identifiers, stable across releases (mirrored from the JNA/FFM libc backends).
+    private static final int CTL_HW = 6;
+    private static final int HW_MACHINE = 1;
+    private static final int HW_MODEL = 2;
+    private static final int HW_CPUSPEED = 12;
+
+    /**
+     * Reads a string sysctl value by name.
+     *
+     * @param name the sysctl name
+     * @param def  the default value
+     * @return the sysctl string value or the default
+     */
+    protected abstract String sysctl(String name, String def);
+
+    /**
+     * Reads a string sysctl value addressed by a Management Information Base (MIB) array.
+     *
+     * @param mib the sysctl MIB
+     * @param def the default value
+     * @return the sysctl string value or the default
+     */
+    protected abstract String sysctl(int[] mib, String def);
+
+    /**
+     * Reads an integer sysctl value addressed by a Management Information Base (MIB) array.
+     *
+     * @param mib the sysctl MIB
+     * @param def the default value
+     * @return the sysctl integer value or the default
+     */
+    protected abstract int sysctl(int[] mib, int def);
+
+    @Override
+    protected ProcessorIdentifier queryProcessorId() {
+        String cpuVendor = sysctl("machdep.cpuvendor", "");
+        int[] mib = { CTL_HW, HW_MODEL };
+        String cpuName = sysctl(mib, "");
+        int cpuid = ParseUtil.hexStringToInt(sysctl("machdep.cpuid", ""), 0);
+        int cpufeature = ParseUtil.hexStringToInt(sysctl("machdep.cpufeature", ""), 0);
+        Triplet<Integer, Integer, Integer> cpu = cpuidToFamilyModelStepping(cpuid);
+        String cpuFamily = cpu.getA().toString();
+        String cpuModel = cpu.getB().toString();
+        String cpuStepping = cpu.getC().toString();
+        long cpuFreq = ParseUtil.parseHertz(cpuName);
+        if (cpuFreq < 0) {
+            cpuFreq = queryMaxFreq();
+        }
+        mib = new int[] { CTL_HW, HW_MACHINE };
+        String machine = sysctl(mib, "");
+        boolean cpu64bit = machine != null && machine.contains("64")
+                || ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
+        String processorID = String.format(Locale.ROOT, "%08x%08x", cpufeature, cpuid);
+
+        return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,
+                cpuFreq);
+    }
+
+    private static Triplet<Integer, Integer, Integer> cpuidToFamilyModelStepping(int cpuid) {
+        // family is bits 27:20 | 11:8
+        int family = cpuid >> 16 & 0xff0 | cpuid >> 8 & 0xf;
+        // model is bits 19:16 | 7:4
+        int model = cpuid >> 12 & 0xf0 | cpuid >> 4 & 0xf;
+        // stepping is bits 3:0
+        int stepping = cpuid & 0xf;
+        return new Triplet<>(family, model, stepping);
+    }
+
+    @Override
+    protected long[] queryCurrentFreq() {
+        long[] freq = new long[1];
+        int[] mib = { CTL_HW, HW_CPUSPEED };
+        freq[0] = sysctl(mib, 0) * 1_000_000L;
+        return freq;
+    }
+
+    @Override
+    protected Pair<Long, Long> queryVmStats() {
+        long contextSwitches = 0L;
+        long interrupts = 0L;
+        List<String> vmstat = ExecutingCommand.runNative("vmstat -s");
+        for (String line : vmstat) {
+            if (line.endsWith("cpu context switches")) {
+                contextSwitches = ParseUtil.getFirstIntValue(line);
+            } else if (line.endsWith("interrupts")) {
+                interrupts = ParseUtil.getFirstIntValue(line);
+            }
+        }
+        return new Pair<>(contextSwitches, interrupts);
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
@@ -103,9 +103,9 @@ public abstract class OpenBsdCentralProcessor extends BsdCentralProcessor {
         List<String> vmstat = ExecutingCommand.runNative("vmstat -s");
         for (String line : vmstat) {
             if (line.endsWith("cpu context switches")) {
-                contextSwitches = ParseUtil.getFirstIntValue(line);
+                contextSwitches = ParseUtil.parseLongOrDefault(line.trim().split("\\s+")[0], 0L);
             } else if (line.endsWith("interrupts")) {
-                interrupts = ParseUtil.getFirstIntValue(line);
+                interrupts = ParseUtil.parseLongOrDefault(line.trim().split("\\s+")[0], 0L);
             }
         }
         return new Pair<>(contextSwitches, interrupts);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorFFM.java
@@ -12,29 +12,12 @@ import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CP_INTR;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CP_NICE;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CP_SYS;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CP_USER;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CTL_HW;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CTL_KERN;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.HW_CPUSPEED;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.HW_MACHINE;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.HW_MODEL;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_CPTIME;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_CPTIME2;
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
 
 import java.lang.foreign.MemorySegment;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,158 +27,34 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.ForeignFunctions;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
-import oshi.hardware.common.AbstractCentralProcessor;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
-import oshi.util.tuples.Pair;
-import oshi.util.tuples.Quartet;
-import oshi.util.tuples.Triplet;
+import oshi.hardware.common.platform.unix.openbsd.OpenBsdCentralProcessor;
 
+/**
+ * OpenBSD Central Processor implementation, backed by FFM sysctl and native library calls.
+ */
 @ThreadSafe
-public class OpenBsdCentralProcessorFFM extends AbstractCentralProcessor {
+public class OpenBsdCentralProcessorFFM extends OpenBsdCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenBsdCentralProcessorFFM.class);
 
-    private final Supplier<Pair<Long, Long>> vmStats = memoize(OpenBsdCentralProcessorFFM::queryVmStats,
-            defaultExpiration());
-    private static final Pattern DMESG_CPU = Pattern.compile("cpu(\\d+): smt (\\d+), core (\\d+), package (\\d+)");
-
     @Override
-    protected ProcessorIdentifier queryProcessorId() {
-        String cpuVendor = OpenBsdSysctlUtilFFM.sysctl("machdep.cpuvendor", "");
-        int[] mib = { CTL_HW, HW_MODEL };
-        String cpuName = OpenBsdSysctlUtilFFM.sysctl(mib, "");
-        int cpuid = ParseUtil.hexStringToInt(OpenBsdSysctlUtilFFM.sysctl("machdep.cpuid", ""), 0);
-        int cpufeature = ParseUtil.hexStringToInt(OpenBsdSysctlUtilFFM.sysctl("machdep.cpufeature", ""), 0);
-        Triplet<Integer, Integer, Integer> cpu = cpuidToFamilyModelStepping(cpuid);
-        String cpuFamily = cpu.getA().toString();
-        String cpuModel = cpu.getB().toString();
-        String cpuStepping = cpu.getC().toString();
-        long cpuFreq = ParseUtil.parseHertz(cpuName);
-        if (cpuFreq < 0) {
-            cpuFreq = queryMaxFreq();
-        }
-        mib = new int[] { CTL_HW, HW_MACHINE };
-        String machine = OpenBsdSysctlUtilFFM.sysctl(mib, "");
-        boolean cpu64bit = machine != null && machine.contains("64")
-                || ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
-        String processorID = String.format(Locale.ROOT, "%08x%08x", cpufeature, cpuid);
-
-        return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,
-                cpuFreq);
-    }
-
-    private static Triplet<Integer, Integer, Integer> cpuidToFamilyModelStepping(int cpuid) {
-        int family = cpuid >> 16 & 0xff0 | cpuid >> 8 & 0xf;
-        int model = cpuid >> 12 & 0xf0 | cpuid >> 4 & 0xf;
-        int stepping = cpuid & 0xf;
-        return new Triplet<>(family, model, stepping);
+    protected int sysctl(String name, int def) {
+        return OpenBsdSysctlUtilFFM.sysctl(name, def);
     }
 
     @Override
-    protected long[] queryCurrentFreq() {
-        long[] freq = new long[1];
-        int[] mib = { CTL_HW, HW_CPUSPEED };
-        freq[0] = OpenBsdSysctlUtilFFM.sysctl(mib, 0) * 1_000_000L;
-        return freq;
+    protected String sysctl(String name, String def) {
+        return OpenBsdSysctlUtilFFM.sysctl(name, def);
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
-        Map<Integer, Integer> coreMap = new HashMap<>();
-        Map<Integer, Integer> packageMap = new HashMap<>();
-        for (String line : ExecutingCommand.runNative("dmesg")) {
-            Matcher m = DMESG_CPU.matcher(line);
-            if (m.matches()) {
-                int cpu = ParseUtil.parseIntOrDefault(m.group(1), 0);
-                coreMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(3), 0));
-                packageMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(4), 0));
-            }
-        }
-        int logicalProcessorCount = OpenBsdSysctlUtilFFM.sysctl("hw.ncpuonline", 1);
-        if (logicalProcessorCount < coreMap.keySet().size()) {
-            logicalProcessorCount = coreMap.keySet().size();
-        }
-        List<LogicalProcessor> logProcs = new ArrayList<>(logicalProcessorCount);
-        for (int i = 0; i < logicalProcessorCount; i++) {
-            logProcs.add(new LogicalProcessor(i, coreMap.getOrDefault(i, 0), packageMap.getOrDefault(i, 0)));
-        }
-        Map<Integer, String> cpuMap = new HashMap<>();
-        Pattern p = Pattern.compile("cpu(\\d+).*: ((ARM|AMD|Intel|Apple).+)");
-
-        Set<ProcessorCache> caches = new HashSet<>();
-        Pattern q = Pattern.compile("cpu(\\d+).*: (.+(I-|D-|L\\d+\\s)cache)");
-        Set<String> featureFlags = new LinkedHashSet<>();
-        for (String s : ExecutingCommand.runNative("dmesg")) {
-            Matcher m = p.matcher(s);
-            if (m.matches()) {
-                int coreId = ParseUtil.parseIntOrDefault(m.group(1), 0);
-                cpuMap.put(coreId, m.group(2).trim());
-            } else {
-                Matcher n = q.matcher(s);
-                if (n.matches()) {
-                    for (String cacheStr : n.group(2).split(",")) {
-                        ProcessorCache cache = parseCacheStr(cacheStr);
-                        if (cache != null) {
-                            caches.add(cache);
-                        }
-                    }
-                }
-            }
-            if (s.startsWith("cpu")) {
-                String[] ss = s.trim().split(": ");
-                if (ss.length == 2 && ss[1].split(",").length > 3) {
-                    featureFlags.add(ss[1]);
-                }
-            }
-        }
-        List<PhysicalProcessor> physProcs = cpuMap.isEmpty() ? null : createProcListFromDmesg(logProcs, cpuMap);
-        return new Quartet<>(logProcs, physProcs, orderedProcCaches(caches), new ArrayList<>(featureFlags));
-    }
-
-    private ProcessorCache parseCacheStr(String cacheStr) {
-        String[] split = ParseUtil.whitespaces.split(cacheStr.trim());
-        if (split.length > 3) {
-            switch (split[split.length - 1]) {
-                case "I-cache":
-                    return new ProcessorCache(1, ParseUtil.getFirstIntValue(split[2]),
-                            ParseUtil.getFirstIntValue(split[1]), ParseUtil.parseDecimalMemorySizeToBinary(split[0]),
-                            Type.INSTRUCTION);
-                case "D-cache":
-                    return new ProcessorCache(1, ParseUtil.getFirstIntValue(split[2]),
-                            ParseUtil.getFirstIntValue(split[1]), ParseUtil.parseDecimalMemorySizeToBinary(split[0]),
-                            Type.DATA);
-                default:
-                    return new ProcessorCache(ParseUtil.getFirstIntValue(split[3]),
-                            ParseUtil.getFirstIntValue(split[2]), ParseUtil.getFirstIntValue(split[1]),
-                            ParseUtil.parseDecimalMemorySizeToBinary(split[0]), Type.UNIFIED);
-            }
-        }
-        return null;
+    protected String sysctl(int[] mib, String def) {
+        return OpenBsdSysctlUtilFFM.sysctl(mib, def);
     }
 
     @Override
-    protected long queryContextSwitches() {
-        return vmStats.get().getA();
-    }
-
-    @Override
-    protected long queryInterrupts() {
-        return vmStats.get().getB();
-    }
-
-    private static Pair<Long, Long> queryVmStats() {
-        long contextSwitches = 0L;
-        long interrupts = 0L;
-        for (String line : ExecutingCommand.runNative("vmstat -s")) {
-            if (line.endsWith("cpu context switches")) {
-                contextSwitches = ParseUtil.getFirstIntValue(line);
-            } else if (line.endsWith("interrupts")) {
-                interrupts = ParseUtil.getFirstIntValue(line);
-            }
-        }
-        return new Pair<>(contextSwitches, interrupts);
+    protected int sysctl(int[] mib, int def) {
+        return OpenBsdSysctlUtilFFM.sysctl(mib, def);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorJNA.java
@@ -9,237 +9,44 @@ import static oshi.jna.platform.unix.OpenBsdLibc.CP_INTR;
 import static oshi.jna.platform.unix.OpenBsdLibc.CP_NICE;
 import static oshi.jna.platform.unix.OpenBsdLibc.CP_SYS;
 import static oshi.jna.platform.unix.OpenBsdLibc.CP_USER;
-import static oshi.jna.platform.unix.OpenBsdLibc.CTL_HW;
 import static oshi.jna.platform.unix.OpenBsdLibc.CTL_KERN;
-import static oshi.jna.platform.unix.OpenBsdLibc.HW_CPUSPEED;
-import static oshi.jna.platform.unix.OpenBsdLibc.HW_MACHINE;
-import static oshi.jna.platform.unix.OpenBsdLibc.HW_MODEL;
 import static oshi.jna.platform.unix.OpenBsdLibc.KERN_CPTIME;
 import static oshi.jna.platform.unix.OpenBsdLibc.KERN_CPTIME2;
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.sun.jna.Memory;
 import com.sun.jna.Native;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
-import oshi.hardware.common.AbstractCentralProcessor;
+import oshi.hardware.common.platform.unix.openbsd.OpenBsdCentralProcessor;
 import oshi.jna.platform.unix.OpenBsdLibc;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
 import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
-import oshi.util.tuples.Pair;
-import oshi.util.tuples.Quartet;
-import oshi.util.tuples.Triplet;
 
 /**
- * OpenBSD Central Processor implementation
+ * OpenBSD Central Processor implementation, backed by JNA sysctl and native library calls.
  */
 @ThreadSafe
-public class OpenBsdCentralProcessorJNA extends AbstractCentralProcessor {
-    private final Supplier<Pair<Long, Long>> vmStats = memoize(OpenBsdCentralProcessorJNA::queryVmStats,
-            defaultExpiration());
-    private static final Pattern DMESG_CPU = Pattern.compile("cpu(\\d+): smt (\\d+), core (\\d+), package (\\d+)");
+public class OpenBsdCentralProcessorJNA extends OpenBsdCentralProcessor {
 
     @Override
-    protected ProcessorIdentifier queryProcessorId() {
-        String cpuVendor = OpenBsdSysctlUtil.sysctl("machdep.cpuvendor", "");
-        int[] mib = { CTL_HW, HW_MODEL };
-        String cpuName = OpenBsdSysctlUtil.sysctl(mib, "");
-        int cpuid = ParseUtil.hexStringToInt(OpenBsdSysctlUtil.sysctl("machdep.cpuid", ""), 0);
-        int cpufeature = ParseUtil.hexStringToInt(OpenBsdSysctlUtil.sysctl("machdep.cpufeature", ""), 0);
-        Triplet<Integer, Integer, Integer> cpu = cpuidToFamilyModelStepping(cpuid);
-        String cpuFamily = cpu.getA().toString();
-        String cpuModel = cpu.getB().toString();
-        String cpuStepping = cpu.getC().toString();
-        long cpuFreq = ParseUtil.parseHertz(cpuName);
-        if (cpuFreq < 0) {
-            cpuFreq = queryMaxFreq();
-        }
-        mib = new int[] { CTL_HW, HW_MACHINE };
-        String machine = OpenBsdSysctlUtil.sysctl(mib, "");
-        boolean cpu64bit = machine != null && machine.contains("64")
-                || ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
-        String processorID = String.format(Locale.ROOT, "%08x%08x", cpufeature, cpuid);
-
-        return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,
-                cpuFreq);
-    }
-
-    private static Triplet<Integer, Integer, Integer> cpuidToFamilyModelStepping(int cpuid) {
-        // family is bits 27:20 | 11:8
-        int family = cpuid >> 16 & 0xff0 | cpuid >> 8 & 0xf;
-        // model is bits 19:16 | 7:4
-        int model = cpuid >> 12 & 0xf0 | cpuid >> 4 & 0xf;
-        // stepping is bits 3:0
-        int stepping = cpuid & 0xf;
-        return new Triplet<>(family, model, stepping);
+    protected int sysctl(String name, int def) {
+        return OpenBsdSysctlUtil.sysctl(name, def);
     }
 
     @Override
-    protected long[] queryCurrentFreq() {
-        long[] freq = new long[1];
-        int[] mib = { CTL_HW, HW_CPUSPEED };
-        freq[0] = OpenBsdSysctlUtil.sysctl(mib, 0) * 1_000_000L;
-        return freq;
+    protected String sysctl(String name, String def) {
+        return OpenBsdSysctlUtil.sysctl(name, def);
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
-        // Iterate dmesg, look for lines:
-        // cpu0: smt 0, core 0, package 0
-        // cpu1: smt 0, core 1, package 0
-        Map<Integer, Integer> coreMap = new HashMap<>();
-        Map<Integer, Integer> packageMap = new HashMap<>();
-        for (String line : ExecutingCommand.runNative("dmesg")) {
-            Matcher m = DMESG_CPU.matcher(line);
-            if (m.matches()) {
-                int cpu = ParseUtil.parseIntOrDefault(m.group(1), 0);
-                coreMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(3), 0));
-                packageMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(4), 0));
-            }
-        }
-        // native call seems to fail here, use fallback
-        int logicalProcessorCount = OpenBsdSysctlUtil.sysctl("hw.ncpuonline", 1);
-        // If we found more procs in dmesg, update
-        if (logicalProcessorCount < coreMap.keySet().size()) {
-            logicalProcessorCount = coreMap.keySet().size();
-        }
-        List<LogicalProcessor> logProcs = new ArrayList<>(logicalProcessorCount);
-        for (int i = 0; i < logicalProcessorCount; i++) {
-            logProcs.add(new LogicalProcessor(i, coreMap.getOrDefault(i, 0), packageMap.getOrDefault(i, 0)));
-        }
-        Map<Integer, String> cpuMap = new HashMap<>();
-        // cpu0 at mainbus0 mpidr 0: ARM Cortex-A7 r0p5
-        // but NOT: cpu0 at mainbus0: apid 0 (boot processor)
-        // cpu0: AMD GX-412TC SOC, 998.28 MHz, 16-30-01
-        // cpu0: AMD EPYC 7313P 16-Core Processor, 2994.74 MHz, 19-01-01
-        // cpu0: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01
-        Pattern p = Pattern.compile("cpu(\\d+).*: ((ARM|AMD|Intel|Apple).+)");
-
-        Set<ProcessorCache> caches = new HashSet<>();
-        // cpu0: 48KB 64b/line 12-way D-cache, 32KB 64b/line 8-way I-cache,
-        // ... 1MB 64b/line 10-way L2 cache, 24MB 64b/line 12-way L3 cache
-        // cpu0: 32KB 64b/line 8-way D-cache, 64KB 64b/line 4-way I-cache,
-        // ... 512KB 64b/line 8-way L2 cache, 4MB 64b/line 16-way L3 cache
-        // cpu0: 32KB 64b/line 2-way I-cache, 32KB 64b/line 8-way D-cache,
-        // ... 2MB 64b/line 16-way L2 cache
-        // cpu0: 32KB 64b/line 8-way I-cache, 32KB 64b/line 8-way D-cache,
-        // ... 512KB 64b/line 8-way L2 cache
-        // cpu0: 256KB 64b/line disabled L2 cache
-        // cpu0: 1MB 64b/line 16-way L2 cache
-        // --- Mac M1 example ---
-        // shows different for icestorm/firestrorm and multiple lines for L1 vs. L2
-        // cpu0 at mainbus0 mpidr 0: Apple Icestorm Pro r2p0
-        // cpu0: 128KB 64b/line 8-way L1 VIPT I-cache, 64KB 64b/line 8-way L1 D-cache
-        // cpu0: 4096KB 128b/line 16-way L2 cache
-        // cpu2 at mainbus0 mpidr 10100: Apple Firestorm Pro r2p0
-        // cpu2: 192KB 64b/line 6-way L1 VIPT I-cache, 128KB 64b/line 8-way L1 D-cache
-        // cpu2: 12288KB 128b/line 12-way L2 cache
-        // --- BIG:little example ---
-        // shows different for A53/A72 and multiple lines for L1 vs. L2
-        // cpu0 at mainbus0 mpidr 0: ARM Cortex-A53 r0p4
-        // cpu0: 32KB 64b/line 2-way L1 VIPT I-cache, 32KB 64b/line 4-way L1 D-cache
-        // cpu0: 512KB 64b/line 16-way L2 cache
-        // cpu4 at mainbus0 mpidr 100: ARM Cortex-A72 r0p2
-        // cpu4: 48KB 64b/line 3-way L1 PIPT I-cache, 32KB 64b/line 2-way L1 D-cache
-        // cpu4: 1024KB 64b/line 16-way L2 cache
-        Pattern q = Pattern.compile("cpu(\\d+).*: (.+(I-|D-|L\\d+\\s)cache)");
-        Set<String> featureFlags = new LinkedHashSet<>();
-        for (String s : ExecutingCommand.runNative("dmesg")) {
-            Matcher m = p.matcher(s);
-            if (m.matches()) {
-                int coreId = ParseUtil.parseIntOrDefault(m.group(1), 0);
-                cpuMap.put(coreId, m.group(2).trim());
-            } else {
-                Matcher n = q.matcher(s);
-                if (n.matches()) {
-                    for (String cacheStr : n.group(2).split(",")) {
-                        ProcessorCache cache = parseCacheStr(cacheStr);
-                        if (cache != null) {
-                            caches.add(cache);
-                        }
-                    }
-                }
-            }
-            if (s.startsWith("cpu")) {
-                String[] ss = s.trim().split(": ");
-                if (ss.length == 2 && ss[1].split(",").length > 3) {
-                    featureFlags.add(ss[1]);
-                }
-            }
-        }
-        List<PhysicalProcessor> physProcs = cpuMap.isEmpty() ? null : createProcListFromDmesg(logProcs, cpuMap);
-        return new Quartet<>(logProcs, physProcs, orderedProcCaches(caches), new ArrayList<>(featureFlags));
+    protected String sysctl(int[] mib, String def) {
+        return OpenBsdSysctlUtil.sysctl(mib, def);
     }
 
-    private ProcessorCache parseCacheStr(String cacheStr) {
-        String[] split = ParseUtil.whitespaces.split(cacheStr.trim());
-        if (split.length > 3) {
-            switch (split[split.length - 1]) {
-                case "I-cache":
-                    return new ProcessorCache(1, ParseUtil.getFirstIntValue(split[2]),
-                            ParseUtil.getFirstIntValue(split[1]), ParseUtil.parseDecimalMemorySizeToBinary(split[0]),
-                            Type.INSTRUCTION);
-                case "D-cache":
-                    return new ProcessorCache(1, ParseUtil.getFirstIntValue(split[2]),
-                            ParseUtil.getFirstIntValue(split[1]), ParseUtil.parseDecimalMemorySizeToBinary(split[0]),
-                            Type.DATA);
-                default:
-                    return new ProcessorCache(ParseUtil.getFirstIntValue(split[3]),
-                            ParseUtil.getFirstIntValue(split[2]), ParseUtil.getFirstIntValue(split[1]),
-                            ParseUtil.parseDecimalMemorySizeToBinary(split[0]), Type.UNIFIED);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Get number of context switches
-     *
-     * @return The context switches
-     */
     @Override
-    protected long queryContextSwitches() {
-        return vmStats.get().getA();
-    }
-
-    /**
-     * Get number of interrupts
-     *
-     * @return The interrupts
-     */
-    @Override
-    protected long queryInterrupts() {
-        return vmStats.get().getB();
-    }
-
-    private static Pair<Long, Long> queryVmStats() {
-        long contextSwitches = 0L;
-        long interrupts = 0L;
-        List<String> vmstat = ExecutingCommand.runNative("vmstat -s");
-        for (String line : vmstat) {
-            if (line.endsWith("cpu context switches")) {
-                contextSwitches = ParseUtil.getFirstIntValue(line);
-            } else if (line.endsWith("interrupts")) {
-                interrupts = ParseUtil.getFirstIntValue(line);
-            }
-        }
-        return new Pair<>(contextSwitches, interrupts);
+    protected int sysctl(int[] mib, int def) {
+        return OpenBsdSysctlUtil.sysctl(mib, def);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add a cross-BSD `BsdCentralProcessor` base (`oshi.hardware.common.platform.unix`) holding the shared `dmesg`-based processor/cache enumeration (`initProcessorCounts`, `parseCacheStr`) and the `vmstat`-backed context-switch/interrupt counters, with an abstract `int sysctl(name, def)` hook and an abstract `queryVmStats()`
- Add an `OpenBsdCentralProcessor` base extending it with the shared processor identification, frequency, and OpenBSD `vmstat` parsing; abstract sysctl overloads let the JNA and FFM subclasses supply their backend
- `OpenBsdCentralProcessorJNA`/`FFM` now contain only sysctl delegation plus the native CPU-tick readers and `getloadavg`; `NetBsdCentralProcessor` extends the cross-BSD base and keeps its command/text-based identification, ticks, and load average
- Eliminates ~180 duplicated lines across the three implementations
- Fixes a pre-existing NetBSD bug: `initProcessorCounts` split the `dmesg` cache line on regex `group(1)` (the cpu number) instead of `group(2)` (the cache description), so `dmesg`-derived cache detection never produced any caches; the shared base uses the correct `group(2)`

## Test plan
- [x] All pre-commit checks pass locally (spotless, checkstyle, forbiddenapis, javadoc) plus a clean full-reactor build
- [x] Unix CI green: OpenBSD, NetBSD, FreeBSD, DragonFly BSD, OpenIndiana

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated BSD processor logic into a shared base to unify OpenBSD/NetBSD behavior.
  * Moved platform-specific sysctl/back-end pieces into small adapters, simplifying implementations.
  * Improved CPU detection and reporting: topology, cache discovery, frequency, and vmstat-derived counters (context switches, interrupts) are now handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->