### PR TITLE
Sonar backlog cleanup: clear remaining Maintainability findings (per-rule)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHWDiskStoreNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHWDiskStoreNF.java
@@ -60,7 +60,12 @@ public final class LinuxHWDiskStoreNF extends LinuxHWDiskStore {
             long size = ParseUtil.parseLongOrDefault(FileUtil.getStringFromFile(sysPath + SIZE).trim(), 0L)
                     * SECTORSIZE;
             String rotational = FileUtil.getStringFromFile(sysPath + "queue/rotational").trim();
-            String diskType = "1".equals(rotational) ? "HDD" : "0".equals(rotational) ? "SSD" : "";
+            String diskType = "";
+            if ("1".equals(rotational)) {
+                diskType = "HDD";
+            } else if ("0".equals(rotational)) {
+                diskType = "SSD";
+            }
 
             LinuxHWDiskStoreNF store = new LinuxHWDiskStoreNF(DevPath.DEV + name, model, serial, size, diskType);
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacPowerSource.java
@@ -48,7 +48,7 @@ public abstract class MacPowerSource extends AbstractPowerSource {
      * @param psSerialNumber             serial number
      * @param psTemperature              temperature
      */
-    public MacPowerSource(String psName, String psDeviceName, double psRemainingCapacityPercent,
+    protected MacPowerSource(String psName, String psDeviceName, double psRemainingCapacityPercent,
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
             CapacityUnits psCapacityUnits, int psCurrentCapacity, int psMaxCapacity, int psDesignCapacity,

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdPowerSource.java
@@ -105,12 +105,9 @@ public final class BsdPowerSource extends AbstractPowerSource {
         String psManufacturer = Constants.UNKNOWN;
 
         double psTimeRemainingInstant = psTimeRemainingEstimated;
-        if (psVoltage > 0) {
-            if (psAmperage > 0 && psPowerUsageRate == 0) {
-                psPowerUsageRate = psAmperage * psVoltage;
-            } else if (psAmperage == 0 && psPowerUsageRate > 0) {
-                psAmperage = psPowerUsageRate / psVoltage;
-            }
+        // apm reports amperage but not power; derive power rate from P = IV
+        if (psVoltage > 0 && psAmperage > 0) {
+            psPowerUsageRate = psAmperage * psVoltage;
         }
 
         return new BsdPowerSource(psName, psDeviceName, psRemainingCapacityPercent, psTimeRemainingEstimated,

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -30,6 +30,10 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
 
     /** Default constructor. */
     protected WindowsCentralProcessor() {
+        // Store the initial query and start the memoizer expiration
+        if (USE_CPU_UTILITY) {
+            setInitialUtilityCounters(processorUtilityCounters.get().getB());
+        }
     }
 
     // populated by initProcessorCounts called by the parent constructor
@@ -55,13 +59,6 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     private final Supplier<Pair<List<String>, Map<ProcessorUtilityTickCountProperty, List<Long>>>> processorUtilityCounters = USE_CPU_UTILITY
             ? memoize(this::queryProcessorCapacityCounters, TimeUnit.MILLISECONDS.toNanos(300L))
             : null;
-
-    {
-        // Store the initial query and start the memoizer expiration
-        if (USE_CPU_UTILITY) {
-            setInitialUtilityCounters(processorUtilityCounters.get().getB());
-        }
-    }
 
     /**
      * Checks whether the OS version is Windows 8 or greater using system property 'os.version'.

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -97,7 +97,7 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
      * @param pid the process ID
      * @param os  the operating system
      */
-    public LinuxOSProcess(int pid, LinuxOperatingSystem os) {
+    protected LinuxOSProcess(int pid, LinuxOperatingSystem os) {
         super(pid);
         this.os = os;
         updateAttributes();

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -56,7 +56,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
     private static final String LSB_RELEASE_A_LOG = "lsb_release -a: {}";
     private static final String LSB_RELEASE_LOG = "lsb-release: {}";
     private static final String RELEASE_DELIM = " release ";
-    private static final String DOUBLE_QUOTES = "(?:(?:^\")|(?:\"$))";
+    private static final String DOUBLE_QUOTES = "(?:^\"|\"$)";
     private static final String FILENAME_PROPERTIES = "oshi.linux.filename.properties";
 
     private final Supplier<List<ApplicationInfo>> installedAppsSupplier = Memoizer

--- a/oshi-common/src/main/java/oshi/util/SystemInfoHelper.java
+++ b/oshi-common/src/main/java/oshi/util/SystemInfoHelper.java
@@ -395,11 +395,11 @@ public final class SystemInfoHelper {
         for (OSFileStore fs : fileSystem.getFileStores(true)) {
             long usable = fs.getUsableSpace();
             long total = fs.getTotalSpace();
-            lines.add(String.format(Locale.ROOT,
-                    " %s (%s) [%s] %s of %s free (%.1f%%), %s of %s files free (%.1f%%) is %s "
-                            + (fs.getLogicalVolume() != null && !fs.getLogicalVolume().isEmpty() ? "[%s]" : "%s")
-                            + " and is mounted at %s",
-                    fs.getName(), fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
+            String fmt = " %s (%s) [%s] %s of %s free (%.1f%%), %s of %s files free (%.1f%%) is %s "
+                    + (fs.getLogicalVolume() != null && !fs.getLogicalVolume().isEmpty() ? "[%s]" : "%s")
+                    + " and is mounted at %s";
+            lines.add(String.format(Locale.ROOT, fmt, fs.getName(),
+                    fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,
                     FormatUtil.formatValue(fs.getFreeInodes(), ""), FormatUtil.formatValue(fs.getTotalInodes(), ""),
                     100d * fs.getFreeInodes() / fs.getTotalInodes(), fs.getVolume(), fs.getLogicalVolume(),

--- a/oshi-common/src/test/java/oshi/driver/common/windows/wmi/WmiUtilTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/windows/wmi/WmiUtilTest.java
@@ -30,57 +30,49 @@ class WmiUtilTest {
 
     @Test
     void testGetStringValid() {
-        WmiResult<TestProp> result = new MockWmiResult<>(TestProp.class, WmiConstants.CIM_STRING, WmiConstants.VT_BSTR,
-                "hello");
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_STRING, WmiConstants.VT_BSTR, "hello");
         assertThat(WmiUtil.getString(result, TestProp.NAME, 0), is("hello"));
     }
 
     @Test
     void testGetStringNull() {
-        WmiResult<TestProp> result = new MockWmiResult<>(TestProp.class, WmiConstants.CIM_STRING, WmiConstants.VT_BSTR,
-                null);
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_STRING, WmiConstants.VT_BSTR, null);
         assertThat(WmiUtil.getString(result, TestProp.NAME, 0), is(""));
     }
 
     @Test
     void testGetStringWrongType() {
-        WmiResult<TestProp> result = new MockWmiResult<>(TestProp.class, WmiConstants.CIM_UINT32, WmiConstants.VT_I4,
-                42);
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_UINT32, WmiConstants.VT_I4, 42);
         assertThrows(ClassCastException.class, () -> WmiUtil.getString(result, TestProp.NAME, 0));
     }
 
     @Test
     void testGetUint32Valid() {
-        WmiResult<TestProp> result = new MockWmiResult<>(TestProp.class, WmiConstants.CIM_UINT32, WmiConstants.VT_I4,
-                42);
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_UINT32, WmiConstants.VT_I4, 42);
         assertThat(WmiUtil.getUint32(result, TestProp.SIZE, 0), is(42));
     }
 
     @Test
     void testGetUint32Null() {
-        WmiResult<TestProp> result = new MockWmiResult<>(TestProp.class, WmiConstants.CIM_UINT32, WmiConstants.VT_I4,
-                null);
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_UINT32, WmiConstants.VT_I4, null);
         assertThat(WmiUtil.getUint32(result, TestProp.SIZE, 0), is(0));
     }
 
     @Test
     void testGetUint64Valid() {
-        WmiResult<TestProp> result = new MockWmiResult<>(TestProp.class, WmiConstants.CIM_UINT64, WmiConstants.VT_BSTR,
-                "123456789");
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_UINT64, WmiConstants.VT_BSTR, "123456789");
         assertThat(WmiUtil.getUint64(result, TestProp.SIZE, 0), is(123456789L));
     }
 
     @Test
     void testGetUint32asLong() {
-        WmiResult<TestProp> result = new MockWmiResult<>(TestProp.class, WmiConstants.CIM_UINT32, WmiConstants.VT_I4,
-                -1);
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_UINT32, WmiConstants.VT_I4, -1);
         assertThat(WmiUtil.getUint32asLong(result, TestProp.SIZE, 0), is(0xFFFFFFFFL));
     }
 
     @Test
     void testGetFloat() {
-        WmiResult<TestProp> result = new MockWmiResult<>(TestProp.class, WmiConstants.CIM_REAL32, WmiConstants.VT_R4,
-                3.14f);
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_REAL32, WmiConstants.VT_R4, 3.14f);
         assertThat(WmiUtil.getFloat(result, TestProp.SIZE, 0), is(3.14f));
     }
 
@@ -96,7 +88,7 @@ class WmiUtilTest {
         private final int vtType;
         private final Object value;
 
-        MockWmiResult(Class<T> enumClass, int cimType, int vtType, Object value) {
+        MockWmiResult(int cimType, int vtType, Object value) {
             this.cimType = cimType;
             this.vtType = vtType;
             this.value = value;

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractCentralProcessorTest.java
@@ -104,7 +104,8 @@ class AbstractCentralProcessorTest {
 
     @Test
     void testSystemCpuLoadBetweenTicksWrongLength() {
-        assertThrows(IllegalArgumentException.class, () -> createProcessor().getSystemCpuLoadBetweenTicks(new long[2]));
+        AbstractCentralProcessor cpu = createProcessor();
+        assertThrows(IllegalArgumentException.class, () -> cpu.getSystemCpuLoadBetweenTicks(new long[2]));
     }
 
     @Test
@@ -321,12 +322,13 @@ class AbstractCentralProcessorTest {
 
     @Test
     void testProcessorCpuLoadBetweenTicksWrongLength() {
+        AbstractCentralProcessor cpu = createProcessor();
         // Outer array length mismatch
         assertThrows(IllegalArgumentException.class,
-                () -> createProcessor().getProcessorCpuLoadBetweenTicks(new long[2][2], new long[1][1]));
+                () -> cpu.getProcessorCpuLoadBetweenTicks(new long[2][2], new long[1][1]));
         // Matching outer length but wrong inner subarray length
         assertThrows(IllegalArgumentException.class,
-                () -> createProcessor().getProcessorCpuLoadBetweenTicks(new long[1][2], new long[1][2]));
+                () -> cpu.getProcessorCpuLoadBetweenTicks(new long[1][2], new long[1][2]));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsComputerSystemTest.java
@@ -23,7 +23,7 @@ class WindowsComputerSystemTest {
     private static final WmiQueryExecutor EMPTY_EXECUTOR = new WmiQueryExecutor() {
         @Override
         public <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query) {
-            return emptyResult(query.getPropertyEnum());
+            return emptyResult();
         }
 
         @Override
@@ -31,7 +31,7 @@ class WindowsComputerSystemTest {
             return queryWMI(query);
         }
 
-        private <T extends Enum<T>> WmiResult<T> emptyResult(Class<T> propEnum) {
+        private <T extends Enum<T>> WmiResult<T> emptyResult() {
             return new WmiResult<T>() {
                 @Override
                 public int getResultCount() {

--- a/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
+++ b/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
@@ -54,7 +54,7 @@ public class SystemInfoTest {
     private static final Logger logger = LoggerFactory.getLogger(SystemInfoTest.class);
 
     @Test
-    public void testPlatformEnum() {
+    void testPlatformEnum() {
         assertThat("Unsupported OS", PlatformEnum.getCurrentPlatform(), is(not(PlatformEnum.UNKNOWN)));
         main(null);
     }

--- a/oshi-common/src/test/java/oshi/util/MemoizerTest.java
+++ b/oshi-common/src/test/java/oshi/util/MemoizerTest.java
@@ -34,13 +34,13 @@ import org.junit.jupiter.api.condition.OS;
 @DisabledOnOs(OS.SOLARIS)
 final class MemoizerTest {
     // We want enough threads that some of them are forced to wait
-    private static final int numberOfThreads = Math.max(5, Runtime.getRuntime().availableProcessors() + 2);
+    private static final int NUMBER_OF_THREADS = Math.max(5, Runtime.getRuntime().availableProcessors() + 2);
 
     private ExecutorService ex;
 
     @BeforeEach
     void before() {
-        final ThreadPoolExecutor executor = new ThreadPoolExecutor(numberOfThreads, numberOfThreads, 0L,
+        final ThreadPoolExecutor executor = new ThreadPoolExecutor(NUMBER_OF_THREADS, NUMBER_OF_THREADS, 0L,
                 TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
         executor.allowCoreThreadTimeOut(false);
         executor.prestartAllCoreThreads(); // make sure we don't lose refreshes in tests because of
@@ -108,7 +108,7 @@ final class MemoizerTest {
         final Collection<Future<Void>> results = new ArrayList<>();
         // Mark the start time, end after iterationDuration
         final long beginNanos = System.nanoTime();
-        for (int tid = 0; tid < numberOfThreads; tid++) {
+        for (int tid = 0; tid < NUMBER_OF_THREADS; tid++) {
             results.add(ex.submit(() -> {
                 // First read from the memoizer. Only one thread will win this race to increment
                 // 0 to 1, but all threads should read at least 1, if not increment further
@@ -184,7 +184,7 @@ final class MemoizerTest {
              * guaranteedIteration. Therefore each thread may do up to 2 additional refreshes.
              */
             final long minExpectedNumberOfIncrements = 2L;
-            final long maxExpectedNumberOfIncrements = (iterationDurationNanos / ttlNanos) + 2L * numberOfThreads;
+            final long maxExpectedNumberOfIncrements = (iterationDurationNanos / ttlNanos) + 2L * NUMBER_OF_THREADS;
 
             assertThat(String.format(Locale.ROOT, "ttlNanos=%s", ttlNanos), minExpectedNumberOfIncrements,
                     is(lessThanOrEqualTo(actualNumberOfIncrements)));

--- a/oshi-common/src/test/java/oshi/util/ProcUtilsTest.java
+++ b/oshi-common/src/test/java/oshi/util/ProcUtilsTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 @EnabledOnOs(OS.LINUX)
-public class ProcUtilsTest {
+class ProcUtilsTest {
 
     @Test
     void testRawNetNetstat() {

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/InstalledAppsDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/InstalledAppsDataFFM.java
@@ -151,7 +151,7 @@ public final class InstalledAppsDataFFM {
                 checkSuccess(rc);
             }
         } catch (Win32Exception e) {
-            LOG.trace("Unable to access " + path + " with flag " + accessFlag + ": " + e.getMessage());
+            LOG.trace("Unable to access {} with flag {}: {}", path, accessFlag, e.getMessage());
             return null;
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -30,6 +30,7 @@ import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -71,9 +72,9 @@ public final class SmcUtilFFM {
     public static final String SMC_KEY_CPU_VOLTAGE = "VC0C";
 
     /** SMC keys for Apple Silicon CPU temperature sensors. */
-    public static final String[] SMC_KEYS_CPU_TEMP_AS = { "Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D" };
+    public static final List<String> SMC_KEYS_CPU_TEMP_AS = List.of("Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D");
     /** SMC keys for Apple Silicon GPU temperature sensors. */
-    public static final String[] SMC_KEYS_GPU_TEMP_AS = { "Tg05", "Tg0D", "Tg0f", "Tg0j" };
+    public static final List<String> SMC_KEYS_GPU_TEMP_AS = List.of("Tg05", "Tg0D", "Tg0f", "Tg0j");
     /** SMC key for Apple Silicon CPU voltage. */
     public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
 
@@ -169,7 +170,7 @@ public final class SmcUtilFFM {
      * @param keys The keys to try in order
      * @return The first value greater than 0, or 0 if all keys fail
      */
-    public static double smcGetFirstFloat(int conn, String... keys) {
+    public static double smcGetFirstFloat(int conn, List<String> keys) {
         for (String key : keys) {
             double val = smcGetFloat(conn, key);
             if (val > 0d) {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
@@ -403,9 +403,9 @@ public final class Advapi32UtilFFM {
 
             long event6005Time = 0L;
 
-            long OFFSET_EVENTID = WinNTFFM.OFFSET_EVENTID;
-            long OFFSET_TIME_GENERATED = WinNTFFM.OFFSET_TIME_GENERATED;
-            long OFFSET_LENGTH = WinNTFFM.OFFSET_LENGTH;
+            long offsetEventId = WinNTFFM.OFFSET_EVENTID;
+            long offsetTimeGenerated = WinNTFFM.OFFSET_TIME_GENERATED;
+            long offsetLength = WinNTFFM.OFFSET_LENGTH;
 
             while (Advapi32FFM.ReadEventLog(hEventLog,
                     WinNTFFM.EVENTLOG_BACKWARDS_READ | WinNTFFM.EVENTLOG_SEQUENTIAL_READ, buffer, bufSize, bytesRead,
@@ -417,8 +417,8 @@ public final class Advapi32UtilFFM {
                 while (offset < read) {
                     MemorySegment record = buffer.asSlice(offset, WinNTFFM.EVENTLOGRECORD.byteSize());
 
-                    int eventId = record.get(JAVA_INT, (int) OFFSET_EVENTID);
-                    long timeGenerated = Integer.toUnsignedLong(record.get(JAVA_INT, (int) OFFSET_TIME_GENERATED));
+                    int eventId = record.get(JAVA_INT, (int) offsetEventId);
+                    long timeGenerated = Integer.toUnsignedLong(record.get(JAVA_INT, (int) offsetTimeGenerated));
 
                     if (eventId == 12) { // system boot
                         Advapi32FFM.CloseEventLog(hEventLog);
@@ -432,7 +432,7 @@ public final class Advapi32UtilFFM {
                     }
 
                     // Advance to next record
-                    int length = record.get(JAVA_INT, (int) OFFSET_LENGTH);
+                    int length = record.get(JAVA_INT, (int) offsetLength);
                     offset += length;
                 }
             }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
@@ -242,7 +242,7 @@ public final class Advapi32UtilFFM {
                 case REG_SZ, REG_EXPAND_SZ -> registryGetString(hKey, valueName, size);
                 case REG_DWORD -> registryGetDword(hKey, valueName);
                 default -> {
-                    LOG.warn("Unsupported registry data type " + type + " for " + valueName);
+                    LOG.warn("Unsupported registry data type {} for {}", type, valueName);
                     yield null;
                 }
             };

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
@@ -170,7 +170,7 @@ public final class Advapi32UtilFFM {
             } finally {
                 rc = RegCloseKey(hKey);
                 if (rc != ERROR_SUCCESS) {
-                    throw new Win32Exception(rc);
+                    LOG.warn("Failed to close registry key, error code: {}", rc);
                 }
             }
         }
@@ -415,10 +415,10 @@ public final class Advapi32UtilFFM {
                 int offset = 0;
 
                 while (offset < read) {
-                    MemorySegment record = buffer.asSlice(offset, WinNTFFM.EVENTLOGRECORD.byteSize());
+                    MemorySegment eventRecord = buffer.asSlice(offset, WinNTFFM.EVENTLOGRECORD.byteSize());
 
-                    int eventId = record.get(JAVA_INT, (int) offsetEventId);
-                    long timeGenerated = Integer.toUnsignedLong(record.get(JAVA_INT, (int) offsetTimeGenerated));
+                    int eventId = eventRecord.get(JAVA_INT, (int) offsetEventId);
+                    long timeGenerated = Integer.toUnsignedLong(eventRecord.get(JAVA_INT, (int) offsetTimeGenerated));
 
                     if (eventId == 12) { // system boot
                         Advapi32FFM.CloseEventLog(hEventLog);
@@ -432,7 +432,7 @@ public final class Advapi32UtilFFM {
                     }
 
                     // Advance to next record
-                    int length = record.get(JAVA_INT, (int) offsetLength);
+                    int length = eventRecord.get(JAVA_INT, (int) offsetLength);
                     offset += length;
                 }
             }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
@@ -207,8 +207,14 @@ public final class WindowsPowerSourceFFM extends WindowsPowerSource {
                             psDesignCapacity = bi.get(JAVA_INT, OFF_BI_DESIGNED);
                             psMaxCapacity = bi.get(JAVA_INT, OFF_BI_FULL);
                             psCycleCount = bi.get(JAVA_INT, OFF_BI_CYCLE);
-                            int maxCapacitySafe = psMaxCapacity > 0 ? psMaxCapacity
-                                    : psDesignCapacity > 0 ? psDesignCapacity : 1;
+                            int maxCapacitySafe;
+                            if (psMaxCapacity > 0) {
+                                maxCapacitySafe = psMaxCapacity;
+                            } else if (psDesignCapacity > 0) {
+                                maxCapacitySafe = psDesignCapacity;
+                            } else {
+                                maxCapacitySafe = 1;
+                            }
 
                             // Query battery status
                             MemorySegment bws = arena.allocate(BATTERY_WAIT_STATUS);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsFFM.java
@@ -25,6 +25,7 @@ public class WindowsInternetProtocolStatsFFM extends AbstractInternetProtocolSta
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsInternetProtocolStatsFFM.class);
 
+    @Override
     public List<IPConnection> getConnections() {
         List<IPConnection> conns = new ArrayList<>();
         conns.addAll(queryTCPv4Connections());

--- a/oshi-core-ffm/src/test/java/oshi/ffm/GlobalMemoryFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/GlobalMemoryFFMTest.java
@@ -30,7 +30,7 @@ import oshi.hardware.PhysicalMemory;
 @EnabledForJreRange(min = JRE.JAVA_25)
 @EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD, OS.SOLARIS, OS.AIX })
 @TestInstance(Lifecycle.PER_CLASS)
-public class GlobalMemoryFFMTest {
+class GlobalMemoryFFMTest {
 
     private GlobalMemory memory;
 

--- a/oshi-core-ffm/src/test/java/oshi/ffm/NativeHandleTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/NativeHandleTest.java
@@ -73,6 +73,7 @@ class NativeHandleTest {
 
     @Test
     void testNullCloserThrows() {
-        assertThrows(NullPointerException.class, () -> NativeHandle.of(MemorySegment.ofAddress(0x1), null));
+        MemorySegment segment = MemorySegment.ofAddress(0x1);
+        assertThrows(NullPointerException.class, () -> NativeHandle.of(segment, null));
     }
 }

--- a/oshi-core-ffm/src/test/java/oshi/ffm/OperatingSystemFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/OperatingSystemFFMTest.java
@@ -28,7 +28,7 @@ import oshi.software.os.mac.MacOperatingSystemFFM;
 @EnabledForJreRange(min = JRE.JAVA_25)
 @EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD, OS.SOLARIS, OS.AIX })
 @TestInstance(Lifecycle.PER_CLASS)
-public class OperatingSystemFFMTest {
+class OperatingSystemFFMTest {
 
     @Test
     void testOperatingSystem() {

--- a/oshi-core-ffm/src/test/java/oshi/ffm/SystemInfoTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/SystemInfoTest.java
@@ -57,13 +57,13 @@ public class SystemInfoTest {
     private static final Logger logger = LoggerFactory.getLogger(SystemInfoTest.class);
 
     @Test
-    public void testPlatformEnum() {
+    void testPlatformEnum() {
         assertThat("Unsupported OS", PlatformEnum.getCurrentPlatform(), is(not(PlatformEnum.UNKNOWN)));
         main(null);
     }
 
     @Test
-    public void testGetCurrentPlatform() {
+    void testGetCurrentPlatform() {
         assertNotNull(PlatformEnum.getCurrentPlatform(), "Platform should not be null");
         assertNotEquals(PlatformEnum.UNKNOWN, PlatformEnum.getCurrentPlatform(), "Platform should be recognized");
     }

--- a/oshi-core-ffm/src/test/java/oshi/ffm/VirtualMemoryFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/VirtualMemoryFFMTest.java
@@ -21,7 +21,7 @@ import oshi.hardware.VirtualMemory;
 
 @EnabledForJreRange(min = JRE.JAVA_25)
 @EnabledOnOs({ OS.LINUX, OS.MAC, OS.WINDOWS, OS.FREEBSD, OS.OPENBSD, OS.SOLARIS, OS.AIX })
-public class VirtualMemoryFFMTest {
+class VirtualMemoryFFMTest {
 
     @Test
     void testVirtualMemory() {

--- a/oshi-core-ffm/src/test/java/oshi/ffm/platform/mac/CoreFoundationTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/platform/mac/CoreFoundationTest.java
@@ -151,7 +151,8 @@ class CoreFoundationTest {
             valuePtr.set(ValueLayout.JAVA_INT, 0, 42);
             var numSeg = CoreFoundationFunctions.CFNumberCreate(allocator, CoreFoundation.kCFNumberIntType, valuePtr);
             try (var cfNum = new CFNumberRef(numSeg)) {
-                assertThrows(ClassCastException.class, () -> new CFStringRef(cfNum.segment()));
+                var seg = cfNum.segment();
+                assertThrows(ClassCastException.class, () -> new CFStringRef(seg));
             }
         }
     }
@@ -450,35 +451,40 @@ class CoreFoundationTest {
     @Test
     void testCFNumberRefRejectsString() {
         try (var cfStr = CFStringRef.createCFString("notANumber")) {
-            assertThrows(ClassCastException.class, () -> new CFNumberRef(cfStr.segment()));
+            var seg = cfStr.segment();
+            assertThrows(ClassCastException.class, () -> new CFNumberRef(seg));
         }
     }
 
     @Test
     void testCFBooleanRefRejectsString() {
         try (var cfStr = CFStringRef.createCFString("notABool")) {
-            assertThrows(ClassCastException.class, () -> new CFBooleanRef(cfStr.segment()));
+            var seg = cfStr.segment();
+            assertThrows(ClassCastException.class, () -> new CFBooleanRef(seg));
         }
     }
 
     @Test
     void testCFArrayRefRejectsString() {
         try (var cfStr = CFStringRef.createCFString("notAnArray")) {
-            assertThrows(ClassCastException.class, () -> new CFArrayRef(cfStr.segment()));
+            var seg = cfStr.segment();
+            assertThrows(ClassCastException.class, () -> new CFArrayRef(seg));
         }
     }
 
     @Test
     void testCFDataRefRejectsString() {
         try (var cfStr = CFStringRef.createCFString("notData")) {
-            assertThrows(ClassCastException.class, () -> new CFDataRef(cfStr.segment()));
+            var seg = cfStr.segment();
+            assertThrows(ClassCastException.class, () -> new CFDataRef(seg));
         }
     }
 
     @Test
     void testCFDictionaryRefRejectsString() {
         try (var cfStr = CFStringRef.createCFString("notADict")) {
-            assertThrows(ClassCastException.class, () -> new CFDictionaryRef(cfStr.segment()));
+            var seg = cfStr.segment();
+            assertThrows(ClassCastException.class, () -> new CFDictionaryRef(seg));
         }
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
@@ -89,7 +89,7 @@ final class MacDisplayJNA extends AbstractDisplay {
                                 edid.release();
                             }
                         }
-                        if (childEntryName != null && propertySource != null) {
+                        if (childEntryName != null) {
                             propertySource.release();
                         }
                     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacVirtualMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacVirtualMemoryJNA.java
@@ -4,6 +4,9 @@
  */
 package oshi.hardware.platform.mac;
 
+import static com.sun.jna.platform.mac.SystemB.HOST_VM_INFO;
+import static com.sun.jna.platform.mac.SystemB.INT_SIZE;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,9 +46,8 @@ final class MacVirtualMemoryJNA extends MacVirtualMemory {
         long swapPagesIn = 0L;
         long swapPagesOut = 0L;
         try (CloseableVMStatistics vmStats = new CloseableVMStatistics();
-                CloseableIntByReference size = new CloseableIntByReference(vmStats.size() / SystemB.INT_SIZE)) {
-            int ret = SystemB.INSTANCE.host_statistics(SystemB.INSTANCE.mach_host_self(), SystemB.HOST_VM_INFO, vmStats,
-                    size);
+                CloseableIntByReference size = new CloseableIntByReference(vmStats.size() / INT_SIZE)) {
+            int ret = SystemB.INSTANCE.host_statistics(SystemB.INSTANCE.mach_host_self(), HOST_VM_INFO, vmStats, size);
             if (0 == ret) {
                 swapPagesIn = ParseUtil.unsignedIntToLong(vmStats.pageins);
                 swapPagesOut = ParseUtil.unsignedIntToLong(vmStats.pageouts);

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
@@ -168,8 +168,13 @@ public final class WindowsPowerSourceJNA extends WindowsPowerSource {
                                                                 psDesignCapacity = bi.DesignedCapacity;
                                                                 psMaxCapacity = bi.FullChargedCapacity;
                                                                 psCycleCount = bi.CycleCount;
-                                                                maxCapacitySafe = psMaxCapacity > 0 ? psMaxCapacity
-                                                                        : psDesignCapacity > 0 ? psDesignCapacity : 1;
+                                                                if (psMaxCapacity > 0) {
+                                                                    maxCapacitySafe = psMaxCapacity;
+                                                                } else if (psDesignCapacity > 0) {
+                                                                    maxCapacitySafe = psDesignCapacity;
+                                                                } else {
+                                                                    maxCapacitySafe = 1;
+                                                                }
 
                                                                 // Query the battery status.
                                                                 bws.BatteryTag = bqi.BatteryTag;

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcessJNA.java
@@ -4,6 +4,9 @@
  */
 package oshi.software.os.linux;
 
+import static com.sun.jna.platform.unix.Resource.RLIMIT_NOFILE;
+import static oshi.jna.platform.unix.CLibrary.RUSAGE_SELF;
+
 import com.sun.jna.platform.unix.Resource;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -31,7 +34,7 @@ public class LinuxOSProcessJNA extends LinuxOSProcess {
         if (getProcessID() == getOs().getProcessId()) {
             this.rusagePopulated = false;
             LinuxLibc.Rusage rusage = new LinuxLibc.Rusage();
-            if (0 == LinuxLibc.INSTANCE.getrusage(LinuxLibc.RUSAGE_SELF, rusage)) {
+            if (0 == LinuxLibc.INSTANCE.getrusage(RUSAGE_SELF, rusage)) {
                 this.cachedVoluntaryContextSwitches = rusage.ru_nvcsw.longValue();
                 this.cachedInvoluntaryContextSwitches = rusage.ru_nivcsw.longValue();
                 this.rusagePopulated = true;
@@ -59,7 +62,7 @@ public class LinuxOSProcessJNA extends LinuxOSProcess {
     @Override
     protected long queryRlimitSoft() {
         final Resource.Rlimit rlimit = new Resource.Rlimit();
-        if (0 == LinuxLibc.INSTANCE.getrlimit(LinuxLibc.RLIMIT_NOFILE, rlimit)) {
+        if (0 == LinuxLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit)) {
             return rlimit.rlim_cur;
         }
         return getProcessOpenFileLimit(getProcessID(), 1);
@@ -68,7 +71,7 @@ public class LinuxOSProcessJNA extends LinuxOSProcess {
     @Override
     protected long queryRlimitHard() {
         final Resource.Rlimit rlimit = new Resource.Rlimit();
-        if (0 == LinuxLibc.INSTANCE.getrlimit(LinuxLibc.RLIMIT_NOFILE, rlimit)) {
+        if (0 == LinuxLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit)) {
             return rlimit.rlim_max;
         }
         return getProcessOpenFileLimit(getProcessID(), 2);

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
@@ -4,6 +4,12 @@
  */
 package oshi.software.os.mac;
 
+import static com.sun.jna.platform.mac.SystemB.INT_SIZE;
+import static com.sun.jna.platform.mac.SystemB.PROC_PIDPATHINFO_MAXSIZE;
+import static com.sun.jna.platform.mac.SystemB.PROC_PIDTASKALLINFO;
+import static com.sun.jna.platform.mac.SystemB.PROC_PIDVNODEPATHINFO;
+import static com.sun.jna.platform.mac.SystemB.RUSAGE_INFO_V2;
+import static oshi.jna.platform.unix.CLibrary.RUSAGE_SELF;
 import static oshi.software.os.OSProcess.State.INVALID;
 
 import java.nio.charset.StandardCharsets;
@@ -110,7 +116,7 @@ public class MacOSProcessJNA extends MacOSProcess {
                 // Sanity check
                 if (nargs > 0 && nargs <= 1024) {
                     // Skip first int (containing value of nargs)
-                    long offset = SystemB.INT_SIZE;
+                    long offset = INT_SIZE;
                     // Skip exec_command, as
                     offset += procargs.getString(offset).length();
                     // Iterate character by character using offset
@@ -181,13 +187,13 @@ public class MacOSProcessJNA extends MacOSProcess {
     public boolean updateAttributes() {
         long now = System.currentTimeMillis();
         try (CloseableProcTaskAllInfo taskAllInfo = new CloseableProcTaskAllInfo()) {
-            if (0 > SystemB.INSTANCE.proc_pidinfo(getProcessID(), SystemB.PROC_PIDTASKALLINFO, 0, taskAllInfo,
+            if (0 > SystemB.INSTANCE.proc_pidinfo(getProcessID(), PROC_PIDTASKALLINFO, 0, taskAllInfo,
                     taskAllInfo.size()) || taskAllInfo.ptinfo.pti_threadnum < 1) {
                 this.state = INVALID;
                 return false;
             }
-            try (Memory buf = new Memory(SystemB.PROC_PIDPATHINFO_MAXSIZE)) {
-                if (0 < SystemB.INSTANCE.proc_pidpath(getProcessID(), buf, SystemB.PROC_PIDPATHINFO_MAXSIZE)) {
+            try (Memory buf = new Memory(PROC_PIDPATHINFO_MAXSIZE)) {
+                if (0 < SystemB.INSTANCE.proc_pidpath(getProcessID(), buf, PROC_PIDPATHINFO_MAXSIZE)) {
                     this.path = buf.getString(0).trim();
                     // Overwrite name with last part of path
                     String[] pathSplit = this.path.split("/");
@@ -226,9 +232,8 @@ public class MacOSProcessJNA extends MacOSProcess {
             this.minorFaults = taskAllInfo.ptinfo.pti_faults - taskAllInfo.ptinfo.pti_pageins; // NOSONAR squid:S2184
             // getrusage(RUSAGE_SELF) aggregates across all threads for current process
             if (getProcessID() == this.os.getProcessId()) {
-                oshi.jna.platform.mac.SystemB.Rusage rusage = new oshi.jna.platform.mac.SystemB.Rusage();
-                if (0 == oshi.jna.platform.mac.SystemB.INSTANCE.getrusage(oshi.jna.platform.mac.SystemB.RUSAGE_SELF,
-                        rusage)) {
+                SystemB.Rusage rusage = new SystemB.Rusage();
+                if (0 == SystemB.INSTANCE.getrusage(RUSAGE_SELF, rusage)) {
                     this.voluntaryContextSwitches = rusage.ru_nvcsw.longValue();
                     this.involuntaryContextSwitches = rusage.ru_nivcsw.longValue();
                     this.contextSwitches = this.voluntaryContextSwitches + this.involuntaryContextSwitches;
@@ -245,7 +250,7 @@ public class MacOSProcessJNA extends MacOSProcess {
         }
         if (this.majorVersion > 10 || (this.majorVersion == 10 && this.minorVersion >= 9)) {
             try (CloseableRUsageInfoV2 rUsageInfoV2 = new CloseableRUsageInfoV2()) {
-                if (0 == SystemB.INSTANCE.proc_pid_rusage(getProcessID(), SystemB.RUSAGE_INFO_V2, rUsageInfoV2)) {
+                if (0 == SystemB.INSTANCE.proc_pid_rusage(getProcessID(), RUSAGE_INFO_V2, rUsageInfoV2)) {
                     this.bytesRead = rUsageInfoV2.ri_diskio_bytesread;
                     this.bytesWritten = rUsageInfoV2.ri_diskio_byteswritten;
                     this.memoryFootprint = rUsageInfoV2.ri_phys_footprint;
@@ -253,7 +258,7 @@ public class MacOSProcessJNA extends MacOSProcess {
             }
         }
         try (CloseableVnodePathInfo vpi = new CloseableVnodePathInfo()) {
-            if (0 < SystemB.INSTANCE.proc_pidinfo(getProcessID(), SystemB.PROC_PIDVNODEPATHINFO, 0, vpi, vpi.size())) {
+            if (0 < SystemB.INSTANCE.proc_pidinfo(getProcessID(), PROC_PIDVNODEPATHINFO, 0, vpi, vpi.size())) {
                 this.currentWorkingDirectory = Native.toString(vpi.pvi_cdir.vip_path, StandardCharsets.US_ASCII);
             }
         }

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcessJNA.java
@@ -4,6 +4,7 @@
  */
 package oshi.software.os.unix.aix;
 
+import static com.sun.jna.platform.unix.Resource.RLIMIT_NOFILE;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
@@ -67,7 +68,7 @@ public final class AixOSProcessJNA extends AixOSProcess {
     public long getSoftOpenFileLimit() {
         if (getProcessID() == this.os.getProcessId()) {
             final Resource.Rlimit rlimit = new Resource.Rlimit();
-            if (AixLibc.INSTANCE.getrlimit(AixLibc.RLIMIT_NOFILE, rlimit) == 0) {
+            if (AixLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit) == 0) {
                 return rlimit.rlim_cur;
             }
         }
@@ -78,7 +79,7 @@ public final class AixOSProcessJNA extends AixOSProcess {
     public long getHardOpenFileLimit() {
         if (getProcessID() == this.os.getProcessId()) {
             final Resource.Rlimit rlimit = new Resource.Rlimit();
-            if (AixLibc.INSTANCE.getrlimit(AixLibc.RLIMIT_NOFILE, rlimit) == 0) {
+            if (AixLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit) == 0) {
                 return rlimit.rlim_max;
             }
         }

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
@@ -4,6 +4,8 @@
  */
 package oshi.software.os.unix.dragonflybsd;
 
+import static oshi.jna.platform.unix.FreeBsdLibc.RLIMIT_NOFILE;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +71,7 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
     public long getSoftOpenFileLimit() {
         if (getProcessID() == this.os.getProcessId()) {
             final Resource.Rlimit rlimit = new Resource.Rlimit();
-            DragonFlyBsdLibc.INSTANCE.getrlimit(DragonFlyBsdLibc.RLIMIT_NOFILE, rlimit);
+            DragonFlyBsdLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit);
             return rlimit.rlim_cur;
         } else {
             return getProcessOpenFileLimit(getProcessID(), 1);
@@ -80,7 +82,7 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
     public long getHardOpenFileLimit() {
         if (getProcessID() == this.os.getProcessId()) {
             final Resource.Rlimit rlimit = new Resource.Rlimit();
-            DragonFlyBsdLibc.INSTANCE.getrlimit(DragonFlyBsdLibc.RLIMIT_NOFILE, rlimit);
+            DragonFlyBsdLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit);
             return rlimit.rlim_max;
         } else {
             return getProcessOpenFileLimit(getProcessID(), 2);

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
@@ -543,6 +543,6 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
             return true;
         }
         HANDLE h = Kernel32.INSTANCE.GetCurrentProcess();
-        return (h == null) ? false : isWow(h);
+        return h != null && isWow(h);
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -7,6 +7,8 @@ package oshi.util.platform.mac;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -61,9 +63,11 @@ public final class SmcUtil {
     public static final String SMC_KEY_CPU_VOLTAGE = "VC0C";
 
     /** Apple Silicon CPU temperature keys, tried in order until one returns a positive value. */
-    public static final String[] SMC_KEYS_CPU_TEMP_AS = { "Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D" };
+    public static final List<String> SMC_KEYS_CPU_TEMP_AS = Collections
+            .unmodifiableList(Arrays.asList("Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D"));
     /** Apple Silicon GPU temperature keys, tried in order until one returns a positive value. */
-    public static final String[] SMC_KEYS_GPU_TEMP_AS = { "Tg05", "Tg0D", "Tg0f", "Tg0j" };
+    public static final List<String> SMC_KEYS_GPU_TEMP_AS = Collections
+            .unmodifiableList(Arrays.asList("Tg05", "Tg0D", "Tg0f", "Tg0j"));
     /** SMC key for CPU voltage (Apple Silicon). */
     public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
 
@@ -148,7 +152,7 @@ public final class SmcUtil {
      * @param keys The keys to try in order
      * @return The first value greater than 0, or 0 if all keys fail
      */
-    public static double smcGetFirstFloat(IOConnect conn, String... keys) {
+    public static double smcGetFirstFloat(IOConnect conn, List<String> keys) {
         for (String key : keys) {
             double val = smcGetFloat(conn, key);
             if (val > 0d) {

--- a/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
@@ -65,7 +65,7 @@ public final class RegistryUtil {
             Object value = Advapi32Util.registryGetValue(root, path, key);
             return Objects.isNull(value) ? null : value;
         } catch (Win32Exception e) {
-            LOG.trace("Unable to access " + path + " with flag " + accessFlag + ": " + e.getMessage());
+            LOG.trace("Unable to access {} with flag {}: {}", path, accessFlag, e.getMessage());
         } finally {
             if (hKey != null) {
                 int rc = ADV.RegCloseKey(hKey);

--- a/oshi-core/src/test/java/oshi/SystemInfoTest.java
+++ b/oshi-core/src/test/java/oshi/SystemInfoTest.java
@@ -58,7 +58,7 @@ public class SystemInfoTest { // NOSONAR squid:S5786
      * Test that this platform is implemented..
      */
     @Test
-    public void testPlatformEnum() {
+    void testPlatformEnum() {
         assertThat("Unsupported OS", PlatformEnum.getCurrentPlatform(), is(not(PlatformEnum.UNKNOWN)));
         // Exercise the main method
         main(null);

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/DisksTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/DisksTest.java
@@ -11,8 +11,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,13 +34,6 @@ class DisksTest {
 
         for (HWDiskStore disk : si.getHardware().getDiskStores()) {
             assertThat(disk, is(notNullValue()));
-            List<HWPartition> parts = disk.getPartitions();
-            List<HWPartition> partList = new ArrayList<>(parts.size());
-            for (HWPartition part : parts) {
-                partList.add(new HWPartition(part.getIdentification(), part.getName(), part.getType(), part.getUuid(),
-                        part.getSize(), part.getMajor(), part.getMinor(), part.getMountPoint()));
-            }
-
             assertThat("Disk name should not be null", disk.getName(), is(notNullValue()));
             assertThat("Disk model should not be null", disk.getModel(), is(notNullValue()));
             assertThat("Disk serial number should not be null", disk.getSerial(), is(notNullValue()));

--- a/oshi-core/src/test/java/oshi/software/os/shared/ApplicationInfoTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/ApplicationInfoTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import oshi.software.os.ApplicationInfo;
 
-public class ApplicationInfoTest {
+class ApplicationInfoTest {
 
     private ApplicationInfo appInfo;
     private final String name = "zstd";
@@ -79,21 +79,21 @@ public class ApplicationInfoTest {
     }
 
     @Test
-    public void equalsWithSameReferenceShouldReturnTrue() {
+    void equalsWithSameReferenceShouldReturnTrue() {
         ApplicationInfo app = new ApplicationInfo("SQL Server Management Studio", "20.2.37.0", "Microsoft Corp.",
                 1746576000000L, new LinkedHashMap<>());
         assertTrue(app.equals(app)); // this == o
     }
 
     @Test
-    public void equalsWithDifferentObjectTypeShouldReturnFalse() {
+    void equalsWithDifferentObjectTypeShouldReturnFalse() {
         ApplicationInfo app = new ApplicationInfo("SQL Server Management Studio", "20.2.37.0", "Microsoft Corp.",
                 1746576000000L, new LinkedHashMap<>());
         assertFalse(app.equals("NotAnApplicationInfo")); // !(o instanceof ApplicationInfo)
     }
 
     @Test
-    public void testEqualsAndHashCodeSameValues() {
+    void testEqualsAndHashCodeSameValues() {
         Map<String, String> info1 = new LinkedHashMap<>();
         info1.put("installLocation", null);
         info1.put("installSource",
@@ -109,7 +109,7 @@ public class ApplicationInfoTest {
     }
 
     @Test
-    public void testEqualsAndHashCodeDifferentVersion() {
+    void testEqualsAndHashCodeDifferentVersion() {
         ApplicationInfo app1 = new ApplicationInfo("SQL Server Management Studio", "20.2.37.0", "Microsoft Corp.",
                 1746576000000L, new LinkedHashMap<>());
         ApplicationInfo app2 = new ApplicationInfo("SQL Server Management Studio", "20.3.37.0", "Microsoft Corp.",
@@ -119,7 +119,7 @@ public class ApplicationInfoTest {
     }
 
     @Test
-    public void testDeduplicationWithListResult() {
+    void testDeduplicationWithListResult() {
         ApplicationInfo app1 = new ApplicationInfo("SQL Server Management Studio", "20.2.37.0", "Microsoft Corp.",
                 1746576000000L, new LinkedHashMap<>());
 

--- a/oshi-demo/src/main/java/oshi/demo/ComputerID.java
+++ b/oshi-demo/src/main/java/oshi/demo/ComputerID.java
@@ -5,6 +5,7 @@
 package oshi.demo;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -29,8 +30,9 @@ public class ComputerID {
     }
 
     /** UUIDs that are known to be non-unique across systems. */
-    public static final List<String> NON_UNIQUE_UUIDS = Arrays.asList("03000200-0400-0500-0006-000700080009",
-            "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF", "00000000-0000-0000-0000-000000000000");
+    public static final List<String> NON_UNIQUE_UUIDS = Collections
+            .unmodifiableList(Arrays.asList("03000200-0400-0500-0006-000700080009",
+                    "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF", "00000000-0000-0000-0000-000000000000"));
 
     /**
      * <p>

--- a/oshi-demo/src/main/java/oshi/demo/PollGpuStats.java
+++ b/oshi-demo/src/main/java/oshi/demo/PollGpuStats.java
@@ -49,8 +49,10 @@ public final class PollGpuStats {
         }
 
         int nameWidth = cards.stream().mapToInt(c -> c.getName().length()).max().orElse(10);
-        String hdr = String.format(Locale.ROOT, "%-" + nameWidth + "s  %8s  %10s  %10s  %8s  %8s  %10s", "Card",
-                "Ticks%", "API Util%", "VRAM Used", "Temp(C)", "Power(W)", "Clock(MHz)");
+        String colFmt = "%-" + nameWidth + "s  %8s  %10s  %10s  %8s  %8s  %10s";
+        String rowFmt = colFmt + "%n";
+        String hdr = String.format(Locale.ROOT, colFmt, "Card", "Ticks%", "API Util%", "VRAM Used", "Temp(C)",
+                "Power(W)", "Clock(MHz)");
         System.out.println(hdr);
         StringBuilder sep = new StringBuilder(hdr.length());
         for (int s = 0; s < hdr.length(); s++)
@@ -87,8 +89,7 @@ public final class PollGpuStats {
                     double power = stats.getPowerDraw();
                     long clock = stats.getCoreClockMhz();
 
-                    System.out.printf(Locale.ROOT, "%-" + nameWidth + "s  %8s  %10s  %10s  %8s  %8s  %10s%n",
-                            card.getName(), tickStr,
+                    System.out.printf(Locale.ROOT, rowFmt, card.getName(), tickStr,
                             apiUtil >= 0 ? String.format(Locale.ROOT, "%.1f%%", apiUtil) : "n/a",
                             vramUsed >= 0 ? FormatUtil.formatBytes(vramUsed) : "n/a",
                             temp >= 0 ? String.format(Locale.ROOT, "%.1f", temp) : "n/a",

--- a/oshi-demo/src/main/java/oshi/demo/WmiNoComInitQueryHandler.java
+++ b/oshi-demo/src/main/java/oshi/demo/WmiNoComInitQueryHandler.java
@@ -9,9 +9,6 @@ import oshi.util.platform.windows.WmiQueryHandler;
 /**
  * Query handler class that avoids COM initialization overhead assuming COM is already initialized by the user.
  */
-/**
- * WMI query handler that does not initialize COM.
- */
 public class WmiNoComInitQueryHandler extends WmiQueryHandler {
 
     /**

--- a/oshi-demo/src/main/java/oshi/demo/gui/Config.java
+++ b/oshi-demo/src/main/java/oshi/demo/gui/Config.java
@@ -24,7 +24,6 @@ public final class Config {
     public static final int REFRESH_FAST = 1000;
     /** Slow refresh interval in ms. */
     public static final int REFRESH_SLOW = 5000;
-    /** Slow refresh interval in ms. */
     /** Slower refresh interval in ms. */
     public static final int REFRESH_SLOWER = 15_000;
 }

--- a/oshi-demo/src/main/java/oshi/demo/jmx/JMXOshiAgentServer.java
+++ b/oshi-demo/src/main/java/oshi/demo/jmx/JMXOshiAgentServer.java
@@ -312,6 +312,11 @@ public class JMXOshiAgentServer implements JMXOshiAgent {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated Conformance stub for a deprecated {@code MBeanServer} interface method; not implemented.
+     */
     @Override
     @Deprecated
     public ObjectInputStream deserialize(ObjectName name, byte[] data)
@@ -319,6 +324,11 @@ public class JMXOshiAgentServer implements JMXOshiAgent {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated Conformance stub for a deprecated {@code MBeanServer} interface method; not implemented.
+     */
     @Override
     @Deprecated
     public ObjectInputStream deserialize(String className, byte[] data)
@@ -326,6 +336,11 @@ public class JMXOshiAgentServer implements JMXOshiAgent {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated Conformance stub for a deprecated {@code MBeanServer} interface method; not implemented.
+     */
     @Override
     @Deprecated
     public ObjectInputStream deserialize(String className, ObjectName loaderName, byte[] data)

--- a/oshi-demo/src/main/java/oshi/demo/jmx/JMXOshiAgentServer.java
+++ b/oshi-demo/src/main/java/oshi/demo/jmx/JMXOshiAgentServer.java
@@ -54,7 +54,6 @@ public class JMXOshiAgentServer implements JMXOshiAgent {
     private Map<String, ?> properties;
 
     private MBeanServer server;
-    private JMXServiceURL address;
     private JMXConnectorServer cntorServer;
     private ContextRegistrationPlatform contextRegistrationPlatform;
     private static JMXOshiAgentServer jmxOshiAgentServer;
@@ -99,7 +98,8 @@ public class JMXOshiAgentServer implements JMXOshiAgent {
         if (LocateRegistry.getRegistry(this.port) != null)
             LocateRegistry.createRegistry(this.port);
 
-        address = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + this.host + ":" + this.port + "/server");
+        JMXServiceURL address = new JMXServiceURL(
+                "service:jmx:rmi:///jndi/rmi://" + this.host + ":" + this.port + "/server");
         cntorServer = JMXConnectorServerFactory.newJMXConnectorServer(address, this.properties, null);
         server = MBeanServerFactory.createMBeanServer();
         ObjectName cntorServerName = ObjectName.getInstance("connectors:protocol=rmi");

--- a/oshi-demo/src/main/java/oshi/demo/jmx/mbeans/Baseboard.java
+++ b/oshi-demo/src/main/java/oshi/demo/jmx/mbeans/Baseboard.java
@@ -29,14 +29,14 @@ import oshi.demo.jmx.demo.PropertiesAvailable;
  */
 public class Baseboard implements DynamicMBean, PropertiesAvailable {
 
-    private oshi.hardware.Baseboard baseboard;
+    private oshi.hardware.Baseboard hwBaseboard;
     private MBeanInfo dMBeanInfo = null;
     private List<String> propertiesAvailable = new ArrayList<>();
     private static final String PROPERTIES = "Properties";
 
     private void setUpMBean() throws IntrospectionException, javax.management.IntrospectionException {
 
-        PropertyDescriptor[] methods = Introspector.getBeanInfo(baseboard.getClass()).getPropertyDescriptors();
+        PropertyDescriptor[] methods = Introspector.getBeanInfo(hwBaseboard.getClass()).getPropertyDescriptors();
         MBeanAttributeInfo[] attributeInfos = new MBeanAttributeInfo[methods.length];
 
         for (int i = 0; i < methods.length; i++) {
@@ -46,7 +46,7 @@ public class Baseboard implements DynamicMBean, PropertiesAvailable {
                     methods[i].getName().substring(0, 1).toUpperCase(Locale.ROOT) + methods[i].getName().substring(1));
         }
 
-        dMBeanInfo = new MBeanInfo(baseboard.getClass().getName(), null, attributeInfos, null, null,
+        dMBeanInfo = new MBeanInfo(hwBaseboard.getClass().getName(), null, attributeInfos, null, null,
                 new MBeanNotificationInfo[0]);
     }
 
@@ -59,7 +59,7 @@ public class Baseboard implements DynamicMBean, PropertiesAvailable {
      */
     public Baseboard(oshi.hardware.Baseboard baseboard)
             throws IntrospectionException, javax.management.IntrospectionException {
-        this.baseboard = baseboard;
+        this.hwBaseboard = baseboard;
         this.setUpMBean();
     }
 
@@ -69,13 +69,13 @@ public class Baseboard implements DynamicMBean, PropertiesAvailable {
             case PROPERTIES:
                 return this.getProperties();
             case "Manufacturer":
-                return baseboard.getManufacturer();
+                return hwBaseboard.getManufacturer();
             case "Model":
-                return baseboard.getModel();
+                return hwBaseboard.getModel();
             case "Version":
-                return baseboard.getVersion();
+                return hwBaseboard.getVersion();
             case "SerialNumber":
-                return baseboard.getSerialNumber();
+                return hwBaseboard.getSerialNumber();
             default:
                 throw new IllegalArgumentException("No attribute " + attribute);
         }

--- a/oshi-metrics/src/main/java/oshi/metrics/NetworkMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/NetworkMetrics.java
@@ -58,7 +58,8 @@ public class NetworkMetrics implements MeterBinder {
     private final Supplier<List<NetworkIF>> networkIFSupplier;
     private final InternetProtocolStats ipStats;
 
-    // Strong reference to prevent GC of NetworkIF objects used by FunctionCounter
+    // Strong reference to prevent GC of NetworkIF objects used by FunctionCounter (Micrometer holds them weakly)
+    @SuppressWarnings("java:S1450") // deliberate GC root; must outlive bindTo(), not a method-local
     private List<NetworkIF> networkIFs;
 
     // Connection count cache to avoid repeated getConnections() calls per scrape


### PR DESCRIPTION
Clears the remaining open SonarCloud findings (all Maintainability; 0 Reliability / 0 Security throughout). Each rule is its own commit; tiny one-off rules are grouped into a final singleton sweep.

## Fixed in code
| Rule | What |
|---|---|
| S2589 | Remove dead/redundant conditions (BSD power-rate derive branch; Mac display release null-check) |
| S3252 | Static-import inherited JNA constants instead of subclass access (preserves platform-specific `RLIMIT_NOFILE` values) |
| S5786 | Drop redundant `public` on JUnit5 test classes/methods |
| S5778 | Hoist non-throwing setup out of `assertThrows` lambdas |
| S3457 | SLF4J `{}` placeholders / hoist runtime-built format strings |
| S2386 | Make `public static` collections immutable (`SMC_KEYS_*`, `NON_UNIQUE_UUIDS`) |
| S3358 | Extract nested ternaries into `if`/`else` |
| S1123 | Add `@deprecated` javadoc to JMX `MBeanServer` conformance stubs |
| S117  | camelCase local offset variables |
| S1172 | Drop unused `Class<T>` params in WMI test mocks |
| S1450 | Localize JMX `address`; keep `NetworkMetrics.networkIFs` as a GC-root field (`@SuppressWarnings`) |
| S5993 | Make abstract-class constructors `protected` |
| S6395 | Drop redundant non-capturing regex groups |
| S8491 | Remove duplicate dangling javadoc |
| singleton sweep | S1125, S115, S1161, S1163 (no throw-in-finally), S1171, S1700, S6213, S4030 |

## Triaged as not-a-code-change (handled in SonarCloud)
- **Accepted (intentional):** S5961, S2925 (timing tests), S5976 (oshi-common checkstyle forbids `junit.jupiter.params`), S5785 (equals()-branch tests), S1133 (JMX deprecated-interface stubs), S3400, S1135, S1479, S1871, plus partials of S3358/S1172/S3358.
- **False positive:** S125 (7 — prose/GUID comments, not commented-out code), S3626 (`forEach…Until` early return is contractual, not redundant).

## Notable
A few were more than mechanical: S2386 was genuine `public static` mutable-state exposure; `NetworkMetrics.networkIFs` / `DiskMetrics.diskStores` are deliberate Micrometer GC roots (kept, not localized); only DragonFly's `RLIMIT_NOFILE` was S3252-flagged because FreeBSD/OpenBSD/Solaris redefine it locally.

## Verification
Clean full-reactor `mvnw clean install`: **BUILD SUCCESS**, 1321 tests, 0 failures / 0 errors (platform-conditional skips on macOS).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Improved code clarity with explicit conditional logic in disk type detection and power source capacity calculations.
  * Reorganized imports and simplified logging patterns across platform-specific utilities.
  * Enhanced test code organization and visibility modifiers for better encapsulation.

* **New Features**
  * Added `WmiNoComInitQueryHandler` for COM initialization control in demo applications.
  * Added `REFRESH_SLOWER` timing constant for GUI refresh configuration.

* **Bug Fixes**
  * Improved registry access error handling and logging on Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->