### PR TITLE
Skip ID 0 sentinels in Windows perf-counter process and thread maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ##### Bug Fixes and Improvements
 
 * [#3424](https://github.com/oshi/oshi/pull/3424): Fix `WrongMethodTypeException` when freeing BSTR strings on the Windows FFM WMI path, caused by a void `invokeExact` in an expression lambda inferring an `Object` return - [@dbwiddis](https://github.com/dbwiddis).
+* [#3425](https://github.com/oshi/oshi/pull/3425): Fix the Windows perf-counter process map occasionally mis-keying a real process under PID 0, when PDH reports its "ID Process" sentinel for a process that is starting or exiting - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 
 # 7.3.0 (2026-06-06), 7.3.1 (2026-06-11), 7.3.2 (2026-06-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ##### Bug Fixes and Improvements
 
 * [#3424](https://github.com/oshi/oshi/pull/3424): Fix `WrongMethodTypeException` when freeing BSTR strings on the Windows FFM WMI path, caused by a void `invokeExact` in an expression lambda inferring an `Object` return - [@dbwiddis](https://github.com/dbwiddis).
-* [#3425](https://github.com/oshi/oshi/pull/3425): Fix the Windows perf-counter process map occasionally mis-keying a real process under PID 0, when PDH reports its "ID Process" sentinel for a process that is starting or exiting - [@dbwiddis](https://github.com/dbwiddis).
+* [#3425](https://github.com/oshi/oshi/pull/3425): Fix the Windows perf-counter process and thread maps occasionally mis-keying a real process/thread under ID 0, when PDH reports its "ID Process"/"ID Thread" sentinel for one that is starting or exiting - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 
 # 7.3.0 (2026-06-06), 7.3.1 (2026-06-11), 7.3.2 (2026-06-26)

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/ProcessPerformanceData.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/ProcessPerformanceData.java
@@ -102,7 +102,10 @@ public final class ProcessPerformanceData {
 
         for (int inst = 0; inst < instances.size(); inst++) {
             int pid = pidList.get(inst).intValue();
-            if (pids == null || pids.contains(pid)) {
+            // Skip PID 0: PDH reports it as the "ID Process" sentinel for the _Total aggregate, the Idle
+            // pseudo-process, and any instance whose real PID is not yet available (starting/exiting). Keying
+            // the map on 0 would clobber one such entry with another, and no real Windows process has PID 0.
+            if (pid != 0 && (pids == null || pids.contains(pid))) {
                 long ctime = elapsedTimeList.get(inst);
                 if (ctime > now) {
                     ctime = ParseUtil.filetimeToUtcMs(ctime, false);

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/ThreadPerformanceData.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/ThreadPerformanceData.java
@@ -50,8 +50,11 @@ public final class ThreadPerformanceData {
         Map<Integer, ThreadPerfCounterBlock> threadMap = new HashMap<>();
         for (Map<ThreadPerformanceProperty, Object> threadInstanceMap : threadInstanceMaps) {
             Integer pid = (Integer) threadInstanceMap.get(ThreadPerformanceProperty.IDPROCESS);
-            if ((pids == null || pids.contains(pid)) && pid > 0) {
-                int tid = ((Integer) threadInstanceMap.get(ThreadPerformanceProperty.IDTHREAD)).intValue();
+            int tid = ((Integer) threadInstanceMap.get(ThreadPerformanceProperty.IDTHREAD)).intValue();
+            // TID 0 is never a real thread -- thread IDs come from the same pool as PIDs -- so never key the map
+            // on it; 0 is the "ID Thread" sentinel the perf-counter path can report for the _Total aggregate or
+            // an exiting thread.
+            if (tid != 0 && (pids == null || pids.contains(pid)) && pid > 0) {
                 String name = (String) threadInstanceMap.get(ThreadPerformanceProperty.NAME);
                 long upTime = (perfTime100nSec - (Long) threadInstanceMap.get(ThreadPerformanceProperty.ELAPSEDTIME))
                         / 10_000L;
@@ -111,8 +114,11 @@ public final class ThreadPerformanceData {
         int nameIndex = 0;
         for (int inst = 0; inst < instances.size(); inst++) {
             int pid = pidList.get(inst).intValue();
-            if (pids == null || pids.contains(pid)) {
-                int tid = tidList.get(inst).intValue();
+            int tid = tidList.get(inst).intValue();
+            // TID 0 is never a real thread (thread IDs share the PID pool). PDH reports it as the "ID Thread"
+            // sentinel for the _Total aggregate and exiting threads; keying the map on 0 would clobber a real
+            // thread with another.
+            if (tid != 0 && (pids == null || pids.contains(pid))) {
                 String name = Integer.toString(nameIndex++);
                 long startTime = startTimeList.get(inst);
                 startTime = ParseUtil.filetimeToUtcMs(startTime, false);


### PR DESCRIPTION
## Problem

`RegistryComparisonTest.testProcessData` flakes on Windows CI:
```
AssertionFailedError: [process[0].name] expected: "Idle" but was: "sppsvc"
```

**Root cause (a real product bug):** PDH's `ID Process` / `ID Thread` counters use **0 as a sentinel** — for the `_Total` aggregate and any instance whose real ID isn't available yet (a process/thread starting or exiting). The perf-counter map builders key their `Map<Integer,…>` on that value, so a real process/thread momentarily reporting ID 0 gets stored under key `0` and **clobbers** whatever was there. No real Windows PID or TID is 0 (they're drawn from the same client-ID pool, nonzero multiples of 4), so 0 must never be a map key.

## Fix

- **Process map** — skip `pid == 0` in `buildProcessMapFromPerfCounters` **only**. The registry builder is left unchanged: it reliably reports the Idle process at PID 0, and `getProcess(0)` returns that valid "Idle" `OSProcess` (registry is queried first; a process is only marked `INVALID` when its perf-counter block is null, not when WTS data is absent). `getProcesses()` is unaffected (its full-list path already excludes Idle by intersecting with the WTS map). **No API behavior change.**
- **Thread map** — skip `tid == 0` in **both** `buildThreadMapFromPerfCounters` and `buildThreadMapFromRegistry`. The map is keyed by TID; since no real thread has TID 0, and — unlike PID 0/Idle — there is no legitimate TID-0 entry to preserve, both builders drop it.

Both the JNA and FFM drivers delegate to these common methods, so one change covers both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows process performance counter handling to avoid incorrectly using PID `0` for process entries.
  * Prevented occasional conflicts when PDH sentinel values appear during process startup or shutdown.
  * Improved Windows thread performance counter/registry handling to exclude `tid == 0`, avoiding map clobbering of real threads.
  * Updated the unreleased changelog to reflect the Windows perf-counter fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->