### PR TITLE
Resolve test-intentionality Sonar findings (S2699, S5838, S8714)

### DIFF
--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -152,7 +152,7 @@ class NativeComparisonTest {
         }
         long[][] jnaProc = jna.getProcessorCpuLoadTicks();
         long[][] ffmProc = ffm.getProcessorCpuLoadTicks();
-        assertThat(ffmProc.length).as("processorCpuLoadTicks length").isEqualTo(jnaProc.length);
+        assertThat(ffmProc).as("processorCpuLoadTicks dimensions").hasSameDimensionsAs(jnaProc);
     }
 
     /** Compares 1-, 5-, and 15-minute system load averages. */
@@ -706,8 +706,7 @@ class NativeComparisonTest {
         // Count unique tuples present in both
         Set<String> intersection = new HashSet<>(ffmKeys);
         intersection.retainAll(jnaKeys);
-        assertThat(intersection.size()).as("unique connection tuple overlap")
-                .isGreaterThanOrEqualTo(ffmKeys.size() / 4);
+        assertThat(intersection).as("unique connection tuple overlap").hasSizeGreaterThanOrEqualTo(ffmKeys.size() / 4);
 
         // Verify structural correctness of FFM connections
         for (InternetProtocolStats.IPConnection c : ffmConns) {

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeFreeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeFreeComparisonTest.java
@@ -131,7 +131,7 @@ class NativeFreeComparisonTest {
         assertThat(nfTicks).hasSameSizeAs(jnaTicks);
         long[][] jnaProc = jna.getProcessorCpuLoadTicks();
         long[][] nfProc = nf.getProcessorCpuLoadTicks();
-        assertThat(nfProc.length).isEqualTo(jnaProc.length);
+        assertThat(nfProc).hasSameDimensionsAs(jnaProc);
     }
 
     // ---- Hardware: Memory ----
@@ -194,7 +194,7 @@ class NativeFreeComparisonTest {
             }
             assertThat(n.getSize()).isEqualTo(j.getSize());
             assertThat(n.getReads()).as("reads(%s)", j.getName()).isGreaterThanOrEqualTo(j.getReads());
-            assertThat(n.getPartitions().size()).as("partitions(%s)", j.getName()).isEqualTo(j.getPartitions().size());
+            assertThat(n.getPartitions()).as("partitions(%s)", j.getName()).hasSameSizeAs(j.getPartitions());
         }
     }
 

