### PR TITLE
Sonar JDK-modernization sweep (S1481, S1117, S6201, S6208, S6880)

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -363,10 +363,8 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         this.userTime = statArray[ProcPidStat.USER_TIME.ordinal()] * 1000L / getOs().getHz();
         this.minorFaults = statArray[ProcPidStat.MINOR_FAULTS.ordinal()];
         this.majorFaults = statArray[ProcPidStat.MAJOR_FAULTS.ordinal()];
-        long nonVoluntaryContextSwitches = ParseUtil.parseLongOrDefault(status.get("nonvoluntary_ctxt_switches"), 0L);
-        long voluntaryContextSwitches = ParseUtil.parseLongOrDefault(status.get("voluntary_ctxt_switches"), 0L);
-        this.voluntaryContextSwitches = voluntaryContextSwitches;
-        this.involuntaryContextSwitches = nonVoluntaryContextSwitches;
+        this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(status.get("voluntary_ctxt_switches"), 0L);
+        this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(status.get("nonvoluntary_ctxt_switches"), 0L);
 
         this.upTime = now - startTime;
 

--- a/oshi-common/src/test/java/oshi/util/MemoizerTest.java
+++ b/oshi-common/src/test/java/oshi/util/MemoizerTest.java
@@ -40,12 +40,12 @@ final class MemoizerTest {
 
     @BeforeEach
     void before() {
-        final ThreadPoolExecutor ex = new ThreadPoolExecutor(numberOfThreads, numberOfThreads, 0L,
+        final ThreadPoolExecutor executor = new ThreadPoolExecutor(numberOfThreads, numberOfThreads, 0L,
                 TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
-        ex.allowCoreThreadTimeOut(false);
-        ex.prestartAllCoreThreads(); // make sure we don't lose refreshes in tests because of
-                                     // spending time to start threads
-        this.ex = ex;
+        executor.allowCoreThreadTimeOut(false);
+        executor.prestartAllCoreThreads(); // make sure we don't lose refreshes in tests because of
+                                           // spending time to start threads
+        this.ex = executor;
     }
 
     @AfterEach

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
@@ -80,7 +80,8 @@ public final class IOReportClientFFM {
             }
             MemorySegment energyChannels = IOReportFunctions.IOReportCopyChannelsInGroup(energyGroup.segment(),
                     MemorySegment.NULL, 0, 0, 0);
-            try (CFTypeRef gpuRef = new CFTypeRef(gpuChannels); CFTypeRef energyRef = new CFTypeRef(energyChannels)) {
+            // wrapped only to release the native CF object on close
+            try (var _ = new CFTypeRef(gpuChannels); var _ = new CFTypeRef(energyChannels)) {
                 if (!energyChannels.equals(MemorySegment.NULL)) {
                     IOReportFunctions.IOReportMergeChannels(gpuChannels, energyChannels, MemorySegment.NULL);
                 }
@@ -116,7 +117,8 @@ public final class IOReportClientFFM {
         return getOrDefault(() -> {
             MemorySegment sample = IOReportFunctions.IOReportCreateSamples(subscription, subscribedChannels,
                     MemorySegment.NULL);
-            try (CFTypeRef sampleRef = new CFTypeRef(sample)) {
+            // wrapped only to release the native CF object on close
+            try (var _ = new CFTypeRef(sample)) {
                 if (sample.equals(MemorySegment.NULL)) {
                     return new GpuTicks(0L, 0L);
                 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/perfmon/PerfmonDisabledFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/perfmon/PerfmonDisabledFFM.java
@@ -42,8 +42,8 @@ public final class PerfmonDisabledFFM {
             String value = "Disable Performance Counters";
             MemorySegment hklm = MemorySegment.ofAddress(WinRegFFM.HKEY_LOCAL_MACHINE);
             Object disabled = Advapi32UtilFFM.registryGetValue(hklm, key, value);
-            if (disabled instanceof Integer) {
-                if ((Integer) disabled > 0) {
+            if (disabled instanceof Integer disabledValue) {
+                if (disabledValue > 0) {
                     LOG.warn("{} counters are disabled and won't return data: {}\\{}\\{} > 0.", service,
                             "HKEY_LOCAL_MACHINE", key, value);
                     return true;

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilFFM.java
@@ -183,16 +183,16 @@ public final class HkeyPerformanceDataUtilFFM extends HkeyPerformanceDataUtil {
                         int size = counterSizeMap.getOrDefault(keyIndex, 0);
                         // Currently, only DWORDs (4 bytes) and ULONGLONGs (8 bytes) are used to provide
                         // counter values.
-                        if (size == 4) {
-                            counterMap.put(key,
-                                    pPerfData.get(JAVA_INT, perfCounterBlockOffset + counterOffsetMap.get(keyIndex)));
-                        } else if (size == 8) {
-                            counterMap.put(key,
-                                    pPerfData.get(JAVA_LONG, perfCounterBlockOffset + counterOffsetMap.get(keyIndex)));
-                        } else {
+                        Object counterValue = switch (size) {
+                            case 4 -> pPerfData.get(JAVA_INT, perfCounterBlockOffset + counterOffsetMap.get(keyIndex));
+                            case 8 -> pPerfData.get(JAVA_LONG, perfCounterBlockOffset + counterOffsetMap.get(keyIndex));
                             // If counter defined in enum isn't in registry, fail
+                            default -> null;
+                        };
+                        if (counterValue == null) {
                             return null;
                         }
+                        counterMap.put(key, counterValue);
                     }
                     counterMaps.add(counterMap);
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/IOKit.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/IOKit.java
@@ -260,7 +260,8 @@ public interface IOKit {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
                     MemorySegment cfValue = createCFProperty(cfKey);
-                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
+                    // CFTypeRef wrappers release the native CF key/value on close; the body uses cfValue directly
+                    try (var _ = new CFTypeRef(cfKey); var _ = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
@@ -275,7 +276,8 @@ public interface IOKit {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
                     MemorySegment cfValue = createCFProperty(cfKey);
-                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
+                    // CFTypeRef wrappers release the native CF key/value on close; the body uses cfValue directly
+                    try (var _ = new CFTypeRef(cfKey); var _ = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
@@ -294,7 +296,8 @@ public interface IOKit {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
                     MemorySegment cfValue = createCFProperty(cfKey);
-                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
+                    // CFTypeRef wrappers release the native CF key/value on close; the body uses cfValue directly
+                    try (var _ = new CFTypeRef(cfKey); var _ = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
@@ -313,7 +316,8 @@ public interface IOKit {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
                     MemorySegment cfValue = createCFProperty(cfKey);
-                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
+                    // CFTypeRef wrappers release the native CF key/value on close; the body uses cfValue directly
+                    try (var _ = new CFTypeRef(cfKey); var _ = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
@@ -332,7 +336,8 @@ public interface IOKit {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
                     MemorySegment cfValue = createCFProperty(cfKey);
-                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
+                    // CFTypeRef wrappers release the native CF key/value on close; the body uses cfValue directly
+                    try (var _ = new CFTypeRef(cfKey); var _ = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }
@@ -349,7 +354,8 @@ public interface IOKit {
                 try (Arena arena = Arena.ofConfined()) {
                     MemorySegment cfKey = createCFString(key, arena);
                     MemorySegment cfValue = createCFProperty(cfKey);
-                    try (CFTypeRef keyRef = new CFTypeRef(cfKey); CFTypeRef valRef = new CFTypeRef(cfValue)) {
+                    // CFTypeRef wrappers release the native CF key/value on close; the body uses cfValue directly
+                    try (var _ = new CFTypeRef(cfKey); var _ = new CFTypeRef(cfValue)) {
                         if (cfValue.equals(MemorySegment.NULL)) {
                             return null;
                         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
@@ -274,8 +274,7 @@ public final class KstatUtilFFM {
                     return namedValueInt32(named);
                 case KSTAT_DATA_UINT32:
                     return FormatUtil.getUnsignedInt(namedValueInt32(named));
-                case KSTAT_DATA_INT64:
-                case KSTAT_DATA_UINT64:
+                case KSTAT_DATA_INT64, KSTAT_DATA_UINT64:
                     return namedValueInt64(named);
                 default:
                     LOG.error("Unimplemented or non-numeric kstat data type {}", dt);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
@@ -387,8 +387,7 @@ public final class IPHlpAPIUtilFFM {
 
     private static TcpState stateLookup(int state) {
         switch (state) {
-            case 1:
-            case 12:
+            case 1, 12:
                 return CLOSED;
             case 2:
                 return LISTEN;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WbemcliUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WbemcliUtilFFM.java
@@ -241,14 +241,10 @@ public final class WbemcliUtilFFM {
                     case VT_BSTR:
                         result.add(vt, cimType, property, getBstrVal(getResult.variant(), arena));
                         break;
-                    case VT_I4:
-                    case VT_INT:
-                    case VT_UI4:
-                    case VT_UINT:
+                    case VT_I4, VT_INT, VT_UI4, VT_UINT:
                         result.add(vt, cimType, property, getIntVal(getResult.variant()));
                         break;
-                    case VT_I8:
-                    case VT_UI8:
+                    case VT_I8, VT_UI8:
                         result.add(vt, cimType, property, getLongVal(getResult.variant()));
                         break;
                     case VT_I2:
@@ -272,8 +268,7 @@ public final class WbemcliUtilFFM {
                     case VT_R8:
                         result.add(vt, cimType, property, getDoubleVal(getResult.variant()));
                         break;
-                    case VT_NULL:
-                    case VT_EMPTY:
+                    case VT_NULL, VT_EMPTY:
                         result.add(vt, cimType, property, null);
                         break;
                     default:

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiUtilFFM.java
@@ -117,8 +117,8 @@ public final class WmiUtilFFM {
         Object o = result.getValue(property, index);
         if (o == null) {
             return 0L;
-        } else if (o instanceof Number) {
-            return ((Number) o).longValue();
+        } else if (o instanceof Number number) {
+            return number.longValue();
         } else if (result.getCIMType(property) == WbemcliFFM.CIM_UINT64
                 && result.getVtType(property) == VariantFFM.VT_BSTR) {
             return ParseUtil.parseLongOrDefault((String) o, 0L);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
@@ -84,10 +84,11 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
                     if (MemorySegment.NULL.equals(udev)) {
                         return readTopologyFromSysfs();
                     }
-                    try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
+                    // wrapped only to release the native handle on close
+                    try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                         MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                        try (NativeHandle enumHandle = NativeHandle.of(enumerate,
-                                UdevFunctions::udev_enumerate_unref)) {
+                        // wrapped only to release the native handle on close
+                        try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                             UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
                             UdevFunctions.udev_enumerate_scan_devices(enumerate);
                             for (MemorySegment entry = UdevFunctions
@@ -101,8 +102,8 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
                                 MemorySegment device = UdevFunctions.deviceNewFromSyspath(udev, syspath, arena);
                                 String modAlias = null;
                                 if (!MemorySegment.NULL.equals(device)) {
-                                    try (NativeHandle devHandle = NativeHandle.of(device,
-                                            UdevFunctions::udev_device_unref)) {
+                                    // wrapped only to release the native handle on close
+                                    try (var _ = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                                         modAlias = UdevFunctions.getPropertyValue(device, "MODALIAS", arena);
                                     }
                                 }
@@ -126,9 +127,11 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
             if (MemorySegment.NULL.equals(udev)) {
                 return false;
             }
-            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
+            // wrapped only to release the native handle on close
+            try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
+                // wrapped only to release the native handle on close
+                try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
                     long max = 0L;
@@ -173,9 +176,11 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
             if (MemorySegment.NULL.equals(udev)) {
                 return -1L;
             }
-            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
+            // wrapped only to release the native handle on close
+            try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
+                // wrapped only to release the native handle on close
+                try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
                     MemorySegment entry = UdevFunctions.udev_enumerate_get_list_entry(enumerate);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
@@ -70,9 +70,11 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
                 }
                 return Collections.emptyList();
             }
-            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
+            // wrapped only to release the native handle on close
+            try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
+                // wrapped only to release the native handle on close
+                try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, BLOCK, arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
                     for (MemorySegment entry = UdevFunctions
@@ -86,7 +88,8 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
                         if (MemorySegment.NULL.equals(device)) {
                             continue;
                         }
-                        try (NativeHandle devHandle = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
+                        // wrapped only to release the native handle on close
+                        try (var _ = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                             String devnode = UdevFunctions.getString(UdevFunctions.udev_device_get_devnode(device),
                                     arena);
                             if (devnode != null && !devnode.startsWith(DevPath.LOOP)

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupFFM.java
@@ -51,9 +51,11 @@ final class LinuxLogicalVolumeGroupFFM extends LinuxLogicalVolumeGroup {
             if (MemorySegment.NULL.equals(udev)) {
                 return Collections.emptyList();
             }
-            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
+            // wrapped only to release the native handle on close
+            try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
+                // wrapped only to release the native handle on close
+                try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, BLOCK, arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
                     for (MemorySegment entry = UdevFunctions
@@ -67,7 +69,8 @@ final class LinuxLogicalVolumeGroupFFM extends LinuxLogicalVolumeGroup {
                         if (MemorySegment.NULL.equals(device)) {
                             continue;
                         }
-                        try (NativeHandle devHandle = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
+                        // wrapped only to release the native handle on close
+                        try (var _ = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                             String devnode = UdevFunctions.getString(UdevFunctions.udev_device_get_devnode(device),
                                     arena);
                             if (devnode != null && devnode.startsWith(DevPath.DM)) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
@@ -46,10 +46,12 @@ public final class LinuxNetworkIFFFM extends LinuxNetworkIF {
             if (MemorySegment.NULL.equals(udev)) {
                 return queryIfModelFromSysfs(name);
             }
-            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
+            // wrapped only to release the native handle on close
+            try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment device = UdevFunctions.deviceNewFromSyspath(udev, SysPath.NET + name, arena);
                 if (!MemorySegment.NULL.equals(device)) {
-                    try (NativeHandle devHandle = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
+                    // wrapped only to release the native handle on close
+                    try (var _ = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                         String devVendor = UdevFunctions.getPropertyValue(device, "ID_VENDOR_FROM_DATABASE", arena);
                         String devModel = UdevFunctions.getPropertyValue(device, "ID_MODEL_FROM_DATABASE", arena);
                         if (!Util.isBlank(devModel)) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceFFM.java
@@ -57,9 +57,11 @@ public final class LinuxPowerSourceFFM extends LinuxPowerSource {
             if (MemorySegment.NULL.equals(udev)) {
                 return null;
             }
-            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
+            // wrapped only to release the native handle on close
+            try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
+                // wrapped only to release the native handle on close
+                try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, "power_supply", arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
                     for (MemorySegment entry = UdevFunctions
@@ -77,7 +79,8 @@ public final class LinuxPowerSourceFFM extends LinuxPowerSource {
                         if (MemorySegment.NULL.equals(device)) {
                             continue;
                         }
-                        try (NativeHandle devHandle = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
+                        // wrapped only to release the native handle on close
+                        try (var _ = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                             if (ParseUtil.parseIntOrDefault(
                                     UdevFunctions.getPropertyValue(device, Prop.POWER_SUPPLY_PRESENT.name(), arena),
                                     1) > 0) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceFFM.java
@@ -79,9 +79,11 @@ public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
             if (MemorySegment.NULL.equals(udev)) {
                 return emptyList();
             }
-            try (NativeHandle udevHandle = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
+            // wrapped only to release the native handle on close
+            try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
                 MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                try (NativeHandle enumHandle = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
+                // wrapped only to release the native handle on close
+                try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, SUBSYSTEM_USB, arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
 
@@ -97,7 +99,8 @@ public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
                         if (MemorySegment.NULL.equals(device)) {
                             continue;
                         }
-                        try (NativeHandle devHandle = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
+                        // wrapped only to release the native handle on close
+                        try (var _ = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                             String devtype = UdevFunctions.getString(UdevFunctions.udev_device_get_devtype(device),
                                     arena);
                             if (!DEVTYPE_USB_DEVICE.equals(devtype)) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
@@ -60,7 +60,8 @@ public final class MacPowerSourceFFM extends MacPowerSource {
         CFStringRef maxCapacityKey = CFStringRef.createCFString("Max Capacity");
         try (nameKey; isPresentKey; currentCapacityKey; maxCapacityKey) {
             MemorySegment powerSourcesInfo = IOPSCopyPowerSourcesInfo();
-            try (CFTypeRef infoRef = new CFTypeRef(powerSourcesInfo)) {
+            // wrapped only to release the native CF object on close
+            try (var _ = new CFTypeRef(powerSourcesInfo)) {
                 CFArrayRef cfList = new CFArrayRef(IOPSCopyPowerSourcesList(powerSourcesInfo));
                 try (cfList) {
                     double psTimeRemainingEstimated = IOPSGetTimeRemainingEstimate();

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsBluetoothDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsBluetoothDeviceFFM.java
@@ -69,11 +69,13 @@ public final class WindowsBluetoothDeviceFFM extends AbstractBluetoothDevice {
                 return Collections.emptyList();
             }
 
-            try (NativeHandle findRadioHandle = NativeHandle.of(hFindRadio,
-                    BluetoothApisFFM::BluetoothFindRadioClose)) {
+            // wrapped only to release the native handle on close
+
+            try (var _ = NativeHandle.of(hFindRadio, BluetoothApisFFM::BluetoothFindRadioClose)) {
                 do {
                     MemorySegment hRadio = phRadio.get(ADDRESS, 0);
-                    try (NativeHandle radioHandle = NativeHandle.of(hRadio, Kernel32FFM::CloseHandle)) {
+                    // wrapped only to release the native handle on close
+                    try (var _ = NativeHandle.of(hRadio, Kernel32FFM::CloseHandle)) {
                         String adapterName = getRadioName(arena, hRadio);
                         queryDevicesForRadio(arena, hRadio, adapterName, devices);
                     }
@@ -118,7 +120,9 @@ public final class WindowsBluetoothDeviceFFM extends AbstractBluetoothDevice {
             return;
         }
 
-        try (NativeHandle findDevHandle = NativeHandle.of(hFind, BluetoothApisFFM::BluetoothFindDeviceClose)) {
+        // wrapped only to release the native handle on close
+
+        try (var _ = NativeHandle.of(hFind, BluetoothApisFFM::BluetoothFindDeviceClose)) {
             do {
                 devices.add(parseDeviceInfo(deviceInfo, adapterName));
                 deviceInfo = arena.allocate(BLUETOOTH_DEVICE_INFO_LAYOUT);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
@@ -281,13 +281,11 @@ final class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
                 long offset = i * (long) PPI_SIZE;
                 // ProcessorPowerInformation: number(4), maxMhz(4), currentMhz(4), mhzLimit(4), maxIdleState(4),
                 // currentIdleState(4)
-                if (fieldIndex == 1) {
-                    freqs[i] = Integer.toUnsignedLong(buffer.get(ValueLayout.JAVA_INT, offset + 4)) * 1_000_000L;
-                } else if (fieldIndex == 2) {
-                    freqs[i] = Integer.toUnsignedLong(buffer.get(ValueLayout.JAVA_INT, offset + 8)) * 1_000_000L;
-                } else {
-                    freqs[i] = -1L;
-                }
+                freqs[i] = switch (fieldIndex) {
+                    case 1 -> Integer.toUnsignedLong(buffer.get(ValueLayout.JAVA_INT, offset + 4)) * 1_000_000L;
+                    case 2 -> Integer.toUnsignedLong(buffer.get(ValueLayout.JAVA_INT, offset + 8)) * 1_000_000L;
+                    default -> -1L;
+                };
                 if (freqs[i] == 0) {
                     freqs[i] = getProcessorIdentifier().getVendorFreq();
                 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
@@ -57,7 +57,8 @@ final class WindowsDisplayFFM extends AbstractDisplay {
                 return displays;
             }
             MemorySegment hDevInfo = hDevInfoOpt.get();
-            try (NativeHandle devInfoHandle = NativeHandle.of(hDevInfo, SetupApiFFM::SetupDiDestroyDeviceInfoList)) {
+            // wrapped only to release the native handle on close
+            try (var _ = NativeHandle.of(hDevInfo, SetupApiFFM::SetupDiDestroyDeviceInfoList)) {
                 MemorySegment devInfoData = arena.allocate(SetupApiFFM.SP_DEVINFO_DATA_SIZE);
                 MemorySegment edidName = arena.allocateFrom("EDID", java.nio.charset.StandardCharsets.UTF_16LE);
 
@@ -73,7 +74,8 @@ final class WindowsDisplayFFM extends AbstractDisplay {
                     if (key == null) {
                         continue;
                     }
-                    try (NativeHandle regKey = NativeHandle.of(key, Advapi32FFM::RegCloseKey)) {
+                    // wrapped only to release the native handle on close
+                    try (var _ = NativeHandle.of(key, Advapi32FFM::RegCloseKey)) {
                         byte[] edid = queryEdidFromKey(key, edidName, arena);
                         if (edid != null) {
                             displays.add(new WindowsDisplayFFM(edid));

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardFFM.java
@@ -279,8 +279,8 @@ final class WindowsGraphicsCardFFM extends AbstractGraphicsCard {
 
     private static String registryString(String keyPath, String valueName) {
         Object val = Advapi32UtilFFM.registryGetValue(HKLM, keyPath, valueName);
-        if (val instanceof String) {
-            return (String) val;
+        if (val instanceof String string) {
+            return string;
         }
         return "";
     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
@@ -131,7 +131,8 @@ public final class WindowsPowerSourceFFM extends WindowsPowerSource {
                 LOG.warn("SetupDiGetClassDevs failed for battery class");
             } else {
                 MemorySegment hdev = hdevOpt.get();
-                try (NativeHandle devInfoHandle = NativeHandle.of(hdev, SetupApiFFM::SetupDiDestroyDeviceInfoList)) {
+                // wrapped only to release the native handle on close
+                try (var _ = NativeHandle.of(hdev, SetupApiFFM::SetupDiDestroyDeviceInfoList)) {
                     boolean batteryFound = false;
                     for (int idev = 0; !batteryFound && idev < 100; idev++) {
                         MemorySegment did = arena.allocate(SP_DEVICE_INTERFACE_DATA);
@@ -164,7 +165,8 @@ public final class WindowsPowerSourceFFM extends WindowsPowerSource {
                             continue;
                         }
                         MemorySegment hBattery = hBatteryOpt.get();
-                        try (NativeHandle batteryHandle = NativeHandle.of(hBattery, Kernel32FFM::CloseHandle)) {
+                        // wrapped only to release the native handle on close
+                        try (var _ = NativeHandle.of(hBattery, Kernel32FFM::CloseHandle)) {
                             // Ask the battery for its tag
                             MemorySegment dwWait = arena.allocate(JAVA_INT);
                             MemorySegment dwTag = arena.allocate(JAVA_INT);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPrinterFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPrinterFFM.java
@@ -53,8 +53,8 @@ final class WindowsPrinterFFM extends WindowsPrinter {
 
     private static boolean getBooleanValue(WmiResult<PrinterProperty> result, PrinterProperty property, int index) {
         Object o = result.getValue(property, index);
-        if (o instanceof Boolean) {
-            return (Boolean) o;
+        if (o instanceof Boolean bool) {
+            return bool;
         }
         return false;
     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsSoundCardFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsSoundCardFFM.java
@@ -73,6 +73,6 @@ final class WindowsSoundCardFFM extends AbstractSoundCard {
 
     private static String getRegString(String keyPath, String valueName) {
         Object val = Advapi32UtilFFM.registryGetValue(HKLM, keyPath, valueName);
-        return val instanceof String ? (String) val : "";
+        return val instanceof String string ? string : "";
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
@@ -154,38 +154,47 @@ public class MacInternetProtocolStatsFFM extends MacInternetProtocolStats {
 
             long protoOffset = SOCKET_INFO.byteOffset(SOI_PROTO);
             int kind = psi.get(JAVA_INT, SOCKET_INFO.byteOffset(SOI_KIND));
-            if (kind == SOCKINFO_TCP) {
-                type = "tcp";
-                MemorySegment tcpsi = psi.asSlice(protoOffset);
-                ini = tcpsi.asSlice(TCP_SOCK_INFO.byteOffset(TCPSI_INI));
-                int tcpState = tcpsi.get(JAVA_INT, TCP_SOCK_INFO.byteOffset(TCPSI_STATE));
-                state = stateLookup(tcpState);
-            } else if (kind == SOCKINFO_IN) {
-                type = "udp";
-                ini = psi.asSlice(protoOffset);
-                state = NONE;
-            } else {
-                return null;
+            switch (kind) {
+                case SOCKINFO_TCP -> {
+                    type = "tcp";
+                    MemorySegment tcpsi = psi.asSlice(protoOffset);
+                    ini = tcpsi.asSlice(TCP_SOCK_INFO.byteOffset(TCPSI_INI));
+                    int tcpState = tcpsi.get(JAVA_INT, TCP_SOCK_INFO.byteOffset(TCPSI_STATE));
+                    state = stateLookup(tcpState);
+                }
+                case SOCKINFO_IN -> {
+                    type = "udp";
+                    ini = psi.asSlice(protoOffset);
+                    state = NONE;
+                }
+                default -> {
+                    return null;
+                }
             }
 
             byte[] laddr;
             byte[] faddr;
 
             byte vflag = ini.get(JAVA_BYTE, IN_SOCK_INFO.byteOffset(INSI_VFLAG));
-            if (vflag == 1) { // IPv4
-                laddr = parseIntToIP(ini.getAtIndex(JAVA_INT, IN_SOCK_INFO.byteOffset(INSI_LADDR) / 4 + 3));
-                faddr = parseIntToIP(ini.getAtIndex(JAVA_INT, IN_SOCK_INFO.byteOffset(INSI_FADDR) / 4 + 3));
-                type += "4";
-            } else if (vflag == 2) { // IPv6
-                laddr = parseIntArrayToIP(ini, IN_SOCK_INFO.byteOffset(INSI_LADDR));
-                faddr = parseIntArrayToIP(ini, IN_SOCK_INFO.byteOffset(INSI_FADDR));
-                type += "6";
-            } else if (vflag == 3) { // IPv4/IPv6
-                laddr = parseIntToIP(ini.getAtIndex(JAVA_INT, IN_SOCK_INFO.byteOffset(INSI_LADDR) / 4 + 3));
-                faddr = parseIntToIP(ini.getAtIndex(JAVA_INT, IN_SOCK_INFO.byteOffset(INSI_FADDR) / 4 + 3));
-                type += "46";
-            } else {
-                return null;
+            switch (vflag) {
+                case 1 -> { // IPv4
+                    laddr = parseIntToIP(ini.getAtIndex(JAVA_INT, IN_SOCK_INFO.byteOffset(INSI_LADDR) / 4 + 3));
+                    faddr = parseIntToIP(ini.getAtIndex(JAVA_INT, IN_SOCK_INFO.byteOffset(INSI_FADDR) / 4 + 3));
+                    type += "4";
+                }
+                case 2 -> { // IPv6
+                    laddr = parseIntArrayToIP(ini, IN_SOCK_INFO.byteOffset(INSI_LADDR));
+                    faddr = parseIntArrayToIP(ini, IN_SOCK_INFO.byteOffset(INSI_FADDR));
+                    type += "6";
+                }
+                case 3 -> { // IPv4/IPv6
+                    laddr = parseIntToIP(ini.getAtIndex(JAVA_INT, IN_SOCK_INFO.byteOffset(INSI_LADDR) / 4 + 3));
+                    faddr = parseIntToIP(ini.getAtIndex(JAVA_INT, IN_SOCK_INFO.byteOffset(INSI_FADDR) / 4 + 3));
+                    type += "46";
+                }
+                default -> {
+                    return null;
+                }
             }
 
             int lport = ParseUtil.bigEndian16ToLittleEndian(ini.get(JAVA_INT, IN_SOCK_INFO.byteOffset(INSI_LPORT)));

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -158,7 +158,8 @@ public class WindowsFileSystemFFM extends AbstractFileSystem {
                 return fs;
             }
             MemorySegment hVol = hVolOpt.get();
-            try (NativeHandle ignored = NativeHandle.of(hVol, Kernel32FFM::FindVolumeClose)) {
+            // wrapped only to release the native handle on close
+            try (var _ = NativeHandle.of(hVol, Kernel32FFM::FindVolumeClose)) {
                 do {
                     String volume = readWideString(volumeNameBuf);
                     if (volumeToMatch != null && !volume.equals(volumeToMatch)) {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -152,7 +152,8 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
                 LOG.error("Failed to open Service Control Manager");
                 return Collections.emptyList();
             }
-            try (NativeHandle ignored = NativeHandle.of(hSCManager, Advapi32FFM::CloseServiceHandle)) {
+            // wrapped only to release the SCM handle on close
+            try (var _ = NativeHandle.of(hSCManager, Advapi32FFM::CloseServiceHandle)) {
                 // First call to get required buffer size
                 MemorySegment pcbBytesNeeded = arena.allocate(JAVA_INT);
                 MemorySegment lpServicesReturned = arena.allocate(JAVA_INT);

--- a/oshi-core-ffm/src/test/java/oshi/ffm/platform/mac/CoreFoundationTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/platform/mac/CoreFoundationTest.java
@@ -383,19 +383,18 @@ class CoreFoundationTest {
 
     @Test
     void testCFMutableDictionarySetValueNullKeyIgnored() throws Throwable {
-        try (var arena = Arena.ofConfined()) {
-            var allocator = CoreFoundationFunctions.CFAllocatorGetDefault();
-            var keyCallbacks = CF_LOOKUP.findOrThrow("kCFTypeDictionaryKeyCallBacks");
-            var valCallbacks = CF_LOOKUP.findOrThrow("kCFTypeDictionaryValueCallBacks");
-            var dictSeg = CoreFoundationFunctions.CFDictionaryCreateMutable(allocator, 0, keyCallbacks, valCallbacks);
-            // setValue with null key should not throw
-            try (var dict = new CFMutableDictionaryRef(dictSeg);
-                    var val1 = CFStringRef.createCFString("val");
-                    var val2 = CFStringRef.createCFString("val")) {
-                dict.setValue(null, val1);
-                dict.setValue(new CFStringRef(NULL), val2);
-                assertThat(dict.getCount(), is(0L));
-            }
+        // No Arena needed here — the dictionary is CF-managed and the strings are CFStringRef-managed
+        var allocator = CoreFoundationFunctions.CFAllocatorGetDefault();
+        var keyCallbacks = CF_LOOKUP.findOrThrow("kCFTypeDictionaryKeyCallBacks");
+        var valCallbacks = CF_LOOKUP.findOrThrow("kCFTypeDictionaryValueCallBacks");
+        var dictSeg = CoreFoundationFunctions.CFDictionaryCreateMutable(allocator, 0, keyCallbacks, valCallbacks);
+        // setValue with null key should not throw
+        try (var dict = new CFMutableDictionaryRef(dictSeg);
+                var val1 = CFStringRef.createCFString("val");
+                var val2 = CFStringRef.createCFString("val")) {
+            dict.setValue(null, val1);
+            dict.setValue(new CFStringRef(NULL), val2);
+            assertThat(dict.getCount(), is(0L));
         }
     }
 

--- a/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
@@ -223,18 +223,19 @@ class OperatingSystemTest {
      */
     @Test
     void testProcessQueryByList() {
-        OperatingSystem os = createOperatingSystem();
-        assertThat("OS family shouldn't be null", os.getFamily(), is(notNullValue()));
-        assertThat("OS manufacturer shouldn't be null", os.getManufacturer(), is(notNullValue()));
-        OSVersionInfo versionInfo = os.getVersionInfo();
+        OperatingSystem system = createOperatingSystem();
+        assertThat("OS family shouldn't be null", system.getFamily(), is(notNullValue()));
+        assertThat("OS manufacturer shouldn't be null", system.getManufacturer(), is(notNullValue()));
+        OSVersionInfo versionInfo = system.getVersionInfo();
         assertThat("OS version info shouldn't be null", versionInfo, is(notNullValue()));
 
-        assertThat("OS currently running processes should be 1 or higher", os.getProcessCount(), is(greaterThan(0)));
-        assertThat("OS thread count should be 1 or higher", os.getThreadCount(), is(greaterThan(0)));
-        assertThat("OS current running process id should be 0 or higher", os.getProcessId(),
+        assertThat("OS currently running processes should be 1 or higher", system.getProcessCount(),
+                is(greaterThan(0)));
+        assertThat("OS thread count should be 1 or higher", system.getThreadCount(), is(greaterThan(0)));
+        assertThat("OS current running process id should be 0 or higher", system.getProcessId(),
                 is(greaterThanOrEqualTo(0)));
 
-        List<OSProcess> processes = os.getProcesses(null, null, 0);
+        List<OSProcess> processes = system.getProcesses(null, null, 0);
         assertThat("Currently running processes shouldn't be null", processes, is(notNullValue()));
         assertThat("every OS should have at least one process running on it", processes, is(not(empty())));
         // the list of pids we want info on
@@ -243,7 +244,7 @@ class OperatingSystemTest {
             pids.add(p.getProcessID());
         }
         // query for just those processes
-        Collection<OSProcess> processes1 = os.getProcesses(pids);
+        Collection<OSProcess> processes1 = system.getProcesses(pids);
         // there's a potential for a race condition here, if a process we
         // queried for initially wasn't running during the second query. In this case,
         // try again with the shorter list
@@ -253,7 +254,7 @@ class OperatingSystemTest {
                 pids.add(p.getProcessID());
             }
             // query for just those processes
-            processes1 = os.getProcesses(pids);
+            processes1 = system.getProcesses(pids);
         }
         assertThat("OS processes should match processes with pids we want info on", pids, hasSize(processes1.size()));
 
@@ -277,8 +278,8 @@ class OperatingSystemTest {
         // processes. On the second poll, we expect at least half of processes in those
         // categories to still be in the same category.
         //
-        OperatingSystem os = createOperatingSystem();
-        List<OSProcess> processes = os.getProcesses(null, null, 0);
+        OperatingSystem system = createOperatingSystem();
+        List<OSProcess> processes = system.getProcesses(null, null, 0);
         Map<Integer, Long> zeroChildMap = new HashMap<>();
         Map<Integer, Long> oneChildMap = new HashMap<>();
         Map<Integer, Long> manyChildMap = new HashMap<>();
@@ -308,8 +309,8 @@ class OperatingSystemTest {
         if (zeroChildMap.size() > 9) {
             int total = 0;
             for (Integer i : zeroChildMap.keySet()) {
-                List<OSProcess> children = os.getChildProcesses(i, null, null, 0);
-                List<OSProcess> descendants = os.getDescendantProcesses(i, null, null, 0);
+                List<OSProcess> children = system.getChildProcesses(i, null, null, 0);
+                List<OSProcess> descendants = system.getDescendantProcesses(i, null, null, 0);
                 if (children.size() == 0) {
                     matchedChild++;
                 }
@@ -333,8 +334,8 @@ class OperatingSystemTest {
         if (oneChildMap.size() > 9) {
             int total = 0;
             for (Integer i : oneChildMap.keySet()) {
-                List<OSProcess> children = os.getChildProcesses(i, null, null, 0);
-                List<OSProcess> descendants = os.getDescendantProcesses(i, null, null, 0);
+                List<OSProcess> children = system.getChildProcesses(i, null, null, 0);
+                List<OSProcess> descendants = system.getDescendantProcesses(i, null, null, 0);
                 if (children.size() == 1) {
                     matchedChild++;
                 }
@@ -364,9 +365,9 @@ class OperatingSystemTest {
             int total = 0;
             for (Integer i : manyChildMap.keySet()) {
                 // Use a non-null sorting for test purposes
-                List<OSProcess> children = os.getChildProcesses(i, ProcessFiltering.VALID_PROCESS,
+                List<OSProcess> children = system.getChildProcesses(i, ProcessFiltering.VALID_PROCESS,
                         ProcessSorting.CPU_DESC, Integer.MAX_VALUE);
-                List<OSProcess> descendants = os.getDescendantProcesses(i, ProcessFiltering.VALID_PROCESS,
+                List<OSProcess> descendants = system.getDescendantProcesses(i, ProcessFiltering.VALID_PROCESS,
                         ProcessSorting.CPU_DESC, Integer.MAX_VALUE);
                 if (children.size() > 0) {
                     matchedChild++;
@@ -395,8 +396,8 @@ class OperatingSystemTest {
     void testGetCommandLine() {
         int processesWithNonEmptyCmdLine = 0;
 
-        OperatingSystem os = createOperatingSystem();
-        for (OSProcess process : os.getProcesses(null, null, 0)) {
+        OperatingSystem system = createOperatingSystem();
+        for (OSProcess process : system.getProcesses(null, null, 0)) {
             if (!process.getCommandLine().trim().isEmpty()) {
                 processesWithNonEmptyCmdLine++;
             }
@@ -408,8 +409,8 @@ class OperatingSystemTest {
 
     @Test
     void testGetArguments() {
-        OperatingSystem os = createOperatingSystem();
-        List<OSProcess> processesWithNonEmptyArguments = os.getProcesses(p -> !p.getArguments().isEmpty(), null, 0);
+        OperatingSystem system = createOperatingSystem();
+        List<OSProcess> processesWithNonEmptyArguments = system.getProcesses(p -> !p.getArguments().isEmpty(), null, 0);
 
         assertThat("Processes with non-empty arguments should be non-empty", processesWithNonEmptyArguments,
                 not(empty()));
@@ -419,8 +420,8 @@ class OperatingSystemTest {
     void testGetEnvironment() {
         int processesWithNonEmptyEnvironment = 0;
 
-        OperatingSystem os = createOperatingSystem();
-        for (OSProcess process : os.getProcesses(null, null, 0)) {
+        OperatingSystem system = createOperatingSystem();
+        for (OSProcess process : system.getProcesses(null, null, 0)) {
             if (!process.getEnvironmentVariables().isEmpty()) {
                 processesWithNonEmptyEnvironment++;
             }
@@ -438,8 +439,8 @@ class OperatingSystemTest {
      */
     @Test
     void testGetServices() {
-        OperatingSystem os = createOperatingSystem();
-        List<OSService> services = os.getServices();
+        OperatingSystem system = createOperatingSystem();
+        List<OSService> services = system.getServices();
         // macOS CI typically has none, though, and some linux distros aren't covered
         if (!services.isEmpty()) {
             int stopped = 0;
@@ -468,8 +469,8 @@ class OperatingSystemTest {
      */
     @Test
     void testGetSessions() {
-        OperatingSystem os = createOperatingSystem();
-        for (OSSession sess : os.getSessions()) {
+        OperatingSystem system = createOperatingSystem();
+        for (OSSession sess : system.getSessions()) {
             assertThat("Logged in user's name for the session shouldn't be empty", sess.getUserName(),
                     is(not(emptyString())));
             assertThat("Sessions' terminal device name shouldn't be empty", sess.getTerminalDevice(),
@@ -488,9 +489,9 @@ class OperatingSystemTest {
      */
     @Test
     void testGetDesktopWindows() {
-        OperatingSystem os = createOperatingSystem();
-        List<OSDesktopWindow> allWindows = os.getDesktopWindows(false);
-        List<OSDesktopWindow> visibleWindows = os.getDesktopWindows(true);
+        OperatingSystem system = createOperatingSystem();
+        List<OSDesktopWindow> allWindows = system.getDesktopWindows(false);
+        List<OSDesktopWindow> visibleWindows = system.getDesktopWindows(true);
         assertThat("Visible should be a subset of all windows", visibleWindows.size(),
                 is(lessThanOrEqualTo(allWindows.size())));
         Set<Long> windowIds = new HashSet<>();


### PR DESCRIPTION
Mechanical SonarCloud modernization, one commit per rule. No behavior change; verified locally with a clean `install -P native-comparison` (NativeComparisonTest green) plus checkstyle/forbiddenapis/javadoc on the touched modules.

### Commits
- **S1481** — close-only FFM RAII wrappers (`CFTypeRef`, `NativeHandle`) wrapped in try-with-resources purely to run the native release on `close()` were flagged as unused locals. Replaced their names with the JDK 22 unnamed variable `_` (oshi-core-ffm is release 25) and added a short comment noting the cleanup-only intent. Deleting them, as the rule literally suggests, would leak the native objects. One genuine stray case (a `CoreFoundationTest` Arena never allocated from) is removed outright.
- **S1117** — three name-shadowing fixes: `LinuxOSProcess` ctxt-switch locals assigned straight to their fields; `MemoizerTest` local `ex` → `executor`; eight `OperatingSystemTest` method locals `os` → `system`. Pure renames.
- **S6201** — five `instanceof X` + cast pairs → pattern-matching `instanceof X binding` (JDK 16).
- **S6208** — consecutive fall-through `case` labels merged into comma-separated labels (JDK 14, colon form).
- **S6880** — four single-variable if/else cascades → `switch` (JDK 14+ arrow form). Two are clean value-producing switch expressions; the two `MacInternetProtocolStatsFFM` chains assign several locals with an early return, so they become arrow switch statements (verified on macOS via NativeComparisonTest).

All changes are confined to `oshi-core-ffm` except the S1117 renames (oshi-common / oshi-core). A separate follow-up will cover the `java8`-tagged findings (project-wide, release 8/9 modules).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code patterns throughout multiple modules for better maintainability and consistency.
  * Modernized Java syntax usage across platform-specific drivers and utilities.
  * Streamlined native resource management handling.

* **Tests**
  * Updated test implementations to use fresh instances for improved isolation.
  * Removed unnecessary test infrastructure patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->