### PR TITLE
Consolidate try/catch-log-return-default patterns to use ExceptionUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#3441](https://github.com/oshi/oshi/pull/3441): Wrap AppKit/Cocoa display-name calls in an autorelease pool, extract `ObjCFunctions` FFM bindings, and use `ExceptionUtil` for consistent error handling - [@dbwiddis](https://github.com/dbwiddis).
 * [#3442](https://github.com/oshi/oshi/pull/3442): Convert static memoized suppliers to instance fields, allowing cached data to be reclaimed when users create new `SystemInfo` instances - [@dbwiddis](https://github.com/dbwiddis).
 * [#3443](https://github.com/oshi/oshi/pull/3443): Share memoized iostat supplier across disk instances; cache pluggable hardware lists (displays, USB, sound cards, graphics cards) in the HAL with a 3-second TTL - [@dbwiddis](https://github.com/dbwiddis).
+* [#3444](https://github.com/oshi/oshi/pull/3444): Consolidate try/catch-log-return-default patterns to use `ExceptionUtil` - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.NetworkIF;
 import oshi.util.Constants;
+import oshi.util.ExceptionUtil;
 import oshi.util.FileUtil;
 import oshi.util.FormatUtil;
 import oshi.util.ParseUtil;
@@ -150,24 +151,15 @@ public abstract class AbstractNetworkIF implements NetworkIF {
      * @return A list of network interfaces
      */
     private static List<NetworkInterface> getAllNetworkInterfaces() {
-        try {
+        return ExceptionUtil.getOrDefault(() -> {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
             return interfaces == null ? Collections.emptyList() : Collections.list(interfaces);
-        } catch (SocketException ex) {
-            LOG.error("Socket exception when retrieving interfaces: {}", ex.getMessage());
-        }
-        return Collections.emptyList();
+        }, Collections.emptyList(), LOG, "Socket exception when retrieving interfaces: {}");
     }
 
     private static boolean isLocalInterface(NetworkInterface networkInterface) {
-        try {
-            // getHardwareAddress also checks for loopback
-            return networkInterface.getHardwareAddress() == null;
-        } catch (SocketException e) {
-            LOG.error("Socket exception when retrieving interface information for {}: {}", networkInterface,
-                    e.getMessage());
-        }
-        return false;
+        return ExceptionUtil.getBooleanOrDefault(() -> networkInterface.getHardwareAddress() == null, false, LOG,
+                "Socket exception when retrieving interface information: {}");
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
+import oshi.util.ExceptionUtil;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
@@ -292,11 +293,8 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     private static ProcessorCache.Type parseCacheType(String type) {
-        try {
-            return ProcessorCache.Type.valueOf(type.toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException e) {
-            return ProcessorCache.Type.UNIFIED;
-        }
+        return ExceptionUtil.getOrDefault(() -> ProcessorCache.Type.valueOf(type.toUpperCase(Locale.ROOT)),
+                ProcessorCache.Type.UNIFIED);
     }
 
     private static Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyFromCpuinfo() {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
@@ -7,7 +7,6 @@ package oshi.hardware.common.platform.linux;
 import static oshi.util.Memoizer.memoize;
 
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Supplier;
@@ -15,6 +14,7 @@ import java.util.function.Supplier;
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.common.AbstractFirmware;
 import oshi.util.Constants;
+import oshi.util.ExceptionUtil;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.driver.linux.Dmidecode;
@@ -127,11 +127,9 @@ final class LinuxFirmware extends AbstractFirmware {
 
         if (vcgencmd.size() >= 3) {
             // First line is date
-            try {
-                vcReleaseDate = DateTimeFormatter.ISO_LOCAL_DATE.format(VCGEN_FORMATTER.parse(vcgencmd.get(0)));
-            } catch (DateTimeParseException e) {
-                vcReleaseDate = Constants.UNKNOWN;
-            }
+            vcReleaseDate = ExceptionUtil.getOrDefault(
+                    () -> DateTimeFormatter.ISO_LOCAL_DATE.format(VCGEN_FORMATTER.parse(vcgencmd.get(0))),
+                    Constants.UNKNOWN);
             // Second line is copyright
             String[] copyright = ParseUtil.whitespaces.split(vcgencmd.get(1));
             vcManufacturer = copyright.length > 0 && !copyright[copyright.length - 1].isEmpty()

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOSProcess;
 import oshi.software.os.OSThread;
+import oshi.util.ExceptionUtil;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.GlobalConfig;
@@ -286,11 +287,7 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         if (split.length == 0) {
             return 0;
         }
-        try {
-            return new BigInteger(split[split.length - 1], 16).longValue();
-        } catch (NumberFormatException e) {
-            return 0;
-        }
+        return ExceptionUtil.getLongOrDefault(() -> new BigInteger(split[split.length - 1], 16).longValue(), 0);
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOperatingSystemNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOperatingSystemNF.java
@@ -4,7 +4,6 @@
  */
 package oshi.software.common.os.linux.nativefree;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -14,6 +13,7 @@ import oshi.software.os.FileSystem;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSProcess.State;
+import oshi.util.ExceptionUtil;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
@@ -99,12 +99,11 @@ public class LinuxOperatingSystemNF extends LinuxOperatingSystem {
 
     @Override
     public int getThreadId() {
-        try {
-            return ParseUtil.parseIntOrDefault(
-                    Files.readSymbolicLink(Paths.get(ProcPath.THREAD_SELF)).getFileName().toString(), 0);
-        } catch (IOException e) {
-            return 0;
-        }
+        return ExceptionUtil
+                .getIntOrDefault(
+                        () -> ParseUtil.parseIntOrDefault(
+                                Files.readSymbolicLink(Paths.get(ProcPath.THREAD_SELF)).getFileName().toString(), 0),
+                        0);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsFFM.java
@@ -17,9 +17,9 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import oshi.ffm.platform.windows.Win32Exception;
 import oshi.ffm.util.platform.windows.IPHlpAPIUtilFFM;
 import oshi.software.common.AbstractInternetProtocolStats;
+import oshi.util.ExceptionUtil;
 
 public class WindowsInternetProtocolStatsFFM extends AbstractInternetProtocolStats {
 
@@ -37,41 +37,25 @@ public class WindowsInternetProtocolStatsFFM extends AbstractInternetProtocolSta
 
     @Override
     public TcpStats getTCPv4Stats() {
-        try {
-            return IPHlpAPIUtilFFM.getTcpStats(AF_INET);
-        } catch (Win32Exception e) {
-            LOG.error("Failed to read TCPv4 stats: {}", e.getMessage());
-            return null;
-        }
+        return ExceptionUtil.getOrDefault(() -> IPHlpAPIUtilFFM.getTcpStats(AF_INET), null, LOG,
+                "Failed to read TCPv4 stats: {}");
     }
 
     @Override
     public TcpStats getTCPv6Stats() {
-        try {
-            return IPHlpAPIUtilFFM.getTcpStats(AF_INET6);
-        } catch (Win32Exception e) {
-            LOG.error("Failed to read TCPv6 stats: {}", e.getMessage());
-            return null;
-        }
+        return ExceptionUtil.getOrDefault(() -> IPHlpAPIUtilFFM.getTcpStats(AF_INET6), null, LOG,
+                "Failed to read TCPv6 stats: {}");
     }
 
     @Override
     public UdpStats getUDPv4Stats() {
-        try {
-            return IPHlpAPIUtilFFM.getUdpStats(AF_INET);
-        } catch (Win32Exception e) {
-            LOG.error("Failed to read UDPv4 stats: {}", e.getMessage());
-            return null;
-        }
+        return ExceptionUtil.getOrDefault(() -> IPHlpAPIUtilFFM.getUdpStats(AF_INET), null, LOG,
+                "Failed to read UDPv4 stats: {}");
     }
 
     @Override
     public UdpStats getUDPv6Stats() {
-        try {
-            return IPHlpAPIUtilFFM.getUdpStats(AF_INET6);
-        } catch (Win32Exception e) {
-            LOG.error("Failed to read UDPv6 stats: {}", e.getMessage());
-            return null;
-        }
+        return ExceptionUtil.getOrDefault(() -> IPHlpAPIUtilFFM.getUdpStats(AF_INET6), null, LOG,
+                "Failed to read UDPv6 stats: {}");
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystemJNA.java
@@ -5,7 +5,6 @@
 package oshi.software.os.linux;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +27,7 @@ import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSProcess.State;
 import oshi.software.os.OSSession;
+import oshi.util.ExceptionUtil;
 import oshi.util.ExecutingCommand;
 import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
@@ -143,12 +143,10 @@ public class LinuxOperatingSystemJNA extends LinuxOperatingSystem {
             return HAS_GETTID ? LinuxLibc.INSTANCE.gettid()
                     : LinuxLibc.INSTANCE.syscall(LinuxLibc.SYS_GETTID).intValue();
         }
-        try {
-            return ParseUtil.parseIntOrDefault(
-                    Files.readSymbolicLink(new File(ProcPath.THREAD_SELF).toPath()).getFileName().toString(), 0);
-        } catch (IOException e) {
-            return 0;
-        }
+        return ExceptionUtil.getIntOrDefault(
+                () -> ParseUtil.parseIntOrDefault(
+                        Files.readSymbolicLink(new File(ProcPath.THREAD_SELF).toPath()).getFileName().toString(), 0),
+                0);
     }
 
     /**


### PR DESCRIPTION
## Summary

Replace manual try/catch blocks that log and return a default value with `ExceptionUtil` method calls, reducing boilerplate and routing exception handling through the common tested path.

Converted patterns:
- `LinuxOSProcess.parseAffinityMask` — BigInteger hex parse → `getLongOrDefault`
- `LinuxOperatingSystemNF.getThreadId` — symlink read → `getIntOrDefault`
- `LinuxOperatingSystemJNA.getThreadId` — same pattern → `getIntOrDefault`
- `LinuxFirmware.queryVcGenCmd` — date format parse → `getOrDefault`
- `LinuxCentralProcessor.parseCacheType` — enum valueOf → `getOrDefault`
- `WindowsInternetProtocolStatsFFM` — 4 TCP/UDP stats methods → `getOrDefault`
- `AbstractNetworkIF` — `getAllNetworkInterfaces` and `isLocalInterface` → `getOrDefault`/`getBooleanOrDefault`

Also downgrades logging from ERROR to DEBUG for network interface and IP stats exceptions — these represent transient/environmental conditions, not application errors.

## Test plan

- [x] `mvn compile` passes for oshi-common, oshi-core, oshi-core-ffm
- [x] `mvn test` passes for oshi-common, oshi-core-ffm, oshi-benchmark
- [x] `mvn spotless:apply`, `checkstyle:check`, `forbiddenapis:check`, `javadoc:javadoc` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience when collecting network, processor, firmware, process, thread, and Windows connection statistics.
  - Added consistent fallback behavior when system values are unavailable or cannot be parsed.
  - Preserved diagnostic logging for failed system-data retrievals.

- **Documentation**
  - Updated the changelog with the latest bug fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->