### PR TITLE
Add autorelease pool, extract ObjCFunctions, use ExceptionUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 7.4.1 (in progress)
 
-* Your contribution here!
+##### Bug Fixes and Improvements
+
+* [#3441](https://github.com/oshi/oshi/pull/3441): Wrap AppKit/Cocoa display-name calls in an autorelease pool, extract `ObjCFunctions` FFM bindings, and use `ExceptionUtil` for consistent error handling - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08)
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/CoreFoundationFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/CoreFoundationFunctions.java
@@ -402,4 +402,5 @@ public final class CoreFoundationFunctions extends MacForeignFunctions {
             throw new ExceptionInInitializerError(e);
         }
     }
+
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/ObjCFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/ObjCFunctions.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.platform.mac;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * Objective-C runtime bindings for dispatching messages to AppKit classes via {@code objc_msgSend}. On ARM64,
+ * {@code objc_msgSend} must be called with a typed signature matching the selector's actual parameter and return types.
+ * Each method below matches a specific argument/return shape.
+ */
+public final class ObjCFunctions extends MacForeignFunctions {
+
+    private ObjCFunctions() {
+    }
+
+    private static final SymbolLookup OBJC_LIBRARY = SymbolLookup.libraryLookup("libobjc.dylib", LIBRARY_ARENA);
+
+    // id objc_getClass(const char * name);
+
+    private static final MethodHandle objc_getClass = LINKER.downcallHandle(OBJC_LIBRARY.findOrThrow("objc_getClass"),
+            FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    public static MemorySegment objc_getClass(MemorySegment name) throws Throwable {
+        return (MemorySegment) objc_getClass.invokeExact(name);
+    }
+
+    // SEL sel_registerName(const char * str);
+
+    private static final MethodHandle sel_registerName = LINKER
+            .downcallHandle(OBJC_LIBRARY.findOrThrow("sel_registerName"), FunctionDescriptor.of(ADDRESS, ADDRESS));
+
+    public static MemorySegment sel_registerName(MemorySegment name) throws Throwable {
+        return (MemorySegment) sel_registerName.invokeExact(name);
+    }
+
+    // id objc_msgSend(id self, SEL op);
+    // id objc_msgSend(id self, SEL op, long arg) — for objectAtIndex: and similar
+
+    private static final MethodHandle objc_msgSend = LINKER.downcallHandle(OBJC_LIBRARY.findOrThrow("objc_msgSend"),
+            FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS));
+    private static final MethodHandle objc_msgSend_long = LINKER.downcallHandle(
+            OBJC_LIBRARY.findOrThrow("objc_msgSend"), FunctionDescriptor.of(ADDRESS, ADDRESS, ADDRESS, JAVA_LONG));
+
+    public static MemorySegment objc_msgSend(MemorySegment receiver, MemorySegment selector) throws Throwable {
+        return (MemorySegment) objc_msgSend.invokeExact(receiver, selector);
+    }
+
+    public static MemorySegment objc_msgSend(MemorySegment receiver, MemorySegment selector, long arg)
+            throws Throwable {
+        return (MemorySegment) objc_msgSend_long.invokeExact(receiver, selector, arg);
+    }
+
+    // long objc_msgSend(id self, SEL op) — for count and similar returning NSUInteger
+
+    private static final MethodHandle objc_msgSend_ret_long = LINKER.downcallHandle(
+            OBJC_LIBRARY.findOrThrow("objc_msgSend"), FunctionDescriptor.of(JAVA_LONG, ADDRESS, ADDRESS));
+
+    public static long objc_msgSend_long(MemorySegment receiver, MemorySegment selector) throws Throwable {
+        return (long) objc_msgSend_ret_long.invokeExact(receiver, selector);
+    }
+
+    // void * objc_autoreleasePoolPush(void);
+
+    private static final MethodHandle objc_autoreleasePoolPush = LINKER
+            .downcallHandle(OBJC_LIBRARY.findOrThrow("objc_autoreleasePoolPush"), FunctionDescriptor.of(ADDRESS));
+
+    public static MemorySegment objc_autoreleasePoolPush() throws Throwable {
+        return (MemorySegment) objc_autoreleasePoolPush.invokeExact();
+    }
+
+    // void objc_autoreleasePoolPop(void * context);
+
+    private static final MethodHandle objc_autoreleasePoolPop = LINKER
+            .downcallHandle(OBJC_LIBRARY.findOrThrow("objc_autoreleasePoolPop"), FunctionDescriptor.ofVoid(ADDRESS));
+
+    public static void objc_autoreleasePoolPop(MemorySegment pool) throws Throwable {
+        objc_autoreleasePoolPop.invokeExact(pool);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
@@ -5,12 +5,8 @@
 package oshi.hardware.platform.mac;
 
 import java.lang.foreign.Arena;
-import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
-import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,14 +19,17 @@ import oshi.ffm.platform.mac.CoreFoundation.CFDataRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFDictionaryRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFNumberRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFStringRef;
+import oshi.ffm.platform.mac.CoreFoundationFunctions;
 import oshi.ffm.platform.mac.CoreGraphicsFunctions;
 import oshi.ffm.platform.mac.IOKit.IOIterator;
 import oshi.ffm.platform.mac.IOKit.IORegistryEntry;
+import oshi.ffm.platform.mac.ObjCFunctions;
 import oshi.ffm.util.platform.mac.IOKitUtilFFM;
 import oshi.hardware.Display;
 import oshi.hardware.DisplayInfo;
 import oshi.hardware.common.AbstractDisplay;
 import oshi.util.EdidUtil;
+import oshi.util.ExceptionUtil;
 
 /**
  * A Display
@@ -207,115 +206,88 @@ final class MacDisplayFFM extends AbstractDisplay {
 
     // Returns the CGDirectDisplayID of the built-in display, or -1 if not found.
     private static int findBuiltInDisplayId() {
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment countSeg = arena.allocate(ValueLayout.JAVA_INT);
-            if (CoreGraphicsFunctions.CGGetActiveDisplayList(0, MemorySegment.NULL, countSeg) != 0) {
-                return -1;
-            }
-            int count = countSeg.get(ValueLayout.JAVA_INT, 0);
-            if (count == 0) {
-                return -1;
-            }
-            MemorySegment idsSeg = arena.allocate(ValueLayout.JAVA_INT, count);
-            if (CoreGraphicsFunctions.CGGetActiveDisplayList(count, idsSeg, countSeg) != 0) {
-                return -1;
-            }
-            for (int i = 0; i < count; i++) {
-                int id = idsSeg.getAtIndex(ValueLayout.JAVA_INT, i);
-                if (CoreGraphicsFunctions.CGDisplayIsBuiltin(id) != 0) {
-                    return id;
+        return ExceptionUtil.getIntOrDefault(() -> {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment countSeg = arena.allocate(ValueLayout.JAVA_INT);
+                if (CoreGraphicsFunctions.CGGetActiveDisplayList(0, MemorySegment.NULL, countSeg) != 0) {
+                    return -1;
+                }
+                int count = countSeg.get(ValueLayout.JAVA_INT, 0);
+                if (count == 0) {
+                    return -1;
+                }
+                MemorySegment idsSeg = arena.allocate(ValueLayout.JAVA_INT, count);
+                if (CoreGraphicsFunctions.CGGetActiveDisplayList(count, idsSeg, countSeg) != 0) {
+                    return -1;
+                }
+                for (int i = 0; i < count; i++) {
+                    int id = idsSeg.getAtIndex(ValueLayout.JAVA_INT, i);
+                    if (CoreGraphicsFunctions.CGDisplayIsBuiltin(id) != 0) {
+                        return id;
+                    }
                 }
             }
-        } catch (Throwable t) {
-            LOG.debug("Failed to find built-in display ID", t);
-        }
-        return -1;
+            return -1;
+        }, -1, LOG, "Failed to find built-in display ID: {}");
     }
-
-    // ObjC runtime handles for NSScreen.localizedName lookup.
-    private static final SymbolLookup OBJC_LOOKUP = SymbolLookup.libraryLookup("libobjc.dylib", Arena.global());
-    private static final SymbolLookup CF_LOOKUP = SymbolLookup
-            .libraryLookup("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation", Arena.global());
-    private static final MethodHandle OBJC_GET_CLASS = Linker.nativeLinker().downcallHandle(
-            OBJC_LOOKUP.find("objc_getClass").orElseThrow(),
-            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-    private static final MethodHandle SEL_REGISTER_NAME = Linker.nativeLinker().downcallHandle(
-            OBJC_LOOKUP.find("sel_registerName").orElseThrow(),
-            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-    private static final MethodHandle MSG_SEND = Linker.nativeLinker().downcallHandle(
-            OBJC_LOOKUP.find("objc_msgSend").orElseThrow(),
-            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-    private static final MethodHandle MSG_SEND_LONG = Linker.nativeLinker()
-            .downcallHandle(OBJC_LOOKUP.find("objc_msgSend").orElseThrow(), FunctionDescriptor.of(ValueLayout.ADDRESS,
-                    ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
-    private static final MethodHandle MSG_SEND_COUNT = Linker.nativeLinker().downcallHandle(
-            OBJC_LOOKUP.find("objc_msgSend").orElseThrow(),
-            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-    private static final MethodHandle CF_DICTIONARY_GET_VALUE = Linker.nativeLinker().downcallHandle(
-            CF_LOOKUP.find("CFDictionaryGetValue").orElseThrow(),
-            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-    private static final MethodHandle CF_NUMBER_GET_VALUE = Linker.nativeLinker()
-            .downcallHandle(CF_LOOKUP.find("CFNumberGetValue").orElseThrow(), FunctionDescriptor
-                    .of(ValueLayout.JAVA_BOOLEAN, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
-    private static final MethodHandle CF_STRING_GET_CSTRING = Linker.nativeLinker().downcallHandle(
-            CF_LOOKUP.find("CFStringGetCString").orElseThrow(), FunctionDescriptor.of(ValueLayout.JAVA_BOOLEAN,
-                    ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT));
 
     // Returns the NSScreen.localizedName for the given CGDirectDisplayID, or null.
     private static String getLocalizedDisplayName(int targetDisplayId) {
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment nsScreenClass = (MemorySegment) OBJC_GET_CLASS.invokeExact(arena.allocateFrom("NSScreen"));
-            if (nsScreenClass.address() == 0) {
-                return null;
+        return ExceptionUtil.getOrDefault(() -> {
+            try (Arena arena = Arena.ofConfined()) {
+                // Autorelease pool is thread-local; concurrent callers each get their own pool
+                MemorySegment pool = ObjCFunctions.objc_autoreleasePoolPush();
+                try {
+                    return queryLocalizedDisplayName(arena, targetDisplayId);
+                } finally {
+                    ObjCFunctions.objc_autoreleasePoolPop(pool);
+                }
             }
-            MemorySegment selScreens = (MemorySegment) SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("screens"));
-            MemorySegment selCount = (MemorySegment) SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("count"));
-            MemorySegment selObjectAt = (MemorySegment) SEL_REGISTER_NAME
-                    .invokeExact(arena.allocateFrom("objectAtIndex:"));
-            MemorySegment selDeviceDesc = (MemorySegment) SEL_REGISTER_NAME
-                    .invokeExact(arena.allocateFrom("deviceDescription"));
-            MemorySegment selLocalizedName = (MemorySegment) SEL_REGISTER_NAME
-                    .invokeExact(arena.allocateFrom("localizedName"));
+        }, null, LOG, "Failed to get localized display name: {}");
+    }
 
-            MemorySegment screensArray = (MemorySegment) MSG_SEND.invokeExact(nsScreenClass, selScreens);
-            if (screensArray.address() == 0) {
-                return null;
-            }
-            long count = (long) MSG_SEND_COUNT.invokeExact(screensArray, selCount);
+    private static String queryLocalizedDisplayName(Arena arena, int targetDisplayId) throws Throwable {
+        MemorySegment nsScreenClass = ObjCFunctions.objc_getClass(arena.allocateFrom("NSScreen"));
+        if (nsScreenClass.address() == 0) {
+            return null;
+        }
+        MemorySegment selScreens = ObjCFunctions.sel_registerName(arena.allocateFrom("screens"));
+        MemorySegment selCount = ObjCFunctions.sel_registerName(arena.allocateFrom("count"));
+        MemorySegment selObjectAt = ObjCFunctions.sel_registerName(arena.allocateFrom("objectAtIndex:"));
+        MemorySegment selDeviceDesc = ObjCFunctions.sel_registerName(arena.allocateFrom("deviceDescription"));
+        MemorySegment selLocalizedName = ObjCFunctions.sel_registerName(arena.allocateFrom("localizedName"));
 
-            try (CFStringRef cfKey = CFStringRef.createCFString("NSScreenNumber")) {
-                for (long i = 0; i < count; i++) {
-                    MemorySegment screen = (MemorySegment) MSG_SEND_LONG.invokeExact(screensArray, selObjectAt, i);
-                    if (screen.address() == 0) {
-                        continue;
-                    }
-                    MemorySegment deviceDesc = (MemorySegment) MSG_SEND.invokeExact(screen, selDeviceDesc);
-                    if (deviceDesc.address() == 0) {
-                        continue;
-                    }
-                    MemorySegment cfNum = (MemorySegment) CF_DICTIONARY_GET_VALUE.invokeExact(deviceDesc,
-                            cfKey.segment());
-                    if (cfNum.address() == 0) {
-                        continue;
-                    }
-                    MemorySegment outId = arena.allocate(ValueLayout.JAVA_INT);
-                    // kCFNumberSInt32Type = 3
-                    boolean ok = (boolean) CF_NUMBER_GET_VALUE.invokeExact(cfNum, 3L, outId);
-                    if (ok && outId.get(ValueLayout.JAVA_INT, 0) == targetDisplayId) {
-                        MemorySegment nsName = (MemorySegment) MSG_SEND.invokeExact(screen, selLocalizedName);
-                        if (nsName.address() != 0) {
-                            MemorySegment buf = arena.allocate(256);
-                            // kCFStringEncodingUTF8 = 0x08000100
-                            boolean got = (boolean) CF_STRING_GET_CSTRING.invokeExact(nsName, buf, 256L, 0x08000100);
-                            if (got) {
-                                return buf.getString(0);
-                            }
-                        }
+        MemorySegment screensArray = ObjCFunctions.objc_msgSend(nsScreenClass, selScreens);
+        if (screensArray.address() == 0) {
+            return null;
+        }
+        long count = ObjCFunctions.objc_msgSend_long(screensArray, selCount);
+
+        try (CFStringRef cfKey = CFStringRef.createCFString("NSScreenNumber")) {
+            for (long i = 0; i < count; i++) {
+                MemorySegment screen = ObjCFunctions.objc_msgSend(screensArray, selObjectAt, i);
+                if (screen.address() == 0) {
+                    continue;
+                }
+                MemorySegment deviceDesc = ObjCFunctions.objc_msgSend(screen, selDeviceDesc);
+                if (deviceDesc.address() == 0) {
+                    continue;
+                }
+                MemorySegment cfNum = CoreFoundationFunctions.CFDictionaryGetValue(deviceDesc, cfKey.segment());
+                if (cfNum.address() == 0) {
+                    continue;
+                }
+                MemorySegment outId = arena.allocate(ValueLayout.JAVA_INT);
+                // kCFNumberSInt32Type = 3
+                boolean ok = CoreFoundationFunctions.CFNumberGetValue(cfNum, 3, outId);
+                if (ok && outId.get(ValueLayout.JAVA_INT, 0) == targetDisplayId) {
+                    MemorySegment nsName = ObjCFunctions.objc_msgSend(screen, selLocalizedName);
+                    if (nsName.address() != 0) {
+                        // Borrowed autoreleased reference — do not close/release
+                        return new CFStringRef(nsName).stringValue();
                     }
                 }
             }
-        } catch (Throwable t) {
-            LOG.debug("Failed to get localized display name", t);
         }
         return null;
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
@@ -33,6 +33,7 @@ import oshi.hardware.common.AbstractDisplay;
 import oshi.jna.platform.mac.CoreGraphicsExt;
 import oshi.jna.platform.mac.ObjCRuntime;
 import oshi.util.EdidUtil;
+import oshi.util.ExceptionUtil;
 
 /**
  * A Display
@@ -277,52 +278,60 @@ final class MacDisplayJNA extends AbstractDisplay {
 
     // Returns the NSScreen.localizedName for the given CGDirectDisplayID, or null.
     private static String getLocalizedDisplayName(int targetDisplayId) {
-        try {
+        return ExceptionUtil.getOrDefault(() -> {
             ObjCRuntime objc = ObjCRuntime.INSTANCE;
-            Pointer nsScreenClass = objc.objc_getClass("NSScreen");
-            if (nsScreenClass == null) {
-                return null;
-            }
-            Pointer selScreens = objc.sel_registerName("screens");
-            Pointer selCount = objc.sel_registerName("count");
-            Pointer selObjectAt = objc.sel_registerName("objectAtIndex:");
-            Pointer selDeviceDesc = objc.sel_registerName("deviceDescription");
-            Pointer selLocalizedName = objc.sel_registerName("localizedName");
-
-            Pointer screensArray = objc.objc_msgSend(nsScreenClass, selScreens);
-            if (screensArray == null) {
-                return null;
-            }
-            long count = Pointer.nativeValue(objc.objc_msgSend(screensArray, selCount));
-            CFStringRef cfKey = CFStringRef.createCFString("NSScreenNumber");
+            // Autorelease pool is thread-local; concurrent callers each get their own pool
+            Pointer pool = objc.objc_autoreleasePoolPush();
             try {
-                for (long i = 0; i < count; i++) {
-                    Pointer screen = objc.objc_msgSend(screensArray, selObjectAt, i);
-                    if (screen == null) {
-                        continue;
-                    }
-                    Pointer deviceDesc = objc.objc_msgSend(screen, selDeviceDesc);
-                    if (deviceDesc == null) {
-                        continue;
-                    }
-                    Pointer cfNum = CF.CFDictionaryGetValue(new CFDictionaryRef(deviceDesc), cfKey);
-                    if (cfNum == null) {
-                        continue;
-                    }
-                    LongByReference outId = new LongByReference();
-                    if (CF.CFNumberGetValue(new CFNumberRef(cfNum), K_CF_NUMBER_SINT64, outId) != 0
-                            && (int) outId.getValue() == targetDisplayId) {
-                        Pointer nsName = objc.objc_msgSend(screen, selLocalizedName);
-                        if (nsName != null) {
-                            return new CFStringRef(nsName).stringValue();
-                        }
+                return queryLocalizedDisplayName(objc, targetDisplayId);
+            } finally {
+                objc.objc_autoreleasePoolPop(pool);
+            }
+        }, null, LOG, "Failed to get localized display name: {}");
+    }
+
+    private static String queryLocalizedDisplayName(ObjCRuntime objc, int targetDisplayId) {
+        Pointer nsScreenClass = objc.objc_getClass("NSScreen");
+        if (nsScreenClass == null) {
+            return null;
+        }
+        Pointer selScreens = objc.sel_registerName("screens");
+        Pointer selCount = objc.sel_registerName("count");
+        Pointer selObjectAt = objc.sel_registerName("objectAtIndex:");
+        Pointer selDeviceDesc = objc.sel_registerName("deviceDescription");
+        Pointer selLocalizedName = objc.sel_registerName("localizedName");
+
+        Pointer screensArray = objc.objc_msgSend(nsScreenClass, selScreens);
+        if (screensArray == null) {
+            return null;
+        }
+        long count = Pointer.nativeValue(objc.objc_msgSend(screensArray, selCount));
+        CFStringRef cfKey = CFStringRef.createCFString("NSScreenNumber");
+        try {
+            for (long i = 0; i < count; i++) {
+                Pointer screen = objc.objc_msgSend(screensArray, selObjectAt, i);
+                if (screen == null) {
+                    continue;
+                }
+                Pointer deviceDesc = objc.objc_msgSend(screen, selDeviceDesc);
+                if (deviceDesc == null) {
+                    continue;
+                }
+                Pointer cfNum = CF.CFDictionaryGetValue(new CFDictionaryRef(deviceDesc), cfKey);
+                if (cfNum == null) {
+                    continue;
+                }
+                LongByReference outId = new LongByReference();
+                if (CF.CFNumberGetValue(new CFNumberRef(cfNum), K_CF_NUMBER_SINT64, outId) != 0
+                        && (int) outId.getValue() == targetDisplayId) {
+                    Pointer nsName = objc.objc_msgSend(screen, selLocalizedName);
+                    if (nsName != null) {
+                        return new CFStringRef(nsName).stringValue();
                     }
                 }
-            } finally {
-                cfKey.release();
             }
-        } catch (Exception e) {
-            LOG.debug("Failed to get localized display name", e);
+        } finally {
+            cfKey.release();
         }
         return null;
     }

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/ObjCRuntime.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/ObjCRuntime.java
@@ -26,4 +26,8 @@ public interface ObjCRuntime extends Library {
     Pointer objc_msgSend(Pointer receiver, Pointer selector);
 
     Pointer objc_msgSend(Pointer receiver, Pointer selector, long index);
+
+    Pointer objc_autoreleasePoolPush();
+
+    void objc_autoreleasePoolPop(Pointer pool);
 }


### PR DESCRIPTION
## Summary

- Wrap AppKit/Cocoa ObjC messaging (`NSScreen.localizedName`) in `objc_autoreleasePoolPush`/`Pop` so autoreleased objects are drained promptly instead of leaking until thread exit (resolves #3439)
- Extract ObjC runtime bindings into a new `ObjCFunctions` FFM class (parallel to the JNA `ObjCRuntime` interface), and use existing `CoreFoundationFunctions` for CF calls — removes duplicate private `MethodHandle` constants from `MacDisplayFFM`
- Adopt `ExceptionUtil.getOrDefault`/`getIntOrDefault` for consistent error handling in `getLocalizedDisplayName` and `findBuiltInDisplayId`
- Add `objc_autoreleasePoolPush`/`Pop` to the JNA `ObjCRuntime` interface

## Test plan

- [x] `mvn clean install` passes (all modules)
- [x] `DisplayTest` passes
- [x] Verified built-in Retina display output via `SystemInfoTest` on local Apple Silicon (both JNA and FFM paths show correct display info)
- [x] `spotless:apply`, `checkstyle:check`, `forbiddenapis:check`, `javadoc:javadoc` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved macOS display name lookup to better return localized monitor names.
* **Bug Fixes**
  * More reliable handling of native display queries, with graceful fallback when localized names can’t be retrieved.
  * Better management of native autorelease pools during macOS display enumeration to reduce related failures.
* **Documentation**
  * Updated the changelog for the latest in-progress bug fixes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->