### PR TITLE
Add numeric setSerialNo overload and guard setPreferredResolution

### DIFF
--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -376,6 +376,25 @@ public final class EdidUtil {
     }
 
     /**
+     * Sets the numeric ID serial number into bytes 12-15 (little-endian), an alternative to
+     * {@link #setSerialNo(byte[], String)} for callers that have the raw 32-bit value (e.g. a synthesized EDID).
+     * {@link #getSerialNo(byte[])} renders the resulting bytes as alphanumeric characters or hex digits per byte.
+     *
+     * @param edid   The EDID byte array to modify
+     * @param serial The ID serial number, an unsigned 32-bit value (0 to 4294967295)
+     * @throws IllegalArgumentException if {@code serial} does not fit in an unsigned 32-bit value
+     */
+    public static void setSerialNo(byte[] edid, long serial) {
+        if (serial < 0 || serial > 0xFFFFFFFFL) {
+            throw new IllegalArgumentException(
+                    "Serial number must be an unsigned 32-bit value (0-4294967295): " + serial);
+        }
+        for (int i = 0; i < 4; i++) {
+            edid[SERIAL_NUMBER_OFFSET + i] = (byte) (serial >> 8 * i & 0xFF);
+        }
+    }
+
+    /**
      * Sets the week of manufacture into byte 16, the inverse of {@link #getWeek(byte[])}.
      *
      * @param edid The EDID byte array to modify
@@ -457,10 +476,14 @@ public final class EdidUtil {
      * fields are left unchanged.
      *
      * @param edid       The EDID byte array to modify
-     * @param resolution The preferred resolution as a {@code WIDTHxHEIGHT} string (e.g. {@code "2560x1440"})
+     * @param resolution The preferred resolution as a {@code WIDTHxHEIGHT} string (e.g. {@code "2560x1440"}); a string
+     *                   without an {@code 'x'} separator leaves the descriptor unchanged
      */
     public static void setPreferredResolution(byte[] edid, String resolution) {
         int x = resolution.indexOf('x');
+        if (x < 0) {
+            return; // no WIDTHxHEIGHT to encode; leave the detailed timing descriptor unchanged
+        }
         int horizontal = ParseUtil.parseIntOrDefault(resolution.substring(0, x), 0);
         int vertical = ParseUtil.parseIntOrDefault(resolution.substring(x + 1), 0);
         int dtd = DESCRIPTOR_OFFSET;

--- a/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
@@ -259,4 +259,29 @@ class EdidUtilTest {
         // Non-alphanumeric 4-character value does not round-trip
         assertThrows(IllegalArgumentException.class, () -> EdidUtil.setSerialNo(edid, "AB-1"));
     }
+
+    @Test
+    void testSetSerialNoNumeric() {
+        // The numeric overload writes the raw 32-bit serial little-endian into bytes 12-15
+        byte[] edid = EdidUtil.newEdidTemplate();
+        EdidUtil.setSerialNo(edid, 0x162C0C25L);
+        assertThat("numeric serial", EdidUtil.getSerialNo(edid), is("162C0C25"));
+        // The full unsigned 32-bit range is accepted
+        EdidUtil.setSerialNo(edid, 0xFFFFFFFFL);
+        assertThat("max serial", EdidUtil.getSerialNo(edid), is("FFFFFFFF"));
+        // Values outside the unsigned 32-bit range are rejected rather than truncated
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setSerialNo(edid, -1L));
+        assertThrows(IllegalArgumentException.class, () -> EdidUtil.setSerialNo(edid, 0x1_0000_0000L));
+    }
+
+    @Test
+    void testSetPreferredResolutionNoSeparator() {
+        byte[] edid = EdidUtil.newEdidTemplate();
+        // A string with no 'x' separator is a no-op rather than throwing
+        EdidUtil.setPreferredResolution(edid, "");
+        assertThat("no separator", EdidUtil.getPreferredResolution(edid), is("0x0"));
+        // A valid resolution still encodes normally
+        EdidUtil.setPreferredResolution(edid, "1920x1080");
+        assertThat("valid resolution", EdidUtil.getPreferredResolution(edid), is("1920x1080"));
+    }
 }


### PR DESCRIPTION
Two small refinements to the `EdidUtil` encoders added in #3415, prompted by sketching the macOS Apple Silicon synthesis path for #3404 (building an EDID from `DisplayAttributes`/`ProductAttributes`):

- **`setSerialNo(byte[], long)`** — writes the raw 32-bit ID serial number little-endian into bytes 12-15. The existing string overload only accepts values that round-trip through `getSerialNo` (8 uppercase hex digits whose bytes are non-alphanumeric, or 4 alphanumeric characters), so an arbitrary numeric serial could not be set; this overload covers that case.
- **`setPreferredResolution`** now returns without modifying the descriptor when the string has no `'x'` separator, instead of throwing `StringIndexOutOfBoundsException`. A synthesizer that has no resolution to supply can pass an empty string safely.

Both are additive/bugfix changes to `EdidUtil` (not part of the `@PublicApi` surface). Tests added for the numeric serial round-trip and the no-separator no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for setting EDID serial numbers using a numeric input format.

* **Bug Fixes**
  * Preferred resolution updates are now safely ignored when the provided value is missing the required `x` separator.
  * Numeric serial updates now validate that the value fits within an unsigned 32-bit range.

* **Tests**
  * Added coverage for the new serial-number overload and for preferred-resolution no-op behavior with invalid input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->