### PR TITLE
Extract macOS JNA/FFM common bases (NetStat, PowerSource, IP stats)

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -62,6 +62,11 @@
     <suppress checks="MemberName" files="(AixCentralProcessor|AixHWDiskStore|AixNetworkIF|AixGlobalMemory)\.java"/>
     <suppress checks="VisibilityModifier" files="(AixCentralProcessor|AixHWDiskStore|AixNetworkIF|AixGlobalMemory)\.java"/>
 
+    <!-- macOS InternetProtocolStats shared base holds tcpstat/udpstat/ipstat/ip6stat carriers whose
+         fields mirror the C struct names (tcps_* / udps_* / ips_* / ip6s_*) verbatim, so the JNA and
+         FFM stat computations read identically. -->
+    <suppress checks="MemberName" files="MacInternetProtocolStats\.java"/>
+
     <!-- BsdOSProcess/BsdOSThread/MacOSProcess are shared OSProcess/OSThread bases; their protected fields are
          populated by the per-backend native updateAttributes() in the subclasses (and the thread id / version are
          set by the per-platform constructors), so they can't be private with accessors. -->

--- a/oshi-common/src/main/java/oshi/driver/common/mac/IFdata.java
+++ b/oshi-common/src/main/java/oshi/driver/common/mac/IFdata.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.mac;
+
+import oshi.annotation.concurrent.Immutable;
+
+/**
+ * Encapsulates network interface statistics read from the macOS {@code NET_RT_IFLIST2} sysctl, shared between the JNA
+ * and FFM NetStat drivers.
+ */
+@Immutable
+public class IFdata {
+    private final int ifType;
+    private final long oPackets;
+    private final long iPackets;
+    private final long oBytes;
+    private final long iBytes;
+    private final long oErrors;
+    private final long iErrors;
+    private final long collisions;
+    private final long iDrops;
+    private final long speed;
+    private final long timeStamp;
+
+    /**
+     * Creates an immutable interface-data record. The {@code long} counters are masked to 32 bits because the
+     * underlying {@code if_data64} fields wrap at {@code 2^32}.
+     *
+     * @param ifType     the interface type
+     * @param oPackets   packets sent
+     * @param iPackets   packets received
+     * @param oBytes     bytes sent
+     * @param iBytes     bytes received
+     * @param oErrors    output errors
+     * @param iErrors    input errors
+     * @param collisions collisions
+     * @param iDrops     input drops
+     * @param speed      interface speed (baud rate)
+     * @param timeStamp  the time the data was sampled, in milliseconds since the epoch
+     */
+    public IFdata(int ifType, // NOSONAR squid:S00107
+            long oPackets, long iPackets, long oBytes, long iBytes, long oErrors, long iErrors, long collisions,
+            long iDrops, long speed, long timeStamp) {
+        this.ifType = ifType;
+        this.oPackets = oPackets & 0xffffffffL;
+        this.iPackets = iPackets & 0xffffffffL;
+        this.oBytes = oBytes & 0xffffffffL;
+        this.iBytes = iBytes & 0xffffffffL;
+        this.oErrors = oErrors & 0xffffffffL;
+        this.iErrors = iErrors & 0xffffffffL;
+        this.collisions = collisions & 0xffffffffL;
+        this.iDrops = iDrops & 0xffffffffL;
+        this.speed = speed & 0xffffffffL;
+        this.timeStamp = timeStamp;
+    }
+
+    /**
+     * @return the ifType
+     */
+    public int getIfType() {
+        return ifType;
+    }
+
+    /**
+     * @return the oPackets
+     */
+    public long getOPackets() {
+        return oPackets;
+    }
+
+    /**
+     * @return the iPackets
+     */
+    public long getIPackets() {
+        return iPackets;
+    }
+
+    /**
+     * @return the oBytes
+     */
+    public long getOBytes() {
+        return oBytes;
+    }
+
+    /**
+     * @return the iBytes
+     */
+    public long getIBytes() {
+        return iBytes;
+    }
+
+    /**
+     * @return the oErrors
+     */
+    public long getOErrors() {
+        return oErrors;
+    }
+
+    /**
+     * @return the iErrors
+     */
+    public long getIErrors() {
+        return iErrors;
+    }
+
+    /**
+     * @return the collisions
+     */
+    public long getCollisions() {
+        return collisions;
+    }
+
+    /**
+     * @return the iDrops
+     */
+    public long getIDrops() {
+        return iDrops;
+    }
+
+    /**
+     * @return the speed
+     */
+    public long getSpeed() {
+        return speed;
+    }
+
+    /**
+     * @return the timeStamp
+     */
+    public long getTimeStamp() {
+        return timeStamp;
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOKitProvider.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOKitProvider.java
@@ -67,5 +67,21 @@ public interface IOKitProvider {
          * @return the property value as a string, or {@code null} if not found
          */
         String getStringProperty(String key);
+
+        /**
+         * Gets an integer property from this registry entry.
+         *
+         * @param key the property key
+         * @return the property value as an {@link Integer}, or {@code null} if not found
+         */
+        Integer getIntegerProperty(String key);
+
+        /**
+         * Gets a boolean property from this registry entry.
+         *
+         * @param key the property key
+         * @return the property value as a {@link Boolean}, or {@code null} if not found
+         */
+        Boolean getBooleanProperty(String key);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacPowerSource.java
@@ -4,13 +4,21 @@
  */
 package oshi.hardware.common.platform.mac;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.PowerSource;
 import oshi.hardware.common.AbstractPowerSource;
+import oshi.hardware.common.platform.mac.IOKitProvider.RegistryEntry;
+import oshi.util.Constants;
 
 /**
- * A Power Source
+ * Abstract base for the macOS PowerSource. The {@code AppleSmartBattery} registry read and the per-power-source field
+ * computation are shared; the JNA and FFM subclasses supply an {@link IOKitProvider} and read the IOKit Power Sources
+ * (IOPS) list into {@link PowerSourceData} carriers via {@link #buildPowerSources}.
  */
 @ThreadSafe
 public abstract class MacPowerSource extends AbstractPowerSource {
@@ -50,5 +58,168 @@ public abstract class MacPowerSource extends AbstractPowerSource {
                 psPowerUsageRate, psVoltage, psAmperage, psPowerOnLine, psCharging, psDischarging, psCapacityUnits,
                 psCurrentCapacity, psMaxCapacity, psDesignCapacity, psCycleCount, psChemistry, psManufactureDate,
                 psManufacturer, psSerialNumber, psTemperature);
+    }
+
+    /** Battery-wide fields read from the {@code AppleSmartBattery} registry entry, shared by every power source. */
+    private static final class BatteryReadings {
+        private String deviceName = Constants.UNKNOWN;
+        private String manufacturer = Constants.UNKNOWN;
+        private String serialNumber = Constants.UNKNOWN;
+        private LocalDate manufactureDate;
+        private CapacityUnits capacityUnits = CapacityUnits.RELATIVE;
+        private int designCapacity = -1;
+        private int maxCapacity = 1;
+        private int currentCapacity;
+        private int cycleCount = -1;
+        private double timeRemainingInstant;
+        private double temperature;
+        private double voltage = -1d;
+        private double amperage;
+        private double powerUsageRate;
+        private boolean powerOnLine;
+        private boolean charging;
+        private boolean discharging;
+    }
+
+    /** Raw values read from a single IOKit Power Source (IOPS) dictionary by the JNA/FFM subclasses. */
+    public static final class PowerSourceData {
+        private final String name;
+        private final double currentCapacity;
+        private final double maxCapacity;
+
+        /**
+         * Creates a single power-source reading.
+         *
+         * @param name            the power source name
+         * @param currentCapacity the current capacity
+         * @param maxCapacity     the maximum capacity
+         */
+        public PowerSourceData(String name, double currentCapacity, double maxCapacity) {
+            this.name = name;
+            this.currentCapacity = currentCapacity;
+            this.maxCapacity = maxCapacity;
+        }
+    }
+
+    /** Creates a concrete (JNA or FFM) Mac power source from the computed battery fields. */
+    @FunctionalInterface
+    protected interface PowerSourceFactory {
+        MacPowerSource create(String psName, String psDeviceName, double psRemainingCapacityPercent,
+                double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate,
+                double psVoltage, double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
+                CapacityUnits psCapacityUnits, int psCurrentCapacity, int psMaxCapacity, int psDesignCapacity,
+                int psCycleCount, String psChemistry, LocalDate psManufactureDate, String psManufacturer,
+                String psSerialNumber, double psTemperature);
+    }
+
+    /**
+     * Reads the {@code AppleSmartBattery} registry entry (via {@code ioKit}) and merges it with the per-source IOPS
+     * readings into a list of power sources.
+     * <p>
+     * Mac PowerSource information comes from two sources: the IORegistry's {@code AppleSmartBattery} entry
+     * (battery-wide fields, read here through the shared {@link IOKitProvider}) and the IOKit's IOPS functions (one
+     * entry per power source, read natively by the caller into {@code sources}).
+     *
+     * @param ioKit                  the IOKit provider backing the registry read
+     * @param timeRemainingEstimated the estimated time remaining (-1 unknown, -2 unlimited) from IOPS
+     * @param sources                the present power sources read from the IOPS list
+     * @param factory                creates the platform-specific instance
+     * @return a list of power sources, one per element of {@code sources}
+     */
+    protected static List<PowerSource> buildPowerSources(IOKitProvider ioKit, double timeRemainingEstimated,
+            List<PowerSourceData> sources, PowerSourceFactory factory) {
+        BatteryReadings b = ioKit.withMatchingService("AppleSmartBattery", MacPowerSource::readBattery);
+        if (b == null) {
+            b = new BatteryReadings();
+        }
+        List<PowerSource> psList = new ArrayList<>(sources.size());
+        for (PowerSourceData src : sources) {
+            double psRemainingCapacityPercent = src.maxCapacity <= 0 ? 0d
+                    : Math.min(1d, src.currentCapacity / src.maxCapacity);
+            psList.add(factory.create(src.name, b.deviceName, psRemainingCapacityPercent, timeRemainingEstimated,
+                    b.timeRemainingInstant, b.powerUsageRate, b.voltage, b.amperage, b.powerOnLine, b.charging,
+                    b.discharging, b.capacityUnits, b.currentCapacity, b.maxCapacity, b.designCapacity, b.cycleCount,
+                    Constants.UNKNOWN, b.manufactureDate, b.manufacturer, b.serialNumber, b.temperature));
+        }
+        return psList;
+    }
+
+    private static BatteryReadings readBattery(RegistryEntry smartBattery) {
+        BatteryReadings b = new BatteryReadings();
+        String s = smartBattery.getStringProperty("DeviceName");
+        if (s != null) {
+            b.deviceName = s;
+        }
+        s = smartBattery.getStringProperty("Manufacturer");
+        if (s != null) {
+            b.manufacturer = s;
+        }
+        s = smartBattery.getStringProperty("BatterySerialNumber");
+        if (s != null) {
+            b.serialNumber = s;
+        }
+
+        Integer temp = smartBattery.getIntegerProperty("ManufactureDate");
+        if (temp != null) {
+            // Bits 0...4 => day (value 1-31; 5 bits)
+            // Bits 5...8 => month (value 1-12; 4 bits)
+            // Bits 9...15 => years since 1980 (value 0-127; 7 bits)
+            int day = temp & 0x1f;
+            int month = (temp >> 5) & 0xf;
+            int year80 = (temp >> 9) & 0x7f;
+            try {
+                b.manufactureDate = LocalDate.of(1980 + year80, month, day);
+            } catch (DateTimeException e) {
+                // Corrupt bitfield — leave manufactureDate as null
+            }
+        }
+
+        temp = smartBattery.getIntegerProperty("DesignCapacity");
+        if (temp != null) {
+            b.designCapacity = temp;
+        }
+        temp = smartBattery.getIntegerProperty("MaxCapacity");
+        if (temp != null) {
+            b.maxCapacity = temp;
+        }
+        temp = smartBattery.getIntegerProperty("CurrentCapacity");
+        if (temp != null) {
+            b.currentCapacity = temp;
+        }
+        b.capacityUnits = CapacityUnits.MAH;
+
+        temp = smartBattery.getIntegerProperty("TimeRemaining");
+        if (temp != null) {
+            b.timeRemainingInstant = temp * 60d;
+        }
+        temp = smartBattery.getIntegerProperty("CycleCount");
+        if (temp != null) {
+            b.cycleCount = temp;
+        }
+        temp = smartBattery.getIntegerProperty("Temperature");
+        if (temp != null) {
+            b.temperature = temp / 100d;
+        }
+        temp = smartBattery.getIntegerProperty("Voltage");
+        if (temp != null) {
+            b.voltage = temp / 1000d;
+        }
+        temp = smartBattery.getIntegerProperty("Amperage");
+        if (temp != null) {
+            b.amperage = temp;
+        }
+        b.powerUsageRate = b.voltage * b.amperage;
+
+        Boolean bool = smartBattery.getBooleanProperty("ExternalConnected");
+        if (bool != null) {
+            b.powerOnLine = bool;
+        }
+        bool = smartBattery.getBooleanProperty("IsCharging");
+        if (bool != null) {
+            b.charging = bool;
+        }
+        b.discharging = !b.charging && !b.powerOnLine;
+
+        return b;
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInternetProtocolStats.java
@@ -93,7 +93,7 @@ public abstract class MacInternetProtocolStats extends AbstractInternetProtocolS
                 Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_total - udp.udps_ipackets)),
                 ParseUtil.unsignedIntToLong(tcp.tcps_sndrexmitpack),
                 Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_badsum + ip.ips_tooshort + ip.ips_toosmall
-                        + ip.ips_badhlen + ip.ips_badlen - udp.udps_hdrops + udp.udps_badsum + udp.udps_badlen)),
+                        + ip.ips_badhlen + ip.ips_badlen - (udp.udps_hdrops + udp.udps_badsum + udp.udps_badlen))),
                 0L);
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInternetProtocolStats.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.mac;
+
+import static oshi.util.Memoizer.defaultExpiration;
+import static oshi.util.Memoizer.memoize;
+
+import java.util.function.Supplier;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractInternetProtocolStats;
+import oshi.util.ParseUtil;
+import oshi.util.driver.unix.NetStat;
+import oshi.util.tuples.Pair;
+
+/**
+ * Abstract base for the macOS InternetProtocolStats. The TCP/UDP statistics computation is shared; the JNA and FFM
+ * subclasses read the {@code net.inet.*.stats} sysctls into the
+ * {@link BsdTcpstat}/{@link BsdUdpstat}/{@link BsdIpstat}/ {@link BsdIp6stat} carriers, and supply their own native
+ * {@link #getConnections()} implementation.
+ */
+@ThreadSafe
+public abstract class MacInternetProtocolStats extends AbstractInternetProtocolStats {
+
+    /** Whether the queries run with elevated permissions, enabling the {@code tcpstat}-only TCP path. */
+    private final boolean isElevated;
+
+    /**
+     * Constructs a Mac InternetProtocolStats.
+     *
+     * @param elevated whether running with elevated permissions
+     */
+    protected MacInternetProtocolStats(boolean elevated) {
+        this.isElevated = elevated;
+    }
+
+    private final Supplier<Pair<Long, Long>> establishedv4v6 = memoize(NetStat::queryTcpnetstat, defaultExpiration());
+    private final Supplier<BsdTcpstat> tcpstat = memoize(this::queryTcpstat, defaultExpiration());
+    private final Supplier<BsdUdpstat> udpstat = memoize(this::queryUdpstat, defaultExpiration());
+    // With elevated permissions use tcpstat only
+    // Backup estimate get ipstat and subtract off udp
+    private final Supplier<BsdIpstat> ipstat = memoize(this::queryIpstat, defaultExpiration());
+    private final Supplier<BsdIp6stat> ip6stat = memoize(this::queryIp6stat, defaultExpiration());
+
+    /**
+     * Reads the {@code net.inet.tcp.stats} sysctl into a carrier.
+     *
+     * @return the TCP statistics
+     */
+    protected abstract BsdTcpstat queryTcpstat();
+
+    /**
+     * Reads the {@code net.inet.udp.stats} sysctl into a carrier.
+     *
+     * @return the UDP statistics
+     */
+    protected abstract BsdUdpstat queryUdpstat();
+
+    /**
+     * Reads the {@code net.inet.ip.stats} sysctl into a carrier.
+     *
+     * @return the IP statistics
+     */
+    protected abstract BsdIpstat queryIpstat();
+
+    /**
+     * Reads the {@code net.inet6.ip6.stats} sysctl into a carrier.
+     *
+     * @return the IPv6 statistics
+     */
+    protected abstract BsdIp6stat queryIp6stat();
+
+    @Override
+    public TcpStats getTCPv4Stats() {
+        BsdTcpstat tcp = tcpstat.get();
+        if (this.isElevated) {
+            return new TcpStats(establishedv4v6.get().getA(), ParseUtil.unsignedIntToLong(tcp.tcps_connattempt),
+                    ParseUtil.unsignedIntToLong(tcp.tcps_accepts), ParseUtil.unsignedIntToLong(tcp.tcps_conndrops),
+                    ParseUtil.unsignedIntToLong(tcp.tcps_drops), ParseUtil.unsignedIntToLong(tcp.tcps_sndpack),
+                    ParseUtil.unsignedIntToLong(tcp.tcps_rcvpack), ParseUtil.unsignedIntToLong(tcp.tcps_sndrexmitpack),
+                    ParseUtil.unsignedIntToLong(
+                            tcp.tcps_rcvbadsum + tcp.tcps_rcvbadoff + tcp.tcps_rcvmemdrop + tcp.tcps_rcvshort),
+                    0L);
+        }
+        BsdIpstat ip = ipstat.get();
+        BsdUdpstat udp = udpstat.get();
+        return new TcpStats(establishedv4v6.get().getA(), ParseUtil.unsignedIntToLong(tcp.tcps_connattempt),
+                ParseUtil.unsignedIntToLong(tcp.tcps_accepts), ParseUtil.unsignedIntToLong(tcp.tcps_conndrops),
+                ParseUtil.unsignedIntToLong(tcp.tcps_drops),
+                Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_delivered - udp.udps_opackets)),
+                Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_total - udp.udps_ipackets)),
+                ParseUtil.unsignedIntToLong(tcp.tcps_sndrexmitpack),
+                Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_badsum + ip.ips_tooshort + ip.ips_toosmall
+                        + ip.ips_badhlen + ip.ips_badlen - udp.udps_hdrops + udp.udps_badsum + udp.udps_badlen)),
+                0L);
+    }
+
+    @Override
+    public TcpStats getTCPv6Stats() {
+        BsdIp6stat ip6 = ip6stat.get();
+        BsdUdpstat udp = udpstat.get();
+        return new TcpStats(establishedv4v6.get().getB(), 0L, 0L, 0L, 0L,
+                Math.max(0L, ip6.ip6s_localout - ParseUtil.unsignedIntToLong(udp.udps_snd6_swcsum)),
+                Math.max(0L, ip6.ip6s_total - ParseUtil.unsignedIntToLong(udp.udps_rcv6_swcsum)), 0L, 0L, 0L);
+    }
+
+    @Override
+    public UdpStats getUDPv4Stats() {
+        BsdUdpstat stat = udpstat.get();
+        return new UdpStats(ParseUtil.unsignedIntToLong(stat.udps_opackets),
+                ParseUtil.unsignedIntToLong(stat.udps_ipackets), ParseUtil.unsignedIntToLong(stat.udps_noportmcast),
+                ParseUtil.unsignedIntToLong(stat.udps_hdrops + stat.udps_badsum + stat.udps_badlen));
+    }
+
+    @Override
+    public UdpStats getUDPv6Stats() {
+        BsdUdpstat stat = udpstat.get();
+        return new UdpStats(ParseUtil.unsignedIntToLong(stat.udps_snd6_swcsum),
+                ParseUtil.unsignedIntToLong(stat.udps_rcv6_swcsum), 0L, 0L);
+    }
+
+    /*
+     * There are multiple versions of some tcp/udp/ip stats structures in macOS. Since we only need a few of the
+     * hundreds of fields, we can improve performance by selectively reading the ints from the appropriate offsets,
+     * which are consistent across the structure. The carriers below hold those selected fields; the subclasses read
+     * them from the sysctl buffer (JNA Memory or FFM MemorySegment).
+     */
+
+    /** Selected fields of the macOS {@code tcpstat} structure. */
+    public static final class BsdTcpstat {
+        private final int tcps_connattempt;
+        private final int tcps_accepts;
+        private final int tcps_drops;
+        private final int tcps_conndrops;
+        private final int tcps_sndpack;
+        private final int tcps_sndrexmitpack;
+        private final int tcps_rcvpack;
+        private final int tcps_rcvbadsum;
+        private final int tcps_rcvbadoff;
+        private final int tcps_rcvmemdrop;
+        private final int tcps_rcvshort;
+
+        /**
+         * Creates a {@code tcpstat} carrier.
+         *
+         * @param connattempt   connection attempts
+         * @param accepts       accepted connections
+         * @param drops         dropped connections
+         * @param conndrops     connections dropped during establishment
+         * @param sndpack       packets sent
+         * @param sndrexmitpack packets retransmitted
+         * @param rcvpack       packets received
+         * @param rcvbadsum     packets received with bad checksum
+         * @param rcvbadoff     packets received with bad offset
+         * @param rcvmemdrop    packets dropped for lack of memory
+         * @param rcvshort      packets received too short
+         */
+        public BsdTcpstat(int connattempt, int accepts, int drops, int conndrops, int sndpack, int sndrexmitpack,
+                int rcvpack, int rcvbadsum, int rcvbadoff, int rcvmemdrop, int rcvshort) {
+            this.tcps_connattempt = connattempt;
+            this.tcps_accepts = accepts;
+            this.tcps_drops = drops;
+            this.tcps_conndrops = conndrops;
+            this.tcps_sndpack = sndpack;
+            this.tcps_sndrexmitpack = sndrexmitpack;
+            this.tcps_rcvpack = rcvpack;
+            this.tcps_rcvbadsum = rcvbadsum;
+            this.tcps_rcvbadoff = rcvbadoff;
+            this.tcps_rcvmemdrop = rcvmemdrop;
+            this.tcps_rcvshort = rcvshort;
+        }
+    }
+
+    /** Selected fields of the macOS {@code udpstat} structure. */
+    public static final class BsdUdpstat {
+        private final int udps_ipackets;
+        private final int udps_hdrops;
+        private final int udps_badsum;
+        private final int udps_badlen;
+        private final int udps_opackets;
+        private final int udps_noportmcast;
+        private final int udps_rcv6_swcsum;
+        private final int udps_snd6_swcsum;
+
+        /**
+         * Creates a {@code udpstat} carrier.
+         *
+         * @param ipackets    datagrams received
+         * @param hdrops      datagrams dropped for bad header
+         * @param badsum      datagrams dropped for bad checksum
+         * @param badlen      datagrams dropped for bad length
+         * @param opackets    datagrams sent
+         * @param noportmcast multicast datagrams with no port
+         * @param rcv6Swcsum  IPv6 datagrams received with software checksum
+         * @param snd6Swcsum  IPv6 datagrams sent with software checksum
+         */
+        public BsdUdpstat(int ipackets, int hdrops, int badsum, int badlen, int opackets, int noportmcast,
+                int rcv6Swcsum, int snd6Swcsum) {
+            this.udps_ipackets = ipackets;
+            this.udps_hdrops = hdrops;
+            this.udps_badsum = badsum;
+            this.udps_badlen = badlen;
+            this.udps_opackets = opackets;
+            this.udps_noportmcast = noportmcast;
+            this.udps_rcv6_swcsum = rcv6Swcsum;
+            this.udps_snd6_swcsum = snd6Swcsum;
+        }
+    }
+
+    /** Selected fields of the macOS {@code ipstat} structure. */
+    public static final class BsdIpstat {
+        private final int ips_total;
+        private final int ips_badsum;
+        private final int ips_tooshort;
+        private final int ips_toosmall;
+        private final int ips_badhlen;
+        private final int ips_badlen;
+        private final int ips_delivered;
+
+        /**
+         * Creates an {@code ipstat} carrier.
+         *
+         * @param total     total packets received
+         * @param badsum    packets with bad checksum
+         * @param tooshort  packets too short
+         * @param toosmall  packets with not enough data
+         * @param badhlen   packets with bad header length
+         * @param badlen    packets with bad length
+         * @param delivered datagrams delivered to upper level
+         */
+        public BsdIpstat(int total, int badsum, int tooshort, int toosmall, int badhlen, int badlen, int delivered) {
+            this.ips_total = total;
+            this.ips_badsum = badsum;
+            this.ips_tooshort = tooshort;
+            this.ips_toosmall = toosmall;
+            this.ips_badhlen = badhlen;
+            this.ips_badlen = badlen;
+            this.ips_delivered = delivered;
+        }
+    }
+
+    /** Selected fields of the macOS {@code ip6stat} structure. */
+    public static final class BsdIp6stat {
+        private final long ip6s_total;
+        private final long ip6s_localout;
+
+        /**
+         * Creates an {@code ip6stat} carrier.
+         *
+         * @param total    total IPv6 packets received
+         * @param localout IPv6 packets sent from this host
+         */
+        public BsdIp6stat(long total, long localout) {
+            this.ip6s_total = total;
+            this.ip6s_localout = localout;
+        }
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/net/NetStatFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/net/NetStatFFM.java
@@ -18,8 +18,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import oshi.annotation.concurrent.Immutable;
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.mac.IFdata;
 import oshi.ffm.platform.mac.MacSystemFunctions;
 
 /**
@@ -149,82 +149,5 @@ public final class NetStatFFM {
             LOG.error("Error querying network interface data", t);
         }
         return data;
-    }
-
-    /**
-     * Class to encapsulate IF data for method return.
-     */
-    @Immutable
-    public static class IFdata {
-        private final int ifType;
-        private final long oPackets;
-        private final long iPackets;
-        private final long oBytes;
-        private final long iBytes;
-        private final long oErrors;
-        private final long iErrors;
-        private final long collisions;
-        private final long iDrops;
-        private final long speed;
-        private final long timeStamp;
-
-        IFdata(int ifType, long oPackets, long iPackets, long oBytes, long iBytes, long oErrors, long iErrors,
-                long collisions, long iDrops, long speed, long timeStamp) {
-            this.ifType = ifType;
-            this.oPackets = oPackets & 0xffffffffL;
-            this.iPackets = iPackets & 0xffffffffL;
-            this.oBytes = oBytes & 0xffffffffL;
-            this.iBytes = iBytes & 0xffffffffL;
-            this.oErrors = oErrors & 0xffffffffL;
-            this.iErrors = iErrors & 0xffffffffL;
-            this.collisions = collisions & 0xffffffffL;
-            this.iDrops = iDrops & 0xffffffffL;
-            this.speed = speed & 0xffffffffL;
-            this.timeStamp = timeStamp;
-        }
-
-        public int getIfType() {
-            return ifType;
-        }
-
-        public long getOPackets() {
-            return oPackets;
-        }
-
-        public long getIPackets() {
-            return iPackets;
-        }
-
-        public long getOBytes() {
-            return oBytes;
-        }
-
-        public long getIBytes() {
-            return iBytes;
-        }
-
-        public long getOErrors() {
-            return oErrors;
-        }
-
-        public long getIErrors() {
-            return iErrors;
-        }
-
-        public long getCollisions() {
-            return collisions;
-        }
-
-        public long getIDrops() {
-            return iDrops;
-        }
-
-        public long getSpeed() {
-            return speed;
-        }
-
-        public long getTimeStamp() {
-            return timeStamp;
-        }
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/IOKitProviderFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/IOKitProviderFFM.java
@@ -80,5 +80,15 @@ final class IOKitProviderFFM implements IOKitProvider {
         public String getStringProperty(String key) {
             return entry.getStringProperty(key);
         }
+
+        @Override
+        public Integer getIntegerProperty(String key) {
+            return entry.getIntegerProperty(key);
+        }
+
+        @Override
+        public Boolean getBooleanProperty(String key) {
+            return entry.getBooleanProperty(key);
+        }
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
@@ -18,8 +18,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.mac.IFdata;
 import oshi.driver.mac.net.NetStatFFM;
-import oshi.driver.mac.net.NetStatFFM.IFdata;
 import oshi.ffm.platform.mac.CoreFoundation.CFArrayRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFStringRef;
 import oshi.hardware.NetworkIF;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
@@ -10,7 +10,6 @@ import static oshi.ffm.platform.mac.IOKitFunctions.IOPSGetPowerSourceDescription
 import static oshi.ffm.platform.mac.IOKitFunctions.IOPSGetTimeRemainingEstimate;
 
 import java.lang.foreign.MemorySegment;
-import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,12 +21,9 @@ import oshi.ffm.platform.mac.CoreFoundation.CFDictionaryRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFNumberRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFStringRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFTypeRef;
-import oshi.ffm.platform.mac.IOKit.IOService;
 import oshi.ffm.util.platform.mac.CFUtilFFM;
-import oshi.ffm.util.platform.mac.IOKitUtilFFM;
 import oshi.hardware.PowerSource;
 import oshi.hardware.common.platform.mac.MacPowerSource;
-import oshi.util.Constants;
 
 /**
  * A Power Source
@@ -52,122 +48,12 @@ public final class MacPowerSourceFFM extends MacPowerSource {
         return getPowerSources();
     }
 
+    /**
+     * Gets Battery Information.
+     *
+     * @return An array of PowerSource objects representing batteries, etc.
+     */
     public static List<PowerSource> getPowerSources() {
-        String psDeviceName = Constants.UNKNOWN;
-        double psTimeRemainingInstant = 0d;
-        double psPowerUsageRate = 0d;
-        double psVoltage = -1d;
-        double psAmperage = 0d;
-        boolean psPowerOnLine = false;
-        boolean psCharging = false;
-        boolean psDischarging = false;
-        CapacityUnits psCapacityUnits = CapacityUnits.RELATIVE;
-        int psCurrentCapacity = 0;
-        int psMaxCapacity = 1;
-        int psDesignCapacity = -1;
-        int psCycleCount = -1;
-        String psChemistry = Constants.UNKNOWN;
-        LocalDate psManufactureDate = null;
-        String psManufacturer = Constants.UNKNOWN;
-        String psSerialNumber = Constants.UNKNOWN;
-        double psTemperature = 0d;
-
-        IOService smartBattery = IOKitUtilFFM.getMatchingService("AppleSmartBattery");
-        if (smartBattery != null) {
-            try (smartBattery) {
-                String s = smartBattery.getStringProperty("DeviceName");
-                if (s != null) {
-                    psDeviceName = s;
-                }
-                s = smartBattery.getStringProperty("Manufacturer");
-                if (s != null) {
-                    psManufacturer = s;
-                }
-                s = smartBattery.getStringProperty("BatterySerialNumber");
-                if (s != null) {
-                    psSerialNumber = s;
-                }
-
-                Integer temp = smartBattery.getIntegerProperty("ManufactureDate");
-                if (temp != null) {
-                    int day = temp & 0x1f;
-                    int month = (temp >> 5) & 0xf;
-                    int year80 = (temp >> 9) & 0x7f;
-                    try {
-                        psManufactureDate = LocalDate.of(1980 + year80, month, day);
-                    } catch (DateTimeException _) {
-                        // Corrupt bitfield — leave psManufactureDate as null
-                    }
-                }
-
-                temp = smartBattery.getIntegerProperty("DesignCapacity");
-                if (temp != null) {
-                    psDesignCapacity = temp;
-                }
-                temp = smartBattery.getIntegerProperty("MaxCapacity");
-                if (temp != null) {
-                    psMaxCapacity = temp;
-                }
-                temp = smartBattery.getIntegerProperty("CurrentCapacity");
-                if (temp != null) {
-                    psCurrentCapacity = temp;
-                }
-                psCapacityUnits = CapacityUnits.MAH;
-
-                temp = smartBattery.getIntegerProperty("TimeRemaining");
-                if (temp != null) {
-                    psTimeRemainingInstant = temp * 60d;
-                }
-                temp = smartBattery.getIntegerProperty("CycleCount");
-                if (temp != null) {
-                    psCycleCount = temp;
-                }
-                temp = smartBattery.getIntegerProperty("Temperature");
-                if (temp != null) {
-                    psTemperature = temp / 100d;
-                }
-                temp = smartBattery.getIntegerProperty("Voltage");
-                if (temp != null) {
-                    psVoltage = temp / 1000d;
-                }
-                temp = smartBattery.getIntegerProperty("Amperage");
-                if (temp != null) {
-                    psAmperage = temp;
-                }
-                psPowerUsageRate = psVoltage * psAmperage;
-
-                Boolean bool = smartBattery.getBooleanProperty("ExternalConnected");
-                if (bool != null) {
-                    psPowerOnLine = bool;
-                }
-                bool = smartBattery.getBooleanProperty("IsCharging");
-                if (bool != null) {
-                    psCharging = bool;
-                }
-                psDischarging = !psCharging && !psPowerOnLine;
-            }
-        }
-
-        // Capture final copies for use in lambda/inner scope
-        final String fDeviceName = psDeviceName;
-        final double fTimeRemainingInstant = psTimeRemainingInstant;
-        final double fPowerUsageRate = psPowerUsageRate;
-        final double fVoltage = psVoltage;
-        final double fAmperage = psAmperage;
-        final boolean fPowerOnLine = psPowerOnLine;
-        final boolean fCharging = psCharging;
-        final boolean fDischarging = psDischarging;
-        final CapacityUnits fCapacityUnits = psCapacityUnits;
-        final int fCurrentCapacity = psCurrentCapacity;
-        final int fMaxCapacity = psMaxCapacity;
-        final int fDesignCapacity = psDesignCapacity;
-        final int fCycleCount = psCycleCount;
-        final String fChemistry = psChemistry;
-        final LocalDate fManufactureDate = psManufactureDate;
-        final String fManufacturer = psManufacturer;
-        final String fSerialNumber = psSerialNumber;
-        final double fTemperature = psTemperature;
-
         CFStringRef nameKey = CFStringRef.createCFString("Name");
         CFStringRef isPresentKey = CFStringRef.createCFString("Is Present");
         CFStringRef currentCapacityKey = CFStringRef.createCFString("Current Capacity");
@@ -180,7 +66,7 @@ public final class MacPowerSourceFFM extends MacPowerSource {
                     double psTimeRemainingEstimated = IOPSGetTimeRemainingEstimate();
                     int powerSourcesCount = cfList.getCount();
 
-                    List<PowerSource> psList = new ArrayList<>(powerSourcesCount);
+                    List<PowerSourceData> sources = new ArrayList<>(powerSourcesCount);
                     for (int ps = 0; ps < powerSourcesCount; ps++) {
                         MemorySegment pwrSrcPtr = cfList.getValueAtIndex(ps);
                         MemorySegment dictionary = IOPSGetPowerSourceDescription(powerSourcesInfo, pwrSrcPtr);
@@ -188,33 +74,25 @@ public final class MacPowerSourceFFM extends MacPowerSource {
                         CFDictionaryRef dict = new CFDictionaryRef(dictionary);
 
                         MemorySegment result = dict.getValue(isPresentKey);
-                        if (!result.equals(MemorySegment.NULL)) {
-                            if (CFBooleanRef.booleanValue(result)) {
-                                result = dict.getValue(nameKey);
-                                String psName = CFUtilFFM.cfPointerToString(result);
+                        if (!result.equals(MemorySegment.NULL) && CFBooleanRef.booleanValue(result)) {
+                            result = dict.getValue(nameKey);
+                            String psName = CFUtilFFM.cfPointerToString(result);
 
-                                double currentCapacity = 0d;
-                                if (dict.getValueIfPresent(currentCapacityKey, MemorySegment.NULL)) {
-                                    result = dict.getValue(currentCapacityKey);
-                                    currentCapacity = CFNumberRef.intValue(result);
-                                }
-                                double maxCapacity = 1d;
-                                if (dict.getValueIfPresent(maxCapacityKey, MemorySegment.NULL)) {
-                                    result = dict.getValue(maxCapacityKey);
-                                    maxCapacity = CFNumberRef.intValue(result);
-                                }
-                                double psRemainingCapacityPercent = maxCapacity <= 0 ? 0d
-                                        : Math.min(1d, currentCapacity / maxCapacity);
-
-                                psList.add(new MacPowerSourceFFM(psName, fDeviceName, psRemainingCapacityPercent,
-                                        psTimeRemainingEstimated, fTimeRemainingInstant, fPowerUsageRate, fVoltage,
-                                        fAmperage, fPowerOnLine, fCharging, fDischarging, fCapacityUnits,
-                                        fCurrentCapacity, fMaxCapacity, fDesignCapacity, fCycleCount, fChemistry,
-                                        fManufactureDate, fManufacturer, fSerialNumber, fTemperature));
+                            double currentCapacity = 0d;
+                            if (dict.getValueIfPresent(currentCapacityKey, MemorySegment.NULL)) {
+                                result = dict.getValue(currentCapacityKey);
+                                currentCapacity = CFNumberRef.intValue(result);
                             }
+                            double maxCapacity = 1d;
+                            if (dict.getValueIfPresent(maxCapacityKey, MemorySegment.NULL)) {
+                                result = dict.getValue(maxCapacityKey);
+                                maxCapacity = CFNumberRef.intValue(result);
+                            }
+                            sources.add(new PowerSourceData(psName, currentCapacity, maxCapacity));
                         }
                     }
-                    return psList;
+                    return buildPowerSources(IOKitProviderFFM.INSTANCE, psTimeRemainingEstimated, sources,
+                            MacPowerSourceFFM::new);
                 }
             }
         } catch (Throwable _) {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
@@ -55,95 +55,31 @@ import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
 import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
 import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
 import static oshi.util.ExceptionUtil.getOrDefault;
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
 import static oshi.util.ParseUtil.parseIntToIP;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.util.platform.mac.SysctlUtilFFM;
-import oshi.software.common.AbstractInternetProtocolStats;
+import oshi.software.common.os.mac.MacInternetProtocolStats;
 import oshi.util.ParseUtil;
-import oshi.util.driver.unix.NetStat;
-import oshi.util.tuples.Pair;
 
 /**
  * Internet Protocol Stats implementation
  */
 @ThreadSafe
-public class MacInternetProtocolStatsFFM extends AbstractInternetProtocolStats {
+public class MacInternetProtocolStatsFFM extends MacInternetProtocolStats {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacInternetProtocolStatsFFM.class);
 
-    private boolean isElevated;
-
     public MacInternetProtocolStatsFFM(boolean elevated) {
-        this.isElevated = elevated;
-    }
-
-    private Supplier<Pair<Long, Long>> establishedv4v6 = memoize(NetStat::queryTcpnetstat, defaultExpiration());
-    private Supplier<BsdTcpstat> tcpstat = memoize(MacInternetProtocolStatsFFM::queryTcpstat, defaultExpiration());
-    private Supplier<BsdUdpstat> udpstat = memoize(MacInternetProtocolStatsFFM::queryUdpstat, defaultExpiration());
-    // With elevated permissions use tcpstat only
-    // Backup estimate get ipstat and subtract off udp
-    private Supplier<BsdIpstat> ipstat = memoize(MacInternetProtocolStatsFFM::queryIpstat, defaultExpiration());
-    private Supplier<BsdIp6stat> ip6stat = memoize(MacInternetProtocolStatsFFM::queryIp6stat, defaultExpiration());
-
-    @Override
-    public TcpStats getTCPv4Stats() {
-        BsdTcpstat tcp = tcpstat.get();
-        if (this.isElevated) {
-            return new TcpStats(establishedv4v6.get().getA(), ParseUtil.unsignedIntToLong(tcp.tcps_connattempt),
-                    ParseUtil.unsignedIntToLong(tcp.tcps_accepts), ParseUtil.unsignedIntToLong(tcp.tcps_conndrops),
-                    ParseUtil.unsignedIntToLong(tcp.tcps_drops), ParseUtil.unsignedIntToLong(tcp.tcps_sndpack),
-                    ParseUtil.unsignedIntToLong(tcp.tcps_rcvpack), ParseUtil.unsignedIntToLong(tcp.tcps_sndrexmitpack),
-                    ParseUtil.unsignedIntToLong(
-                            tcp.tcps_rcvbadsum + tcp.tcps_rcvbadoff + tcp.tcps_rcvmemdrop + tcp.tcps_rcvshort),
-                    0L);
-        }
-        BsdIpstat ip = ipstat.get();
-        BsdUdpstat udp = udpstat.get();
-        return new TcpStats(establishedv4v6.get().getA(), ParseUtil.unsignedIntToLong(tcp.tcps_connattempt),
-                ParseUtil.unsignedIntToLong(tcp.tcps_accepts), ParseUtil.unsignedIntToLong(tcp.tcps_conndrops),
-                ParseUtil.unsignedIntToLong(tcp.tcps_drops),
-                Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_delivered - udp.udps_opackets)),
-                Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_total - udp.udps_ipackets)),
-                ParseUtil.unsignedIntToLong(tcp.tcps_sndrexmitpack),
-                Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_badsum + ip.ips_tooshort + ip.ips_toosmall
-                        + ip.ips_badhlen + ip.ips_badlen - udp.udps_hdrops + udp.udps_badsum + udp.udps_badlen)),
-                0L);
-    }
-
-    @Override
-    public TcpStats getTCPv6Stats() {
-        BsdIp6stat ip6 = ip6stat.get();
-        BsdUdpstat udp = udpstat.get();
-        return new TcpStats(establishedv4v6.get().getB(), 0L, 0L, 0L, 0L,
-                Math.max(0L, ip6.ip6s_localout - ParseUtil.unsignedIntToLong(udp.udps_snd6_swcsum)),
-                Math.max(0L, ip6.ip6s_total - ParseUtil.unsignedIntToLong(udp.udps_rcv6_swcsum)), 0L, 0L, 0L);
-    }
-
-    @Override
-    public UdpStats getUDPv4Stats() {
-        BsdUdpstat stat = udpstat.get();
-        return new UdpStats(ParseUtil.unsignedIntToLong(stat.udps_opackets),
-                ParseUtil.unsignedIntToLong(stat.udps_ipackets), ParseUtil.unsignedIntToLong(stat.udps_noportmcast),
-                ParseUtil.unsignedIntToLong(stat.udps_hdrops + stat.udps_badsum + stat.udps_badlen));
-    }
-
-    @Override
-    public UdpStats getUDPv6Stats() {
-        BsdUdpstat stat = udpstat.get();
-        return new UdpStats(ParseUtil.unsignedIntToLong(stat.udps_snd6_swcsum),
-                ParseUtil.unsignedIntToLong(stat.udps_rcv6_swcsum), 0L, 0L);
+        super(elevated);
     }
 
     @Override
@@ -287,29 +223,8 @@ public class MacInternetProtocolStatsFFM extends AbstractInternetProtocolStats {
         };
     }
 
