### PR TITLE
Unify FileSystem file-descriptor methods behind common bases (JNA/FFM dedup)

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacFileSystem.java
@@ -121,4 +121,27 @@ public abstract class MacFileSystem extends AbstractFileSystem {
         OPTIONS_MAP.put(MNT_MULTILABEL, "multilabel");
         OPTIONS_MAP.put(MNT_NOATIME, "noatime");
     }
+
+    @Override
+    public long getOpenFileDescriptors() {
+        return querySysctl("kern.num_files");
+    }
+
+    @Override
+    public long getMaxFileDescriptors() {
+        return querySysctl("kern.maxfiles");
+    }
+
+    @Override
+    public long getMaxFileDescriptorsPerProcess() {
+        return querySysctl("kern.maxfilesperproc");
+    }
+
+    /**
+     * Reads a system-wide file-descriptor {@code sysctl} value via the subclass's native mechanism (JNA or FFM).
+     *
+     * @param name the sysctl name to query
+     * @return the value, or 0 if unavailable
+     */
+    protected abstract long querySysctl(String name);
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
@@ -38,6 +38,29 @@ public abstract class OpenBsdFileSystem extends AbstractFileSystem {
         return getFileStoreMatching(null, localOnly);
     }
 
+    @Override
+    public long getOpenFileDescriptors() {
+        return querySysctl("kern.nfiles");
+    }
+
+    @Override
+    public long getMaxFileDescriptors() {
+        return querySysctl("kern.maxfiles");
+    }
+
+    @Override
+    public long getMaxFileDescriptorsPerProcess() {
+        return querySysctl("kern.maxfilesperproc");
+    }
+
+    /**
+     * Reads a system-wide file-descriptor {@code sysctl} value via the subclass's native mechanism (JNA or FFM).
+     *
+     * @param name the sysctl name to query
+     * @return the value, or 0 if unavailable
+     */
+    protected abstract long querySysctl(String name);
+
     /**
      * Gets file stores matching the given name (or all if null).
      *

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsFileSystem.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.windows;
+
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.ProcessInformation.HandleCountProperty;
+import oshi.software.common.AbstractFileSystem;
+
+/**
+ * Common file-descriptor logic for the Windows file system implementations. The volume enumeration
+ * ({@code getFileStores}) is backend-specific (Kernel32/WMI via JNA vs FFM) and remains in the subclasses; only the
+ * handle-count query differs by a single native call, abstracted here via {@link #queryHandles()}.
+ */
+@ThreadSafe
+public abstract class WindowsFileSystem extends AbstractFileSystem {
+
+    /**
+     * The maximum number of Windows handles. Both the 32-bit and 64-bit limits are essentially infinite for practical
+     * purposes. See
+     * <a href="https://blogs.technet.microsoft.com/markrussinovich/2009/09/29/pushing-the-limits-of-windows-handles/">
+     * Pushing the Limits of Windows: Handles</a>.
+     */
+    protected static final long MAX_WINDOWS_HANDLES;
+    static {
+        if (System.getenv("ProgramFiles(x86)") == null) {
+            MAX_WINDOWS_HANDLES = 16_777_216L - 32_768L;
+        } else {
+            MAX_WINDOWS_HANDLES = 16_777_216L - 65_536L;
+        }
+    }
+
+    @Override
+    public long getOpenFileDescriptors() {
+        return queryHandles().getOrDefault(HandleCountProperty.HANDLECOUNT, 0L);
+    }
+
+    @Override
+    public long getMaxFileDescriptors() {
+        return MAX_WINDOWS_HANDLES;
+    }
+
+    @Override
+    public long getMaxFileDescriptorsPerProcess() {
+        // Windows has no separate per-process handle limit; return the system-wide maximum.
+        return MAX_WINDOWS_HANDLES;
+    }
+
+    /**
+     * Queries the current system-wide open handle count via the subclass's native mechanism (JNA or FFM).
+     *
+     * @return a map including the {@link HandleCountProperty#HANDLECOUNT} total
+     */
+    protected abstract Map<HandleCountProperty, Long> queryHandles();
+}

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
@@ -190,17 +190,7 @@ public class MacFileSystemFFM extends MacFileSystem {
     }
 
     @Override
