### PR TITLE
Add NVD cache warmer and make the site build reuse a warm cache

### DIFF
--- a/.github/workflows/nvd-cache.yaml
+++ b/.github/workflows/nvd-cache.yaml
@@ -37,9 +37,19 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
-          cache: maven
           distribution: temurin
           java-version: 25
+      # Cache Maven artifacts but exclude the NVD data dir -- it has its own
+      # rolling cache below, and setup-java's built-in `cache: maven` would
+      # otherwise store the ~1.5 GB database a second time.
+      - name: Cache Maven dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/owasp/dependency-check-data
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
       # Rolling cache: restore the newest previous snapshot via the prefix, and
       # always save under a unique key (actions/cache never overwrites a key).
       # Old snapshots LRU-evict; this keeps the DB fresh and incremental.
@@ -63,10 +73,11 @@ jobs:
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
           key: nvd-db-${{ github.run_id }}
-      # Scan against the now-warm DB (nvdValidForHours in the pom keeps this from
-      # re-hitting the network). A CVE at or above the threshold fails the run,
-      # which is the alert. Tune the threshold to taste (11 disables it).
+      # Scan against the cached DB only (-DautoUpdate=false): the update step
+      # above owns the network fetch, so the scan can't launch a second full
+      # download under the remaining job budget. A CVE at or above the threshold
+      # fails the run, which is the alert. Tune the threshold to taste (11 off).
       - name: Scan dependencies for vulnerabilities
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: ./mvnw install dependency-check:aggregate -DskipTests -Djacoco.skip=true -Dmaven.gitcommitid.skip=true -DfailBuildOnCVSS=7 -B --settings ./.mvn/settings.xml
+        run: ./mvnw install dependency-check:aggregate -DskipTests -Djacoco.skip=true -Dmaven.gitcommitid.skip=true -DautoUpdate=false -DfailBuildOnCVSS=7 -B --settings ./.mvn/settings.xml

--- a/.github/workflows/nvd-cache.yaml
+++ b/.github/workflows/nvd-cache.yaml
@@ -1,25 +1,14 @@
 name: NVD Cache Warmer
 
-# Keeps the OWASP dependency-check NVD database warm and alerts on newly
-# disclosed vulnerabilities in current dependencies.
-#
-# The Site (release) build is the only other NVD consumer and it runs at most
-# every few weeks -- longer than BOTH GitHub's 7-day cache-eviction window and
-# dependency-check's 7-day incremental-update window. Without this warmer every
-# release faces a cold, multi-hour full NVD download that is exposed to NVD API
-# throttling (which once ran into the 6-hour job cap and was killed).
-#
-# Running on a schedule keeps the cached database inside both windows, so the
-# release build restores a warm cache and only does a fast incremental update
-# (or none at all). GitHub makes caches created on the default branch readable
-# from every branch, so the cache this builds on master is available to the
-# `site` branch build. A run that fails on a CVE is the vulnerability alert.
+# Keeps the OWASP dependency-check NVD database warm so the Site (release) build
+# never has to do a cold full download -- that repeatedly failed on NVD 503s and
+# timed out. Running every ~3 days stays inside both GitHub's 7-day cache-eviction
+# window and dependency-check's 7-day incremental window, so each run is a fast
+# incremental. A failing run (a CVE at or above the threshold) is the vuln alert.
 
 on:
   workflow_dispatch:
   schedule:
-    # Every 3 days at 07:00 UTC -- comfortably inside the 7-day windows even if
-    # a scheduled run is skipped (GitHub drops scheduled runs under high load).
     - cron: '0 7 */3 * *'
 
 permissions:
@@ -29,7 +18,9 @@ jobs:
   update-and-scan:
     if: github.repository_owner == 'oshi'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Generous ceiling only ever reached by the first (cold) seed at the gentle NVD
+    # pace; warm runs finish in minutes.
+    timeout-minutes: 210
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -37,47 +28,35 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
+          cache: maven
           distribution: temurin
           java-version: 25
