### PR TITLE
Convert static memoized suppliers to instance fields for memory reclaim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug Fixes and Improvements
 
 * [#3441](https://github.com/oshi/oshi/pull/3441): Wrap AppKit/Cocoa display-name calls in an autorelease pool, extract `ObjCFunctions` FFM bindings, and use `ExceptionUtil` for consistent error handling - [@dbwiddis](https://github.com/dbwiddis).
+* [#3442](https://github.com/oshi/oshi/pull/3442): Convert static memoized suppliers to instance fields, allowing cached data to be reclaimed when users create new `SystemInfo` instances - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
@@ -29,10 +29,12 @@ import oshi.util.tuples.Quartet;
 @ThreadSafe
 public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
 
-    private final Supplier<List<String>> iostat = memoize(NetBsdHWDiskStore::queryIostat, defaultExpiration());
+    private final Supplier<List<String>> iostat;
 
-    private NetBsdHWDiskStore(String name, String model, String serial, long size) {
+    private NetBsdHWDiskStore(String name, String model, String serial, long size,
+            Supplier<List<String>> iostatSupplier) {
         super(name, model, serial, size);
+        this.iostat = iostatSupplier;
     }
 
     /**
@@ -43,6 +45,7 @@ public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
     public static List<HWDiskStore> getDisks() {
         List<HWDiskStore> diskList = new ArrayList<>();
         List<String> dmesg = null;
+        Supplier<List<String>> iostatSupplier = memoize(NetBsdHWDiskStore::queryIostat, defaultExpiration());
 
         // Get list of disks from sysctl
         // NetBSD: hw.disknames = ld0 fd0 dk0 dk1 cd0 (space-separated, no colon suffix)
@@ -86,7 +89,7 @@ public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
                     }
                 }
             }
-            store = new NetBsdHWDiskStore(diskName, model, diskdata.getB(), size);
+            store = new NetBsdHWDiskStore(diskName, model, diskdata.getB(), size, iostatSupplier);
             store.setPartitionList(diskdata.getD());
             store.updateAttributes();
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
@@ -29,7 +29,7 @@ import oshi.util.tuples.Quartet;
 @ThreadSafe
 public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
 
-    private static final Supplier<List<String>> IOSTAT = memoize(NetBsdHWDiskStore::queryIostat, defaultExpiration());
+    private final Supplier<List<String>> iostat = memoize(NetBsdHWDiskStore::queryIostat, defaultExpiration());
 
     private NetBsdHWDiskStore(String name, String model, String serial, long size) {
         super(name, model, serial, size);
@@ -99,7 +99,7 @@ public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
     public boolean updateAttributes() {
         long now = System.currentTimeMillis();
         boolean diskFound = false;
-        for (String line : IOSTAT.get()) {
+        for (String line : iostat.get()) {
             String[] split = ParseUtil.whitespaces.split(line.trim());
             // iostat -x -I output (cumulative totals, 9 fields):
             // device read KB/t xfr time MB write KB/t xfr time MB

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
@@ -58,7 +58,8 @@ public final class Advapi32UtilFFM {
 
     private static final Logger LOG = LoggerFactory.getLogger(Advapi32UtilFFM.class);
 
-    private static Supplier<String> systemLog = memoize(Advapi32UtilFFM::querySystemLog, TimeUnit.HOURS.toNanos(1));
+    private static final Supplier<String> SYSTEM_LOG = memoize(Advapi32UtilFFM::querySystemLog,
+            TimeUnit.HOURS.toNanos(1));
 
     /**
      * Checks whether the current process is running with elevated privileges.
@@ -386,7 +387,7 @@ public final class Advapi32UtilFFM {
      * @return the boot time as a Unix epoch timestamp in seconds
      */
     public static long querySystemBootTime() {
-        String eventLog = systemLog.get();
+        String eventLog = SYSTEM_LOG.get();
         try (Arena arena = Arena.ofConfined()) {
             Optional<MemorySegment> hEventLogOpt = Advapi32FFM.OpenEventLog(arena, eventLog);
             if (hEventLogOpt.isEmpty()) {

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisFileSystemJNA.java
@@ -24,14 +24,14 @@ import oshi.util.tuples.Pair;
 @ThreadSafe
 public final class SolarisFileSystemJNA extends SolarisFileSystem {
 
-    private static final Supplier<Pair<Long, Long>> FILE_DESC = Memoizer
-            .memoize(SolarisFileSystemJNA::queryFileDescriptors, defaultExpiration());
+    private final Supplier<Pair<Long, Long>> fileDesc = Memoizer.memoize(SolarisFileSystemJNA::queryFileDescriptors,
+            defaultExpiration());
 
     @Override
     public long getOpenFileDescriptors() {
         if (HAS_KSTAT2) {
             // Use Kstat2 implementation
-            return FILE_DESC.get().getA();
+            return fileDesc.get().getA();
         }
         try (KstatChain kc = KstatUtil.openChain()) {
             Kstat ksp = kc.lookup(null, -1, "file_cache");
@@ -47,7 +47,7 @@ public final class SolarisFileSystemJNA extends SolarisFileSystem {
     public long getMaxFileDescriptors() {
         if (HAS_KSTAT2) {
             // Use Kstat2 implementation
-            return FILE_DESC.get().getB();
+            return fileDesc.get().getB();
         }
         try (KstatChain kc = KstatUtil.openChain()) {
             Kstat ksp = kc.lookup(null, -1, "file_cache");

--- a/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystemJNA.java
@@ -29,7 +29,6 @@ import oshi.util.GlobalConfig;
 import oshi.util.Memoizer;
 import oshi.util.platform.unix.solaris.KstatUtil;
 import oshi.util.platform.unix.solaris.KstatUtil.KstatChain;
-import oshi.util.tuples.Pair;
 
 /**
  * JNA-backed Solaris OperatingSystem. Uses Kstat2 (Solaris 11.4+) where available, falling back to the legacy
@@ -90,10 +89,10 @@ public class SolarisOperatingSystemJNA extends SolarisOperatingSystem {
         return false;
     }
 
-    private static final Supplier<Pair<Long, Long>> BOOT_UPTIME = Memoizer
-            .memoize(SolarisOperatingSystemJNA::queryBootAndUptime, defaultExpiration());
-
     private static final long BOOTTIME = querySystemBootTime();
+
+    private final Supplier<Long> uptimeSupplier = Memoizer.memoize(SolarisOperatingSystemJNA::queryUptime,
+            defaultExpiration());
 
     @Override
     public FileSystem getFileSystem() {
@@ -127,22 +126,7 @@ public class SolarisOperatingSystemJNA extends SolarisOperatingSystem {
 
     @Override
     public long getSystemUptime() {
-        return querySystemUptime();
-    }
-
-    private static long querySystemUptime() {
-        if (HAS_KSTAT2) {
-            // Use Kstat2 implementation
-            return BOOT_UPTIME.get().getB();
-        }
-        try (KstatChain kc = KstatUtil.openChain()) {
-            Kstat ksp = kc.lookup("unix", 0, "system_misc");
-            if (ksp != null && kc.read(ksp)) {
-                // Snap Time is in nanoseconds; divide for seconds
-                return ksp.ks_snaptime / 1_000_000_000L;
-            }
-        }
-        return 0L;
+        return uptimeSupplier.get();
     }
 
     @Override
@@ -152,8 +136,10 @@ public class SolarisOperatingSystemJNA extends SolarisOperatingSystem {
 
     private static long querySystemBootTime() {
         if (HAS_KSTAT2) {
-            // Use Kstat2 implementation
-            return BOOT_UPTIME.get().getA();
+            Object[] results = KstatUtil.queryKstat2("kstat:/misc/unix/system_misc", "boot_time");
+            if (results[0] != null) {
+                return (long) results[0];
+            }
         }
         try (KstatChain kc = KstatUtil.openChain()) {
             Kstat ksp = kc.lookup("unix", 0, "system_misc");
@@ -161,18 +147,25 @@ public class SolarisOperatingSystemJNA extends SolarisOperatingSystem {
                 return KstatUtil.dataLookupLong(ksp, "boot_time");
             }
         }
-        return System.currentTimeMillis() / 1000L - querySystemUptime();
+        return System.currentTimeMillis() / 1000L;
     }
 
-    private static Pair<Long, Long> queryBootAndUptime() {
-        Object[] results = KstatUtil.queryKstat2("kstat:/misc/unix/system_misc", "boot_time", "snaptime");
-
-        // boot_time is epoch seconds; keep the fallback in seconds to match getSystemBootTime()
-        long boot = results[0] == null ? System.currentTimeMillis() / 1000L : (long) results[0];
-        // Snap Time is in nanoseconds; divide for seconds
-        long snap = results[1] == null ? 0L : (long) results[1] / 1_000_000_000L;
-
-        return new Pair<>(boot, snap);
+    private static long queryUptime() {
+        if (HAS_KSTAT2) {
+            Object[] results = KstatUtil.queryKstat2("kstat:/misc/unix/system_misc", "snaptime");
+            if (results[0] != null) {
+                // Snap Time is in nanoseconds; divide for seconds
+                return (long) results[0] / 1_000_000_000L;
+            }
+        }
+        try (KstatChain kc = KstatUtil.openChain()) {
+            Kstat ksp = kc.lookup("unix", 0, "system_misc");
+            if (ksp != null && kc.read(ksp)) {
+                // Snap Time is in nanoseconds; divide for seconds
+                return ksp.ks_snaptime / 1_000_000_000L;
+            }
+        }
+        return 0L;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
@@ -98,7 +98,7 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
     /*
      * Windows event log name
      */
-    private static Supplier<String> systemLog = memoize(WindowsOperatingSystemJNA::querySystemLog,
+    private static final Supplier<String> SYSTEM_LOG = memoize(WindowsOperatingSystemJNA::querySystemLog,
             TimeUnit.HOURS.toNanos(1));
 
     private static final long BOOTTIME = querySystemBootTime();
@@ -357,7 +357,7 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
     }
 
     private static long querySystemBootTime() {
-        String eventLog = systemLog.get();
+        String eventLog = SYSTEM_LOG.get();
         if (eventLog != null) {
             try {
                 EventLogIterator iter = new EventLogIterator(null, eventLog, WinNT.EVENTLOG_BACKWARDS_READ);


### PR DESCRIPTION
## Summary

- Convert static memoized `Supplier` fields to instance fields in `NetBsdHWDiskStore`, `SolarisFileSystemJNA`, and `SolarisOperatingSystemJNA`, allowing cached data to be garbage-collected when users create new `SystemInfo` instances.
- Make `systemLog` suppliers in `WindowsOperatingSystemJNA` and `Advapi32UtilFFM` properly `static final` with conventional naming (these hold OS-constant data so static is appropriate, but they were missing `final`).
- Separate boot-time (queried once, constant) from uptime (periodically refreshed) in `SolarisOperatingSystemJNA` to eliminate a paired static memoizer that bundled both.

## Test plan

- [x] `mvn compile` passes for all affected modules
- [x] `mvn test` passes for oshi-common, oshi-core-ffm
- [x] `mvn test` passes for oshi-benchmark (JNA vs FFM comparison)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system information caching to better reclaim cached data when new system instances are created.
  * Enhanced Solaris/illumos uptime and boot-time reporting, including more robust Kstat2 and legacy fallbacks.
  * Improved accuracy and consistency of disk info, file descriptor counts, and Windows “System” event-log name retrieval across supported platforms.
* **Documentation**
  * Updated the changelog to reflect the above improvements and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->