-    public long getOpenFileDescriptors() {
-        return SysctlUtilFFM.sysctl("kern.num_files", 0);
-    }
-
-    @Override
-    public long getMaxFileDescriptors() {
-        return SysctlUtilFFM.sysctl("kern.maxfiles", 0);
-    }
-
-    @Override
-    public long getMaxFileDescriptorsPerProcess() {
-        return SysctlUtilFFM.sysctl("kern.maxfilesperproc", 0);
+    protected long querySysctl(String name) {
+        return SysctlUtilFFM.sysctl(name, 0);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdFileSystemFFM.java
@@ -16,17 +16,7 @@ import oshi.software.common.os.unix.openbsd.OpenBsdFileSystem;
 public final class OpenBsdFileSystemFFM extends OpenBsdFileSystem {
 
     @Override
-    public long getOpenFileDescriptors() {
-        return OpenBsdSysctlUtilFFM.sysctl("kern.nfiles", 0);
-    }
-
-    @Override
-    public long getMaxFileDescriptors() {
-        return OpenBsdSysctlUtilFFM.sysctl("kern.maxfiles", 0);
-    }
-
-    @Override
-    public long getMaxFileDescriptorsPerProcess() {
-        return OpenBsdSysctlUtilFFM.sysctl("kern.maxfilesperproc", 0);
+    protected long querySysctl(String name) {
+        return OpenBsdSysctlUtilFFM.sysctl(name, 0);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -30,12 +30,12 @@ import oshi.driver.windows.perfmon.ProcessInformationFFM;
 import oshi.driver.windows.wmi.Win32LogicalDiskFFM;
 import oshi.ffm.NativeHandle;
 import oshi.ffm.platform.windows.Kernel32FFM;
-import oshi.software.common.AbstractFileSystem;
+import oshi.software.common.os.windows.WindowsFileSystem;
 import oshi.software.os.OSFileStore;
 import oshi.util.ParseUtil;
 
 @ThreadSafe
-public class WindowsFileSystemFFM extends AbstractFileSystem {
+public class WindowsFileSystemFFM extends WindowsFileSystem {
 
     private static final int BUFSIZE = 255;
 
@@ -78,9 +78,6 @@ public class WindowsFileSystemFFM extends AbstractFileSystem {
         OPTIONS_MAP.put(FILE_VOLUME_IS_COMPRESSED, "vcomp");
         OPTIONS_MAP.put(FILE_VOLUME_QUOTAS, "quota");
     }
-
-    // Maximum file handles: 2^24 - 2^16 (assumes 64-bit Windows per FileSystem javadoc)
-    static final long MAX_WINDOWS_HANDLES = 16_777_216L - 65_536L;
 
     private static final int DRIVE_REMOVABLE = 2;
     private static final int DRIVE_FIXED = 3;
@@ -300,17 +297,7 @@ public class WindowsFileSystemFFM extends AbstractFileSystem {
     }
 
     @Override
-    public long getOpenFileDescriptors() {
-        return ProcessInformationFFM.queryHandles().getOrDefault(HandleCountProperty.HANDLECOUNT, 0L);
-    }
-
-    @Override
-    public long getMaxFileDescriptors() {
-        return MAX_WINDOWS_HANDLES;
-    }
-
-    @Override
-    public long getMaxFileDescriptorsPerProcess() {
-        return MAX_WINDOWS_HANDLES;
+    protected Map<HandleCountProperty, Long> queryHandles() {
+        return ProcessInformationFFM.queryHandles();
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
@@ -174,17 +174,7 @@ public class MacFileSystemJNA extends MacFileSystem {
     }
 
     @Override
-    public long getOpenFileDescriptors() {
-        return SysctlUtil.sysctl("kern.num_files", 0);
-    }
-
-    @Override
-    public long getMaxFileDescriptors() {
-        return SysctlUtil.sysctl("kern.maxfiles", 0);
-    }
-
-    @Override
-    public long getMaxFileDescriptorsPerProcess() {
-        return SysctlUtil.sysctl("kern.maxfilesperproc", 0);
+    protected long querySysctl(String name) {
+        return SysctlUtil.sysctl(name, 0);
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdFileSystemJNA.java
@@ -16,17 +16,7 @@ import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
 public class OpenBsdFileSystemJNA extends OpenBsdFileSystem {
 
     @Override
-    public long getOpenFileDescriptors() {
-        return OpenBsdSysctlUtil.sysctl("kern.nfiles", 0);
-    }
-
-    @Override
-    public long getMaxFileDescriptors() {
-        return OpenBsdSysctlUtil.sysctl("kern.maxfiles", 0);
-    }
-
-    @Override
-    public long getMaxFileDescriptorsPerProcess() {
-        return OpenBsdSysctlUtil.sysctl("kern.maxfilesperproc", 0);
+    protected long querySysctl(String name) {
+        return OpenBsdSysctlUtil.sysctl(name, 0);
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
@@ -24,7 +24,7 @@ import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.driver.windows.perfmon.ProcessInformationJNA;
 import oshi.driver.windows.wmi.Win32LogicalDiskJNA;
 import oshi.jna.ByRef.CloseableIntByReference;
-import oshi.software.common.AbstractFileSystem;
+import oshi.software.common.os.windows.WindowsFileSystem;
 import oshi.software.os.OSFileStore;
 import oshi.util.ParseUtil;
 
@@ -34,7 +34,7 @@ import oshi.util.ParseUtil;
  * represented by a drive letter, e.g., "A:\" and "C:\"
  */
 @ThreadSafe
-public class WindowsFileSystemJNA extends AbstractFileSystem {
+public class WindowsFileSystemJNA extends WindowsFileSystem {
 
     private static final int BUFSIZE = 255;
 
@@ -76,18 +76,6 @@ public class WindowsFileSystemJNA extends AbstractFileSystem {
         OPTIONS_MAP.put(FILE_UNICODE_ON_DISK, "unicode");
         OPTIONS_MAP.put(FILE_VOLUME_IS_COMPRESSED, "vcomp");
         OPTIONS_MAP.put(FILE_VOLUME_QUOTAS, "quota");
-    }
-
-    static final long MAX_WINDOWS_HANDLES;
-    static {
-        // Determine whether 32-bit or 64-bit handle limit, although both are
-        // essentially infinite for practical purposes. See
-        // https://blogs.technet.microsoft.com/markrussinovich/2009/09/29/pushing-the-limits-of-windows-handles/
-        if (System.getenv("ProgramFiles(x86)") == null) {
-            MAX_WINDOWS_HANDLES = 16_777_216L - 32_768L;
-        } else {
-            MAX_WINDOWS_HANDLES = 16_777_216L - 65_536L;
-        }
     }
 
     /**
@@ -268,17 +256,7 @@ public class WindowsFileSystemJNA extends AbstractFileSystem {
     }
 
     @Override
-    public long getOpenFileDescriptors() {
-        return ProcessInformationJNA.queryHandles().getOrDefault(HandleCountProperty.HANDLECOUNT, 0L);
-    }
-
-    @Override
-    public long getMaxFileDescriptors() {
-        return MAX_WINDOWS_HANDLES;
-    }
-
-    @Override
-    public long getMaxFileDescriptorsPerProcess() {
-        return MAX_WINDOWS_HANDLES;
+    protected Map<HandleCountProperty, Long> queryHandles() {
+        return ProcessInformationJNA.queryHandles();
     }
 }


### PR DESCRIPTION
First subsystem in the cross-OS consistency/dedup audit. **No user-facing behavior change** — pure structural consolidation.

## What
Hoist the file-descriptor query methods (`getOpenFileDescriptors`/`getMaxFileDescriptors`/`getMaxFileDescriptorsPerProcess`) into common base classes so the JNA/FFM subclasses shrink to a single native hook — matching the pattern `FreeBsdFileSystem` already used (base implements the public methods, subclass provides one native call).

| Platform | Base change | Subclass |
|---|---|---|
| **macOS** | `MacFileSystem` gains the 3 FD methods + a `querySysctl(String)` hook | JNA/FFM → one-line `sysctl` |
| **OpenBSD** | `OpenBsdFileSystem` same treatment | JNA/FFM → one-line `sysctl` |
| **Windows** | new `WindowsFileSystem` base holds `MAX_WINDOWS_HANDLES` + FD methods behind a `queryHandles()` hook | JNA/FFM extend it |

Net −29 lines, and five platforms are now structurally uniform on the FreeBSD hook pattern.

## Notes
- **MAX_WINDOWS_HANDLES**: the FFM path had hardcoded the 64-bit value while JNA computed 32- vs 64-bit conditionally. The shared base uses the conditional form. This is *not* a behavioral fix — FFM only runs on 64-bit Windows (JDK 25+), where the values coincide — just backend consistency.
- **Deferred**: the native `getFileStores` volume enumeration stays per-backend (`Kernel32`/WMI vs `getfsstat` are genuinely different native code, not mergeable without abstracting the whole native layer). Its JNA/FFM merge loop has a real drift (order handling + description enrichment differ), but hoisting it is coupled to the `static` `WindowsOSFileStore.updateAttributes` calls and needs a Windows-tested decision — split out to a follow-up.

Part of the subsystem-by-subsystem audit; more platforms/subsystems to follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file-descriptor usage and limit reporting for macOS, OpenBSD, and Windows.
  * Windows now reports open handles and shared system limits consistently across supported runtime options.

* **Improvements**
  * Standardized file-descriptor reporting across native integration variants.
  * Added graceful fallback behavior when platform metrics are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->