-      # Cache Maven artifacts but exclude the NVD data dir -- it has its own
-      # rolling cache below, and setup-java's built-in `cache: maven` would
-      # otherwise store the ~1.5 GB database a second time.
-      - name: Cache Maven dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.m2/repository
-            !~/.m2/repository/org/owasp/dependency-check-data
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
-      # Rolling cache: restore the newest previous snapshot via the prefix, and
-      # always save under a unique key (actions/cache never overwrites a key).
-      # Old snapshots LRU-evict; this keeps the DB fresh and incremental.
+      # Restore the newest previous snapshot. The key is per-run (github.run_id)
+      # because GitHub caches are immutable per key -- a static key could never be
+      # refreshed -- so each run reads the latest via restore-keys and writes a new
+      # snapshot. Default-branch caches are readable from every branch, so the Site
+      # build restores this one too; superseded snapshots evict after 7 idle days.
       - name: Restore NVD database cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
           key: nvd-db-${{ github.run_id }}
           restore-keys: nvd-db-
-      # Warm the DB. Bounded and non-fatal so a bad NVD day can't fail the alert
-      # or burn the job budget -- whatever downloaded is still saved below.
       - name: Update NVD database
-        timeout-minutes: 30
-        continue-on-error: true
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: ./mvnw dependency-check:update-only -B --settings ./.mvn/settings.xml -Dmaven.gitcommitid.skip=true
+      # Only reached when the update above succeeded (default success() gating), so
+      # the cache never holds a partial/incomplete DB.
       - name: Save NVD database cache
-        if: always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
           key: nvd-db-${{ github.run_id }}
-      # Scan against the cached DB only (-DautoUpdate=false): the update step
-      # above owns the network fetch, so the scan can't launch a second full
-      # download under the remaining job budget. A CVE at or above the threshold
-      # fails the run, which is the alert. Tune the threshold to taste (11 off).
+      # Alert: scan against the just-updated DB (fresh, so no network) and fail on a
+      # CVE at or above the threshold. Runs after the save, so a CVE never blocks the
+      # cache refresh. Tune the threshold to taste (11 disables it).
       - name: Scan dependencies for vulnerabilities
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: ./mvnw install dependency-check:aggregate -DskipTests -Djacoco.skip=true -Dmaven.gitcommitid.skip=true -DautoUpdate=false -DfailBuildOnCVSS=7 -B --settings ./.mvn/settings.xml
+        run: ./mvnw install dependency-check:aggregate -DskipTests -Djacoco.skip=true -Dmaven.gitcommitid.skip=true -DfailBuildOnCVSS=7 -B --settings ./.mvn/settings.xml

--- a/.github/workflows/nvd-cache.yaml
+++ b/.github/workflows/nvd-cache.yaml
@@ -59,4 +59,5 @@ jobs:
       - name: Scan dependencies for vulnerabilities
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          SONATYPE_GUIDE_TOKEN: ${{ secrets.SONATYPE_GUIDE_TOKEN }}
         run: ./mvnw install dependency-check:aggregate -DskipTests -Djacoco.skip=true -Dmaven.gitcommitid.skip=true -DfailBuildOnCVSS=7 -B --settings ./.mvn/settings.xml

--- a/.github/workflows/nvd-cache.yaml
+++ b/.github/workflows/nvd-cache.yaml
@@ -14,6 +14,13 @@ on:
 permissions:
   contents: read
 
+# Serialize all runs (scheduled + manual dispatch) so two warmers never hit the
+# NVD API or write the cache at the same time. Queue rather than cancel, so a
+# manual run can't abort an in-progress (possibly long cold-seed) scheduled one.
+concurrency:
+  group: nvd-cache-warmer
+  cancel-in-progress: false
+
 jobs:
   update-and-scan:
     if: github.repository_owner == 'oshi'

