### PR TITLE
Avoid SLF4J 2-only Logger API in logging helpers

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,6 +38,8 @@ jobs:
         run: ./mvnw forbiddenapis:check forbiddenapis:testCheck
       - name: Javadoc
         run: ./mvnw javadoc:javadoc -DskipTests
+      - name: Verify SLF4J 1.7 API compatibility
+        run: ./mvnw -Pverify-slf4j-17 clean compile
 
   test:
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * [#3424](https://github.com/oshi/oshi/pull/3424): Fix `WrongMethodTypeException` when freeing BSTR strings on the Windows FFM WMI path, caused by a void `invokeExact` in an expression lambda inferring an `Object` return - [@dbwiddis](https://github.com/dbwiddis).
 * [#3425](https://github.com/oshi/oshi/pull/3425): Fix the Windows perf-counter process and thread maps occasionally mis-keying a real process/thread under ID 0, when PDH reports its "ID Process"/"ID Thread" sentinel for one that is starting or exiting - [@dbwiddis](https://github.com/dbwiddis).
+* [#3432](https://github.com/oshi/oshi/pull/3432): Replace `Logger#atLevel`/`setCause`/`isEnabledForLevel` usage in `ExceptionUtil`, `PerfDataUtil`, and `ForeignFunctions` with level-switches to the classic SLF4J methods, so oshi no longer requires slf4j-api 2.x at runtime - [@wolfs](https://github.com/wolfs).
 * Your contribution here!
 
 # 7.3.0 (2026-06-06), 7.3.1 (2026-06-11), 7.3.2 (2026-06-26)

--- a/oshi-common/src/main/java/oshi/util/ExceptionUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ExceptionUtil.java
@@ -24,6 +24,37 @@ public final class ExceptionUtil {
     }
 
     /**
+     * Logs a throwable at the given level using only SLF4J 1.x-compatible {@link Logger} methods (no {@code atLevel}
+     * fluent API). Relies on SLF4J's implicit-cause handling: when the last of the extra arguments is a
+     * {@link Throwable}, it is attached as the log event's cause rather than substituted into the format string.
+     *
+     * @param log   the logger to use
+     * @param level the level at which to log
+     * @param msg   the log message (use {} for the exception message placeholder)
+     * @param t     the throwable to log
+     */
+    private static void logAtLevel(Logger log, Level level, String msg, Throwable t) {
+        switch (level) {
+            case ERROR:
+                log.error(msg, t.getMessage(), t);
+                break;
+            case WARN:
+                log.warn(msg, t.getMessage(), t);
+                break;
+            case INFO:
+                log.info(msg, t.getMessage(), t);
+                break;
+            case TRACE:
+                log.trace(msg, t.getMessage(), t);
+                break;
+            case DEBUG:
+            default:
+                log.debug(msg, t.getMessage(), t);
+                break;
+        }
+    }
+
+    /**
      * A supplier that may throw any {@link Throwable}, including checked exceptions.
      *
      * @param <T> the type of result supplied
@@ -156,7 +187,7 @@ public final class ExceptionUtil {
         try {
             return supplier.get();
         } catch (Throwable t) {
-            log.atLevel(level).setCause(t).log(msg, t.getMessage());
+            logAtLevel(log, level, msg, t);
             return defaultValue;
         }
     }
@@ -206,7 +237,7 @@ public final class ExceptionUtil {
         try {
             return supplier.getAsInt();
         } catch (Throwable t) {
-            log.atLevel(level).setCause(t).log(msg, t.getMessage());
+            logAtLevel(log, level, msg, t);
             return defaultValue;
         }
     }
@@ -256,7 +287,7 @@ public final class ExceptionUtil {
         try {
             return supplier.getAsLong();
         } catch (Throwable t) {
-            log.atLevel(level).setCause(t).log(msg, t.getMessage());
+            logAtLevel(log, level, msg, t);
             return defaultValue;
         }
     }
@@ -307,7 +338,7 @@ public final class ExceptionUtil {
         try {
             return supplier.getAsBoolean();
         } catch (Throwable t) {
-            log.atLevel(level).setCause(t).log(msg, t.getMessage());
+            logAtLevel(log, level, msg, t);
             return defaultValue;
         }
     }
@@ -358,7 +389,7 @@ public final class ExceptionUtil {
         try {
             return supplier.getAsDouble();
         } catch (Throwable t) {
-            log.atLevel(level).setCause(t).log(msg, t.getMessage());
+            logAtLevel(log, level, msg, t);
             return defaultValue;
         }
     }
@@ -391,7 +422,7 @@ public final class ExceptionUtil {
         try {
             return Optional.ofNullable(supplier.get());
         } catch (Throwable t) {
-            log.atLevel(level).setCause(t).log(msg, t.getMessage());
+            logAtLevel(log, level, msg, t);
             return Optional.empty();
         }
     }
@@ -423,7 +454,7 @@ public final class ExceptionUtil {
         try {
             return OptionalInt.of(supplier.getAsInt());
         } catch (Throwable t) {
-            log.atLevel(level).setCause(t).log(msg, t.getMessage());
+            logAtLevel(log, level, msg, t);
             return OptionalInt.empty();
         }
     }
@@ -455,7 +486,7 @@ public final class ExceptionUtil {
         try {
             return OptionalLong.of(supplier.getAsLong());
         } catch (Throwable t) {
-            log.atLevel(level).setCause(t).log(msg, t.getMessage());
+            logAtLevel(log, level, msg, t);
             return OptionalLong.empty();
         }
     }
@@ -496,7 +527,7 @@ public final class ExceptionUtil {
         try {
             runnable.run();
         } catch (Throwable t) {
-            log.atLevel(level).setCause(t).log(msg, t.getMessage());
+            logAtLevel(log, level, msg, t);
         }
     }
 }

--- a/oshi-common/src/main/java/oshi/util/ExceptionUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ExceptionUtil.java
@@ -27,13 +27,15 @@ public final class ExceptionUtil {
      * Logs a throwable at the given level using only SLF4J 1.x-compatible {@link Logger} methods (no {@code atLevel}
      * fluent API). Relies on SLF4J's implicit-cause handling: when the last of the extra arguments is a
      * {@link Throwable}, it is attached as the log event's cause rather than substituted into the format string.
+     * <p>
+     * Public so other modules (e.g., {@code oshi-core-ffm}) can share this dispatch instead of duplicating it.
      *
      * @param log   the logger to use
      * @param level the level at which to log
      * @param msg   the log message (use {} for the exception message placeholder)
      * @param t     the throwable to log
      */
-    private static void logAtLevel(Logger log, Level level, String msg, Throwable t) {
+    public static void logAtLevel(Logger log, Level level, String msg, Throwable t) {
         switch (level) {
             case ERROR:
                 log.error(msg, t.getMessage(), t);

--- a/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
@@ -381,4 +381,14 @@ class ExceptionUtilTest {
         String result = ExceptionUtil.getOrDefault(() -> "ok", "fallback", LOG, Level.WARN, "Should not log");
         assertThat(result, is(equalTo("ok")));
     }
+
+    @Test
+    void testLogsAndReturnsDefaultAtEveryLevel() {
+        for (Level level : Level.values()) {
+            String result = ExceptionUtil.getOrDefault(() -> {
+                throw new IllegalStateException("boom");
+            }, "no exception", LOG, level, "failed: {}");
+            assertThat(result, is("no exception"));
+        }
+    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -22,6 +22,8 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
+import oshi.util.ExceptionUtil;
+
 /**
  * Base class providing utility methods for working with the Java Foreign Function and Memory (FFM) API.
  * <p>
@@ -484,24 +486,6 @@ public abstract class ForeignFunctions {
     private static void logThrowable(Logger logger, Level level, String message, Throwable t) {
         Objects.requireNonNull(logger, "logger");
         Objects.requireNonNull(level, "level");
-        String format = message + ": {}";
-        switch (level) {
-            case ERROR:
-                logger.error(format, t.getMessage(), t);
-                break;
-            case WARN:
-                logger.warn(format, t.getMessage(), t);
-                break;
-            case INFO:
-                logger.info(format, t.getMessage(), t);
-                break;
-            case TRACE:
-                logger.trace(format, t.getMessage(), t);
-                break;
-            case DEBUG:
-            default:
-                logger.debug(format, t.getMessage(), t);
-                break;
-        }
+        ExceptionUtil.logAtLevel(logger, level, message + ": {}", t);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -484,6 +484,24 @@ public abstract class ForeignFunctions {
     private static void logThrowable(Logger logger, Level level, String message, Throwable t) {
         Objects.requireNonNull(logger, "logger");
         Objects.requireNonNull(level, "level");
-        logger.atLevel(level).setCause(t).log(message + ": {}", t.getMessage());
+        String format = message + ": {}";
+        switch (level) {
+            case ERROR:
+                logger.error(format, t.getMessage(), t);
+                break;
+            case WARN:
+                logger.warn(format, t.getMessage(), t);
+                break;
+            case INFO:
+                logger.info(format, t.getMessage(), t);
+                break;
+            case TRACE:
+                logger.trace(format, t.getMessage(), t);
+                break;
+            case DEBUG:
+            default:
+                logger.debug(format, t.getMessage(), t);
+                break;
+        }
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
@@ -158,46 +158,38 @@ public final class PerfDataUtil {
         return WinError.ERROR_SUCCESS == PDH.PdhRemoveCounter(p.getValue());
     }
 
-    private static boolean isEnabled(Level level) {
-        switch (level) {
-            case ERROR:
-                return LOG.isErrorEnabled();
-            case WARN:
-                return LOG.isWarnEnabled();
-            case INFO:
-                return LOG.isInfoEnabled();
-            case TRACE:
-                return LOG.isTraceEnabled();
-            case DEBUG:
-            default:
-                return LOG.isDebugEnabled();
-        }
-    }
-
-    private static void logAtLevel(Level level, String format, Object... args) {
-        switch (level) {
-            case ERROR:
-                LOG.error(format, args);
-                break;
-            case WARN:
-                LOG.warn(format, args);
-                break;
-            case INFO:
-                LOG.info(format, args);
-                break;
-            case TRACE:
-                LOG.trace(format, args);
-                break;
-            case DEBUG:
-            default:
-                LOG.debug(format, args);
-                break;
-        }
+    private static String formatErrorMessage(String message, int ret) {
+        return message + " Error code: " + String.format(Locale.ROOT, FormatUtil.formatError(ret));
     }
 
     static <T> T handleError(int ret, Level level, String message, T defaultValue) {
-        if (isEnabled(level)) {
-            logAtLevel(level, "{} Error code: {}", message, String.format(Locale.ROOT, FormatUtil.formatError(ret)));
+        switch (level) {
+            case ERROR:
+                if (LOG.isErrorEnabled()) {
+                    LOG.error(formatErrorMessage(message, ret));
+                }
+                break;
+            case WARN:
+                if (LOG.isWarnEnabled()) {
+                    LOG.warn(formatErrorMessage(message, ret));
+                }
+                break;
+            case INFO:
+                if (LOG.isInfoEnabled()) {
+                    LOG.info(formatErrorMessage(message, ret));
+                }
+                break;
+            case TRACE:
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace(formatErrorMessage(message, ret));
+                }
+                break;
+            case DEBUG:
+            default:
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(formatErrorMessage(message, ret));
+                }
+                break;
         }
         return defaultValue;
     }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
@@ -158,11 +158,29 @@ public final class PerfDataUtil {
         return WinError.ERROR_SUCCESS == PDH.PdhRemoveCounter(p.getValue());
     }
 
-    static <T> T handleError(int ret, Level level, String message, T defaultValue) {
-        if (LOG.isEnabledForLevel(level)) {
-            LOG.atLevel(level).log("{} Error code: {}", message,
-                    String.format(Locale.ROOT, FormatUtil.formatError(ret)));
+    private static void logAtLevel(Level level, String format, Object... args) {
+        switch (level) {
+            case ERROR:
+                LOG.error(format, args);
+                break;
+            case WARN:
+                LOG.warn(format, args);
+                break;
+            case INFO:
+                LOG.info(format, args);
+                break;
+            case TRACE:
+                LOG.trace(format, args);
+                break;
+            case DEBUG:
+            default:
+                LOG.debug(format, args);
+                break;
         }
+    }
+
+    static <T> T handleError(int ret, Level level, String message, T defaultValue) {
+        logAtLevel(level, "{} Error code: {}", message, String.format(Locale.ROOT, FormatUtil.formatError(ret)));
         return defaultValue;
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
@@ -158,6 +158,22 @@ public final class PerfDataUtil {
         return WinError.ERROR_SUCCESS == PDH.PdhRemoveCounter(p.getValue());
     }
 
+    private static boolean isEnabled(Level level) {
+        switch (level) {
+            case ERROR:
+                return LOG.isErrorEnabled();
+            case WARN:
+                return LOG.isWarnEnabled();
+            case INFO:
+                return LOG.isInfoEnabled();
+            case TRACE:
+                return LOG.isTraceEnabled();
+            case DEBUG:
+            default:
+                return LOG.isDebugEnabled();
+        }
+    }
+
     private static void logAtLevel(Level level, String format, Object... args) {
         switch (level) {
             case ERROR:
@@ -180,7 +196,9 @@ public final class PerfDataUtil {
     }
 
     static <T> T handleError(int ret, Level level, String message, T defaultValue) {
-        logAtLevel(level, "{} Error code: {}", message, String.format(Locale.ROOT, FormatUtil.formatError(ret)));
+        if (isEnabled(level)) {
+            logAtLevel(level, "{} Error code: {}", message, String.format(Locale.ROOT, FormatUtil.formatError(ret)));
+        }
         return defaultValue;
     }
 }

--- a/oshi-core/src/test/java/oshi/util/platform/windows/PerfDataUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/windows/PerfDataUtilTest.java
@@ -12,6 +12,7 @@ import static org.slf4j.event.Level.WARN;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.slf4j.event.Level;
 
 import com.sun.jna.platform.win32.PdhMsg;
 
@@ -34,5 +35,12 @@ class PerfDataUtilTest {
     void testHandleErrorStringDefault() {
         assertThat(PerfDataUtil.handleError(PdhMsg.PDH_INVALID_HANDLE, WARN, "Failed to get counter.", "default"),
                 is("default"));
+    }
+
+    @Test
+    void testHandleErrorAtEveryLevel() {
+        for (Level level : Level.values()) {
+            assertThat(PerfDataUtil.handleError(PdhMsg.PDH_INVALID_HANDLE, level, "Failed.", "default"), is("default"));
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1136,6 +1136,16 @@
                 <module>oshi-dist</module>
             </modules>
         </profile>
+        <!-- Compiles against the oldest supported SLF4J 1.x API to catch accidental
+             use of SLF4J 2.0-only Logger methods (atLevel, isEnabledForLevel, etc.)
+             that would break consumers pinning an older slf4j-api on the runtime
+             classpath. Use: mvnw -Pverify-slf4j-17 clean compile -->
+        <profile>
+            <id>verify-slf4j-17</id>
+            <properties>
+                <slf4j.version>1.7.36</slf4j.version>
+            </properties>
+        </profile>
         <profile>
             <!-- Activates oshi-benchmark tests and aggregate JaCoCo report.
                  Use: mvnw test -Paggregate-coverage

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         property in their POM -->
         <jna.version>5.19.1</jna.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <osgi.slf4j.import.packages>org.slf4j;version="[1.7,3.0)"</osgi.slf4j.import.packages>
+        <osgi.slf4j.import.packages>org.slf4j;version="[1.7,3.0)",org.slf4j.event;version="[1.7,3.0)"</osgi.slf4j.import.packages>
         <junit.version>6.1.1</junit.version>
         <!-- JUnit parallel-execution config; overridable per CI run (see OpenIndiana). -->
         <junit.parallel.executor-service>WORKER_THREAD_POOL</junit.parallel.executor-service>


### PR DESCRIPTION
oshi compiles against slf4j-api 2.x, and `ExceptionUtil`, `PerfDataUtil#handleError`, and `ForeignFunctions#logThrowable` call `Logger#atLevel/setCause` and `isEnabledForLevel`, which don't exist in slf4j-api 1.x. Consumers embedded in tooling that still pins an older slf4j-api 1.x on the runtime classpath — some Gradle and Maven versions, for example — hit a NoSuchMethodError.

We currently use oshi for Gradle plugins / Maven extensions and want to support those older versions. I think the change is low-cost and allows using oshi in more situations.

This PR replaces those calls with a level-switch to the classic error/warn/info/debug/ trace methods, which are identical in 1.x and 2.x. Log output doesn't change: a trailing Throwable is still attached as the log event's cause via SLF4J's implicit-cause handling, and PerfDataUtil still skips formatting the error message when the level is disabled.

No change to the slf4j.version build dependency — this only drops the compile-time dependency on API introduced in 2.x. Though I am open to change the compile time API to slf4j 1.x to make sure this is not changed again incidentally.

Tested: `mvn test` passes in oshi-common and oshi-core. Verified the replacement call pattern compiles against both slf4j-api 1.7.36 and 2.0.18 and produces identical log output in both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception, foreign-function, and Windows performance-data error logging consistency by switching from `atLevel/setCause` usage to classic SLF4J level-specific logging.
  * Added a shared helper to log exceptions reliably across all supported log levels.
* **Tests**
  * Expanded unit coverage to verify default return behavior and error handling across every log level.
* **Chores / CI**
  * Added a build check to compile against an older SLF4J API for compatibility.
* **Documentation**
  * Updated the 7.4.0 (in progress) changelog with the logging compatibility improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->