### PR TITLE
Sonar mechanical sweep: idioms, functional interfaces, merge-if, logging (11 rules)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/CentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/CentralProcessor.java
@@ -799,7 +799,7 @@ public interface CentralProcessor {
             if (this == obj) {
                 return true;
             }
-            if (obj == null || !(obj instanceof ProcessorCache)) {
+            if (!(obj instanceof ProcessorCache)) {
                 return false;
             }
             ProcessorCache other = (ProcessorCache) obj;

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -110,7 +110,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
 
             for (InterfaceAddress interfaceAddress : networkInterface.getInterfaceAddresses()) {
                 InetAddress address = interfaceAddress.getAddress();
-                if (address.getHostAddress().length() > 0) {
+                if (!address.getHostAddress().isEmpty()) {
                     if (address.getHostAddress().contains(":")) {
                         ipv6list.add(address.getHostAddress().split("%")[0]);
                         prefixLengthList.add(interfaceAddress.getNetworkPrefixLength());

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
@@ -93,7 +93,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
                 case "model name":
                 case "processor": // some ARM chips
                     // Ignore processor number
-                    if (!splitLine[1].matches("[0-9]+")) {
+                    if (!splitLine[1].matches("\\d+")) {
                         cpuName = splitLine[1];
                     }
                     break;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.ToLongFunction;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.GraphicsCard;
@@ -213,7 +214,7 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
      * @return list of graphics cards
      */
     static List<GraphicsCard> getGraphicsCardsFromLspci(List<String> lspci, Function<Attrs, GraphicsCard> factory,
-            Function<String, Long> vramLookup, Function<String, Triplet<String, String, String>> drmLookup) {
+            ToLongFunction<String> vramLookup, Function<String, Triplet<String, String, String>> drmLookup) {
         List<GraphicsCard> cardList = new ArrayList<>();
         String name = Constants.UNKNOWN;
         String deviceId = Constants.UNKNOWN;
@@ -242,8 +243,8 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
                     Triplet<String, String, String> drmInfo = drmLookup.apply(lookupDevice);
                     cardList.add(factory.apply(new Attrs(name, deviceId, vendor,
                             versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList),
-                            lookupDevice != null ? vramLookup.apply(lookupDevice) : 0L, drmInfo.getA(), drmInfo.getB(),
-                            drmInfo.getC())));
+                            lookupDevice != null ? vramLookup.applyAsLong(lookupDevice) : 0L, drmInfo.getA(),
+                            drmInfo.getB(), drmInfo.getC())));
                     versionInfoList.clear();
                     found = false;
                 } else {
@@ -271,7 +272,7 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
             Triplet<String, String, String> drmInfo = drmLookup.apply(lookupDevice);
             cardList.add(factory.apply(new Attrs(name, deviceId, vendor,
                     versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList),
-                    lookupDevice != null ? vramLookup.apply(lookupDevice) : 0L, drmInfo.getA(), drmInfo.getB(),
+                    lookupDevice != null ? vramLookup.applyAsLong(lookupDevice) : 0L, drmInfo.getA(), drmInfo.getB(),
                     drmInfo.getC())));
         }
         return cardList;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
@@ -13,7 +13,6 @@ import oshi.hardware.CentralProcessor;
 import oshi.hardware.ComputerSystem;
 import oshi.hardware.Display;
 import oshi.hardware.GlobalMemory;
-import oshi.hardware.GraphicsCard;
 import oshi.hardware.Sensors;
 import oshi.hardware.SoundCard;
 import oshi.hardware.common.AbstractHardwareAbstractionLayer;
@@ -66,7 +65,4 @@ public abstract class LinuxHardwareAbstractionLayer extends AbstractHardwareAbst
     public List<BluetoothDevice> getBluetoothDevices() {
         return LinuxBluetoothDevice.getBluetoothDevices();
     }
-
-    @Override
-    public abstract List<GraphicsCard> getGraphicsCards();
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHWDiskStoreNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHWDiskStoreNF.java
@@ -50,11 +50,9 @@ public final class LinuxHWDiskStoreNF extends LinuxHWDiskStore {
 
             // Filter to real disks (skip loop, ram, etc.)
             String devType = FileUtil.getStringFromFile(sysPath + "device/type").trim();
-            if (devType.isEmpty()) {
-                // No device/type means it's a virtual device; check if it has a device/ subdir
-                if (!new File(sysPath + "device").exists()) {
-                    continue;
-                }
+            // No device/type means it's a virtual device; check if it has a device/ subdir
+            if (devType.isEmpty() && !new File(sysPath + "device").exists()) {
+                continue;
             }
 
             String model = FileUtil.getStringFromFile(sysPath + "device/model").trim();

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOKitProvider.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOKitProvider.java
@@ -6,6 +6,7 @@ package oshi.hardware.common.platform.mac;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Abstracts IOKit registry operations so that iteration logic can be shared between JNA and FFM implementations.
@@ -38,7 +39,7 @@ public interface IOKitProvider {
      * @param serviceName the IOService class name (e.g. "AppleARMIODevice")
      * @param visitor     function invoked for each matched entry; return {@code true} to stop iteration
      */
-    void forEachMatchingServiceUntil(String serviceName, Function<RegistryEntry, Boolean> visitor);
+    void forEachMatchingServiceUntil(String serviceName, Predicate<RegistryEntry> visitor);
 
     /**
      * A handle to an IORegistry entry, providing property access.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/CupsPrinter.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/CupsPrinter.java
@@ -7,6 +7,7 @@ package oshi.hardware.common.platform.unix;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Printer;
@@ -72,8 +73,8 @@ public abstract class CupsPrinter extends AbstractPrinter {
      * @return list of printers
      */
     static List<Printer> getPrintersFromLpstat(List<String> lpstatLines, String defaultPrinter,
-            Map<String, String> portMap, Map<String, String> descriptionMap,
-            java.util.function.Function<String, String> driverLookup, PrinterFactory factory) {
+            Map<String, String> portMap, Map<String, String> descriptionMap, UnaryOperator<String> driverLookup,
+            PrinterFactory factory) {
         List<Printer> printers = new ArrayList<>();
 
         for (String line : lpstatLines) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.freebsd.disk.GeomDiskList;
@@ -63,8 +63,8 @@ public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
      * @param factory   constructs the platform-specific instance
      * @return a list of {@link HWDiskStore} objects representing the disks
      */
-    protected static <T extends FreeBsdHWDiskStore> List<HWDiskStore> getDisks(
-            BiFunction<String, String, String> sysctlStr, DiskStoreFactory<T> factory) {
+    protected static <T extends FreeBsdHWDiskStore> List<HWDiskStore> getDisks(BinaryOperator<String> sysctlStr,
+            DiskStoreFactory<T> factory) {
         List<HWDiskStore> diskList = new ArrayList<>();
 
         Map<String, List<HWPartition>> partitionMap = GeomPartList.queryPartitions();

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
@@ -9,7 +9,7 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -43,8 +43,8 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
      * @param factory   constructs the platform-specific instance
      * @return a list of {@link HWDiskStore} objects representing the disks
      */
-    protected static <T extends OpenBsdHWDiskStore> List<HWDiskStore> getDisks(
-            BiFunction<String, String, String> sysctlStr, DiskStoreFactory<T> factory) {
+    protected static <T extends OpenBsdHWDiskStore> List<HWDiskStore> getDisks(BinaryOperator<String> sysctlStr,
+            DiskStoreFactory<T> factory) {
         List<HWDiskStore> diskList = new ArrayList<>();
         List<String> dmesg = null;
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsSensors.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -246,7 +246,7 @@ public abstract class WindowsSensors extends AbstractSensors {
     }
 
     private static double getAverageValueFromLHM(String hardwareType, String sensorType,
-            BiFunction<String, Double, Boolean> sensorValidFunction) {
+            BiPredicate<String, Double> sensorValidFunction) {
         List<?> sensors = getLhmSensors(hardwareType, sensorType);
         if (sensors == null || sensors.isEmpty()) {
             return 0;
@@ -263,7 +263,7 @@ public abstract class WindowsSensors extends AbstractSensors {
             for (Object sensor : sensors) {
                 String name = (String) getNameMethod.invoke(sensor);
                 double value = (double) getValueMethod.invoke(sensor);
-                if (sensorValidFunction.apply(name, value)) {
+                if (sensorValidFunction.test(name, value)) {
                     sum += value;
                     validCount++;
                 }

--- a/oshi-common/src/main/java/oshi/software/common/AbstractNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractNetworkParams.java
@@ -67,7 +67,7 @@ public abstract class AbstractNetworkParams implements NetworkParams {
             String line = resolv.get(i);
             if (line.startsWith(key)) {
                 String value = line.substring(key.length()).replaceFirst("^[ \t]+", "");
-                if (value.length() != 0 && value.charAt(0) != '#' && value.charAt(0) != ';') {
+                if (!value.isEmpty() && value.charAt(0) != '#' && value.charAt(0) != ';') {
                     String val = value.split("[ \t#;]", 2)[0];
                     servers.add(val);
                 }

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInternetProtocolStats.java
@@ -42,9 +42,9 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
     protected LinuxInternetProtocolStats() {
     }
 
-    private final String tcpColon = "Tcp:";
-    private final String udpColon = "Udp:";
-    private final String udp6 = "Udp6";
+    private static final String TCP_COLON = "Tcp:";
+    private static final String UDP_COLON = "Udp:";
+    private static final String UDP6 = "Udp6";
 
     private enum TcpStat {
         RtoAlgorithm, RtoMin, RtoMax, MaxConn, ActiveOpens, PassiveOpens, AttemptFails, EstabResets, CurrEstab, InSegs,
@@ -62,9 +62,9 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         Map<TcpStat, Long> tcpData = new EnumMap<>(TcpStat.class);
 
         for (int line = 0; line < lines.size() - 1; line += 2) {
-            if (lines.get(line).startsWith(tcpColon) && lines.get(line + 1).startsWith(tcpColon)) {
+            if (lines.get(line).startsWith(TCP_COLON) && lines.get(line + 1).startsWith(TCP_COLON)) {
                 Map<TcpStat, String> parsedData = ParseUtil.stringToEnumMap(TcpStat.class,
-                        lines.get(line + 1).substring(tcpColon.length()).trim(), ' ');
+                        lines.get(line + 1).substring(TCP_COLON.length()).trim(), ' ');
                 for (Map.Entry<TcpStat, String> entry : parsedData.entrySet()) {
                     tcpData.put(entry.getKey(), ParseUtil.parseLongOrDefault(entry.getValue(), 0L));
                 }
@@ -86,9 +86,9 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         Map<UdpStat, Long> udpData = new EnumMap<>(UdpStat.class);
 
         for (int line = 0; line < lines.size() - 1; line += 2) {
-            if (lines.get(line).startsWith(udpColon) && lines.get(line + 1).startsWith(udpColon)) {
+            if (lines.get(line).startsWith(UDP_COLON) && lines.get(line + 1).startsWith(UDP_COLON)) {
                 Map<UdpStat, String> parsedData = ParseUtil.stringToEnumMap(UdpStat.class,
-                        lines.get(line + 1).substring(udpColon.length()).trim(), ' ');
+                        lines.get(line + 1).substring(UDP_COLON.length()).trim(), ' ');
                 for (Map.Entry<UdpStat, String> entry : parsedData.entrySet()) {
                     udpData.put(entry.getKey(), ParseUtil.parseLongOrDefault(entry.getValue(), 0L));
                 }
@@ -112,9 +112,9 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         int foundUDPv6StatsCount = 0;
 
         // Traverse bottom-to-top for efficiency as the /etc/proc/snmp6 file follows sequential format -> ip6, icmp6,
-        // udp6, udplite6 stats
+        // UDP6, udplite6 stats
         for (int line = lines.size() - 1; line >= 0 && foundUDPv6StatsCount < 4; line--) {
-            if (lines.get(line).startsWith(udp6)) {
+            if (lines.get(line).startsWith(UDP6)) {
                 String[] parts = lines.get(line).split("\\s+");
                 switch (parts[0]) {
                     case "Udp6InDatagrams":

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -215,11 +215,9 @@ public final class MacInstalledApps {
 
     static String parseStringArray(String arrayInner) {
         int lt = arrayInner.indexOf('<');
-        if (lt >= 0) {
-            if (startsWith(arrayInner, lt, TAG_STRING_OPEN)) {
-                String inner = extractSimpleInner(arrayInner, lt, TAG_STRING_OPEN, TAG_STRING_CLOSE);
-                return unescape(inner);
-            }
+        if (lt >= 0 && startsWith(arrayInner, lt, TAG_STRING_OPEN)) {
+            String inner = extractSimpleInner(arrayInner, lt, TAG_STRING_OPEN, TAG_STRING_CLOSE);
+            return unescape(inner);
         }
         return null;
     }

--- a/oshi-common/src/main/java/oshi/spi/SystemInfoFactory.java
+++ b/oshi-common/src/main/java/oshi/spi/SystemInfoFactory.java
@@ -55,10 +55,8 @@ public final class SystemInfoFactory {
         while (iterator.hasNext()) {
             try {
                 SystemInfoProvider provider = iterator.next();
-                if (provider.isAvailable()) {
-                    if (best == null || provider.getPriority() > best.getPriority()) {
-                        best = provider;
-                    }
+                if (provider.isAvailable() && (best == null || provider.getPriority() > best.getPriority())) {
+                    best = provider;
                 }
             } catch (ServiceConfigurationError | RuntimeException e) {
                 LOG.debug("Skipping unavailable provider: {}", e.getMessage());

--- a/oshi-common/src/main/java/oshi/util/FileSystemUtil.java
+++ b/oshi-common/src/main/java/oshi/util/FileSystemUtil.java
@@ -72,7 +72,7 @@ public final class FileSystemUtil {
         FileSystem fs = FileSystems.getDefault(); // can't be closed
         List<PathMatcher> patterns = new ArrayList<>();
         for (String item : config.split(",")) {
-            if (item.length() > 0) {
+            if (!item.isEmpty()) {
                 // Using glob: prefix as the defult unless user has specified glob or regex. See
                 // https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-
                 if (!(item.startsWith(GLOB_PREFIX) || item.startsWith(REGEX_PREFIX))) {

--- a/oshi-common/src/main/java/oshi/util/Memoizer.java
+++ b/oshi-common/src/main/java/oshi/util/Memoizer.java
@@ -49,7 +49,7 @@ public final class Memoizer {
      * Store a supplier in a delegate function to be computed once, and only again after time to live (ttl) has expired.
      *
      * @param <T>      The type of object supplied
-     * @param original The {@link java.util.function.Supplier} to memoize
+     * @param original The {@link Supplier} to memoize
      * @param ttlNanos Time in nanoseconds to retain calculation. If negative, retain indefinitely.
      * @return A memoized version of the supplier
      */
@@ -84,7 +84,7 @@ public final class Memoizer {
      * Store a supplier in a delegate function to be computed only once.
      *
      * @param <T>      The type of object supplied
-     * @param original The {@link java.util.function.Supplier} to memoize
+     * @param original The {@link Supplier} to memoize
      * @return A memoized version of the supplier
      */
     public static <T> Supplier<T> memoize(Supplier<T> original) {

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -127,10 +127,10 @@ public final class ParseUtil {
     public static final Pattern whitespaces = Pattern.compile("\\s+");
 
     /** Constant <code>notDigits</code> */
-    public static final Pattern notDigits = Pattern.compile("[^0-9]+");
+    public static final Pattern notDigits = Pattern.compile("\\D+");
 
     /** Constant <code>startWithNotDigits</code> */
-    public static final Pattern startWithNotDigits = Pattern.compile("^[^0-9]*");
+    public static final Pattern startWithNotDigits = Pattern.compile("^\\D*");
 
     /** Constant <code>forwardSlash</code> */
     public static final Pattern slash = Pattern.compile("\\/");
@@ -995,7 +995,7 @@ public final class ParseUtil {
             }
         }
         long capacity = ParseUtil.parseLongOrDefault(mem[0], 0L);
-        if (mem.length == 2 && mem[1].length() > 0) {
+        if (mem.length == 2 && !mem[1].isEmpty()) {
             switch (mem[1].charAt(0)) {
                 case 'T':
                     capacity <<= 40;

--- a/oshi-common/src/main/java/oshi/util/PrivilegedUtil.java
+++ b/oshi-common/src/main/java/oshi/util/PrivilegedUtil.java
@@ -132,6 +132,7 @@ public final class PrivilegedUtil {
     }
 
     private static String queryPrefix() {
+        // Switch (rather than if) is intentional: kept open for additional per-OS prefixes as platform support grows.
         switch (PlatformEnum.getCurrentPlatform()) {
             case LINUX:
                 return GlobalConfig.get(OSHI_OS_LINUX_PRIVILEGED_PREFIX, "");
@@ -141,6 +142,7 @@ public final class PrivilegedUtil {
     }
 
     private static Set<String> queryCommandAllowlist() {
+        // Switch (rather than if) is intentional: kept open for additional per-OS allowlists as platform support grows.
         switch (PlatformEnum.getCurrentPlatform()) {
             case LINUX:
                 return parseAllowlist(GlobalConfig.get(OSHI_OS_LINUX_PRIVILEGED_ALLOWLIST, ""));
@@ -150,6 +152,7 @@ public final class PrivilegedUtil {
     }
 
     private static Set<String> queryFileAllowlist() {
+        // Switch (rather than if) is intentional: kept open for additional per-OS allowlists as platform support grows.
         switch (PlatformEnum.getCurrentPlatform()) {
             case LINUX:
                 return parseAllowlist(GlobalConfig.get(OSHI_OS_LINUX_PRIVILEGED_FILE_ALLOWLIST, ""));

--- a/oshi-common/src/main/java/oshi/util/SystemInfoHelper.java
+++ b/oshi-common/src/main/java/oshi/util/SystemInfoHelper.java
@@ -397,7 +397,7 @@ public final class SystemInfoHelper {
             long total = fs.getTotalSpace();
             lines.add(String.format(Locale.ROOT,
                     " %s (%s) [%s] %s of %s free (%.1f%%), %s of %s files free (%.1f%%) is %s "
-                            + (fs.getLogicalVolume() != null && fs.getLogicalVolume().length() > 0 ? "[%s]" : "%s")
+                            + (fs.getLogicalVolume() != null && !fs.getLogicalVolume().isEmpty() ? "[%s]" : "%s")
                             + " and is mounted at %s",
                     fs.getName(), fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,
@@ -490,7 +490,7 @@ public final class SystemInfoHelper {
             lines.add(" None detected.");
         } else {
             for (BluetoothDevice device : list) {
-                lines.add(" " + String.valueOf(device));
+                lines.add(" " + device);
             }
         }
     }
@@ -504,7 +504,7 @@ public final class SystemInfoHelper {
     public static void printSoundCards(List<String> lines, List<SoundCard> list) {
         lines.add("Sound Cards:");
         for (SoundCard card : list) {
-            lines.add(" " + String.valueOf(card));
+            lines.add(" " + card);
         }
     }
 
@@ -520,7 +520,7 @@ public final class SystemInfoHelper {
             lines.add(" None detected.");
         } else {
             for (GraphicsCard card : list) {
-                lines.add(" " + String.valueOf(card));
+                lines.add(" " + card);
             }
         }
     }
@@ -537,7 +537,7 @@ public final class SystemInfoHelper {
             lines.add(" None detected.");
         } else {
             for (Printer printer : list) {
-                lines.add(" " + String.valueOf(printer));
+                lines.add(" " + printer);
             }
         }
     }

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Xwininfo.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Xwininfo.java
@@ -32,7 +32,7 @@ public final class Xwininfo {
     private static final String[] XPROP_NET_WM_PID_ID = ParseUtil.whitespaces.split("xprop _NET_WM_PID -id");
 
     private static final Pattern WINDOW_PATTERN = Pattern.compile(
-            "(0x\\S+) (?:\"(.+)\")?.*: \\((?:\"(.+)\" \".+\")?\\)  (\\d+)x(\\d+)\\+.+  \\+(-?\\d+)\\+(-?\\d+)");
+            "(0x\\S+) (?:\"(.+)\")?.*: \\((?:\"(.+)\" \".+\")?\\) {2}(\\d+)x(\\d+)\\+.+ {2}\\+(-?\\d+)\\+(-?\\d+)");
 
     private Xwininfo() {
     }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.ToLongFunction;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -197,7 +198,7 @@ class LinuxGraphicsCardTest {
             attrs.getDrmDevicePath(), attrs.getDriverName(), attrs.getPciBusId());
 
     // No-op lookups for pure parsing tests
-    private static final Function<String, Long> NO_VRAM = slot -> 0L;
+    private static final ToLongFunction<String> NO_VRAM = slot -> 0L;
     private static final Function<String, Triplet<String, String, String>> NO_DRM = slot -> new Triplet<>("", "", "");
 
     @Test

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/ProcessStatTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/ProcessStatTest.java
@@ -80,7 +80,7 @@ class ProcessStatTest {
         Triplet<String, Character, Map<PidStat, Long>> stats = ProcessStat.getPidStats(pid);
         assertNotNull(stats);
         State procState = ProcessStat.getState(stats.getB());
-        return stats.getA().length() > 0 // at least one process should have nonempty name
+        return !stats.getA().isEmpty() // at least one process should have nonempty name
                 // At least one process should be running or sleeping
                 && (procState.equals(OSProcess.State.RUNNING) || procState.equals(OSProcess.State.SLEEPING))
                 // Have keys at least up to RSS

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/freebsd/BsdSysctlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/freebsd/BsdSysctlUtilFFM.java
@@ -145,7 +145,10 @@ public final class BsdSysctlUtilFFM {
         MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
         int result = FreeBsdLibcFunctions.sysctlbyname(callState, name, oldp, oldlenp, MemorySegment.NULL, 0L);
         if (result != 0) {
-            LOG.warn(SYSCTL_FAIL, name.getString(0), getErrno(callState));
+            // Guard so the native getErrno read is skipped when WARN is disabled
+            if (LOG.isWarnEnabled()) {
+                LOG.warn(SYSCTL_FAIL, name.getString(0), getErrno(callState));
+            }
             return false;
         }
         return true;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFM.java
@@ -190,7 +190,10 @@ public final class OpenBsdSysctlUtilFFM {
         MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
         int result = OpenBsdLibcFunctions.sysctl(callState, mibSeg, mib.length, oldp, oldlenp, MemorySegment.NULL, 0L);
         if (result != 0) {
-            LOG.warn(SYSCTL_FAIL, Arrays.toString(mib), getErrno(callState));
+            // Guard so the native getErrno read is skipped when WARN is disabled
+            if (LOG.isWarnEnabled()) {
+                LOG.warn(SYSCTL_FAIL, Arrays.toString(mib), getErrno(callState));
+            }
             return false;
         }
         return true;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -268,7 +269,7 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
      * @param rowProcessor  processor to populate result object from WMI row
      * @return list of result objects, empty list if query fails
      */
-    public <T> List<T> queryWMI(String wmiClassName, String whereClause, java.util.function.Supplier<T> resultFactory,
+    public <T> List<T> queryWMI(String wmiClassName, String whereClause, Supplier<T> resultFactory,
             TriConsumer<MemorySegment, Arena, T> rowProcessor) {
         return queryWMI(WbemcliFFM.DEFAULT_NAMESPACE, wmiClassName, whereClause, resultFactory, rowProcessor);
     }
@@ -284,8 +285,8 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
      * @param rowProcessor  processor to populate result object from WMI row
      * @return list of result objects, empty list if query fails
      */
-    public <T> List<T> queryWMI(String namespace, String wmiClassName, String whereClause,
-            java.util.function.Supplier<T> resultFactory, TriConsumer<MemorySegment, Arena, T> rowProcessor) {
+    public <T> List<T> queryWMI(String namespace, String wmiClassName, String whereClause, Supplier<T> resultFactory,
+            TriConsumer<MemorySegment, Arena, T> rowProcessor) {
         if (failedWmiClassNames.contains(wmiClassName)) {
             return new ArrayList<>();
         }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/IOKitProviderFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/IOKitProviderFFM.java
@@ -6,6 +6,7 @@ package oshi.hardware.platform.mac;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import oshi.ffm.platform.mac.IOKit.IOIterator;
 import oshi.ffm.platform.mac.IOKit.IORegistryEntry;
@@ -42,14 +43,14 @@ final class IOKitProviderFFM implements IOKitProvider {
     }
 
     @Override
-    public void forEachMatchingServiceUntil(String serviceName, Function<RegistryEntry, Boolean> visitor) {
+    public void forEachMatchingServiceUntil(String serviceName, Predicate<RegistryEntry> visitor) {
         IOIterator iter = IOKitUtilFFM.getMatchingServices(serviceName);
         if (iter != null) {
             try (iter) {
                 IORegistryEntry entry = iter.next();
                 while (entry != null) {
                     try (IORegistryEntry current = entry) {
-                        if (Boolean.TRUE.equals(visitor.apply(new FfmRegistryEntry(current)))) {
+                        if (visitor.test(new FfmRegistryEntry(current))) {
                             return;
                         }
                     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
@@ -51,12 +51,10 @@ public final class MacNetworkIfFFM extends MacNetworkIF {
                 for (int i = 0; i < count; i++) {
                     MemorySegment pNetIf = cfArray.getValueAtIndex(i);
                     MemorySegment cfNameSeg = SCNetworkInterfaceGetBSDName(pNetIf);
-                    if (!cfNameSeg.equals(MemorySegment.NULL)) {
-                        if (name.equals(CFStringRef.stringValue(cfNameSeg))) {
-                            MemorySegment cfDisplayNameSeg = SCNetworkInterfaceGetLocalizedDisplayName(pNetIf);
-                            if (!cfDisplayNameSeg.equals(MemorySegment.NULL)) {
-                                return CFStringRef.stringValue(cfDisplayNameSeg);
-                            }
+                    if (!cfNameSeg.equals(MemorySegment.NULL) && name.equals(CFStringRef.stringValue(cfNameSeg))) {
+                        MemorySegment cfDisplayNameSeg = SCNetworkInterfaceGetLocalizedDisplayName(pNetIf);
+                        if (!cfDisplayNameSeg.equals(MemorySegment.NULL)) {
+                            return CFStringRef.stringValue(cfDisplayNameSeg);
                         }
                     }
                 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -181,13 +181,13 @@ public class WindowsFileSystemFFM extends AbstractFileSystem {
                     int mountBufSize = BUFSIZE;
                     var pathNamesResult = Kernel32FFM.GetVolumePathNamesForVolumeName(toWideString(arena, volume),
                             mountBuf, mountBufSize, returnLengthBuf);
-                    if (pathNamesResult.isEmpty() || pathNamesResult.getAsInt() == 0) {
-                        if (Kernel32FFM.GetLastError().orElse(0) == 0x7A) { // ERROR_MORE_DATA
-                            mountBufSize = returnLengthBuf.get(JAVA_INT, 0);
-                            mountBuf = arena.allocate(mountBufSize * JAVA_CHAR.byteSize());
-                            pathNamesResult = Kernel32FFM.GetVolumePathNamesForVolumeName(toWideString(arena, volume),
-                                    mountBuf, mountBufSize, returnLengthBuf);
-                        }
+                    // ERROR_MORE_DATA
+                    if ((pathNamesResult.isEmpty() || pathNamesResult.getAsInt() == 0)
+                            && Kernel32FFM.GetLastError().orElse(0) == 0x7A) {
+                        mountBufSize = returnLengthBuf.get(JAVA_INT, 0);
+                        mountBuf = arena.allocate(mountBufSize * JAVA_CHAR.byteSize());
+                        pathNamesResult = Kernel32FFM.GetVolumePathNamesForVolumeName(toWideString(arena, volume),
+                                mountBuf, mountBufSize, returnLengthBuf);
                     }
                     if (pathNamesResult.isEmpty() || pathNamesResult.getAsInt() == 0) {
                         continue;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -345,16 +345,15 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                         MemorySegment envAddress = upp.get(ADDRESS, UPP_ENVIRONMENT_OFFSET);
                         if (envAddress.address() != 0) {
                             MemorySegment envBuffer = arena.allocate((int) envSize);
-                            if (Kernel32FFM.ReadProcessMemory(h.get(), envAddress, envBuffer, envSize, bytesRead)) {
-                                if (bytesRead.get(JAVA_LONG, 0) > 0) {
-                                    char[] env = new char[(int) (envSize / 2)];
-                                    for (int i = 0; i < env.length; i++) {
-                                        env[i] = envBuffer.get(JAVA_CHAR, (long) i * 2);
-                                    }
-                                    Map<String, String> envMap = ParseUtil.parseCharArrayToStringMap(env);
-                                    envMap.remove("");
-                                    return new Triplet<>(cwd, cl, Collections.unmodifiableMap(envMap));
+                            if (Kernel32FFM.ReadProcessMemory(h.get(), envAddress, envBuffer, envSize, bytesRead)
+                                    && bytesRead.get(JAVA_LONG, 0) > 0) {
+                                char[] env = new char[(int) (envSize / 2)];
+                                for (int i = 0; i < env.length; i++) {
+                                    env[i] = envBuffer.get(JAVA_CHAR, (long) i * 2);
                                 }
+                                Map<String, String> envMap = ParseUtil.parseCharArrayToStringMap(env);
+                                envMap.remove("");
+                                return new Triplet<>(cwd, cl, Collections.unmodifiableMap(envMap));
                             }
                         }
                     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/IOKitProviderJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/IOKitProviderJNA.java
@@ -6,6 +6,7 @@ package oshi.hardware.platform.mac;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import com.sun.jna.platform.mac.IOKit.IOIterator;
 import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
@@ -45,14 +46,14 @@ final class IOKitProviderJNA implements IOKitProvider {
     }
 
     @Override
-    public void forEachMatchingServiceUntil(String serviceName, Function<RegistryEntry, Boolean> visitor) {
+    public void forEachMatchingServiceUntil(String serviceName, Predicate<RegistryEntry> visitor) {
         IOIterator iter = IOKitUtil.getMatchingServices(serviceName);
         if (iter != null) {
             try {
                 IORegistryEntry entry = iter.next();
                 while (entry != null) {
                     try {
-                        if (Boolean.TRUE.equals(visitor.apply(new JnaRegistryEntry(entry)))) {
+                        if (visitor.test(new JnaRegistryEntry(entry))) {
                             return;
                         }
                     } finally {

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
@@ -231,7 +231,7 @@ public class WindowsFileSystemJNA extends AbstractFileSystem {
             } else {
                 volume = WmiUtil.getString(drives, LogicalDiskProperty.PROVIDERNAME, i);
                 String[] split = volume.split("\\\\");
-                if (split.length > 1 && split[split.length - 1].length() > 0) {
+                if (split.length > 1 && !split[split.length - 1].isEmpty()) {
                     description = split[split.length - 1];
                 }
             }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
@@ -70,7 +70,7 @@ public final class RegistryUtil {
             if (hKey != null) {
                 int rc = ADV.RegCloseKey(hKey);
                 if (rc != ERROR_SUCCESS) {
-                    LOG.trace("Unable to close registry key " + path + ": " + rc);
+                    LOG.trace("Unable to close registry key {}: {}", path, rc);
                 }
             }
         }

--- a/oshi-demo/src/main/java/oshi/demo/jmx/JMXOshiAgentServer.java
+++ b/oshi-demo/src/main/java/oshi/demo/jmx/JMXOshiAgentServer.java
@@ -116,14 +116,12 @@ public class JMXOshiAgentServer implements JMXOshiAgent {
         StrategyRegistrationPlatformMBeans platformMBeans = null;
         SystemInfo si = new SystemInfo();
 
-        switch (PlatformEnum.getCurrentPlatform()) {
-            case WINDOWS:
-                platformMBeans = new WindowsStrategyRegistrattionPlatform();
-                contextRegistrationPlatform.setStrategyRegistrationContext(platformMBeans);
-                break;
-            default:
-                System.out.println("Couldn't Initialize server ");
-                throw new Exception("Server could not be initialized");
+        if (PlatformEnum.getCurrentPlatform() == PlatformEnum.WINDOWS) {
+            platformMBeans = new WindowsStrategyRegistrattionPlatform();
+            contextRegistrationPlatform.setStrategyRegistrationContext(platformMBeans);
+        } else {
+            System.out.println("Couldn't Initialize server ");
+            throw new Exception("Server could not be initialized");
         }
 
         platformMBeans.registerMBeans(si, this.server);

--- a/oshi-demo/src/main/java/oshi/demo/jmx/mbeans/Baseboard.java
+++ b/oshi-demo/src/main/java/oshi/demo/jmx/mbeans/Baseboard.java
@@ -32,7 +32,7 @@ public class Baseboard implements DynamicMBean, PropertiesAvailable {
     private oshi.hardware.Baseboard baseboard;
     private MBeanInfo dMBeanInfo = null;
     private List<String> propertiesAvailable = new ArrayList<>();
-    private final String PROPERTIES = "Properties";
+    private static final String PROPERTIES = "Properties";
 
     private void setUpMBean() throws IntrospectionException, javax.management.IntrospectionException {
 


### PR DESCRIPTION
A batch of mechanical Sonar fixes, grouped into 6 thematic commits. Each finding was validated as real before fixing. No behavior change to query results; verified with a clean `install -P aggregate-coverage,native-comparison` (full unit suite + NativeComparisonTest green) plus checkstyle/forbiddenapis/javadoc.

### Fixed (~40 findings)
- **S7158** (7) `length()==0/>0` → `isEmpty()`
- **S4201** (1) drop redundant null check before `instanceof`
- **S6353** (3) / **S6326** (2) concise regex (`\d`, `\D`, `{2}`)
- **S1153** (4) drop redundant `String.valueOf()` in concatenation
- **S1066** (6) merge collapsible nested `if`s (parenthesized where an `||` is involved)
- **S4276** (8) + **S5411** (1) specialize functional interfaces: `BiPredicate` / `Predicate` / `BinaryOperator` / `ToLongFunction` / `UnaryOperator` (incl. removing the now-needless `Boolean.TRUE.equals` guard in IOKit)
- **S1170** (4) instance constants → `static final` (Linux fields renamed UPPER_CASE to stay convention-compliant)
- **S3038** (1) remove `LinuxHAL`'s bare redundant abstract method
- **S1301** (1) demo switch → `if`
- **S2629** (3): `RegistryUtil` concat-log → parameterized; the two **sysctl** WARN logs guarded with `isWarnEnabled()` so the native `getErrno()` read is skipped when WARN is off
- **FQN cleanup**: `java.util.function.*` inline/javadoc FQNs → imports

### Accepted as won't-fix (with reasons), not in this diff
- **S2629 ×12** — already-parameterized logs whose only arg is a cheap `Integer.toHexString(int)` in rarely-taken failure branches (guarding = boilerplate for negligible gain; the native-call ones above were guarded instead)
- **S1301 ×3** (`PrivilegedUtil`) — single-case platform switches intentionally kept open for future-OS extensibility (comment added)
- **S3038 ×1** (`AixGlobalMemory`) — the abstract re-declaration carries class-specific javadoc the interface doesn't

### Note on slf4j
The lazy fluent API (`atWarn().addArgument(() -> …)`) would have been the elegant fix for the `getErrno` logs, but OSHI's OSGi `Import-Package` pins slf4j to `[1.7,3.0)` and uses no 2.0-only API — so an `isWarnEnabled()` guard is used to stay runtime-compatible with slf4j 1.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified conditional logic and improved code readability across multiple modules for better maintainability.
  * Standardized string validation patterns using modern Java API conventions.
  * Refactored callback and function types to use more semantically appropriate interfaces.

* **Performance**
  * Optimized native code logging to avoid unnecessary system calls when logging is disabled.

* **Documentation**
  * Updated code comments and Javadoc references for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->