--- a/.github/workflows/nvd-cache.yaml
+++ b/.github/workflows/nvd-cache.yaml
@@ -1,0 +1,72 @@
+name: NVD Cache Warmer
+
+# Keeps the OWASP dependency-check NVD database warm and alerts on newly
+# disclosed vulnerabilities in current dependencies.
+#
+# The Site (release) build is the only other NVD consumer and it runs at most
+# every few weeks -- longer than BOTH GitHub's 7-day cache-eviction window and
+# dependency-check's 7-day incremental-update window. Without this warmer every
+# release faces a cold, multi-hour full NVD download that is exposed to NVD API
+# throttling (which once ran into the 6-hour job cap and was killed).
+#
+# Running on a schedule keeps the cached database inside both windows, so the
+# release build restores a warm cache and only does a fast incremental update
+# (or none at all). GitHub makes caches created on the default branch readable
+# from every branch, so the cache this builds on master is available to the
+# `site` branch build. A run that fails on a CVE is the vulnerability alert.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every 3 days at 07:00 UTC -- comfortably inside the 7-day windows even if
+    # a scheduled run is skipped (GitHub drops scheduled runs under high load).
+    - cron: '0 7 */3 * *'
+
+permissions:
+  contents: read
+
+jobs:
+  update-and-scan:
+    if: github.repository_owner == 'oshi'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Setup Java
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+        with:
+          cache: maven
+          distribution: temurin
+          java-version: 25
+      # Rolling cache: restore the newest previous snapshot via the prefix, and
+      # always save under a unique key (actions/cache never overwrites a key).
+      # Old snapshots LRU-evict; this keeps the DB fresh and incremental.
+      - name: Restore NVD database cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: nvd-db-${{ github.run_id }}
+          restore-keys: nvd-db-
+      # Warm the DB. Bounded and non-fatal so a bad NVD day can't fail the alert
+      # or burn the job budget -- whatever downloaded is still saved below.
+      - name: Update NVD database
+        timeout-minutes: 30
+        continue-on-error: true
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: ./mvnw dependency-check:update-only -B --settings ./.mvn/settings.xml -Dmaven.gitcommitid.skip=true
+      - name: Save NVD database cache
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: nvd-db-${{ github.run_id }}
+      # Scan against the now-warm DB (nvdValidForHours in the pom keeps this from
+      # re-hitting the network). A CVE at or above the threshold fails the run,
+      # which is the alert. Tune the threshold to taste (11 disables it).
+      - name: Scan dependencies for vulnerabilities
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: ./mvnw install dependency-check:aggregate -DskipTests -Djacoco.skip=true -Dmaven.gitcommitid.skip=true -DfailBuildOnCVSS=7 -B --settings ./.mvn/settings.xml

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -17,6 +17,7 @@ jobs:
   build:
     if: github.repository_owner == 'oshi'
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Java
@@ -25,11 +26,31 @@ jobs:
           cache: maven
           distribution: temurin
           java-version: 25
-      - name: Cache NVD database
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Rolling cache: restore the newest snapshot the NVD Cache Warmer saved on
+      # master (default-branch caches are readable from every branch). The old
+      # static `nvd-db` key never updated and evicted between releases, forcing a
+      # cold full download every time.
+      - name: Restore NVD database cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
-          key: nvd-db
+          key: nvd-db-${{ github.run_id }}
+          restore-keys: nvd-db-
+      # Bounded and non-fatal: on a warm cache this is a fast incremental update;
+      # on a cold cache a bad NVD day fails this step in minutes instead of the
+      # whole job at the 6-hour cap, and whatever downloaded is saved below.
+      - name: Update NVD database
+        timeout-minutes: 20
+        continue-on-error: true
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: ./mvnw dependency-check:update-only -B --settings ./.mvn/settings.xml -Dmaven.gitcommitid.skip=true
+      - name: Save NVD database cache
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: nvd-db-${{ github.run_id }}
       - name: Build site
         run: ./mvnw site site:stage -Djacoco.skip=true -DskipTests -B --settings ./.mvn/settings.xml
         env:

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 50
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Setup Java
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -43,6 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          SONATYPE_GUIDE_TOKEN: ${{ secrets.SONATYPE_GUIDE_TOKEN }}
       - name: Deploy Site to gh-pages
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
         with:

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -17,7 +17,7 @@ jobs:
   build:
     if: github.repository_owner == 'oshi'
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -25,49 +25,21 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
+          cache: maven
           distribution: temurin
           java-version: 25
-      # Cache Maven artifacts but exclude the NVD data dir -- it has its own
-      # rolling cache below, and setup-java's built-in `cache: maven` would
-      # otherwise store the ~1.5 GB database a second time.
-      - name: Cache Maven dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.m2/repository
-            !~/.m2/repository/org/owasp/dependency-check-data
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
-      # Rolling cache: restore the newest snapshot the NVD Cache Warmer saved on
-      # master (default-branch caches are readable from every branch). The old
-      # static `nvd-db` key never updated and evicted between releases, forcing a
-      # cold full download every time.
+      # Restore the warm NVD database the NVD Cache Warmer maintains on master
+      # (default-branch caches are readable from every branch), so the site report
+      # does a fast incremental instead of the cold full download that used to time
+      # out. Restore-only: the warmer owns refreshing the cache.
       - name: Restore NVD database cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
           key: nvd-db-${{ github.run_id }}
           restore-keys: nvd-db-
