### PR TITLE
Fix DragonFly CpTime resource leak and KstatUtil loop termination

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdCentralProcessorJNA.java
@@ -28,8 +28,8 @@ public class DragonFlyBsdCentralProcessorJNA extends FreeBsdCentralProcessorJNA 
     @Override
     public long[] querySystemCpuLoadTicks() {
         long[] ticks = new long[TickType.values().length];
-        FreeBsdLibc.CpTime cpTime = new FreeBsdLibc.CpTime();
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference(cpTime.size())) {
+        try (FreeBsdLibc.CpTime cpTime = new FreeBsdLibc.CpTime();
+                CloseableSizeTByReference size = new CloseableSizeTByReference(cpTime.size())) {
             if (0 == DragonFlyBsdLibc.INSTANCE.sysctlbyname("kern.cp_time", cpTime.getPointer(), size, null,
                     size_t.ZERO)) {
                 cpTime.read();

--- a/oshi-core/src/main/java/oshi/util/platform/unix/solaris/KstatUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/solaris/KstatUtil.java
@@ -306,6 +306,7 @@ public final class KstatUtil {
             Kstat2Handle handle = new Kstat2Handle();
             try {
                 for (s = 0; consecutiveMisses < 256; s++) {
+                    boolean hit = false;
                     try {
                         Object[] result = new Object[names.length];
                         Kstat2Map map = handle.lookupMap(beforeStr + s + afterStr);
@@ -313,10 +314,12 @@ public final class KstatUtil {
                             result[i] = map.getValue(names[i]);
                         }
                         results.add(result);
-                        consecutiveMisses = 0;
+                        hit = true;
                     } catch (Kstat2StatusException e) {
-                        consecutiveMisses++;
+                        // Instance s is not present
                     }
+                    // Update the miss counter in normal control flow so the loop has a normal termination condition
+                    consecutiveMisses = hit ? 0 : consecutiveMisses + 1;
                 }
             } finally {
                 handle.close();


### PR DESCRIPTION
Two fixes prompted by Coverity static analysis (both pre-existing, unrelated to recent EDID work):

- **`DragonFlyBsdCentralProcessorJNA.querySystemCpuLoadTicks`** (RESOURCE_LEAK): the `FreeBsdLibc.CpTime` is an `AutoCloseable` that was created outside the try-with-resources and never closed, relying on the JNA `Structure` finalizer instead. Moved it into the try-with-resources (before `size`, which uses `cpTime.size()`), matching the FreeBSD implementation.
- **`KstatUtil.queryKstat2List`** (INFINITE_LOOP): the consecutive-miss counter was only updated inside the `catch` block, so the loop's termination depended solely on the exception ("abnormal") path. The counter is now updated in normal control flow via a `hit` flag, giving the loop a normal termination condition. Behavior is unchanged: a hit resets the counter, a miss increments it, and 256 consecutive misses end the scan.

The other three Coverity defects in the same run were verified as false positives and marked Intentional (Windows/Linux `getSessions` deliberately use platform-specific session sources rather than the unix `who`; `WmiUtil.getDateTime` never returns null).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of CPU load reporting on some Unix-based systems.
  * Made system data collection more resilient when hardware status information is temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->