--- a/oshi-benchmark/src/test/java/oshi/comparison/RegistryComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/RegistryComparisonTest.java
@@ -43,8 +43,8 @@ class RegistryComparisonTest {
         Set<Integer> commonPids = new HashSet<>(reg.keySet());
         commonPids.retainAll(pdh.keySet());
         int minSize = Math.min(reg.size(), pdh.size());
-        assertThat(commonPids.size()).as("common PID overlap (reg=%d, pdh=%d)", reg.size(), pdh.size())
-                .isGreaterThanOrEqualTo((minSize * 90 + 99) / 100);
+        assertThat(commonPids).as("common PID overlap (reg=%d, pdh=%d)", reg.size(), pdh.size())
+                .hasSizeGreaterThanOrEqualTo((minSize * 90 + 99) / 100);
 
         for (int pid : commonPids) {
             ProcessPerfCounterBlock r = reg.get(pid);
@@ -86,8 +86,8 @@ class RegistryComparisonTest {
         Set<Integer> commonTids = new HashSet<>(reg.keySet());
         commonTids.retainAll(pdh.keySet());
         int minSize = Math.min(reg.size(), pdh.size());
-        assertThat(commonTids.size()).as("common TID overlap (reg=%d, pdh=%d)", reg.size(), pdh.size())
-                .isGreaterThanOrEqualTo((minSize * 90 + 99) / 100);
+        assertThat(commonTids).as("common TID overlap (reg=%d, pdh=%d)", reg.size(), pdh.size())
+                .hasSizeGreaterThanOrEqualTo((minSize * 90 + 99) / 100);
 
         for (int tid : commonTids) {
             ThreadPerfCounterBlock r = reg.get(tid);

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOSProcessTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOSProcessTest.java
@@ -6,6 +6,7 @@ package oshi.software.common.os.linux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -72,7 +73,7 @@ class LinuxOSProcessTest {
 
     @Test
     void testGetMissingDetailsNullStatusNoException() {
-        LinuxOSProcess.getMissingDetails(null, "1234 (java) S 1 1234 1234 0");
+        assertDoesNotThrow(() -> LinuxOSProcess.getMissingDetails(null, "1234 (java) S 1 1234 1234 0"));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -263,18 +264,16 @@ class ExceptionUtilTest {
 
     @Test
     void testRunSilentlySwallowsException() {
-        // Should not throw
-        ExceptionUtil.runSilently(() -> {
+        assertDoesNotThrow(() -> ExceptionUtil.runSilently(() -> {
             throw new RuntimeException("fail");
-        });
+        }));
     }
 
     @Test
     void testRunSilentlySwallowsError() {
-        // Should not throw
-        ExceptionUtil.runSilently(() -> {
+        assertDoesNotThrow(() -> ExceptionUtil.runSilently(() -> {
             throw new StackOverflowError("simulated");
-        });
+        }));
     }
 
     // -- runOrLog --
@@ -288,10 +287,9 @@ class ExceptionUtilTest {
 
     @Test
     void testRunOrLogHandlesException() {
-        // Should not throw
-        ExceptionUtil.runOrLog(() -> {
+        assertDoesNotThrow(() -> ExceptionUtil.runOrLog(() -> {
             throw new RuntimeException("test error");
-        }, LOG, "RunOrLog failed: {}");
+        }, LOG, "RunOrLog failed: {}"));
     }
 
     // -- Edge cases --
@@ -372,10 +370,9 @@ class ExceptionUtilTest {
 
     @Test
     void testRunOrLogWithTraceLevel() {
-        // Should not throw
-        ExceptionUtil.runOrLog(() -> {
+        assertDoesNotThrow(() -> ExceptionUtil.runOrLog(() -> {
             throw new RuntimeException("fail");
-        }, LOG, Level.TRACE, "Runnable trace failure");
+        }, LOG, Level.TRACE, "Runnable trace failure"));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/util/FileUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/FileUtilTest.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -46,14 +46,12 @@ class FileUtilTest {
     @Test
     void testReadFile() {
         // Write to a temp file
-        Path multilineFile = null;
-        try {
-            multilineFile = Files.createTempFile("oshitest.multiline", null);
+        Path multilineFile = assertDoesNotThrow(() -> {
+            Path file = Files.createTempFile("oshitest.multiline", null);
             String s = "Line 1\nLine 2\nThe third line\nLine 4\nLine 5\n";
-            Files.write(multilineFile, s.getBytes(StandardCharsets.UTF_8));
-        } catch (IOException e) {
-            fail("IO Exception creating or writing to temporary multiline file.");
-        }
+            Files.write(file, s.getBytes(StandardCharsets.UTF_8));
+            return file;
+        }, "IO Exception creating or writing to temporary multiline file.");
 
         // Try the new temp file
         List<String> tempFileStrings = FileUtil.readFile(multilineFile.toString());
@@ -63,11 +61,8 @@ class FileUtilTest {
         assertThat("Matching lines mismatch", matchingLines.size(), is(4));
 
         // Delete the temp file
-        try {
-            Files.deleteIfExists(multilineFile);
-        } catch (IOException e) {
-            fail("IO Exception deleting temporary multiline file.");
-        }
+        assertDoesNotThrow(() -> Files.deleteIfExists(multilineFile),
+                "IO Exception deleting temporary multiline file.");
 
         // Try file not found on deleted file
         assertThat("Deleted file should return empty", FileUtil.readFile(multilineFile.toString()), is(empty()));
@@ -79,44 +74,32 @@ class FileUtilTest {
     @Test
     void testGetFromFile() {
         // Write to temp file
-        Path integerFile = null;
-        try {
-            integerFile = Files.createTempFile("oshitest.int", null);
-            Files.write(integerFile, "123\n".getBytes(StandardCharsets.UTF_8));
-        } catch (IOException e) {
-            fail("IO Exception creating or writing to temporary integer file.");
-        }
+        Path integerFile = assertDoesNotThrow(() -> {
+            Path file = Files.createTempFile("oshitest.int", null);
+            Files.write(file, "123\n".getBytes(StandardCharsets.UTF_8));
+            return file;
+        }, "IO Exception creating or writing to temporary integer file.");
         assertThat("unsigned long from int", FileUtil.getUnsignedLongFromFile(integerFile.toString()), is(123L));
         assertThat("long from int", FileUtil.getLongFromFile(integerFile.toString()), is(123L));
         assertThat("int from int", FileUtil.getIntFromFile(integerFile.toString()), is(123));
         assertThat("string from int", FileUtil.getStringFromFile(integerFile.toString()), is("123"));
 
         // Delete the temp file
-        try {
-            Files.deleteIfExists(integerFile);
-        } catch (IOException e) {
-            fail("IO Exception deleting temporary integer file.");
-        }
+        assertDoesNotThrow(() -> Files.deleteIfExists(integerFile), "IO Exception deleting temporary integer file.");
 
         // Write to temp file
-        Path stringFile = null;
-        try {
-            stringFile = Files.createTempFile("oshitest.str", null);
-            Files.write(stringFile, "foo bar\n".getBytes(StandardCharsets.UTF_8));
-        } catch (IOException e) {
-            fail("IO Exception creating or writing to temporary string file.");
-        }
+        Path stringFile = assertDoesNotThrow(() -> {
+            Path file = Files.createTempFile("oshitest.str", null);
+            Files.write(file, "foo bar\n".getBytes(StandardCharsets.UTF_8));
+            return file;
+        }, "IO Exception creating or writing to temporary string file.");
 
         assertThat("unsigned long from string", FileUtil.getUnsignedLongFromFile(stringFile.toString()), is(0L));
         assertThat("long from string", FileUtil.getLongFromFile(stringFile.toString()), is(0L));
         assertThat("int from string", FileUtil.getIntFromFile(stringFile.toString()), is(0));
         assertThat("string from string", FileUtil.getStringFromFile(stringFile.toString()), is("foo bar"));
         // Delete the temp file
-        try {
-            Files.deleteIfExists(stringFile);
-        } catch (IOException e) {
-            fail("IO Exception deleting temporary string file.");
-        }
+        assertDoesNotThrow(() -> Files.deleteIfExists(stringFile), "IO Exception deleting temporary string file.");
 
         // Try file not found on deleted file
         assertThat("unsigned long from invalid", FileUtil.getUnsignedLongFromFile(stringFile.toString()), is(0L));
@@ -136,16 +119,14 @@ class FileUtilTest {
         expected.put("write_bytes", "124780544");
         expected.put("cancelled_write_bytes", "42");
         // Write this to a temp file
-        Path procIoFile = null;
-        try {
-            procIoFile = Files.createTempFile("oshitest.procio", null);
+        Path procIoFile = assertDoesNotThrow(() -> {
+            Path file = Files.createTempFile("oshitest.procio", null);
             for (Entry<String, String> e : expected.entrySet()) {
                 String s = e.getKey() + ": " + e.getValue() + "\n";
-                Files.write(procIoFile, s.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                Files.write(file, s.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
             }
-        } catch (IOException e) {
-            fail("IO Exception creating or writing to temporary procIo file.");
-        }
+            return file;
+        }, "IO Exception creating or writing to temporary procIo file.");
         // Read into map
         Map<String, String> actual = FileUtil.getKeyValueMapFromFile(procIoFile.toString(), ":");
         assertThat("procio size", actual, is(aMapWithSize(expected.size())));
@@ -154,11 +135,7 @@ class FileUtilTest {
         }
 
         // Cleanup
-        try {
-            Files.deleteIfExists(procIoFile);
-        } catch (IOException e) {
-            fail("IO Exception deleting temporary procIo file.");
-        }
+        assertDoesNotThrow(() -> Files.deleteIfExists(procIoFile), "IO Exception deleting temporary procIo file.");
 
         // Test deleted file
         actual = FileUtil.getKeyValueMapFromFile(procIoFile.toString(), ":");
@@ -203,14 +180,13 @@ class FileUtilTest {
         byte[] arr = new byte[] { 1, 2, 3 };
         buff.put(arr);
 
-        // Write to temp file
-        Path binaryFile = null;
-        try {
-            binaryFile = Files.createTempFile("oshitest.binary", null);
-            Files.write(binaryFile, buff.array());
-        } catch (IOException e) {
-            fail("IO Exception creating or writing to temporary binary file.");
-        }
+        // Write to temp file (snapshot the backing array since buff is reassigned below)
+        byte[] binaryData = buff.array();
+        Path binaryFile = assertDoesNotThrow(() -> {
+            Path file = Files.createTempFile("oshitest.binary", null);
+            Files.write(file, binaryData);
+            return file;
+        }, "IO Exception creating or writing to temporary binary file.");
 
         // Read from file
         buff = FileUtil.readAllBytesAsBuffer(binaryFile.toString());
@@ -233,11 +209,7 @@ class FileUtilTest {
         assertArrayEquals(arr0, array, "Byte array from buffer at limit should be all 0s");
 
         // Cleanup
-        try {
-            Files.deleteIfExists(binaryFile);
-        } catch (IOException e) {
-            fail("IO Exception deleting temporary procIo file.");
-        }
+        assertDoesNotThrow(() -> Files.deleteIfExists(binaryFile), "IO Exception deleting temporary binary file.");
     }
 
     @Test


### PR DESCRIPTION
## Summary
Mechanical, test-only cleanup of three SonarCloud "test intentionality" rules. One commit per rule.

- **java:S8714 (10, FileUtilTest)** — replace `try/catch`-with-`fail()` temp-file setup/cleanup blocks with `assertDoesNotThrow(...)`. Blocks that produced a `Path` used later use the `ThrowingSupplier` overload (`return file;`); one snapshots `buff.array()` into a final local since `buff` is reassigned later.
- **java:S2699 (5, ExceptionUtilTest ×4 + LinuxOSProcessTest ×1)** — the "should not throw" tests had no assertion; wrap the body in `assertDoesNotThrow(...)` so the no-throw expectation is explicit.
- **java:S5838 (6, comparison tests)** — replace `assertThat(coll.size()).isEqualTo/isGreaterThanOrEqualTo(...)` with the size-aware `hasSameSizeAs` / `hasSizeGreaterThanOrEqualTo`. The two `long[][]` cases use `hasSameDimensionsAs` (the 2D-array equivalent; `hasSameSizeAs` is not defined on AssertJ’s 2D array assert).

No production code changes; no behavior change.

## Test plan
- [x] spotless / checkstyle + clean full-reactor build **with tests** (`-P aggregate-coverage`): BUILD SUCCESS, 0 failures
- [x] On macOS: FileUtilTest, ExceptionUtilTest, NativeComparisonTest all pass (LinuxOSProcessTest/RegistryComparisonTest/NativeFreeComparisonTest are OS-gated and run on their platforms in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test assertions across benchmark and utility modules to improve validation accuracy and clarity.
  * Updated test methods to use modern assertion patterns for better error detection and reporting.
  * Strengthened verification of null-safety and exception-handling behaviors in core utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->