### PR TITLE
Consolidate Linux UsbDevice udev logic into a shared tree builder

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxUsbDevice.java
@@ -1,13 +1,13 @@
 /*
- * Copyright 2026 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.common.platform.linux;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.sort;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -16,53 +16,83 @@ import oshi.hardware.UsbDevice;
 import oshi.hardware.common.AbstractUsbDevice;
 
 /**
- * Linux USB device base class.
+ * A Linux USB device. Backends (udev via JNA or FFM, or the native-free sysfs reader) enumerate raw
+ * {@link UdevUsbDevice} attributes; this class builds the controller device tree from them, so all the
+ * parsing/parent-child/sorting logic lives in one place.
  */
 @Immutable
-public class LinuxUsbDevice extends AbstractUsbDevice {
+public final class LinuxUsbDevice extends AbstractUsbDevice {
 
-    /**
-     * Creates a LinuxUsbDevice.
-     *
-     * @param name             the device name
-     * @param vendor           the vendor
-     * @param vendorId         the vendor ID
-     * @param productId        the product ID
-     * @param serialNumber     the serial number
-     * @param uniqueDeviceId   the unique device ID
-     * @param connectedDevices the connected devices
-     */
-    protected LinuxUsbDevice(String name, String vendor, String vendorId, String productId, String serialNumber,
+    private LinuxUsbDevice(String name, String vendor, String vendorId, String productId, String serialNumber,
             String uniqueDeviceId, List<UsbDevice> connectedDevices) {
         super(name, vendor, vendorId, productId, serialNumber, uniqueDeviceId, connectedDevices);
     }
 
     /**
-     * No-arg constructor required so that subclasses, which extend this class solely to inherit its static helper
-     * methods, can compile without an explicit constructor. No subclass is ever instantiated; only this class is, via
-     * the full constructor.
+     * Builds the USB controller device tree from raw per-device attributes gathered by a backend.
+     *
+     * @param rawDevices the enumerated {@code usb_device} entries, in any order
+     * @return a list of USB controllers, each with its connected-device tree
      */
-    protected LinuxUsbDevice() {
-        this("", "", "", "", "", "", emptyList());
+    public static List<UsbDevice> getUsbDevices(List<UdevUsbDevice> rawDevices) {
+        // Build lookup maps keyed by syspath, plus the parent -> children (hub) map and the list of root controllers
+        Map<String, String> nameMap = new HashMap<>();
+        Map<String, String> vendorMap = new HashMap<>();
+        Map<String, String> vendorIdMap = new HashMap<>();
+        Map<String, String> productIdMap = new HashMap<>();
+        Map<String, String> serialMap = new HashMap<>();
+        Map<String, List<String>> hubMap = new HashMap<>();
+        List<String> usbControllers = new ArrayList<>();
+        for (UdevUsbDevice device : rawDevices) {
+            String syspath = device.getSyspath();
+            if (device.getProduct() != null) {
+                nameMap.put(syspath, device.getProduct());
+            }
+            if (device.getManufacturer() != null) {
+                vendorMap.put(syspath, device.getManufacturer());
+            }
+            if (device.getVendorId() != null) {
+                vendorIdMap.put(syspath, device.getVendorId());
+            }
+            if (device.getProductId() != null) {
+                productIdMap.put(syspath, device.getProductId());
+            }
+            if (device.getSerial() != null) {
+                serialMap.put(syspath, device.getSerial());
+            }
+            String parent = device.getParentSyspath();
+            if (parent == null) {
+                usbControllers.add(syspath);
+            } else {
+                hubMap.computeIfAbsent(parent, x -> new ArrayList<>()).add(syspath);
+            }
+        }
+
+        List<UsbDevice> controllerDevices = new ArrayList<>();
+        for (String controller : usbControllers) {
+            controllerDevices.add(getDeviceAndChildren(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
+                    productIdMap, serialMap, hubMap));
+        }
+        return controllerDevices;
     }
 
     /**
-     * Recursively creates LinuxUsbDevices by fetching information from maps to populate fields
+     * Recursively creates a LinuxUsbDevice by fetching information from the maps to populate its fields.
      *
-     * @param devPath      The device node path.
-     * @param vid          The default (parent) vendor ID
-     * @param pid          The default (parent) product ID
-     * @param nameMap      the map of names
-     * @param vendorMap    the map of vendors
-     * @param vendorIdMap  the map of vendorIds
-     * @param productIdMap the map of productIds
-     * @param serialMap    the map of serial numbers
-     * @param hubMap       the map of hubs
-     * @return A LinuxUsbDevice corresponding to this device
+     * @param devPath      the syspath of the device to create
+     * @param vid          the default vendor ID, inherited from the parent if this device has none
+     * @param pid          the default product ID, inherited from the parent if this device has none
+     * @param nameMap      syspath to product name
+     * @param vendorMap    syspath to manufacturer name
+     * @param vendorIdMap  syspath to vendor ID
+     * @param productIdMap syspath to product ID
+     * @param serialMap    syspath to serial number
+     * @param hubMap       parent syspath to its child syspaths
+     * @return a {@link LinuxUsbDevice} for {@code devPath} with its connected devices populated recursively
      */
-    protected static LinuxUsbDevice getDeviceAndChildren(String devPath, String vid, String pid,
-            Map<String, String> nameMap, Map<String, String> vendorMap, Map<String, String> vendorIdMap,
-            Map<String, String> productIdMap, Map<String, String> serialMap, Map<String, List<String>> hubMap) {
+    static LinuxUsbDevice getDeviceAndChildren(String devPath, String vid, String pid, Map<String, String> nameMap,
+            Map<String, String> vendorMap, Map<String, String> vendorIdMap, Map<String, String> productIdMap,
+            Map<String, String> serialMap, Map<String, List<String>> hubMap) {
         String vendorId = vendorIdMap.getOrDefault(devPath, vid);
         String productId = productIdMap.getOrDefault(devPath, pid);
         List<String> childPaths = hubMap.getOrDefault(devPath, new ArrayList<>());

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/UdevUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/UdevUsbDevice.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.linux;
+
+import oshi.annotation.concurrent.Immutable;
+
+/**
+ * Raw attributes for a single Linux USB device, gathered by a backend enumeration (udev via JNA or FFM, or the
+ * native-free sysfs reader). The backend only iterates and extracts these fields; {@link LinuxUsbDevice} builds the
+ * device tree from a list of these carriers, so the parsing/parent-child/sorting logic lives in one place. Any field
+ * may be {@code null} if the backend did not report it; {@link #getParentSyspath()} is {@code null} for a root USB
+ * controller.
+ */
+@Immutable
+public class UdevUsbDevice {
+
+    private final String syspath;
+    private final String product;
+    private final String manufacturer;
+    private final String vendorId;
+    private final String productId;
+    private final String serial;
+    private final String parentSyspath;
+
+    /**
+     * Creates a UdevUsbDevice.
+     *
+     * @param syspath       the device's sysfs path (the map key)
+     * @param product       the product name, or {@code null}
+     * @param manufacturer  the manufacturer/vendor name, or {@code null}
+     * @param vendorId      the vendor ID, or {@code null}
+     * @param productId     the product ID, or {@code null}
+     * @param serial        the serial number, or {@code null}
+     * @param parentSyspath the parent device's syspath, or {@code null} if this is a root controller
+     */
+    public UdevUsbDevice(String syspath, String product, String manufacturer, String vendorId, String productId,
+            String serial, String parentSyspath) {
+        this.syspath = syspath;
+        this.product = product;
+        this.manufacturer = manufacturer;
+        this.vendorId = vendorId;
+        this.productId = productId;
+        this.serial = serial;
+        this.parentSyspath = parentSyspath;
+    }
+
+    /**
+     * @return the device's sysfs path (the map key)
+     */
+    public String getSyspath() {
+        return syspath;
+    }
+
+    /**
+     * @return the product name, or {@code null}
+     */
+    public String getProduct() {
+        return product;
+    }
+
+    /**
+     * @return the manufacturer/vendor name, or {@code null}
+     */
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    /**
+     * @return the vendor ID, or {@code null}
+     */
+    public String getVendorId() {
+        return vendorId;
+    }
+
+    /**
+     * @return the product ID, or {@code null}
+     */
+    public String getProductId() {
+        return productId;
+    }
+
+    /**
+     * @return the serial number, or {@code null}
+     */
+    public String getSerial() {
+        return serial;
+    }
+
+    /**
+     * @return the parent device's syspath, or {@code null} if this is a root controller
+     */
+    public String getParentSyspath() {
+        return parentSyspath;
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHardwareAbstractionLayerNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHardwareAbstractionLayerNF.java
@@ -17,6 +17,7 @@ import oshi.hardware.UsbDevice;
 import oshi.hardware.common.platform.linux.LinuxGlobalMemory;
 import oshi.hardware.common.platform.linux.LinuxHardwareAbstractionLayer;
 import oshi.hardware.common.platform.linux.LinuxPowerSource;
+import oshi.hardware.common.platform.linux.LinuxUsbDevice;
 import oshi.software.common.os.linux.nativefree.LinuxOperatingSystemNF;
 
 /**
@@ -53,7 +54,7 @@ public final class LinuxHardwareAbstractionLayerNF extends LinuxHardwareAbstract
 
     @Override
     protected List<UsbDevice> createUsbDevices() {
-        return LinuxUsbDeviceNF.getUsbDevices();
+        return LinuxUsbDevice.getUsbDevices(LinuxUsbDeviceNF.queryUsbDevices());
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNF.java
@@ -4,21 +4,21 @@
  */
 package oshi.hardware.common.platform.linux.nativefree;
 
+import static java.util.Collections.emptyList;
+
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import oshi.hardware.UsbDevice;
-import oshi.hardware.common.platform.linux.LinuxUsbDevice;
+import oshi.hardware.common.platform.linux.UdevUsbDevice;
 import oshi.util.FileUtil;
 import oshi.util.linux.SysPath;
 
 /**
- * Native-free Linux USB device enumeration from {@code /sys/bus/usb/devices/}.
+ * Native-free Linux USB device enumeration from {@code /sys/bus/usb/devices/}, returning raw {@link UdevUsbDevice}
+ * attributes for {@link oshi.hardware.common.platform.linux.LinuxUsbDevice} to assemble into a device tree.
  */
-public final class LinuxUsbDeviceNF extends LinuxUsbDevice {
+public final class LinuxUsbDeviceNF {
 
     private static final String SYS_USB = SysPath.SYS + "bus/usb/devices/";
 
@@ -26,89 +26,59 @@ public final class LinuxUsbDeviceNF extends LinuxUsbDevice {
     }
 
     /**
-     * Gets the USB controller device tree on this machine. The flat form is derived by the caller (the HAL).
+     * Enumerates USB devices from sysfs.
      *
-     * @return a list of USB controllers, each with its connected-device tree
+     * @return the raw USB device attributes
      */
-    public static List<UsbDevice> getUsbDevices() {
+    public static List<UdevUsbDevice> queryUsbDevices() {
         return queryUsbDevices(SYS_USB);
     }
 
     /**
-     * Queries USB devices from the specified sysfs path.
+     * Enumerates USB devices from the specified sysfs path.
      *
      * @param sysUsbPath the path to the USB devices directory (e.g., /sys/bus/usb/devices/)
-     * @return a list of USB device trees rooted at controllers
+     * @return the raw USB device attributes
      */
-    static List<UsbDevice> queryUsbDevices(String sysUsbPath) {
+    static List<UdevUsbDevice> queryUsbDevices(String sysUsbPath) {
         if (!sysUsbPath.endsWith(File.separator)) {
             sysUsbPath += File.separator;
         }
-        File usbDir = new File(sysUsbPath);
-        File[] deviceDirs = usbDir.listFiles();
+        File[] deviceDirs = new File(sysUsbPath).listFiles();
         if (deviceDirs == null) {
-            return new ArrayList<>();
+            return emptyList();
         }
 
-        List<String> usbControllers = new ArrayList<>();
-        Map<String, String> nameMap = new HashMap<>();
-        Map<String, String> vendorMap = new HashMap<>();
-        Map<String, String> vendorIdMap = new HashMap<>();
-        Map<String, String> productIdMap = new HashMap<>();
-        Map<String, String> serialMap = new HashMap<>();
-        Map<String, List<String>> hubMap = new HashMap<>();
-
+        List<UdevUsbDevice> devices = new ArrayList<>();
         for (File devDir : deviceDirs) {
             String syspath = devDir.getAbsolutePath();
-            String devtype = FileUtil.getStringFromFile(syspath + "/devnum").trim();
-            if (devtype.isEmpty()) {
+            if (FileUtil.getStringFromFile(syspath + "/devnum").trim().isEmpty()) {
                 continue;
             }
+            String product = emptyToNull(FileUtil.getStringFromFile(syspath + "/product").trim());
+            String manufacturer = emptyToNull(FileUtil.getStringFromFile(syspath + "/manufacturer").trim());
+            String idVendor = emptyToNull(FileUtil.getStringFromFile(syspath + "/idVendor").trim());
+            String idProduct = emptyToNull(FileUtil.getStringFromFile(syspath + "/idProduct").trim());
+            String serial = emptyToNull(FileUtil.getStringFromFile(syspath + "/serial").trim());
 
-            String product = FileUtil.getStringFromFile(syspath + "/product").trim();
-            if (!product.isEmpty()) {
-                nameMap.put(syspath, product);
-            }
-            String manufacturer = FileUtil.getStringFromFile(syspath + "/manufacturer").trim();
-            if (!manufacturer.isEmpty()) {
-                vendorMap.put(syspath, manufacturer);
-            }
-            String idVendor = FileUtil.getStringFromFile(syspath + "/idVendor").trim();
-            if (!idVendor.isEmpty()) {
-                vendorIdMap.put(syspath, idVendor);
-            }
-            String idProduct = FileUtil.getStringFromFile(syspath + "/idProduct").trim();
-            if (!idProduct.isEmpty()) {
-                productIdMap.put(syspath, idProduct);
-            }
-            String serial = FileUtil.getStringFromFile(syspath + "/serial").trim();
-            if (!serial.isEmpty()) {
-                serialMap.put(syspath, serial);
-            }
-
-            // Determine parent: USB root hubs have names like "usbN", children have "N-N.N..."
+            // Determine the parent from the device name: USB root hubs are "usbN", children are "N-N.N..."
             String name = devDir.getName();
+            String parentSyspath;
             if (name.startsWith("usb")) {
-                usbControllers.add(syspath);
+                parentSyspath = null;
+            } else if (name.contains(".")) {
+                parentSyspath = sysUsbPath + name.substring(0, name.lastIndexOf('.'));
+            } else if (name.contains("-")) {
+                parentSyspath = sysUsbPath + "usb" + name.substring(0, name.indexOf('-'));
             } else {
-                String parentName;
-                if (name.contains(".")) {
-                    parentName = name.substring(0, name.lastIndexOf('.'));
-                } else if (name.contains("-")) {
-                    parentName = "usb" + name.substring(0, name.indexOf('-'));
-                } else {
-                    parentName = name;
-                }
-                String parentPath = sysUsbPath + parentName;
-                hubMap.computeIfAbsent(parentPath, x -> new ArrayList<>()).add(syspath);
+                parentSyspath = sysUsbPath + name;
             }
+            devices.add(new UdevUsbDevice(syspath, product, manufacturer, idVendor, idProduct, serial, parentSyspath));
         }
+        return devices;
+    }
 
-        List<UsbDevice> controllerDevices = new ArrayList<>();
-        for (String controller : usbControllers) {
-            controllerDevices.add(getDeviceAndChildren(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
-                    productIdMap, serialMap, hubMap));
-        }
-        return controllerDevices;
+    private static String emptyToNull(String value) {
+        return value.isEmpty() ? null : value;
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNFTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNFTest.java
@@ -21,13 +21,15 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import oshi.hardware.UsbDevice;
+import oshi.hardware.common.platform.linux.LinuxUsbDevice;
 
 @EnabledOnOs(OS.LINUX)
 class LinuxUsbDeviceNFTest {
 
     @Test
     void testQueryUsbDevicesNonexistentPath(@TempDir Path tempDir) {
-        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(tempDir.resolve("missing").toString() + "/");
+        List<UsbDevice> devices = LinuxUsbDevice
+                .getUsbDevices(LinuxUsbDeviceNF.queryUsbDevices(tempDir.resolve("missing").toString() + "/"));
         assertThat(devices, is(empty()));
     }
 
@@ -35,7 +37,8 @@ class LinuxUsbDeviceNFTest {
     void testQueryUsbDevicesEmptyDir(@TempDir Path tempDir) throws IOException {
         Path usbDir = tempDir.resolve("usb");
         Files.createDirectories(usbDir);
-        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/");
+        List<UsbDevice> devices = LinuxUsbDevice
+                .getUsbDevices(LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/"));
         assertThat(devices, is(empty()));
     }
 
@@ -44,7 +47,8 @@ class LinuxUsbDeviceNFTest {
         Path usbDir = tempDir.resolve("usb");
         Path dev = usbDir.resolve("usb1");
         Files.createDirectories(dev);
-        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/");
+        List<UsbDevice> devices = LinuxUsbDevice
+                .getUsbDevices(LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/"));
         assertThat(devices, is(empty()));
     }
 
@@ -60,7 +64,8 @@ class LinuxUsbDeviceNFTest {
         writeFile(usb1.resolve("idProduct"), "0003");
         writeFile(usb1.resolve("serial"), "0000:00:14.0");
 
-        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/");
+        List<UsbDevice> devices = LinuxUsbDevice
+                .getUsbDevices(LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/"));
         assertThat(devices, hasSize(1));
         assertThat(devices.get(0).getName(), is("xHCI Host Controller"));
         assertThat(devices.get(0).getVendor(), is("Linux Foundation"));
@@ -88,7 +93,8 @@ class LinuxUsbDeviceNFTest {
         writeFile(child.resolve("idVendor"), "046d");
         writeFile(child.resolve("idProduct"), "c077");
 
-        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/");
+        List<UsbDevice> devices = LinuxUsbDevice
+                .getUsbDevices(LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/"));
         assertThat(devices, hasSize(1));
         assertThat(devices.get(0).getConnectedDevices(), hasSize(1));
         assertThat(devices.get(0).getConnectedDevices().get(0).getName(), is("USB Mouse"));
@@ -118,7 +124,8 @@ class LinuxUsbDeviceNFTest {
         writeFile(device.resolve("idVendor"), "04f2");
         writeFile(device.resolve("idProduct"), "0112");
 
-        List<UsbDevice> devices = LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/");
+        List<UsbDevice> devices = LinuxUsbDevice
+                .getUsbDevices(LinuxUsbDeviceNF.queryUsbDevices(usbDir.toString() + "/"));
         assertThat(devices, hasSize(1));
         UsbDevice root = devices.get(0);
         assertThat(root.getConnectedDevices(), hasSize(1));

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerFFM.java
@@ -18,6 +18,7 @@ import oshi.hardware.Printer;
 import oshi.hardware.UsbDevice;
 import oshi.hardware.common.platform.linux.LinuxGlobalMemory;
 import oshi.hardware.common.platform.linux.LinuxHardwareAbstractionLayer;
+import oshi.hardware.common.platform.linux.LinuxUsbDevice;
 import oshi.hardware.platform.unix.CupsPrinterFFM;
 import oshi.software.os.linux.LinuxOperatingSystemFFM;
 
@@ -70,6 +71,6 @@ public final class LinuxHardwareAbstractionLayerFFM extends LinuxHardwareAbstrac
 
     @Override
     protected List<UsbDevice> createUsbDevices() {
-        return LinuxUsbDeviceFFM.getUsbDevices();
+        return LinuxUsbDevice.getUsbDevices(LinuxUsbDeviceFFM.queryUsbDevices());
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceFFM.java
@@ -11,22 +11,20 @@ import static oshi.software.os.linux.LinuxOperatingSystemFFM.HAS_UDEV;
 
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.ffm.NativeHandle;
 import oshi.ffm.platform.linux.UdevFunctions;
-import oshi.hardware.UsbDevice;
-import oshi.hardware.common.platform.linux.LinuxUsbDevice;
+import oshi.hardware.common.platform.linux.UdevUsbDevice;
 
 /**
- * Linux USB device helper using FFM/udev. Instantiates {@link LinuxUsbDevice} objects.
+ * Enumerates Linux USB devices via FFM/libudev, returning raw {@link UdevUsbDevice} attributes for
+ * {@link oshi.hardware.common.platform.linux.LinuxUsbDevice} to assemble into a device tree.
  */
-public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
+public final class LinuxUsbDeviceFFM {
 
     private LinuxUsbDeviceFFM() {
     }
@@ -42,31 +40,20 @@ public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
     private static final String ATTR_SERIAL = "serial";
 
     /**
-     * Instantiates the USB controller device tree. The flat form is derived by the caller (the HAL).
+     * Enumerates all {@code usb_device} entries via libudev.
      *
-     * @return a list of USB controllers, each with its connected-device tree.
+     * @return the raw USB device attributes, or an empty list if libudev is unavailable
      */
-    public static List<UsbDevice> getUsbDevices() {
-        return queryUsbDevices();
-    }
-
-    private static List<UsbDevice> queryUsbDevices() {
+    public static List<UdevUsbDevice> queryUsbDevices() {
         if (!HAS_UDEV) {
             LOG.warn("USB Device information requires libudev, which is not present.");
             return emptyList();
         }
         return callInArenaOrDefault(arena -> {
-            List<String> usbControllers = new ArrayList<>();
-            Map<String, String> nameMap = new HashMap<>();
-            Map<String, String> vendorMap = new HashMap<>();
-            Map<String, String> vendorIdMap = new HashMap<>();
-            Map<String, String> productIdMap = new HashMap<>();
-            Map<String, String> serialMap = new HashMap<>();
-            Map<String, List<String>> hubMap = new HashMap<>();
-
+            List<UdevUsbDevice> devices = new ArrayList<>();
             MemorySegment udev = UdevFunctions.udev_new();
             if (MemorySegment.NULL.equals(udev)) {
-                return emptyList();
+                return devices;
             }
             // wrapped only to release the native handle on close
             try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
@@ -75,12 +62,10 @@ public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
                 try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
                     UdevFunctions.addMatchSubsystem(enumerate, SUBSYSTEM_USB, arena);
                     UdevFunctions.udev_enumerate_scan_devices(enumerate);
-
                     for (MemorySegment entry = UdevFunctions
                             .udev_enumerate_get_list_entry(enumerate); !MemorySegment.NULL
                                     .equals(entry); entry = UdevFunctions.udev_list_entry_get_next(entry)) {
-                        MemorySegment namePtr = UdevFunctions.udev_list_entry_get_name(entry);
-                        String syspath = UdevFunctions.getString(namePtr, arena);
+                        String syspath = UdevFunctions.getString(UdevFunctions.udev_list_entry_get_name(entry), arena);
                         if (syspath == null) {
                             continue;
                         }
@@ -95,48 +80,21 @@ public final class LinuxUsbDeviceFFM extends LinuxUsbDevice {
                             if (!DEVTYPE_USB_DEVICE.equals(devtype)) {
                                 continue;
                             }
-                            String value = UdevFunctions.getSysattrValue(device, ATTR_PRODUCT, arena);
-                            if (value != null) {
-                                nameMap.put(syspath, value);
-                            }
-                            value = UdevFunctions.getSysattrValue(device, ATTR_MANUFACTURER, arena);
-                            if (value != null) {
-                                vendorMap.put(syspath, value);
-                            }
-                            value = UdevFunctions.getSysattrValue(device, ATTR_VENDOR_ID, arena);
-                            if (value != null) {
-                                vendorIdMap.put(syspath, value);
-                            }
-                            value = UdevFunctions.getSysattrValue(device, ATTR_PRODUCT_ID, arena);
-                            if (value != null) {
-                                productIdMap.put(syspath, value);
-                            }
-                            value = UdevFunctions.getSysattrValue(device, ATTR_SERIAL, arena);
-                            if (value != null) {
-                                serialMap.put(syspath, value);
-                            }
                             MemorySegment parent = UdevFunctions.getParentWithSubsystemDevtype(device, SUBSYSTEM_USB,
                                     DEVTYPE_USB_DEVICE, arena);
-                            if (MemorySegment.NULL.equals(parent)) {
-                                usbControllers.add(syspath);
-                            } else {
-                                String parentPath = UdevFunctions
-                                        .getString(UdevFunctions.udev_device_get_syspath(parent), arena);
-                                if (parentPath != null) {
-                                    hubMap.computeIfAbsent(parentPath, x -> new ArrayList<>()).add(syspath);
-                                }
-                            }
+                            String parentPath = MemorySegment.NULL.equals(parent) ? null
+                                    : UdevFunctions.getString(UdevFunctions.udev_device_get_syspath(parent), arena);
+                            devices.add(new UdevUsbDevice(syspath,
+                                    UdevFunctions.getSysattrValue(device, ATTR_PRODUCT, arena),
+                                    UdevFunctions.getSysattrValue(device, ATTR_MANUFACTURER, arena),
+                                    UdevFunctions.getSysattrValue(device, ATTR_VENDOR_ID, arena),
+                                    UdevFunctions.getSysattrValue(device, ATTR_PRODUCT_ID, arena),
+                                    UdevFunctions.getSysattrValue(device, ATTR_SERIAL, arena), parentPath));
                         }
                     }
                 }
             }
-
-            List<UsbDevice> controllerDevices = new ArrayList<>();
-            for (String controller : usbControllers) {
-                controllerDevices.add(getDeviceAndChildren(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
-                        productIdMap, serialMap, hubMap));
-            }
-            return controllerDevices;
+            return devices;
         }, LOG, WARN, "Error enumerating USB devices", emptyList());
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHardwareAbstractionLayerJNA.java
@@ -18,6 +18,7 @@ import oshi.hardware.Printer;
 import oshi.hardware.UsbDevice;
 import oshi.hardware.common.platform.linux.LinuxGlobalMemory;
 import oshi.hardware.common.platform.linux.LinuxHardwareAbstractionLayer;
+import oshi.hardware.common.platform.linux.LinuxUsbDevice;
 import oshi.hardware.platform.unix.CupsPrinterJNA;
 import oshi.software.os.linux.LinuxOperatingSystemJNA;
 
@@ -55,7 +56,7 @@ public final class LinuxHardwareAbstractionLayerJNA extends LinuxHardwareAbstrac
 
     @Override
     protected List<UsbDevice> createUsbDevices() {
-        return LinuxUsbDeviceJNA.getUsbDevices();
+        return LinuxUsbDevice.getUsbDevices(LinuxUsbDeviceJNA.queryUsbDevices());
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceJNA.java
@@ -8,9 +8,7 @@ import static java.util.Collections.emptyList;
 import static oshi.software.os.linux.LinuxOperatingSystemJNA.HAS_UDEV;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,13 +18,13 @@ import com.sun.jna.platform.linux.Udev.UdevDevice;
 import com.sun.jna.platform.linux.Udev.UdevEnumerate;
 import com.sun.jna.platform.linux.Udev.UdevListEntry;
 
-import oshi.hardware.UsbDevice;
-import oshi.hardware.common.platform.linux.LinuxUsbDevice;
+import oshi.hardware.common.platform.linux.UdevUsbDevice;
 
 /**
- * Linux USB device helper using JNA/udev. Instantiates {@link LinuxUsbDevice} objects.
+ * Enumerates Linux USB devices via JNA/libudev, returning raw {@link UdevUsbDevice} attributes for
+ * {@link oshi.hardware.common.platform.linux.LinuxUsbDevice} to assemble into a device tree.
  */
-public final class LinuxUsbDeviceJNA extends LinuxUsbDevice {
+public final class LinuxUsbDeviceJNA {
 
     private LinuxUsbDeviceJNA() {
     }
@@ -42,31 +40,16 @@ public final class LinuxUsbDeviceJNA extends LinuxUsbDevice {
     private static final String ATTR_SERIAL = "serial";
 
     /**
-     * Instantiates the USB controller device tree. The flat form is derived by the caller (the HAL).
+     * Enumerates all {@code usb_device} entries via libudev.
      *
-     * @return a list of USB controllers, each with its connected-device tree.
+     * @return the raw USB device attributes, or an empty list if libudev is unavailable
      */
-    public static List<UsbDevice> getUsbDevices() {
-        return queryUsbDevices();
-    }
-
-    private static List<UsbDevice> queryUsbDevices() {
+    public static List<UdevUsbDevice> queryUsbDevices() {
         if (!HAS_UDEV) {
             LOG.warn("USB Device information requires libudev, which is not present.");
             return emptyList();
         }
-        // Build a list of devices with no parent; these will be the roots
-        List<String> usbControllers = new ArrayList<>();
-
-        // Maps to store information using device syspath as the key
-        Map<String, String> nameMap = new HashMap<>();
-        Map<String, String> vendorMap = new HashMap<>();
-        Map<String, String> vendorIdMap = new HashMap<>();
-        Map<String, String> productIdMap = new HashMap<>();
-        Map<String, String> serialMap = new HashMap<>();
-        Map<String, List<String>> hubMap = new HashMap<>();
-
-        // Enumerate all usb devices and build information maps
+        List<UdevUsbDevice> devices = new ArrayList<>();
         Udev.UdevContext udev = Udev.INSTANCE.udev_new();
         if (udev == null) {
             LOG.warn("Failed to create udev context.");
@@ -77,8 +60,6 @@ public final class LinuxUsbDeviceJNA extends LinuxUsbDevice {
             try {
                 enumerate.addMatchSubsystem(SUBSYSTEM_USB);
                 enumerate.scanDevices();
-
-                // For each item enumerated, store information in the maps
                 for (UdevListEntry entry = enumerate.getListEntry(); entry != null; entry = entry.getNext()) {
                     String syspath = entry.getName();
                     UdevDevice device = udev.deviceNewFromSyspath(syspath);
@@ -86,37 +67,13 @@ public final class LinuxUsbDeviceJNA extends LinuxUsbDevice {
                         try {
                             // Only include usb_device devtype, skipping usb_interface
                             if (DEVTYPE_USB_DEVICE.equals(device.getDevtype())) {
-                                String value = device.getSysattrValue(ATTR_PRODUCT);
-                                if (value != null) {
-                                    nameMap.put(syspath, value);
-                                }
-                                value = device.getSysattrValue(ATTR_MANUFACTURER);
-                                if (value != null) {
-                                    vendorMap.put(syspath, value);
-                                }
-                                value = device.getSysattrValue(ATTR_VENDOR_ID);
-                                if (value != null) {
-                                    vendorIdMap.put(syspath, value);
-                                }
-                                value = device.getSysattrValue(ATTR_PRODUCT_ID);
-                                if (value != null) {
-                                    productIdMap.put(syspath, value);
-                                }
-                                value = device.getSysattrValue(ATTR_SERIAL);
-                                if (value != null) {
-                                    serialMap.put(syspath, value);
-                                }
-
                                 UdevDevice parent = device.getParentWithSubsystemDevtype(SUBSYSTEM_USB,
                                         DEVTYPE_USB_DEVICE);
-                                if (parent == null) {
-                                    // This is a controller with no parent, add to list
-                                    usbControllers.add(syspath);
-                                } else {
-                                    // Add child syspath to parent's path
-                                    String parentPath = parent.getSyspath();
-                                    hubMap.computeIfAbsent(parentPath, x -> new ArrayList<>()).add(syspath);
-                                }
+                                devices.add(new UdevUsbDevice(syspath, device.getSysattrValue(ATTR_PRODUCT),
+                                        device.getSysattrValue(ATTR_MANUFACTURER),
+                                        device.getSysattrValue(ATTR_VENDOR_ID), device.getSysattrValue(ATTR_PRODUCT_ID),
+                                        device.getSysattrValue(ATTR_SERIAL),
+                                        parent == null ? null : parent.getSyspath()));
                             }
                         } finally {
                             device.unref();
@@ -129,13 +86,6 @@ public final class LinuxUsbDeviceJNA extends LinuxUsbDevice {
         } finally {
             udev.unref();
         }
-
-        // Build tree and return
-        List<UsbDevice> controllerDevices = new ArrayList<>();
-        for (String controller : usbControllers) {
-            controllerDevices.add(getDeviceAndChildren(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
-                    productIdMap, serialMap, hubMap));
-        }
-        return controllerDevices;
+        return devices;
     }
 }


### PR DESCRIPTION
## Summary

Part of the ongoing cross-OS consistency/dedup audit. The three Linux USB backends (JNA libudev, FFM libudev, and the native-free sysfs reader) each carried a *full copy* of the same map-building, parent/child hub-graph, sorting, and recursive device-tree construction — differing only in how they enumerated devices from the OS.

This splits at the carrier boundary: each backend enumerates once and returns a list of raw attributes; a single shared builder assembles the tree.

## Changes

- **New `UdevUsbDevice`** (oshi-common) — immutable carrier for one device's raw attributes: `syspath`, `product`, `manufacturer`, `vendorId`, `productId`, `serial`, `parentSyspath` (`null` parent = root controller). Any field may be `null` if the backend didn't report it.
- **`LinuxUsbDevice`** — now `final`; holds the single copy of `getUsbDevices(List<UdevUsbDevice>)` (lookup maps + hub graph + sort + recursive tree). `getDeviceAndChildren` kept package-visible for its existing unit test.
- **Backends reduced to pure enumeration**, each returning `List<UdevUsbDevice>`:
  - `LinuxUsbDeviceJNA` — JNA libudev (`unref()` finally chain)
  - `LinuxUsbDeviceFFM` — FFM libudev (`callInArenaOrDefault` + `NativeHandle`)
  - `LinuxUsbDeviceNF` — sysfs `/sys/bus/usb/devices/` reader
- **All 3 Linux HALs** `createUsbDevices()` → `LinuxUsbDevice.getUsbDevices(XxxDriver.queryUsbDevices())`.

Net **−82 LOC** of hand-written logic (three copies collapsed to one).

## Behavior

No user-facing change: same device tree, same map fallbacks, same sort order. `LinuxUsbDeviceNFTest` now routes its sysfs fixtures through `getUsbDevices` so it keeps asserting on the built tree; `LinuxUsbDeviceTest` still unit-tests `getDeviceAndChildren` directly.

## Testing

- spotless / checkstyle / forbiddenapis / javadoc: clean
- Clean full-reactor `install` with tests: **BUILD SUCCESS**, 0 tests failed
- Linux-only NF/tree tests validated by CI on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Linux USB device detection across native-free, FFM, and JNA implementations.
  * USB devices now expose more consistent product, manufacturer, vendor, product ID, serial number, and hierarchy information.
  * Added a shared representation for raw USB device details.

* **Bug Fixes**
  * Improved construction and ordering of nested USB device trees.
  * Empty USB attributes are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->