### PR TITLE
Sonar Category C cleanup: dead code + redundant casts (S1905, S1068, S1144, S1130)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
@@ -277,10 +277,6 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
         return cardList;
     }
 
-    private static long queryLspciMemorySize(String lookupDevice) {
-        return queryLspciMemorySize(ExecutingCommand.runNative("lspci -v -s " + lookupDevice));
-    }
-
     /**
      * Parse prefetchable memory size from lspci verbose output.
      *

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
@@ -126,7 +126,7 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
      * @return the mutable partition list
      */
     protected List<HWPartition> getMutablePartitionList() {
-        return (List<HWPartition>) getPartitions();
+        return getPartitions();
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -287,7 +287,7 @@ public final class MacInstalledApps {
                 .replace("&apos;", "'");
     }
 
-    private static String readStringValue(String xml, String keyName) throws Exception {
+    private static String readStringValue(String xml, String keyName) {
         int i = xml.indexOf("<key>" + keyName + "</key>");
         if (i > 0) {
             i = xml.indexOf("<string>", i);

--- a/oshi-core-ffm/src/main/java/oshi/driver/linux/WhoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/linux/WhoFFM.java
@@ -109,7 +109,7 @@ public final class WhoFFM {
 
             try {
                 // Read array of string pointers
-                MemorySegment ptrArray = sessions.reinterpret((long) count * ADDRESS.byteSize(), arena, null);
+                MemorySegment ptrArray = sessions.reinterpret(count * ADDRESS.byteSize(), arena, null);
                 for (int i = 0; i < count; i++) {
                     MemorySegment sessionIdPtr = ptrArray.getAtIndex(ADDRESS, i);
                     if (sessionIdPtr.equals(MemorySegment.NULL)) {
@@ -127,7 +127,7 @@ public final class WhoFFM {
                 }
             } finally {
                 // Free each string, then the array
-                MemorySegment ptrArray = sessions.reinterpret((long) count * ADDRESS.byteSize(), arena, null);
+                MemorySegment ptrArray = sessions.reinterpret(count * ADDRESS.byteSize(), arena, null);
                 for (int i = 0; i < count; i++) {
                     MemorySegment ptr = ptrArray.getAtIndex(ADDRESS, i);
                     if (!ptr.equals(MemorySegment.NULL)) {

--- a/oshi-core-ffm/src/main/java/oshi/driver/unix/aix/PsInfoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/unix/aix/PsInfoFFM.java
@@ -89,7 +89,7 @@ public final class PsInfoFFM {
                 long argp = bufStart == 0 ? 0 : readPointerFromBuffer(buffer, argv - bufStart, increment);
                 if (argp > 0) {
                     for (int i = 0; i < argc; i++) {
-                        long offset = argp + (long) i * increment;
+                        long offset = argp + i * increment;
                         bufStart = conditionallyReadPage(fd, buffer, bufStart, offset);
                         argPtr[i] = bufStart == 0 ? 0 : readPointerFromBuffer(buffer, offset - bufStart, increment);
                     }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -131,10 +131,10 @@ public abstract class ForeignFunctions {
     protected static final SymbolLookup SYMBOL_LOOKUP = SymbolLookup.loaderLookup();
 
     /** The size in bytes of the C {@code long} type on this platform. */
-    public static final long NATIVE_LONG_SIZE = ((ValueLayout) LINKER.canonicalLayouts().get("long")).byteSize();
+    public static final long NATIVE_LONG_SIZE = LINKER.canonicalLayouts().get("long").byteSize();
 
     /** The size in bytes of the C {@code size_t} type on this platform. */
-    public static final long NATIVE_SIZE_T_SIZE = ((ValueLayout) LINKER.canonicalLayouts().get("size_t")).byteSize();
+    public static final long NATIVE_SIZE_T_SIZE = LINKER.canonicalLayouts().get("size_t").byteSize();
 
     /** The size in bytes of a native pointer on this platform. */
     public static final long NATIVE_POINTER_SIZE = ValueLayout.ADDRESS.byteSize();

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/CupsFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/CupsFunctions.java
@@ -67,7 +67,6 @@ public final class CupsFunctions extends ForeignFunctions {
     public static final VarHandle CUPS_DEST_OPTIONS = CUPS_DEST_T
             .varHandle(MemoryLayout.PathElement.groupElement("options"));
 
-    private static final SymbolLookup CUPS_LIBRARY;
     private static final boolean AVAILABLE;
 
     // int cupsGetDests(cups_dest_t **dests);
@@ -99,7 +98,6 @@ public final class CupsFunctions extends ForeignFunctions {
         } catch (Throwable _) {
             // libcups not available or symbol binding failed; callers should fall back to lpstat
         }
-        CUPS_LIBRARY = lookup;
         AVAILABLE = available;
         cupsGetDests = hGetDests;
         cupsFreeDests = hFreeDests;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Shell32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Shell32FFM.java
@@ -61,10 +61,10 @@ public final class Shell32FFM extends WindowsForeignFunctions {
 
                 List<String> args = new ArrayList<>(numArgs);
                 // Reinterpret the pointer array with proper size
-                MemorySegment argvArray = argvPtr.reinterpret((long) numArgs * ADDRESS.byteSize());
+                MemorySegment argvArray = argvPtr.reinterpret(numArgs * ADDRESS.byteSize());
 
                 for (int i = 0; i < numArgs; i++) {
-                    MemorySegment argPtr = argvArray.get(ADDRESS, (long) i * ADDRESS.byteSize());
+                    MemorySegment argPtr = argvArray.get(ADDRESS, i * ADDRESS.byteSize());
                     if (argPtr != null && argPtr.address() != 0) {
                         // Calculate string length by finding null terminator
                         // Reinterpret with large size to scan for null

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/ComObjectFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/ComObjectFFM.java
@@ -56,7 +56,7 @@ public class ComObjectFFM extends IUnknownFFM {
      * @return the function pointer
      */
     protected static MemorySegment getVtableFunction(MemorySegment vtable, int index) {
-        return vtable.get(ADDRESS, (long) index * PTR_SIZE);
+        return vtable.get(ADDRESS, index * PTR_SIZE);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
@@ -52,7 +52,6 @@ public final class AdlUtilFFM {
     private static final int PERF_STATUS_SIZE = 72;
     private static final long PERF_CORE_CLOCK_OFFSET = 0;
     private static final long PERF_MEMORY_CLOCK_OFFSET = 4;
-    private static final long PERF_GPU_ACTIVITY_OFFSET = 24;
 
     // ADLODNFanControl: 8 ints = 32 bytes
     private static final int FAN_CONTROL_SIZE = 32;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WbemcliUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WbemcliUtilFFM.java
@@ -251,13 +251,13 @@ public final class WbemcliUtilFFM {
                         result.add(vt, cimType, property, (int) getShortVal(getResult.variant()));
                         break;
                     case VT_UI2:
-                        result.add(vt, cimType, property, (int) getShortVal(getResult.variant()) & 0xFFFF);
+                        result.add(vt, cimType, property, getShortVal(getResult.variant()) & 0xFFFF);
                         break;
                     case VT_I1:
                         result.add(vt, cimType, property, (int) getByteVal(getResult.variant()));
                         break;
                     case VT_UI1:
-                        result.add(vt, cimType, property, (int) (getByteVal(getResult.variant()) & 0xFF));
+                        result.add(vt, cimType, property, getByteVal(getResult.variant()) & 0xFF);
                         break;
                     case VT_BOOL:
                         result.add(vt, cimType, property, getBoolVal(getResult.variant()));

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -8,9 +8,6 @@ import java.lang.foreign.MemorySegment;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.mac.IOReportClientFFM;
 import oshi.ffm.platform.mac.CoreFoundation.CFDictionaryRef;
@@ -42,8 +39,6 @@ import oshi.hardware.GpuTicks;
 @ThreadSafe
 final class MacGpuStatsFFM implements GpuStats {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MacGpuStatsFFM.class);
-
     private static final String PERF_STATS_KEY = "PerformanceStatistics";
     private static final String GPU_CORE_UTIL_KEY = "GPU Core Utilization";
     private static final String DEVICE_UTIL_KEY = "Device Utilization %";
@@ -53,7 +48,6 @@ final class MacGpuStatsFFM implements GpuStats {
     private static final Pattern TRADEMARK_PATTERN = Pattern.compile("[®™]|\\([Rr]\\)|\\([Tt][Mm]\\)");
 
     private final boolean isAppleSilicon;
-    private final String cardName;
     private final IOReportClientFFM ioReportClient;
     private final String normCardName;
     private final Pattern cardNamePattern;
@@ -62,7 +56,6 @@ final class MacGpuStatsFFM implements GpuStats {
 
     MacGpuStatsFFM(boolean isAppleSilicon, String cardName) {
         this.isAppleSilicon = isAppleSilicon;
-        this.cardName = cardName;
         this.ioReportClient = IOReportClientFFM.create();
         this.normCardName = TRADEMARK_PATTERN.matcher(cardName.toLowerCase(Locale.ROOT)).replaceAll("").trim();
         this.cardNamePattern = Pattern.compile("\\b" + Pattern.quote(normCardName) + "\\b");

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -43,12 +43,6 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacHWDiskStoreFFM.class);
 
-    private MacHWDiskStoreFFM(String name, String model, String serial, long size, DASessionRef session,
-            Map<String, String> mountPointMap, Map<CFKey, CFStringRef> cfKeyMap) {
-        super(name, model, serial, size);
-        updateDiskStats(session, mountPointMap, cfKeyMap);
-    }
-
     private MacHWDiskStoreFFM(String name, String model, String serial, long size, String diskType,
             DASessionRef session, Map<String, String> mountPointMap, Map<CFKey, CFStringRef> cfKeyMap) {
         super(name, model, serial, size, diskType);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreFFM.java
@@ -48,10 +48,6 @@ public final class WindowsHWDiskStoreFFM extends WindowsHWDiskStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsHWDiskStoreFFM.class);
 
-    private WindowsHWDiskStoreFFM(String name, String model, String serial, long size) {
-        super(name, model, serial, size);
-    }
-
     private WindowsHWDiskStoreFFM(String name, String model, String serial, long size, String diskType) {
         super(name, model, serial, size, diskType);
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
@@ -63,7 +63,7 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
         return callInArenaOrDefault(arena -> {
             MemorySegment mib = arena.allocateFrom(JAVA_INT, CTL_KERN, KERN_PROC, KERN_PROC_ARGS, getProcessID());
             MemorySegment buf = arena.allocate(ARGMAX);
-            MemorySegment size = arena.allocateFrom(SIZE_T, (long) ARGMAX);
+            MemorySegment size = arena.allocateFrom(SIZE_T, ARGMAX);
             MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
             int rc = FreeBsdLibcFunctions.sysctl(callState, mib, 4, buf, size, MemorySegment.NULL, 0L);
             if (rc != 0) {
@@ -86,7 +86,7 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
         return callInArenaOrDefault(arena -> {
             MemorySegment mib = arena.allocateFrom(JAVA_INT, CTL_KERN, KERN_PROC, KERN_PROC_ENV, getProcessID());
             MemorySegment buf = arena.allocate(ARGMAX);
-            MemorySegment size = arena.allocateFrom(SIZE_T, (long) ARGMAX);
+            MemorySegment size = arena.allocateFrom(SIZE_T, ARGMAX);
             MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
             int rc = FreeBsdLibcFunctions.sysctl(callState, mib, 4, buf, size, MemorySegment.NULL, 0L);
             if (rc != 0) {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
@@ -69,7 +69,7 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
                     mibSeg.setAtIndex(JAVA_INT, i, mib[i]);
                 }
                 MemorySegment buf = arena.allocate(ARGMAX);
-                MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, (long) ARGMAX);
+                MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, ARGMAX);
                 MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
                 if (OpenBsdLibcFunctions.sysctl(callState, mibSeg, mib.length, buf, sizeSeg, MemorySegment.NULL,
                         0L) == 0) {
@@ -103,7 +103,7 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
                     mibSeg.setAtIndex(JAVA_INT, i, mib[i]);
                 }
                 MemorySegment buf = arena.allocate(ARGMAX);
-                MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, (long) ARGMAX);
+                MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, ARGMAX);
                 MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
                 if (OpenBsdLibcFunctions.sysctl(callState, mibSeg, mib.length, buf, sizeSeg, MemorySegment.NULL,
                         0L) == 0) {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -22,9 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.HandleCountProperty;
 import oshi.driver.common.windows.wmi.Win32LogicalDisk.LogicalDiskProperty;
@@ -39,8 +36,6 @@ import oshi.util.ParseUtil;
 
 @ThreadSafe
 public class WindowsFileSystemFFM extends AbstractFileSystem {
-
-    private static final Logger LOG = LoggerFactory.getLogger(WindowsFileSystemFFM.class);
 
     private static final int BUFSIZE = 255;
 
@@ -189,7 +184,7 @@ public class WindowsFileSystemFFM extends AbstractFileSystem {
                     if (pathNamesResult.isEmpty() || pathNamesResult.getAsInt() == 0) {
                         if (Kernel32FFM.GetLastError().orElse(0) == 0x7A) { // ERROR_MORE_DATA
                             mountBufSize = returnLengthBuf.get(JAVA_INT, 0);
-                            mountBuf = arena.allocate((long) mountBufSize * JAVA_CHAR.byteSize());
+                            mountBuf = arena.allocate(mountBufSize * JAVA_CHAR.byteSize());
                             pathNamesResult = Kernel32FFM.GetVolumePathNamesForVolumeName(toWideString(arena, volume),
                                     mountBuf, mountBufSize, returnLengthBuf);
                         }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -180,7 +180,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
                 List<OSService> svcArray = new ArrayList<>(count);
 
                 for (int i = 0; i < count; i++) {
-                    long base = (long) i * ENUM_SERVICE_STATUS_PROCESS_SIZE;
+                    long base = i * ENUM_SERVICE_STATUS_PROCESS_SIZE;
                     MemorySegment pDisplayName = lpServices.get(ADDRESS, base + DISPLAY_NAME_OFFSET).reinterpret(512);
                     String displayName = readWideString(pDisplayName);
                     int currentState = lpServices.get(JAVA_INT, base + CURRENT_STATE_OFFSET);

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardJNA.java
@@ -74,9 +74,6 @@ final class WindowsGraphicsCardJNA extends AbstractGraphicsCard {
 
     private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
 
-    // Conversion: LHM reports memory in MB; 1 MB = 1_048_576 bytes
-    private static final long MB_TO_BYTES = 1_048_576L;
-
     public static final String ADAPTER_STRING = "HardwareInformation.AdapterString";
     public static final String DRIVER_DESC = "DriverDesc";
     public static final String DRIVER_VERSION = "DriverVersion";

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreJNA.java
@@ -43,10 +43,6 @@ public final class WindowsHWDiskStoreJNA extends WindowsHWDiskStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsHWDiskStoreJNA.class);
 
-    private WindowsHWDiskStoreJNA(String name, String model, String serial, long size) {
-        super(name, model, serial, size);
-    }
-
     private WindowsHWDiskStoreJNA(String name, String model, String serial, long size, String diskType) {
         super(name, model, serial, size, diskType);
     }

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
@@ -8,9 +8,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sun.jna.Memory;
 import com.sun.jna.platform.unix.LibCAPI.size_t;
 import com.sun.jna.platform.unix.Resource;
@@ -29,8 +26,6 @@ import oshi.util.common.platform.unix.dragonflybsd.ProcstatUtil;
  */
 @ThreadSafe
 public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
-
-    private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOSProcessJNA.class);
 
     private final DragonFlyBsdOperatingSystemJNA os;
 

--- a/oshi-core/src/main/java/oshi/util/gpu/AdlUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/AdlUtilJNA.java
@@ -72,7 +72,7 @@ public final class AdlUtilJNA {
                     if (size <= 0) {
                         return Pointer.NULL;
                     }
-                    long addr = Native.malloc((long) size);
+                    long addr = Native.malloc(size);
                     return addr == 0L ? Pointer.NULL : new Pointer(addr);
                 };
                 loaded = true;

--- a/oshi-metrics/src/main/java/oshi/metrics/DiskMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/DiskMetrics.java
@@ -46,6 +46,10 @@ public class DiskMetrics implements MeterBinder {
     private static final double MS_PER_SECOND = 1000.0;
 
     private final Supplier<List<HWDiskStore>> diskStoreSupplier;
+    // Intentionally retained though never read: holds a strong reference to the disk stores so the GC cannot clear
+    // the WeakReferences that Micrometer's FunctionCounter keeps to them (see bindTo). Removing this would silently
+    // break the disk metrics after a garbage collection.
+    @SuppressWarnings("java:S1068") // intentionally unused field — see above
     private List<HWDiskStore> diskStores;
 
     /**

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import oshi.SystemInfo;
-import oshi.hardware.HardwareAbstractionLayer;
 import oshi.software.os.OperatingSystem;
 import oshi.spi.SystemInfoProvider;
 import oshi.util.PlatformEnum;
@@ -31,14 +30,12 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 class OshiMetricsTest {
 
     private static MeterRegistry registry;
-    private static HardwareAbstractionLayer hal;
     private static OperatingSystem os;
 
     @BeforeAll
     static void setUp() {
         registry = new SimpleMeterRegistry();
         SystemInfoProvider si = new SystemInfo();
-        hal = si.getHardware();
         os = si.getOperatingSystem();
         OshiMetrics.bindTo(registry, si);
     }


### PR DESCRIPTION
Mechanical dead-code / redundancy cleanup from the Sonar triage backlog, one commit per rule. No behavior change; verified locally with a clean `install -P aggregate-coverage,native-comparison` (full unit suite + NativeComparisonTest green) plus checkstyle/forbiddenapis/javadoc on the touched modules.

### Fixed
- **S1905 (18)** — removed redundant casts. Each verified safe: every `(long) i * X` had a `long` right operand (so the product was already computed in `long` — no overflow was being prevented), the `(int)` casts on `short`/`byte` are redundant under `&` promotion, and `getPartitions()` is already `List<HWPartition>`.
- **S1068 (8)** — deleted genuinely dead private fields (unused loggers, write-only fields whose derived state is what's used, leftover constants).
- **S1144 (4)** — removed dead constructor/method overloads (pre-`diskType` constructors; an inlined `queryLspciMemorySize(String)`). These are not prevent-instantiation idioms.
- **S1130 (1)** — removed a vestigial `throws Exception` on `MacInstalledApps.readStringValue`.

### Notable: a bug *not* introduced
`DiskMetrics.diskStores` looks like an unused field (S1068) but is a deliberate **GC root** — Micrometer's `FunctionCounter` only holds a `WeakReference` to each disk object, so this strong reference keeps them alive. Deleting it would silently break the disk metrics after a GC. Kept it, documented, and marked `@SuppressWarnings("java:S1068")`.

### Intentionally deferred
- **S1130 ×6** (`JMXOshiAgentServer`) — `@Override` stubs whose `throws` mirror the JMX `MBeanServer` interface contract; removing Sonar's flagged subset would make them inconsistent with their siblings. Better suppressed-as-conformance or left.

Remaining Category C (`S1168` null→empty, `S4144` identical bodies) involves caller-by-caller analysis and is a deliberate follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified native memory operations and pointer handling across platform implementations.
  * Removed unnecessary type conversions throughout codebase.
  * Consolidated constructor signatures for improved consistency.
  * Eliminated unused constants and helper methods.

* **Chores**
  * Removed unused logging dependencies from several components.
  * Added documentation to prevent unintended garbage collection of internal references.

* **Tests**
  * Improved test setup infrastructure for metrics validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->