### PR TITLE
macOS Apple Silicon: detect built-in Retina display (#3404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### New Features
 
 * [#3415](https://github.com/oshi/oshi/pull/3415): Add `Display.getDisplayInfo()` and `Display.isEdidSynthetic()`, a new `DisplayInfo` interface, and EDID-encoding methods in `EdidUtil`, allowing display attributes to be exposed without a raw EDID - [@dbwiddis](https://github.com/dbwiddis).
+* [#3436](https://github.com/oshi/oshi/pull/3436): Detect the Apple Silicon built-in Retina display via `IOMobileFramebuffer` and synthesize a `DisplayInfo` from CoreGraphics and NSScreen properties (resolution, physical size, serial, model name) - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug Fixes and Improvements
 

--- a/oshi-common/src/main/java/oshi/hardware/DisplayInfoImpl.java
+++ b/oshi-common/src/main/java/oshi/hardware/DisplayInfoImpl.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.EdidUtil;
+import oshi.util.ParseUtil;
 
 /**
  * The default {@link DisplayInfo} implementation. This is not part of the OSHI public API and may change between minor
@@ -188,7 +189,7 @@ public class DisplayInfoImpl implements DisplayInfo {
         byte[] e = EdidUtil.newEdidTemplate();
         EdidUtil.setManufacturerID(e, this.manufacturerID);
         EdidUtil.setProductID(e, this.productID);
-        EdidUtil.setSerialNo(e, this.serialNo);
+        setSerialNoSafe(e, this.serialNo);
         EdidUtil.setWeek(e, this.week);
         EdidUtil.setYear(e, this.year);
         EdidUtil.setVersion(e, this.version);
@@ -202,6 +203,25 @@ public class DisplayInfoImpl implements DisplayInfo {
         }
         EdidUtil.updateChecksum(e);
         return e;
+    }
+
+    // Sets the serial number into EDID bytes 12-15. Tries the string form first (which validates round-trip); if that
+    // fails (e.g. bytes happen to be printable ASCII causing getSerialNo to interpret differently), falls back to the
+    // numeric long form which writes the bytes directly.
+    private static void setSerialNoSafe(byte[] edid, String serialNo) {
+        if (serialNo == null || serialNo.isEmpty()) {
+            return;
+        }
+        try {
+            EdidUtil.setSerialNo(edid, serialNo);
+        } catch (IllegalArgumentException e) {
+            if (serialNo.length() == 8) {
+                long numeric = ParseUtil.hexStringToLong(serialNo, 0L);
+                if (numeric != 0L) {
+                    EdidUtil.setSerialNo(edid, numeric);
+                }
+            }
+        }
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -480,6 +480,9 @@ public final class EdidUtil {
      *                   without an {@code 'x'} separator leaves the descriptor unchanged
      */
     public static void setPreferredResolution(byte[] edid, String resolution) {
+        if (resolution == null) {
+            return;
+        }
         int x = resolution.indexOf('x');
         if (x < 0) {
             return; // no WIDTHxHEIGHT to encode; leave the detailed timing descriptor unchanged
@@ -580,6 +583,87 @@ public final class EdidUtil {
             sum += edid[i] & 0xFF;
         }
         edid[CHECKSUM_OFFSET] = (byte) ((256 - sum % 256) % 256);
+    }
+
+    /**
+     * Decodes a packed 16-bit manufacturer ID into the EDID three-letter manufacturer code. This is the inverse of
+     * {@link #getManufacturerID(byte[])}: three 5-bit values (1=A .. 26=Z) packed into the low 15 bits. For example
+     * {@code 1552} decodes to {@code "APP"} (Apple).
+     *
+     * @param packed the packed manufacturer id
+     * @return the three-letter code, or {@code null} if any field is not an A-Z letter
+     */
+    public static String decodeManufacturerId(long packed) {
+        int v = (int) packed;
+        int[] codes = { (v >> 10) & 0x1F, (v >> 5) & 0x1F, v & 0x1F };
+        StringBuilder sb = new StringBuilder(3);
+        for (int code : codes) {
+            if (code < 1 || code > 26) {
+                return null;
+            }
+            sb.append((char) ('A' - 1 + code));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Builds a synthetic {@link oshi.hardware.DisplayInfo DisplayInfo} from individual display properties, for displays
+     * that report their attributes without providing an EDID (such as Apple Silicon built-in panels). Fields that are
+     * absent are defaulted; the result is flagged synthetic so callers can distinguish it from a real EDID via
+     * {@link oshi.hardware.DisplayInfo#isEdidSynthetic()}.
+     *
+     * @param legacyManufacturerId packed manufacturer id, or {@code null}
+     * @param modelNumber          the 16-bit model/product number, or {@code null}
+     * @param serialNumber         the 32-bit serial number, or {@code null}
+     * @param week                 week of manufacture, or {@code null}
+     * @param year                 year of manufacture, or {@code null}
+     * @param model                the product name / model, or {@code null}
+     * @param productSerial        the alphanumeric serial number, or {@code null}
+     * @param displayWidth         native pixel width, or {@code null}
+     * @param displayHeight        native pixel height, or {@code null}
+     * @param fallbackName         a fallback display name if {@code model} and {@code displayName} are both null, or
+     *                             {@code null}
+     * @param screenWidthMm        physical width in mm, or {@code null}
+     * @param screenHeightMm       physical height in mm, or {@code null}
+     * @param displayName          the localized display name, or {@code null}
+     * @return a synthetic {@link oshi.hardware.DisplayInfo DisplayInfo}, or {@code null} if the manufacturer id can not
+     *         be decoded
+     */
+    @SuppressWarnings("java:S107")
+    public static oshi.hardware.DisplayInfo synthesizeDisplayInfo(Long legacyManufacturerId, Integer modelNumber,
+            Integer serialNumber, Integer week, Integer year, String model, String productSerial, Long displayWidth,
+            Long displayHeight, String fallbackName, Double screenWidthMm, Double screenHeightMm, String displayName) {
+        if (legacyManufacturerId == null) {
+            return null;
+        }
+        String manufacturer = decodeManufacturerId(legacyManufacturerId);
+        if (manufacturer == null) {
+            return null;
+        }
+        String product = Integer.toHexString(modelNumber == null ? 0 : modelNumber & 0xFFFF);
+        byte wk = (byte) (week == null ? 0 : week);
+        int yr = year == null ? 1990 : year;
+        String serialNo = serialNumber != null ? String.format(Locale.ROOT, "%08X", serialNumber) : "00000000";
+        String resolution = null;
+        if (displayWidth != null && displayHeight != null && displayWidth > 0 && displayHeight > 0) {
+            resolution = displayWidth + "x" + displayHeight;
+        }
+        int hcm = screenWidthMm != null ? (int) Math.round(screenWidthMm / 10.0) : 0;
+        int vcm = screenHeightMm != null ? (int) Math.round(screenHeightMm / 10.0) : 0;
+        String modelName = model;
+        if (modelName == null) {
+            modelName = displayName;
+        }
+        if (modelName == null) {
+            modelName = fallbackName;
+        }
+        // Use the numeric serial as the product serial descriptor if no alphanumeric serial was provided.
+        String serialDescriptor = productSerial;
+        if (serialDescriptor == null && serialNumber != null) {
+            serialDescriptor = serialNo;
+        }
+        return new oshi.hardware.DisplayInfoImpl(manufacturer, product, serialNo, wk, yr, "1.4", true, hcm, vcm,
+                resolution, modelName == null ? "" : modelName, serialDescriptor == null ? "" : serialDescriptor);
     }
 
     /**

--- a/oshi-common/src/test/java/oshi/hardware/DisplayInfoImplTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/DisplayInfoImplTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -83,13 +82,81 @@ class DisplayInfoImplTest {
 
     @Test
     void testSyntheticToStringDoesNotSynthesize() {
-        // A serial number that EdidUtil.setSerialNo rejects: toString must still work (it formats from the decoded
-        // fields), while getEdid (which synthesizes) fails. This proves toString does not encode the EDID.
+        // A serial number that EdidUtil.setSerialNo string form rejects: toString must still work (it formats from the
+        // decoded fields) without triggering EDID synthesis. getEdid gracefully falls back to zeroed bytes 12-15.
         DisplayInfo info = new DisplayInfoImpl("AUO", "9227", "BADSERIAL", (byte) 1, 2020, "1.4", true, 50, 30,
                 "1920x1080", "Acme", "SN12345");
         assertThat("toString model", info.toString(), containsString("Acme"));
         assertThat("toString serial", info.toString(), containsString("SN12345"));
-        assertThrows(IllegalArgumentException.class, info::getEdid);
+        // getEdid no longer throws; it falls back to zero serial bytes
+        byte[] edid = info.getEdid();
+        assertThat("edid length", edid.length, is(128));
+    }
+
+    @Test
+    void testSyntheticNumericSerialFallback() {
+        // A serial like "FD626D62" fails EdidUtil.setSerialNo(String) because byte 0xFD is not alphanumeric while
+        // 0x62/'b' and 0x6D/'m' are, causing getSerialNo to return a mixed-format string that doesn't match.
+        // setSerialNoSafe falls back to the numeric overload, writing the bytes directly.
+        DisplayInfo info = new DisplayInfoImpl("APP", "a050", "FD626D62", (byte) 0, 1990, "1.4", true, 34, 22,
+                "3456x2234", "Built-in Retina Display", "");
+        assertThat("serialNo field", info.getSerialNo(), is("FD626D62"));
+        // getEdid succeeds (no exception) and produces a valid 128-byte EDID
+        byte[] edid = info.getEdid();
+        assertThat("edid length", edid.length, is(128));
+        // Bytes 12-15 contain the numeric serial in little-endian
+        assertThat("edid[12]", edid[12] & 0xFF, is(0x62));
+        assertThat("edid[13]", edid[13] & 0xFF, is(0x6D));
+        assertThat("edid[14]", edid[14] & 0xFF, is(0x62));
+        assertThat("edid[15]", edid[15] & 0xFF, is(0xFD));
+    }
+
+    @Test
+    void testSyntheticNullPreferredResolution() {
+        // A null preferred resolution should not cause an NPE during EDID synthesis
+        DisplayInfo info = new DisplayInfoImpl("APP", "a050", "00000000", (byte) 0, 1990, "1.4", true, 34, 22, null,
+                "Built-in Retina Display", "");
+        byte[] edid = info.getEdid();
+        assertThat("edid length", edid.length, is(128));
+    }
+
+    @Test
+    void testSyntheticNullSerialNo() {
+        // A null serialNo is treated as absent — bytes 12-15 stay zeroed
+        DisplayInfo info = new DisplayInfoImpl("APP", "a050", null, (byte) 0, 1990, "1.4", true, 0, 0, "3456x2234",
+                "Test", "");
+        byte[] edid = info.getEdid();
+        assertThat("edid length", edid.length, is(128));
+        assertThat("edid[12]", edid[12], is((byte) 0));
+        assertThat("edid[13]", edid[13], is((byte) 0));
+        assertThat("edid[14]", edid[14], is((byte) 0));
+        assertThat("edid[15]", edid[15], is((byte) 0));
+    }
+
+    @Test
+    void testSyntheticEmptySerialNo() {
+        // An empty serialNo is treated as absent — bytes 12-15 stay zeroed
+        DisplayInfo info = new DisplayInfoImpl("APP", "a050", "", (byte) 0, 1990, "1.4", true, 0, 0, "3456x2234",
+                "Test", "");
+        byte[] edid = info.getEdid();
+        assertThat("edid length", edid.length, is(128));
+        assertThat("edid[12]", edid[12], is((byte) 0));
+        assertThat("edid[13]", edid[13], is((byte) 0));
+        assertThat("edid[14]", edid[14], is((byte) 0));
+        assertThat("edid[15]", edid[15], is((byte) 0));
+    }
+
+    @Test
+    void testSyntheticNonHexSerialNoFallsBackToZero() {
+        // A non-hex 8-char serial that also fails the string form falls back to zeroed bytes
+        DisplayInfo info = new DisplayInfoImpl("APP", "a050", "NOTAHEX!", (byte) 0, 1990, "1.4", true, 0, 0,
+                "3456x2234", "Test", "");
+        byte[] edid = info.getEdid();
+        assertThat("edid length", edid.length, is(128));
+        assertThat("edid[12]", edid[12], is((byte) 0));
+        assertThat("edid[13]", edid[13], is((byte) 0));
+        assertThat("edid[14]", edid[14], is((byte) 0));
+        assertThat("edid[15]", edid[15], is((byte) 0));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
@@ -8,11 +8,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+
+import oshi.hardware.DisplayInfo;
 
 /*
  * Tests EdidUtil
@@ -283,5 +286,123 @@ class EdidUtilTest {
         // A valid resolution still encodes normally
         EdidUtil.setPreferredResolution(edid, "1920x1080");
         assertThat("valid resolution", EdidUtil.getPreferredResolution(edid), is("1920x1080"));
+    }
+
+    @Test
+    void testSetPreferredResolutionNull() {
+        byte[] edid = EdidUtil.newEdidTemplate();
+        EdidUtil.setPreferredResolution(edid, null);
+        assertThat("null resolution", EdidUtil.getPreferredResolution(edid), is("0x0"));
+    }
+
+    @Test
+    void testDecodeManufacturerIdApple() {
+        assertThat(EdidUtil.decodeManufacturerId(0x610), is("APP"));
+    }
+
+    @Test
+    void testDecodeManufacturerIdDell() {
+        assertThat(EdidUtil.decodeManufacturerId(0x10AC), is("DEL"));
+    }
+
+    @Test
+    void testDecodeManufacturerIdZero() {
+        assertThat(EdidUtil.decodeManufacturerId(0), is(nullValue()));
+    }
+
+    @Test
+    void testDecodeManufacturerIdOutOfRange() {
+        assertThat(EdidUtil.decodeManufacturerId(0x7C00), is(nullValue()));
+    }
+
+    @Test
+    void testSynthesizeDisplayInfoNullManufacturer() {
+        assertThat(EdidUtil.synthesizeDisplayInfo(null, null, null, null, null, null, null, null, null, null, null,
+                null, null), is(nullValue()));
+    }
+
+    @Test
+    void testSynthesizeDisplayInfoInvalidManufacturer() {
+        assertThat(EdidUtil.synthesizeDisplayInfo(0L, null, null, null, null, null, null, null, null, null, null, null,
+                null), is(nullValue()));
+    }
+
+    @Test
+    void testSynthesizeDisplayInfoMinimalFields() {
+        DisplayInfo info = EdidUtil.synthesizeDisplayInfo(0x610L, null, null, null, null, null, null, null, null, null,
+                null, null, null);
+        assertThat(info.getManufacturerID(), is("APP"));
+        assertThat(info.getProductID(), is("0"));
+        assertThat(info.getSerialNo(), is("00000000"));
+        assertThat(info.getWeek(), is((byte) 0));
+        assertThat(info.getYear(), is(1990));
+        assertThat(info.getHcm(), is(0));
+        assertThat(info.getVcm(), is(0));
+        assertThat(info.getModel(), is(""));
+        assertThat(info.isEdidSynthetic(), is(true));
+    }
+
+    @Test
+    void testSynthesizeDisplayInfoFullFields() {
+        DisplayInfo info = EdidUtil.synthesizeDisplayInfo(0x610L, 0xa050, 0x12345678, 10, 2023, "Retina", "ABC123",
+                3456L, 2234L, "disp0 (Built-in Display)", 344.2, 222.5, "Built-in Retina Display");
+        assertThat(info.getManufacturerID(), is("APP"));
+        assertThat(info.getProductID(), is("a050"));
+        assertThat(info.getSerialNo(), is("12345678"));
+        assertThat(info.getWeek(), is((byte) 10));
+        assertThat(info.getYear(), is(2023));
+        assertThat(info.getHcm(), is(34));
+        assertThat(info.getVcm(), is(22));
+        assertThat(info.getPreferredResolution(), is("3456x2234"));
+        assertThat(info.getModel(), is("Retina"));
+        assertThat(info.getProductSerialNumber(), is("ABC123"));
+        assertThat(info.isEdidSynthetic(), is(true));
+    }
+
+    @Test
+    void testSynthesizeDisplayInfoFallbackName() {
+        DisplayInfo info = EdidUtil.synthesizeDisplayInfo(0x610L, null, null, null, null, null, null, null, null,
+                "disp0 (Built-in Display)", null, null, null);
+        assertThat(info.getModel(), is("disp0 (Built-in Display)"));
+    }
+
+    @Test
+    void testSynthesizeDisplayInfoDisplayNamePreferred() {
+        DisplayInfo info = EdidUtil.synthesizeDisplayInfo(0x610L, null, null, null, null, null, null, null, null,
+                "disp0 (Built-in Display)", null, null, "Built-in Retina Display");
+        assertThat(info.getModel(), is("Built-in Retina Display"));
+    }
+
+    @Test
+    void testSynthesizeDisplayInfoNullResolutionWhenDimensionsZero() {
+        DisplayInfo info = EdidUtil.synthesizeDisplayInfo(0x610L, null, null, null, null, null, null, 0L, 0L, null,
+                null, null, null);
+        assertThat(info.getPreferredResolution(), is(nullValue()));
+    }
+
+    @Test
+    void testSynthesizeDisplayInfoDimensionRounding() {
+        DisplayInfo info = EdidUtil.synthesizeDisplayInfo(0x610L, null, null, null, null, null, null, null, null, null,
+                344.2, 225.9, null);
+        assertThat(info.getHcm(), is(34));
+        assertThat(info.getVcm(), is(23));
+    }
+
+    @Test
+    void testSynthesizeDisplayInfoSerialFallbackToDescriptor() {
+        // When productSerial is null but serialNumber is present, the numeric serial populates both fields
+        DisplayInfo info = EdidUtil.synthesizeDisplayInfo(0x610L, null, 0xFD626D62, null, null, null, null, null, null,
+                null, null, null, null);
+        assertThat(info.getSerialNo(), is("FD626D62"));
+        assertThat(info.getProductSerialNumber(), is("FD626D62"));
+    }
+
+    @Test
+    void testSynthesizeDisplayInfoProductSerialTakesPrecedence() {
+        // When productSerial is explicitly provided, it takes precedence over the numeric fallback
+        DisplayInfo info = EdidUtil.synthesizeDisplayInfo(0x610L, null, 0xFD626D62, null, null, null, "ABC123", null,
+                null, null, null, null, null);
+        assertThat(info.getSerialNo(), is("FD626D62"));
+        assertThat(info.getProductSerialNumber(), is("ABC123"));
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/CoreGraphicsFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/CoreGraphicsFunctions.java
@@ -6,10 +6,13 @@ package oshi.ffm.platform.mac;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
+import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
 
@@ -45,5 +48,55 @@ public final class CoreGraphicsFunctions extends MacForeignFunctions {
     public static boolean CGRectMakeWithDictionaryRepresentation(MemorySegment dict, MemorySegment rect)
             throws Throwable {
         return (boolean) CGRectMakeWithDictionaryRepresentation.invokeExact(dict, rect);
+    }
+
+    // CGError CGGetActiveDisplayList(uint32_t maxDisplays, CGDirectDisplayID *activeDisplays, uint32_t *displayCount);
+
+    private static final MethodHandle CGGetActiveDisplayList = LINKER.downcallHandle(
+            CORE_GRAPHICS.findOrThrow("CGGetActiveDisplayList"),
+            FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS, ADDRESS));
+
+    public static int CGGetActiveDisplayList(int maxDisplays, MemorySegment activeDisplays, MemorySegment displayCount)
+            throws Throwable {
+        return (int) CGGetActiveDisplayList.invokeExact(maxDisplays, activeDisplays, displayCount);
+    }
+
+    // boolean CGDisplayIsBuiltin(CGDirectDisplayID display);
+
+    private static final MethodHandle CGDisplayIsBuiltin = LINKER
+            .downcallHandle(CORE_GRAPHICS.findOrThrow("CGDisplayIsBuiltin"), FunctionDescriptor.of(JAVA_INT, JAVA_INT));
+
+    public static int CGDisplayIsBuiltin(int display) throws Throwable {
+        return (int) CGDisplayIsBuiltin.invokeExact(display);
+    }
+
+    // uint32_t CGDisplayModelNumber(CGDirectDisplayID display);
+
+    private static final MethodHandle CGDisplayModelNumber = LINKER.downcallHandle(
+            CORE_GRAPHICS.findOrThrow("CGDisplayModelNumber"), FunctionDescriptor.of(JAVA_INT, JAVA_INT));
+
+    public static int CGDisplayModelNumber(int display) throws Throwable {
+        return (int) CGDisplayModelNumber.invokeExact(display);
+    }
+
+    // uint32_t CGDisplaySerialNumber(CGDirectDisplayID display);
+
+    private static final MethodHandle CGDisplaySerialNumber = LINKER.downcallHandle(
+            CORE_GRAPHICS.findOrThrow("CGDisplaySerialNumber"), FunctionDescriptor.of(JAVA_INT, JAVA_INT));
+
+    public static int CGDisplaySerialNumber(int display) throws Throwable {
+        return (int) CGDisplaySerialNumber.invokeExact(display);
+    }
+
+    // CGSize CGDisplayScreenSize(CGDirectDisplayID display); — returns a struct { double width; double height; }
+
+    private static final MemoryLayout CG_SIZE_LAYOUT = MemoryLayout.structLayout(JAVA_DOUBLE.withName("width"),
+            JAVA_DOUBLE.withName("height"));
+
+    private static final MethodHandle CGDisplayScreenSize = LINKER.downcallHandle(
+            CORE_GRAPHICS.findOrThrow("CGDisplayScreenSize"), FunctionDescriptor.of(CG_SIZE_LAYOUT, JAVA_INT));
+
+    public static MemorySegment CGDisplayScreenSize(SegmentAllocator allocator, int display) throws Throwable {
+        return (MemorySegment) CGDisplayScreenSize.invokeExact(allocator, display);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
@@ -4,7 +4,13 @@
  */
 package oshi.hardware.platform.mac;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,13 +18,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.Immutable;
+import oshi.ffm.platform.mac.CoreFoundation.CFBooleanRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFDataRef;
+import oshi.ffm.platform.mac.CoreFoundation.CFDictionaryRef;
+import oshi.ffm.platform.mac.CoreFoundation.CFNumberRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFStringRef;
+import oshi.ffm.platform.mac.CoreGraphicsFunctions;
 import oshi.ffm.platform.mac.IOKit.IOIterator;
 import oshi.ffm.platform.mac.IOKit.IORegistryEntry;
 import oshi.ffm.util.platform.mac.IOKitUtilFFM;
 import oshi.hardware.Display;
+import oshi.hardware.DisplayInfo;
 import oshi.hardware.common.AbstractDisplay;
+import oshi.util.EdidUtil;
 
 /**
  * A Display
@@ -33,10 +45,19 @@ final class MacDisplayFFM extends AbstractDisplay {
         LOG.debug("Initialized MacDisplayFFM");
     }
 
+    MacDisplayFFM(DisplayInfo displayInfo) {
+        super(displayInfo);
+        LOG.debug("Initialized MacDisplayFFM (synthetic)");
+    }
+
     public static List<Display> getDisplays() {
         List<Display> displays = new ArrayList<>();
+        // Intel: real EDID exposed under IODisplayConnect (returns nothing on Apple Silicon).
         displays.addAll(getDisplaysFromService("IODisplayConnect", "IODisplayEDID", "IOService"));
+        // Apple Silicon external monitors: same stripped EDID as Intel path, just different service.
         displays.addAll(getDisplaysFromService("IOPortTransportStateDisplayPort", "EDID", null));
+        // Apple Silicon built-in panel: no real EDID exposed, synthesize from DisplayAttributes.
+        displays.addAll(getAppleSiliconBuiltInDisplay());
         return displays;
     }
 
@@ -73,5 +94,253 @@ final class MacDisplayFFM extends AbstractDisplay {
             }
         }
         return displays;
+    }
+
+    /**
+     * Discovers the Apple Silicon built-in display by matching the stable {@code IOMobileFramebuffer} base class (the
+     * leaf class name varies by macOS version). External monitors are skipped here (they are already enumerated via
+     * {@code IOPortTransportStateDisplayPort} with their real EDID); only the built-in panel, which has no physical
+     * EDID EPROM, is synthesized from {@code DisplayAttributes}.
+     *
+     * @return A list containing the built-in display, or empty if not found
+     */
+    private static List<Display> getAppleSiliconBuiltInDisplay() {
+        List<Display> displays = new ArrayList<>();
+        IOIterator iter = IOKitUtilFFM.getMatchingServices("IOMobileFramebuffer");
+        if (iter == null) {
+            return displays;
+        }
+        CFStringRef cfExternal = CFStringRef.createCFString("external");
+        CFStringRef cfAttrs = CFStringRef.createCFString("DisplayAttributes");
+        try (iter; cfExternal; cfAttrs) {
+            IORegistryEntry fb = iter.next();
+            while (fb != null) {
+                try (IORegistryEntry current = fb) {
+                    addBuiltInDisplay(current, cfExternal, cfAttrs, displays);
+                }
+                fb = iter.next();
+            }
+        }
+        return displays;
+    }
+
+    // Synthesizes a display for the built-in panel from its DisplayAttributes dictionary. External framebuffer nodes
+    // (marked with "external" = true) are skipped, as are idle pipes with no DisplayAttributes.
+    private static void addBuiltInDisplay(IORegistryEntry fb, CFStringRef cfExternal, CFStringRef cfAttrs,
+            List<Display> displays) {
+        // Skip external monitors — they are already enumerated via IOPortTransportStateDisplayPort.
+        MemorySegment externalRaw = fb.createCFProperty(cfExternal.segment());
+        if (externalRaw != null && !externalRaw.equals(MemorySegment.NULL)) {
+            try (CFBooleanRef externalBool = new CFBooleanRef(externalRaw)) {
+                if (externalBool.booleanValue()) {
+                    return;
+                }
+            }
+        }
+        // Synthesize from DisplayAttributes, read from the node or (fallback) its IODeviceTree parent.
+        MemorySegment attrsRaw = fb.createCFProperty(cfAttrs.segment());
+        if (attrsRaw == null || attrsRaw.equals(MemorySegment.NULL)) {
+            IORegistryEntry parent = fb.getParentEntry("IODeviceTree");
+            if (parent != null) {
+                try (parent) {
+                    attrsRaw = parent.createCFProperty(cfAttrs.segment());
+                }
+            }
+        }
+        if (attrsRaw == null || attrsRaw.equals(MemorySegment.NULL)) {
+            return;
+        }
+        try (CFDictionaryRef attrs = new CFDictionaryRef(attrsRaw)) {
+            DisplayInfo info = synthesize(fb, attrs);
+            if (info != null) {
+                displays.add(new MacDisplayFFM(info));
+            }
+        }
+    }
+
+    // Maps an Apple Silicon DisplayAttributes dictionary onto a synthetic DisplayInfo via EdidUtil, enriched with
+    // native resolution and device name from the framebuffer node and CoreGraphics.
+    private static DisplayInfo synthesize(IORegistryEntry fb, CFDictionaryRef attrs) {
+        CFDictionaryRef product = cfDictGetDictionary(attrs, "ProductAttributes");
+        if (product == null) {
+            return null;
+        }
+        Long legacyMfg = cfDictGetLong(product, "LegacyManufacturerID");
+        Long week = cfDictGetLong(product, "WeekOfManufacture");
+        Long year = cfDictGetLong(product, "YearOfManufacture");
+        String model = cfDictGetString(product, "ProductName");
+        String serial = cfDictGetString(product, "AlphanumericSerialNumber");
+        // Native pixel resolution from the framebuffer node.
+        Long displayWidth = fb.getLongProperty("DisplayWidth");
+        Long displayHeight = fb.getLongProperty("DisplayHeight");
+        // Device tree name for fallback model name.
+        String fallbackName = null;
+        String ioNameMatched = fb.getStringProperty("IONameMatched");
+        if (ioNameMatched != null) {
+            String shortName = ioNameMatched.contains(",") ? ioNameMatched.substring(0, ioNameMatched.indexOf(','))
+                    : ioNameMatched;
+            fallbackName = shortName + " (Built-in Display)";
+        }
+        // CoreGraphics properties: model number, serial number, physical size, and localized name.
+        Integer cgModel = null;
+        Integer cgSerial = null;
+        Double widthMm = null;
+        Double heightMm = null;
+        String displayName = null;
+        int builtInId = findBuiltInDisplayId();
+        if (builtInId >= 0) {
+            try (Arena sizeArena = Arena.ofConfined()) {
+                cgModel = CoreGraphicsFunctions.CGDisplayModelNumber(builtInId);
+                cgSerial = CoreGraphicsFunctions.CGDisplaySerialNumber(builtInId);
+                MemorySegment size = CoreGraphicsFunctions.CGDisplayScreenSize(sizeArena, builtInId);
+                widthMm = size.get(ValueLayout.JAVA_DOUBLE, 0);
+                heightMm = size.get(ValueLayout.JAVA_DOUBLE, 8);
+            } catch (Throwable t) {
+                LOG.debug("Failed to get built-in display CoreGraphics properties", t);
+            }
+            displayName = getLocalizedDisplayName(builtInId);
+        }
+        return EdidUtil.synthesizeDisplayInfo(legacyMfg, cgModel, cgSerial, week == null ? null : week.intValue(),
+                year == null ? null : year.intValue(), model, serial, displayWidth, displayHeight, fallbackName,
+                widthMm, heightMm, displayName);
+    }
+
+    // Returns the CGDirectDisplayID of the built-in display, or -1 if not found.
+    private static int findBuiltInDisplayId() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment countSeg = arena.allocate(ValueLayout.JAVA_INT);
+            if (CoreGraphicsFunctions.CGGetActiveDisplayList(0, MemorySegment.NULL, countSeg) != 0) {
+                return -1;
+            }
+            int count = countSeg.get(ValueLayout.JAVA_INT, 0);
+            if (count == 0) {
+                return -1;
+            }
+            MemorySegment idsSeg = arena.allocate(ValueLayout.JAVA_INT, count);
+            if (CoreGraphicsFunctions.CGGetActiveDisplayList(count, idsSeg, countSeg) != 0) {
+                return -1;
+            }
+            for (int i = 0; i < count; i++) {
+                int id = idsSeg.getAtIndex(ValueLayout.JAVA_INT, i);
+                if (CoreGraphicsFunctions.CGDisplayIsBuiltin(id) != 0) {
+                    return id;
+                }
+            }
+        } catch (Throwable t) {
+            LOG.debug("Failed to find built-in display ID", t);
+        }
+        return -1;
+    }
+
+    // ObjC runtime handles for NSScreen.localizedName lookup.
+    private static final SymbolLookup OBJC_LOOKUP = SymbolLookup.libraryLookup("libobjc.dylib", Arena.global());
+    private static final SymbolLookup CF_LOOKUP = SymbolLookup
+            .libraryLookup("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation", Arena.global());
+    private static final MethodHandle OBJC_GET_CLASS = Linker.nativeLinker().downcallHandle(
+            OBJC_LOOKUP.find("objc_getClass").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    private static final MethodHandle SEL_REGISTER_NAME = Linker.nativeLinker().downcallHandle(
+            OBJC_LOOKUP.find("sel_registerName").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    private static final MethodHandle MSG_SEND = Linker.nativeLinker().downcallHandle(
+            OBJC_LOOKUP.find("objc_msgSend").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    private static final MethodHandle MSG_SEND_LONG = Linker.nativeLinker()
+            .downcallHandle(OBJC_LOOKUP.find("objc_msgSend").orElseThrow(), FunctionDescriptor.of(ValueLayout.ADDRESS,
+                    ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+    private static final MethodHandle MSG_SEND_COUNT = Linker.nativeLinker().downcallHandle(
+            OBJC_LOOKUP.find("objc_msgSend").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    private static final MethodHandle CF_DICTIONARY_GET_VALUE = Linker.nativeLinker().downcallHandle(
+            CF_LOOKUP.find("CFDictionaryGetValue").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    private static final MethodHandle CF_NUMBER_GET_VALUE = Linker.nativeLinker()
+            .downcallHandle(CF_LOOKUP.find("CFNumberGetValue").orElseThrow(), FunctionDescriptor
+                    .of(ValueLayout.JAVA_BOOLEAN, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+    private static final MethodHandle CF_STRING_GET_CSTRING = Linker.nativeLinker().downcallHandle(
+            CF_LOOKUP.find("CFStringGetCString").orElseThrow(), FunctionDescriptor.of(ValueLayout.JAVA_BOOLEAN,
+                    ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT));
+
+    // Returns the NSScreen.localizedName for the given CGDirectDisplayID, or null.
+    private static String getLocalizedDisplayName(int targetDisplayId) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment nsScreenClass = (MemorySegment) OBJC_GET_CLASS.invokeExact(arena.allocateFrom("NSScreen"));
+            if (nsScreenClass.address() == 0) {
+                return null;
+            }
+            MemorySegment selScreens = (MemorySegment) SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("screens"));
+            MemorySegment selCount = (MemorySegment) SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("count"));
+            MemorySegment selObjectAt = (MemorySegment) SEL_REGISTER_NAME
+                    .invokeExact(arena.allocateFrom("objectAtIndex:"));
+            MemorySegment selDeviceDesc = (MemorySegment) SEL_REGISTER_NAME
+                    .invokeExact(arena.allocateFrom("deviceDescription"));
+            MemorySegment selLocalizedName = (MemorySegment) SEL_REGISTER_NAME
+                    .invokeExact(arena.allocateFrom("localizedName"));
+
+            MemorySegment screensArray = (MemorySegment) MSG_SEND.invokeExact(nsScreenClass, selScreens);
+            if (screensArray.address() == 0) {
+                return null;
+            }
+            long count = (long) MSG_SEND_COUNT.invokeExact(screensArray, selCount);
+
+            try (CFStringRef cfKey = CFStringRef.createCFString("NSScreenNumber")) {
+                for (long i = 0; i < count; i++) {
+                    MemorySegment screen = (MemorySegment) MSG_SEND_LONG.invokeExact(screensArray, selObjectAt, i);
+                    if (screen.address() == 0) {
+                        continue;
+                    }
+                    MemorySegment deviceDesc = (MemorySegment) MSG_SEND.invokeExact(screen, selDeviceDesc);
+                    if (deviceDesc.address() == 0) {
+                        continue;
+                    }
+                    MemorySegment cfNum = (MemorySegment) CF_DICTIONARY_GET_VALUE.invokeExact(deviceDesc,
+                            cfKey.segment());
+                    if (cfNum.address() == 0) {
+                        continue;
+                    }
+                    MemorySegment outId = arena.allocate(ValueLayout.JAVA_INT);
+                    // kCFNumberSInt32Type = 3
+                    boolean ok = (boolean) CF_NUMBER_GET_VALUE.invokeExact(cfNum, 3L, outId);
+                    if (ok && outId.get(ValueLayout.JAVA_INT, 0) == targetDisplayId) {
+                        MemorySegment nsName = (MemorySegment) MSG_SEND.invokeExact(screen, selLocalizedName);
+                        if (nsName.address() != 0) {
+                            MemorySegment buf = arena.allocate(256);
+                            // kCFStringEncodingUTF8 = 0x08000100
+                            boolean got = (boolean) CF_STRING_GET_CSTRING.invokeExact(nsName, buf, 256L, 0x08000100);
+                            if (got) {
+                                return buf.getString(0);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            LOG.debug("Failed to get localized display name", t);
+        }
+        return null;
+    }
+
+    // CFDictionary accessors. CFDictionaryGetValue returns a borrowed reference: the returned wrappers must NOT be
+    // released.
+
+    private static CFDictionaryRef cfDictGetDictionary(CFDictionaryRef dict, String key) {
+        try (CFStringRef k = CFStringRef.createCFString(key)) {
+            MemorySegment v = dict.getValue(k);
+            return v == null || v.equals(MemorySegment.NULL) ? null : new CFDictionaryRef(v);
+        }
+    }
+
+    private static String cfDictGetString(CFDictionaryRef dict, String key) {
+        try (CFStringRef k = CFStringRef.createCFString(key)) {
+            MemorySegment v = dict.getValue(k);
+            return v == null || v.equals(MemorySegment.NULL) ? null : new CFStringRef(v).stringValue();
+        }
+    }
+
+    private static Long cfDictGetLong(CFDictionaryRef dict, String key) {
+        try (CFStringRef k = CFStringRef.createCFString(key)) {
+            MemorySegment v = dict.getValue(k);
+            return v == null || v.equals(MemorySegment.NULL) ? null : new CFNumberRef(v).longValue();
+        }
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
@@ -11,16 +11,28 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sun.jna.Pointer;
+import com.sun.jna.platform.mac.CoreFoundation;
+import com.sun.jna.platform.mac.CoreFoundation.CFBooleanRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFDataRef;
+import com.sun.jna.platform.mac.CoreFoundation.CFDictionaryRef;
+import com.sun.jna.platform.mac.CoreFoundation.CFIndex;
+import com.sun.jna.platform.mac.CoreFoundation.CFNumberRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFStringRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFTypeRef;
+import com.sun.jna.platform.mac.CoreGraphics;
 import com.sun.jna.platform.mac.IOKit.IOIterator;
 import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
 import com.sun.jna.platform.mac.IOKitUtil;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.LongByReference;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Display;
+import oshi.hardware.DisplayInfo;
 import oshi.hardware.common.AbstractDisplay;
+import oshi.jna.platform.mac.CoreGraphicsExt;
+import oshi.jna.platform.mac.ObjCRuntime;
+import oshi.util.EdidUtil;
 
 /**
  * A Display
@@ -30,8 +42,13 @@ final class MacDisplayJNA extends AbstractDisplay {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacDisplayJNA.class);
 
+    private static final CoreFoundation CF = CoreFoundation.INSTANCE;
+
+    /** kCFNumberSInt64Type, as the CFIndex expected by CFNumberGetValue. */
+    private static final CFIndex K_CF_NUMBER_SINT64 = new CFIndex(4);
+
     /**
-     * Constructor for MacDisplayJNA.
+     * Constructor for MacDisplayJNA from a real EDID byte array.
      *
      * @param edid a byte array representing a display EDID
      */
@@ -41,17 +58,29 @@ final class MacDisplayJNA extends AbstractDisplay {
     }
 
     /**
+     * Constructor for MacDisplayJNA from a synthetic {@link DisplayInfo}, used for the Apple Silicon built-in panel
+     * which has no EDID EPROM.
+     *
+     * @param displayInfo the synthesized display info
+     */
+    MacDisplayJNA(DisplayInfo displayInfo) {
+        super(displayInfo);
+        LOG.debug("Initialized MacDisplayJNA (synthetic)");
+    }
+
+    /**
      * Gets Display Information
      *
      * @return An array of Display objects representing monitors, etc.
      */
     public static List<Display> getDisplays() {
         List<Display> displays = new ArrayList<>();
-        // Intel
+        // Intel: real EDID exposed under IODisplayConnect (returns nothing on Apple Silicon).
         displays.addAll(getDisplaysFromService("IODisplayConnect", "IODisplayEDID", "IOService"));
-        // Apple Silicon
+        // Apple Silicon external monitors: same stripped EDID as Intel path, just different service.
         displays.addAll(getDisplaysFromService("IOPortTransportStateDisplayPort", "EDID", null));
-
+        // Apple Silicon built-in panel: no real EDID exposed, synthesize from DisplayAttributes.
+        displays.addAll(getAppleSiliconBuiltInDisplay());
         return displays;
     }
 
@@ -102,5 +131,277 @@ final class MacDisplayJNA extends AbstractDisplay {
             cfEdid.release();
         }
         return displays;
+    }
+
+    /**
+     * Discovers the Apple Silicon built-in display by matching the stable {@code IOMobileFramebuffer} base class. The
+     * leaf class name varies by macOS version ({@code IOMobileFramebufferShim} on current releases, {@code AppleCLCD2}
+     * on older ones), so matching the base class covers all generations. External monitors are skipped here (they are
+     * already enumerated via {@code IOPortTransportStateDisplayPort} with their real EDID); only the built-in panel,
+     * which has no physical EDID EPROM, is synthesized from {@code DisplayAttributes}.
+     *
+     * @return A list containing the built-in display, or empty if not found
+     */
+    private static List<Display> getAppleSiliconBuiltInDisplay() {
+        List<Display> displays = new ArrayList<>();
+        IOIterator iter = IOKitUtil.getMatchingServices("IOMobileFramebuffer");
+        if (iter == null) {
+            return displays;
+        }
+        CFStringRef cfExternal = CFStringRef.createCFString("external");
+        CFStringRef cfAttrs = CFStringRef.createCFString("DisplayAttributes");
+        try {
+            IORegistryEntry fb = iter.next();
+            while (fb != null) {
+                try {
+                    addBuiltInDisplay(fb, cfExternal, cfAttrs, displays);
+                } finally {
+                    fb.release();
+                }
+                fb = iter.next();
+            }
+        } finally {
+            iter.release();
+            cfExternal.release();
+            cfAttrs.release();
+        }
+        return displays;
+    }
+
+    // Synthesizes a display for the built-in panel from its DisplayAttributes dictionary. External framebuffer nodes
+    // (marked with "external" = true) are skipped, as are idle pipes with no DisplayAttributes.
+    private static void addBuiltInDisplay(IORegistryEntry fb, CFStringRef cfExternal, CFStringRef cfAttrs,
+            List<Display> displays) {
+        // Skip external monitors — they are already enumerated via IOPortTransportStateDisplayPort.
+        CFTypeRef externalRef = fb.createCFProperty(cfExternal);
+        if (externalRef != null) {
+            try {
+                if (new CFBooleanRef(externalRef.getPointer()).booleanValue()) {
+                    return;
+                }
+            } finally {
+                externalRef.release();
+            }
+        }
+        // Synthesize from DisplayAttributes, read from the node or (fallback) its IODeviceTree parent.
+        CFTypeRef attrsRaw = fb.createCFProperty(cfAttrs);
+        if (attrsRaw == null) {
+            IORegistryEntry parent = fb.getParentEntry("IODeviceTree");
+            if (parent != null) {
+                try {
+                    attrsRaw = parent.createCFProperty(cfAttrs);
+                } finally {
+                    parent.release();
+                }
+            }
+        }
+        if (attrsRaw == null) {
+            return;
+        }
+        try {
+            DisplayInfo info = synthesize(fb, new CFDictionaryRef(attrsRaw.getPointer()));
+            if (info != null) {
+                displays.add(new MacDisplayJNA(info));
+            }
+        } finally {
+            attrsRaw.release();
+        }
+    }
+
+    // Maps an Apple Silicon DisplayAttributes dictionary onto a synthetic DisplayInfo via EdidUtil, enriched with
+    // native resolution and device name from the framebuffer node and CoreGraphics.
+    private static DisplayInfo synthesize(IORegistryEntry fb, CFDictionaryRef attrs) {
+        CFDictionaryRef product = cfDictGetDictionary(attrs, "ProductAttributes");
+        if (product == null) {
+            return null;
+        }
+        Long legacyMfg = cfDictGetLong(product, "LegacyManufacturerID");
+        Long week = cfDictGetLong(product, "WeekOfManufacture");
+        Long year = cfDictGetLong(product, "YearOfManufacture");
+        String model = cfDictGetString(product, "ProductName");
+        String serial = cfDictGetString(product, "AlphanumericSerialNumber");
+        // Native pixel resolution from the framebuffer node.
+        Long displayWidth = cfRegistryEntryGetLong(fb, "DisplayWidth");
+        Long displayHeight = cfRegistryEntryGetLong(fb, "DisplayHeight");
+        // Device tree name for fallback model name.
+        String fallbackName = null;
+        String ioNameMatched = cfRegistryEntryGetString(fb, "IONameMatched");
+        if (ioNameMatched != null) {
+            String shortName = ioNameMatched.contains(",") ? ioNameMatched.substring(0, ioNameMatched.indexOf(','))
+                    : ioNameMatched;
+            fallbackName = shortName + " (Built-in Display)";
+        }
+        // CoreGraphics properties: model number, serial number, physical size, and localized name.
+        Integer cgModel = null;
+        Integer cgSerial = null;
+        Double widthMm = null;
+        Double heightMm = null;
+        String displayName = null;
+        int builtInId = findBuiltInDisplayId();
+        if (builtInId >= 0) {
+            try {
+                CoreGraphics cg = CoreGraphics.INSTANCE;
+                cgModel = cg.CGDisplayModelNumber(builtInId);
+                cgSerial = cg.CGDisplaySerialNumber(builtInId);
+                CoreGraphicsExt.CGSizeByValue size = CoreGraphicsExt.INSTANCE.CGDisplayScreenSize(builtInId);
+                widthMm = size.width;
+                heightMm = size.height;
+            } catch (Exception e) {
+                LOG.debug("Failed to get built-in display CoreGraphics properties", e);
+            }
+            displayName = getLocalizedDisplayName(builtInId);
+        }
+        return EdidUtil.synthesizeDisplayInfo(legacyMfg, cgModel, cgSerial, week == null ? null : week.intValue(),
+                year == null ? null : year.intValue(), model, serial, displayWidth, displayHeight, fallbackName,
+                widthMm, heightMm, displayName);
+    }
+
+    // Returns the CGDirectDisplayID of the built-in display, or -1 if not found.
+    private static int findBuiltInDisplayId() {
+        CoreGraphics cg = CoreGraphics.INSTANCE;
+        IntByReference count = new IntByReference();
+        if (cg.CGGetActiveDisplayList(0, null, count) != 0 || count.getValue() == 0) {
+            return -1;
+        }
+        int[] displayIds = new int[count.getValue()];
+        if (cg.CGGetActiveDisplayList(displayIds.length, displayIds, count) != 0) {
+            return -1;
+        }
+        for (int id : displayIds) {
+            if (cg.CGDisplayIsBuiltin(id) != 0) {
+                return id;
+            }
+        }
+        return -1;
+    }
+
+    // Returns the NSScreen.localizedName for the given CGDirectDisplayID, or null.
+    private static String getLocalizedDisplayName(int targetDisplayId) {
+        try {
+            ObjCRuntime objc = ObjCRuntime.INSTANCE;
+            Pointer nsScreenClass = objc.objc_getClass("NSScreen");
+            if (nsScreenClass == null) {
+                return null;
+            }
+            Pointer selScreens = objc.sel_registerName("screens");
+            Pointer selCount = objc.sel_registerName("count");
+            Pointer selObjectAt = objc.sel_registerName("objectAtIndex:");
+            Pointer selDeviceDesc = objc.sel_registerName("deviceDescription");
+            Pointer selLocalizedName = objc.sel_registerName("localizedName");
+
+            Pointer screensArray = objc.objc_msgSend(nsScreenClass, selScreens);
+            if (screensArray == null) {
+                return null;
+            }
+            long count = Pointer.nativeValue(objc.objc_msgSend(screensArray, selCount));
+            CFStringRef cfKey = CFStringRef.createCFString("NSScreenNumber");
+            try {
+                for (long i = 0; i < count; i++) {
+                    Pointer screen = objc.objc_msgSend(screensArray, selObjectAt, i);
+                    if (screen == null) {
+                        continue;
+                    }
+                    Pointer deviceDesc = objc.objc_msgSend(screen, selDeviceDesc);
+                    if (deviceDesc == null) {
+                        continue;
+                    }
+                    Pointer cfNum = CF.CFDictionaryGetValue(new CFDictionaryRef(deviceDesc), cfKey);
+                    if (cfNum == null) {
+                        continue;
+                    }
+                    LongByReference outId = new LongByReference();
+                    if (CF.CFNumberGetValue(new CFNumberRef(cfNum), K_CF_NUMBER_SINT64, outId) != 0
+                            && (int) outId.getValue() == targetDisplayId) {
+                        Pointer nsName = objc.objc_msgSend(screen, selLocalizedName);
+                        if (nsName != null) {
+                            return new CFStringRef(nsName).stringValue();
+                        }
+                    }
+                }
+            } finally {
+                cfKey.release();
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to get localized display name", e);
+        }
+        return null;
+    }
+
+    // Reads a long value from an IORegistryEntry property.
+    private static Long cfRegistryEntryGetLong(IORegistryEntry entry, String key) {
+        CFStringRef k = CFStringRef.createCFString(key);
+        try {
+            CFTypeRef ref = entry.createCFProperty(k);
+            if (ref == null) {
+                return null;
+            }
+            try {
+                CFNumberRef num = new CFNumberRef(ref.getPointer());
+                LongByReference out = new LongByReference();
+                CF.CFNumberGetValue(num, K_CF_NUMBER_SINT64, out);
+                return out.getValue();
+            } finally {
+                ref.release();
+            }
+        } finally {
+            k.release();
+        }
+    }
+
+    // Reads a string value from an IORegistryEntry property.
+    private static String cfRegistryEntryGetString(IORegistryEntry entry, String key) {
+        CFStringRef k = CFStringRef.createCFString(key);
+        try {
+            CFTypeRef ref = entry.createCFProperty(k);
+            if (ref == null) {
+                return null;
+            }
+            try {
+                return new CFStringRef(ref.getPointer()).stringValue();
+            } finally {
+                ref.release();
+            }
+        } finally {
+            k.release();
+        }
+    }
+
+    // CFDictionary accessors. CFDictionaryGetValue returns a borrowed reference: the returned values must NOT be
+    // released.
+
+    private static CFDictionaryRef cfDictGetDictionary(CFDictionaryRef dict, String key) {
+        CFStringRef k = CFStringRef.createCFString(key);
+        try {
+            Pointer v = CF.CFDictionaryGetValue(dict, k);
+            return v == null ? null : new CFDictionaryRef(v);
+        } finally {
+            k.release();
+        }
+    }
+
+    private static String cfDictGetString(CFDictionaryRef dict, String key) {
+        CFStringRef k = CFStringRef.createCFString(key);
+        try {
+            Pointer v = CF.CFDictionaryGetValue(dict, k);
+            return v == null ? null : new CFStringRef(v).stringValue();
+        } finally {
+            k.release();
+        }
+    }
+
+    private static Long cfDictGetLong(CFDictionaryRef dict, String key) {
+        CFStringRef k = CFStringRef.createCFString(key);
+        try {
+            Pointer v = CF.CFDictionaryGetValue(dict, k);
+            if (v == null) {
+                return null;
+            }
+            CFNumberRef num = new CFNumberRef(v);
+            LongByReference out = new LongByReference();
+            CF.CFNumberGetValue(num, K_CF_NUMBER_SINT64, out);
+            return out.getValue();
+        } finally {
+            k.release();
+        }
     }
 }

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/CoreGraphicsExt.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/CoreGraphicsExt.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.jna.platform.mac;
+
+import com.sun.jna.Native;
+import com.sun.jna.Structure;
+import com.sun.jna.Structure.FieldOrder;
+import com.sun.jna.platform.mac.CoreGraphics;
+
+/**
+ * Extensions to JNA's {@link CoreGraphics} for functions not yet bound upstream. This class should be considered
+ * non-API as it may be removed if/when its code is incorporated into the JNA project.
+ */
+public interface CoreGraphicsExt extends CoreGraphics {
+
+    CoreGraphicsExt INSTANCE = Native.load("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+            CoreGraphicsExt.class);
+
+    /**
+     * A {@link com.sun.jna.platform.mac.CoreGraphics.CGSize CGSize} returned by value from native functions.
+     */
+    @FieldOrder({ "width", "height" })
+    class CGSizeByValue extends Structure implements Structure.ByValue {
+        public double width;
+        public double height;
+    }
+
+    /**
+     * Returns the physical size of the display in millimeters.
+     *
+     * @param display The display identifier.
+     * @return A {@link CGSizeByValue} containing the width and height in millimeters.
+     */
+    CGSizeByValue CGDisplayScreenSize(int display);
+}

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/ObjCRuntime.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/ObjCRuntime.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.jna.platform.mac;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+
+/**
+ * Objective-C runtime bindings for dispatching messages to AppKit classes via {@code objc_msgSend}. This class should
+ * be considered non-API as it may be removed if/when its code is incorporated into the JNA project.
+ * <p>
+ * On ARM64, {@code objc_msgSend} must be called with a typed signature matching the selector's actual parameter types.
+ * Variadic {@code Object...} dispatch does not work reliably. Each overload below matches a specific argument shape.
+ */
+public interface ObjCRuntime extends Library {
+
+    ObjCRuntime INSTANCE = Native.load("objc", ObjCRuntime.class);
+
+    Pointer objc_getClass(String className);
+
+    Pointer sel_registerName(String selectorName);
+
+    Pointer objc_msgSend(Pointer receiver, Pointer selector);
+
+    Pointer objc_msgSend(Pointer receiver, Pointer selector, long index);
+}


### PR DESCRIPTION
## Summary

- Detect the Apple Silicon built-in Retina panel (which has no EDID EPROM) by enumerating `IOMobileFramebuffer` nodes and synthesizing a `DisplayInfo` from CoreGraphics and NSScreen properties
- External monitors are explicitly skipped via the `external` boolean property since they are already enumerated with their real EDID via `IOPortTransportStateDisplayPort`, preserving backward-compatible output
- Intel `IODisplayConnect` path is unchanged

The synthesized `DisplayInfo` (flagged `isEdidSynthetic()`) includes:
- Native pixel resolution from the framebuffer node (`DisplayWidth`/`DisplayHeight`)
- Physical dimensions from `CGDisplayScreenSize`
- Product ID from `CGDisplayModelNumber`
- Serial from `CGDisplaySerialNumber`
- Display name from `NSScreen.localizedName` (via ObjC runtime bridge)

JNA (`oshi-core`) and FFM (`oshi-core-ffm`) parity, sharing the native-agnostic `EdidUtil` in `oshi-common`.

Closes #3404

## New bindings
- `CoreGraphicsExt` (JNA): `CGDisplayScreenSize`
- `CoreGraphicsFunctions` (FFM): `CGGetActiveDisplayList`, `CGDisplayIsBuiltin`, `CGDisplayModelNumber`, `CGDisplaySerialNumber`, `CGDisplayScreenSize`
- `ObjCRuntime` (JNA): `objc_getClass`, `sel_registerName`, `objc_msgSend`
- ObjC runtime (FFM): inline `MethodHandle` bindings for `NSScreen` dispatch

## Test plan
- [x] Validated live on M2 Max (both JNA and FFM)
- [x] External monitor EDID output matches master
- [x] `NativeComparisonTest.displays()` passes (JNA/FFM parity)
- [x] New unit tests for `MacDisplayUtil` and `DisplayInfoImpl` edge cases
- [X] CI (macOS runner is Apple Silicon) and local tests on both M2 and M3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Mac display detection to recognize Apple Silicon built-in Retina panels and show richer display details.
  * Added broader support for display metadata, including manufacturer decoding, serial handling, resolution, size, and model naming.

* **Bug Fixes**
  * Prevented failures when display serials or preferred resolutions are missing or malformed.
  * Made display info generation more resilient, falling back gracefully when some details can’t be read.

* **Tests**
  * Added coverage for Apple display synthesis, serial fallback behavior, and null-handling edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->