### PR TITLE
Restore optional JNA native access for NetBSD with command-line fallback

### DIFF
--- a/.github/workflows/unix.yaml
+++ b/.github/workflows/unix.yaml
@@ -147,9 +147,10 @@ jobs:
             mount -t procfs procfs /proc 2>/dev/null || true
             ./mvnw clean test -B -Djacoco.skip=true
 
-  # Runs on NetBSD 10.1 x86 VM without JNA native library
+  # Runs on NetBSD 10.1 x86 VM WITHOUT the JNA native library (java-jna not installed), exercising the
+  # command-line fallback path (NetBsdSysctlUtil.JNA_AVAILABLE == false).
   testnetbsd:
-    name: Test JDK 21, NetBSD
+    name: Test JDK 21, NetBSD (no JNA)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -167,5 +168,31 @@ jobs:
           run: |
             export JAVA_HOME=/usr/pkg/java/openjdk21
             export PATH=$JAVA_HOME/bin:$PATH
+            mount -t procfs procfs /proc 2>/dev/null || true
+            ./mvnw clean test -B -Djacoco.skip=true
+
+  # Runs on NetBSD 10.1 x86 VM WITH the JNA native library (pkgsrc java-jna), exercising the native path
+  # (NetBsdSysctlUtil.JNA_AVAILABLE == true). jna.boot.library.path points JNA at the pkgsrc libjnidispatch.
+  testnetbsdjna:
+    name: Test JDK 21, NetBSD (JNA)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Test in NetBSD
+        id: test-netbsd-jna
+        uses: vmactions/netbsd-vm@1d9767765fd3f986e6de3aff4b1148f0c3a45f01 # v1
+        with:
+          release: "10.1"
+          usesh: true
+          prepare: |
+            pkg_add curl
+            pkg_add openjdk21
+            pkg_add java-jna
+          run: |
+            export JAVA_HOME=/usr/pkg/java/openjdk21
+            export PATH=$JAVA_HOME/bin:$PATH
+            export JAVA_TOOL_OPTIONS="-Djna.boot.library.path=/usr/pkg/lib"
             mount -t procfs procfs /proc 2>/dev/null || true
             ./mvnw clean test -B -Djacoco.skip=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#3425](https://github.com/oshi/oshi/pull/3425): Fix the Windows perf-counter process and thread maps occasionally mis-keying a real process/thread under ID 0, when PDH reports its "ID Process"/"ID Thread" sentinel for one that is starting or exiting - [@dbwiddis](https://github.com/dbwiddis).
 * [#3432](https://github.com/oshi/oshi/pull/3432): Replace `Logger#atLevel`/`setCause`/`isEnabledForLevel` usage in `ExceptionUtil`, `PerfDataUtil`, and `ForeignFunctions` with level-switches to the classic SLF4J methods, so oshi no longer requires slf4j-api 2.x at runtime - [@wolfs](https://github.com/wolfs).
 * [#3431](https://github.com/oshi/oshi/pull/3431): Declare the optional jlibrehardwaremonitor OSGi package imports as optional, so oshi-common resolves in OSGi environments that do not provide it - [@MrEasy](https://github.com/MrEasy).
+* [#3433](https://github.com/oshi/oshi/pull/3433): Restore optional JNA native access for NetBSD, falling back to the command-line implementation when the JNA native library is not installed - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 
 # 7.3.0 (2026-06-06), 7.3.1 (2026-06-11), 7.3.2 (2026-06-26)

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHardwareAbstractionLayer.java
@@ -32,7 +32,7 @@ import oshi.hardware.common.platform.unix.UnixDisplay;
  * NetBsdHardwareAbstractionLayer class.
  */
 @ThreadSafe
-public final class NetBsdHardwareAbstractionLayer extends AbstractHardwareAbstractionLayer {
+public class NetBsdHardwareAbstractionLayer extends AbstractHardwareAbstractionLayer {
 
     @Override
     public ComputerSystem createComputerSystem() {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -59,7 +59,7 @@ public class NetBsdOSProcess extends BsdOSProcess {
     public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
-    private final NetBsdOperatingSystem os;
+    protected final NetBsdOperatingSystem os;
 
     public NetBsdOSProcess(int pid, Map<BsdPsKeyword, String> psMap, NetBsdOperatingSystem os) {
         super(pid);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
@@ -80,11 +80,23 @@ public class NetBsdOperatingSystem extends BsdOperatingSystem {
                     proc.trim(), ' ');
             // Check if last (thus all) value populated
             if (psMap.containsKey(BsdPsKeyword.ARGS)) {
-                procs.add(new NetBsdOSProcess(
-                        pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid, psMap, this));
+                procs.add(createProcess(pid < 0 ? ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PID), 0) : pid,
+                        psMap));
             }
         }
         return procs;
+    }
+
+    /**
+     * Creates a process object from parsed {@code ps} output. Overridden by the JNA subclass to return a native-capable
+     * {@link NetBsdOSProcess} implementation.
+     *
+     * @param pid   the process ID
+     * @param psMap the parsed {@code ps} columns for the process
+     * @return a new {@link OSProcess}
+     */
+    protected OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap) {
+        return new NetBsdOSProcess(pid, psMap, this);
     }
 
     @Override

--- a/oshi-core/src/main/java/module-info.java
+++ b/oshi-core/src/main/java/module-info.java
@@ -23,6 +23,7 @@ module com.github.oshi {
     exports oshi.util.gpu;
     exports oshi.util.platform.mac;
     exports oshi.util.platform.unix.freebsd;
+    exports oshi.util.platform.unix.netbsd;
     exports oshi.util.platform.unix.openbsd;
     exports oshi.util.platform.unix.solaris;
     exports oshi.util.platform.windows;

--- a/oshi-core/src/main/java/oshi/SystemInfo.java
+++ b/oshi-core/src/main/java/oshi/SystemInfo.java
@@ -10,22 +10,22 @@ import java.util.function.Supplier;
 
 import oshi.annotation.PublicApi;
 import oshi.hardware.HardwareAbstractionLayer;
-import oshi.hardware.common.platform.unix.netbsd.NetBsdHardwareAbstractionLayer;
 import oshi.hardware.platform.linux.LinuxHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.mac.MacHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.aix.AixHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.dragonflybsd.DragonFlyBsdHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.freebsd.FreeBsdHardwareAbstractionLayerJNA;
+import oshi.hardware.platform.unix.netbsd.NetBsdHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.openbsd.OpenBsdHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.unix.solaris.SolarisHardwareAbstractionLayerJNA;
 import oshi.hardware.platform.windows.WindowsHardwareAbstractionLayerJNA;
-import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem;
 import oshi.software.os.OperatingSystem;
 import oshi.software.os.linux.LinuxOperatingSystemJNA;
 import oshi.software.os.mac.MacOperatingSystemJNA;
 import oshi.software.os.unix.aix.AixOperatingSystemJNA;
 import oshi.software.os.unix.dragonflybsd.DragonFlyBsdOperatingSystemJNA;
 import oshi.software.os.unix.freebsd.FreeBsdOperatingSystemJNA;
+import oshi.software.os.unix.netbsd.NetBsdOperatingSystemJNA;
 import oshi.software.os.unix.openbsd.OpenBsdOperatingSystemJNA;
 import oshi.software.os.unix.solaris.SolarisOperatingSystemJNA;
 import oshi.software.os.windows.WindowsOperatingSystemJNA;
@@ -130,7 +130,7 @@ public class SystemInfo implements SystemInfoProvider {
             case DRAGONFLYBSD:
                 return new DragonFlyBsdOperatingSystemJNA();
             case NETBSD:
-                return new NetBsdOperatingSystem();
+                return new NetBsdOperatingSystemJNA();
             default:
                 throw new UnsupportedOperationException(NOT_SUPPORTED + PlatformEnum.getCurrentPlatform().getName());
         }
@@ -166,7 +166,7 @@ public class SystemInfo implements SystemInfoProvider {
             case DRAGONFLYBSD:
                 return new DragonFlyBsdHardwareAbstractionLayerJNA();
             case NETBSD:
-                return new NetBsdHardwareAbstractionLayer();
+                return new NetBsdHardwareAbstractionLayerJNA();
             default:
                 throw new UnsupportedOperationException(NOT_SUPPORTED + PlatformEnum.getCurrentPlatform().getName());
         }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdCentralProcessorJNA.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.netbsd;
+
+import static oshi.jna.platform.unix.NetBsdLibc.CPUSTATES;
+import static oshi.jna.platform.unix.NetBsdLibc.CP_IDLE;
+import static oshi.jna.platform.unix.NetBsdLibc.CP_INTR;
+import static oshi.jna.platform.unix.NetBsdLibc.CP_NICE;
+import static oshi.jna.platform.unix.NetBsdLibc.CP_SYS;
+import static oshi.jna.platform.unix.NetBsdLibc.CP_USER;
+import static oshi.jna.platform.unix.NetBsdLibc.CTL_KERN;
+import static oshi.jna.platform.unix.NetBsdLibc.KERN_CP_TIME;
+
+import java.util.Arrays;
+
+import com.sun.jna.Memory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.common.platform.unix.netbsd.NetBsdCentralProcessor;
+import oshi.jna.platform.unix.NetBsdLibc;
+import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
+
+/**
+ * A CentralProcessor for NetBSD that uses JNA native sysctl calls when the JNA native library is available, falling
+ * back to the command-line {@link NetBsdCentralProcessor} implementation otherwise.
+ */
+@ThreadSafe
+public class NetBsdCentralProcessorJNA extends NetBsdCentralProcessor {
+
+    @Override
+    protected long[] querySystemCpuLoadTicks() {
+        if (!NetBsdSysctlUtil.JNA_AVAILABLE) {
+            return super.querySystemCpuLoadTicks();
+        }
+        long[] ticks = new long[TickType.values().length];
+        int[] mib = { CTL_KERN, KERN_CP_TIME };
+        try (Memory m = NetBsdSysctlUtil.sysctl(mib)) {
+            if (m != null) {
+                long[] cpuTicks = cpTimeToTicks(m);
+                if (cpuTicks.length >= CPUSTATES) {
+                    ticks[TickType.USER.getIndex()] = cpuTicks[CP_USER];
+                    ticks[TickType.NICE.getIndex()] = cpuTicks[CP_NICE];
+                    ticks[TickType.SYSTEM.getIndex()] = cpuTicks[CP_SYS];
+                    ticks[TickType.IRQ.getIndex()] = cpuTicks[CP_INTR];
+                    ticks[TickType.IDLE.getIndex()] = cpuTicks[CP_IDLE];
+                }
+            }
+        }
+        return ticks;
+    }
+
+    @Override
+    protected long[][] queryProcessorCpuLoadTicks() {
+        if (!NetBsdSysctlUtil.JNA_AVAILABLE) {
+            return super.queryProcessorCpuLoadTicks();
+        }
+        long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
+        // On NetBSD, kern.cp_time with a third MIB element gives per-CPU data
+        int[] mib = { CTL_KERN, KERN_CP_TIME, 0 };
+        for (int cpu = 0; cpu < getLogicalProcessorCount(); cpu++) {
+            mib[2] = cpu;
+            try (Memory m = NetBsdSysctlUtil.sysctl(mib)) {
+                if (m != null) {
+                    long[] cpuTicks = cpTimeToTicks(m);
+                    if (cpuTicks.length >= CPUSTATES) {
+                        ticks[cpu][TickType.USER.getIndex()] = cpuTicks[CP_USER];
+                        ticks[cpu][TickType.NICE.getIndex()] = cpuTicks[CP_NICE];
+                        ticks[cpu][TickType.SYSTEM.getIndex()] = cpuTicks[CP_SYS];
+                        ticks[cpu][TickType.IRQ.getIndex()] = cpuTicks[CP_INTR];
+                        ticks[cpu][TickType.IDLE.getIndex()] = cpuTicks[CP_IDLE];
+                    }
+                }
+            }
+        }
+        return ticks;
+    }
+
+    /**
+     * Parse memory buffer returned from sysctl kern.cp_time to an array of longs representing CPU states.
+     *
+     * @param m A buffer containing the array of 64-bit values.
+     * @return The array
+     */
+    private static long[] cpTimeToTicks(Memory m) {
+        int arraySize = (int) (m.size() / 8L);
+        return m.getLongArray(0, arraySize);
+    }
+
+    @Override
+    public double[] getSystemLoadAverage(int nelem) {
+        if (!NetBsdSysctlUtil.JNA_AVAILABLE) {
+            return super.getSystemLoadAverage(nelem);
+        }
+        if (nelem < 1 || nelem > 3) {
+            throw new IllegalArgumentException("Must include from one to three elements.");
+        }
+        double[] average = new double[nelem];
+        int retval = NetBsdLibc.INSTANCE.getloadavg(average, nelem);
+        if (retval < nelem) {
+            Arrays.fill(average, -1d);
+        }
+        return average;
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/NetBsdHardwareAbstractionLayerJNA.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.netbsd;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.common.platform.unix.netbsd.NetBsdHardwareAbstractionLayer;
+
+/**
+ * A HardwareAbstractionLayer for NetBSD that supplies the JNA-capable {@link NetBsdCentralProcessorJNA}. All other
+ * hardware components are native-free and inherited unchanged from {@link NetBsdHardwareAbstractionLayer}.
+ */
+@ThreadSafe
+public final class NetBsdHardwareAbstractionLayerJNA extends NetBsdHardwareAbstractionLayer {
+
+    @Override
+    public CentralProcessor createProcessor() {
+        return new NetBsdCentralProcessorJNA();
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/package-info.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/netbsd/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides JNA-based hardware implementations for NetBSD.
+ */
+package oshi.hardware.platform.unix.netbsd;

--- a/oshi-core/src/main/java/oshi/jna/platform/unix/NetBsdLibc.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/unix/NetBsdLibc.java
@@ -60,6 +60,13 @@ public interface NetBsdLibc extends CLibrary {
     }
 
     /**
+     * NetBSD's {@code RLIMIT_NOFILE} from {@code <sys/resource.h>} is 8, not 7 like Linux. JNA's inherited
+     * {@code Resource.RLIMIT_NOFILE} from the platform module is the Linux value, so calling
+     * {@code getrlimit(Resource.RLIMIT_NOFILE, …)} on NetBSD would query the wrong resource.
+     */
+    int RLIMIT_NOFILE = 8;
+
+    /**
      * Returns the LWP (lightweight process/thread) ID of the calling thread.
      *
      * @return the LWP ID of the calling thread.

--- a/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdOSProcessJNA.java
@@ -22,6 +22,7 @@ import oshi.jna.platform.unix.NetBsdLibc;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.netbsd.NetBsdOSProcess;
 import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem;
+import oshi.util.ParseUtil;
 import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
 
 /**
@@ -94,19 +95,15 @@ public class NetBsdOSProcessJNA extends NetBsdOSProcess {
         int[] mib = { NetBsdLibc.CTL_KERN, KERN_PROC_ARGS, getProcessID(), KERN_PROC_ENV };
         try (Memory m = new Memory(ARGMAX); CloseableSizeTByReference size = new CloseableSizeTByReference(ARGMAX)) {
             if (NetBsdLibc.INSTANCE.sysctl(mib, mib.length, m, size, null, size_t.ZERO) == 0) {
+                // The payload is a NUL-delimited byte buffer of KEY=VALUE entries. Parse by raw bytes rather than
+                // Memory.getString/String.length, which would misalign the offset on a multibyte charset.
+                byte[] envBytes = m.getByteArray(0, (int) size.getValue().longValue());
                 Map<String, String> env = new LinkedHashMap<>();
-                long bytesReturned = size.getValue().longValue();
-                long offset = 0;
-                while (offset < bytesReturned) {
-                    String envStr = m.getString(offset);
-                    if (envStr.isEmpty()) {
-                        break;
-                    }
+                for (String envStr : ParseUtil.parseByteArrayToStrings(envBytes)) {
                     int idx = envStr.indexOf('=');
                     if (idx > 0) {
                         env.put(envStr.substring(0, idx), envStr.substring(idx + 1));
                     }
-                    offset += envStr.length() + 1;
                 }
                 if (!env.isEmpty()) {
                     return Collections.unmodifiableMap(env);

--- a/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdOSProcessJNA.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.unix.netbsd;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.platform.unix.LibCAPI.size_t;
+import com.sun.jna.platform.unix.Resource;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.jna.ByRef.CloseableSizeTByReference;
+import oshi.jna.platform.unix.NetBsdLibc;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.common.os.unix.netbsd.NetBsdOSProcess;
+import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem;
+import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
+
+/**
+ * An OSProcess for NetBSD that uses JNA native calls for the process open-file limits ({@code getrlimit}) and for
+ * reading the environment of other processes ({@code kern.proc_args}) when the JNA native library is available, and
+ * falls back to the command-line {@link NetBsdOSProcess} implementation otherwise.
+ */
+@ThreadSafe
+public class NetBsdOSProcessJNA extends NetBsdOSProcess {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NetBsdOSProcessJNA.class);
+
+    // KERN_PROC_ARGS sysctl selectors from <sys/sysctl.h>
+    private static final int KERN_PROC_ARGS = 48;
+    private static final int KERN_PROC_ENV = 3;
+
+    // Maximum size of process argument/environment data (kern.argmax); 0 if JNA or the call is unavailable.
+    private static final int ARGMAX;
+    static {
+        int argmax = 0;
+        if (NetBsdSysctlUtil.JNA_AVAILABLE) {
+            int[] mib = { NetBsdLibc.CTL_KERN, NetBsdLibc.KERN_ARGMAX };
+            try (Memory m = new Memory(Integer.BYTES);
+                    CloseableSizeTByReference size = new CloseableSizeTByReference(Integer.BYTES)) {
+                if (NetBsdLibc.INSTANCE.sysctl(mib, mib.length, m, size, null, size_t.ZERO) == 0) {
+                    argmax = m.getInt(0);
+                } else {
+                    LOG.warn("Failed sysctl call for kern.argmax. Error code: {}", Native.getLastError());
+                }
+            }
+        }
+        ARGMAX = argmax;
+    }
+
+    public NetBsdOSProcessJNA(int pid, Map<BsdPsKeyword, String> psMap, NetBsdOperatingSystem os) {
+        super(pid, psMap, os);
+    }
+
+    @Override
+    public long getSoftOpenFileLimit() {
+        // getrlimit only reports limits for the calling (current) process
+        if (!NetBsdSysctlUtil.JNA_AVAILABLE || getProcessID() != this.os.getProcessId()) {
+            return super.getSoftOpenFileLimit();
+        }
+        Resource.Rlimit rlimit = new Resource.Rlimit();
+        NetBsdLibc.INSTANCE.getrlimit(NetBsdLibc.RLIMIT_NOFILE, rlimit);
+        return rlimit.rlim_cur;
+    }
+
+    @Override
+    public long getHardOpenFileLimit() {
+        if (!NetBsdSysctlUtil.JNA_AVAILABLE || getProcessID() != this.os.getProcessId()) {
+            return super.getHardOpenFileLimit();
+        }
+        Resource.Rlimit rlimit = new Resource.Rlimit();
+        NetBsdLibc.INSTANCE.getrlimit(NetBsdLibc.RLIMIT_NOFILE, rlimit);
+        return rlimit.rlim_max;
+    }
+
+    @Override
+    protected Map<String, String> queryEnvironmentVariables() {
+        // For the current process, use Java's System.getenv()
+        if (getProcessID() == this.os.getProcessId()) {
+            return System.getenv();
+        }
+        // Other processes' environment is only accessible natively; fall back to the (empty) command-line result
+        if (!NetBsdSysctlUtil.JNA_AVAILABLE || ARGMAX <= 0) {
+            return super.queryEnvironmentVariables();
+        }
+        int[] mib = { NetBsdLibc.CTL_KERN, KERN_PROC_ARGS, getProcessID(), KERN_PROC_ENV };
+        try (Memory m = new Memory(ARGMAX); CloseableSizeTByReference size = new CloseableSizeTByReference(ARGMAX)) {
+            if (NetBsdLibc.INSTANCE.sysctl(mib, mib.length, m, size, null, size_t.ZERO) == 0) {
+                Map<String, String> env = new LinkedHashMap<>();
+                long bytesReturned = size.getValue().longValue();
+                long offset = 0;
+                while (offset < bytesReturned) {
+                    String envStr = m.getString(offset);
+                    if (envStr.isEmpty()) {
+                        break;
+                    }
+                    int idx = envStr.indexOf('=');
+                    if (idx > 0) {
+                        env.put(envStr.substring(0, idx), envStr.substring(idx + 1));
+                    }
+                    offset += envStr.length() + 1;
+                }
+                if (!env.isEmpty()) {
+                    return Collections.unmodifiableMap(env);
+                }
+            }
+        }
+        return super.queryEnvironmentVariables();
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdOperatingSystemJNA.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.unix.netbsd;
+
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.jna.platform.unix.NetBsdLibc;
+import oshi.software.common.os.unix.bsd.BsdPsKeyword;
+import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem;
+import oshi.software.os.OSProcess;
+import oshi.util.platform.unix.netbsd.NetBsdSysctlUtil;
+
+/**
+ * An OperatingSystem for NetBSD that uses JNA native calls for process/thread identity when the JNA native library is
+ * available, and constructs JNA-capable {@link NetBsdOSProcessJNA} processes. Falls back to the command-line
+ * {@link NetBsdOperatingSystem} implementation when JNA is unavailable.
+ */
+@ThreadSafe
+public class NetBsdOperatingSystemJNA extends NetBsdOperatingSystem {
+
+    @Override
+    public int getProcessId() {
+        if (!NetBsdSysctlUtil.JNA_AVAILABLE) {
+            return super.getProcessId();
+        }
+        return NetBsdLibc.INSTANCE.getpid();
+    }
+
+    @Override
+    public int getThreadId() {
+        if (!NetBsdSysctlUtil.JNA_AVAILABLE) {
+            return super.getThreadId();
+        }
+        return NetBsdLibc.INSTANCE._lwp_self();
+    }
+
+    @Override
+    protected OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap) {
+        return new NetBsdOSProcessJNA(pid, psMap, this);
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/unix/netbsd/package-info.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/netbsd/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides JNA-based operating system implementations for NetBSD.
+ */
+package oshi.software.os.unix.netbsd;

--- a/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/NetBsdSysctlUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/NetBsdSysctlUtil.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.platform.unix.netbsd;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.Structure;
+import com.sun.jna.platform.unix.LibCAPI.size_t;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.jna.ByRef.CloseableSizeTByReference;
+import oshi.jna.platform.unix.NetBsdLibc;
+
+/**
+ * Provides access to native sysctl calls on NetBSD via JNA.
+ * <p>
+ * JNA does not distribute a native binary for NetBSD; it is only available as an optional pkgsrc package
+ * ({@code java-jna}), and OSHI does not require it to be installed. Callers must therefore gate every native call on
+ * {@link #JNA_AVAILABLE} and fall back to the command-line implementations in
+ * {@code oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil} when it is {@code false}.
+ */
+@ThreadSafe
+public final class NetBsdSysctlUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NetBsdSysctlUtil.class);
+
+    private static final String SYSCTL_FAIL = "Failed sysctl call: {}, Error code: {}";
+
+    /**
+     * Whether the JNA native library is available on this system. When {@code false}, the native methods in this class
+     * will not function and callers must use the command-line fallbacks. Detected once at class load by forcing the
+     * {@link NetBsdLibc} native library to load and making a trivial call.
+     */
+    public static final boolean JNA_AVAILABLE;
+    static {
+        boolean available = false;
+        try {
+            // Forcing INSTANCE triggers loading of the JNA native dispatch library and the NetBSD libc binding, which
+            // throws UnsatisfiedLinkError (wrapped in ExceptionInInitializerError on first access) when the java-jna
+            // package is not installed. A trivial call confirms the binding is actually functional.
+            available = NetBsdLibc.INSTANCE.getpid() >= 0;
+        } catch (UnsatisfiedLinkError | NoClassDefFoundError | ExceptionInInitializerError e) {
+            LOG.info("JNA native library is not available on NetBSD; using command-line fallbacks.");
+        }
+        JNA_AVAILABLE = available;
+    }
+
+    private NetBsdSysctlUtil() {
+    }
+
+    /**
+     * Executes a sysctl call with an int result.
+     *
+     * @param name MIB array identifying the sysctl
+     * @param def  default int value
+     * @return The int result of the call if successful; the default otherwise
+     */
+    public static int sysctl(int[] name, int def) {
+        int intSize = NetBsdLibc.INT_SIZE;
+        try (Memory p = new Memory(intSize); CloseableSizeTByReference size = new CloseableSizeTByReference(intSize)) {
+            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
+                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
+                return def;
+            }
+            return p.getInt(0);
+        }
+    }
+
+    /**
+     * Executes a sysctl call with a long result.
+     *
+     * @param name MIB array identifying the sysctl
+     * @param def  default long value
+     * @return The long result of the call if successful; the default otherwise
+     */
+    public static long sysctl(int[] name, long def) {
+        int uint64Size = NetBsdLibc.UINT64_SIZE;
+        try (Memory p = new Memory(uint64Size);
+                CloseableSizeTByReference size = new CloseableSizeTByReference(uint64Size)) {
+            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
+                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
+                return def;
+            }
+            return p.getLong(0);
+        }
+    }
+
+    /**
+     * Executes a sysctl call with a String result.
+     *
+     * @param name MIB array identifying the sysctl
+     * @param def  default String value
+     * @return The String result of the call if successful; the default otherwise
+     */
+    public static String sysctl(int[] name, String def) {
+        // Call first time with null pointer to get value of size
+        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
+            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, null, size, null, size_t.ZERO)) {
+                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
+                return def;
+            }
+            // Add 1 to size for null terminated string
+            try (Memory p = new Memory(size.longValue() + 1L)) {
+                if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
+                    LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
+                    return def;
+                }
+                return p.getString(0);
+            }
+        }
+    }
+
+    /**
+     * Executes a sysctl call with a Structure result.
+     *
+     * @param name   MIB array identifying the sysctl
+     * @param struct structure for the result
+     * @return True if structure is successfully populated, false otherwise
+     */
+    public static boolean sysctl(int[] name, Structure struct) {
+        try (CloseableSizeTByReference size = new CloseableSizeTByReference(struct.size())) {
+            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, struct.getPointer(), size, null, size_t.ZERO)) {
+                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
+                return false;
+            }
+        }
+        struct.read();
+        return true;
+    }
+
+    /**
+     * Executes a sysctl call with a Pointer result.
+     *
+     * @param name MIB array identifying the sysctl
+     * @return An allocated memory buffer containing the result on success, null otherwise. Its value on failure is
+     *         undefined.
+     */
+    public static Memory sysctl(int[] name) {
+        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
+            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, null, size, null, size_t.ZERO)) {
+                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
+                return null;
+            }
+            Memory m = new Memory(size.longValue());
+            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, m, size, null, size_t.ZERO)) {
+                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
+                m.close();
+                return null;
+            }
+            return m;
+        }
+    }
+}

