### PR TITLE
Make the FFM SystemInfo provider unavailable on Android so the SPI falls back

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/SystemInfo.java
@@ -92,7 +92,10 @@ public class SystemInfo implements SystemInfoProvider {
 
     @Override
     public boolean isAvailable() {
-        return true;
+        // Report unavailable only on Android, where java.lang.foreign is absent (ART), so the SPI falls back to the
+        // JNA/command-line provider. Any other (unsupported) platform stays "available" and errors out in the switch
+        // below rather than silently falling back.
+        return PlatformEnum.getCurrentPlatform() != PlatformEnum.ANDROID;
     }
 
     private static OperatingSystem createOperatingSystem() {
@@ -115,6 +118,10 @@ public class SystemInfo implements SystemInfoProvider {
                 return new SolarisOperatingSystemFFM();
             case AIX:
                 return new AixOperatingSystemFFM();
+            case ANDROID:
+                // Android's ART has no java.lang.foreign; isAvailable() reports this provider unavailable on Android,
+                // so the SPI falls back to the JNA/command-line provider before reaching here.
+                // falls through
             default:
                 throw new UnsupportedOperationException(NOT_SUPPORTED);
         }
@@ -140,6 +147,10 @@ public class SystemInfo implements SystemInfoProvider {
                 return new SolarisHardwareAbstractionLayerFFM();
             case AIX:
                 return new AixHardwareAbstractionLayerFFM();
+            case ANDROID:
+                // Android's ART has no java.lang.foreign; isAvailable() reports this provider unavailable on Android,
+                // so the SPI falls back to the JNA/command-line provider before reaching here.
+                // falls through
             default:
                 throw new UnsupportedOperationException(NOT_SUPPORTED);
         }

--- a/oshi-core-ffm/src/test/java/oshi/ffm/SystemInfoTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/SystemInfoTest.java
@@ -78,6 +78,13 @@ public class SystemInfoTest {
         assertNotNull(new SystemInfo().getHardware());
     }
 
+    @Test
+    void testIsAvailable() {
+        // This suite only runs on JDK 25+ where the FFM API is present, so the provider must report available.
+        assertThat("FFM provider should be available when java.lang.foreign is present", new SystemInfo().isAvailable(),
+                is(true));
+    }
+
     public static void main(String[] args) {
         logger.info("------------------------------------------------------------------------");
         logger.info("Using FFM");


### PR DESCRIPTION
## Problem

The `SystemInfoProvider` SPI selects the highest-priority provider whose `isAvailable()` returns true (FFM = 20, JNA = 10). But `oshi.ffm.SystemInfo.isAvailable()` returned `true` **unconditionally**, so on Android — where `java.lang.foreign` is absent from ART — the FFM provider would be selected over JNA and then fail on the first native call (`NoClassDefFoundError` from the FFM implementations). The SPI interface javadoc already anticipates this ("a provider may be unavailable if required runtime features such as the FFM API are not present"); it just wasn't implemented.

## Fix

- `isAvailable()` now returns false **only** on Android, so the SPI falls back to the JNA/command-line provider there.
- Every other platform stays available — so a genuinely unsupported OS still **errors out** via the switch `default` (`UnsupportedOperationException`) rather than silently falling back.
- Both `createOperatingSystem`/`createHardware` switches now have an explicit `case ANDROID` (falling through to default) documenting the exclusion.
- Added `testIsAvailable` asserting the provider reports available on the FFM-capable test platforms (guards against the check being inverted/broken).

No documentation change (consistent with how NetBSD etc. are handled — the SPI self-selects).

Found via a GitHub AI code-review finding on this file; the other AI finding on the same file (the `static final NOT_SUPPORTED` message) is a non-issue — `getCurrentPlatform()` is constant per-JVM, so eager vs. throw-time evaluation is identical — and was dismissed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform detection so the FFM-based provider now correctly reports as unavailable on Android.
  * Android-specific system and hardware creation now fail with a clear unsupported-platform response instead of being routed through normal paths.

* **Tests**
  * Added coverage to verify the provider reports itself as available in supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->