### PR TITLE
Use protected fields (not setters) in mutable common bases (NetworkIF, HWDiskStore, OSFileStore)

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -78,6 +78,7 @@
          than via setters. -->
     <suppress checks="VisibilityModifier" files="AbstractNetworkIF\.java"/>
     <suppress checks="VisibilityModifier" files="AbstractHWDiskStore\.java"/>
+    <suppress checks="VisibilityModifier" files="AbstractOSFileStore\.java"/>
 
     <!-- BsdOSProcess/BsdOSThread/MacOSProcess are shared OSProcess/OSThread bases; their protected fields are
          populated by the per-backend native updateAttributes() in the subclasses (and the thread id / version are

--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -77,6 +77,7 @@
          protected so each platform's updateAttributes()/updateNetworkStats() assigns them directly, rather
          than via setters. -->
     <suppress checks="VisibilityModifier" files="AbstractNetworkIF\.java"/>
+    <suppress checks="VisibilityModifier" files="AbstractHWDiskStore\.java"/>
 
     <!-- BsdOSProcess/BsdOSThread/MacOSProcess are shared OSProcess/OSThread bases; their protected fields are
          populated by the per-backend native updateAttributes() in the subclasses (and the thread id / version are

--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -73,6 +73,11 @@
     <suppress checks="VisibilityModifier" files="AbstractOSProcess\.java"/>
     <suppress checks="VisibilityModifier" files="AbstractProcOSProcess\.java"/>
 
+    <!-- Mutable hardware/software value bases follow the AbstractOSProcess model: attribute fields are
+         protected so each platform's updateAttributes()/updateNetworkStats() assigns them directly, rather
+         than via setters. -->
+    <suppress checks="VisibilityModifier" files="AbstractNetworkIF\.java"/>
+
     <!-- BsdOSProcess/BsdOSThread/MacOSProcess are shared OSProcess/OSThread bases; their protected fields are
          populated by the per-backend native updateAttributes() in the subclasses (and the thread id / version are
          set by the per-platform constructors), so they can't be private with accessors. -->

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractHWDiskStore.java
@@ -25,14 +25,17 @@ public abstract class AbstractHWDiskStore implements HWDiskStore {
     private final long size;
     private final String diskType;
 
-    private volatile long reads;
-    private volatile long readBytes;
-    private volatile long writes;
-    private volatile long writeBytes;
-    private volatile long currentQueueLength;
-    private volatile long transferTime;
-    private volatile long timeStamp;
-    private final AtomicReference<List<HWPartition>> partitionList = new AtomicReference<>(Collections.emptyList());
+    // Refreshed by each platform's updateAttributes(); protected (volatile retained for visibility) so subclasses
+    // assign directly, matching the AbstractOSProcess model. See the VisibilityModifier suppression for this file.
+    // The bulk setDiskStats()/setPartitionList() helpers are retained for multi-line and cross-instance call sites.
+    protected volatile long reads;
+    protected volatile long readBytes;
+    protected volatile long writes;
+    protected volatile long writeBytes;
+    protected volatile long currentQueueLength;
+    protected volatile long transferTime;
+    protected volatile long timeStamp;
+    protected final AtomicReference<List<HWPartition>> partitionList = new AtomicReference<>(Collections.emptyList());
 
     /**
      * Creates an AbstractHWDiskStore with unknown disk type.
@@ -147,69 +150,6 @@ public abstract class AbstractHWDiskStore implements HWDiskStore {
         this.writeBytes = writeBytes;
         this.currentQueueLength = currentQueueLength;
         this.transferTime = transferTime;
-        this.timeStamp = timeStamp;
-    }
-
-    /**
-     * Sets the reads.
-     *
-     * @param reads the reads
-     */
-    protected void setReads(long reads) {
-        this.reads = reads;
-    }
-
-    /**
-     * Sets the read bytes.
-     *
-     * @param readBytes the read bytes
-     */
-    protected void setReadBytes(long readBytes) {
-        this.readBytes = readBytes;
-    }
-
-    /**
-     * Sets the writes.
-     *
-     * @param writes the writes
-     */
-    protected void setWrites(long writes) {
-        this.writes = writes;
-    }
-
-    /**
-     * Sets the write bytes.
-     *
-     * @param writeBytes the write bytes
-     */
-    protected void setWriteBytes(long writeBytes) {
-        this.writeBytes = writeBytes;
-    }
-
-    /**
-     * Sets the current queue length.
-     *
-     * @param currentQueueLength the queue length
-     */
-    protected void setCurrentQueueLength(long currentQueueLength) {
-        this.currentQueueLength = currentQueueLength;
-    }
-
-    /**
-     * Sets the transfer time.
-     *
-     * @param transferTime the transfer time in ms
-     */
-    protected void setTransferTime(long transferTime) {
-        this.transferTime = transferTime;
-    }
-
-    /**
-     * Sets the timestamp.
-     *
-     * @param timeStamp the timestamp
-     */
-    protected void setTimeStamp(long timeStamp) {
         this.timeStamp = timeStamp;
     }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -51,16 +51,18 @@ public abstract class AbstractNetworkIF implements NetworkIF {
     private String[] ipv6;
     private Short[] prefixLengths;
 
-    private long bytesRecv;
-    private long bytesSent;
-    private long packetsRecv;
-    private long packetsSent;
-    private long inErrors;
-    private long outErrors;
-    private long inDrops;
-    private long collisions;
-    private long speed;
-    private long timeStamp;
+    // Refreshed by each platform's updateNetworkStats(); protected so subclasses assign directly (see the
+    // VisibilityModifier suppression for this file), matching the AbstractOSProcess model.
+    protected long bytesRecv;
+    protected long bytesSent;
+    protected long packetsRecv;
+    protected long packetsSent;
+    protected long inErrors;
+    protected long outErrors;
+    protected long inDrops;
+    protected long collisions;
+    protected long speed;
+    protected long timeStamp;
 
     private final Supplier<Properties> vmMacAddrProps = memoize(AbstractNetworkIF::queryVmMacAddrProps);
 
@@ -276,96 +278,6 @@ public abstract class AbstractNetworkIF implements NetworkIF {
     @Override
     public long getTimeStamp() {
         return this.timeStamp;
-    }
-
-    /**
-     * Sets the bytes received.
-     *
-     * @param bytesRecv the bytes received
-     */
-    protected void setBytesRecv(long bytesRecv) {
-        this.bytesRecv = bytesRecv;
-    }
-
-    /**
-     * Sets the bytes sent.
-     *
-     * @param bytesSent the bytes sent
-     */
-    protected void setBytesSent(long bytesSent) {
-        this.bytesSent = bytesSent;
-    }
-
-    /**
-     * Sets the packets received.
-     *
-     * @param packetsRecv the packets received
-     */
-    protected void setPacketsRecv(long packetsRecv) {
-        this.packetsRecv = packetsRecv;
-    }
-
-    /**
-     * Sets the packets sent.
-     *
-     * @param packetsSent the packets sent
-     */
-    protected void setPacketsSent(long packetsSent) {
-        this.packetsSent = packetsSent;
-    }
-
-    /**
-     * Sets the input errors.
-     *
-     * @param inErrors the input errors
-     */
-    protected void setInErrors(long inErrors) {
-        this.inErrors = inErrors;
-    }
-
-    /**
-     * Sets the output errors.
-     *
-     * @param outErrors the output errors
-     */
-    protected void setOutErrors(long outErrors) {
-        this.outErrors = outErrors;
-    }
-
-    /**
-     * Sets the input drops.
-     *
-     * @param inDrops the input drops
-     */
-    protected void setInDrops(long inDrops) {
-        this.inDrops = inDrops;
-    }
-
-    /**
-     * Sets the collisions.
-     *
-     * @param collisions the collisions
-     */
-    protected void setCollisions(long collisions) {
-        this.collisions = collisions;
-    }
-
-    /**
-     * Sets the speed.
-     *
-     * @param speed the speed in bits per second
-     */
-    protected void setSpeed(long speed) {
-        this.speed = speed;
-    }
-
-    /**
-     * Sets the timestamp.
-     *
-     * @param timeStamp the timestamp
-     */
-    protected void setTimeStamp(long timeStamp) {
-        this.timeStamp = timeStamp;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
@@ -92,20 +92,20 @@ public abstract class LinuxNetworkIF extends AbstractNetworkIF {
             return false;
         }
 
-        setTimeStamp(System.currentTimeMillis());
+        this.timeStamp = System.currentTimeMillis();
         this.ifType = FileUtil.getIntFromFile(name + "/type");
         this.connectorPresent = FileUtil.getIntFromFile(name + "/carrier") > 0;
-        setBytesSent(FileUtil.getUnsignedLongFromFile(name + "/statistics/tx_bytes"));
-        setBytesRecv(FileUtil.getUnsignedLongFromFile(name + "/statistics/rx_bytes"));
-        setPacketsSent(FileUtil.getUnsignedLongFromFile(name + "/statistics/tx_packets"));
-        setPacketsRecv(FileUtil.getUnsignedLongFromFile(name + "/statistics/rx_packets"));
-        setOutErrors(FileUtil.getUnsignedLongFromFile(name + "/statistics/tx_errors"));
-        setInErrors(FileUtil.getUnsignedLongFromFile(name + "/statistics/rx_errors"));
-        setCollisions(FileUtil.getUnsignedLongFromFile(name + "/statistics/collisions"));
-        setInDrops(FileUtil.getUnsignedLongFromFile(name + "/statistics/rx_dropped"));
+        this.bytesSent = FileUtil.getUnsignedLongFromFile(name + "/statistics/tx_bytes");
+        this.bytesRecv = FileUtil.getUnsignedLongFromFile(name + "/statistics/rx_bytes");
+        this.packetsSent = FileUtil.getUnsignedLongFromFile(name + "/statistics/tx_packets");
+        this.packetsRecv = FileUtil.getUnsignedLongFromFile(name + "/statistics/rx_packets");
+        this.outErrors = FileUtil.getUnsignedLongFromFile(name + "/statistics/tx_errors");
+        this.inErrors = FileUtil.getUnsignedLongFromFile(name + "/statistics/rx_errors");
+        this.collisions = FileUtil.getUnsignedLongFromFile(name + "/statistics/collisions");
+        this.inDrops = FileUtil.getUnsignedLongFromFile(name + "/statistics/rx_dropped");
         long speedMbps = FileUtil.getUnsignedLongFromFile(name + "/speed");
         // speed may be -1 from file.
-        setSpeed(speedMbps < 0 ? 0 : speedMbps * 1000000L);
+        this.speed = speedMbps < 0 ? 0 : speedMbps * 1000000L;
         this.ifAlias = FileUtil.getStringFromFile(name + "/ifalias");
         this.ifOperStatus = parseIfOperStatus(FileUtil.getStringFromFile(name + "/operstate"));
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdNetworkIF.java
@@ -51,20 +51,20 @@ public final class BsdNetworkIF extends AbstractNetworkIF {
     @Override
     public boolean updateAttributes() {
         String stats = ExecutingCommand.getAnswerAt("netstat -bI " + getName(), 1);
-        setTimeStamp(System.currentTimeMillis());
+        this.timeStamp = System.currentTimeMillis();
         String[] split = ParseUtil.whitespaces.split(stats);
         if (split.length < 12) {
             // No update
             return false;
         }
-        setBytesSent(ParseUtil.parseUnsignedLongOrDefault(split[10], 0L));
-        setBytesRecv(ParseUtil.parseUnsignedLongOrDefault(split[7], 0L));
-        setPacketsSent(ParseUtil.parseUnsignedLongOrDefault(split[8], 0L));
-        setPacketsRecv(ParseUtil.parseUnsignedLongOrDefault(split[4], 0L));
-        setOutErrors(ParseUtil.parseUnsignedLongOrDefault(split[9], 0L));
-        setInErrors(ParseUtil.parseUnsignedLongOrDefault(split[5], 0L));
-        setCollisions(ParseUtil.parseUnsignedLongOrDefault(split[11], 0L));
-        setInDrops(ParseUtil.parseUnsignedLongOrDefault(split[6], 0L));
+        this.bytesSent = ParseUtil.parseUnsignedLongOrDefault(split[10], 0L);
+        this.bytesRecv = ParseUtil.parseUnsignedLongOrDefault(split[7], 0L);
+        this.packetsSent = ParseUtil.parseUnsignedLongOrDefault(split[8], 0L);
+        this.packetsRecv = ParseUtil.parseUnsignedLongOrDefault(split[4], 0L);
+        this.outErrors = ParseUtil.parseUnsignedLongOrDefault(split[9], 0L);
+        this.inErrors = ParseUtil.parseUnsignedLongOrDefault(split[5], 0L);
+        this.collisions = ParseUtil.parseUnsignedLongOrDefault(split[11], 0L);
+        this.inDrops = ParseUtil.parseUnsignedLongOrDefault(split[6], 0L);
         return true;
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixHWDiskStore.java
@@ -41,23 +41,23 @@ public abstract class AixHWDiskStore extends AbstractHWDiskStore {
             // No block-split info: attribute all transfers to reads, but stay monotonic with the
             // non-zero branch below — never decrease a previously-reported counter.
             if (stats.xfers > getReads()) {
-                setReads(stats.xfers);
+                this.reads = stats.xfers;
             }
         } else {
             long approximateReads = Math.round(stats.xfers * stats.rblks / (double) blks);
             long approximateWrites = stats.xfers - approximateReads;
             if (approximateReads > getReads()) {
-                setReads(approximateReads);
+                this.reads = approximateReads;
             }
             if (approximateWrites > getWrites()) {
-                setWrites(approximateWrites);
+                this.writes = approximateWrites;
             }
         }
-        setReadBytes(stats.rblks * stats.bsize);
-        setWriteBytes(stats.wblks * stats.bsize);
-        setCurrentQueueLength(stats.qdepth);
-        setTransferTime(stats.time);
-        setTimeStamp(now);
+        this.readBytes = stats.rblks * stats.bsize;
+        this.writeBytes = stats.wblks * stats.bsize;
+        this.currentQueueLength = stats.qdepth;
+        this.transferTime = stats.time;
+        this.timeStamp = now;
         return true;
     }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixNetworkIF.java
@@ -39,16 +39,16 @@ public abstract class AixNetworkIF extends AbstractNetworkIF {
         if (stats == null) {
             return false;
         }
-        setBytesSent(stats.bytesSent);
-        setBytesRecv(stats.bytesRecv);
-        setPacketsSent(stats.packetsSent);
-        setPacketsRecv(stats.packetsRecv);
-        setOutErrors(stats.outErrors);
-        setInErrors(stats.inErrors);
-        setCollisions(stats.collisions);
-        setInDrops(stats.inDrops);
-        setSpeed(stats.speed);
-        setTimeStamp(System.currentTimeMillis());
+        this.bytesSent = stats.bytesSent;
+        this.bytesRecv = stats.bytesRecv;
+        this.packetsSent = stats.packetsSent;
+        this.packetsRecv = stats.packetsRecv;
+        this.outErrors = stats.outErrors;
+        this.inErrors = stats.inErrors;
+        this.collisions = stats.collisions;
+        this.inDrops = stats.inDrops;
+        this.speed = stats.speed;
+        this.timeStamp = System.currentTimeMillis();
         return true;
     }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
@@ -44,13 +44,13 @@ public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
                 continue;
             }
             diskFound = true;
-            setReads((long) ParseUtil.parseDoubleOrDefault(split[1], 0d));
-            setWrites((long) ParseUtil.parseDoubleOrDefault(split[2], 0d));
-            setReadBytes((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024));
-            setWriteBytes((long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024));
-            setCurrentQueueLength(ParseUtil.parseLongOrDefault(split[5], 0L));
-            setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
-            setTimeStamp(now);
+            this.reads = (long) ParseUtil.parseDoubleOrDefault(split[1], 0d);
+            this.writes = (long) ParseUtil.parseDoubleOrDefault(split[2], 0d);
+            this.readBytes = (long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024);
+            this.writeBytes = (long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024);
+            this.currentQueueLength = ParseUtil.parseLongOrDefault(split[5], 0L);
+            this.transferTime = (long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000);
+            this.timeStamp = now;
         }
         return diskFound;
     }
@@ -84,17 +84,17 @@ public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
                 Triplet<String, String, Long> storeInfo = diskInfoMap.get(split[0]);
                 T store = (storeInfo == null) ? factory.create(split[0], Constants.UNKNOWN, Constants.UNKNOWN, 0L)
                         : factory.create(split[0], storeInfo.getA(), storeInfo.getB(), storeInfo.getC());
-                store.setReads((long) ParseUtil.parseDoubleOrDefault(split[1], 0d));
-                store.setWrites((long) ParseUtil.parseDoubleOrDefault(split[2], 0d));
-                store.setReadBytes((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024));
-                store.setWriteBytes((long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024));
-                store.setCurrentQueueLength(ParseUtil.parseLongOrDefault(split[5], 0L));
-                store.setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000));
+                store.reads = (long) ParseUtil.parseDoubleOrDefault(split[1], 0d);
+                store.writes = (long) ParseUtil.parseDoubleOrDefault(split[2], 0d);
+                store.readBytes = (long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1024);
+                store.writeBytes = (long) (ParseUtil.parseDoubleOrDefault(split[4], 0d) * 1024);
+                store.currentQueueLength = ParseUtil.parseLongOrDefault(split[5], 0L);
+                store.transferTime = (long) (ParseUtil.parseDoubleOrDefault(split[6], 0d) * 1000);
                 store.setPartitionList(
                         Collections.unmodifiableList(partitionMap.getOrDefault(split[0], Collections.emptyList())
                                 .stream().sorted(Comparator.comparing(HWPartition::getName))
                                 .collect(java.util.stream.Collectors.toList())));
-                store.setTimeStamp(now);
+                store.timeStamp = now;
                 diskList.add(store);
             }
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
@@ -111,13 +111,13 @@ public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
                 long writes = ParseUtil.parseLongOrDefault(split[6], 0L);
                 double readKBPerTransfer = ParseUtil.parseDoubleOrDefault(split[1], 0d);
                 double writeKBPerTransfer = ParseUtil.parseDoubleOrDefault(split[5], 0d);
-                setReads(reads);
-                setWrites(writes);
-                setReadBytes((long) (readKBPerTransfer * reads * 1024));
-                setWriteBytes((long) (writeKBPerTransfer * writes * 1024));
-                setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1000)
-                        + (long) (ParseUtil.parseDoubleOrDefault(split[7], 0d) * 1000));
-                setTimeStamp(now);
+                this.reads = reads;
+                this.writes = writes;
+                this.readBytes = (long) (readKBPerTransfer * reads * 1024);
+                this.writeBytes = (long) (writeKBPerTransfer * writes * 1024);
+                this.transferTime = (long) (ParseUtil.parseDoubleOrDefault(split[3], 0d) * 1000)
+                        + (long) (ParseUtil.parseDoubleOrDefault(split[7], 0d) * 1000);
+                this.timeStamp = now;
                 break;
             }
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
@@ -54,24 +54,24 @@ public final class NetBsdNetworkIF extends AbstractNetworkIF {
         // Name Mtu Network Address Ibytes Obytes
         // wm0 1500 <Link> 52:54:00:12:34:56 689584214 13656411
         String stats = ExecutingCommand.getAnswerAt("netstat -bI " + getName(), 1);
-        setTimeStamp(System.currentTimeMillis());
+        this.timeStamp = System.currentTimeMillis();
         String[] split = ParseUtil.whitespaces.split(stats);
         if (split.length < 6) {
             return false;
         }
-        setBytesRecv(ParseUtil.parseUnsignedLongOrDefault(split[4], 0L));
-        setBytesSent(ParseUtil.parseUnsignedLongOrDefault(split[5], 0L));
+        this.bytesRecv = ParseUtil.parseUnsignedLongOrDefault(split[4], 0L);
+        this.bytesSent = ParseUtil.parseUnsignedLongOrDefault(split[5], 0L);
 
         // Get packet counts from netstat -iI <name> (without -b)
         // Name Mtu Network Address Ipkts Ierrs Opkts Oerrs Coll
         String pktStats = ExecutingCommand.getAnswerAt("netstat -iI " + getName(), 1);
         String[] pktSplit = ParseUtil.whitespaces.split(pktStats);
         if (pktSplit.length >= 9) {
-            setPacketsRecv(ParseUtil.parseUnsignedLongOrDefault(pktSplit[4], 0L));
-            setInErrors(ParseUtil.parseUnsignedLongOrDefault(pktSplit[5], 0L));
-            setPacketsSent(ParseUtil.parseUnsignedLongOrDefault(pktSplit[6], 0L));
-            setOutErrors(ParseUtil.parseUnsignedLongOrDefault(pktSplit[7], 0L));
-            setCollisions(ParseUtil.parseUnsignedLongOrDefault(pktSplit[8], 0L));
+            this.packetsRecv = ParseUtil.parseUnsignedLongOrDefault(pktSplit[4], 0L);
+            this.inErrors = ParseUtil.parseUnsignedLongOrDefault(pktSplit[5], 0L);
+            this.packetsSent = ParseUtil.parseUnsignedLongOrDefault(pktSplit[6], 0L);
+            this.outErrors = ParseUtil.parseUnsignedLongOrDefault(pktSplit[7], 0L);
+            this.collisions = ParseUtil.parseUnsignedLongOrDefault(pktSplit[8], 0L);
         }
         return true;
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
@@ -106,12 +106,12 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
             String[] split = ParseUtil.whitespaces.split(line);
             if (split.length >= 6 && split[0].equals(getName())) {
                 diskFound = true;
-                setReadBytes(ParseUtil.parseMultipliedToLongs(split[1]));
-                setWriteBytes(ParseUtil.parseMultipliedToLongs(split[2]));
-                setReads((long) ParseUtil.parseDoubleOrDefault(split[3], 0d));
-                setWrites((long) ParseUtil.parseDoubleOrDefault(split[4], 0d));
-                setTransferTime((long) (ParseUtil.parseDoubleOrDefault(split[5], 0d) * 1000));
-                setTimeStamp(now);
+                this.readBytes = ParseUtil.parseMultipliedToLongs(split[1]);
+                this.writeBytes = ParseUtil.parseMultipliedToLongs(split[2]);
+                this.reads = (long) ParseUtil.parseDoubleOrDefault(split[3], 0d);
+                this.writes = (long) ParseUtil.parseDoubleOrDefault(split[4], 0d);
+                this.transferTime = (long) (ParseUtil.parseDoubleOrDefault(split[5], 0d) * 1000);
+                this.timeStamp = now;
             }
         }
         return diskFound;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisHWDiskStore.java