--- a/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/package-info.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides JNA-based native sysctl utilities for NetBSD.
+ */
+package oshi.util.platform.unix.netbsd;


### PR DESCRIPTION
Resolves #3347.

## Summary

NetBSD's JNA native support was removed in #3310 because JNA does not distribute a native binary for NetBSD — it is only available as the optional pkgsrc `java-jna` package, and OSHI does not require users to install dependencies. This PR **restores the native path while keeping the command-line implementation as a runtime fallback**, so NetBSD gets native performance when `java-jna` is present and continues to work without it.

## How it works

- **Availability gate** — `NetBsdSysctlUtil.JNA_AVAILABLE` (following the `SolarisOperatingSystemJNA` / `HAS_KSTAT2` pattern) forces `NetBsdLibc.INSTANCE` at class load and catches `UnsatisfiedLinkError`. Detected once.
- **Native `*JNA` subclasses in oshi-core**, each extending the command-line `NetBsd*` base in oshi-common and gating per method (`if (!JNA_AVAILABLE) return super.x();`):
  - `NetBsdCentralProcessorJNA` — `kern.cp_time` ticks (system + per-CPU) and `getloadavg`
  - `NetBsdOperatingSystemJNA` — `getpid` / `_lwp_self` for process/thread identity
  - `NetBsdOSProcessJNA` — `getrlimit` open-file limits and `kern.proc_args` for other processes' environment
  - `NetBsdHardwareAbstractionLayerJNA` — supplies the JNA processor