-      # Bounded and non-fatal: on a warm cache this is a fast incremental update;
-      # on a cold cache a bad NVD day fails this step in minutes instead of the
-      # whole job at the 6-hour cap, and whatever downloaded is saved below.
-      - name: Update NVD database
-        timeout-minutes: 20
-        continue-on-error: true
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: ./mvnw dependency-check:update-only -B --settings ./.mvn/settings.xml -Dmaven.gitcommitid.skip=true
-      - name: Save NVD database cache
-        if: always()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/org/owasp/dependency-check-data
-          key: nvd-db-${{ github.run_id }}
-      # -DautoUpdate=false: the update step above owns the NVD fetch, so the
-      # dependency-check site report uses only the cached DB and never launches
-      # its own (potentially multi-hour) download on the release path.
       - name: Build site
-        run: ./mvnw site site:stage -Djacoco.skip=true -DskipTests -DautoUpdate=false -B --settings ./.mvn/settings.xml
+        run: ./mvnw site site:stage -Djacoco.skip=true -DskipTests -B --settings ./.mvn/settings.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -17,15 +17,25 @@ jobs:
   build:
     if: github.repository_owner == 'oshi'
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Java
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
-          cache: maven
           distribution: temurin
           java-version: 25
+      # Cache Maven artifacts but exclude the NVD data dir -- it has its own
+      # rolling cache below, and setup-java's built-in `cache: maven` would
+      # otherwise store the ~1.5 GB database a second time.
+      - name: Cache Maven dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/owasp/dependency-check-data
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
       # Rolling cache: restore the newest snapshot the NVD Cache Warmer saved on
       # master (default-branch caches are readable from every branch). The old
       # static `nvd-db` key never updated and evicted between releases, forcing a
@@ -51,8 +61,11 @@ jobs:
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
           key: nvd-db-${{ github.run_id }}
+      # -DautoUpdate=false: the update step above owns the NVD fetch, so the
+      # dependency-check site report uses only the cached DB and never launches
+      # its own (potentially multi-hour) download on the release path.
       - name: Build site
-        run: ./mvnw site site:stage -Djacoco.skip=true -DskipTests -B --settings ./.mvn/settings.xml
+        run: ./mvnw site site:stage -Djacoco.skip=true -DskipTests -DautoUpdate=false -B --settings ./.mvn/settings.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -25,5 +25,10 @@
             <id>github</id>
             <password>${env.GITHUB_TOKEN}</password>
         </server>
+        <!-- Sonatype OSS Index / Guide: the Guide API token is the password; username is optional. -->
+        <server>
+            <id>ossindex</id>
+            <password>${env.SONATYPE_GUIDE_TOKEN}</password>
+        </server>
     </servers>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -630,6 +630,10 @@
                         <nvdApiDelay>${dependency-check.nvdApiDelay}</nvdApiDelay>
                         <nvdMaxRetryCount>${dependency-check.nvdMaxRetryCount}</nvdMaxRetryCount>
                         <nvdValidForHours>${dependency-check.nvdValidForHours}</nvdValidForHours>
+                        <!-- Sonatype OSS Index auth via the `ossindex` server in .mvn/settings.xml
+                             (Guide token as password). Warn-only so an OSS Index outage never fails a build. -->
+                        <ossIndexServerId>ossindex</ossIndexServerId>
+                        <ossIndexWarnOnlyOnRemoteErrors>true</ossIndexWarnOnlyOnRemoteErrors>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1031,11 +1035,12 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <configuration>
                     <!-- Reporting plugins do not inherit build/pluginManagement
-                         config, so repeat the NVD resilience settings here so the
-                         site report reuses a warm cache instead of re-downloading. -->
+                         config, so repeat the NVD + OSS Index settings here. -->
                     <nvdApiDelay>${dependency-check.nvdApiDelay}</nvdApiDelay>
                     <nvdMaxRetryCount>${dependency-check.nvdMaxRetryCount}</nvdMaxRetryCount>
                     <nvdValidForHours>${dependency-check.nvdValidForHours}</nvdValidForHours>
