### PR TITLE
Hoist common OSProcess fields + add Solaris/AIX /proc base

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -67,6 +67,12 @@
          FFM stat computations read identically. -->
     <suppress checks="MemberName" files="MacInternetProtocolStats\.java"/>
 
+    <!-- AbstractOSProcess holds the common OSProcess attribute fields as protected so each platform's
+         updateAttributes() can assign them directly (the alternative, private fields + protected setters,
+         would churn every native refresh method). -->
+    <suppress checks="VisibilityModifier" files="AbstractOSProcess\.java"/>
+    <suppress checks="VisibilityModifier" files="AbstractProcOSProcess\.java"/>
+
     <!-- BsdOSProcess/BsdOSThread/MacOSProcess are shared OSProcess/OSThread bases; their protected fields are
          populated by the per-backend native updateAttributes() in the subclasses (and the thread id / version are
          set by the per-platform constructors), so they can't be private with accessors. -->

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -46,6 +46,7 @@ module com.github.oshi.common {
     exports oshi.software.common;
     exports oshi.software.common.os.linux;
     exports oshi.software.common.os.mac;
+    exports oshi.software.common.os.unix;
     exports oshi.software.common.os.unix.aix;
     exports oshi.software.common.os.unix.bsd;
     exports oshi.software.common.os.unix.dragonflybsd;

--- a/oshi-common/src/main/java/oshi/software/common/AbstractOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOSProcess.java
@@ -24,6 +24,23 @@ public abstract class AbstractOSProcess implements OSProcess {
 
     private int processID;
 
+    // Common attributes populated by each platform's updateAttributes(). Declared protected (rather than private with
+    // setters) so the platform subclasses can assign them directly in their native refresh methods; see the
+    // VisibilityModifier suppression for this file.
+    protected String name;
+    protected String path = "";
+    protected State state = State.INVALID;
+    protected int parentProcessID;
+    protected int threadCount;
+    protected int priority;
+    protected long virtualSize;
+    protected long kernelTime;
+    protected long userTime;
+    protected long startTime;
+    protected long upTime;
+    protected long bytesRead;
+    protected long bytesWritten;
+
     /**
      * Creates an AbstractOSProcess for the given process ID.
      *
@@ -36,6 +53,71 @@ public abstract class AbstractOSProcess implements OSProcess {
     @Override
     public int getProcessID() {
         return this.processID;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getPath() {
+        return this.path;
+    }
+
+    @Override
+    public State getState() {
+        return this.state;
+    }
+
+    @Override
+    public int getParentProcessID() {
+        return this.parentProcessID;
+    }
+
+    @Override
+    public int getThreadCount() {
+        return this.threadCount;
+    }
+
+    @Override
+    public int getPriority() {
+        return this.priority;
+    }
+
+    @Override
+    public long getVirtualSize() {
+        return this.virtualSize;
+    }
+
+    @Override
+    public long getKernelTime() {
+        return this.kernelTime;
+    }
+
+    @Override
+    public long getUserTime() {
+        return this.userTime;
+    }
+
+    @Override
+    public long getUpTime() {
+        return this.upTime;
+    }
+
+    @Override
+    public long getStartTime() {
+        return this.startTime;
+    }
+
+    @Override
+    public long getBytesRead() {
+        return this.bytesRead;
+    }
+
+    @Override
+    public long getBytesWritten() {
+        return this.bytesWritten;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -82,23 +82,10 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
     private Supplier<String> user = memoize(this::queryUser);
     private Supplier<String> group = memoize(this::queryGroup);
 
-    private String name;
-    private String path = "";
     private String userID;
     private String groupID;
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
     private long residentSetSize;
     private long privateResidentMemory;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
     private long minorFaults;
     private long majorFaults;
     private long voluntaryContextSwitches;
@@ -114,16 +101,6 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         super(pid);
         this.os = os;
         updateAttributes();
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
     }
 
     @Override
@@ -200,31 +177,6 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
     public long getResidentMemory() {
         return this.residentSetSize;
     }
@@ -232,36 +184,6 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
     @Override
     public long getPrivateResidentMemory() {
         return this.privateResidentMemory;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSProcess.java
@@ -4,7 +4,6 @@
  */
 package oshi.software.common.os.mac;
 
-import static oshi.software.os.OSProcess.State.INVALID;
 import static oshi.software.os.OSProcess.State.NEW;
 import static oshi.software.os.OSProcess.State.OTHER;
 import static oshi.software.os.OSProcess.State.RUNNING;
@@ -61,26 +60,13 @@ public abstract class MacOSProcess extends AbstractOSProcess {
     private final Supplier<Pair<List<String>, Map<String, String>>> argsEnviron = memoize(
             this::queryArgsAndEnvironment);
 
-    protected String name = "";
-    protected String path = "";
     protected String currentWorkingDirectory;
     protected String user;
     protected String userID;
     protected String group;
     protected String groupID;
-    protected State state = INVALID;
-    protected int parentProcessID;
-    protected int threadCount;
-    protected int priority;
-    protected long virtualSize;
     protected long residentSetSize;
     protected long memoryFootprint;
-    protected long kernelTime;
-    protected long userTime;
-    protected long startTime;
-    protected long upTime;
-    protected long bytesRead;
-    protected long bytesWritten;
     protected long openFiles;
     protected int bitness;
     protected long minorFaults;
@@ -94,16 +80,8 @@ public abstract class MacOSProcess extends AbstractOSProcess {
         this.majorVersion = major;
         this.minorVersion = minor;
         this.os = os;
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
+        // macOS historically reports an empty (not null) name until updateAttributes() populates it
+        this.name = "";
     }
 
     @Override
@@ -151,21 +129,6 @@ public abstract class MacOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
     public List<OSThread> getThreadDetails() {
         long now = System.currentTimeMillis();
         return ThreadInfo.queryTaskThreads(getProcessID()).stream().parallel().map(stat -> {
@@ -177,16 +140,6 @@ public abstract class MacOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
     public long getResidentMemory() {
         return this.residentSetSize;
     }
@@ -194,36 +147,6 @@ public abstract class MacOSProcess extends AbstractOSProcess {
     @Override
     public long getPrivateResidentMemory() {
         return this.memoryFootprint;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/AbstractProcOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/AbstractProcOSProcess.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix;
+
+import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
+import static oshi.util.Memoizer.memoize;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractOSProcess;
+import oshi.software.os.OSThread;
+import oshi.util.Constants;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
+
+/**
+ * Abstract base for the {@code /proc}-filesystem Unix OSProcess implementations (Solaris and AIX). Both read process
+ * info from {@code /proc}, enumerate threads from {@code /proc/<pid>/lwp}, count open files from
+ * {@code /proc/<pid>/fd}, determine bitness from {@code pflags}, and fall back to a truncated command line. Subclasses
+ * supply their native argument/environment read, their {@link OSThread} factory, and their platform-specific
+ * {@code updateAttributes()}.
+ */
+@ThreadSafe
+public abstract class AbstractProcOSProcess extends AbstractOSProcess {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractProcOSProcess.class);
+
+    private final Supplier<Integer> bitness = memoize(this::queryBitness);
+    private final Supplier<String> commandLine = memoize(this::queryCommandLine);
+    private final Supplier<Pair<List<String>, Map<String, String>>> cmdEnv = memoize(this::queryCommandlineEnvironment);
+
+    // Populated by the subclass updateAttributes()
+    protected String commandLineBackup;
+    protected String user;
+    protected String userID;
+    protected String group;
+    protected String groupID;
+    protected long residentSetSize;
+    protected long privateResidentMemory;
+
+    protected AbstractProcOSProcess(int pid) {
+        super(pid);
+    }
+
+    @Override
+    public String getCommandLine() {
+        return this.commandLine.get();
+    }
+
+    private String queryCommandLine() {
+        String cl = String.join(" ", getArguments());
+        return cl.isEmpty() ? this.commandLineBackup : cl;
+    }
+
+    @Override
+    public List<String> getArguments() {
+        return cmdEnv.get().getA();
+    }
+
+    @Override
+    public Map<String, String> getEnvironmentVariables() {
+        return cmdEnv.get().getB();
+    }
+
+    @Override
+    public String getCurrentWorkingDirectory() {
+        try {
+            String cwdLink = "/proc/" + getProcessID() + "/cwd";
+            String cwd = new File(cwdLink).getCanonicalPath();
+            if (!cwd.equals(cwdLink)) {
+                return cwd;
+            }
+        } catch (IOException e) {
+            LOG.trace("Couldn't find cwd for pid {}: {}", getProcessID(), e.getMessage());
+        }
+        return "";
+    }
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    @Override
+    public String getUserID() {
+        return this.userID;
+    }
+
+    @Override
+    public String getGroup() {
+        return this.group;
+    }
+
+    @Override
+    public String getGroupID() {
+        return this.groupID;
+    }
+
+    @Override
+    public long getResidentMemory() {
+        return this.residentSetSize;
+    }
+
+    @Override
+    public long getPrivateResidentMemory() {
+        return this.privateResidentMemory;
+    }
+
+    @Override
+    public long getOpenFiles() {
+        try (Stream<Path> fd = Files.list(Paths.get("/proc/" + getProcessID() + "/fd"))) {
+            return fd.count();
+        } catch (IOException e) {
+            return 0L;
+        }
+    }
+
+    @Override
+    public int getBitness() {
+        return this.bitness.get();
+    }
+
+    private int queryBitness() {
+        List<String> pflags = ExecutingCommand.runNative("pflags " + getProcessID());
+        for (String line : pflags) {
+            if (line.contains("data model")) {
+                if (line.contains("LP32")) {
+                    return 32;
+                } else if (line.contains("LP64")) {
+                    return 64;
+                }
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public List<OSThread> getThreadDetails() {
+        // Get process files in proc
+        File directory = new File(String.format(Locale.ROOT, "/proc/%d/lwp", getProcessID()));
+        File[] numericFiles = directory.listFiles(file -> Constants.DIGITS.matcher(file.getName()).matches());
+        if (numericFiles == null) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(numericFiles).parallel()
+                .map(lwpidFile -> createThread(ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
+                .filter(VALID_THREAD).collect(Collectors.toList());
+    }
+
+    /**
+     * Reads this process's argument list and environment.
+     *
+     * @return a pair of (arg list, env map); either may be empty if it cannot be read
+     */
+    protected abstract Pair<List<String>, Map<String, String>> queryCommandlineEnvironment();
+
+    /**
+     * Creates a platform-specific {@link OSThread} for the given lwpid of this process.
+     *
+     * @param lwpid the thread (lwp) ID
+     * @return a new OSThread
+     */
+    protected abstract OSThread createThread(int lwpid);
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
@@ -5,76 +5,37 @@
 package oshi.software.common.os.unix.aix;
 
 import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.aix.AixLwpsInfo;
 import oshi.driver.common.unix.aix.AixPsInfo;
 import oshi.driver.common.unix.aix.PsInfo;
-import oshi.software.common.AbstractOSProcess;
+import oshi.software.common.os.unix.AbstractProcOSProcess;
 import oshi.software.os.OSThread;
 import oshi.util.Constants;
-import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.UserGroupInfo;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Quartet;
 
 /**
- * Abstract base for AIX OSProcess. The /proc parsing, command-line/env memoization, thread enumeration, and field
- * assignment are shared; concrete subclasses (JNA/FFM) provide the perfstat lookup, the {@code rlimit} read, the
- * affinity supplier, and the actual {@code queryArgsEnv} address-space read.
+ * Abstract base for AIX OSProcess. The {@code /proc} parsing, command-line/env memoization, thread enumeration, and
+ * field assignment are shared (via {@link AbstractProcOSProcess}); concrete subclasses (JNA/FFM) provide the perfstat
+ * lookup, the {@code rlimit} read, the affinity supplier, and the actual {@code queryArgsEnv} address-space read.
  */
 @ThreadSafe
-public abstract class AixOSProcess extends AbstractOSProcess {
+public abstract class AixOSProcess extends AbstractProcOSProcess {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AixOSProcess.class);
-
-    private final Supplier<Integer> bitnessSupplier = memoize(this::queryBitness);
     private final Supplier<AixPsInfo> psinfo = memoize(this::queryPsInfoMemo, defaultExpiration());
-    private final Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private final Supplier<Pair<List<String>, Map<String, String>>> cmdEnv = memoize(this::queryCommandlineEnvironment);
-
-    private String name;
-    private String path = "";
-    private String commandLineBackup;
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = State.INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long privateResidentMemory;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
 
     protected AixOSProcess(int pid) {
         super(pid);
@@ -85,76 +46,8 @@ public abstract class AixOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        String cl = String.join(" ", getArguments());
-        return cl.isEmpty() ? this.commandLineBackup : cl;
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return cmdEnv.get().getA();
-    }
-
-    @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return cmdEnv.get().getB();
-    }
-
-    private Pair<List<String>, Map<String, String>> queryCommandlineEnvironment() {
+    protected Pair<List<String>, Map<String, String>> queryCommandlineEnvironment() {
         return queryArgsEnv(getProcessID(), psinfo.get());
-    }
-
-    @Override
-    public String getCurrentWorkingDirectory() {
-        try {
-            String cwdLink = "/proc" + getProcessID() + "/cwd";
-            String cwd = new File(cwdLink).getCanonicalPath();
-            if (!cwd.equals(cwdLink)) {
-                return cwd;
-            }
-        } catch (IOException e) {
-            LOG.trace("Couldn't find cwd for pid {}: {}", getProcessID(), e.getMessage());
-        }
-        return "";
-    }
-
-    @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
     }
 
     /**
@@ -170,91 +63,8 @@ public abstract class AixOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getPrivateResidentMemory() {
-        return this.privateResidentMemory;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
-    }
-
-    @Override
-    public long getOpenFiles() {
-        try (Stream<Path> fd = Files.list(Paths.get("/proc/" + getProcessID() + "/fd"))) {
-            return fd.count();
-        } catch (IOException e) {
-            return 0L;
-        }
-    }
-
-    @Override
-    public int getBitness() {
-        return this.bitnessSupplier.get();
-    }
-
-    private int queryBitness() {
-        List<String> pflags = ExecutingCommand.runNative("pflags " + getProcessID());
-        for (String line : pflags) {
-            if (line.contains("data model")) {
-                if (line.contains("LP32")) {
-                    return 32;
-                } else if (line.contains("LP64")) {
-                    return 64;
-                }
-            }
-        }
-        return 0;
+    protected OSThread createThread(int lwpid) {
+        return new AixOSThread(getProcessID(), lwpid);
     }
 
     @Override
@@ -274,19 +84,6 @@ public abstract class AixOSProcess extends AbstractOSProcess {
         }
         mask &= getCpuAffinityMask();
         return mask;
-    }
-
-    @Override
-    public List<OSThread> getThreadDetails() {
-        File directory = new File(String.format(Locale.ROOT, "/proc/%d/lwp", getProcessID()));
-        File[] numericFiles = directory.listFiles(file -> Constants.DIGITS.matcher(file.getName()).matches());
-        if (numericFiles == null) {
-            return Collections.emptyList();
-        }
-        return Arrays.stream(numericFiles).parallel()
-                .map(lwpidFile -> (OSThread) new AixOSThread(getProcessID(),
-                        ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
-                .filter(VALID_THREAD).collect(Collectors.toList());
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
@@ -41,24 +41,11 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
     private final Supplier<List<String>> arguments = memoize(this::queryArguments);
     private final Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
 
-    protected String name;
-    protected String path = "";
     protected String user;
     protected String userID;
     protected String group;
     protected String groupID;
-    protected State state = State.INVALID;
-    protected int parentProcessID;
-    protected int threadCount;
-    protected int priority;
-    protected long virtualSize;
     protected long residentSetSize;
-    protected long kernelTime;
-    protected long userTime;
-    protected long startTime;
-    protected long upTime;
-    protected long bytesRead;
-    protected long bytesWritten;
     protected long minorFaults;
     protected long majorFaults;
     protected long voluntaryContextSwitches;
@@ -67,16 +54,6 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
 
     protected BsdOSProcess(int pid) {
         super(pid);
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
     }
 
     @Override
@@ -120,63 +97,8 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
     public long getResidentMemory() {
         return this.residentSetSize;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/package-info.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides shared abstract base classes for the {@code /proc}-filesystem Unix operating systems
+ */
+package oshi.software.common.os.unix;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
@@ -11,34 +11,19 @@ import static oshi.software.os.OSProcess.State.SLEEPING;
 import static oshi.software.os.OSProcess.State.STOPPED;
 import static oshi.software.os.OSProcess.State.WAITING;
 import static oshi.software.os.OSProcess.State.ZOMBIE;
-import static oshi.software.os.OSThread.ThreadFiltering.VALID_THREAD;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.driver.common.unix.solaris.PsInfo;
 import oshi.driver.common.unix.solaris.SolarisPrUsage;
 import oshi.driver.common.unix.solaris.SolarisPsInfo;
-import oshi.software.common.AbstractOSProcess;
+import oshi.software.common.os.unix.AbstractProcOSProcess;
 import oshi.software.os.OSThread;
-import oshi.util.Constants;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.UserGroupInfo;
@@ -46,39 +31,14 @@ import oshi.util.tuples.Pair;
 
 /**
  * Abstract base for Solaris OSProcess. The {@code /proc} parsing, command-line/env memoization, thread enumeration, and
- * field assignment are shared; concrete subclasses (JNA/FFM) provide the {@code queryArgsEnv} read, the self-process
- * {@code rlimit} read, and the {@link OSThread} factory.
+ * field assignment are shared (via {@link AbstractProcOSProcess}); concrete subclasses (JNA/FFM) provide the
+ * {@code queryArgsEnv} read, the self-process {@code rlimit} read, and the {@link OSThread} factory.
  */
-public abstract class SolarisOSProcess extends AbstractOSProcess {
+public abstract class SolarisOSProcess extends AbstractProcOSProcess {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SolarisOSProcess.class);
-
-    private final Supplier<Integer> bitness = memoize(this::queryBitness);
     private final Supplier<SolarisPsInfo> psinfo = memoize(this::queryPsInfo, defaultExpiration());
-    private final Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private final Supplier<Pair<List<String>, Map<String, String>>> cmdEnv = memoize(this::queryCommandlineEnvironment);
     private final Supplier<SolarisPrUsage> prusage = memoize(this::queryPrUsage, defaultExpiration());
 
-    private String name;
-    private String path = "";
-    private String commandLineBackup;
-    private String user;
-    private String userID;
-    private String group;
-    private String groupID;
-    private State state = State.INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
-    private long residentSetSize;
-    private long residentSetSizePrivate;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
     private long minorFaults;
     private long majorFaults;
     private long voluntaryContextSwitches;
@@ -106,136 +66,8 @@ public abstract class SolarisOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
-    }
-
-    @Override
-    public String getCommandLine() {
-        return this.commandLine.get();
-    }
-
-    private String queryCommandLine() {
-        String cl = String.join(" ", getArguments());
-        return cl.isEmpty() ? this.commandLineBackup : cl;
-    }
-
-    @Override
-    public List<String> getArguments() {
-        return cmdEnv.get().getA();
-    }
-
-    @Override
-    public Map<String, String> getEnvironmentVariables() {
-        return cmdEnv.get().getB();
-    }
-
-    private Pair<List<String>, Map<String, String>> queryCommandlineEnvironment() {
+    protected Pair<List<String>, Map<String, String>> queryCommandlineEnvironment() {
         return queryArgsEnv();
-    }
-
-    @Override
-    public String getCurrentWorkingDirectory() {
-        try {
-            String cwdLink = "/proc/" + getProcessID() + "/cwd";
-            String cwd = new File(cwdLink).getCanonicalPath();
-            if (!cwd.equals(cwdLink)) {
-                return cwd;
-            }
-        } catch (IOException e) {
-            LOG.trace("Couldn't find cwd for pid {}: {}", getProcessID(), e.getMessage());
-        }
-        return "";
-    }
-
-    @Override
-    public String getUser() {
-        return this.user;
-    }
-
-    @Override
-    public String getUserID() {
-        return this.userID;
-    }
-
-    @Override
-    public String getGroup() {
-        return this.group;
-    }
-
-    @Override
-    public String getGroupID() {
-        return this.groupID;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
-    public long getResidentMemory() {
-        return this.residentSetSize;
-    }
-
-    @Override
-    public long getPrivateResidentMemory() {
-        return this.residentSetSizePrivate;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
     }
 
     @Override
@@ -256,34 +88,6 @@ public abstract class SolarisOSProcess extends AbstractOSProcess {
     @Override
     public long getInvoluntaryContextSwitches() {
         return this.involuntaryContextSwitches;
-    }
-
-    @Override
-    public long getOpenFiles() {
-        try (Stream<Path> fd = Files.list(Paths.get("/proc/" + getProcessID() + "/fd"))) {
-            return fd.count();
-        } catch (IOException e) {
-            return 0L;
-        }
-    }
-
-    @Override
-    public int getBitness() {
-        return this.bitness.get();
-    }
-
-    private int queryBitness() {
-        List<String> pflags = ExecutingCommand.runNative("pflags " + getProcessID());
-        for (String line : pflags) {
-            if (line.contains("data model")) {
-                if (line.contains("LP32")) {
-                    return 32;
-                } else if (line.contains("LP64")) {
-                    return 64;
-                }
-            }
-        }
-        return 0;
     }
 
     @Override
@@ -320,20 +124,6 @@ public abstract class SolarisOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public List<OSThread> getThreadDetails() {
-        // Get process files in proc
-        File directory = new File(String.format(Locale.ROOT, "/proc/%d/lwp", getProcessID()));
-        File[] numericFiles = directory.listFiles(file -> Constants.DIGITS.matcher(file.getName()).matches());
-        if (numericFiles == null) {
-            return Collections.emptyList();
-        }
-
-        return Arrays.stream(numericFiles).parallel()
-                .map(lwpidFile -> createThread(ParseUtil.parseIntOrDefault(lwpidFile.getName(), 0)))
-                .filter(VALID_THREAD).collect(Collectors.toList());
-    }
-
-    @Override
     public boolean updateAttributes() {
         SolarisPsInfo info = psinfo.get();
         if (info == null) {
@@ -353,7 +143,7 @@ public abstract class SolarisOSProcess extends AbstractOSProcess {
         // These are in KB, multiply
         this.virtualSize = info.pr_size * 1024;
         this.residentSetSize = info.pr_rssize * 1024;
-        this.residentSetSizePrivate = info.pr_rssizepriv * 1024;
+        this.privateResidentMemory = info.pr_rssizepriv * 1024;
         this.startTime = info.pr_start.toMillis();
         // Avoid divide by zero for processes up less than a millisecond
         long elapsedTime = now - this.startTime;
@@ -441,12 +231,4 @@ public abstract class SolarisOSProcess extends AbstractOSProcess {
      * @return a pair of (arg list, env map); either may be empty if it cannot be read
      */
     protected abstract Pair<List<String>, Map<String, String>> queryArgsEnv();
-
-    /**
-     * Creates a platform-specific {@link OSThread} for the given lwpid of this process.
-     *
-     * @param lwpid the thread (lwp) ID
-     * @return a new OSThread
-     */
-    protected abstract OSThread createThread(int lwpid);
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
@@ -64,21 +64,8 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
             this::queryCwdCommandlineEnvironment);
     private Map<Integer, ThreadPerfCounterBlock> tcb;
 
-    private String name;
-    private String path = "";
-    private State state = INVALID;
-    private int parentProcessID;
-    private int threadCount;
-    private int priority;
-    private long virtualSize;
     private long workingSetSize;
     private long privateWorkingSetSize;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private long bytesRead;
-    private long bytesWritten;
     private long openFiles;
     private int bitness;
     private long pageFaults;
@@ -117,16 +104,6 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
      */
     protected Triplet<String, String, Map<String, String>> getCwdCmdEnv() {
         return cwdCmdEnv.get();
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public String getPath() {
-        return this.path;
     }
 
     @Override
@@ -170,31 +147,6 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public int getParentProcessID() {
-        return this.parentProcessID;
-    }
-
-    @Override
-    public int getThreadCount() {
-        return this.threadCount;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
-    }
-
-    @Override
-    public long getVirtualSize() {
-        return this.virtualSize;
-    }
-
-    @Override
     public long getResidentMemory() {
         return this.workingSetSize;
     }
@@ -202,36 +154,6 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     @Override
     public long getPrivateResidentMemory() {
         return this.privateWorkingSetSize;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getBytesRead() {
-        return this.bytesRead;
-    }
-
-    @Override
-    public long getBytesWritten() {
-        return this.bytesWritten;
     }
 
     @Override

--- a/oshi-common/src/test/java/oshi/software/common/AbstractOSProcessTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/AbstractOSProcessTest.java
@@ -19,7 +19,7 @@ import oshi.software.os.OSThread;
 
 class AbstractOSProcessTest {
 
-    private static AbstractOSProcess createProcess(int pid, long kernelTime, long userTime, long upTime) {
+    private static AbstractOSProcess createProcess(int pid, long kernelTimeArg, long userTimeArg, long upTimeArg) {
         return new AbstractOSProcess(pid) {
             @Override
             public String getName() {
@@ -103,17 +103,17 @@ class AbstractOSProcessTest {
 
             @Override
             public long getKernelTime() {
-                return kernelTime;
+                return kernelTimeArg;
             }
 
             @Override
             public long getUserTime() {
-                return userTime;
+                return userTimeArg;
             }
 
             @Override
             public long getUpTime() {
-                return upTime;
+                return upTimeArg;
             }
 
             @Override


### PR DESCRIPTION
## Summary
Two cross-platform `OSProcess` deduplications (the per-OS bases all extend `AbstractOSProcess`):

- **Hoist 13 uniform attribute fields + trivial getters into `AbstractOSProcess`** — `name`, `path`, `state`, `parentProcessID`, `threadCount`, `priority`, `virtualSize`, `kernelTime`, `userTime`, `startTime`, `upTime`, `bytesRead`, `bytesWritten`. Declared `protected` (with a `VisibilityModifier` suppression) so each platform's `updateAttributes()` keeps assigning them directly — no setter churn. Removed from all six bases (Linux, Windows, macOS, BSD, Solaris, AIX). macOS preserves its historical empty-string `name` default via its constructor.
- **Add `AbstractProcOSProcess`** (`oshi.software.common.os.unix`) for the `/proc`-struct readers Solaris and AIX, sharing `getCurrentWorkingDirectory`, fd-count `getOpenFiles`, `pflags` `getBitness`, the `/proc/<pid>/lwp` thread skeleton (via a `createThread` hook; AIX now implements it concretely), the command-line backup fallback, and the user/group/resident-memory accessors.
- Eliminates ~450 duplicated lines.

Fixes a **pre-existing AIX bug**: `getCurrentWorkingDirectory` built `"/proc" + pid` (missing the slash) instead of `"/proc/" + pid`; the shared base uses the correct path.

Deliberately left per-OS (genuine divergence): `updateAttributes`, `getAffinityMask`, thread factories, args/env container plumbing, and the **state-char mappings** (`R` means RUNNING on Linux/BSD but WAITING on Solaris; macOS uses ints).

## Test plan
- [x] Pre-commit checks (spotless, checkstyle, forbiddenapis, javadoc) + clean full-reactor build
- [x] `NativeComparisonTest` (JNA==FFM) on macOS: 39/39 (covers `currentProcess`, `currentProcessUpdateAttributes`, threads)
- [x] Linux / Windows / macOS via PR CI
- [x] BSD + OpenIndiana (Solaris) via dispatched `unix.yml`; AIX via cfarm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated common process attribute handling across platforms for more consistent process metadata.

* **New Features**
  * Improved /proc-backed Unix implementations: memoized command-line/environment, robust current working directory lookup, open-file counts, bitness detection, and unified thread enumeration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->