### PR TITLE
Fix WrongMethodTypeException in BStrFFM.free void invokeExact (#3422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ##### Bug Fixes and Improvements
 
+* [#3424](https://github.com/oshi/oshi/pull/3424): Fix `WrongMethodTypeException` when freeing BSTR strings on the Windows FFM WMI path, caused by a void `invokeExact` in an expression lambda inferring an `Object` return - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 
 # 7.3.0 (2026-06-06), 7.3.1 (2026-06-11), 7.3.2 (2026-06-26)

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/BStrFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/BStrFFM.java
@@ -69,7 +69,12 @@ public final class BStrFFM extends WindowsForeignFunctions {
         if (bstr == null || bstr.equals(MemorySegment.NULL)) {
             return;
         }
-        runOrLog(() -> SysFreeString.invokeExact(bstr), LOG, "BStrFFM.free failed");
+        // Block lambda (not an expression lambda) so invokeExact() on this void
+        // handle is in a statement context and its return type is inferred as
+        // void; an expression lambda infers Object -> WrongMethodTypeException.
+        runOrLog(() -> {
+            SysFreeString.invokeExact(bstr);
+        }, LOG, "BStrFFM.free failed");
     }
 
     // SysStringLen

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/BStrFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/BStrFFM.java
@@ -69,10 +69,10 @@ public final class BStrFFM extends WindowsForeignFunctions {
         if (bstr == null || bstr.equals(MemorySegment.NULL)) {
             return;
         }
-        // Block lambda (not an expression lambda) so invokeExact() on this void
-        // handle is in a statement context and its return type is inferred as
-        // void; an expression lambda infers Object -> WrongMethodTypeException.
-        runOrLog(() -> {
+        // Block lambda (not an expression lambda) so invokeExact() on this void handle is in a statement context and
+        // its return type is inferred as void; an expression lambda infers Object -> WrongMethodTypeException (#3422).
+        // NOSONAR on the next line so S1602 does not collapse the block back to the buggy expression form.
+        runOrLog(() -> { // NOSONAR java:S1602 - block form required; expression lambda miscompiles void invokeExact
             SysFreeString.invokeExact(bstr);
         }, LOG, "BStrFFM.free failed");
     }

--- a/oshi-core-ffm/src/test/java/oshi/ffm/VoidInvokeExactSourceTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/VoidInvokeExactSourceTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -39,8 +40,10 @@ import org.junit.jupiter.api.Test;
 class VoidInvokeExactSourceTest {
 
     // run(OrLog|Silently)(() -> ... invokeExact with no '{' before invokeExact is an expression lambda -- the bug.
+    // Scanned against whole-file content, so a lambda wrapped across lines is still caught. [^{};]* stays within the
+    // single statement (no brace/semicolon crossing) to avoid matching an unrelated later invokeExact.
     private static final Pattern EXPRESSION_LAMBDA_INVOKE_EXACT = Pattern
-            .compile("run(?:OrLog|Silently)\\(\\(\\)\\s*->[^{]*invokeExact");
+            .compile("run(?:OrLog|Silently)\\(\\(\\)\\s*->[^{};]*invokeExact");
 
     @Test
     void noVoidInvokeExactInExpressionLambda() throws IOException {
@@ -51,11 +54,11 @@ class VoidInvokeExactSourceTest {
         try (Stream<Path> paths = Files.walk(srcRoot)) {
             paths.filter(p -> p.toString().endsWith(".java")).forEach(p -> {
                 try {
-                    List<String> lines = Files.readAllLines(p, StandardCharsets.UTF_8);
-                    for (int i = 0; i < lines.size(); i++) {
-                        if (EXPRESSION_LAMBDA_INVOKE_EXACT.matcher(lines.get(i)).find()) {
-                            offenders.add(p + ":" + (i + 1) + "  " + lines.get(i).strip());
-                        }
+                    String content = Files.readString(p, StandardCharsets.UTF_8);
+                    Matcher matcher = EXPRESSION_LAMBDA_INVOKE_EXACT.matcher(content);
+                    while (matcher.find()) {
+                        long line = content.substring(0, matcher.start()).chars().filter(c -> c == '\n').count() + 1;
+                        offenders.add(p + ":" + line + "  " + matcher.group().replaceAll("\\s+", " "));
                     }
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);

--- a/oshi-core-ffm/src/test/java/oshi/ffm/VoidInvokeExactSourceTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/VoidInvokeExactSourceTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Source-policy guard for a footgun that has already regressed twice (issues #3301 / #3422): a <em>void</em>
+ * {@link java.lang.invoke.MethodHandle#invokeExact} invoked from an expression-bodied lambda passed to a void-returning
+ * helper such as {@code ExceptionUtil.runOrLog}.
+ * <p>
+ * {@code invokeExact} is signature-polymorphic: its return type is inferred from the call site. In an expression lambda
+ * targeting a void functional interface, javac infers {@code Object} instead of {@code void}, so the call site
+ * ({@code (X)Object}) does not match the handle ({@code (X)void}) and throws {@code WrongMethodTypeException} at
+ * runtime. The failure only surfaces on the native platform and is swallowed by the logging helper, so a normal unit
+ * test can't see it. A block lambda ({@code () -> { handle.invokeExact(...); }}) keeps the call in a statement context
+ * where the return type is correctly {@code void}.
+ * <p>
+ * Scanning the sources catches the regression on every build (not only on the platform where the call runs), which
+ * matters because the fix keeps getting lost whenever the FFM code is moved between packages.
+ */
+class VoidInvokeExactSourceTest {
+
+    // run(OrLog|Silently)(() -> ... invokeExact with no '{' before invokeExact is an expression lambda -- the bug.
+    private static final Pattern EXPRESSION_LAMBDA_INVOKE_EXACT = Pattern
+            .compile("run(?:OrLog|Silently)\\(\\(\\)\\s*->[^{]*invokeExact");
+
+    @Test
+    void noVoidInvokeExactInExpressionLambda() throws IOException {
+        Path srcRoot = Path.of("src", "main", "java");
+        assumeTrue(Files.isDirectory(srcRoot), "FFM source tree not on the working directory; skipping source scan");
+
+        List<String> offenders = new ArrayList<>();
+        try (Stream<Path> paths = Files.walk(srcRoot)) {
+            paths.filter(p -> p.toString().endsWith(".java")).forEach(p -> {
+                try {
+                    List<String> lines = Files.readAllLines(p, StandardCharsets.UTF_8);
+                    for (int i = 0; i < lines.size(); i++) {
+                        if (EXPRESSION_LAMBDA_INVOKE_EXACT.matcher(lines.get(i)).find()) {
+                            offenders.add(p + ":" + (i + 1) + "  " + lines.get(i).strip());
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
+
+        assertThat("void invokeExact in an expression lambda infers Object and throws WrongMethodTypeException at "
+                + "runtime; use a block lambda instead: () -> { handle.invokeExact(...); }. Offenders: " + offenders,
+                offenders, is(empty()));
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #3422. On the Windows FFM path, `BStrFFM.free` throws at runtime:

```
java.lang.invoke.WrongMethodTypeException: handle's method type (MemorySegment)void but found (MemorySegment)Object
	at oshi.ffm.platform.windows.com.BStrFFM.lambda$free$0(BStrFFM.java:72)
```

`SysFreeString` is a **void** downcall (handle type `(MemorySegment)void`). `MethodHandle.invokeExact` is signature-polymorphic and infers its return type from the call site. In an **expression-bodied lambda** passed to the void-returning `runOrLog(ThrowingRunnable)`, javac infers `Object` rather than `void`, so the call site's `(MemorySegment)Object` mismatches the handle and throws. It's caught and logged at DEBUG by `runOrLog`, so it doesn't crash — but the BSTR is never freed, leaking memory on every WMI query.

## Regression note

This is a regression of #3302 (which fixed #3301). #3302 fixed this exact line with a block lambda. It was **not** lost in the later FFM package move (#3356 preserved it); it was re-broken by `1d0cb9cf97` "Collapse single-statement block lambdas to expression form (**S1602**)", a Sonar mechanical sweep that collapsed `() -> { invokeExact(); }` back to `() -> invokeExact()` — reintroducing the footgun. S1602 (and its autofix) will do this again to any such line.

## Fix

- Convert back to a block lambda so `invokeExact` is in a statement context where its return type is correctly inferred as `void`, with a comment marking why the block form matters.
- Add `VoidInvokeExactSourceTest`, a source-policy test that scans `oshi-core-ffm` main sources for the expression-lambda form and fails with the offending `file:line`. Because the runtime `WrongMethodTypeException` only fires on the native platform and is swallowed by `runOrLog`, no ordinary unit test can observe it — the source scan runs on every build (incl. non-Windows CI) and is the guard against the next S1602-style collapse. Verified it fails on the pre-fix form and passes on the fix.

I scanned the whole `oshi-core-ffm` tree — `BStrFFM.free` was the only remaining reintroduction (sibling methods pin the type with casts; `Ole32FFM` uses a `::invokeExact` method reference where the void SAM pins it).

Pre-commit gate (spotless, checkstyle, install, forbiddenapis, javadoc) passes on `oshi-core-ffm`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could trigger a `WrongMethodTypeException` when releasing Windows WMI BSTR strings, improving stability on affected systems.

* **Tests**
  * Added a safeguard test to catch similar low-level invocation regressions before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->