+                    <ossIndexServerId>ossindex</ossIndexServerId>
+                    <ossIndexWarnOnlyOnRemoteErrors>true</ossIndexWarnOnlyOnRemoteErrors>
                 </configuration>
                 <reportSets>
                     <reportSet>

--- a/pom.xml
+++ b/pom.xml
@@ -144,8 +144,8 @@
         <dependency-check-maven.version>12.2.2</dependency-check-maven.version>
         <!-- OWASP dependency-check NVD tuning: treat cached data as fresh for a week (skips updates on a
              warm cache) and ride out NVD API throttling. See the NVD Cache Warmer and Site workflows. -->
-        <dependency-check.nvdApiDelay>6000</dependency-check.nvdApiDelay>
-        <dependency-check.nvdMaxRetryCount>25</dependency-check.nvdMaxRetryCount>
+        <dependency-check.nvdApiDelay>7500</dependency-check.nvdApiDelay>
+        <dependency-check.nvdMaxRetryCount>50</dependency-check.nvdMaxRetryCount>
         <dependency-check.nvdValidForHours>168</dependency-check.nvdValidForHours>
         <japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>
         <puppycrawl.checkstyle.version>13.7.0</puppycrawl.checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -621,6 +621,14 @@
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${dependency-check-maven.version}</version>
+                    <configuration>
+                        <!-- Treat cached NVD data as fresh for a week so a warm
+                             cache skips the update; delay/retries ride out NVD
+                             API throttling. See the NVD Cache Warmer workflow. -->
+                        <nvdApiDelay>6000</nvdApiDelay>
+                        <nvdMaxRetryCount>25</nvdMaxRetryCount>
+                        <nvdValidForHours>168</nvdValidForHours>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
@@ -1019,6 +1027,14 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
+                <configuration>
+                    <!-- Reporting plugins do not inherit build/pluginManagement
+                         config, so repeat the NVD resilience settings here so the
+                         site report reuses a warm cache instead of re-downloading. -->
+                    <nvdApiDelay>6000</nvdApiDelay>
+                    <nvdMaxRetryCount>25</nvdMaxRetryCount>
+                    <nvdValidForHours>168</nvdValidForHours>
+                </configuration>
                 <reportSets>
                     <reportSet>
                         <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
         <!-- Misc. -->
         <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
         <dependency-check-maven.version>12.2.2</dependency-check-maven.version>
+        <!-- OWASP dependency-check NVD tuning: treat cached data as fresh for a week (skips updates on a
+             warm cache) and ride out NVD API throttling. See the NVD Cache Warmer and Site workflows. -->
+        <dependency-check.nvdApiDelay>6000</dependency-check.nvdApiDelay>
+        <dependency-check.nvdMaxRetryCount>25</dependency-check.nvdMaxRetryCount>
+        <dependency-check.nvdValidForHours>168</dependency-check.nvdValidForHours>
         <japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>
         <puppycrawl.checkstyle.version>13.7.0</puppycrawl.checkstyle.version>
         <m2e.lifecycle-mapping.version>1.0.0</m2e.lifecycle-mapping.version>
@@ -622,12 +627,9 @@
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${dependency-check-maven.version}</version>
                     <configuration>
-                        <!-- Treat cached NVD data as fresh for a week so a warm
-                             cache skips the update; delay/retries ride out NVD
-                             API throttling. See the NVD Cache Warmer workflow. -->
-                        <nvdApiDelay>6000</nvdApiDelay>
-                        <nvdMaxRetryCount>25</nvdMaxRetryCount>
-                        <nvdValidForHours>168</nvdValidForHours>
+                        <nvdApiDelay>${dependency-check.nvdApiDelay}</nvdApiDelay>
+                        <nvdMaxRetryCount>${dependency-check.nvdMaxRetryCount}</nvdMaxRetryCount>
+                        <nvdValidForHours>${dependency-check.nvdValidForHours}</nvdValidForHours>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1031,9 +1033,9 @@
                     <!-- Reporting plugins do not inherit build/pluginManagement
                          config, so repeat the NVD resilience settings here so the
                          site report reuses a warm cache instead of re-downloading. -->
