### PR TITLE
Share memoized iostat supplier across disk instances; cache pluggable hardware in HAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#3441](https://github.com/oshi/oshi/pull/3441): Wrap AppKit/Cocoa display-name calls in an autorelease pool, extract `ObjCFunctions` FFM bindings, and use `ExceptionUtil` for consistent error handling - [@dbwiddis](https://github.com/dbwiddis).
 * [#3442](https://github.com/oshi/oshi/pull/3442): Convert static memoized suppliers to instance fields, allowing cached data to be reclaimed when users create new `SystemInfo` instances - [@dbwiddis](https://github.com/dbwiddis).
+* [#3443](https://github.com/oshi/oshi/pull/3443): Share memoized iostat supplier across disk instances; cache pluggable hardware lists (displays, USB, sound cards, graphics cards) in the HAL with a 3-second TTL - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractHardwareAbstractionLayer.java
@@ -5,17 +5,23 @@
 package oshi.hardware.common;
 
 import static oshi.util.Memoizer.memoize;
+import static oshi.util.Memoizer.slowExpiration;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.ComputerSystem;
+import oshi.hardware.Display;
 import oshi.hardware.GlobalMemory;
+import oshi.hardware.GraphicsCard;
 import oshi.hardware.HardwareAbstractionLayer;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.Sensors;
+import oshi.hardware.SoundCard;
+import oshi.hardware.UsbDevice;
 
 /**
  * Common fields or methods used by platform-specific implementations of HardwareAbstractionLayer
@@ -36,6 +42,14 @@ public abstract class AbstractHardwareAbstractionLayer implements HardwareAbstra
     private final Supplier<GlobalMemory> memory = memoize(this::createMemory);
 
     private final Supplier<Sensors> sensors = memoize(this::createSensors);
+
+    private final Supplier<List<Display>> displays = memoize(this::createDisplays, slowExpiration());
+
+    private final Supplier<List<SoundCard>> soundCards = memoize(this::createSoundCards, slowExpiration());
+
+    private final Supplier<List<GraphicsCard>> graphicsCards = memoize(this::createGraphicsCards, slowExpiration());
+
+    private final Supplier<List<UsbDevice>> usbDevicesTree = memoize(this::createUsbDevices, slowExpiration());
 
     @Override
     public ComputerSystem getComputerSystem() {
@@ -84,6 +98,69 @@ public abstract class AbstractHardwareAbstractionLayer implements HardwareAbstra
      * @return platform-specific {@link Sensors} object
      */
     protected abstract Sensors createSensors();
+
+    @Override
+    public List<Display> getDisplays() {
+        return displays.get();
+    }
+
+    /**
+     * Instantiates the platform-specific list of {@link Display} objects
+     *
+     * @return platform-specific list of {@link Display} objects
+     */
+    protected abstract List<Display> createDisplays();
+
+    @Override
+    public List<SoundCard> getSoundCards() {
+        return soundCards.get();
+    }
+
+    /**
+     * Instantiates the platform-specific list of {@link SoundCard} objects
+     *
+     * @return platform-specific list of {@link SoundCard} objects
+     */
+    protected abstract List<SoundCard> createSoundCards();
+
+    @Override
+    public List<GraphicsCard> getGraphicsCards() {
+        return graphicsCards.get();
+    }
+
+    /**
+     * Instantiates the platform-specific list of {@link GraphicsCard} objects
+     *
+     * @return platform-specific list of {@link GraphicsCard} objects
+     */
+    protected abstract List<GraphicsCard> createGraphicsCards();
+
+    @Override
+    public List<UsbDevice> getUsbDevices(boolean tree) {
+        List<UsbDevice> devices = usbDevicesTree.get();
+        if (tree) {
+            return devices;
+        }
+        List<UsbDevice> deviceList = new ArrayList<>();
+        for (UsbDevice device : devices) {
+            addDevicesToList(deviceList, device.getConnectedDevices());
+        }
+        return deviceList;
+    }
+
+    private static void addDevicesToList(List<UsbDevice> deviceList, List<UsbDevice> list) {
+        for (UsbDevice device : list) {
+            deviceList.add(device);
+            addDevicesToList(deviceList, device.getConnectedDevices());
+        }
+    }
+
+    /**
+     * Instantiates the platform-specific list of {@link UsbDevice} objects in tree form
+     *
+     * @return platform-specific list of {@link UsbDevice} objects
+     */
+    protected abstract List<UsbDevice> createUsbDevices();
 
     @Override
     public List<NetworkIF> getNetworkIFs() {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
@@ -48,7 +48,7 @@ public abstract class LinuxHardwareAbstractionLayer extends AbstractHardwareAbst
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         List<byte[]> edids = DrmEdid.getEdidArrays();
         if (!edids.isEmpty()) {
             return edids.stream().map(UnixDisplay::new).collect(Collectors.toList());
@@ -57,7 +57,7 @@ public abstract class LinuxHardwareAbstractionLayer extends AbstractHardwareAbst
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return LinuxSoundCard.getSoundCards();
     }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHardwareAbstractionLayerNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHardwareAbstractionLayerNF.java
@@ -52,12 +52,12 @@ public final class LinuxHardwareAbstractionLayerNF extends LinuxHardwareAbstract
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return LinuxUsbDeviceNF.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return LinuxUsbDeviceNF.getUsbDevices(true);
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return LinuxGraphicsCardNF.getGraphicsCards();
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacHardwareAbstractionLayer.java
@@ -30,7 +30,7 @@ public abstract class MacHardwareAbstractionLayer extends AbstractHardwareAbstra
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return MacSoundCard.getSoundCards();
     }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHardwareAbstractionLayer.java
@@ -65,7 +65,7 @@ public class NetBsdHardwareAbstractionLayer extends AbstractHardwareAbstractionL
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -75,17 +75,17 @@ public class NetBsdHardwareAbstractionLayer extends AbstractHardwareAbstractionL
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return BsdUsbDevice.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return BsdUsbDevice.getUsbDevices(true);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return BsdSoundCard.getSoundCards();
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return BsdGraphicsCard.getGraphicsCards();
     }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
@@ -29,10 +29,12 @@ import oshi.util.tuples.Quartet;
 @ThreadSafe
 public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
 
-    private final Supplier<List<String>> iostat = memoize(OpenBsdHWDiskStore::querySystatIostat, defaultExpiration());
+    private final Supplier<List<String>> iostat;
 
-    protected OpenBsdHWDiskStore(String name, String model, String serial, long size) {
+    protected OpenBsdHWDiskStore(String name, String model, String serial, long size,
+            Supplier<List<String>> iostatSupplier) {
         super(name, model, serial, size);
+        this.iostat = iostatSupplier;
     }
 
     /**
@@ -47,6 +49,7 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
             DiskStoreFactory<T> factory) {
         List<HWDiskStore> diskList = new ArrayList<>();
         List<String> dmesg = null;
+        Supplier<List<String>> iostatSupplier = memoize(OpenBsdHWDiskStore::querySystatIostat, defaultExpiration());
 
         String disknames = sysctlStr.apply("hw.disknames", "");
         if (disknames.isEmpty()) {
@@ -89,7 +92,7 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
                     }
                 }
             }
-            store = factory.create(diskName, model, diskdata.getB(), size);
+            store = factory.create(diskName, model, diskdata.getB(), size, iostatSupplier);
             store.setPartitionList(diskdata.getD());
             store.updateAttributes();
 
@@ -128,6 +131,6 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
      */
     @FunctionalInterface
     protected interface DiskStoreFactory<T extends OpenBsdHWDiskStore> {
-        T create(String name, String model, String serial, long size);
+        T create(String name, String model, String serial, long size, Supplier<List<String>> iostatSupplier);
     }
 }

--- a/oshi-common/src/main/java/oshi/util/Memoizer.java
+++ b/oshi-common/src/main/java/oshi/util/Memoizer.java
@@ -27,6 +27,15 @@ public final class Memoizer {
     }
 
     /**
+     * Expiration for slowly-changing hardware state (e.g., connected displays) in nanoseconds. Default is 3 seconds.
+     *
+     * @return The number of nanoseconds to keep memoized values before refreshing
+     */
+    public static long slowExpiration() {
+        return TimeUnit.SECONDS.toNanos(3);
+    }
+
+    /**
      * Gets the expiration for installed apps cache.
      *
      * @return the expiration in nanoseconds

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractHardwareAbstractionLayerTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractHardwareAbstractionLayerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.ComputerSystem;
+import oshi.hardware.Display;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.GraphicsCard;
+import oshi.hardware.HWDiskStore;
+import oshi.hardware.NetworkIF;
+import oshi.hardware.PowerSource;
+import oshi.hardware.Sensors;
+import oshi.hardware.SoundCard;
+import oshi.hardware.UsbDevice;
+
+class AbstractHardwareAbstractionLayerTest {
+
+    private static AbstractHardwareAbstractionLayer createHal(List<UsbDevice> usbTree) {
+        return new AbstractHardwareAbstractionLayer() {
+            @Override
+            protected ComputerSystem createComputerSystem() {
+                return null;
+            }
+
+            @Override
+            protected CentralProcessor createProcessor() {
+                return null;
+            }
+
+            @Override
+            protected GlobalMemory createMemory() {
+                return null;
+            }
+
+            @Override
+            protected Sensors createSensors() {
+                return null;
+            }
+
+            @Override
+            protected List<Display> createDisplays() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            protected List<SoundCard> createSoundCards() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            protected List<GraphicsCard> createGraphicsCards() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            protected List<UsbDevice> createUsbDevices() {
+                return usbTree;
+            }
+
+            @Override
+            public List<PowerSource> getPowerSources() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<HWDiskStore> getDiskStores() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<NetworkIF> getNetworkIFs(boolean includeLocalInterfaces) {
+                return Collections.emptyList();
+            }
+        };
+    }
+
+    private static UsbDevice createUsb(String name, List<UsbDevice> children) {
+        return new AbstractUsbDevice(name, "", "", "", "", "", children) {
+        };
+    }
+
+    @Test
+    void testGetUsbDevicesTreeReturnsCachedTree() {
+        UsbDevice child = createUsb("child", Collections.emptyList());
+        UsbDevice root = createUsb("root", Collections.singletonList(child));
+        AbstractHardwareAbstractionLayer hal = createHal(Collections.singletonList(root));
+
+        List<UsbDevice> tree = hal.getUsbDevices(true);
+        assertThat(tree, hasSize(1));
+        assertThat(tree.get(0).getName(), is("root"));
+        assertThat(tree.get(0).getConnectedDevices(), hasSize(1));
+    }
+
+    @Test
+    void testGetUsbDevicesFlatFlattensTree() {
+        UsbDevice grandchild = createUsb("grandchild", Collections.emptyList());
+        UsbDevice child = createUsb("child", Collections.singletonList(grandchild));
+        UsbDevice root = createUsb("root", Collections.singletonList(child));
+        AbstractHardwareAbstractionLayer hal = createHal(Collections.singletonList(root));
+
+        List<UsbDevice> flat = hal.getUsbDevices(false);
+        assertThat(flat, hasSize(2));
+        assertThat(flat.get(0).getName(), is("child"));
+        assertThat(flat.get(1).getName(), is("grandchild"));
+    }
+
+    @Test
+    void testGetUsbDevicesFlatEmptyTree() {
+        AbstractHardwareAbstractionLayer hal = createHal(Collections.emptyList());
+
+        List<UsbDevice> flat = hal.getUsbDevices(false);
+        assertThat(flat, is(empty()));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerFFM.java
@@ -54,7 +54,7 @@ public final class LinuxHardwareAbstractionLayerFFM extends LinuxHardwareAbstrac
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return LinuxGraphicsCardFFM.getGraphicsCards();
     }
 
@@ -69,7 +69,7 @@ public final class LinuxHardwareAbstractionLayerFFM extends LinuxHardwareAbstrac
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return LinuxUsbDeviceFFM.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return LinuxUsbDeviceFFM.getUsbDevices(true);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerFFM.java
@@ -59,7 +59,7 @@ public final class MacHardwareAbstractionLayerFFM extends MacHardwareAbstraction
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return MacDisplayFFM.getDisplays();
     }
 
@@ -69,12 +69,12 @@ public final class MacHardwareAbstractionLayerFFM extends MacHardwareAbstraction
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return MacUsbDeviceFFM.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return MacUsbDeviceFFM.getUsbDevices(true);
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return MacGraphicsCardFFM.getGraphicsCards();
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/aix/AixHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/aix/AixHardwareAbstractionLayerFFM.java
@@ -76,7 +76,7 @@ public final class AixHardwareAbstractionLayerFFM extends AbstractHardwareAbstra
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -86,17 +86,17 @@ public final class AixHardwareAbstractionLayerFFM extends AbstractHardwareAbstra
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return AixUsbDevice.getUsbDevices(tree, lscfg);
+    protected List<UsbDevice> createUsbDevices() {
+        return AixUsbDevice.getUsbDevices(true, lscfg);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return AixSoundCard.getSoundCards(lscfg);
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return AixGraphicsCard.getGraphicsCards(lscfg);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerFFM.java
@@ -70,7 +70,7 @@ public final class DragonFlyBsdHardwareAbstractionLayerFFM extends AbstractHardw
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -80,17 +80,17 @@ public final class DragonFlyBsdHardwareAbstractionLayerFFM extends AbstractHardw
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return FreeBsdUsbDevice.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return FreeBsdUsbDevice.getUsbDevices(true);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return FreeBsdSoundCard.getSoundCards();
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return FreeBsdGraphicsCard.getGraphicsCards();
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHardwareAbstractionLayerFFM.java
@@ -65,7 +65,7 @@ public final class FreeBsdHardwareAbstractionLayerFFM extends AbstractHardwareAb
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -75,17 +75,17 @@ public final class FreeBsdHardwareAbstractionLayerFFM extends AbstractHardwareAb
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return FreeBsdUsbDevice.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return FreeBsdUsbDevice.getUsbDevices(true);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return FreeBsdSoundCard.getSoundCards();
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return FreeBsdGraphicsCard.getGraphicsCards();
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreFFM.java
@@ -5,6 +5,7 @@
 package oshi.hardware.platform.unix.openbsd;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
@@ -17,8 +18,9 @@ import oshi.hardware.common.platform.unix.openbsd.OpenBsdHWDiskStore;
 @ThreadSafe
 public final class OpenBsdHWDiskStoreFFM extends OpenBsdHWDiskStore {
 
-    private OpenBsdHWDiskStoreFFM(String name, String model, String serial, long size) {
-        super(name, model, serial, size);
+    private OpenBsdHWDiskStoreFFM(String name, String model, String serial, long size,
+            Supplier<List<String>> iostatSupplier) {
+        super(name, model, serial, size, iostatSupplier);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHardwareAbstractionLayerFFM.java
@@ -63,7 +63,7 @@ public final class OpenBsdHardwareAbstractionLayerFFM extends AbstractHardwareAb
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -73,17 +73,17 @@ public final class OpenBsdHardwareAbstractionLayerFFM extends AbstractHardwareAb
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return BsdUsbDevice.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return BsdUsbDevice.getUsbDevices(true);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return BsdSoundCard.getSoundCards();
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return BsdGraphicsCard.getGraphicsCards();
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHardwareAbstractionLayerFFM.java
@@ -62,7 +62,7 @@ public final class SolarisHardwareAbstractionLayerFFM extends AbstractHardwareAb
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -72,17 +72,17 @@ public final class SolarisHardwareAbstractionLayerFFM extends AbstractHardwareAb
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return SolarisUsbDevice.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return SolarisUsbDevice.getUsbDevices(true);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return SolarisSoundCard.getSoundCards();
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return SolarisGraphicsCard.getGraphicsCards();
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsHardwareAbstractionLayerFFM.java
@@ -56,7 +56,7 @@ public final class WindowsHardwareAbstractionLayerFFM extends AbstractHardwareAb
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return WindowsGraphicsCardFFM.getGraphicsCards();
     }
 
@@ -71,13 +71,13 @@ public final class WindowsHardwareAbstractionLayerFFM extends AbstractHardwareAb
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return WindowsDisplayFFM.getDisplays();
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return WindowsUsbDeviceFFM.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return WindowsUsbDeviceFFM.getUsbDevices(true);
     }
 
     @Override
@@ -86,7 +86,7 @@ public final class WindowsHardwareAbstractionLayerFFM extends AbstractHardwareAb
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return WindowsSoundCardFFM.getSoundCards();
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerJNA.java
@@ -54,12 +54,12 @@ public final class LinuxHardwareAbstractionLayerJNA extends LinuxHardwareAbstrac
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return LinuxUsbDeviceJNA.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return LinuxUsbDeviceJNA.getUsbDevices(true);
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return LinuxGraphicsCardJNA.getGraphicsCards();
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHardwareAbstractionLayerJNA.java
@@ -58,7 +58,7 @@ public final class MacHardwareAbstractionLayerJNA extends MacHardwareAbstraction
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return MacDisplayJNA.getDisplays();
     }
 
@@ -68,12 +68,12 @@ public final class MacHardwareAbstractionLayerJNA extends MacHardwareAbstraction
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return MacUsbDeviceJNA.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return MacUsbDeviceJNA.getUsbDevices(true);
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return MacGraphicsCardJNA.getGraphicsCards();
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixHardwareAbstractionLayerJNA.java
@@ -77,7 +77,7 @@ public final class AixHardwareAbstractionLayerJNA extends AbstractHardwareAbstra
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -87,17 +87,17 @@ public final class AixHardwareAbstractionLayerJNA extends AbstractHardwareAbstra
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return AixUsbDevice.getUsbDevices(tree, lscfg);
+    protected List<UsbDevice> createUsbDevices() {
+        return AixUsbDevice.getUsbDevices(true, lscfg);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return AixSoundCard.getSoundCards(lscfg);
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return AixGraphicsCard.getGraphicsCards(lscfg);
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerJNA.java
@@ -69,7 +69,7 @@ public final class DragonFlyBsdHardwareAbstractionLayerJNA extends AbstractHardw
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -79,17 +79,17 @@ public final class DragonFlyBsdHardwareAbstractionLayerJNA extends AbstractHardw
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return FreeBsdUsbDevice.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return FreeBsdUsbDevice.getUsbDevices(true);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return FreeBsdSoundCard.getSoundCards();
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return FreeBsdGraphicsCard.getGraphicsCards();
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHardwareAbstractionLayerJNA.java
@@ -64,7 +64,7 @@ public final class FreeBsdHardwareAbstractionLayerJNA extends AbstractHardwareAb
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -74,17 +74,17 @@ public final class FreeBsdHardwareAbstractionLayerJNA extends AbstractHardwareAb
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return FreeBsdUsbDevice.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return FreeBsdUsbDevice.getUsbDevices(true);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return FreeBsdSoundCard.getSoundCards();
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return FreeBsdGraphicsCard.getGraphicsCards();
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreJNA.java
@@ -5,6 +5,7 @@
 package oshi.hardware.platform.unix.openbsd;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.HWDiskStore;
@@ -17,8 +18,9 @@ import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
 @ThreadSafe
 public final class OpenBsdHWDiskStoreJNA extends OpenBsdHWDiskStore {
 
-    private OpenBsdHWDiskStoreJNA(String name, String model, String serial, long size) {
-        super(name, model, serial, size);
+    private OpenBsdHWDiskStoreJNA(String name, String model, String serial, long size,
+            Supplier<List<String>> iostatSupplier) {
+        super(name, model, serial, size, iostatSupplier);
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHardwareAbstractionLayerJNA.java
@@ -66,7 +66,7 @@ public final class OpenBsdHardwareAbstractionLayerJNA extends AbstractHardwareAb
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -76,17 +76,17 @@ public final class OpenBsdHardwareAbstractionLayerJNA extends AbstractHardwareAb
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return BsdUsbDevice.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return BsdUsbDevice.getUsbDevices(true);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return BsdSoundCard.getSoundCards();
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return BsdGraphicsCard.getGraphicsCards();
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHardwareAbstractionLayerJNA.java
@@ -65,7 +65,7 @@ public final class SolarisHardwareAbstractionLayerJNA extends AbstractHardwareAb
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return UnixDisplay.getDisplays();
     }
 
@@ -75,17 +75,17 @@ public final class SolarisHardwareAbstractionLayerJNA extends AbstractHardwareAb
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return SolarisUsbDevice.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return SolarisUsbDevice.getUsbDevices(true);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return SolarisSoundCard.getSoundCards();
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return SolarisGraphicsCard.getGraphicsCards();
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsHardwareAbstractionLayerJNA.java
@@ -65,7 +65,7 @@ public class WindowsHardwareAbstractionLayerJNA extends AbstractHardwareAbstract
     }
 
     @Override
-    public List<Display> getDisplays() {
+    protected List<Display> createDisplays() {
         return WindowsDisplayJNA.getDisplays();
     }
 
@@ -75,17 +75,17 @@ public class WindowsHardwareAbstractionLayerJNA extends AbstractHardwareAbstract
     }
 
     @Override
-    public List<UsbDevice> getUsbDevices(boolean tree) {
-        return WindowsUsbDeviceJNA.getUsbDevices(tree);
+    protected List<UsbDevice> createUsbDevices() {
+        return WindowsUsbDeviceJNA.getUsbDevices(true);
     }
 
     @Override
-    public List<SoundCard> getSoundCards() {
+    protected List<SoundCard> createSoundCards() {
         return WindowsSoundCardJNA.getSoundCards();
     }
 
     @Override
-    public List<GraphicsCard> getGraphicsCards() {
+    protected List<GraphicsCard> createGraphicsCards() {
         return WindowsGraphicsCardJNA.getGraphicsCards();
     }
 


### PR DESCRIPTION
## Summary

- **OpenBSD disk stores**: Pass a shared memoized `iostat` supplier through the constructor (same pattern as NetBSD in #3442). All disk instances from the same `getDisks()` batch share one `systat -ab iostat` call, but the supplier is GC-eligible when unreachable.
- **Pluggable hardware caching**: Add `Memoizer.slowExpiration()` (3 seconds) and use it in `AbstractHardwareAbstractionLayer` to cache displays, sound cards, graphics cards, and USB devices. These rarely change but involve expensive native/command-line queries. The `create*()` pattern matches the existing `createProcessor()` / `createMemory()` / `createSensors()` model.
- **USB optimization**: Cache only the tree form; derive the flat form from the cached tree on demand, avoiding redundant native queries.

## Test plan

- [x] `mvn compile` passes for oshi-common, oshi-core, oshi-core-ffm
- [x] `mvn test` passes for oshi-common, oshi-core-ffm, oshi-benchmark
- [x] `mvn checkstyle:check`, `forbiddenapis:check`, `javadoc:javadoc` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added display enumeration through the hardware abstraction layer, with results cached for faster repeated access.
* **Bug Fixes**
  * Improved disk monitoring by sharing cached iostat data across disk instances.
  * Added hardware-list caching (e.g., displays and other pluggable hardware lists) with a 3-second TTL.
* **Tests**
  * Added coverage for USB device tree caching and flattening behavior.
* **Documentation**
  * Updated the changelog to reflect these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->