### PR TITLE
Deprecate Display.getEdid(); remove unreleased Display.isEdidSynthetic()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ##### New Features
 
-* [#3415](https://github.com/oshi/oshi/pull/3415): Add `Display.getDisplayInfo()` and `Display.isEdidSynthetic()`, a new `DisplayInfo` interface, and EDID-encoding methods in `EdidUtil`, allowing display attributes to be exposed without a raw EDID - [@dbwiddis](https://github.com/dbwiddis).
+* [#3415](https://github.com/oshi/oshi/pull/3415): Add `Display.getDisplayInfo()` and a new `DisplayInfo` interface (exposing decoded attributes including `isEdidSynthetic()`), plus EDID-encoding methods in `EdidUtil`, allowing display attributes to be exposed without a raw EDID - [@dbwiddis](https://github.com/dbwiddis).
 * [#3436](https://github.com/oshi/oshi/pull/3436): Detect the Apple Silicon built-in Retina display via `IOMobileFramebuffer` and synthesize a `DisplayInfo` from CoreGraphics and NSScreen properties (resolution, physical size, serial, model name) - [@dbwiddis](https://github.com/dbwiddis).
 
 ##### Bug Fixes and Improvements
@@ -13,6 +13,7 @@
 * [#3431](https://github.com/oshi/oshi/pull/3431): Declare the optional jlibrehardwaremonitor OSGi package imports as optional, so oshi-common resolves in OSGi environments that do not provide it - [@MrEasy](https://github.com/MrEasy).
 * [#3433](https://github.com/oshi/oshi/pull/3433): Restore optional JNA native access for NetBSD, falling back to the command-line implementation when the JNA native library is not installed - [@dbwiddis](https://github.com/dbwiddis).
 * [#3437](https://github.com/oshi/oshi/pull/3437): Add `ParseUtil.decodeIntOrDefault`/`decodeLongOrDefault` and forbid direct use of `Integer.decode`, `Long.decode`, `parseUnsignedInt`, and `parseUnsignedLong` - [@dbwiddis](https://github.com/dbwiddis).
+* [#3438](https://github.com/oshi/oshi/pull/3438): Deprecate `Display.getEdid()` (for removal in the next major version) in favor of `Display.getDisplayInfo().getEdid()`, and remove the redundant `Display.isEdidSynthetic()` in favor of `DisplayInfo.isEdidSynthetic()`, consolidating display data access under `DisplayInfo` - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 
 # 7.3.0 (2026-06-06), 7.3.1 (2026-06-11), 7.3.2 (2026-06-26)

--- a/oshi-common/src/main/java/oshi/hardware/Display.java
+++ b/oshi-common/src/main/java/oshi/hardware/Display.java
@@ -10,30 +10,27 @@ import oshi.annotation.concurrent.Immutable;
 /**
  * Display refers to the information regarding a video source and monitor identified by the EDID standard.
  * <p>
- * The {@link #getEdid()} method returns the raw EDID (Extended Display Identification Data) byte array, a 128-byte (or
- * longer) structure that monitors transmit to describe their capabilities. Use the {@link oshi.util.EdidUtil} class to
- * parse this byte array into human-readable fields such as manufacturer ID, product ID, serial number, display
- * dimensions, and supported resolutions.
+ * {@link #getDisplayInfo()} returns a {@link DisplayInfo} exposing the display's decoded attributes — manufacturer ID,
+ * product ID, serial number, physical dimensions, preferred resolution, model name, and the raw (or synthesized) EDID
+ * byte array.
  * <p>
  * Example: extracting monitor manufacturer and dimensions:
  *
  * <pre>{@code
  * for (Display display : hal.getDisplays()) {
- *     byte[] edid = display.getEdid();
- *     System.out.println("Manufacturer: " + EdidUtil.getManufacturerID(edid));
- *     System.out.println("Product ID:   " + EdidUtil.getProductID(edid));
- *     int hCm = EdidUtil.getHcm(edid);
- *     int vCm = EdidUtil.getVcm(edid);
- *     System.out.printf("Size: %d cm x %d cm%n", hCm, vCm);
+ *     DisplayInfo info = display.getDisplayInfo();
+ *     System.out.println("Manufacturer: " + info.getManufacturerID());
+ *     System.out.println("Product ID:   " + info.getProductID());
+ *     System.out.printf("Size: %d cm x %d cm%n", info.getHcm(), info.getVcm());
  * }
  * }</pre>
  *
  * For displays that report their attributes without providing an EDID (such as a built-in macOS Retina panel),
- * {@link #isEdidSynthetic()} returns {@code true} and {@link #getEdid()} returns an EDID synthesized from those
- * attributes. The decoded fields are also available directly through {@link #getDisplayInfo()}.
+ * {@link DisplayInfo#isEdidSynthetic()} returns {@code true} and {@link DisplayInfo#getEdid()} returns an EDID
+ * synthesized from those attributes.
  *
- * @see oshi.util.EdidUtil
  * @see DisplayInfo
+ * @see oshi.util.EdidUtil
  */
 @PublicApi
 @Immutable
@@ -41,23 +38,19 @@ public interface Display {
     /**
      * The EDID byte array.
      *
-     * @return The EDID byte array, either reported by the display or, when {@link #isEdidSynthetic()} is {@code true},
-     *         synthesized from the display's reported attributes.
+     * @return The EDID byte array, either reported by the display or, when {@link DisplayInfo#isEdidSynthetic()} is
+     *         {@code true}, synthesized from the display's reported attributes.
+     * @deprecated As of 7.4.0, use {@link #getDisplayInfo()}.{@link DisplayInfo#getEdid() getEdid()} instead; the
+     *             decoded attributes are also available directly from {@link DisplayInfo}. Scheduled for removal in the
+     *             next major release.
      */
+    @Deprecated
     byte[] getEdid();
 
     /**
-     * The decoded display information, equivalent to parsing {@link #getEdid()} with {@link oshi.util.EdidUtil}.
+     * The decoded display information.
      *
      * @return A {@link DisplayInfo} holding the display's decoded attributes.
      */
     DisplayInfo getDisplayInfo();
-
-    /**
-     * Indicates whether the EDID returned by {@link #getEdid()} was synthesized from the display's reported attributes
-     * rather than read directly from the display.
-     *
-     * @return {@code true} if the EDID is synthetic, {@code false} if it is the display's raw EDID.
-     */
-    boolean isEdidSynthetic();
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractDisplay.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractDisplay.java
@@ -36,6 +36,7 @@ public abstract class AbstractDisplay implements Display {
         this.displayInfo = displayInfo;
     }
 
+    @Deprecated
     @Override
     public byte[] getEdid() {
         return this.displayInfo.getEdid();
@@ -44,11 +45,6 @@ public abstract class AbstractDisplay implements Display {
     @Override
     public DisplayInfo getDisplayInfo() {
         return this.displayInfo;
-    }
-
-    @Override
-    public boolean isEdidSynthetic() {
-        return this.displayInfo.isEdidSynthetic();
     }
 
     @Override

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractDisplayTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractDisplayTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import oshi.hardware.DisplayInfo;
 import oshi.hardware.DisplayInfoImpl;
 
+@SuppressWarnings("deprecation") // exercises the deprecated Display.getEdid() until its removal
 class AbstractDisplayTest {
 
     @Test
@@ -45,7 +46,7 @@ class AbstractDisplayTest {
         AbstractDisplay display = new AbstractDisplay(new byte[128]) {
         };
         assertThat(display.getDisplayInfo(), is(notNullValue()));
-        assertThat(display.isEdidSynthetic(), is(false));
+        assertThat(display.getDisplayInfo().isEdidSynthetic(), is(false));
     }
 
     @Test
@@ -54,7 +55,7 @@ class AbstractDisplayTest {
         AbstractDisplay display = new AbstractDisplay(info) {
         };
         assertThat(display.getDisplayInfo(), is(sameInstance(info)));
-        assertThat(display.isEdidSynthetic(), is(false));
+        assertThat(display.getDisplayInfo().isEdidSynthetic(), is(false));
         assertThat(display.getEdid(), is(new byte[128]));
     }
 
@@ -64,7 +65,7 @@ class AbstractDisplayTest {
                 "2560x1440", "Thunderbolt", "C02JM2PFF2GC");
         AbstractDisplay display = new AbstractDisplay(info) {
         };
-        assertThat(display.isEdidSynthetic(), is(true));
+        assertThat(display.getDisplayInfo().isEdidSynthetic(), is(true));
         assertThat(display.getDisplayInfo().getModel(), is("Thunderbolt"));
     }
 }

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/DisplayTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/DisplayTest.java
@@ -28,7 +28,8 @@ class DisplayTest {
         SystemInfo si = new SystemInfo();
         List<Display> displays = si.getHardware().getDisplays();
         for (Display d : displays) {
-            assertThat("EDID Byte length should be at least 128", d.getEdid().length, is(greaterThanOrEqualTo(128)));
+            assertThat("EDID Byte length should be at least 128", d.getDisplayInfo().getEdid().length,
+                    is(greaterThanOrEqualTo(128)));
         }
     }
 }

--- a/oshi-demo/src/main/java/oshi/demo/gui/OsHwTextPanel.java
+++ b/oshi-demo/src/main/java/oshi/demo/gui/OsHwTextPanel.java
@@ -147,7 +147,7 @@ public class OsHwTextPanel extends OshiJPanel { // NOSONAR squid:S110
         } else {
             int i = 0;
             for (Display display : displays) {
-                byte[] edid = display.getEdid();
+                byte[] edid = display.getDisplayInfo().getEdid();
                 byte[][] desc = EdidUtil.getDescriptors(edid);
                 String name = "Display " + i;
                 for (byte[] b : desc) {


### PR DESCRIPTION
Consolidates all display data access under `Display.getDisplayInfo()`, so `DisplayInfo` is the single accessor going forward.

## Changes
- **Deprecate `Display.getEdid()`** in favor of `getDisplayInfo().getEdid()`. The `@deprecated` javadoc documents "as of 7.4.0" and "scheduled for removal in the next major version" (oshi-common targets Java 8, so plain `@Deprecated` — no `since`/`forRemoval` elements).
- **Remove `Display.isEdidSynthetic()`.** It was introduced in #3415 during this **still-unreleased** 7.4.0 cycle, so removing it now avoids shipping-then-deprecating a redundant method. `DisplayInfo.isEdidSynthetic()` remains the accessor.
- **Migrate internal consumers** (`DisplayTest`, `OsHwTextPanel` demo) to `getDisplayInfo().getEdid()`; `AbstractDisplayTest` keeps `getEdid()` coverage via `@SuppressWarnings("deprecation")` until removal.
- **Modernize the `Display` javadoc** example to lead with `getDisplayInfo()`.
- **CHANGELOG**: correct the #3415 entry (no longer advertises the removed `Display.isEdidSynthetic()`) and add the deprecation note.

## Why now
The API surface should be settled before 7.4.0 ships. `isEdidSynthetic()` is unreleased, so this is the last free window to drop it without a deprecation cycle; deprecating `getEdid()` in the same release gives consumers a clean pointer to the richer `DisplayInfo` API (including synthetic-EDID displays, currently macOS built-in Retina).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Display EDID details now come through the updated display information view, with synthetic-EDID status exposed there as well.
  * The older direct EDID access path is now deprecated in favor of the newer display information-based method.
  * Display-related output and checks were updated to use the revised EDID access path, keeping results consistent for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->