@@ -52,18 +52,18 @@ public abstract class SolarisHWDiskStore extends AbstractHWDiskStore {
 
     @Override
     public boolean updateAttributes() {
-        setTimeStamp(System.currentTimeMillis());
+        this.timeStamp = System.currentTimeMillis();
         DiskStats stats = queryStats();
         if (stats == null) {
             return false;
         }
-        setReads(stats.reads);
-        setWrites(stats.writes);
-        setReadBytes(stats.readBytes);
-        setWriteBytes(stats.writeBytes);
-        setCurrentQueueLength(stats.currentQueueLength);
-        setTransferTime(stats.transferTime);
-        setTimeStamp(stats.timeStamp);
+        this.reads = stats.reads;
+        this.writes = stats.writes;
+        this.readBytes = stats.readBytes;
+        this.writeBytes = stats.writeBytes;
+        this.currentQueueLength = stats.currentQueueLength;
+        this.transferTime = stats.transferTime;
+        this.timeStamp = stats.timeStamp;
         return true;
     }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisNetworkIF.java
@@ -51,21 +51,21 @@ public abstract class SolarisNetworkIF extends AbstractNetworkIF {
     @Override
     public boolean updateAttributes() {
         // Initialize to a sane default value
-        setTimeStamp(System.currentTimeMillis());
+        this.timeStamp = System.currentTimeMillis();
         IfStats stats = queryStats();
         if (stats == null) {
             return false;
         }
-        setBytesSent(stats.bytesSent);
-        setBytesRecv(stats.bytesRecv);
-        setPacketsSent(stats.packetsSent);
-        setPacketsRecv(stats.packetsRecv);
-        setOutErrors(stats.outErrors);
-        setInErrors(stats.inErrors);
-        setCollisions(stats.collisions);
-        setInDrops(stats.inDrops);
-        setSpeed(stats.speed);
-        setTimeStamp(stats.timeStamp);
+        this.bytesSent = stats.bytesSent;
+        this.bytesRecv = stats.bytesRecv;
+        this.packetsSent = stats.packetsSent;
+        this.packetsRecv = stats.packetsRecv;
+        this.outErrors = stats.outErrors;
+        this.inErrors = stats.inErrors;
+        this.collisions = stats.collisions;
+        this.inDrops = stats.inDrops;
+        this.speed = stats.speed;
+        this.timeStamp = stats.timeStamp;
         return true;
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/AbstractOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOSFileStore.java
@@ -21,15 +21,18 @@ public abstract class AbstractOSFileStore implements OSFileStore {
     private String uuid;
     private boolean local;
 
-    private volatile String logicalVolume;
-    private volatile String description;
-    private volatile String fsType;
+    // Mutable state refreshed by updateFrom()/updateSpace*(); protected (volatile retained) to match the
+    // AbstractOSProcess model. See the VisibilityModifier suppression for this file. The bulk update helpers are
+    // retained; the immutable identity fields above stay private.
+    protected volatile String logicalVolume;
+    protected volatile String description;
+    protected volatile String fsType;
 
-    private volatile long freeSpace;
-    private volatile long usableSpace;
-    private volatile long totalSpace;
-    private volatile long freeInodes;
-    private volatile long totalInodes;
+    protected volatile long freeSpace;
+    protected volatile long usableSpace;
+    protected volatile long totalSpace;
+    protected volatile long freeInodes;
+    protected volatile long totalInodes;
 
     /**
      * Creates an AbstractOSFileStore with all parameters.

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractHWDiskStoreTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractHWDiskStoreTest.java
@@ -38,7 +38,7 @@ class AbstractHWDiskStoreTest {
         }
 
         void applyCurrentQueueLength(long queueLen) {
-            setCurrentQueueLength(queueLen);
+            this.currentQueueLength = queueLen;
         }
 
         void applyPartitions(List<HWPartition> parts) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -113,23 +113,23 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                                 MemorySegment result = properties.getValue(cfKeyMap.get(CFKey.STATISTICS));
                                 if (!result.equals(MemorySegment.NULL)) {
                                     MemorySegment statsSeg = result;
-                                    setTimeStamp(System.currentTimeMillis());
+                                    this.timeStamp = System.currentTimeMillis();
 
                                     result = CFDictionaryRef.getValue(statsSeg, cfKeyMap.get(CFKey.READ_OPS));
                                     if (!result.equals(MemorySegment.NULL)) {
-                                        setReads(CFNumberRef.longValue(result));
+                                        this.reads = CFNumberRef.longValue(result);
                                     }
                                     result = CFDictionaryRef.getValue(statsSeg, cfKeyMap.get(CFKey.READ_BYTES));
                                     if (!result.equals(MemorySegment.NULL)) {
-                                        setReadBytes(CFNumberRef.longValue(result));
+                                        this.readBytes = CFNumberRef.longValue(result);
                                     }
                                     result = CFDictionaryRef.getValue(statsSeg, cfKeyMap.get(CFKey.WRITE_OPS));
                                     if (!result.equals(MemorySegment.NULL)) {
-                                        setWrites(CFNumberRef.longValue(result));
+                                        this.writes = CFNumberRef.longValue(result);
                                     }
                                     result = CFDictionaryRef.getValue(statsSeg, cfKeyMap.get(CFKey.WRITE_BYTES));
                                     if (!result.equals(MemorySegment.NULL)) {
-                                        setWriteBytes(CFNumberRef.longValue(result));
+                                        this.writeBytes = CFNumberRef.longValue(result);
                                     }
 
                                     MemorySegment readTimeResult = CFDictionaryRef.getValue(statsSeg,
@@ -140,7 +140,7 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                                             && !writeTimeResult.equals(MemorySegment.NULL)) {
                                         long xferTime = CFNumberRef.longValue(readTimeResult);
                                         xferTime += CFNumberRef.longValue(writeTimeResult);
-                                        setTransferTime(xferTime / 1_000_000L);
+                                        this.transferTime = xferTime / 1_000_000L;
                                     }
                                 }
                             }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
@@ -91,16 +91,16 @@ public final class MacNetworkIfFFM extends MacNetworkIF {
         if (data.containsKey(index)) {
             IFdata ifData = data.get(index);
             setIfType(ifData.getIfType());
-            setBytesSent(ifData.getOBytes());
-            setBytesRecv(ifData.getIBytes());
-            setPacketsSent(ifData.getOPackets());
-            setPacketsRecv(ifData.getIPackets());
-            setOutErrors(ifData.getOErrors());
-            setInErrors(ifData.getIErrors());
-            setCollisions(ifData.getCollisions());
-            setInDrops(ifData.getIDrops());
-            setSpeed(ifData.getSpeed());
-            setTimeStamp(ifData.getTimeStamp());
+            this.bytesSent = ifData.getOBytes();
+            this.bytesRecv = ifData.getIBytes();
+            this.packetsSent = ifData.getOPackets();
+            this.packetsRecv = ifData.getIPackets();
+            this.outErrors = ifData.getOErrors();
+            this.inErrors = ifData.getIErrors();
+            this.collisions = ifData.getCollisions();
+            this.inDrops = ifData.getIDrops();
+            this.speed = ifData.getSpeed();
+            this.timeStamp = ifData.getTimeStamp();
             return true;
         }
         return false;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
@@ -97,15 +97,15 @@ public final class WindowsNetworkIfFFM extends AbstractNetworkIF {
             this.ndisPhysicalMediumType = ifRow.get(ValueLayout.JAVA_INT, IPHlpAPIFFM.OFFSET_PHYSICAL_MEDIUM_TYPE);
             byte flags = ifRow.get(ValueLayout.JAVA_BYTE, IPHlpAPIFFM.OFFSET_FLAGS);
             this.connectorPresent = (flags & CONNECTOR_PRESENT_BIT) > 0;
-            setSpeed(ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_RECEIVE_LINK_SPEED));
-            setBytesRecv(ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_OCTETS));
-            setPacketsRecv(ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_UCAST_PKTS));
-            setInErrors(ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_ERRORS));
-            setInDrops(ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_DISCARDS));
-            setBytesSent(ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_OCTETS));
-            setPacketsSent(ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_UCAST_PKTS));
-            setOutErrors(ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_ERRORS));
-            setCollisions(ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_DISCARDS));
+            this.speed = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_RECEIVE_LINK_SPEED);
+            this.bytesRecv = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_OCTETS);
+            this.packetsRecv = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_UCAST_PKTS);
+            this.inErrors = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_ERRORS);
+            this.inDrops = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_DISCARDS);
+            this.bytesSent = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_OCTETS);
+            this.packetsSent = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_UCAST_PKTS);
+            this.outErrors = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_ERRORS);
+            this.collisions = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_DISCARDS);
             // Alias is WCHAR[257] at OFFSET_ALIAS
             MemorySegment aliasSlice = ifRow.asSlice(IPHlpAPIFFM.OFFSET_ALIAS, 257 * 2L);
             this.ifAlias = readWideString(aliasSlice);
@@ -115,7 +115,7 @@ public final class WindowsNetworkIfFFM extends AbstractNetworkIF {
         }, LOG, ERROR, "Failed to retrieve data for interface " + queryNetworkInterface().getIndex() + ", " + getName(),
                 false);
         if (success) {
-            setTimeStamp(System.currentTimeMillis());
+            this.timeStamp = System.currentTimeMillis();
         }
         return success;
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
@@ -106,22 +106,22 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
                             // statistics we need on it. Fetch them
                             Pointer result = properties.getValue(cfKeyMap.get(CFKey.STATISTICS));
                             CFDictionaryRef statistics = new CFDictionaryRef(result);
-                            setTimeStamp(System.currentTimeMillis());
+                            this.timeStamp = System.currentTimeMillis();
 
                             // Now get the stats we want
                             result = statistics.getValue(cfKeyMap.get(CFKey.READ_OPS));
                             CFNumberRef stat = new CFNumberRef(result);
-                            setReads(stat.longValue());
+                            this.reads = stat.longValue();
                             result = statistics.getValue(cfKeyMap.get(CFKey.READ_BYTES));
                             stat.setPointer(result);
-                            setReadBytes(stat.longValue());
+                            this.readBytes = stat.longValue();
 
                             result = statistics.getValue(cfKeyMap.get(CFKey.WRITE_OPS));
                             stat.setPointer(result);
-                            setWrites(stat.longValue());
+                            this.writes = stat.longValue();
                             result = statistics.getValue(cfKeyMap.get(CFKey.WRITE_BYTES));
                             stat.setPointer(result);
-                            setWriteBytes(stat.longValue());
+                            this.writeBytes = stat.longValue();
 
                             // Total time is in nanoseconds. Add read+write
                             // and convert total to ms
@@ -133,7 +133,7 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
                                 long xferTime = stat.longValue();
                                 stat.setPointer(writeTimeResult);
                                 xferTime += stat.longValue();
-                                setTransferTime(xferTime / 1_000_000L);
+                                this.transferTime = xferTime / 1_000_000L;
                             }
 
                             properties.release();

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIfJNA.java
@@ -90,16 +90,16 @@ public final class MacNetworkIfJNA extends MacNetworkIF {
         if (data.containsKey(index)) {
             IFdata ifData = data.get(index);
             setIfType(ifData.getIfType());
-            setBytesSent(ifData.getOBytes());
-            setBytesRecv(ifData.getIBytes());
-            setPacketsSent(ifData.getOPackets());
-            setPacketsRecv(ifData.getIPackets());
-            setOutErrors(ifData.getOErrors());
-            setInErrors(ifData.getIErrors());
-            setCollisions(ifData.getCollisions());
-            setInDrops(ifData.getIDrops());
-            setSpeed(ifData.getSpeed());
-            setTimeStamp(ifData.getTimeStamp());
+            this.bytesSent = ifData.getOBytes();
+            this.bytesRecv = ifData.getIBytes();
+            this.packetsSent = ifData.getOPackets();
+            this.packetsRecv = ifData.getIPackets();
+            this.outErrors = ifData.getOErrors();
+            this.inErrors = ifData.getIErrors();
+            this.collisions = ifData.getCollisions();
+            this.inDrops = ifData.getIDrops();
+            this.speed = ifData.getSpeed();
+            this.timeStamp = ifData.getTimeStamp();
             return true;
         }
         return false;

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
@@ -103,15 +103,15 @@ public final class WindowsNetworkIfJNA extends AbstractNetworkIF {
                 this.ifType = ifRow.Type;
                 this.ndisPhysicalMediumType = ifRow.PhysicalMediumType;
                 this.connectorPresent = (ifRow.InterfaceAndOperStatusFlags & CONNECTOR_PRESENT_BIT) > 0;
-                setBytesSent(ifRow.OutOctets);
-                setBytesRecv(ifRow.InOctets);
-                setPacketsSent(ifRow.OutUcastPkts);
-                setPacketsRecv(ifRow.InUcastPkts);
-                setOutErrors(ifRow.OutErrors);
-                setInErrors(ifRow.InErrors);
-                setCollisions(ifRow.OutDiscards);
-                setInDrops(ifRow.InDiscards);
-                setSpeed(ifRow.ReceiveLinkSpeed);
+                this.bytesSent = ifRow.OutOctets;
+                this.bytesRecv = ifRow.InOctets;
+                this.packetsSent = ifRow.OutUcastPkts;
+                this.packetsRecv = ifRow.InUcastPkts;
+                this.outErrors = ifRow.OutErrors;
+                this.inErrors = ifRow.InErrors;
+                this.collisions = ifRow.OutDiscards;
+                this.inDrops = ifRow.InDiscards;
+                this.speed = ifRow.ReceiveLinkSpeed;
                 this.ifAlias = Native.toString(ifRow.Alias);
                 this.ifOperStatus = IfOperStatus.byValue(ifRow.OperStatus);
             }
@@ -127,20 +127,20 @@ public final class WindowsNetworkIfJNA extends AbstractNetworkIF {
                 }
                 this.ifType = ifRow.dwType;
                 // These are unsigned ints. Widen them to longs.
-                setBytesSent(ParseUtil.unsignedIntToLong(ifRow.dwOutOctets));
-                setBytesRecv(ParseUtil.unsignedIntToLong(ifRow.dwInOctets));
-                setPacketsSent(ParseUtil.unsignedIntToLong(ifRow.dwOutUcastPkts));
-                setPacketsRecv(ParseUtil.unsignedIntToLong(ifRow.dwInUcastPkts));
-                setOutErrors(ParseUtil.unsignedIntToLong(ifRow.dwOutErrors));
-                setInErrors(ParseUtil.unsignedIntToLong(ifRow.dwInErrors));
-                setCollisions(ParseUtil.unsignedIntToLong(ifRow.dwOutDiscards));
-                setInDrops(ParseUtil.unsignedIntToLong(ifRow.dwInDiscards));
-                setSpeed(ParseUtil.unsignedIntToLong(ifRow.dwSpeed));
+                this.bytesSent = ParseUtil.unsignedIntToLong(ifRow.dwOutOctets);
+                this.bytesRecv = ParseUtil.unsignedIntToLong(ifRow.dwInOctets);
+                this.packetsSent = ParseUtil.unsignedIntToLong(ifRow.dwOutUcastPkts);
+                this.packetsRecv = ParseUtil.unsignedIntToLong(ifRow.dwInUcastPkts);
+                this.outErrors = ParseUtil.unsignedIntToLong(ifRow.dwOutErrors);
+                this.inErrors = ParseUtil.unsignedIntToLong(ifRow.dwInErrors);
+                this.collisions = ParseUtil.unsignedIntToLong(ifRow.dwOutDiscards);
+                this.inDrops = ParseUtil.unsignedIntToLong(ifRow.dwInDiscards);
+                this.speed = ParseUtil.unsignedIntToLong(ifRow.dwSpeed);
                 this.ifAlias = ""; // not supported by MIB_IFROW
                 this.ifOperStatus = IfOperStatus.UNKNOWN; // not supported
             }
         }
-        setTimeStamp(System.currentTimeMillis());
+        this.timeStamp = System.currentTimeMillis();
         return true;
     }
 }


### PR DESCRIPTION
## Summary
Aligns the mutable common value-bases with the `AbstractOSProcess` model — `protected` attribute fields assigned in place by each platform, rather than per-field setters. One commit per class.

- **AbstractNetworkIF** — 10 stat fields → `protected`; 10 per-field setters removed; subclasses assign directly in `updateNetworkStats()`.
- **AbstractHWDiskStore** — 7 stat fields (`volatile` retained) + `partitionList` `AtomicReference` → `protected`; 7 per-field setters removed. Immutable identity fields (name/model/serial/size/diskType) stay `final`; the bulk `setDiskStats(...)`/`setPartitionList(...)` helpers are kept (Windows `DiskStats` mapping + multi-line/cross-instance factory call sites).
- **AbstractOSFileStore** — mutable space/inode/type fields (`volatile` retained) → `protected`; identity fields stay private; the bulk `updateFrom()`/`updateSpace*()` helpers are kept (no per-field setters existed, so no subclass call sites change).
- Each gets a per-file `VisibilityModifier` suppression.

**Deliberately left unchanged** (immutability applies): `AbstractPowerSource` is a fully-constructed all-args value object (private fields, no setters, no subclass field access — assigned only within the base ctor + `updateAttributes()`); flipping it would add a suppression for no benefit and unwind the factory. The pure value-object snapshots (UsbDevice/GraphicsCard/Display/Printer/SoundCard/Bluetooth) and the field-less Pattern-D bases are untouched.

No behavior change. Caught + fixed a latent issue while converting: a NetBSD `setReads(reads)` (local named like the field) became a correct `this.reads = reads` rather than a self-assignment.

## Test plan
- [x] spotless / checkstyle / forbiddenapis / javadoc + clean full-reactor build (incl. test compile, which caught a test-double using a removed setter)
- [x] `NativeComparisonTest` (JNA==FFM) on macOS: 39/39 (diskStores, networkInterfaces, + updateAttributes variants)
- [x] Linux/Windows/macOS via PR CI; BSD + OpenIndiana via dispatched unix.yml; AIX via cfarm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Internal code reorganization across multiple platform implementations (Linux, BSD, macOS, Windows, Solaris, AIX) to standardize how system data updates are handled and processed more consistently. This structural improvement enhances code maintainability and consistency by refining internal data access patterns for hardware statistics, network interface metrics, and file system information management throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->