-                    <nvdApiDelay>6000</nvdApiDelay>
-                    <nvdMaxRetryCount>25</nvdMaxRetryCount>
-                    <nvdValidForHours>168</nvdValidForHours>
+                    <nvdApiDelay>${dependency-check.nvdApiDelay}</nvdApiDelay>
+                    <nvdMaxRetryCount>${dependency-check.nvdMaxRetryCount}</nvdMaxRetryCount>
+                    <nvdValidForHours>${dependency-check.nvdValidForHours}</nvdValidForHours>
                 </configuration>
                 <reportSets>
                     <reportSet>
@@ -1195,9 +1197,9 @@
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
                         <configuration>
-                            <nvdMaxRetryCount>25</nvdMaxRetryCount>
-                            <nvdApiDelay>6000</nvdApiDelay>
-                            <nvdValidForHours>168</nvdValidForHours>
+                            <nvdMaxRetryCount>${dependency-check.nvdMaxRetryCount}</nvdMaxRetryCount>
+                            <nvdApiDelay>${dependency-check.nvdApiDelay}</nvdApiDelay>
+                            <nvdValidForHours>${dependency-check.nvdValidForHours}</nvdValidForHours>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
## Problem

The Site (release) build is the project's main OWASP dependency-check / NVD consumer, but it runs at most every few weeks. That cadence is longer than **both**:

- GitHub's **7-day cache-eviction** window (caches unused for 7 days are dropped), and
- dependency-check's **7-day incremental-update** window (`nvdValidForHours`).

So nearly every release hits a **cold, full NVD download** (~362k records) that is fully exposed to NVD API throttling. The latest release's Site run failed 6–7 times in a row; one attempt stalled mid-download and was killed at GitHub's hard **6-hour job cap** (`The operation was canceled`). The API key is present and correctly wired via `.mvn/settings.xml` — the failure is the cold download, not auth.

## Changes

1. **New `NVD Cache Warmer` workflow** (`nvd-cache.yaml`), scheduled every 3 days:
   - Keeps the NVD database warm. Since **default-branch caches are readable from every branch**, the cache it builds on `master` is restorable by the `site`-branch Site build.
   - Doubles as a **vulnerability alert**: it runs `dependency-check:aggregate` with `failBuildOnCVSS=7`, so a newly disclosed CVE in a current dependency surfaces as a failed scheduled run. (Threshold is easy to tune; `11` disables it.)
   - Rolling cache key + `restore-keys`, a bounded/non-fatal update step, and `save` with `if: always()` so partial progress is never lost.

2. **`site.yaml`**: replaced the static `nvd-db` cache key (write-once, never refreshed, evicted between releases) with a **rolling key + `restore-keys`** so it restores the warmer's cache; added a **bounded, non-fatal update step** that saves partial progress and a **job `timeout-minutes`** so a bad NVD day fails in minutes instead of at the 6-hour cap.

3. **`pom.xml`**: added `nvdValidForHours=168` (+ `nvdApiDelay`/`nvdMaxRetryCount`) to dependency-check in **both** `pluginManagement` (for the warmer's CLI goal) and `reporting` (reporting plugins don't inherit build/pluginManagement config), so a warm cache is treated as fresh and the download is skipped entirely.

## Rollout

Once merged, the warmer runs from the default branch (schedules only fire there) and warms the cache. A subsequent `site` push then restores it and publishes fast. Nothing here touches the `site` branch directly.

## Notes for review

@hazendaz — would value your Maven eyes on:
- The `dependency-check` config split across `pluginManagement` vs `reporting` (needed because reporting plugins don't inherit pluginManagement config — is there a cleaner idiom you'd prefer?).
- The warmer invocation `./mvnw install dependency-check:aggregate ...` — `install` is there so reactor sibling artifacts resolve for the aggregate scan; open to a lighter approach.
- `failBuildOnCVSS=7` as the alert threshold and the 3-day cadence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated **NVD Cache Warmer** GitHub Actions workflow with scheduled refresh and manual trigger to improve security scan speed.

* **Improvements**
  * Enhanced Dependency-Check configuration with new tunable NVD throttling/retry settings and documented cache freshness (~1 week).
  * Updated CI caching for NVD data to restore more safely (restore-key based) and added an explicit site build timeout.
  * Extended Maven/guide reporting setup to use a **Guide API token** via environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->