### PR TITLE
Sonar cleanup: demo MBean stubs (S1168), deprecations (S1874), duplicated literals (S1192)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdGraphicsCard.java
@@ -23,6 +23,7 @@ import oshi.util.ExecutingCommand;
 public final class BsdGraphicsCard extends AbstractGraphicsCard {
 
     private static final String PCI_CLASS_DISPLAY = "Class: 03 Display";
+    private static final String UNKNOWN_PCI_ID = "0x0000";
     private static final Pattern PCI_DUMP_HEADER = Pattern.compile(" \\d+:\\d+:\\d+: (.+)");
 
     public BsdGraphicsCard(String name, String deviceId, String vendor, String versionInfo, long vram) {
@@ -50,7 +51,8 @@ public final class BsdGraphicsCard extends AbstractGraphicsCard {
             if (m.matches()) {
                 if (classCodeFound) {
                     cardList.add(new BsdGraphicsCard(name.isEmpty() ? Constants.UNKNOWN : name,
-                            productId.isEmpty() ? "0x0000" : productId, vendorId.isEmpty() ? "0x0000" : vendorId,
+                            productId.isEmpty() ? UNKNOWN_PCI_ID : productId,
+                            vendorId.isEmpty() ? UNKNOWN_PCI_ID : vendorId,
                             versionInfo.isEmpty() ? Constants.UNKNOWN : versionInfo, 0L));
                 }
                 name = m.group(1);
@@ -82,7 +84,7 @@ public final class BsdGraphicsCard extends AbstractGraphicsCard {
         }
         if (classCodeFound) {
             cardList.add(new BsdGraphicsCard(name.isEmpty() ? Constants.UNKNOWN : name,
-                    productId.isEmpty() ? "0x0000" : productId, vendorId.isEmpty() ? "0x0000" : vendorId,
+                    productId.isEmpty() ? UNKNOWN_PCI_ID : productId, vendorId.isEmpty() ? UNKNOWN_PCI_ID : vendorId,
                     versionInfo.isEmpty() ? Constants.UNKNOWN : versionInfo, 0L));
         }
         return cardList;

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -34,6 +34,11 @@ public final class MacInstalledApps {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacInstalledApps.class);
 
+    private static final String TAG_STRING_OPEN = "<string>";
+    private static final String TAG_STRING_CLOSE = "</string>";
+    private static final String TAG_ARRAY_OPEN = "<array>";
+    private static final String TAG_ARRAY_CLOSE = "</array>";
+
     private MacInstalledApps() {
     }
 
@@ -146,12 +151,12 @@ public final class MacInstalledApps {
             return Collections.emptyList();
         }
 
-        int arrayOpen = xml.indexOf("<array>", m.end());
+        int arrayOpen = xml.indexOf(TAG_ARRAY_OPEN, m.end());
         if (arrayOpen < 0) {
             return Collections.emptyList();
         }
 
-        String arrayBody = extractBalancedInner(xml, arrayOpen, "<array>", "</array>");
+        String arrayBody = extractBalancedInner(xml, arrayOpen, TAG_ARRAY_OPEN, TAG_ARRAY_CLOSE);
         if (arrayBody == null) {
             return Collections.emptyList();
         }
@@ -184,19 +189,19 @@ public final class MacInstalledApps {
             }
 
             String val;
-            if (startsWith(dictInner, vOpen, "<string>")) {
-                String inner = extractSimpleInner(dictInner, vOpen, "<string>", "</string>");
+            if (startsWith(dictInner, vOpen, TAG_STRING_OPEN)) {
+                String inner = extractSimpleInner(dictInner, vOpen, TAG_STRING_OPEN, TAG_STRING_CLOSE);
                 val = unescape(inner);
-                pos = dictInner.indexOf("</string>", vOpen) + "</string>".length();
+                pos = dictInner.indexOf(TAG_STRING_CLOSE, vOpen) + TAG_STRING_CLOSE.length();
             } else if (startsWith(dictInner, vOpen, "<date>")) {
                 String inner = extractSimpleInner(dictInner, vOpen, "<date>", "</date>");
                 val = inner.trim();
                 pos = dictInner.indexOf("</date>", vOpen) + "</date>".length();
-            } else if (startsWith(dictInner, vOpen, "<array>")) {
-                String inner = extractBalancedInner(dictInner, vOpen, "<array>", "</array>");
+            } else if (startsWith(dictInner, vOpen, TAG_ARRAY_OPEN)) {
+                String inner = extractBalancedInner(dictInner, vOpen, TAG_ARRAY_OPEN, TAG_ARRAY_CLOSE);
                 String parsed = inner == null ? null : parseStringArray(inner);
                 val = parsed == null ? "" : parsed;
-                pos = dictInner.indexOf("</array>", vOpen) + "</array>".length();
+                pos = dictInner.indexOf(TAG_ARRAY_CLOSE, vOpen) + TAG_ARRAY_CLOSE.length();
             } else {
                 // other irrelevant tags: go to next tag
                 pos = vOpen + 1;
@@ -211,8 +216,8 @@ public final class MacInstalledApps {
     static String parseStringArray(String arrayInner) {
         int lt = arrayInner.indexOf('<');
         if (lt >= 0) {
-            if (startsWith(arrayInner, lt, "<string>")) {
-                String inner = extractSimpleInner(arrayInner, lt, "<string>", "</string>");
+            if (startsWith(arrayInner, lt, TAG_STRING_OPEN)) {
+                String inner = extractSimpleInner(arrayInner, lt, TAG_STRING_OPEN, TAG_STRING_CLOSE);
                 return unescape(inner);
             }
         }
@@ -290,10 +295,10 @@ public final class MacInstalledApps {
     private static String readStringValue(String xml, String keyName) {
         int i = xml.indexOf("<key>" + keyName + "</key>");
         if (i > 0) {
-            i = xml.indexOf("<string>", i);
+            i = xml.indexOf(TAG_STRING_OPEN, i);
             if (i > 0) {
-                i += 8; // lengh of "<string>"
-                int e = xml.indexOf("</string>", i);
+                i += TAG_STRING_OPEN.length();
+                int e = xml.indexOf(TAG_STRING_CLOSE, i);
                 if (e > 0) {
                     return xml.substring(i, e);
                 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
@@ -95,6 +95,8 @@ public class NetBsdOperatingSystem extends BsdOperatingSystem {
     }
 
     @Override
+    // Thread.threadId() (the non-deprecated replacement) requires Java 19; this module compiles to Java 8.
+    @SuppressWarnings({ "deprecation", "java:S1874" })
     public int getThreadId() {
         return (int) Thread.currentThread().getId();
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGlobalMemoryJNA.java
@@ -14,7 +14,7 @@ import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.platform.mac.MacGlobalMemory;
 import oshi.hardware.common.platform.mac.SysctlProvider;
 import oshi.jna.ByRef.CloseableIntByReference;
-import oshi.jna.ByRef.CloseableLongByReference;
+import oshi.jna.ByRef.CloseableNativeLongByReference;
 import oshi.jna.Struct.CloseableVMStatistics;
 
 @ThreadSafe
@@ -44,10 +44,10 @@ final class MacGlobalMemoryJNA extends MacGlobalMemory {
     @Override
     protected long queryPageSize() {
         int ret = -1;
-        try (CloseableLongByReference pPageSize = new CloseableLongByReference()) {
+        try (CloseableNativeLongByReference pPageSize = new CloseableNativeLongByReference()) {
             ret = SystemB.INSTANCE.host_page_size(SystemB.INSTANCE.mach_host_self(), pPageSize);
             if (0 == ret) {
-                return pPageSize.getValue();
+                return pPageSize.getValue().longValue();
             }
         }
         LOG.error("Failed to get host page size. Error code: {}", ret);

--- a/oshi-demo/src/main/java/oshi/demo/jmx/JMXOshiAgentServer.java
+++ b/oshi-demo/src/main/java/oshi/demo/jmx/JMXOshiAgentServer.java
@@ -7,6 +7,7 @@ package oshi.demo.jmx;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.rmi.registry.LocateRegistry;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -185,12 +186,12 @@ public class JMXOshiAgentServer implements JMXOshiAgent {
 
     @Override
     public Set<ObjectInstance> queryMBeans(ObjectName name, QueryExp query) {
-        return null;
+        return Collections.emptySet();
     }
 
     @Override
     public Set<ObjectName> queryNames(ObjectName name, QueryExp query) {
-        return null;
+        return Collections.emptySet();
     }
 
     @Override
@@ -212,7 +213,7 @@ public class JMXOshiAgentServer implements JMXOshiAgent {
     @Override
     public AttributeList getAttributes(ObjectName name, String[] attributes)
             throws InstanceNotFoundException, ReflectionException {
-        return null;
+        return new AttributeList();
     }
 
     @Override
@@ -224,7 +225,7 @@ public class JMXOshiAgentServer implements JMXOshiAgent {
     @Override
     public AttributeList setAttributes(ObjectName name, AttributeList attributes)
             throws InstanceNotFoundException, ReflectionException {
-        return null;
+        return new AttributeList();
     }
 
     @Override
@@ -314,18 +315,21 @@ public class JMXOshiAgentServer implements JMXOshiAgent {
     }
 
     @Override
+    @Deprecated
     public ObjectInputStream deserialize(ObjectName name, byte[] data)
             throws InstanceNotFoundException, OperationsException {
         return null;
     }
 
     @Override
+    @Deprecated
     public ObjectInputStream deserialize(String className, byte[] data)
             throws OperationsException, ReflectionException {
         return null;
     }
 
     @Override
+    @Deprecated
     public ObjectInputStream deserialize(String className, ObjectName loaderName, byte[] data)
             throws InstanceNotFoundException, OperationsException, ReflectionException {
         return null;

--- a/oshi-demo/src/main/java/oshi/demo/jmx/mbeans/Baseboard.java
+++ b/oshi-demo/src/main/java/oshi/demo/jmx/mbeans/Baseboard.java
@@ -99,12 +99,12 @@ public class Baseboard implements DynamicMBean, PropertiesAvailable {
 
     @Override
     public AttributeList getAttributes(String[] attributes) {
-        return null;
+        return new AttributeList();
     }
 
     @Override
     public AttributeList setAttributes(AttributeList attributes) {
-        return null;
+        return new AttributeList();
     }
 
     @Override


### PR DESCRIPTION
Targeted Sonar fixes, one commit per concern. No behavior change to production query results; verified locally with a clean `install -P aggregate-coverage,native-comparison` (full unit suite + NativeComparisonTest green — the latter exercises the page-size path on macOS) plus checkstyle/forbiddenapis/javadoc.

### Fixed
- **S1168 (6)** — `JMXOshiAgentServer` / `Baseboard` demo MBean stubs returned `null` from interface methods that contractually return collections; return empty collections instead. No sentinel meaning to preserve.
- **S1874 (5)**
  - `MacGlobalMemoryJNA.queryPageSize` → the non-deprecated `SystemB.host_page_size(int, NativeLongByReference)` overload (JNA 5.19, already on the classpath) — native-width `vm_size_t` out-param instead of a fixed 64-bit `LongByReference`.
  - 3 `deserialize(...)` overrides implement deprecated JMX `MBeanServer` methods → marked `@Deprecated` (truthful, and silences the javac warning too).
  - `NetBsdOperatingSystem.getThreadId` uses `Thread.getId()`; the replacement `Thread.threadId()` needs Java 19 but this module compiles to Java 8, so it's suppressed in code with a comment.
- **S1192 (5)** — extracted constants for the repeated plist XML tags (`MacInstalledApps`) and `0x0000` default PCI id (`BsdGraphicsCard`).

### Context: the rest of these rules were triaged separately
The bulk of S1168 (19), all of S107 (8), and 23 S1192 were evaluated and **accepted as won't-fix** with reasons — notably, OSHI's native code deliberately uses `null` = "native call failed/unavailable" vs. empty = "succeeded, zero results" to drive retry/fallback logic (e.g. `AdlUtil`/`NvmlUtil` return null on driver error but `emptyMap` for zero adapters; `LinuxFileSystem` null triggers the Java `File` fallback). Returning empty there would break that logic, so those are intentional sentinels, not bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code maintainability through constant extraction and cleanup across multiple components
  * Corrected JNA binding for macOS page-size queries to use native-long references
  * Standardized null-return handling in JMX components to return empty collections instead

* **Deprecations**
  * Marked two deserialization methods in JMX agent server as deprecated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->