### PR TITLE
Sonar java8-era modernization sweep (S1602, S1611, S1612, S8694)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxSensors.java
@@ -47,10 +47,10 @@ class LinuxSensors extends AbstractSensors {
 
     private static final List<String> HWMON_NAME_PRIORITY = Stream.of(GlobalConfig
             .get(OSHI_HWMON_NAME_PRIORITY, "coretemp,k10temp,zenpower,k8temp,via-cputemp,acpitz").split(","))
-            .filter((s) -> !s.isEmpty()).collect(Collectors.toList());
+            .filter(s -> !s.isEmpty()).collect(Collectors.toList());
     private static final List<String> THERMAL_ZONE_TYPE_PRIORITY = Stream
             .of(GlobalConfig.get(OSHI_THERMAL_ZONE_TYPE_PRIORITY, "cpu-thermal,x86_pkg_temp").split(","))
-            .filter((s) -> !s.isEmpty()).collect(Collectors.toList());
+            .filter(s -> !s.isEmpty()).collect(Collectors.toList());
 
     private static final String TYPE = "type";
     private static final String NAME = "/name";
@@ -164,7 +164,7 @@ class LinuxSensors extends AbstractSensors {
         getSensorFilesFromPath(thermalZonePath, TEMP, f -> f.getName().equals(TYPE) || f.getName().equals(TEMP),
                 files -> Stream.of(files).filter(f -> TYPE.equals(f.getName())).findFirst().map(File::getPath)
                         .map(FileUtil::getStringFromFile).map(THERMAL_ZONE_TYPE_PRIORITY::indexOf)
-                        .filter((index) -> index >= 0).orElse(THERMAL_ZONE_TYPE_PRIORITY.size()));
+                        .filter(index -> index >= 0).orElse(THERMAL_ZONE_TYPE_PRIORITY.size()));
     }
 
     /**
@@ -175,7 +175,7 @@ class LinuxSensors extends AbstractSensors {
      * @param sensorFileFilter A FileFilter for detecting valid sensor files
      */
     private void getSensorFilesFromPath(String sensorPath, String sensor, FileFilter sensorFileFilter) {
-        getSensorFilesFromPath(sensorPath, sensor, sensorFileFilter, (files) -> 0);
+        getSensorFilesFromPath(sensorPath, sensor, sensorFileFilter, files -> 0);
     }
 
     /**

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractPowerSourceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractPowerSourceTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Collections;
 import java.util.List;
 
@@ -20,8 +21,8 @@ class AbstractPowerSourceTest {
 
     private static AbstractPowerSource createSource(String name) {
         return createSource(name, 0.75, -2.0, 3600.0, 15.0, 12.0, 500.0, true, true, false,
-                PowerSource.CapacityUnits.MWH, 7500, 10000, 10500, 42, "Li-ion", LocalDate.of(2024, 1, 15), "TestMfg",
-                "SN123", 35.5);
+                PowerSource.CapacityUnits.MWH, 7500, 10000, 10500, 42, "Li-ion", LocalDate.of(2024, Month.JANUARY, 15),
+                "TestMfg", "SN123", 35.5);
     }
 
     private static AbstractPowerSource createSource(String name, double remainPct, double timeEst, double timeInst,
@@ -58,7 +59,7 @@ class AbstractPowerSourceTest {
         assertThat(ps.getDesignCapacity(), is(10500));
         assertThat(ps.getCycleCount(), is(42));
         assertThat(ps.getChemistry(), is("Li-ion"));
-        assertThat(ps.getManufactureDate(), is(LocalDate.of(2024, 1, 15)));
+        assertThat(ps.getManufactureDate(), is(LocalDate.of(2024, Month.JANUARY, 15)));
         assertThat(ps.getManufacturer(), is("TestMfg"));
         assertThat(ps.getSerialNumber(), is("SN123"));
         assertThat(ps.getTemperature(), is(35.5));

--- a/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -967,18 +968,20 @@ class ParseUtilTest {
 
     @Test
     void testParseDateToEpoch() {
-        assertThat("Parse yyyyMMdd", ParseUtil.parseDateToEpoch("20240101", "yyyyMMdd"),
-                is(LocalDate.of(2024, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()));
+        assertThat("Parse yyyyMMdd", ParseUtil.parseDateToEpoch("20240101", "yyyyMMdd"), is(
+                LocalDate.of(2024, Month.JANUARY, 1).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()));
 
         assertThat("Parse dd/MM/yy, HH:mm", ParseUtil.parseDateToEpoch("01/01/24, 12:30", "dd/MM/yy, HH:mm"),
-                is(LocalDateTime.of(2024, 1, 1, 12, 30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()));
+                is(LocalDateTime.of(2024, Month.JANUARY, 1, 12, 30).atZone(ZoneId.systemDefault()).toInstant()
+                        .toEpochMilli()));
 
         assertThat("Parse YYYY-'W'ww-e ISO week date", ParseUtil.parseDateToEpoch("2025-W25-2", "YYYY-'W'ww-e"),
-                is(LocalDate.of(2025, 6, 16).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()));
+                is(LocalDate.of(2025, Month.JUNE, 16).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()));
 
         assertThat("Parse EEE MMM dd HH:mm:ss yyyy",
-                ParseUtil.parseDateToEpoch("Fri Sep 18 15:53:11 2020", "EEE MMM dd HH:mm:ss yyyy"), is(LocalDateTime
-                        .of(2020, 9, 18, 15, 53, 11).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()));
+                ParseUtil.parseDateToEpoch("Fri Sep 18 15:53:11 2020", "EEE MMM dd HH:mm:ss yyyy"),
+                is(LocalDateTime.of(2020, Month.SEPTEMBER, 18, 15, 53, 11).atZone(ZoneId.systemDefault()).toInstant()
+                        .toEpochMilli()));
 
         assertThat("Parse empty date string", ParseUtil.parseDateToEpoch("", "yyyyMMdd"), is(0L));
 

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/AuxvTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/AuxvTest.java
@@ -23,7 +23,7 @@ class AuxvTest {
             || "aarch64".equals(System.getProperty("os.arch"));
 
     private static final Auxv.NativeLongReader READER = IS_64_BIT ? FileUtil::readLongFromBuffer
-            : buff -> FileUtil.readIntFromBuffer(buff);
+            : FileUtil::readIntFromBuffer;
 
     @Test
     void testQueryAuxv() {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/NtDllFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/NtDllFFM.java
@@ -123,10 +123,10 @@ public final class NtDllFFM extends WindowsForeignFunctions {
      */
     public static int NtQueryInformationProcess(MemorySegment processHandle, int processInformationClass,
             MemorySegment processInformation, int processInformationLength, MemorySegment returnLength) {
-        return getIntOrDefault(() -> {
-            return (int) NtQueryInformationProcess.invokeExact(processHandle, processInformationClass,
-                    processInformation, processInformationLength, returnLength);
-        }, -1, LOG, "NtDllFFM.NtQueryInformationProcess failed");
+        return getIntOrDefault(
+                () -> (int) NtQueryInformationProcess.invokeExact(processHandle, processInformationClass,
+                        processInformation, processInformationLength, returnLength),
+                -1, LOG, "NtDllFFM.NtQueryInformationProcess failed");
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/BStrFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/BStrFFM.java
@@ -69,9 +69,7 @@ public final class BStrFFM extends WindowsForeignFunctions {
         if (bstr == null || bstr.equals(MemorySegment.NULL)) {
             return;
         }
-        runOrLog(() -> {
-            SysFreeString.invokeExact(bstr);
-        }, LOG, "BStrFFM.free failed");
+        runOrLog(() -> SysFreeString.invokeExact(bstr), LOG, "BStrFFM.free failed");
     }
 
     // SysStringLen

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/Ole32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/Ole32FFM.java
@@ -95,9 +95,7 @@ public final class Ole32FFM extends WindowsForeignFunctions {
      * Closes the COM library on the current thread.
      */
     public static void CoUninitialize() {
-        runOrLog(() -> {
-            CoUninitialize.invokeExact();
-        }, LOG, "Ole32FFM.CoUninitialize failed");
+        runOrLog(CoUninitialize::invokeExact, LOG, "Ole32FFM.CoUninitialize failed");
     }
 
     // CoInitializeSecurity

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
@@ -132,10 +132,10 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
                             procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, (long) offset + MacSystem.CPU_STATE_IDLE));
                 }
             } finally {
-                runOrLog(() -> {
-                    MacSystemFunctions.vm_deallocate(MacSystemFunctions.mach_task_self(), rawProcInfoPtr.address(),
-                            (long) procInfoCount * MacSystem.INT_SIZE);
-                }, LOG, "Failed to vm_deallocate processor info buffer");
+                runOrLog(
+                        () -> MacSystemFunctions.vm_deallocate(MacSystemFunctions.mach_task_self(),
+                                rawProcInfoPtr.address(), (long) procInfoCount * MacSystem.INT_SIZE),
+                        LOG, "Failed to vm_deallocate processor info buffer");
             }
         } catch (Throwable e) {
             LOG.error("Failed to update CPU Load", e);


### PR DESCRIPTION
Follow-up to #3393, covering the mechanical `java8`-tagged SonarCloud findings. One commit per rule. No behavior change; verified locally with a clean `install -P aggregate-coverage,native-comparison` (full unit suite + NativeComparisonTest green) plus checkstyle/forbiddenapis/javadoc on the touched modules.

### Applied
- **S1602** — three FFM cleanup/downcall lambdas with a redundant `{ ... }` (one also a redundant `return`) collapsed to expression form.
- **S1611** — four `LinuxSensors` single-parameter lambdas had parenthesized params; parentheses removed.
- **S1612** — two lambdas that just forward their argument replaced with method references (`Ole32FFM::CoUninitialize` via `runOrLog`, and `AuxvTest`'s `NativeLongReader`).
- **S8694** — numeric month arguments in `LocalDate.of` / `LocalDateTime.of` test literals replaced with `java.time.Month` constants.

### Intentionally left (false positives in context)
- **S1612 × 5** (the `assertDoesNotThrow(...)` call sites in `DmidecodeTest`, `LshalTest`, `CpuInfoTest`) — a method reference there is ambiguous between the `Executable` and `ThrowingSupplier<T>` overloads of `assertDoesNotThrow`; the lambda is required to compile.
- **S2093 × 5** (`WindowsInternetProtocolStatsJNA` × 4, `MacHWDiskStoreFFM` × 1) — the JNA sites reassign `buf` inside the buffer-grow loop (not effectively final), and the Mac site's outer `try` wraps a borrowed-singleton `CFAllocatorRef` (`@SuppressWarnings("resource")`) that must not be closed. Neither converts to try-with-resources without changing behavior.
- **S3824 × 1** (`SolarisComputerSystem`) — the guard is `!containsKey(k) || isBlank(get(k))`, i.e. it also replaces blank values; `computeIfAbsent` only fires when the key is absent, so the suggestion would change behavior.
- **S2143 × 1** (`ProcessorPanel` demo) — the `java.util.Date` is required by JFreeChart's `new Second(Date)` constructor.

I'll mark the false-positive findings as won't-fix in SonarCloud separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved lambda expressions and method references across sensor and Windows FFM platform code.
  * Transitioned from numeric month literals to Month enum constants in date handling.

* **Tests**
  * Enhanced test code readability by updating date specifications to use Month enum constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->