### PR TITLE
#3430 Declared optional Import-Package instruction in oshi-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#3424](https://github.com/oshi/oshi/pull/3424): Fix `WrongMethodTypeException` when freeing BSTR strings on the Windows FFM WMI path, caused by a void `invokeExact` in an expression lambda inferring an `Object` return - [@dbwiddis](https://github.com/dbwiddis).
 * [#3425](https://github.com/oshi/oshi/pull/3425): Fix the Windows perf-counter process and thread maps occasionally mis-keying a real process/thread under ID 0, when PDH reports its "ID Process"/"ID Thread" sentinel for one that is starting or exiting - [@dbwiddis](https://github.com/dbwiddis).
 * [#3432](https://github.com/oshi/oshi/pull/3432): Replace `Logger#atLevel`/`setCause`/`isEnabledForLevel` usage in `ExceptionUtil`, `PerfDataUtil`, and `ForeignFunctions` with level-switches to the classic SLF4J methods, so oshi no longer requires slf4j-api 2.x at runtime - [@wolfs](https://github.com/wolfs).
+* [#3431](https://github.com/oshi/oshi/pull/3431): Declare the optional jlibrehardwaremonitor OSGi package imports as optional, so oshi-common resolves in OSGi environments that do not provide it - [@MrEasy](https://github.com/MrEasy).
 * Your contribution here!
 
 # 7.3.0 (2026-06-06), 7.3.1 (2026-06-11), 7.3.2 (2026-06-26)

--- a/oshi-common/pom.xml
+++ b/oshi-common/pom.xml
@@ -48,7 +48,7 @@
                 <artifactId>bnd-maven-plugin</artifactId>
                 <configuration>
                     <bnd><![CDATA[Export-Package: oshi.*;-noimport:=true
-                    Import-Package: ${osgi.slf4j.import.packages}, *
+                    Import-Package: io.github.pandalxb.jlibrehardwaremonitor.*;resolution:=optional, ${osgi.slf4j.import.packages}, *
                     Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                     -snapshot: SNAPSHOT]]></bnd>
                 </configuration>

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -155,7 +155,7 @@
                 <artifactId>bnd-maven-plugin</artifactId>
                 <configuration>
                     <bnd><![CDATA[Export-Package: oshi,oshi.jna.*,!oshi.driver.common.*,!oshi.driver.unix.bsd.*,!oshi.driver.unix.freebsd.disk.*,!oshi.driver.unix.solaris.disk.*,oshi.driver.*,oshi.hardware.platform.*,!oshi.software.common.*,oshi.software.os.linux.*,oshi.software.os.mac.*,oshi.software.os.unix.*,oshi.software.os.windows.*,oshi.util.gpu.*,oshi.util.platform.*;-noimport:=true
-                    Import-Package: io.github.pandalxb.jlibrehardwaremonitor.*;resolution:=optional, ${osgi.slf4j.import.packages}, *
+                    Import-Package: ${osgi.slf4j.import.packages}, *
                     Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                     -snapshot: SNAPSHOT]]></bnd>
                 </configuration>


### PR DESCRIPTION
Moved from oshi-core where now unused

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OSGi compatibility so the shared module can resolve even when an external hardware-monitoring package is not available.
  * Adjusted package import handling to avoid runtime resolution issues in environments that don’t provide that optional dependency.

* **Chores**
  * Updated the changelog with this improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->