### PR TITLE
Fix and clean up CodeQL Code Quality findings (format strings, @Override, null checks)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystem.java
@@ -132,7 +132,7 @@ public class SolarisComputerSystem extends AbstractComputerSystem {
                 break;
             }
             // Based on the smbTypeID we are processing for
-            Integer colonDelimiterIndex = checkLine.indexOf(":");
+            int colonDelimiterIndex = checkLine.indexOf(":");
             if (smbTypeId != null && colonDelimiterIndex >= 0) {
                 String key = checkLine.substring(0, colonDelimiterIndex).trim();
                 String val = checkLine.substring(colonDelimiterIndex + 1).trim();

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxFileSystemTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +48,7 @@ class LinuxFileSystemTest {
                 break;
             }
         }
-        assertThat("Root mount should be present", root != null, is(true));
+        assertNotNull(root, "Root mount should be present");
         assertThat(root.getMount(), is("/"));
         assertThat(root.getType(), is(not(emptyString())));
         assertThat(root.getTotalSpace(), is(greaterThan(0L)));

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/perfmon/PerfmonDisabledFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/perfmon/PerfmonDisabledFFM.java
@@ -44,13 +44,13 @@ public final class PerfmonDisabledFFM {
             Object disabled = Advapi32UtilFFM.registryGetValue(hklm, key, value);
             if (disabled instanceof Integer disabledValue) {
                 if (disabledValue > 0) {
-                    LOG.warn("{} counters are disabled and won't return data: {}\\{}\\{} > 0.", service,
+                    LOG.warn("{} counters are disabled and won't return data: {}\\\\{}\\\\{} > 0.", service,
                             "HKEY_LOCAL_MACHINE", key, value);
                     return true;
                 }
             } else if (disabled != null) {
                 LOG.warn(
-                        "Invalid registry value type detected for {} counters. Should be REG_DWORD. Ignoring: {}\\{}\\{}.",
+                        "Invalid registry value type detected for {} counters. Should be REG_DWORD. Ignoring: {}\\\\{}\\\\{}.",
                         service, "HKEY_LOCAL_MACHINE", key, value);
             }
             return false;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
@@ -150,6 +150,7 @@ public class SystemInfo implements SystemInfoProvider {
      *
      * @return A new platform-specific instance implementing {@link OperatingSystem}.
      */
+    @Override
     public OperatingSystem getOperatingSystem() {
         return os.get();
     }
@@ -159,6 +160,7 @@ public class SystemInfo implements SystemInfoProvider {
      *
      * @return A new platform-specific instance implementing {@link HardwareAbstractionLayer}.
      */
+    @Override
     public HardwareAbstractionLayer getHardware() {
         return hardware.get();
     }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
@@ -371,11 +371,11 @@ public final class Advapi32UtilFFM {
             } finally {
                 int closeRc = RegCloseKey(hKey);
                 if (closeRc != ERROR_SUCCESS) {
-                    LOG.debug("Failed to close registry key {}\\{}: error {}", keyPath, valueName, closeRc);
+                    LOG.debug("Failed to close registry key {}\\\\{}: error {}", keyPath, valueName, closeRc);
                 }
             }
         } catch (Throwable t) {
-            LOG.warn("Failed to read registry string array {}\\{}: {}", keyPath, valueName, t.getMessage());
+            LOG.warn("Failed to read registry string array {}\\\\{}: {}", keyPath, valueName, t.getMessage());
             return new String[0];
         }
     }

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -105,6 +105,7 @@ public class SystemInfo implements SystemInfoProvider {
      *
      * @return A new instance of {@link oshi.software.os.OperatingSystem}.
      */
+    @Override
     public OperatingSystem getOperatingSystem() {
         return os.get();
     }
@@ -140,6 +141,7 @@ public class SystemInfo implements SystemInfoProvider {
      *
      * @return A new instance of {@link oshi.hardware.HardwareAbstractionLayer}.
      */
+    @Override
     public HardwareAbstractionLayer getHardware() {
         return hardware.get();
     }


### PR DESCRIPTION
Triage and fixes from the new CodeQL **Code Quality** (public preview) findings, one commit per finding type. Each is a genuine (if minor) fix — the false-positive-heavy rules were assessed and dismissed separately rather than churned.

## Fixes (10 findings, will auto-resolve on the next scan)

- **`unused-format-argument` (4)** — SLF4J escaped-brace bug. In a Java literal `"\\{}"` is the runtime pattern `\{}`, and SLF4J treats a single backslash before `{}` as an **escape** → it prints a literal `{}` and drops the argument. So registry-path log lines silently dropped their key/value args and printed literal braces (`PerfmonDisabledFFM`, `Advapi32UtilFFM`). Doubled the backslashes so the runtime pattern is `\\{}` (literal `\` + placeholder).
- **`dereferenced-value-may-be-null` (1)** — replaced the awkward `assertThat(root != null, is(true))` with `assertNotNull(root)` in `LinuxFileSystemTest` (cleaner idiom that CodeQL models as a null guard). The two `WhoJNA` findings of this rule are false positives (guarded by `nativeValue(ptr) != 0`, which compiles to a null check) and were dismissed.
- **`non-null-boxed-variable` (1)** — `Integer`→`int` for `colonDelimiterIndex` in `SolarisComputerSystem` (`indexOf` returns a primitive; it's never null).
- **`missing-override-annotation` (4)** — added `@Override` to `SystemInfo.getOperatingSystem()`/`getHardware()` in both `oshi-core` and `oshi-core-ffm`; they implement the `SystemInfoProvider` SPI but were missing the annotation. Compiler-verified.

## Assessed as false positives, dismissed (not in this PR)

- `uncaught-number-format-exception` (10) — all regex-/literal-constrained.
- `evaluation-to-constant` (4) — deliberate uniform `CP_xxx * UINT64_SIZE` offset formula (one still carried a legacy `// lgtm`).
- `dereferenced-value-may-be-null` (2, WhoJNA) — guarded by the null-safe `nativeValue(...) != 0`.
- `useless-null-check` (3, MacCentralProcessorTest stub) — **not actually useless**: the `MacCentralProcessor` super-constructor calls the overridable `sysctlInt()` before the stub's fields are initialized, so the `== null` guard is load-bearing during construction. Dismissed rather than "fixed."

Clean full-reactor build + spotless/checkstyle/forbiddenapis/javadoc pass; oshi-common test suite green.
