### PR TITLE
Fix AIX inode collection: use correct df format and include NFS mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 7.3.2 (in progress)
 
-* Your contribution here!
+##### Bug Fixes and Improvements
+
+* [#3409](https://github.com/oshi/oshi/pull/3409): Fix AIX `getFileStores()` inode collection: switch to AIX-native `df -F %n %l`, fix NFS mount filtering, correct column parsing, and fix free/used inode swap - [@jank](https://github.com/jank).
 
 # 7.3.0 (2026-06-06), 7.3.1 (2026-06-11)
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractFileSystem;
@@ -40,6 +41,8 @@ public class AixFileSystem extends AbstractFileSystem {
     private static final List<PathMatcher> FS_VOLUME_INCLUDES = FileSystemUtil
             .loadAndParseFileSystemConfig(OSHI_AIX_FS_VOLUME_INCLUDES);
 
+    private static final Pattern FS_PATTERN = Pattern.compile("^(?:[\\w.]+:)?/");
+
     @Override
     public List<OSFileStore> getFileStores(boolean localOnly) {
         return getFileStoreMatching(null, localOnly);
@@ -52,26 +55,28 @@ public class AixFileSystem extends AbstractFileSystem {
         // Get inode usage data
         Map<String, Long> inodeFreeMap = new HashMap<>();
         Map<String, Long> inodeTotalMap = new HashMap<>();
-        String command = "df -i" + (localOnly ? " -l" : "");
+        String command = "df -F \"%l %n\"" + (localOnly ? " -T local" : "");
         for (String line : ExecutingCommand.runNative(command)) {
             /*- Sample Output:
-             $ df -i
-            Filesystem            Inodes   IUsed   IFree IUse% Mounted on
-            /dev/hd4               75081   16741   58340   23% /
-            /dev/hd2              269640   43104  226536   16% /usr
-            /dev/hd9var            43598    1370   42228    4% /var
-            /dev/hd3               79936     386   79550    1% /tmp
-            /dev/hd11admin         29138       7   29131    1% /admin
-            /proc                      0       0       0    -  /proc
-            /dev/hd10opt           47477    4232   43245    9% /opt
-            /dev/livedump          58204       4   58200    1% /var/adm/ras/livedump
-            /dev/fslv00          12419240  292668 12126572    3% /home
-            */
-            if (line.startsWith("/")) {
+             * $ df -F "%l %n"
+             * Filesystem              free      used
+             * /dev/hd4               58071     18137
+             * /dev/hd2              102455     44046
+             * /dev/hd9var            28280      9919
+             * /dev/hd3               39126       179
+             * /dev/hd11admin         29131         7
+             * /proc                      -         -
+             * /dev/hd10opt           89642       412
+             * /dev/livedump          58200         4
+             * 192.168.253.80:/export  5662375   84670
+             */
+            if (FS_PATTERN.matcher(line).find()) {
                 String[] split = ParseUtil.whitespaces.split(line);
-                if (split.length > 5) {
-                    inodeTotalMap.put(split[0], ParseUtil.parseLongOrDefault(split[1], 0L));
-                    inodeFreeMap.put(split[0], ParseUtil.parseLongOrDefault(split[3], 0L));
+                if (split.length >= 3) {
+                    long used = ParseUtil.parseLongOrDefault(split[split.length - 2], 0L);
+                    long free = ParseUtil.parseLongOrDefault(split[split.length - 1], 0L);
+                    inodeTotalMap.put(split[0], used + free);
+                    inodeFreeMap.put(split[0], free);
                 }
             }
         }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
@@ -55,27 +55,29 @@ public class AixFileSystem extends AbstractFileSystem {
         // Get inode usage data
         Map<String, Long> inodeFreeMap = new HashMap<>();
         Map<String, Long> inodeTotalMap = new HashMap<>();
-        String command = "df -F \"%l %n\"" + (localOnly ? " -T local" : "");
+        String command = "df -F %n %l" + (localOnly ? " -T local" : "");
         for (String line : ExecutingCommand.runNative(command)) {
             /*- Sample Output:
-             * $ df -F "%l %n"
-             * Filesystem              free      used
-             * /dev/hd4               58071     18137
-             * /dev/hd2              102455     44046
-             * /dev/hd9var            28280      9919
-             * /dev/hd3               39126       179
-             * /dev/hd11admin         29131         7
-             * /proc                      -         -
-             * /dev/hd10opt           89642       412
-             * /dev/livedump          58200         4
-             * 192.168.253.80:/export  5662375   84670
+             * $ df -F %n %l
+             * Filesystem    512-blocks     Ifree    Iused
+             * /dev/hd4         4194304   164951    15969
+             * /dev/hd2        52690944  2894117   196692
+             * /dev/hd9var      6291456   605443     2317
+             * /dev/hd3         6291456   450968     1349
+             * /dev/hd1         6291456   550843      110
+             * /dev/hd11admin    2097152   233048        5
+             * /proc                  -        -        -
+             * /dev/hd10opt    16777216   600058    17220
+             * /dev/livedump     524288    58200        4
+             * NFS mounts appear as hostname:/path or ip:/path and are matched by FS_PATTERN
              */
             if (FS_PATTERN.matcher(line).find()) {
                 String[] split = ParseUtil.whitespaces.split(line);
-                if (split.length >= 3) {
-                    long used = ParseUtil.parseLongOrDefault(split[split.length - 2], 0L);
-                    long free = ParseUtil.parseLongOrDefault(split[split.length - 1], 0L);
-                    inodeTotalMap.put(split[0], used + free);
+                // Columns: Filesystem, 512-blocks, Ifree (%n), Iused (%l)
+                if (split.length >= 4) {
+                    long free = ParseUtil.parseLongOrDefault(split[split.length - 2], 0L);
+                    long used = ParseUtil.parseLongOrDefault(split[split.length - 1], 0L);
+                    inodeTotalMap.put(split[0], free + used);
                     inodeFreeMap.put(split[0], free);
                 }
             }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
@@ -55,6 +55,8 @@ public class AixFileSystem extends AbstractFileSystem {
         // Get inode usage data
         Map<String, Long> inodeFreeMap = new HashMap<>();
         Map<String, Long> inodeTotalMap = new HashMap<>();
+        // AIX 7.3+ supports POSIX df -i, but AIX 7.1/7.2 only have the native format-specifier
+        // syntax. df -F %n %l (%n = Ifree, %l = Iused) works across all three versions.
         String command = "df -F %n %l" + (localOnly ? " -T local" : "");
         for (String line : ExecutingCommand.runNative(command)) {
             /*- Sample Output:


### PR DESCRIPTION
## Problem

\`AixFileSystem.getFileStoreMatching()\` has two bugs in its inode-data collection step that affect AIX systems in production:

**1. Wrong \`df\` command.** The code ran \`df -i\`, which is a Linux/POSIX flag that does not exist on AIX. The AIX-native equivalent is \`df -F %n %l\` (format specifiers: \`%n\` = free file nodes / Ifree, \`%l\` = used file nodes / Iused). On real AIX hosts, \`df -i\` either fails or produces no parseable inode output, causing all file stores to report 0 inodes.

Note: the format string must **not** be quoted. \`df -F "%n %l"\` (with shell quotes) causes AIX to treat the entire string as a single specifier, silently dropping \`%l\` and outputting only the Ifree column.

**2. NFS mounts silently dropped.** The inode-data loop filtered with \`line.startsWith("/")\`. On AIX, NFS entries in \`df\` output appear as \`hostname:/path\` or \`192.168.x.x:/path\`, which do not start with \`/\`. All NFS file stores therefore reported 0 inodes regardless.

Both issues were observed on AIX 7.x production systems.

## Fix

- Switch to \`df -F %n %l\` (AIX-native inode format, unquoted); use \`-T local\` instead of \`-l\` for local-only filtering.
- Replace \`line.startsWith("/")\` with a regex \`^(?:[\w.]+:)?/\` that matches both local device paths (\`/dev/hd4\`) and NFS \`host:/path\` entries.
- Fix column parsing: \`df -F %n %l\` always emits four columns (Filesystem, 512-blocks, Ifree, Iused); parse Ifree as \`split[length-2]\` and Iused as \`split[length-1]\`, and tighten the guard to \`>= 4\`.
- Correct a free/used swap: the previous relative-index code assigned Ifree to \`used\` and Iused to \`free\`, so \`inodeFreeMap\` was populated with the used count.
- Update the sample output comment to reflect actual \`df -F %n %l\` output from an AIX 7.2 host.

## Testing

AIX is not in CI. Manual verification on AIX 7.2 confirms that:
- Local file stores now show correct non-zero inode counts.
- \`/proc\` (which outputs \`-\` for all columns) is handled gracefully via \`ParseUtil.parseLongOrDefault\` returning 0L.
- NFS-mounted file stores are no longer silently skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem inode reporting on AIX by enhancing how filesystem/mount output is detected and matched, leading to more accurate inode statistics.
  * Fixed inode free/used/total calculation for matched filesystems, improving the correctness of disk usage details shown in system reports.

* **Documentation**
  * Updated the 7.3.2 changelog with a dedicated entry describing the AIX inode reporting fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->