- **Wiring** — the oshi-core (JNA) `SystemInfo` selects the `*JNA` classes; **oshi-core-ffm is unchanged** (keeps the native-free command-line classes). Common `NetBsdOperatingSystem` gains an overridable `createProcess` factory and `NetBsdHardwareAbstractionLayer` is de-finalized, mirroring the existing FreeBSD hooks.
- **Bug fix along the way** — `NetBsdLibc` now defines `RLIMIT_NOFILE = 8` (NetBSD's value from `<sys/resource.h>`). JNA's inherited `Resource.RLIMIT_NOFILE` is the Linux value `7`, so the pre-#3310 code would have queried the wrong resource.

## Testing

`unix.yaml` now runs the NetBSD 10.1 VM on **both** paths:
- **`Test JDK 21, NetBSD (no JNA)`** — no `java-jna`; exercises the command-line fallback (`JNA_AVAILABLE == false`)
- **`Test JDK 21, NetBSD (JNA)`** — installs `java-jna` and points `jna.boot.library.path` at the pkgsrc `libjnidispatch`; exercises the native path (`JNA_AVAILABLE == true`)

Clean full-reactor build + spotless/checkstyle/forbiddenapis/javadoc pass locally. Runtime behavior on NetBSD is validated by the two CI jobs above (JNA native calls can't be exercised on the local macOS build).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional JNA-backed NetBSD support for CPU and process details (including improved tick breakdown and system load average), activated only when the native library is present.
  * Enhanced NetBSD environment and open-file limit retrieval under JNA.
  * Expanded the NetBSD JNA package exposure in the public module surface.
* **Bug Fixes**
  * Restored correct NetBSD file-descriptor limit behavior with automatic fallback when JNA native access isn’t available.
* **Chores**
  * Updated CI to run NetBSD tests separately with and without JNA installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->