### PR TITLE
Add DisplayInfo and EDID encoding to expose display attributes without a raw EDID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 7.3.3 (in progress)
+# 7.4.0 (in progress)
+
+##### New Features
+
+* [#3415](https://github.com/oshi/oshi/pull/3415): Add `Display.getDisplayInfo()` and `Display.isEdidSynthetic()`, a new `DisplayInfo` interface, and EDID-encoding methods in `EdidUtil`, allowing display attributes to be exposed without a raw EDID - [@dbwiddis](https://github.com/dbwiddis).
+
+##### Bug Fixes and Improvements
 
 * Your contribution here!
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Stable Release Versions
   * FFM: [oshi-core-ffm-7.3.2](https://central.sonatype.com/artifact/com.github.oshi/oshi-core-ffm/7.3.2)
 
 Current Development (SNAPSHOT) Versions
-  * JNA: [oshi-core-7.3.3-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core/7.3.3-SNAPSHOT)
-  * FFM: [oshi-core-ffm-7.3.3-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core-ffm/7.3.3-SNAPSHOT/)
+  * JNA: [oshi-core-7.4.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core/7.4.0-SNAPSHOT)
+  * FFM: [oshi-core-ffm-7.4.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core-ffm/7.4.0-SNAPSHOT/)
 
 Legacy Versions
   * JDK7: [oshi-core-3.13.6](https://central.sonatype.com/artifact/com.github.oshi/oshi-core/3.13.6)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Stable Release Versions
   * FFM: [oshi-core-ffm-7.3.2](https://central.sonatype.com/artifact/com.github.oshi/oshi-core-ffm/7.3.2)
 
 Current Development (SNAPSHOT) Versions
-  * JNA: [oshi-core-7.4.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core/7.4.0-SNAPSHOT)
+  * JNA: [oshi-core-7.4.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core/7.4.0-SNAPSHOT/)
   * FFM: [oshi-core-ffm-7.4.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core-ffm/7.4.0-SNAPSHOT/)
 
 Legacy Versions

--- a/oshi-benchmark/pom.xml
+++ b/oshi-benchmark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.oshi</groupId>
         <artifactId>oshi-parent</artifactId>
-        <version>7.3.3-SNAPSHOT</version>
+        <version>7.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oshi-benchmark</artifactId>

--- a/oshi-common/pom.xml
+++ b/oshi-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.oshi</groupId>
         <artifactId>oshi-parent</artifactId>
-        <version>7.3.3-SNAPSHOT</version>
+        <version>7.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oshi-common</artifactId>

--- a/oshi-common/src/main/java/oshi/hardware/Display.java
+++ b/oshi-common/src/main/java/oshi/hardware/Display.java
@@ -28,7 +28,12 @@ import oshi.annotation.concurrent.Immutable;
  * }
  * }</pre>
  *
+ * For displays that report their attributes without providing an EDID (such as a built-in macOS Retina panel),
+ * {@link #isEdidSynthetic()} returns {@code true} and {@link #getEdid()} returns an EDID synthesized from those
+ * attributes. The decoded fields are also available directly through {@link #getDisplayInfo()}.
+ *
  * @see oshi.util.EdidUtil
+ * @see DisplayInfo
  */
 @PublicApi
 @Immutable
@@ -36,7 +41,23 @@ public interface Display {
     /**
      * The EDID byte array.
      *
-     * @return The original unparsed EDID byte array.
+     * @return The EDID byte array, either reported by the display or, when {@link #isEdidSynthetic()} is {@code true},
+     *         synthesized from the display's reported attributes.
      */
     byte[] getEdid();
+
+    /**
+     * The decoded display information, equivalent to parsing {@link #getEdid()} with {@link oshi.util.EdidUtil}.
+     *
+     * @return A {@link DisplayInfo} holding the display's decoded attributes.
+     */
+    DisplayInfo getDisplayInfo();
+
+    /**
+     * Indicates whether the EDID returned by {@link #getEdid()} was synthesized from the display's reported attributes
+     * rather than read directly from the display.
+     *
+     * @return {@code true} if the EDID is synthetic, {@code false} if it is the display's raw EDID.
+     */
+    boolean isEdidSynthetic();
 }

--- a/oshi-common/src/main/java/oshi/hardware/DisplayInfo.java
+++ b/oshi-common/src/main/java/oshi/hardware/DisplayInfo.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware;
+
+import oshi.annotation.PublicApi;
+import oshi.annotation.concurrent.Immutable;
+
+/**
+ * Holds the human-readable information described by a display's EDID (Extended Display Identification Data), exposing
+ * the same values that {@link oshi.util.EdidUtil} parses from a raw EDID byte array.
+ * <p>
+ * For a display that reports a raw EDID, {@link #getEdid()} returns those bytes and {@link #isEdidSynthetic()} is
+ * {@code false}. For a display that reports its attributes without an EDID (such as a built-in macOS Retina panel),
+ * {@link #isEdidSynthetic()} is {@code true} and {@link #getEdid()} returns an EDID synthesized from those attributes.
+ * <p>
+ * A synthesized EDID is a valid 128-byte EDID (correct header and checksum) that re-parses to the same values this
+ * interface exposes, so it is interchangeable with a real EDID for {@link oshi.util.EdidUtil} decoding. It carries only
+ * those values, however: unlike a panel's real EDID it does not include the additional detail (chromaticity
+ * coordinates, full detailed-timing parameters, extension blocks, etc.) that was never reported.
+ *
+ * @see oshi.util.EdidUtil
+ */
+@PublicApi
+@Immutable
+public interface DisplayInfo {
+
+    /**
+     * Gets the EDID byte array: the bytes reported by the display, or, when {@link #isEdidSynthetic()} is {@code true},
+     * an EDID synthesized from the display's reported attributes.
+     *
+     * @return A copy of the EDID byte array.
+     */
+    byte[] getEdid();
+
+    /**
+     * Indicates whether the EDID returned by {@link #getEdid()} was synthesized from reported attributes rather than
+     * read directly from the display.
+     *
+     * @return {@code true} if the EDID is synthetic, {@code false} if it is the display's raw EDID.
+     */
+    boolean isEdidSynthetic();
+
+    /**
+     * Gets the manufacturer ID.
+     *
+     * @return The manufacturer ID.
+     */
+    String getManufacturerID();
+
+    /**
+     * Gets the product ID.
+     *
+     * @return The product ID.
+     */
+    String getProductID();
+
+    /**
+     * Gets the serial number, the numeric ID serial number from bytes 12-15 of the EDID. This is distinct from
+     * {@link #getProductSerialNumber()}.
+     *
+     * @return The serial number.
+     */
+    String getSerialNo();
+
+    /**
+     * Gets the week of manufacture.
+     *
+     * @return The week of manufacture.
+     */
+    byte getWeek();
+
+    /**
+     * Gets the year of manufacture.
+     *
+     * @return The year of manufacture.
+     */
+    int getYear();
+
+    /**
+     * Gets the EDID version.
+     *
+     * @return The EDID version.
+     */
+    String getVersion();
+
+    /**
+     * Tests whether the display is digital.
+     *
+     * @return {@code true} if the display is digital, {@code false} otherwise.
+     */
+    boolean isDigital();
+
+    /**
+     * Gets the monitor width in cm.
+     *
+     * @return The monitor width in cm.
+     */
+    int getHcm();
+
+    /**
+     * Gets the monitor height in cm.
+     *
+     * @return The monitor height in cm.
+     */
+    int getVcm();
+
+    /**
+     * Gets the preferred resolution.
+     *
+     * @return The preferred resolution (e.g. {@code "2560x1440"}).
+     */
+    String getPreferredResolution();
+
+    /**
+     * Gets the monitor model.
+     *
+     * @return The monitor model.
+     */
+    String getModel();
+
+    /**
+     * Gets the display product serial number, the text of the serial-number descriptor. This is distinct from
+     * {@link #getSerialNo()}, which returns the numeric ID serial number.
+     *
+     * @return The display product serial number, or {@code null} if not available.
+     */
+    String getProductSerialNumber();
+}

--- a/oshi-common/src/main/java/oshi/hardware/DisplayInfo.java
+++ b/oshi-common/src/main/java/oshi/hardware/DisplayInfo.java
@@ -124,7 +124,7 @@ public interface DisplayInfo {
      * Gets the display product serial number, the text of the serial-number descriptor. This is distinct from
      * {@link #getSerialNo()}, which returns the numeric ID serial number.
      *
-     * @return The display product serial number, or {@code null} if not available.
+     * @return The display product serial number, or an empty string if not available.
      */
     String getProductSerialNumber();
 }

--- a/oshi-common/src/main/java/oshi/hardware/DisplayInfoImpl.java
+++ b/oshi-common/src/main/java/oshi/hardware/DisplayInfoImpl.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.EdidUtil;
+
+/**
+ * The default {@link DisplayInfo} implementation. This is not part of the OSHI public API and may change between minor
+ * releases.
+ * <p>
+ * An instance is created either from a raw EDID byte array (fields decoded from the EDID on demand) or from individual
+ * field values, in which case {@link #isEdidSynthetic()} is {@code true} and {@link #getEdid()} lazily synthesizes an
+ * EDID from the supplied fields. The synthetic serial number must be in a form accepted by
+ * {@link EdidUtil#setSerialNo(byte[], String)} (8 hex characters or 4 printable characters).
+ */
+@ThreadSafe
+public class DisplayInfoImpl implements DisplayInfo {
+
+    private final boolean synthetic;
+
+    // For a real EDID this is set in the constructor and the field getters parse it on demand; for a synthetic instance
+    // it starts null and is lazily populated by getEdid() from the field values below.
+    private volatile byte[] edid;
+
+    // Populated only for a synthetic instance; for a real instance the getters derive these from the EDID bytes.
+    private final String manufacturerID;
+    private final String productID;
+    private final String serialNo;
+    private final byte week;
+    private final int year;
+    private final String version;
+    private final boolean digital;
+    private final int hcm;
+    private final int vcm;
+    private final String preferredResolution;
+    private final String model;
+    private final String productSerialNumber;
+
+    /**
+     * Constructs a {@code DisplayInfoImpl} from a raw EDID byte array. The fields are parsed from the EDID on demand.
+     *
+     * @param edid The raw EDID byte array as reported by the display.
+     */
+    public DisplayInfoImpl(byte[] edid) {
+        this.edid = Arrays.copyOf(edid, edid.length);
+        this.synthetic = false;
+        this.manufacturerID = null;
+        this.productID = null;
+        this.serialNo = null;
+        this.week = 0;
+        this.year = 0;
+        this.version = null;
+        this.digital = false;
+        this.hcm = 0;
+        this.vcm = 0;
+        this.preferredResolution = null;
+        this.model = null;
+        this.productSerialNumber = null;
+    }
+
+    /**
+     * Constructs a synthetic {@code DisplayInfoImpl} from individual field values, for displays that report their
+     * attributes without providing an EDID. The EDID returned by {@link #getEdid()} is synthesized on demand from these
+     * values, and {@link #isEdidSynthetic()} returns {@code true}.
+     *
+     * @param manufacturerID      The three-letter manufacturer ID (see {@link EdidUtil#getManufacturerID(byte[])}).
+     * @param productID           The product ID as a hex string (see {@link EdidUtil#getProductID(byte[])}).
+     * @param serialNo            The serial number, either 8 hex characters or 4 printable characters (see
+     *                            {@link EdidUtil#getSerialNo(byte[])}).
+     * @param week                The week of manufacture.
+     * @param year                The four-digit year of manufacture.
+     * @param version             The EDID version as a {@code major.minor} string (e.g. {@code "1.4"}).
+     * @param digital             Whether the display is digital.
+     * @param hcm                 The monitor width in cm.
+     * @param vcm                 The monitor height in cm.
+     * @param preferredResolution The preferred resolution as a {@code WIDTHxHEIGHT} string (e.g. {@code "2560x1440"}).
+     * @param model               The monitor model.
+     * @param productSerialNumber The display product serial number (the serial-number descriptor text, distinct from
+     *                            {@code serialNo}), or {@code null} if not available.
+     */
+    @SuppressWarnings("java:S107") // value holder mirroring the EdidUtil field set
+    public DisplayInfoImpl(String manufacturerID, String productID, String serialNo, byte week, int year,
+            String version, boolean digital, int hcm, int vcm, String preferredResolution, String model,
+            String productSerialNumber) {
+        this.edid = null;
+        this.synthetic = true;
+        this.manufacturerID = manufacturerID;
+        this.productID = productID;
+        this.serialNo = serialNo;
+        this.week = week;
+        this.year = year;
+        this.version = version;
+        this.digital = digital;
+        this.hcm = hcm;
+        this.vcm = vcm;
+        this.preferredResolution = preferredResolution;
+        this.model = model;
+        this.productSerialNumber = productSerialNumber;
+    }
+
+    @Override
+    public byte[] getEdid() {
+        byte[] result = this.edid;
+        if (result == null) {
+            synchronized (this) {
+                result = this.edid;
+                if (result == null) {
+                    result = synthesizeEdid();
+                    this.edid = result;
+                }
+            }
+        }
+        return Arrays.copyOf(result, result.length);
+    }
+
+    @Override
+    public boolean isEdidSynthetic() {
+        return this.synthetic;
+    }
+
+    @Override
+    public String getManufacturerID() {
+        return this.synthetic ? this.manufacturerID : EdidUtil.getManufacturerID(this.edid);
+    }
+
+    @Override
+    public String getProductID() {
+        return this.synthetic ? this.productID : EdidUtil.getProductID(this.edid);
+    }
+
+    @Override
+    public String getSerialNo() {
+        return this.synthetic ? this.serialNo : EdidUtil.getSerialNo(this.edid);
+    }
+
+    @Override
+    public byte getWeek() {
+        return this.synthetic ? this.week : EdidUtil.getWeek(this.edid);
+    }
+
+    @Override
+    public int getYear() {
+        return this.synthetic ? this.year : EdidUtil.getYear(this.edid);
+    }
+
+    @Override
+    public String getVersion() {
+        return this.synthetic ? this.version : EdidUtil.getVersion(this.edid);
+    }
+
+    @Override
+    public boolean isDigital() {
+        return this.synthetic ? this.digital : EdidUtil.isDigital(this.edid);
+    }
+
+    @Override
+    public int getHcm() {
+        return this.synthetic ? this.hcm : EdidUtil.getHcm(this.edid);
+    }
+
+    @Override
+    public int getVcm() {
+        return this.synthetic ? this.vcm : EdidUtil.getVcm(this.edid);
+    }
+
+    @Override
+    public String getPreferredResolution() {
+        return this.synthetic ? this.preferredResolution : EdidUtil.getPreferredResolution(this.edid);
+    }
+
+    @Override
+    public String getModel() {
+        return this.synthetic ? this.model : EdidUtil.getModel(this.edid);
+    }
+
+    @Override
+    public String getProductSerialNumber() {
+        return this.synthetic ? this.productSerialNumber : EdidUtil.getProductSerialNumber(this.edid);
+    }
+
+    private byte[] synthesizeEdid() {
+        byte[] e = EdidUtil.newEdidTemplate();
+        EdidUtil.setManufacturerID(e, this.manufacturerID);
+        EdidUtil.setProductID(e, this.productID);
+        EdidUtil.setSerialNo(e, this.serialNo);
+        EdidUtil.setWeek(e, this.week);
+        EdidUtil.setYear(e, this.year);
+        EdidUtil.setVersion(e, this.version);
+        EdidUtil.setDigital(e, this.digital);
+        EdidUtil.setHcm(e, this.hcm);
+        EdidUtil.setVcm(e, this.vcm);
+        EdidUtil.setPreferredResolution(e, this.preferredResolution);
+        EdidUtil.setModel(e, this.model);
+        if (this.productSerialNumber != null) {
+            EdidUtil.setProductSerialNumber(e, this.productSerialNumber);
+        }
+        EdidUtil.updateChecksum(e);
+        return e;
+    }
+
+    @Override
+    public String toString() {
+        // For a real EDID, defer to the full EdidUtil rendering of the existing bytes. For a synthetic instance, format
+        // directly from the decoded fields so toString never triggers (and re-decodes) a synthesized EDID.
+        if (!this.synthetic) {
+            return EdidUtil.toString(this.edid);
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("  Manuf. ID=").append(this.manufacturerID);
+        sb.append(", Product ID=").append(this.productID);
+        sb.append(", ").append(this.digital ? "Digital" : "Analog");
+        sb.append(", Serial=").append(this.serialNo);
+        sb.append(", ManufDate=").append(this.week * 12 / 52 + 1).append('/').append(this.year);
+        sb.append(", EDID v").append(this.version);
+        sb.append(String.format(Locale.ROOT, "%n  %d x %d cm (%.1f x %.1f in)", this.hcm, this.vcm, this.hcm / 2.54,
+                this.vcm / 2.54));
+        sb.append(String.format(Locale.ROOT, "%n  Preferred Resolution: %s", this.preferredResolution));
+        sb.append(String.format(Locale.ROOT, "%n  Monitor Name: %s", this.model));
+        if (this.productSerialNumber != null) {
+            sb.append(String.format(Locale.ROOT, "%n  Serial Number: %s", this.productSerialNumber));
+        }
+        return sb.toString();
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/DisplayInfoImpl.java
+++ b/oshi-common/src/main/java/oshi/hardware/DisplayInfoImpl.java
@@ -82,7 +82,7 @@ public class DisplayInfoImpl implements DisplayInfo {
      * @param preferredResolution The preferred resolution as a {@code WIDTHxHEIGHT} string (e.g. {@code "2560x1440"}).
      * @param model               The monitor model.
      * @param productSerialNumber The display product serial number (the serial-number descriptor text, distinct from
-     *                            {@code serialNo}), or {@code null} if not available.
+     *                            {@code serialNo}); {@code null} or empty if not available.
      */
     @SuppressWarnings("java:S107") // value holder mirroring the EdidUtil field set
     public DisplayInfoImpl(String manufacturerID, String productID, String serialNo, byte week, int year,
@@ -101,22 +101,22 @@ public class DisplayInfoImpl implements DisplayInfo {
         this.vcm = vcm;
         this.preferredResolution = preferredResolution;
         this.model = model;
-        this.productSerialNumber = productSerialNumber;
+        // Normalize to empty so getProductSerialNumber never returns null, matching getSerialNo/getModel
+        this.productSerialNumber = productSerialNumber == null ? "" : productSerialNumber;
     }
 
     @Override
     public byte[] getEdid() {
-        byte[] result = this.edid;
-        if (result == null) {
-            synchronized (this) {
-                result = this.edid;
-                if (result == null) {
-                    result = synthesizeEdid();
-                    this.edid = result;
-                }
-            }
-        }
+        byte[] result = cachedEdid();
         return Arrays.copyOf(result, result.length);
+    }
+
+    private synchronized byte[] cachedEdid() {
+        // For a real EDID this is set in the constructor; for a synthetic instance it is synthesized once on first use.
+        if (this.edid == null) {
+            this.edid = synthesizeEdid();
+        }
+        return this.edid;
     }
 
     @Override
@@ -197,7 +197,7 @@ public class DisplayInfoImpl implements DisplayInfo {
         EdidUtil.setVcm(e, this.vcm);
         EdidUtil.setPreferredResolution(e, this.preferredResolution);
         EdidUtil.setModel(e, this.model);
-        if (this.productSerialNumber != null) {
+        if (!this.productSerialNumber.isEmpty()) {
             EdidUtil.setProductSerialNumber(e, this.productSerialNumber);
         }
         EdidUtil.updateChecksum(e);
@@ -222,7 +222,7 @@ public class DisplayInfoImpl implements DisplayInfo {
                 this.vcm / 2.54));
         sb.append(String.format(Locale.ROOT, "%n  Preferred Resolution: %s", this.preferredResolution));
         sb.append(String.format(Locale.ROOT, "%n  Monitor Name: %s", this.model));
-        if (this.productSerialNumber != null) {
+        if (!this.productSerialNumber.isEmpty()) {
             sb.append(String.format(Locale.ROOT, "%n  Serial Number: %s", this.productSerialNumber));
         }
         return sb.toString();

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractDisplay.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractDisplay.java
@@ -4,11 +4,10 @@
  */
 package oshi.hardware.common;
 
-import java.util.Arrays;
-
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Display;
-import oshi.util.EdidUtil;
+import oshi.hardware.DisplayInfo;
+import oshi.hardware.DisplayInfoImpl;
 
 /**
  * A Display
@@ -16,24 +15,44 @@ import oshi.util.EdidUtil;
 @Immutable
 public abstract class AbstractDisplay implements Display {
 
-    private final byte[] edid;
+    private final DisplayInfo displayInfo;
 
     /**
-     * Constructor for AbstractDisplay.
+     * Constructor for AbstractDisplay from a raw EDID byte array.
      *
      * @param edid a byte array representing a display EDID
      */
     protected AbstractDisplay(byte[] edid) {
-        this.edid = Arrays.copyOf(edid, edid.length);
+        this.displayInfo = new DisplayInfoImpl(edid);
+    }
+
+    /**
+     * Constructor for AbstractDisplay from decoded display information, used when a display reports its attributes
+     * without providing an EDID. Pass a synthetic {@link DisplayInfo} to expose a synthesized EDID.
+     *
+     * @param displayInfo the decoded display information
+     */
+    protected AbstractDisplay(DisplayInfo displayInfo) {
+        this.displayInfo = displayInfo;
     }
 
     @Override
     public byte[] getEdid() {
-        return Arrays.copyOf(this.edid, this.edid.length);
+        return this.displayInfo.getEdid();
+    }
+
+    @Override
+    public DisplayInfo getDisplayInfo() {
+        return this.displayInfo;
+    }
+
+    @Override
+    public boolean isEdidSynthetic() {
+        return this.displayInfo.isEdidSynthetic();
     }
 
     @Override
     public String toString() {
-        return EdidUtil.toString(this.edid);
+        return this.displayInfo.toString();
     }
 }

--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -116,8 +116,8 @@ public final class EdidUtil {
      * @return The year of manufacture
      */
     public static int getYear(byte[] edid) {
-        // Byte 17 is manufacture year-1990
-        byte temp = edid[YEAR_OFFSET];
+        // Byte 17 is manufacture year-1990 (unsigned)
+        int temp = edid[YEAR_OFFSET] & 0xFF;
         LOG.debug("Year-1990: {}", temp);
         return temp + YEAR_BASE;
     }
@@ -151,8 +151,8 @@ public final class EdidUtil {
      * @return Monitor width in cm
      */
     public static int getHcm(byte[] edid) {
-        // Byte 21 is horizontal size in cm
-        return edid[HORIZONTAL_SIZE_OFFSET];
+        // Byte 21 is horizontal size in cm (unsigned)
+        return edid[HORIZONTAL_SIZE_OFFSET] & 0xFF;
     }
 
     /**
@@ -162,8 +162,8 @@ public final class EdidUtil {
      * @return Monitor height in cm
      */
     public static int getVcm(byte[] edid) {
-        // Byte 22 is vertical size in cm
-        return edid[VERTICAL_SIZE_OFFSET];
+        // Byte 22 is vertical size in cm (unsigned)
+        return edid[VERTICAL_SIZE_OFFSET] & 0xFF;
     }
 
     /**
@@ -242,28 +242,17 @@ public final class EdidUtil {
      * Get the monitor model from the EDID
      *
      * @param edid The edid Byte array
-     * @return Plain text monitor model
+     * @return Plain text monitor model, or an empty string if the EDID has no monitor-name descriptor
      */
-
     public static String getModel(byte[] edid) {
-
-        byte[][] desc = EdidUtil.getDescriptors(edid);
-        String model = null;
-
-        for (byte[] b : desc) {
-
-            if (EdidUtil.getDescriptorType(b) == MONITOR_NAME_TYPE) {
-                model = EdidUtil.getDescriptorText(b);
-                break;
+        for (byte[] b : getDescriptors(edid)) {
+            if (getDescriptorType(b) == MONITOR_NAME_TYPE) {
+                // The model name is the final whitespace-delimited token of the monitor-name descriptor
+                String[] tokens = getDescriptorText(b).split("\\s+");
+                return tokens[tokens.length - 1].trim();
             }
         }
-
-        assert model != null;
-        String[] tokens = model.split("\\s+");
-        if (tokens.length >= 1) {
-            model = tokens[tokens.length - 1];
-        }
-        return model.trim();
+        return "";
     }
 
     /**
@@ -271,7 +260,7 @@ public final class EdidUtil {
      * is distinct from {@link #getSerialNo(byte[])}, which returns the numeric ID serial number in bytes 12-15.
      *
      * @param edid The edid byte array
-     * @return The serial-number descriptor text, or {@code null} if the EDID has no serial-number descriptor.
+     * @return The serial-number descriptor text, or an empty string if the EDID has no serial-number descriptor.
      */
     public static String getProductSerialNumber(byte[] edid) {
         for (byte[] desc : getDescriptors(edid)) {
@@ -279,7 +268,7 @@ public final class EdidUtil {
                 return getDescriptorText(desc);
             }
         }
-        return null;
+        return "";
     }
 
     /**
@@ -307,20 +296,25 @@ public final class EdidUtil {
     }
 
     /**
-     * Sets the Manufacturer ID into bytes 8 and 9, the inverse of {@link #getManufacturerID(byte[])}.
-     * <p>
-     * Reliably round-trips a standard three-letter A-Z code. An identifier whose decoded form begins with a stripped
-     * '@' (zero-valued) character cannot be reconstructed and is not supported.
+     * Sets the Manufacturer ID into bytes 8 and 9, the inverse of {@link #getManufacturerID(byte[])}. Requires a
+     * standard three-letter A-Z code so the value round-trips cleanly.
      *
      * @param edid           The EDID byte array to modify
-     * @param manufacturerId A three-letter manufacturer ID (e.g. {@code "AUO"})
+     * @param manufacturerId A three-letter (A-Z) manufacturer ID (e.g. {@code "AUO"})
+     * @throws IllegalArgumentException if {@code manufacturerId} is not exactly three uppercase A-Z letters
      */
     public static void setManufacturerID(byte[] edid, String manufacturerId) {
-        // Pack 3 5-bit characters (value = letter - 64) into bytes 8-9, MSB reserved 0
+        if (manufacturerId.length() != 3) {
+            throw new IllegalArgumentException("Manufacturer ID must be three letters: " + manufacturerId);
+        }
+        // Pack 3 5-bit characters (value = letter - 'A' + 1) into bytes 8-9, MSB reserved 0
         int packed = 0;
         for (int i = 0; i < 3; i++) {
-            int c = i < manufacturerId.length() ? manufacturerId.charAt(i) - 64 : 0;
-            packed = packed << 5 | c & 0x1F;
+            int c = manufacturerId.charAt(i) - 'A' + 1;
+            if (c < 1 || c > 26) {
+                throw new IllegalArgumentException("Manufacturer ID must be uppercase A-Z: " + manufacturerId);
+            }
+            packed = packed << 5 | c;
         }
         edid[MANUFACTURER_ID_OFFSET] = (byte) (packed >> 8 & 0xFF);
         edid[MANUFACTURER_ID_OFFSET + 1] = (byte) (packed & 0xFF);
@@ -330,11 +324,15 @@ public final class EdidUtil {
      * Sets the Product ID into bytes 10 and 11, the inverse of {@link #getProductID(byte[])}.
      *
      * @param edid      The EDID byte array to modify
-     * @param productId The product ID as a hex string
+     * @param productId The product ID as a hex string representing an unsigned 16-bit value (0-FFFF)
+     * @throws IllegalArgumentException if {@code productId} is not a hex value in the range 0-FFFF
      */
     public static void setProductID(byte[] edid, String productId) {
         // Bytes 10-11 store the product ID little-endian
-        int value = ParseUtil.hexStringToInt(productId, 0);
+        int value = ParseUtil.hexStringToInt(productId, -1);
+        if (value < 0 || value > 0xFFFF) {
+            throw new IllegalArgumentException("Product ID must be a hex value in the range 0-FFFF: " + productId);
+        }
         edid[PRODUCT_ID_OFFSET] = (byte) (value & 0xFF);
         edid[PRODUCT_ID_OFFSET + 1] = (byte) (value >> 8 & 0xFF);
     }
@@ -342,29 +340,39 @@ public final class EdidUtil {
     /**
      * Sets the Serial number into bytes 12-15, the inverse of {@link #getSerialNo(byte[])}.
      * <p>
-     * Because {@link #getSerialNo(byte[])} renders each byte as either a single alphanumeric character or two hex
-     * digits, only the unambiguous forms are accepted: an 8-character hex string (all four bytes non-printable) or a
-     * 4-character printable string (all four bytes alphanumeric).
+     * Because {@link #getSerialNo(byte[])} renders each byte as either a single alphanumeric character or two uppercase
+     * hex digits, only inputs that reproduce verbatim through {@link #getSerialNo(byte[])} are accepted: eight
+     * uppercase hex digits whose bytes are each non-alphanumeric, or four alphanumeric characters. Ambiguous values
+     * such as hex-looking ASCII (e.g. {@code "41424344"}) or non-alphanumeric four-character strings are rejected.
      *
      * @param edid     The EDID byte array to modify
-     * @param serialNo An 8-character hex string or 4-character printable string as returned by
-     *                 {@link #getSerialNo(byte[])}
-     * @throws IllegalArgumentException if {@code serialNo} is neither 8 hex characters nor 4 printable characters
+     * @param serialNo A serial number as returned by {@link #getSerialNo(byte[])}
+     * @throws IllegalArgumentException if {@code serialNo} does not round-trip through {@link #getSerialNo(byte[])}
      */
     public static void setSerialNo(byte[] edid, String serialNo) {
         // getSerialNo emits bytes 15,14,13,12 in order; reverse that mapping back into bytes 12-15
         byte[] bytes;
         if (serialNo.length() == 8) {
-            bytes = ParseUtil.hexStringToByteArray(serialNo);
+            bytes = ParseUtil.hexStringToByteArray(serialNo); // empty array if not valid hex
         } else if (serialNo.length() == 4) {
             bytes = serialNo.getBytes(StandardCharsets.US_ASCII);
         } else {
-            throw new IllegalArgumentException(
-                    "Serial number must be 8 hex characters or 4 printable characters: " + serialNo);
+            bytes = new byte[0];
         }
-        for (int i = 0; i < 4; i++) {
-            edid[SERIAL_NUMBER_OFFSET + 3 - i] = bytes[i];
+        if (bytes.length == 4) {
+            byte[] candidate = new byte[SERIAL_NUMBER_OFFSET + 4];
+            for (int i = 0; i < 4; i++) {
+                candidate[SERIAL_NUMBER_OFFSET + 3 - i] = bytes[i];
+            }
+            // Accept only if the written bytes reproduce the input exactly through getSerialNo
+            if (getSerialNo(candidate).equals(serialNo)) {
+                System.arraycopy(candidate, SERIAL_NUMBER_OFFSET, edid, SERIAL_NUMBER_OFFSET, 4);
+                return;
+            }
         }
+        throw new IllegalArgumentException(
+                "Serial number must round-trip through getSerialNo (8 uppercase hex digits or 4 alphanumeric characters): "
+                        + serialNo);
     }
 
     /**
@@ -381,9 +389,14 @@ public final class EdidUtil {
      * Sets the year of manufacture into byte 17, the inverse of {@link #getYear(byte[])}.
      *
      * @param edid The EDID byte array to modify
-     * @param year The four-digit year of manufacture (stored as {@code year - 1990})
+     * @param year The four-digit year of manufacture (stored as {@code year - 1990}, so 1990-2245)
+     * @throws IllegalArgumentException if {@code year} is outside the range 1990-2245
      */
     public static void setYear(byte[] edid, int year) {
+        if (year < YEAR_BASE || year > YEAR_BASE + 0xFF) {
+            throw new IllegalArgumentException(
+                    "Year must be in the range " + YEAR_BASE + "-" + (YEAR_BASE + 0xFF) + ": " + year);
+        }
         edid[YEAR_OFFSET] = (byte) (year - YEAR_BASE);
     }
 
@@ -414,9 +427,13 @@ public final class EdidUtil {
      * Sets the monitor width in cm into byte 21, the inverse of {@link #getHcm(byte[])}.
      *
      * @param edid The EDID byte array to modify
-     * @param hcm  Monitor width in cm
+     * @param hcm  Monitor width in cm (0-255)
+     * @throws IllegalArgumentException if {@code hcm} is outside the range 0-255
      */
     public static void setHcm(byte[] edid, int hcm) {
+        if (hcm < 0 || hcm > 0xFF) {
+            throw new IllegalArgumentException("Horizontal size must be in the range 0-255: " + hcm);
+        }
         edid[HORIZONTAL_SIZE_OFFSET] = (byte) hcm;
     }
 
@@ -424,9 +441,13 @@ public final class EdidUtil {
      * Sets the monitor height in cm into byte 22, the inverse of {@link #getVcm(byte[])}.
      *
      * @param edid The EDID byte array to modify
-     * @param vcm  Monitor height in cm
+     * @param vcm  Monitor height in cm (0-255)
+     * @throws IllegalArgumentException if {@code vcm} is outside the range 0-255
      */
     public static void setVcm(byte[] edid, int vcm) {
+        if (vcm < 0 || vcm > 0xFF) {
+            throw new IllegalArgumentException("Vertical size must be in the range 0-255: " + vcm);
+        }
         edid[VERTICAL_SIZE_OFFSET] = (byte) vcm;
     }
 

--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -24,6 +24,26 @@ public final class EdidUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(EdidUtil.class);
 
+    // EDID byte offsets and field lengths
+    private static final int EDID_LENGTH = 128;
+    private static final int MANUFACTURER_ID_OFFSET = 8;
+    private static final int PRODUCT_ID_OFFSET = 10;
+    private static final int SERIAL_NUMBER_OFFSET = 12;
+    private static final int WEEK_OFFSET = 16;
+    private static final int YEAR_OFFSET = 17;
+    private static final int YEAR_BASE = 1990;
+    private static final int VERSION_OFFSET = 18;
+    private static final int VIDEO_PARAMS_OFFSET = 20;
+    private static final int HORIZONTAL_SIZE_OFFSET = 21;
+    private static final int VERTICAL_SIZE_OFFSET = 22;
+    private static final int STD_TIMING_OFFSET = 38;
+    private static final int DESCRIPTOR_OFFSET = 54;
+    private static final int DESCRIPTOR_LENGTH = 18;
+    private static final int DESCRIPTOR_COUNT = 4;
+    private static final int CHECKSUM_OFFSET = 127;
+    private static final int MONITOR_NAME_TYPE = 0xFC;
+    private static final int DISPLAY_SERIAL_TYPE = 0xFF;
+
     private EdidUtil() {
     }
 
@@ -36,8 +56,8 @@ public final class EdidUtil {
     @SuppressForbidden(reason = "customized base 2 parsing not in Util class")
     public static String getManufacturerID(byte[] edid) {
         // Bytes 8-9 are manufacturer ID in 3 5-bit characters.
-        String temp = String.format(Locale.ROOT, "%8s%8s", Integer.toBinaryString(edid[8] & 0xFF),
-                Integer.toBinaryString(edid[9] & 0xFF)).replace(' ', '0');
+        String temp = String.format(Locale.ROOT, "%8s%8s", Integer.toBinaryString(edid[MANUFACTURER_ID_OFFSET] & 0xFF),
+                Integer.toBinaryString(edid[MANUFACTURER_ID_OFFSET + 1] & 0xFF)).replace(' ', '0');
         LOG.debug("Manufacurer ID: {}", temp);
         return String.format(Locale.ROOT, "%s%s%s", (char) (64 + Integer.parseInt(temp.substring(1, 6), 2)),
                 (char) (64 + Integer.parseInt(temp.substring(6, 11), 2)),
@@ -52,8 +72,8 @@ public final class EdidUtil {
      */
     public static String getProductID(byte[] edid) {
         // Bytes 10-11 are product ID expressed in hex characters
-        return Integer.toHexString(
-                ByteBuffer.wrap(Arrays.copyOfRange(edid, 10, 12)).order(ByteOrder.LITTLE_ENDIAN).getShort() & 0xffff);
+        return Integer.toHexString(ByteBuffer.wrap(Arrays.copyOfRange(edid, PRODUCT_ID_OFFSET, PRODUCT_ID_OFFSET + 2))
+                .order(ByteOrder.LITTLE_ENDIAN).getShort() & 0xffff);
     }
 
     /**
@@ -65,10 +85,12 @@ public final class EdidUtil {
     public static String getSerialNo(byte[] edid) {
         // Bytes 12-15 are Serial number (last 4 characters)
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Serial number: {}", Arrays.toString(Arrays.copyOfRange(edid, 12, 16)));
+            LOG.debug("Serial number: {}",
+                    Arrays.toString(Arrays.copyOfRange(edid, SERIAL_NUMBER_OFFSET, SERIAL_NUMBER_OFFSET + 4)));
         }
-        return String.format(Locale.ROOT, "%s%s%s%s", getAlphaNumericOrHex(edid[15]), getAlphaNumericOrHex(edid[14]),
-                getAlphaNumericOrHex(edid[13]), getAlphaNumericOrHex(edid[12]));
+        return String.format(Locale.ROOT, "%s%s%s%s", getAlphaNumericOrHex(edid[SERIAL_NUMBER_OFFSET + 3]),
+                getAlphaNumericOrHex(edid[SERIAL_NUMBER_OFFSET + 2]),
+                getAlphaNumericOrHex(edid[SERIAL_NUMBER_OFFSET + 1]), getAlphaNumericOrHex(edid[SERIAL_NUMBER_OFFSET]));
     }
 
     private static String getAlphaNumericOrHex(byte b) {
@@ -84,7 +106,7 @@ public final class EdidUtil {
      */
     public static byte getWeek(byte[] edid) {
         // Byte 16 is manufacture week
-        return edid[16];
+        return edid[WEEK_OFFSET];
     }
 
     /**
@@ -95,9 +117,9 @@ public final class EdidUtil {
      */
     public static int getYear(byte[] edid) {
         // Byte 17 is manufacture year-1990
-        byte temp = edid[17];
+        byte temp = edid[YEAR_OFFSET];
         LOG.debug("Year-1990: {}", temp);
-        return temp + 1990;
+        return temp + YEAR_BASE;
     }
 
     /**
@@ -108,7 +130,7 @@ public final class EdidUtil {
      */
     public static String getVersion(byte[] edid) {
         // Bytes 18-19 are EDID version
-        return edid[18] + "." + edid[19];
+        return edid[VERSION_OFFSET] + "." + edid[VERSION_OFFSET + 1];
     }
 
     /**
@@ -119,7 +141,7 @@ public final class EdidUtil {
      */
     public static boolean isDigital(byte[] edid) {
         // Byte 20 is Video input params
-        return 1 == (edid[20] & 0xff) >> 7;
+        return 1 == (edid[VIDEO_PARAMS_OFFSET] & 0xff) >> 7;
     }
 
     /**
@@ -130,7 +152,7 @@ public final class EdidUtil {
      */
     public static int getHcm(byte[] edid) {
         // Byte 21 is horizontal size in cm
-        return edid[21];
+        return edid[HORIZONTAL_SIZE_OFFSET];
     }
 
     /**
@@ -141,7 +163,7 @@ public final class EdidUtil {
      */
     public static int getVcm(byte[] edid) {
         // Byte 22 is vertical size in cm
-        return edid[22];
+        return edid[VERTICAL_SIZE_OFFSET];
     }
 
     /**
@@ -151,9 +173,9 @@ public final class EdidUtil {
      * @return A 2D array with four 18-byte elements representing VESA descriptors
      */
     public static byte[][] getDescriptors(byte[] edid) {
-        byte[][] desc = new byte[4][18];
+        byte[][] desc = new byte[DESCRIPTOR_COUNT][DESCRIPTOR_LENGTH];
         for (int i = 0; i < desc.length; i++) {
-            System.arraycopy(edid, 54 + 18 * i, desc[i], 0, 18);
+            System.arraycopy(edid, DESCRIPTOR_OFFSET + DESCRIPTOR_LENGTH * i, desc[i], 0, DESCRIPTOR_LENGTH);
         }
         return desc;
     }
@@ -210,7 +232,7 @@ public final class EdidUtil {
      */
 
     public static String getPreferredResolution(byte[] edid) {
-        int dtd = 54;
+        int dtd = DESCRIPTOR_OFFSET;
         int horizontalRes = (edid[dtd + 4] & 0xF0) << 4 | edid[dtd + 2] & 0xFF;
         int verticalRes = (edid[dtd + 7] & 0xF0) << 4 | edid[dtd + 5] & 0xFF;
         return horizontalRes + "x" + verticalRes;
@@ -230,7 +252,7 @@ public final class EdidUtil {
 
         for (byte[] b : desc) {
 
-            if (EdidUtil.getDescriptorType(b) == 0xfc) {
+            if (EdidUtil.getDescriptorType(b) == MONITOR_NAME_TYPE) {
                 model = EdidUtil.getDescriptorText(b);
                 break;
             }
@@ -242,6 +264,278 @@ public final class EdidUtil {
             model = tokens[tokens.length - 1];
         }
         return model.trim();
+    }
+
+    /**
+     * Get the display product serial number from the EDID, the text of the serial-number descriptor (type 0xFF). This
+     * is distinct from {@link #getSerialNo(byte[])}, which returns the numeric ID serial number in bytes 12-15.
+     *
+     * @param edid The edid byte array
+     * @return The serial-number descriptor text, or {@code null} if the EDID has no serial-number descriptor.
+     */
+    public static String getProductSerialNumber(byte[] edid) {
+        for (byte[] desc : getDescriptors(edid)) {
+            if (getDescriptorType(desc) == DISPLAY_SERIAL_TYPE) {
+                return getDescriptorText(desc);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates a 128-byte EDID array populated with the fixed header, EDID version 1.4, "unused" standard timing slots,
+     * and zero extension blocks, ready to be populated by the {@code set*} methods.
+     * <p>
+     * The checksum is not valid until {@link #updateChecksum(byte[])} is called after all fields have been set.
+     *
+     * @return A new, mutable 128-byte EDID array.
+     */
+    public static byte[] newEdidTemplate() {
+        byte[] edid = new byte[EDID_LENGTH];
+        // Fixed 8-byte header: 00 FF FF FF FF FF FF 00
+        for (int i = 1; i <= 6; i++) {
+            edid[i] = (byte) 0xFF;
+        }
+        // EDID version 1.4
+        edid[VERSION_OFFSET] = 0x01;
+        edid[VERSION_OFFSET + 1] = 0x04;
+        // Mark the eight standard timing slots (bytes 38-53) as unused (0x01 0x01)
+        for (int i = STD_TIMING_OFFSET; i < DESCRIPTOR_OFFSET; i++) {
+            edid[i] = 0x01;
+        }
+        return edid;
+    }
+
+    /**
+     * Sets the Manufacturer ID into bytes 8 and 9, the inverse of {@link #getManufacturerID(byte[])}.
+     * <p>
+     * Reliably round-trips a standard three-letter A-Z code. An identifier whose decoded form begins with a stripped
+     * '@' (zero-valued) character cannot be reconstructed and is not supported.
+     *
+     * @param edid           The EDID byte array to modify
+     * @param manufacturerId A three-letter manufacturer ID (e.g. {@code "AUO"})
+     */
+    public static void setManufacturerID(byte[] edid, String manufacturerId) {
+        // Pack 3 5-bit characters (value = letter - 64) into bytes 8-9, MSB reserved 0
+        int packed = 0;
+        for (int i = 0; i < 3; i++) {
+            int c = i < manufacturerId.length() ? manufacturerId.charAt(i) - 64 : 0;
+            packed = packed << 5 | c & 0x1F;
+        }
+        edid[MANUFACTURER_ID_OFFSET] = (byte) (packed >> 8 & 0xFF);
+        edid[MANUFACTURER_ID_OFFSET + 1] = (byte) (packed & 0xFF);
+    }
+
+    /**
+     * Sets the Product ID into bytes 10 and 11, the inverse of {@link #getProductID(byte[])}.
+     *
+     * @param edid      The EDID byte array to modify
+     * @param productId The product ID as a hex string
+     */
+    public static void setProductID(byte[] edid, String productId) {
+        // Bytes 10-11 store the product ID little-endian
+        int value = ParseUtil.hexStringToInt(productId, 0);
+        edid[PRODUCT_ID_OFFSET] = (byte) (value & 0xFF);
+        edid[PRODUCT_ID_OFFSET + 1] = (byte) (value >> 8 & 0xFF);
+    }
+
+    /**
+     * Sets the Serial number into bytes 12-15, the inverse of {@link #getSerialNo(byte[])}.
+     * <p>
+     * Because {@link #getSerialNo(byte[])} renders each byte as either a single alphanumeric character or two hex
+     * digits, only the unambiguous forms are accepted: an 8-character hex string (all four bytes non-printable) or a
+     * 4-character printable string (all four bytes alphanumeric).
+     *
+     * @param edid     The EDID byte array to modify
+     * @param serialNo An 8-character hex string or 4-character printable string as returned by
+     *                 {@link #getSerialNo(byte[])}
+     * @throws IllegalArgumentException if {@code serialNo} is neither 8 hex characters nor 4 printable characters
+     */
+    public static void setSerialNo(byte[] edid, String serialNo) {
+        // getSerialNo emits bytes 15,14,13,12 in order; reverse that mapping back into bytes 12-15
+        byte[] bytes;
+        if (serialNo.length() == 8) {
+            bytes = ParseUtil.hexStringToByteArray(serialNo);
+        } else if (serialNo.length() == 4) {
+            bytes = serialNo.getBytes(StandardCharsets.US_ASCII);
+        } else {
+            throw new IllegalArgumentException(
+                    "Serial number must be 8 hex characters or 4 printable characters: " + serialNo);
+        }
+        for (int i = 0; i < 4; i++) {
+            edid[SERIAL_NUMBER_OFFSET + 3 - i] = bytes[i];
+        }
+    }
+
+    /**
+     * Sets the week of manufacture into byte 16, the inverse of {@link #getWeek(byte[])}.
+     *
+     * @param edid The EDID byte array to modify
+     * @param week The week of manufacture
+     */
+    public static void setWeek(byte[] edid, byte week) {
+        edid[WEEK_OFFSET] = week;
+    }
+
+    /**
+     * Sets the year of manufacture into byte 17, the inverse of {@link #getYear(byte[])}.
+     *
+     * @param edid The EDID byte array to modify
+     * @param year The four-digit year of manufacture (stored as {@code year - 1990})
+     */
+    public static void setYear(byte[] edid, int year) {
+        edid[YEAR_OFFSET] = (byte) (year - YEAR_BASE);
+    }
+
+    /**
+     * Sets the EDID version into bytes 18 and 19, the inverse of {@link #getVersion(byte[])}.
+     *
+     * @param edid    The EDID byte array to modify
+     * @param version The version as a {@code major.minor} string (e.g. {@code "1.4"})
+     */
+    public static void setVersion(byte[] edid, String version) {
+        String[] parts = version.split("\\.");
+        edid[VERSION_OFFSET] = (byte) ParseUtil.parseIntOrDefault(parts[0], 1);
+        edid[VERSION_OFFSET + 1] = (byte) (parts.length > 1 ? ParseUtil.parseIntOrDefault(parts[1], 0) : 0);
+    }
+
+    /**
+     * Sets the digital/analog bit (bit 7) of the video input parameters in byte 20, the inverse of
+     * {@link #isDigital(byte[])}. The remaining bits of byte 20 are left unchanged.
+     *
+     * @param edid    The EDID byte array to modify
+     * @param digital Whether the EDID represents a digital monitor
+     */
+    public static void setDigital(byte[] edid, boolean digital) {
+        edid[VIDEO_PARAMS_OFFSET] = (byte) (edid[VIDEO_PARAMS_OFFSET] & 0x7F | (digital ? 0x80 : 0x00));
+    }
+
+    /**
+     * Sets the monitor width in cm into byte 21, the inverse of {@link #getHcm(byte[])}.
+     *
+     * @param edid The EDID byte array to modify
+     * @param hcm  Monitor width in cm
+     */
+    public static void setHcm(byte[] edid, int hcm) {
+        edid[HORIZONTAL_SIZE_OFFSET] = (byte) hcm;
+    }
+
+    /**
+     * Sets the monitor height in cm into byte 22, the inverse of {@link #getVcm(byte[])}.
+     *
+     * @param edid The EDID byte array to modify
+     * @param vcm  Monitor height in cm
+     */
+    public static void setVcm(byte[] edid, int vcm) {
+        edid[VERTICAL_SIZE_OFFSET] = (byte) vcm;
+    }
+
+    /**
+     * Sets the preferred resolution into the first (detailed timing) descriptor, the inverse of the resolution decoded
+     * by {@link #getPreferredResolution(byte[])}. Only the active-pixel fields are written; other detailed-timing
+     * fields are left unchanged.
+     *
+     * @param edid       The EDID byte array to modify
+     * @param resolution The preferred resolution as a {@code WIDTHxHEIGHT} string (e.g. {@code "2560x1440"})
+     */
+    public static void setPreferredResolution(byte[] edid, String resolution) {
+        int x = resolution.indexOf('x');
+        int horizontal = ParseUtil.parseIntOrDefault(resolution.substring(0, x), 0);
+        int vertical = ParseUtil.parseIntOrDefault(resolution.substring(x + 1), 0);
+        int dtd = DESCRIPTOR_OFFSET;
+        edid[dtd + 2] = (byte) (horizontal & 0xFF);
+        edid[dtd + 4] = (byte) (edid[dtd + 4] & 0x0F | horizontal >> 4 & 0xF0);
+        edid[dtd + 5] = (byte) (vertical & 0xFF);
+        edid[dtd + 7] = (byte) (edid[dtd + 7] & 0x0F | vertical >> 4 & 0xF0);
+    }
+
+    /**
+     * Sets the monitor model by writing a monitor-name (type 0xFC) descriptor, the inverse of
+     * {@link #getModel(byte[])}. The descriptor is written into descriptor slot one, leaving slot zero for the detailed
+     * timing descriptor used by {@link #getPreferredResolution(byte[])}.
+     * <p>
+     * Since {@link #getModel(byte[])} returns only the final whitespace-delimited token, a single-token model
+     * round-trips; a multi-token model is preserved in the EDID bytes but {@code getModel} returns only its last token.
+     *
+     * @param edid  The EDID byte array to modify
+     * @param model The monitor model (truncated to 13 ASCII characters)
+     */
+    public static void setModel(byte[] edid, String model) {
+        setDescriptorText(edid, 1, MONITOR_NAME_TYPE, model);
+    }
+
+    /**
+     * Sets the display product serial number by writing a serial-number (type 0xFF) descriptor, the inverse of
+     * {@link #getProductSerialNumber(byte[])}. The descriptor is written into the third descriptor slot, after the
+     * detailed timing descriptor (slot zero) and the monitor name (slot one). This is distinct from
+     * {@link #setSerialNo(byte[], String)}, which sets the numeric ID serial number in bytes 12-15.
+     *
+     * @param edid         The EDID byte array to modify
+     * @param serialNumber The product serial number (truncated to 13 ASCII characters)
+     */
+    public static void setProductSerialNumber(byte[] edid, String serialNumber) {
+        setDescriptorText(edid, 2, DISPLAY_SERIAL_TYPE, serialNumber);
+    }
+
+    /**
+     * Writes a raw 18-byte VESA descriptor into one of the four descriptor slots (0-3), the inverse of
+     * {@link #getDescriptors(byte[])}. Slot 0 is conventionally the preferred detailed timing descriptor; slots 1-3
+     * hold monitor descriptors (e.g. monitor name, serial number, range limits).
+     *
+     * @param edid       The EDID byte array to modify
+     * @param slot       The descriptor slot, 0-3
+     * @param descriptor An 18-byte VESA descriptor
+     * @throws IllegalArgumentException if {@code slot} is not in 0-3 or {@code descriptor} is not 18 bytes
+     */
+    public static void setDescriptor(byte[] edid, int slot, byte[] descriptor) {
+        if (slot < 0 || slot >= DESCRIPTOR_COUNT) {
+            throw new IllegalArgumentException("Descriptor slot must be 0-" + (DESCRIPTOR_COUNT - 1) + ": " + slot);
+        }
+        if (descriptor.length != DESCRIPTOR_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Descriptor must be " + DESCRIPTOR_LENGTH + " bytes: " + descriptor.length);
+        }
+        System.arraycopy(descriptor, 0, edid, DESCRIPTOR_OFFSET + slot * DESCRIPTOR_LENGTH, DESCRIPTOR_LENGTH);
+    }
+
+    /**
+     * Writes a text VESA descriptor (e.g. type 0xFC monitor name, 0xFF serial number, 0xFE unspecified text) holding up
+     * to 13 ASCII characters into one of the four descriptor slots (0-3), the inverse of
+     * {@link #getDescriptorText(byte[])}. The text is 0x0A-terminated and 0x20-padded per the EDID specification.
+     *
+     * @param edid The EDID byte array to modify
+     * @param slot The descriptor slot, 0-3
+     * @param type The descriptor type tag
+     * @param text The descriptor text (truncated to 13 ASCII characters)
+     * @throws IllegalArgumentException if {@code slot} is not in 0-3
+     */
+    public static void setDescriptorText(byte[] edid, int slot, int type, String text) {
+        byte[] desc = new byte[DESCRIPTOR_LENGTH];
+        desc[3] = (byte) type;
+        byte[] bytes = text.getBytes(StandardCharsets.US_ASCII);
+        int n = Math.min(13, bytes.length);
+        System.arraycopy(bytes, 0, desc, 5, n);
+        if (n < 13) {
+            desc[5 + n] = 0x0A; // line feed terminator
+            for (int i = 6 + n; i < DESCRIPTOR_LENGTH; i++) {
+                desc[i] = 0x20; // space padding
+            }
+        }
+        setDescriptor(edid, slot, desc);
+    }
+
+    /**
+     * Recomputes and stores the EDID checksum in byte 127 so the sum of all 128 bytes is zero modulo 256. Call this
+     * after populating an EDID built with {@link #newEdidTemplate()}.
+     *
+     * @param edid The EDID byte array to modify
+     */
+    public static void updateChecksum(byte[] edid) {
+        int sum = 0;
+        for (int i = 0; i < CHECKSUM_OFFSET; i++) {
+            sum += edid[i] & 0xFF;
+        }
+        edid[CHECKSUM_OFFSET] = (byte) ((256 - sum % 256) % 256);
     }
 
     /**

--- a/oshi-common/src/test/java/oshi/hardware/DisplayInfoImplTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/DisplayInfoImplTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.ParseUtil;
+
+/*
+ * Tests DisplayInfoImpl
+ */
+class DisplayInfoImplTest {
+
+    private static final String EDID_STR = "00FFFFFFFFFFFF00" + "06af" + "2792" + "250C2C16" + "2C16" + "0104"
+            + "B53C2278226FB1A7554C9E250C5054000000" + "01010101010101010101010101010101"
+            + "565E00A0A0A029503020350055502100001A" + "1A1D008051D01C204080350055502100001C"
+            + "000000FF004330324A4D325046463247430A" + "000000FC005468756E646572626F6C740A20" + "01" + "C7";
+    private static final byte[] EDID = ParseUtil.hexStringToByteArray(EDID_STR);
+
+    @Test
+    void testFromEdid() {
+        DisplayInfo info = new DisplayInfoImpl(EDID);
+        assertThat("synthetic", info.isEdidSynthetic(), is(false));
+        assertThat("manufacturerId", info.getManufacturerID(), is("AUO"));
+        assertThat("productId", info.getProductID(), is("9227"));
+        assertThat("serialNo", info.getSerialNo(), is("162C0C25"));
+        assertThat("week", info.getWeek(), is((byte) 44));
+        assertThat("year", info.getYear(), is(2012));
+        assertThat("version", info.getVersion(), is("1.4"));
+        assertThat("digital", info.isDigital(), is(true));
+        assertThat("hcm", info.getHcm(), is(60));
+        assertThat("vcm", info.getVcm(), is(34));
+        assertThat("preferredResolution", info.getPreferredResolution(), is("2560x1440"));
+        assertThat("model", info.getModel(), is("Thunderbolt"));
+        assertThat("productSerialNumber", info.getProductSerialNumber(), is("C02JM2PFF2GC"));
+        assertThat("edid", info.getEdid(), is(EDID));
+    }
+
+    @Test
+    void testSyntheticRoundTrip() {
+        DisplayInfo info = new DisplayInfoImpl("AUO", "9227", "162C0C25", (byte) 44, 2012, "1.4", true, 60, 34,
+                "2560x1440", "Thunderbolt", "C02JM2PFF2GC");
+        assertThat("synthetic", info.isEdidSynthetic(), is(true));
+        // getEdid() is idempotent and stable across calls
+        assertThat("stable edid", info.getEdid(), is(info.getEdid()));
+        // Re-parsing the synthesized EDID yields the same field values
+        DisplayInfo reparsed = new DisplayInfoImpl(info.getEdid());
+        assertThat("reparsed not synthetic", reparsed.isEdidSynthetic(), is(false));
+        assertThat("manufacturerId", reparsed.getManufacturerID(), is("AUO"));
+        assertThat("productId", reparsed.getProductID(), is("9227"));
+        assertThat("serialNo", reparsed.getSerialNo(), is("162C0C25"));
+        assertThat("week", reparsed.getWeek(), is((byte) 44));
+        assertThat("year", reparsed.getYear(), is(2012));
+        assertThat("version", reparsed.getVersion(), is("1.4"));
+        assertThat("digital", reparsed.isDigital(), is(true));
+        assertThat("hcm", reparsed.getHcm(), is(60));
+        assertThat("vcm", reparsed.getVcm(), is(34));
+        assertThat("preferredResolution", reparsed.getPreferredResolution(), is("2560x1440"));
+        assertThat("model", reparsed.getModel(), is("Thunderbolt"));
+        assertThat("productSerialNumber", reparsed.getProductSerialNumber(), is("C02JM2PFF2GC"));
+    }
+
+    @Test
+    void testSyntheticToStringDoesNotSynthesize() {
+        // A serial number that EdidUtil.setSerialNo rejects: toString must still work (it formats from the decoded
+        // fields), while getEdid (which synthesizes) fails. This proves toString does not encode the EDID.
+        DisplayInfo info = new DisplayInfoImpl("AUO", "9227", "BADSERIAL", (byte) 1, 2020, "1.4", true, 50, 30,
+                "1920x1080", "Acme", "SN12345");
+        assertThat("toString model", info.toString(), containsString("Acme"));
+        assertThat("toString serial", info.toString(), containsString("SN12345"));
+        assertThrows(IllegalArgumentException.class, info::getEdid);
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/DisplayInfoImplTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/DisplayInfoImplTest.java
@@ -7,6 +7,7 @@ package oshi.hardware;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,19 @@ class DisplayInfoImplTest {
         DisplayInfo info = new DisplayInfoImpl("AUO", "9227", "162C0C25", (byte) 44, 2012, "1.4", true, 60, 34,
                 "2560x1440", "Thunderbolt", "C02JM2PFF2GC");
         assertThat("synthetic", info.isEdidSynthetic(), is(true));
+        // Exercise the synthetic-branch field getters (return the stored values directly)
+        assertThat("synth manufacturerId", info.getManufacturerID(), is("AUO"));
+        assertThat("synth productId", info.getProductID(), is("9227"));
+        assertThat("synth serialNo", info.getSerialNo(), is("162C0C25"));
+        assertThat("synth week", info.getWeek(), is((byte) 44));
+        assertThat("synth year", info.getYear(), is(2012));
+        assertThat("synth version", info.getVersion(), is("1.4"));
+        assertThat("synth digital", info.isDigital(), is(true));
+        assertThat("synth hcm", info.getHcm(), is(60));
+        assertThat("synth vcm", info.getVcm(), is(34));
+        assertThat("synth preferredResolution", info.getPreferredResolution(), is("2560x1440"));
+        assertThat("synth model", info.getModel(), is("Thunderbolt"));
+        assertThat("synth productSerialNumber", info.getProductSerialNumber(), is("C02JM2PFF2GC"));
         // getEdid() is idempotent and stable across calls
         assertThat("stable edid", info.getEdid(), is(info.getEdid()));
         // Re-parsing the synthesized EDID yields the same field values
@@ -76,5 +90,21 @@ class DisplayInfoImplTest {
         assertThat("toString model", info.toString(), containsString("Acme"));
         assertThat("toString serial", info.toString(), containsString("SN12345"));
         assertThrows(IllegalArgumentException.class, info::getEdid);
+    }
+
+    @Test
+    void testSyntheticNullProductSerialNumber() {
+        // A null product serial number is omitted from both the synthesized EDID and the toString output; an analog
+        // display also exercises the non-digital toString branch
+        DisplayInfo info = new DisplayInfoImpl("AUO", "9227", "162C0C25", (byte) 44, 2012, "1.4", false, 60, 34,
+                "2560x1440", "Thunderbolt", null);
+        assertThat("analog", info.isDigital(), is(false));
+        assertThat("toString analog", info.toString(), containsString("Analog"));
+        // An absent product serial number is reported as an empty string, never null
+        assertThat("productSerialNumber", info.getProductSerialNumber(), is(""));
+        assertThat("toString omits serial", info.toString(), not(containsString("Serial Number")));
+        // The synthesized EDID has no serial-number descriptor, so a reparse also finds none
+        DisplayInfo reparsed = new DisplayInfoImpl(info.getEdid());
+        assertThat("reparsed productSerialNumber", reparsed.getProductSerialNumber(), is(""));
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractDisplayTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractDisplayTest.java
@@ -7,8 +7,12 @@ package oshi.hardware.common;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 import org.junit.jupiter.api.Test;
+
+import oshi.hardware.DisplayInfo;
+import oshi.hardware.DisplayInfoImpl;
 
 class AbstractDisplayTest {
 
@@ -34,5 +38,33 @@ class AbstractDisplayTest {
         AbstractDisplay display = new AbstractDisplay(new byte[128]) {
         };
         assertThat(display.toString(), is(notNullValue()));
+    }
+
+    @Test
+    void testEdidConstructorNotSynthetic() {
+        AbstractDisplay display = new AbstractDisplay(new byte[128]) {
+        };
+        assertThat(display.getDisplayInfo(), is(notNullValue()));
+        assertThat(display.isEdidSynthetic(), is(false));
+    }
+
+    @Test
+    void testDisplayInfoConstructor() {
+        DisplayInfo info = new DisplayInfoImpl(new byte[128]);
+        AbstractDisplay display = new AbstractDisplay(info) {
+        };
+        assertThat(display.getDisplayInfo(), is(sameInstance(info)));
+        assertThat(display.isEdidSynthetic(), is(false));
+        assertThat(display.getEdid(), is(new byte[128]));
+    }
+
+    @Test
+    void testSyntheticDisplayInfoConstructor() {
+        DisplayInfo info = new DisplayInfoImpl("AUO", "9227", "162C0C25", (byte) 44, 2012, "1.4", true, 60, 34,
+                "2560x1440", "Thunderbolt", "C02JM2PFF2GC");
+        AbstractDisplay display = new AbstractDisplay(info) {
+        };
+        assertThat(display.isEdidSynthetic(), is(true));
+        assertThat(display.getDisplayInfo().getModel(), is("Thunderbolt"));
     }
 }

--- a/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
@@ -6,6 +6,7 @@ package oshi.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -102,6 +103,22 @@ class EdidUtilTest {
     }
 
     @Test
+    void testGetModelAbsent() {
+        // An EDID with no monitor-name (0xFC) descriptor returns an empty string rather than throwing
+        assertThat("absent model", EdidUtil.getModel(EdidUtil.newEdidTemplate()), is(""));
+    }
+
+    @Test
+    void testToStringNegativeDescriptorType() {
+        // A descriptor whose type decodes to a negative int falls through to the preferred-timing branch
+        byte[] edid = EdidUtil.newEdidTemplate();
+        byte[] desc = new byte[18];
+        desc[0] = (byte) 0x80; // high bit set so getDescriptorType is negative
+        EdidUtil.setDescriptor(edid, 1, desc);
+        assertThat("preferred timing", EdidUtil.toString(edid), containsString("Preferred Timing"));
+    }
+
+    @Test
     void testFieldRoundTrip() {
         // Synthesize an EDID from field values, then confirm each set* encoder inverts its get*/is* parser
         byte[] edid = EdidUtil.newEdidTemplate();
@@ -184,12 +201,62 @@ class EdidUtilTest {
     }
 
     @Test
+    void testEncoderEdgeCases() {
+        byte[] edid = EdidUtil.newEdidTemplate();
+        // Version with no minor component defaults the minor to 0
+        EdidUtil.setVersion(edid, "2");
+        assertThat("major-only version", EdidUtil.getVersion(edid), is("2.0"));
+        // Analog (non-digital) display clears the digital bit
+        EdidUtil.setDigital(edid, false);
+        assertThat("analog", EdidUtil.isDigital(edid), is(false));
+        // High unsigned byte values round-trip (guards against signed-byte sign extension)
+        EdidUtil.setHcm(edid, 200);
+        assertThat("hcm 200", EdidUtil.getHcm(edid), is(200));
+        EdidUtil.setVcm(edid, 255);
+        assertThat("vcm 255", EdidUtil.getVcm(edid), is(255));
+        EdidUtil.setYear(edid, 2200);
+        assertThat("year 2200", EdidUtil.getYear(edid), is(2200));
+        // Descriptor text longer than 13 characters is truncated with no terminator/padding
+        EdidUtil.setDescriptorText(edid, 3, 0xFE, "ThisIsAVeryLongName");
+        assertThat("truncated descriptor", EdidUtil.getDescriptorText(EdidUtil.getDescriptors(edid)[3]),
+                is("ThisIsAVeryLo"));
+        // No serial-number descriptor present returns an empty string (never null), like getSerialNo/getModel
+        assertThat("absent serial", EdidUtil.getProductSerialNumber(EdidUtil.newEdidTemplate()), is(""));
+    }
+
+    @Test
+    void testEncoderValidation() {
+        byte[] edid = EdidUtil.newEdidTemplate();
+        // Manufacturer ID must be exactly three uppercase A-Z letters
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setManufacturerID(edid, "AB"));
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setManufacturerID(edid, "auo"));
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setManufacturerID(edid, "A1B"));
+        // Product ID must be a hex value within 0-FFFF
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setProductID(edid, "10000"));
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setProductID(edid, "GG"));
+        // Year must be within 1990-2245
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setYear(edid, 1989));
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setYear(edid, 2246));
+        // Size in cm must be within 0-255
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setHcm(edid, 256));
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setHcm(edid, -1));
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setVcm(edid, 256));
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setVcm(edid, -1));
+        // A negative descriptor slot is rejected
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setDescriptor(edid, -1, new byte[18]));
+    }
+
+    @Test
     void testSetSerialNo() {
-        // A 4-character all-printable serial also round-trips
+        // A 4-character all-alphanumeric serial round-trips
         byte[] edid = EdidUtil.newEdidTemplate();
         EdidUtil.setSerialNo(edid, "AB12");
-        assertThat("printable serial", EdidUtil.getSerialNo(edid), is("AB12"));
-        // Ambiguous lengths are rejected
+        assertThat("alphanumeric serial", EdidUtil.getSerialNo(edid), is("AB12"));
+        // Wrong length is rejected
         assertThrows(IllegalArgumentException.class, () -> EdidUtil.setSerialNo(edid, "ABC"));
+        // Hex-looking ASCII whose bytes are letters does not round-trip (getSerialNo would render "ABCD")
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setSerialNo(edid, "41424344"));
+        // Non-alphanumeric 4-character value does not round-trip
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setSerialNo(edid, "AB-1"));
     }
 }

--- a/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
@@ -7,6 +7,9 @@ package oshi.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +57,7 @@ class EdidUtilTest {
         assertThat("vcm", EdidUtil.getVcm(EDID), is(34));
         assertThat("preferredResolution", EdidUtil.getPreferredResolution(EDID), is("2560x1440"));
         assertThat("model", EdidUtil.getModel(EDID), is("Thunderbolt"));
+        assertThat("productSerialNumber", EdidUtil.getProductSerialNumber(EDID), is("C02JM2PFF2GC"));
     }
 
     @Test
@@ -95,5 +99,97 @@ class EdidUtilTest {
         assertThat("edid toString", EdidUtil.toString(EDID).split("\\n"), is(arrayWithSize(6)));
         assertThat("edid2 toString", EdidUtil.toString(ParseUtil.hexStringToByteArray(EDID_STR2)).split("\\n"),
                 is(arrayWithSize(6)));
+    }
+
+    @Test
+    void testFieldRoundTrip() {
+        // Synthesize an EDID from field values, then confirm each set* encoder inverts its get*/is* parser
+        byte[] edid = EdidUtil.newEdidTemplate();
+        EdidUtil.setManufacturerID(edid, "AUO");
+        EdidUtil.setProductID(edid, "9227");
+        EdidUtil.setSerialNo(edid, "162C0C25");
+        EdidUtil.setWeek(edid, (byte) 44);
+        EdidUtil.setYear(edid, 2012);
+        EdidUtil.setVersion(edid, "1.4");
+        EdidUtil.setDigital(edid, true);
+        EdidUtil.setHcm(edid, 60);
+        EdidUtil.setVcm(edid, 34);
+        EdidUtil.setPreferredResolution(edid, "2560x1440");
+        EdidUtil.setModel(edid, "Thunderbolt");
+        EdidUtil.setProductSerialNumber(edid, "C02JM2PFF2GC");
+        EdidUtil.updateChecksum(edid);
+
+        assertThat("manufacturerId", EdidUtil.getManufacturerID(edid), is("AUO"));
+        assertThat("productId", EdidUtil.getProductID(edid), is("9227"));
+        assertThat("serialNo", EdidUtil.getSerialNo(edid), is("162C0C25"));
+        assertThat("week", EdidUtil.getWeek(edid), is((byte) 44));
+        assertThat("year", EdidUtil.getYear(edid), is(2012));
+        assertThat("version", EdidUtil.getVersion(edid), is("1.4"));
+        assertThat("digital", EdidUtil.isDigital(edid), is(true));
+        assertThat("hcm", EdidUtil.getHcm(edid), is(60));
+        assertThat("vcm", EdidUtil.getVcm(edid), is(34));
+        assertThat("preferredResolution", EdidUtil.getPreferredResolution(edid), is("2560x1440"));
+        assertThat("model", EdidUtil.getModel(edid), is("Thunderbolt"));
+        assertThat("productSerialNumber", EdidUtil.getProductSerialNumber(edid), is("C02JM2PFF2GC"));
+
+        // A valid EDID's 128 bytes sum to zero modulo 256
+        int sum = 0;
+        for (byte b : edid) {
+            sum += b & 0xFF;
+        }
+        assertThat("checksum", sum % 256, is(0));
+    }
+
+    @Test
+    void testByteRoundTrip() {
+        // For injective fields, set*(template, get*(EDID)) reproduces the original EDID bytes exactly
+        byte[] edid = EdidUtil.newEdidTemplate();
+        EdidUtil.setManufacturerID(edid, EdidUtil.getManufacturerID(EDID));
+        EdidUtil.setProductID(edid, EdidUtil.getProductID(EDID));
+        EdidUtil.setSerialNo(edid, EdidUtil.getSerialNo(EDID));
+        EdidUtil.setWeek(edid, EdidUtil.getWeek(EDID));
+        EdidUtil.setYear(edid, EdidUtil.getYear(EDID));
+        EdidUtil.setVersion(edid, EdidUtil.getVersion(EDID));
+        EdidUtil.setHcm(edid, EdidUtil.getHcm(EDID));
+        EdidUtil.setVcm(edid, EdidUtil.getVcm(EDID));
+
+        assertThat("manufacturer bytes 8-9", Arrays.copyOfRange(edid, 8, 10), is(Arrays.copyOfRange(EDID, 8, 10)));
+        assertThat("product bytes 10-11", Arrays.copyOfRange(edid, 10, 12), is(Arrays.copyOfRange(EDID, 10, 12)));
+        assertThat("serial bytes 12-15", Arrays.copyOfRange(edid, 12, 16), is(Arrays.copyOfRange(EDID, 12, 16)));
+        assertThat("week byte 16", edid[16], is(EDID[16]));
+        assertThat("year byte 17", edid[17], is(EDID[17]));
+        assertThat("version bytes 18-19", Arrays.copyOfRange(edid, 18, 20), is(Arrays.copyOfRange(EDID, 18, 20)));
+        assertThat("hcm byte 21", edid[21], is(EDID[21]));
+        assertThat("vcm byte 22", edid[22], is(EDID[22]));
+    }
+
+    @Test
+    void testSetDescriptors() {
+        byte[] edid = EdidUtil.newEdidTemplate();
+        // Text descriptors can be written into any of the four slots, including the fourth
+        EdidUtil.setDescriptorText(edid, 3, 0xFE, "Extra Text");
+        byte[][] descs = EdidUtil.getDescriptors(edid);
+        assertThat("slot 3 type", EdidUtil.getDescriptorType(descs[3]), is(0xFE));
+        assertThat("slot 3 text", EdidUtil.getDescriptorText(descs[3]), is("Extra Text"));
+
+        // A raw 18-byte descriptor round-trips through getDescriptors
+        byte[] raw = descs[3];
+        byte[] edid2 = EdidUtil.newEdidTemplate();
+        EdidUtil.setDescriptor(edid2, 0, raw);
+        assertThat("raw descriptor", EdidUtil.getDescriptors(edid2)[0], is(raw));
+
+        // Out-of-range slot and wrong-size descriptor are rejected
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setDescriptorText(edid, 4, 0xFE, "x"));
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setDescriptor(edid, 0, new byte[10]));
+    }
+
+    @Test
+    void testSetSerialNo() {
+        // A 4-character all-printable serial also round-trips
+        byte[] edid = EdidUtil.newEdidTemplate();
+        EdidUtil.setSerialNo(edid, "AB12");
+        assertThat("printable serial", EdidUtil.getSerialNo(edid), is("AB12"));
+        // Ambiguous lengths are rejected
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setSerialNo(edid, "ABC"));
     }
 }

--- a/oshi-core-ffm/pom.xml
+++ b/oshi-core-ffm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.oshi</groupId>
         <artifactId>oshi-parent</artifactId>
-        <version>7.3.3-SNAPSHOT</version>
+        <version>7.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oshi-core-ffm</artifactId>

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.oshi</groupId>
         <artifactId>oshi-parent</artifactId>
-        <version>7.3.3-SNAPSHOT</version>
+        <version>7.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oshi-core</artifactId>

--- a/oshi-demo/pom.xml
+++ b/oshi-demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.oshi</groupId>
         <artifactId>oshi-parent</artifactId>
-        <version>7.3.3-SNAPSHOT</version>
+        <version>7.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oshi-demo</artifactId>

--- a/oshi-dist/pom.xml
+++ b/oshi-dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.oshi</groupId>
         <artifactId>oshi-parent</artifactId>
-        <version>7.3.3-SNAPSHOT</version>
+        <version>7.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oshi-dist</artifactId>

--- a/oshi-metrics/pom.xml
+++ b/oshi-metrics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.oshi</groupId>
         <artifactId>oshi-parent</artifactId>
-        <version>7.3.3-SNAPSHOT</version>
+        <version>7.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>oshi-metrics</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.oshi</groupId>
     <artifactId>oshi-parent</artifactId>
-    <version>7.3.3-SNAPSHOT</version>
+    <version>7.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Operating System and Hardware Information</name>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -51,8 +51,8 @@ Stable Release Versions
   * FFM: [oshi-core-ffm-7.3.2](https://central.sonatype.com/artifact/com.github.oshi/oshi-core-ffm/7.3.2)
 
 Current Development (SNAPSHOT) Versions
-  * JNA: [oshi-core-7.3.3-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core/7.3.3-SNAPSHOT)
-  * FFM: [oshi-core-ffm-7.3.3-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core-ffm/7.3.3-SNAPSHOT/)
+  * JNA: [oshi-core-7.4.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core/7.4.0-SNAPSHOT)
+  * FFM: [oshi-core-ffm-7.4.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core-ffm/7.4.0-SNAPSHOT/)
 
 Legacy Versions
   * JDK7: [oshi-core-3.13.6](https://central.sonatype.com/artifact/com.github.oshi/oshi-core/3.13.6)

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -51,7 +51,7 @@ Stable Release Versions
   * FFM: [oshi-core-ffm-7.3.2](https://central.sonatype.com/artifact/com.github.oshi/oshi-core-ffm/7.3.2)
 
 Current Development (SNAPSHOT) Versions
-  * JNA: [oshi-core-7.4.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core/7.4.0-SNAPSHOT)
+  * JNA: [oshi-core-7.4.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core/7.4.0-SNAPSHOT/)
   * FFM: [oshi-core-ffm-7.4.0-SNAPSHOT](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/github/oshi/oshi-core-ffm/7.4.0-SNAPSHOT/)
 
 Legacy Versions


### PR DESCRIPTION
## Summary

Groundwork for #3404 (built-in macOS Retina panels expose no EDID). This adds a way to surface decoded display attributes whether or not a raw EDID is available, without changing any existing behavior. The macOS implementation that actually populates Retina panels is deferred to a follow-on PR.

### EdidUtil

Adds the inverse of the existing `get*`/`is*` parsers so an EDID can be built from field values:

- `newEdidTemplate()`, `set*` encoders for the encodable header fields, and `updateChecksum()`
- `getProductSerialNumber()` / `setProductSerialNumber()` for the serial-number (`0xFF`) descriptor, distinct from the numeric `getSerialNo()` in bytes 12-15
- generic `setDescriptor(slot, ...)` / `setDescriptorText(slot, ...)` covering all four descriptor slots
- byte-offset magic numbers extracted into named constants (existing getters refactored to use them)

A literal `edid -> value -> edid` round trip isn't achievable for every field (e.g. the serial number's char-or-hex rendering, or a single digital bit), so the tests assert value round-trips for each field, exact byte round-trips for the injective fields, and a full synthesize-then-reparse path.

### DisplayInfo

New `DisplayInfo` public interface exposing the decoded EDID fields plus `getEdid()` and `isEdidSynthetic()`. The backing `DisplayInfoImpl` (not public API) is built either from a raw EDID (fields decoded on demand) or from field values, in which case it lazily synthesizes a spec-compliant EDID and reports `isEdidSynthetic() == true`. A synthesized EDID re-parses to the same values it was built from, so it is interchangeable with a real EDID for `EdidUtil` decoding; it carries only those values, not the extra detail a real panel's EDID may include.

Keeping the multi-arg constructor on the non-API impl rather than on the public interface lets the synthetic field set grow without a compatibility break.

### Display

`Display` gains `getDisplayInfo()` and `isEdidSynthetic()`. `AbstractDisplay` wraps a `DisplayInfo`, so every platform implementation inherits both methods unchanged; a new protected constructor accepts a `DisplayInfo` for the synthetic case.

Because these add methods to a public interface, the development version is bumped to 7.4.0-SNAPSHOT.

Part of #3404; the macOS Retina implementation will follow in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new display metadata API exposing EDID-derived, human-readable fields and indicating when EDID is synthesized.
  * Enhanced EDID support with generation/encoding utilities to build complete 128-byte EDID templates with updated checksums.
* **Bug Fixes**
  * Improved EDID parsing and descriptor handling for better fidelity and round-trip behavior (including monitor identifiers).
* **Documentation**
  * Expanded API documentation and updated the changelog; refreshed snapshot/version links across project docs.
* **Tests**
  * Added and expanded coverage for real EDID, synthesized EDID, and encoder edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->