### PR TITLE
Hoist common OSThread fields and getters into AbstractOSThread

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -67,11 +67,12 @@
          FFM stat computations read identically. -->
     <suppress checks="MemberName" files="MacInternetProtocolStats\.java"/>
 
-    <!-- AbstractOSProcess holds the common OSProcess attribute fields as protected so each platform's
-         updateAttributes() can assign them directly (the alternative, private fields + protected setters,
+    <!-- AbstractOSProcess/AbstractOSThread hold the common OSProcess/OSThread attribute fields as protected so each
+         platform's updateAttributes() can assign them directly (the alternative, private fields + protected setters,
          would churn every native refresh method). -->
     <suppress checks="VisibilityModifier" files="AbstractOSProcess\.java"/>
     <suppress checks="VisibilityModifier" files="AbstractProcOSProcess\.java"/>
+    <suppress checks="VisibilityModifier" files="AbstractOSThread\.java"/>
 
     <!-- Mutable hardware/software value bases follow the AbstractOSProcess model: attribute fields are
          protected so each platform's updateAttributes()/updateNetworkStats() assigns them directly, rather
@@ -80,10 +81,10 @@
     <suppress checks="VisibilityModifier" files="AbstractHWDiskStore\.java"/>
     <suppress checks="VisibilityModifier" files="AbstractOSFileStore\.java"/>
 
-    <!-- BsdOSProcess/BsdOSThread/MacOSProcess are shared OSProcess/OSThread bases; their protected fields are
-         populated by the per-backend native updateAttributes() in the subclasses (and the thread id / version are
-         set by the per-platform constructors), so they can't be private with accessors. -->
-    <suppress checks="VisibilityModifier" files="(BsdOSProcess|BsdOSThread|MacOSProcess)\.java"/>
+    <!-- BsdOSProcess/MacOSProcess are shared OSProcess bases; their protected fields are populated by the per-backend
+         native updateAttributes() in the subclasses (and the version is set by the per-platform constructors), so they
+         can't be private with accessors. -->
+    <suppress checks="VisibilityModifier" files="(BsdOSProcess|MacOSProcess)\.java"/>
 
     <!-- Solaris shared HAL abstract bases use public data POJOs (DiskStats, IfStats, BatteryReadings)
          for the kstat I/O, interface, and battery counters that the JNA and FFM subclasses populate. -->