-    /*
-     * There are multiple versions of some tcp/udp/ip stats structures in macOS. Since we only need a few of the
-     * hundreds of fields, we can improve performance by selectively reading the ints from the appropriate offsets,
-     * which are consistent across the structure.
-     */
-
-    record BsdTcpstat(
-            //
-            int tcps_connattempt, // 0
-            int tcps_accepts, // 4
-            int tcps_drops, // 12
-            int tcps_conndrops, // 16
-            int tcps_sndpack, // 64
-            int tcps_sndrexmitpack, // 72
-            int tcps_rcvpack, // 104
-            int tcps_rcvbadsum, // 112
-            int tcps_rcvbadoff, // 116
-            int tcps_rcvmemdrop, // 120
-            int tcps_rcvshort // 124
-    ) {
-    }
-
-    private static BsdTcpstat queryTcpstat() {
+    @Override
+    protected BsdTcpstat queryTcpstat() {
         MemorySegment m = SysctlUtilFFM.sysctl("net.inet.tcp.stats");
         if (m != null && m.byteSize() >= 128) {
             return new BsdTcpstat(m.get(JAVA_INT, 0), m.get(JAVA_INT, 4), m.get(JAVA_INT, 12), m.get(JAVA_INT, 16),
@@ -319,20 +234,8 @@ public class MacInternetProtocolStatsFFM extends AbstractInternetProtocolStats {
         return new BsdTcpstat(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 
-    record BsdUdpstat(
-            //
-            int udps_ipackets, // 0
-            int udps_hdrops, // 4
-            int udps_badsum, // 8
-            int udps_badlen, // 12
-            int udps_opackets, // 36
-            int udps_noportmcast, // 48
-            int udps_rcv6_swcsum, // 64
-            int udps_snd6_swcsum // 80
-    ) {
-    }
-
-    private static BsdUdpstat queryUdpstat() {
+    @Override
+    protected BsdUdpstat queryUdpstat() {
         MemorySegment m = SysctlUtilFFM.sysctl("net.inet.udp.stats");
         if (m != null && m.byteSize() >= 84) {
             return new BsdUdpstat(m.get(JAVA_INT, 0), m.get(JAVA_INT, 4), m.get(JAVA_INT, 8), m.get(JAVA_INT, 12),
@@ -341,19 +244,8 @@ public class MacInternetProtocolStatsFFM extends AbstractInternetProtocolStats {
         return new BsdUdpstat(0, 0, 0, 0, 0, 0, 0, 0);
     }
 
-    record BsdIpstat(
-            //
-            int ips_total, // 0
-            int ips_badsum, // 4
-            int ips_tooshort, // 8
-            int ips_toosmall, // 12
-            int ips_badhlen, // 16
-            int ips_badlen, // 20
-            int ips_delivered // 56
-    ) {
-    }
-
-    private static BsdIpstat queryIpstat() {
+    @Override
+    protected BsdIpstat queryIpstat() {
         MemorySegment m = SysctlUtilFFM.sysctl("net.inet.ip.stats");
         if (m != null && m.byteSize() >= 60) {
             return new BsdIpstat(m.get(JAVA_INT, 0), m.get(JAVA_INT, 4), m.get(JAVA_INT, 8), m.get(JAVA_INT, 12),
@@ -362,19 +254,12 @@ public class MacInternetProtocolStatsFFM extends AbstractInternetProtocolStats {
         return new BsdIpstat(0, 0, 0, 0, 0, 0, 0);
     }
 
-    record BsdIp6stat(
-            //
-            long ip6s_total, // 0
-            long ip6s_localout // 88
-    ) {
-    }
-
-    private static BsdIp6stat queryIp6stat() {
+    @Override
+    protected BsdIp6stat queryIp6stat() {
         MemorySegment m = SysctlUtilFFM.sysctl("net.inet6.ip6.stats");
         if (m != null && m.byteSize() >= 96) {
             return new BsdIp6stat(m.get(JAVA_LONG, 0), m.get(JAVA_LONG, 88));
         }
         return new BsdIp6stat(0, 0);
     }
-
 }

--- a/oshi-core/src/main/java/oshi/driver/mac/net/NetStat.java
+++ b/oshi-core/src/main/java/oshi/driver/mac/net/NetStat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.mac.net;
@@ -17,8 +17,8 @@ import com.sun.jna.platform.mac.SystemB.IFmsgHdr;
 import com.sun.jna.platform.mac.SystemB.IFmsgHdr2;
 import com.sun.jna.platform.unix.LibCAPI.size_t;
 
-import oshi.annotation.concurrent.Immutable;
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.mac.IFdata;
 import oshi.jna.ByRef.CloseableSizeTByReference;
 
 /**
@@ -95,116 +95,5 @@ public final class NetStat {
             }
         }
         return data;
-    }
-
-    /**
-     * Class to encapsulate IF data for method return
-     */
-    @Immutable
-    public static class IFdata {
-        private final int ifType;
-        private final long oPackets;
-        private final long iPackets;
-        private final long oBytes;
-        private final long iBytes;
-        private final long oErrors;
-        private final long iErrors;
-        private final long collisions;
-        private final long iDrops;
-        private final long speed;
-        private final long timeStamp;
-
-        IFdata(int ifType, // NOSONAR squid:S00107
-                long oPackets, long iPackets, long oBytes, long iBytes, long oErrors, long iErrors, long collisions,
-                long iDrops, long speed, long timeStamp) {
-            this.ifType = ifType;
-            this.oPackets = oPackets & 0xffffffffL;
-            this.iPackets = iPackets & 0xffffffffL;
-            this.oBytes = oBytes & 0xffffffffL;
-            this.iBytes = iBytes & 0xffffffffL;
-            this.oErrors = oErrors & 0xffffffffL;
-            this.iErrors = iErrors & 0xffffffffL;
-            this.collisions = collisions & 0xffffffffL;
-            this.iDrops = iDrops & 0xffffffffL;
-            this.speed = speed & 0xffffffffL;
-            this.timeStamp = timeStamp;
-        }
-
-        /**
-         * @return the ifType
-         */
-        public int getIfType() {
-            return ifType;
-        }
-
-        /**
-         * @return the oPackets
-         */
-        public long getOPackets() {
-            return oPackets;
-        }
-
-        /**
-         * @return the iPackets
-         */
-        public long getIPackets() {
-            return iPackets;
-        }
-
-        /**
-         * @return the oBytes
-         */
-        public long getOBytes() {
-            return oBytes;
-        }
-
-        /**
-         * @return the iBytes
-         */
-        public long getIBytes() {
-            return iBytes;
-        }
-
-        /**
-         * @return the oErrors
-         */
-        public long getOErrors() {
-            return oErrors;
-        }
-
-        /**
-         * @return the iErrors
-         */
-        public long getIErrors() {
-            return iErrors;
-        }
-
-        /**
-         * @return the collisions
-         */
-        public long getCollisions() {
-            return collisions;
-        }
-
-        /**
-         * @return the iDrops
-         */
-        public long getIDrops() {
-            return iDrops;
-        }
-
-        /**
-         * @return the speed
-         */
-        public long getSpeed() {
-            return speed;
-        }
-
-        /**
-         * @return the timeStamp
-         */
-        public long getTimeStamp() {
-            return timeStamp;
-        }
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/IOKitProviderJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/IOKitProviderJNA.java
@@ -87,5 +87,15 @@ final class IOKitProviderJNA implements IOKitProvider {
         public String getStringProperty(String key) {
             return entry.getStringProperty(key);
         }
+
+        @Override
+        public Integer getIntegerProperty(String key) {
+            return entry.getIntegerProperty(key);
+        }
+
+        @Override
+        public Boolean getBooleanProperty(String key) {
+            return entry.getBooleanProperty(key);
+        }
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIfJNA.java
@@ -17,8 +17,8 @@ import com.sun.jna.platform.mac.CoreFoundation.CFArrayRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFStringRef;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.mac.IFdata;
 import oshi.driver.mac.net.NetStat;
-import oshi.driver.mac.net.NetStat.IFdata;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.common.platform.mac.MacNetworkIF;
 import oshi.jna.platform.mac.SystemConfiguration;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacPowerSourceJNA.java
@@ -17,13 +17,10 @@ import com.sun.jna.platform.mac.CoreFoundation.CFNumberRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFStringRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFTypeRef;
 import com.sun.jna.platform.mac.IOKit;
-import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
-import com.sun.jna.platform.mac.IOKitUtil;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.PowerSource;
 import oshi.hardware.common.platform.mac.MacPowerSource;
-import oshi.util.Constants;
 import oshi.util.platform.mac.CFUtil;
 
 /**
@@ -58,112 +55,6 @@ public final class MacPowerSourceJNA extends MacPowerSource {
      * @return An array of PowerSource objects representing batteries, etc.
      */
     public static List<PowerSource> getPowerSources() {
-        String psDeviceName = Constants.UNKNOWN;
-        double psTimeRemainingInstant = 0d;
-        double psPowerUsageRate = 0d;
-        double psVoltage = -1d;
-        double psAmperage = 0d;
-        boolean psPowerOnLine = false;
-        boolean psCharging = false;
-        boolean psDischarging = false;
-        CapacityUnits psCapacityUnits = CapacityUnits.RELATIVE;
-        int psCurrentCapacity = 0;
-        int psMaxCapacity = 1;
-        int psDesignCapacity = -1;
-        int psCycleCount = -1;
-        String psChemistry = Constants.UNKNOWN;
-        LocalDate psManufactureDate = null;
-        String psManufacturer = Constants.UNKNOWN;
-        String psSerialNumber = Constants.UNKNOWN;
-        double psTemperature = 0d;
-
-        // Mac PowerSource information comes from two sources: the IOKit's IOPS
-        // functions (which, in theory, return an array of objects but in most cases
-        // should return one), and the IORegistry's entry for AppleSmartBattery, which
-        // always returns one object.
-        //
-        // We start by fetching the registry information, which will be replicated
-        // across all IOPS entries if there are more than one.
-
-        IORegistryEntry smartBattery = IOKitUtil.getMatchingService("AppleSmartBattery");
-        if (smartBattery != null) {
-            String s = smartBattery.getStringProperty("DeviceName");
-            if (s != null) {
-                psDeviceName = s;
-            }
-            s = smartBattery.getStringProperty("Manufacturer");
-            if (s != null) {
-                psManufacturer = s;
-            }
-            s = smartBattery.getStringProperty("BatterySerialNumber");
-            if (s != null) {
-                psSerialNumber = s;
-            }
-
-            Integer temp = smartBattery.getIntegerProperty("ManufactureDate");
-            if (temp != null) {
-                // Bits 0...4 => day (value 1-31; 5 bits)
-                // Bits 5...8 => month (value 1-12; 4 bits)
-                // Bits 9...15 => years since 1980 (value 0-127; 7 bits)
-                int day = temp & 0x1f;
-                int month = (temp >> 5) & 0xf;
-                int year80 = (temp >> 9) & 0x7f;
-                try {
-                    psManufactureDate = LocalDate.of(1980 + year80, month, day);
-                } catch (java.time.DateTimeException e) {
-                    // Corrupt bitfield — leave psManufactureDate as null
-                }
-            }
-
-            temp = smartBattery.getIntegerProperty("DesignCapacity");
-            if (temp != null) {
-                psDesignCapacity = temp;
-            }
-            temp = smartBattery.getIntegerProperty("MaxCapacity");
-            if (temp != null) {
-                psMaxCapacity = temp;
-            }
-            temp = smartBattery.getIntegerProperty("CurrentCapacity");
-            if (temp != null) {
-                psCurrentCapacity = temp;
-            }
-            psCapacityUnits = CapacityUnits.MAH;
-
-            temp = smartBattery.getIntegerProperty("TimeRemaining");
-            if (temp != null) {
-                psTimeRemainingInstant = temp * 60d;
-            }
-            temp = smartBattery.getIntegerProperty("CycleCount");
-            if (temp != null) {
-                psCycleCount = temp;
-            }
-            temp = smartBattery.getIntegerProperty("Temperature");
-            if (temp != null) {
-                psTemperature = temp / 100d;
-            }
-            temp = smartBattery.getIntegerProperty("Voltage");
-            if (temp != null) {
-                psVoltage = temp / 1000d;
-            }
-            temp = smartBattery.getIntegerProperty("Amperage");
-            if (temp != null) {
-                psAmperage = temp;
-            }
-            psPowerUsageRate = psVoltage * psAmperage;
-
-            Boolean bool = smartBattery.getBooleanProperty("ExternalConnected");
-            if (bool != null) {
-                psPowerOnLine = bool;
-            }
-            bool = smartBattery.getBooleanProperty("IsCharging");
-            if (bool != null) {
-                psCharging = bool;
-            }
-            psDischarging = !psCharging && !psPowerOnLine;
-
-            smartBattery.release();
-        }
-
         // Get the blob containing current power source state
         CFTypeRef powerSourcesInfo = IO.IOPSCopyPowerSourcesInfo();
         CFArrayRef powerSourcesList = IO.IOPSCopyPowerSourcesList(powerSourcesInfo);
@@ -177,8 +68,8 @@ public final class MacPowerSourceJNA extends MacPowerSource {
         CFStringRef isPresentKey = CFStringRef.createCFString("Is Present");
         CFStringRef currentCapacityKey = CFStringRef.createCFString("Current Capacity");
         CFStringRef maxCapacityKey = CFStringRef.createCFString("Max Capacity");
-        // For each power source, output various info
-        List<PowerSource> psList = new ArrayList<>(powerSourcesCount);
+        // For each power source, capture the present ones for the shared computation
+        List<PowerSourceData> sources = new ArrayList<>(powerSourcesCount);
         for (int ps = 0; ps < powerSourcesCount; ps++) {
             // Get the dictionary for that Power Source
             Pointer pwrSrcPtr = powerSourcesList.getValueAtIndex(ps);
@@ -208,14 +99,7 @@ public final class MacPowerSourceJNA extends MacPowerSource {
                         CFNumberRef cap = new CFNumberRef(result);
                         maxCapacity = cap.intValue();
                     }
-                    double psRemainingCapacityPercent = maxCapacity <= 0 ? 0d
-                            : Math.min(1d, currentCapacity / maxCapacity);
-                    // Add to list
-                    psList.add(new MacPowerSourceJNA(psName, psDeviceName, psRemainingCapacityPercent,
-                            psTimeRemainingEstimated, psTimeRemainingInstant, psPowerUsageRate, psVoltage, psAmperage,
-                            psPowerOnLine, psCharging, psDischarging, psCapacityUnits, psCurrentCapacity, psMaxCapacity,
-                            psDesignCapacity, psCycleCount, psChemistry, psManufactureDate, psManufacturer,
-                            psSerialNumber, psTemperature));
+                    sources.add(new PowerSourceData(psName, currentCapacity, maxCapacity));
                 }
             }
         }
@@ -227,6 +111,6 @@ public final class MacPowerSourceJNA extends MacPowerSource {
         powerSourcesList.release();
         powerSourcesInfo.release();
 
-        return psList;
+        return buildPowerSources(IOKitProviderJNA.INSTANCE, psTimeRemainingEstimated, sources, MacPowerSourceJNA::new);
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
@@ -26,12 +26,9 @@ import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
 import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
 import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
 import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
 
 import com.sun.jna.Memory;
 import com.sun.jna.platform.mac.SystemB.InSockInfo;
@@ -40,83 +37,18 @@ import com.sun.jna.platform.mac.SystemB.ProcFdInfo;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.Struct.CloseableSocketFdInfo;
 import oshi.jna.platform.mac.SystemB;
-import oshi.jna.platform.unix.CLibrary.BsdIp6stat;
-import oshi.jna.platform.unix.CLibrary.BsdIpstat;
-import oshi.jna.platform.unix.CLibrary.BsdTcpstat;
-import oshi.jna.platform.unix.CLibrary.BsdUdpstat;
-import oshi.software.common.AbstractInternetProtocolStats;
+import oshi.software.common.os.mac.MacInternetProtocolStats;
 import oshi.util.ParseUtil;
-import oshi.util.driver.unix.NetStat;
 import oshi.util.platform.mac.SysctlUtil;
-import oshi.util.tuples.Pair;
 
 /**
  * Internet Protocol Stats implementation
  */
 @ThreadSafe
-public class MacInternetProtocolStatsJNA extends AbstractInternetProtocolStats {
-
-    private boolean isElevated;
+public class MacInternetProtocolStatsJNA extends MacInternetProtocolStats {
 
     public MacInternetProtocolStatsJNA(boolean elevated) {
-        this.isElevated = elevated;
-    }
-
-    private Supplier<Pair<Long, Long>> establishedv4v6 = memoize(NetStat::queryTcpnetstat, defaultExpiration());
-    private Supplier<BsdTcpstat> tcpstat = memoize(MacInternetProtocolStatsJNA::queryTcpstat, defaultExpiration());
-    private Supplier<BsdUdpstat> udpstat = memoize(MacInternetProtocolStatsJNA::queryUdpstat, defaultExpiration());
-    // With elevated permissions use tcpstat only
-    // Backup estimate get ipstat and subtract off udp
-    private Supplier<BsdIpstat> ipstat = memoize(MacInternetProtocolStatsJNA::queryIpstat, defaultExpiration());
-    private Supplier<BsdIp6stat> ip6stat = memoize(MacInternetProtocolStatsJNA::queryIp6stat, defaultExpiration());
-
-    @Override
-    public TcpStats getTCPv4Stats() {
-        BsdTcpstat tcp = tcpstat.get();
-        if (this.isElevated) {
-            return new TcpStats(establishedv4v6.get().getA(), ParseUtil.unsignedIntToLong(tcp.tcps_connattempt),
-                    ParseUtil.unsignedIntToLong(tcp.tcps_accepts), ParseUtil.unsignedIntToLong(tcp.tcps_conndrops),
-                    ParseUtil.unsignedIntToLong(tcp.tcps_drops), ParseUtil.unsignedIntToLong(tcp.tcps_sndpack),
-                    ParseUtil.unsignedIntToLong(tcp.tcps_rcvpack), ParseUtil.unsignedIntToLong(tcp.tcps_sndrexmitpack),
-                    ParseUtil.unsignedIntToLong(
-                            tcp.tcps_rcvbadsum + tcp.tcps_rcvbadoff + tcp.tcps_rcvmemdrop + tcp.tcps_rcvshort),
-                    0L);
-        }
-        BsdIpstat ip = ipstat.get();
-        BsdUdpstat udp = udpstat.get();
-        return new TcpStats(establishedv4v6.get().getA(), ParseUtil.unsignedIntToLong(tcp.tcps_connattempt),
-                ParseUtil.unsignedIntToLong(tcp.tcps_accepts), ParseUtil.unsignedIntToLong(tcp.tcps_conndrops),
-                ParseUtil.unsignedIntToLong(tcp.tcps_drops),
-                Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_delivered - udp.udps_opackets)),
-                Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_total - udp.udps_ipackets)),
-                ParseUtil.unsignedIntToLong(tcp.tcps_sndrexmitpack),
-                Math.max(0L, ParseUtil.unsignedIntToLong(ip.ips_badsum + ip.ips_tooshort + ip.ips_toosmall
-                        + ip.ips_badhlen + ip.ips_badlen - udp.udps_hdrops + udp.udps_badsum + udp.udps_badlen)),
-                0L);
-    }
-
-    @Override
-    public TcpStats getTCPv6Stats() {
-        BsdIp6stat ip6 = ip6stat.get();
-        BsdUdpstat udp = udpstat.get();
-        return new TcpStats(establishedv4v6.get().getB(), 0L, 0L, 0L, 0L,
-                Math.max(0L, ip6.ip6s_localout - ParseUtil.unsignedIntToLong(udp.udps_snd6_swcsum)),
-                Math.max(0L, ip6.ip6s_total - ParseUtil.unsignedIntToLong(udp.udps_rcv6_swcsum)), 0L, 0L, 0L);
-    }
-
-    @Override
-    public UdpStats getUDPv4Stats() {
-        BsdUdpstat stat = udpstat.get();
-        return new UdpStats(ParseUtil.unsignedIntToLong(stat.udps_opackets),
-                ParseUtil.unsignedIntToLong(stat.udps_ipackets), ParseUtil.unsignedIntToLong(stat.udps_noportmcast),
-                ParseUtil.unsignedIntToLong(stat.udps_hdrops + stat.udps_badsum + stat.udps_badlen));
-    }
-
-    @Override
-    public UdpStats getUDPv6Stats() {
-        BsdUdpstat stat = udpstat.get();
-        return new UdpStats(ParseUtil.unsignedIntToLong(stat.udps_snd6_swcsum),
-                ParseUtil.unsignedIntToLong(stat.udps_rcv6_swcsum), 0L, 0L);
+        super(elevated);
     }
 
     @Override
@@ -236,73 +168,46 @@ public class MacInternetProtocolStatsJNA extends AbstractInternetProtocolStats {
         }
     }
 
-    /*
-     * There are multiple versions of some tcp/udp/ip stats structures in macOS. Since we only need a few of the
-     * hundreds of fields, we can improve performance by selectively reading the ints from the appropriate offsets,
-     * which are consistent across the structure.
-     */
-
-    private static BsdTcpstat queryTcpstat() {
-        BsdTcpstat mt = new BsdTcpstat();
+    @Override
+    protected BsdTcpstat queryTcpstat() {
         try (Memory m = SysctlUtil.sysctl("net.inet.tcp.stats")) {
             if (m != null && m.size() >= 128) {
-                mt.tcps_connattempt = m.getInt(0);
-                mt.tcps_accepts = m.getInt(4);
-                mt.tcps_drops = m.getInt(12);
-                mt.tcps_conndrops = m.getInt(16);
-                mt.tcps_sndpack = m.getInt(64);
-                mt.tcps_sndrexmitpack = m.getInt(72);
-                mt.tcps_rcvpack = m.getInt(104);
-                mt.tcps_rcvbadsum = m.getInt(112);
-                mt.tcps_rcvbadoff = m.getInt(116);
-                mt.tcps_rcvmemdrop = m.getInt(120);
-                mt.tcps_rcvshort = m.getInt(124);
+                return new BsdTcpstat(m.getInt(0), m.getInt(4), m.getInt(12), m.getInt(16), m.getInt(64), m.getInt(72),
+                        m.getInt(104), m.getInt(112), m.getInt(116), m.getInt(120), m.getInt(124));
             }
         }
-        return mt;
+        return new BsdTcpstat(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 
-    private static BsdIpstat queryIpstat() {
-        BsdIpstat mi = new BsdIpstat();
+    @Override
+    protected BsdIpstat queryIpstat() {
         try (Memory m = SysctlUtil.sysctl("net.inet.ip.stats")) {
             if (m != null && m.size() >= 60) {
-                mi.ips_total = m.getInt(0);
-                mi.ips_badsum = m.getInt(4);
-                mi.ips_tooshort = m.getInt(8);
-                mi.ips_toosmall = m.getInt(12);
-                mi.ips_badhlen = m.getInt(16);
-                mi.ips_badlen = m.getInt(20);
-                mi.ips_delivered = m.getInt(56);
+                return new BsdIpstat(m.getInt(0), m.getInt(4), m.getInt(8), m.getInt(12), m.getInt(16), m.getInt(20),
+                        m.getInt(56));
             }
         }
-        return mi;
+        return new BsdIpstat(0, 0, 0, 0, 0, 0, 0);
     }
 
-    private static BsdIp6stat queryIp6stat() {
-        BsdIp6stat mi6 = new BsdIp6stat();
+    @Override
+    protected BsdIp6stat queryIp6stat() {
         try (Memory m = SysctlUtil.sysctl("net.inet6.ip6.stats")) {
             if (m != null && m.size() >= 96) {
-                mi6.ip6s_total = m.getLong(0);
-                mi6.ip6s_localout = m.getLong(88);
+                return new BsdIp6stat(m.getLong(0), m.getLong(88));
             }
         }
-        return mi6;
+        return new BsdIp6stat(0, 0);
     }
 
-    public static BsdUdpstat queryUdpstat() {
-        BsdUdpstat ut = new BsdUdpstat();
+    @Override
+    protected BsdUdpstat queryUdpstat() {
         try (Memory m = SysctlUtil.sysctl("net.inet.udp.stats")) {
             if (m != null && m.size() >= 84) {
-                ut.udps_ipackets = m.getInt(0);
-                ut.udps_hdrops = m.getInt(4);
-                ut.udps_badsum = m.getInt(8);
-                ut.udps_badlen = m.getInt(12);
-                ut.udps_opackets = m.getInt(36);
-                ut.udps_noportmcast = m.getInt(48);
-                ut.udps_rcv6_swcsum = m.getInt(64);
-                ut.udps_snd6_swcsum = m.getInt(80);
+                return new BsdUdpstat(m.getInt(0), m.getInt(4), m.getInt(8), m.getInt(12), m.getInt(36), m.getInt(48),
+                        m.getInt(64), m.getInt(80));
             }
         }
-        return ut;
+        return new BsdUdpstat(0, 0, 0, 0, 0, 0, 0, 0);
     }
 }


### PR DESCRIPTION
## Summary
Deduplicates three pairs of macOS JNA/FFM classes whose logic was identical apart from the native-access backend (JNA `Pointer`/`.release()` vs FFM `MemorySegment`/try-with-resources):

- **NetStat** — the byte-identical `IFdata` carrier moves to a shared `oshi.driver.common.mac.IFdata`; both `NetStat` (JNA) and `NetStatFFM` return it, and `MacNetworkIf*` consume it.
- **MacPowerSource** — the `AppleSmartBattery` registry read and per-source field computation move into the `MacPowerSource` base. `IOKitProvider.RegistryEntry` gains `getIntegerProperty`/`getBooleanProperty` (already implemented in both backends, just not surfaced) so the battery block is shared; the JNA and FFM subclasses now read only the IOKit Power Sources (IOPS) list into `PowerSourceData` carriers.
- **MacInternetProtocolStats** — the TCP/UDP statistics computation, memoizers, and the `tcpstat`/`udpstat`/`ipstat`/`ip6stat` carriers move into a shared `MacInternetProtocolStats` base with abstract sysctl-read hooks; the backend-specific `getConnections()` (proc_* walks) stays in the subclasses.
- Eliminates ~600 duplicated lines across the three pairs.

`MacGpuStats` and `MacUsbDevice` were assessed and deferred to a follow-up: `MacGpuStats` is deeply native across three subsystems (IOReport/SMC/CF-dict) with backend-specific return types, and `MacUsbDevice` needs a recursive registry-tree abstraction beyond the current `IOKitProvider`.

## Test plan
- [x] All pre-commit checks pass locally (spotless, checkstyle, forbiddenapis, javadoc) plus a clean full-reactor build
- [x] `NativeComparisonTest` (JNA==FFM) passes locally on macOS: 39 tests, 0 failures (covers `powerSources`, `internetProtocolStats`, `networkInterfaces`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS-specific TCP/UDP/IP connection statistics added.
  * IOKit property access extended to retrieve integer and boolean values.

* **Refactor**
  * Unified network interface statistics into a shared implementation.
  * Power source construction centralized to a shared build path across macOS providers.

* **Chore**
  * Added tooling suppression for macOS networking naming checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->