--- a/oshi-common/src/main/java/oshi/software/common/AbstractOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOSThread.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.os.OSProcess;
 import oshi.software.os.OSThread;
 
 /**
@@ -22,6 +23,31 @@ public abstract class AbstractOSThread implements OSThread {
     private final Supplier<Double> cumulativeCpuLoad = memoize(this::queryCumulativeCpuLoad, defaultExpiration());
 
     private final int owningProcessId;
+
+    /** The thread id (OS-dependent meaning). */
+    protected int threadId;
+    /** The thread name; defaults to empty and is never returned as {@code null}. */
+    protected String name = "";
+    /** The thread execution state. */
+    protected OSProcess.State state = OSProcess.State.INVALID;
+    /** Minor (soft) page faults; populated on Linux/BSD only. */
+    protected long minorFaults;
+    /** Major (hard) page faults; populated on Linux/BSD only. */
+    protected long majorFaults;
+    /** The start memory address. */
+    protected long startMemoryAddress;
+    /** Voluntary + involuntary context switches. */
+    protected long contextSwitches;
+    /** Kernel (privileged) time in milliseconds. */
+    protected long kernelTime;
+    /** User time in milliseconds. */
+    protected long userTime;
+    /** Start time in milliseconds since the epoch. */
+    protected long startTime;
+    /** Elapsed up-time in milliseconds. */
+    protected long upTime;
+    /** OS-dependent priority. */
+    protected int priority;
 
     /**
      * Creates an AbstractOSThread for the given owning process ID.
@@ -35,6 +61,66 @@ public abstract class AbstractOSThread implements OSThread {
     @Override
     public int getOwningProcessId() {
         return this.owningProcessId;
+    }
+
+    @Override
+    public int getThreadId() {
+        return this.threadId;
+    }
+
+    @Override
+    public String getName() {
+        return this.name != null ? this.name : "";
+    }
+
+    @Override
+    public OSProcess.State getState() {
+        return this.state;
+    }
+
+    @Override
+    public long getStartMemoryAddress() {
+        return this.startMemoryAddress;
+    }
+
+    @Override
+    public long getContextSwitches() {
+        return this.contextSwitches;
+    }
+
+    @Override
+    public long getMinorFaults() {
+        return this.minorFaults;
+    }
+
+    @Override
+    public long getMajorFaults() {
+        return this.majorFaults;
+    }
+
+    @Override
+    public long getKernelTime() {
+        return this.kernelTime;
+    }
+
+    @Override
+    public long getUserTime() {
+        return this.userTime;
+    }
+
+    @Override
+    public long getUpTime() {
+        return this.upTime;
+    }
+
+    @Override
+    public long getStartTime() {
+        return this.startTime;
+    }
+
+    @Override
+    public int getPriority() {
+        return this.priority;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSThread.java
@@ -30,19 +30,7 @@ public class LinuxOSThread extends AbstractOSThread {
         }
     }
 
-    private final int threadId;
     private final LinuxOperatingSystem os;
-    private String name;
-    private State state = State.INVALID;
-    private long minorFaults;
-    private long majorFaults;
-    private long startMemoryAddress;
-    private long contextSwitches;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private int priority;
 
     /**
      * Creates a LinuxOSThread.
@@ -56,66 +44,6 @@ public class LinuxOSThread extends AbstractOSThread {
         this.threadId = tid;
         this.os = os;
         updateAttributes();
-    }
-
-    @Override
-    public int getThreadId() {
-        return this.threadId;
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public State getState() {
-        return this.state;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public long getStartMemoryAddress() {
-        return this.startMemoryAddress;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
-    }
-
-    @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSThread.java
@@ -14,14 +14,6 @@ import oshi.software.os.OSProcess.State;
 @ThreadSafe
 public class MacOSThread extends AbstractOSThread {
 
-    private final int threadId;
-    private final State state;
-    private final long kernelTime;
-    private final long userTime;
-    private final long startTime;
-    private final long upTime;
-    private final int priority;
-
     /**
      * Creates a MacOSThread with full parameters.
      *
@@ -55,38 +47,4 @@ public class MacOSThread extends AbstractOSThread {
         this(processId, 0, State.INVALID, 0L, 0L, 0L, 0L, 0);
     }
 
-    @Override
-    public int getThreadId() {
-        return threadId;
-    }
-
-    @Override
-    public State getState() {
-        return state;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return userTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return startTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return upTime;
-    }
-
-    @Override
-    public int getPriority() {
-        return priority;
-    }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSThread.java
@@ -17,65 +17,10 @@ import oshi.software.os.OSProcess;
 @ThreadSafe
 public class AixOSThread extends AbstractOSThread {
 
-    private int threadId;
-    private OSProcess.State state = OSProcess.State.INVALID;
-    private long startMemoryAddress;
-    private long contextSwitches;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private int priority;
-
     public AixOSThread(int pid, int tid) {
         super(pid);
         this.threadId = tid;
         updateAttributes();
-    }
-
-    @Override
-    public int getThreadId() {
-        return this.threadId;
-    }
-
-    @Override
-    public OSProcess.State getState() {
-        return this.state;
-    }
-
-    @Override
-    public long getStartMemoryAddress() {
-        return this.startMemoryAddress;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSThread.java
@@ -23,81 +23,8 @@ import oshi.util.ParseUtil;
 @ThreadSafe
 public abstract class BsdOSThread extends AbstractOSThread {
 
-    protected int threadId;
-    protected String name = "";
-    protected OSProcess.State state = OSProcess.State.INVALID;
-    protected long minorFaults;
-    protected long majorFaults;
-    protected long startMemoryAddress;
-    protected long contextSwitches;
-    protected long kernelTime;
-    protected long userTime;
-    protected long startTime;
-    protected long upTime;
-    protected int priority;
-
     protected BsdOSThread(int processId) {
         super(processId);
-    }
-
-    @Override
-    public int getThreadId() {
-        return this.threadId;
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public OSProcess.State getState() {
-        return this.state;
-    }
-
-    @Override
-    public long getStartMemoryAddress() {
-        return this.startMemoryAddress;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
-    }
-
-    @Override
-    public long getMinorFaults() {
-        return this.minorFaults;
-    }
-
-    @Override
-    public long getMajorFaults() {
-        return this.majorFaults;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSThread.java
@@ -14,7 +14,6 @@ import oshi.driver.common.unix.solaris.PsInfo;
 import oshi.driver.common.unix.solaris.SolarisLwpsInfo;
 import oshi.driver.common.unix.solaris.SolarisPrUsage;
 import oshi.software.common.AbstractOSThread;
-import oshi.software.os.OSProcess;
 import oshi.util.Util;
 
 /**
@@ -25,17 +24,6 @@ public abstract class SolarisOSThread extends AbstractOSThread {
 
     private final Supplier<SolarisLwpsInfo> lwpsinfo = memoize(this::queryLwpsInfo, defaultExpiration());
     private final Supplier<SolarisPrUsage> prusage = memoize(this::queryPrUsage, defaultExpiration());
-
-    private String name;
-    private final int threadId;
-    private OSProcess.State state = OSProcess.State.INVALID;
-    private long startMemoryAddress;
-    private long contextSwitches;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private int priority;
 
     protected SolarisOSThread(int pid, int lwpid) {
         super(pid);
@@ -49,56 +37,6 @@ public abstract class SolarisOSThread extends AbstractOSThread {
 
     private SolarisPrUsage queryPrUsage() {
         return PsInfo.queryPrUsage(this.getOwningProcessId(), this.getThreadId());
-    }
-
-    @Override
-    public String getName() {
-        return this.name != null ? name : "";
-    }
-
-    @Override
-    public int getThreadId() {
-        return this.threadId;
-    }
-
-    @Override
-    public OSProcess.State getState() {
-        return this.state;
-    }
-
-    @Override
-    public long getStartMemoryAddress() {
-        return this.startMemoryAddress;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return this.contextSwitches;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return this.kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return this.userTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return this.upTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return this.startTime;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSThread.java
@@ -16,24 +16,12 @@ import static oshi.software.os.OSProcess.State.WAITING;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.software.common.AbstractOSThread;
-import oshi.software.os.OSProcess.State;
 
 /**
  * Common base class for Windows OS thread implementations.
  */
 @ThreadSafe
 public abstract class WindowsOSThread extends AbstractOSThread {
-
-    private final int threadId;
-    private String name;
-    private State state;
-    private long startMemoryAddress;
-    private long contextSwitches;
-    private long kernelTime;
-    private long userTime;
-    private long startTime;
-    private long upTime;
-    private int priority;
 
     /**
      * Constructor.
@@ -47,56 +35,6 @@ public abstract class WindowsOSThread extends AbstractOSThread {
         super(pid);
         this.threadId = tid;
         updateAttributes(procName, pcb);
-    }
-
-    @Override
-    public int getThreadId() {
-        return threadId;
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public State getState() {
-        return state;
-    }
-
-    @Override
-    public long getStartMemoryAddress() {
-        return startMemoryAddress;
-    }
-
-    @Override
-    public long getContextSwitches() {
-        return contextSwitches;
-    }
-
-    @Override
-    public long getKernelTime() {
-        return kernelTime;
-    }
-
-    @Override
-    public long getUserTime() {
-        return userTime;
-    }
-
-    @Override
-    public long getStartTime() {
-        return startTime;
-    }
-
-    @Override
-    public long getUpTime() {
-        return upTime;
-    }
-
-    @Override
-    public int getPriority() {
-        return this.priority;
     }
 
     /**

--- a/oshi-common/src/test/java/oshi/software/common/AbstractOSThreadTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/AbstractOSThreadTest.java
@@ -17,42 +17,16 @@ class AbstractOSThreadTest {
 
     private static AbstractOSThread createThread(int ownerPid, int threadId, long kernelTime, long userTime,
             long upTime) {
-        return new AbstractOSThread(ownerPid) {
-            @Override
-            public int getThreadId() {
-                return threadId;
-            }
-
-            @Override
-            public State getState() {
-                return State.RUNNING;
-            }
-
-            @Override
-            public long getKernelTime() {
-                return kernelTime;
-            }
-
-            @Override
-            public long getUserTime() {
-                return userTime;
-            }
-
-            @Override
-            public long getUpTime() {
-                return upTime;
-            }
-
-            @Override
-            public long getStartTime() {
-                return 0L;
-            }
-
-            @Override
-            public int getPriority() {
-                return 0;
-            }
+        // AbstractOSThread now provides the field-backed getters, so set the protected fields directly (this test is
+        // in the same package) rather than overriding getters.
+        AbstractOSThread thread = new AbstractOSThread(ownerPid) {
         };
+        thread.threadId = threadId;
+        thread.state = State.RUNNING;
+        thread.kernelTime = kernelTime;
+        thread.userTime = userTime;
+        thread.upTime = upTime;
+        return thread;
     }
 
     @Test


### PR DESCRIPTION
Second subsystem in the cross-OS consistency/dedup audit. **Pure structural consolidation** — no observable change for valid threads.

## What
Every `OSThread` implementation declared the same 12 thread-attribute fields (`threadId`, `name`, `state`, kernel/user/start/up time, `priority`, minor/major faults, context switches, start address) with identical `return this.field` getters. This hoists them into `AbstractOSThread` as `protected` fields + field-backed getters — the same field-hoist model `AbstractOSProcess` already uses — so each platform keeps **only its own parsing** in `updateAttributes()`.

| File | Change |
|---|---|
| `AbstractOSThread` | gains the 12 `protected` fields + the getters |
| `Linux`/`AIX`/`Solaris`/`BSD`/`Windows`/`Mac` `OSThread` | drop the fields + getters; keep constructors + parsing |

Platform-specific bits stay put: Linux's `os` field, Solaris's memoized `psinfo`/`prusage` suppliers, Windows's `getProcName()` + perf-counter `updateAttributes(procName, pcb)`, BSD's `ps`-row parsing. `BsdOSThread`'s `protected` fields (already the full superset) simply moved up a level, and its checkstyle `VisibilityModifier` suppression migrated to `AbstractOSThread`.

**Net −279 lines** (8 files, +93/−372).

## Note
`getName()` is now uniformly null-safe in the base (`name != null ? name : ""`), matching the interface's documented default of `""` and what Solaris already did. Previously Windows/Linux could return `null` for an invalid/unset thread; they now return `""`. Not a change for any valid thread, and it aligns to the contract — flagging it for transparency, not treating it as user-facing.

## Deferred (from the map)
- PsInfo Solaris↔AIX: the `lwpsinfo` structs genuinely differ (field count/order/types), so the flagged "twin" can't merge its parser — only a ~30-line JNA buffer-read helper is shareable, and it's really OSProcess plumbing. Folding that into the OSProcess PR (#8) instead.

Part of the subsystem-by-subsystem audit; follows #3445 (FileSystem).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized thread information handling across supported operating systems.
  - Thread identifiers, names, states, timing, memory, fault, context-switch, and priority metrics now use consistent shared access behavior.
  - Improved default handling for unavailable thread names and invalid/unknown states, while platform updates continue refreshing metrics as before.

- **Tests**
  - Updated thread test helpers to align with the new shared attribute storage.

- **Chores**
  - Refreshed code-quality suppression rules related to visibility warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->