### PR TITLE
Share the Mac USB IOKit walk behind backend-neutral registry views

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
@@ -143,7 +143,12 @@ public final class MacUsbDevice extends AbstractUsbDevice {
                 RegistryEntry controller = device.getParentEntry(IOSERVICE);
                 if (controller != null) {
                     id = controller.getRegistryEntryID();
-                    nameMap.put(id, controller.getName());
+                    // Skip a null name so getDeviceAndChildren can fall back to vid:pid (getOrDefault only substitutes
+                    // for absent keys, not null values)
+                    String controllerName = controller.getName();
+                    if (controllerName != null) {
+                        nameMap.put(id, controllerName);
+                    }
                     // The only controller info in the registry is its locationID; use it to find the matching PCI
                     // device and pull vendor/product IDs.
                     String[] vidPid = controller.lookupControllerVidPid();
@@ -195,8 +200,12 @@ public final class MacUsbDevice extends AbstractUsbDevice {
         long id = device.getRegistryEntryID();
         // Store id as a child of parent in the hub map
         hubMap.computeIfAbsent(parentId, x -> new ArrayList<>()).add(id);
-        // Get device name and store in map
-        nameMap.put(id, device.getName().trim());
+        // Get device name and store in map (skip if null so the walk isn't aborted before native handles are released
+        // and getDeviceAndChildren can fall back to vid:pid)
+        String name = device.getName();
+        if (name != null) {
+            nameMap.put(id, name.trim());
+        }
         // Get vendor and store in map
         String vendor = device.getStringProperty("USB Vendor Name");
         if (vendor != null) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
@@ -143,20 +143,24 @@ public final class MacUsbDevice extends AbstractUsbDevice {
                 RegistryEntry controller = device.getParentEntry(IOSERVICE);
                 if (controller != null) {
                     id = controller.getRegistryEntryID();
-                    // Skip a null name so getDeviceAndChildren can fall back to vid:pid (getOrDefault only substitutes
-                    // for absent keys, not null values)
-                    String controllerName = controller.getName();
-                    if (controllerName != null) {
-                        nameMap.put(id, controllerName);
-                    }
-                    // The only controller info in the registry is its locationID; use it to find the matching PCI
-                    // device and pull vendor/product IDs.
-                    String[] vidPid = controller.lookupControllerVidPid();
-                    if (vidPid[0] != null) {
-                        vendorIdMap.put(id, vidPid[0]);
-                    }
-                    if (vidPid[1] != null) {
-                        productIdMap.put(id, vidPid[1]);
+                    // Devices sharing a controller yield the same deterministic name/vid/pid, so only read them the
+                    // first time this controller is seen; later devices still register under it via usbControllers.
+                    if (!usbControllers.contains(id)) {
+                        // Skip a null name so getDeviceAndChildren can fall back to vid:pid (getOrDefault only
+                        // substitutes for absent keys, not null values)
+                        String controllerName = controller.getName();
+                        if (controllerName != null) {
+                            nameMap.put(id, controllerName);
+                        }
+                        // The only controller info in the registry is its locationID; use it to find the matching PCI
+                        // device and pull vendor/product IDs.
+                        String[] vidPid = controller.lookupControllerVidPid();
+                        if (vidPid[0] != null) {
+                            vendorIdMap.put(id, vidPid[0]);
+                        }
+                        if (vidPid[1] != null) {
+                            productIdMap.put(id, vidPid[1]);
+                        }
                     }
                     controller.release();
                 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.common.platform.mac;
@@ -8,59 +8,245 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.sort;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.UsbDevice;
 import oshi.hardware.common.AbstractUsbDevice;
 
 /**
- * Mac USB device base class.
+ * A Mac USB device. Backends (IOKit via JNA or FFM) supply a {@link RegistryEntry} view of the IO registry root; this
+ * class walks it once and builds the controller device tree, so all the parsing/parent-child/sorting logic lives in one
+ * place.
  */
 @Immutable
-public class MacUsbDevice extends AbstractUsbDevice {
+public final class MacUsbDevice extends AbstractUsbDevice {
 
-    /**
-     * Creates a MacUsbDevice.
-     *
-     * @param name             the device name
-     * @param vendor           the vendor
-     * @param vendorId         the vendor ID
-     * @param productId        the product ID
-     * @param serialNumber     the serial number
-     * @param uniqueDeviceId   the unique device ID
-     * @param connectedDevices the connected devices
-     */
-    protected MacUsbDevice(String name, String vendor, String vendorId, String productId, String serialNumber,
+    private static final String IOUSB = "IOUSB";
+    private static final String IOSERVICE = "IOService";
+
+    private MacUsbDevice(String name, String vendor, String vendorId, String productId, String serialNumber,
             String uniqueDeviceId, List<UsbDevice> connectedDevices) {
         super(name, vendor, vendorId, productId, serialNumber, uniqueDeviceId, connectedDevices);
     }
 
     /**
-     * No-arg constructor required so that subclasses, which extend this class solely to inherit its static helper
-     * methods, can compile without an explicit constructor. No subclass is ever instantiated; only this class is, via
-     * the full constructor.
+     * A backend-neutral view of an IOKit registry entry, letting the shared walk in {@link MacUsbDevice} run against
+     * either the JNA or FFM IOKit bindings. Each backend adapts its native registry-entry wrapper to this interface.
      */
-    protected MacUsbDevice() {
-        this("", "", "", "", "", "", emptyList());
+    public interface RegistryEntry extends AutoCloseable {
+        /**
+         * @return the entry's globally-unique registry ID
+         */
+        long getRegistryEntryID();
+
+        /**
+         * @return the entry's name, or {@code null}
+         */
+        String getName();
+
+        /**
+         * @param key the property key
+         * @return the string-valued property, or {@code null} if absent
+         */
+        String getStringProperty(String key);
+
+        /**
+         * @param key the property key
+         * @return the long-valued property, or {@code null} if absent
+         */
+        Long getLongProperty(String key);
+
+        /**
+         * @param plane the registry plane to search
+         * @return the parent entry in the given plane, or {@code null} if none
+         */
+        RegistryEntry getParentEntry(String plane);
+
+        /**
+         * @param plane the registry plane to iterate
+         * @return an iterator over child entries in the given plane, or {@code null} if none
+         */
+        RegistryIterator getChildIterator(String plane);
+
+        /**
+         * Resolves this (controller) entry's vendor and product IDs by cross-referencing its {@code locationID} against
+         * the matching PCI device, encapsulating the backend-specific CoreFoundation dictionary matching.
+         *
+         * @return a two-element array {@code {vendorId, productId}}; either element may be {@code null} if not found
+         */
+        String[] lookupControllerVidPid();
+
+        /**
+         * Releases the underlying native entry.
+         */
+        void release();
+
+        @Override
+        default void close() {
+            release();
+        }
     }
 
     /**
-     * Recursively creates MacUsbDevices by fetching information from maps to populate fields
+     * A backend-neutral view of an IOKit registry iterator.
+     */
+    public interface RegistryIterator extends AutoCloseable {
+        /**
+         * @return the next entry, or {@code null} when the iterator is exhausted
+         */
+        RegistryEntry next();
+
+        /**
+         * Releases the underlying native iterator.
+         */
+        void release();
+
+        @Override
+        default void close() {
+            release();
+        }
+    }
+
+    /**
+     * Walks the IO registry from {@code root} and builds the USB controller device tree.
      *
-     * @param registryEntryId The device unique registry id.
-     * @param vid             The default (parent) vendor ID
-     * @param pid             The default (parent) product ID
+     * @param root the IO registry root as a backend-neutral view, or {@code null} if unavailable
+     * @return a list of USB controllers, each with its connected-device tree
+     */
+    public static List<UsbDevice> getUsbDevices(RegistryEntry root) {
+        if (root == null) {
+            return emptyList();
+        }
+        // Maps to store information using the RegistryEntryID as the key
+        Map<Long, String> nameMap = new HashMap<>();
+        Map<Long, String> vendorMap = new HashMap<>();
+        Map<Long, String> vendorIdMap = new HashMap<>();
+        Map<Long, String> productIdMap = new HashMap<>();
+        Map<Long, String> serialMap = new HashMap<>();
+        Map<Long, List<Long>> hubMap = new HashMap<>();
+        Set<Long> usbControllers = new LinkedHashSet<>();
+
+        // Iterate over children of root in the IOUSB plane. This does not include the controllers, so we check each
+        // device's parent in the IOService plane.
+        RegistryIterator iter = root.getChildIterator(IOUSB);
+        if (iter != null) {
+            RegistryEntry device = iter.next();
+            while (device != null) {
+                long id = 0L;
+                // The parent of this device in the IOService plane is the controller
+                RegistryEntry controller = device.getParentEntry(IOSERVICE);
+                if (controller != null) {
+                    id = controller.getRegistryEntryID();
+                    nameMap.put(id, controller.getName());
+                    // The only controller info in the registry is its locationID; use it to find the matching PCI
+                    // device and pull vendor/product IDs.
+                    String[] vidPid = controller.lookupControllerVidPid();
+                    if (vidPid[0] != null) {
+                        vendorIdMap.put(id, vidPid[0]);
+                    }
+                    if (vidPid[1] != null) {
+                        productIdMap.put(id, vidPid[1]);
+                    }
+                    controller.release();
+                }
+                // If controller is null, id remains 0L, acting as an anonymous catch-all controller so that devices
+                // whose parent cannot be identified are not lost.
+                usbControllers.add(id);
+                // Recursively add this device and its children to the maps, keyed under the controller id
+                addDeviceAndChildrenToMaps(device, id, nameMap, vendorMap, vendorIdMap, productIdMap, serialMap,
+                        hubMap);
+                device.release();
+                device = iter.next();
+            }
+            iter.release();
+        }
+        root.release();
+
+        List<UsbDevice> controllerDevices = new ArrayList<>();
+        for (Long controller : usbControllers) {
+            controllerDevices.add(getDeviceAndChildren(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
+                    productIdMap, serialMap, hubMap));
+        }
+        return controllerDevices;
+    }
+
+    /**
+     * Recursively populates the maps with information from a USB device and its children.
+     *
+     * @param device       the device which, along with its children, should be added
+     * @param parentId     the id of the device's parent
+     * @param nameMap      the map of names
+     * @param vendorMap    the map of vendors
+     * @param vendorIdMap  the map of vendorIds
+     * @param productIdMap the map of productIds
+     * @param serialMap    the map of serial numbers
+     * @param hubMap       the map of hubs
+     */
+    private static void addDeviceAndChildrenToMaps(RegistryEntry device, long parentId, Map<Long, String> nameMap,
+            Map<Long, String> vendorMap, Map<Long, String> vendorIdMap, Map<Long, String> productIdMap,
+            Map<Long, String> serialMap, Map<Long, List<Long>> hubMap) {
+        // Unique global identifier for this device
+        long id = device.getRegistryEntryID();
+        // Store id as a child of parent in the hub map
+        hubMap.computeIfAbsent(parentId, x -> new ArrayList<>()).add(id);
+        // Get device name and store in map
+        nameMap.put(id, device.getName().trim());
+        // Get vendor and store in map
+        String vendor = device.getStringProperty("USB Vendor Name");
+        if (vendor != null) {
+            vendorMap.put(id, vendor.trim());
+        }
+        // Get vendorId and store in map
+        Long vendorId = device.getLongProperty("idVendor");
+        if (vendorId != null) {
+            vendorIdMap.put(id, String.format(Locale.ROOT, "%04x", 0xffff & vendorId));
+        }
+        // Get productId and store in map
+        Long productId = device.getLongProperty("idProduct");
+        if (productId != null) {
+            productIdMap.put(id, String.format(Locale.ROOT, "%04x", 0xffff & productId));
+        }
+        // Get serial and store in map
+        String serial = device.getStringProperty("USB Serial Number");
+        if (serial != null) {
+            serialMap.put(id, serial.trim());
+        }
+
+        // Now get this device's children (if any) and recurse
+        RegistryIterator childIter = device.getChildIterator(IOUSB);
+        if (childIter != null) {
+            RegistryEntry childDevice = childIter.next();
+            while (childDevice != null) {
+                addDeviceAndChildrenToMaps(childDevice, id, nameMap, vendorMap, vendorIdMap, productIdMap, serialMap,
+                        hubMap);
+                childDevice.release();
+                childDevice = childIter.next();
+            }
+            childIter.release();
+        }
+    }
+
+    /**
+     * Recursively creates MacUsbDevices by fetching information from maps to populate fields.
+     *
+     * @param registryEntryId the device's unique registry id
+     * @param vid             the default (parent) vendor ID
+     * @param pid             the default (parent) product ID
      * @param nameMap         the map of names
      * @param vendorMap       the map of vendors
      * @param vendorIdMap     the map of vendorIds
      * @param productIdMap    the map of productIds
      * @param serialMap       the map of serial numbers
      * @param hubMap          the map of hubs
-     * @return A MacUsbDevice corresponding to this device
+     * @return a MacUsbDevice corresponding to this device
      */
-    protected static MacUsbDevice getDeviceAndChildren(Long registryEntryId, String vid, String pid,
+    private static MacUsbDevice getDeviceAndChildren(Long registryEntryId, String vid, String pid,
             Map<Long, String> nameMap, Map<Long, String> vendorMap, Map<Long, String> vendorIdMap,
             Map<Long, String> productIdMap, Map<Long, String> serialMap, Map<Long, List<Long>> hubMap) {
         String vendorId = vendorIdMap.getOrDefault(registryEntryId, vid);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
@@ -1,20 +1,14 @@
 /*
- * Copyright 2026 The OSHI Project Contributors
+ * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.hardware.platform.mac;
 
-import static java.util.Collections.emptyList;
 import static oshi.util.ExceptionUtil.runOrLog;
 
 import java.lang.foreign.MemorySegment;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,14 +25,14 @@ import oshi.hardware.UsbDevice;
 import oshi.hardware.common.platform.mac.MacUsbDevice;
 
 /**
- * Mac USB device helper using FFM/IOKit. Instantiates {@link MacUsbDevice} objects.
+ * Enumerates Mac USB devices via FFM/IOKit, adapting the FFM registry-entry wrapper to {@link MacUsbDevice}'s
+ * backend-neutral view so the tree-building logic is shared.
  */
-public final class MacUsbDeviceFFM extends MacUsbDevice {
+public final class MacUsbDeviceFFM {
 
     private MacUsbDeviceFFM() {
     }
 
-    private static final String IOUSB = "IOUSB";
     private static final String IOSERVICE = "IOService";
     private static final Logger LOG = LoggerFactory.getLogger(MacUsbDeviceFFM.class);
 
@@ -48,139 +42,143 @@ public final class MacUsbDeviceFFM extends MacUsbDevice {
      * @return a list of USB controllers, each with its connected-device tree.
      */
     public static List<UsbDevice> getUsbDevices() {
-        return queryUsbDevices();
+        IORegistryEntry root = IOKitUtilFFM.getRoot();
+        return MacUsbDevice.getUsbDevices(root == null ? null : new FfmRegistryEntry(root));
     }
 
-    private static List<UsbDevice> queryUsbDevices() {
-        Map<Long, String> nameMap = new HashMap<>();
-        Map<Long, String> vendorMap = new HashMap<>();
-        Map<Long, String> vendorIdMap = new HashMap<>();
-        Map<Long, String> productIdMap = new HashMap<>();
-        Map<Long, String> serialMap = new HashMap<>();
-        Map<Long, List<Long>> hubMap = new HashMap<>();
+    /**
+     * Adapts an FFM {@link IORegistryEntry} to {@link MacUsbDevice.RegistryEntry}.
+     */
+    private static final class FfmRegistryEntry implements MacUsbDevice.RegistryEntry {
+        private final IORegistryEntry entry;
 
-        Set<Long> usbControllers = new LinkedHashSet<>();
-        IORegistryEntry root = IOKitUtilFFM.getRoot();
-        if (root == null) {
-            return emptyList();
+        FfmRegistryEntry(IORegistryEntry entry) {
+            this.entry = entry;
         }
-        IOIterator iter = root.getChildIterator(IOUSB);
-        if (iter != null) {
+
+        @Override
+        public long getRegistryEntryID() {
+            return entry.getRegistryEntryID();
+        }
+
+        @Override
+        public String getName() {
+            return entry.getName();
+        }
+
+        @Override
+        public String getStringProperty(String key) {
+            return entry.getStringProperty(key);
+        }
+
+        @Override
+        public Long getLongProperty(String key) {
+            return entry.getLongProperty(key);
+        }
+
+        @Override
+        public MacUsbDevice.RegistryEntry getParentEntry(String plane) {
+            IORegistryEntry parent = entry.getParentEntry(plane);
+            return parent == null ? null : new FfmRegistryEntry(parent);
+        }
+
+        @Override
+        public MacUsbDevice.RegistryIterator getChildIterator(String plane) {
+            IOIterator iter = entry.getChildIterator(plane);
+            return iter == null ? null : new FfmRegistryIterator(iter);
+        }
+
+        @Override
+        public String[] lookupControllerVidPid() {
+            String[] result = new String[2];
             CFStringRef locationIDKey = CFStringRef.createCFString("locationID");
             CFStringRef ioPropertyMatchKey = CFStringRef.createCFString("IOPropertyMatch");
-            try (iter; locationIDKey; ioPropertyMatchKey) {
-                IORegistryEntry device = iter.next();
-                while (device != null) {
-                    long id = 0L;
-                    IORegistryEntry controller = device.getParentEntry(IOSERVICE);
-                    if (controller != null) {
-                        id = controller.getRegistryEntryID();
-                        nameMap.put(id, controller.getName());
-                        MemorySegment ref = controller.createCFProperty(locationIDKey.segment());
-                        if (ref != null && !ref.equals(MemorySegment.NULL)) {
-                            CFTypeRef locationId = new CFTypeRef(ref);
-                            getControllerIdByLocation(id, locationId, locationIDKey, ioPropertyMatchKey, vendorIdMap,
-                                    productIdMap);
-                            locationId.release();
+            try (locationIDKey; ioPropertyMatchKey) {
+                MemorySegment ref = entry.createCFProperty(locationIDKey.segment());
+                if (ref == null || ref.equals(MemorySegment.NULL)) {
+                    return result;
+                }
+                CFTypeRef locationId = new CFTypeRef(ref);
+                try (locationId) {
+                    // Build matching dict: { IOPropertyMatch: { locationID: <locationId> } }
+                    runOrLog(() -> {
+                        CFAllocatorRef alloc = new CFAllocatorRef(CoreFoundationFunctions.CFAllocatorGetDefault());
+                        CFMutableDictionaryRef propertyDict = new CFMutableDictionaryRef(CoreFoundationFunctions
+                                .CFDictionaryCreateMutable(alloc.segment(), 0, MemorySegment.NULL, MemorySegment.NULL));
+                        propertyDict.setValue(locationIDKey, locationId);
+                        CFMutableDictionaryRef matchingDict = new CFMutableDictionaryRef(CoreFoundationFunctions
+                                .CFDictionaryCreateMutable(alloc.segment(), 0, MemorySegment.NULL, MemorySegment.NULL));
+                        matchingDict.setValue(ioPropertyMatchKey, propertyDict);
+
+                        IOIterator serviceIterator = IOKitUtilFFM.getMatchingServices(matchingDict.segment());
+                        propertyDict.release();
+                        readVidPid(serviceIterator, result);
+                    }, LOG, "Failed to retrieve controller vendor/product IDs");
+                }
+            }
+            return result;
+        }
+
+        /**
+         * Iterates matching services, reading vendor-id/device-id from the first parent that carries them.
+         *
+         * @param serviceIterator the iterator of matching services, or {@code null}
+         * @param result          the two-element {@code {vendorId, productId}} array to populate
+         */
+        private static void readVidPid(IOIterator serviceIterator, String[] result) {
+            if (serviceIterator == null) {
+                return;
+            }
+            try (serviceIterator) {
+                boolean found = false;
+                IORegistryEntry matchingService = serviceIterator.next();
+                while (matchingService != null && !found) {
+                    // The parent holds the vendor-id/device-id keys, each a 4-byte array
+                    IORegistryEntry parent = matchingService.getParentEntry(IOSERVICE);
+                    if (parent != null) {
+                        byte[] vid = parent.getByteArrayProperty("vendor-id");
+                        if (vid != null && vid.length >= 2) {
+                            result[0] = String.format(Locale.ROOT, "%02x%02x", vid[1], vid[0]);
+                            found = true;
                         }
-                        controller.release();
+                        byte[] pid = parent.getByteArrayProperty("device-id");
+                        if (pid != null && pid.length >= 2) {
+                            result[1] = String.format(Locale.ROOT, "%02x%02x", pid[1], pid[0]);
+                            found = true;
+                        }
+                        parent.release();
                     }
-                    // If controller is null, id remains 0L, acting as an anonymous catch-all
-                    // controller so that devices whose parent cannot be identified are not lost.
-                    usbControllers.add(id);
-                    addDeviceAndChildrenToMaps(device, id, nameMap, vendorMap, vendorIdMap, productIdMap, serialMap,
-                            hubMap);
-                    device.release();
-                    device = iter.next();
+                    matchingService.release();
+                    matchingService = serviceIterator.next();
                 }
             }
         }
-        root.release();
 
-        List<UsbDevice> controllerDevices = new ArrayList<>();
-        for (Long controller : usbControllers) {
-            controllerDevices.add(getDeviceAndChildren(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
-                    productIdMap, serialMap, hubMap));
-        }
-        return controllerDevices;
-    }
-
-    private static void addDeviceAndChildrenToMaps(IORegistryEntry device, long parentId, Map<Long, String> nameMap,
-            Map<Long, String> vendorMap, Map<Long, String> vendorIdMap, Map<Long, String> productIdMap,
-            Map<Long, String> serialMap, Map<Long, List<Long>> hubMap) {
-        long id = device.getRegistryEntryID();
-        hubMap.computeIfAbsent(parentId, x -> new ArrayList<>()).add(id);
-        nameMap.put(id, device.getName().trim());
-        String vendor = device.getStringProperty("USB Vendor Name");
-        if (vendor != null) {
-            vendorMap.put(id, vendor.trim());
-        }
-        Long vendorId = device.getLongProperty("idVendor");
-        if (vendorId != null) {
-            vendorIdMap.put(id, String.format(Locale.ROOT, "%04x", 0xffff & vendorId));
-        }
-        Long productId = device.getLongProperty("idProduct");
-        if (productId != null) {
-            productIdMap.put(id, String.format(Locale.ROOT, "%04x", 0xffff & productId));
-        }
-        String serial = device.getStringProperty("USB Serial Number");
-        if (serial != null) {
-            serialMap.put(id, serial.trim());
-        }
-
-        IOIterator childIter = device.getChildIterator(IOUSB);
-        if (childIter != null) {
-            try (childIter) {
-                IORegistryEntry childDevice = childIter.next();
-                while (childDevice != null) {
-                    addDeviceAndChildrenToMaps(childDevice, id, nameMap, vendorMap, vendorIdMap, productIdMap,
-                            serialMap, hubMap);
-                    childDevice.release();
-                    childDevice = childIter.next();
-                }
-            }
+        @Override
+        public void release() {
+            entry.release();
         }
     }
 
-    private static void getControllerIdByLocation(long id, CFTypeRef locationId, CFStringRef locationIDKey,
-            CFStringRef ioPropertyMatchKey, Map<Long, String> vendorIdMap, Map<Long, String> productIdMap) {
-        // Build matching dict: { IOPropertyMatch: { locationID: <locationId> } }
-        runOrLog(() -> {
-            CFAllocatorRef alloc = new CFAllocatorRef(CoreFoundationFunctions.CFAllocatorGetDefault());
-            CFMutableDictionaryRef propertyDict = new CFMutableDictionaryRef(CoreFoundationFunctions
-                    .CFDictionaryCreateMutable(alloc.segment(), 0, MemorySegment.NULL, MemorySegment.NULL));
-            propertyDict.setValue(locationIDKey, locationId);
-            CFMutableDictionaryRef matchingDict = new CFMutableDictionaryRef(CoreFoundationFunctions
-                    .CFDictionaryCreateMutable(alloc.segment(), 0, MemorySegment.NULL, MemorySegment.NULL));
-            matchingDict.setValue(ioPropertyMatchKey, propertyDict);
+    /**
+     * Adapts an FFM {@link IOIterator} to {@link MacUsbDevice.RegistryIterator}.
+     */
+    private static final class FfmRegistryIterator implements MacUsbDevice.RegistryIterator {
+        private final IOIterator iter;
 
-            IOIterator serviceIterator = IOKitUtilFFM.getMatchingServices(matchingDict.segment());
-            propertyDict.release();
+        FfmRegistryIterator(IOIterator iter) {
+            this.iter = iter;
+        }
 
-            boolean found = false;
-            if (serviceIterator != null) {
-                try (serviceIterator) {
-                    IORegistryEntry matchingService = serviceIterator.next();
-                    while (matchingService != null && !found) {
-                        IORegistryEntry parent = matchingService.getParentEntry(IOSERVICE);
-                        if (parent != null) {
-                            byte[] vid = parent.getByteArrayProperty("vendor-id");
-                            if (vid != null && vid.length >= 2) {
-                                vendorIdMap.put(id, String.format(Locale.ROOT, "%02x%02x", vid[1], vid[0]));
-                                found = true;
-                            }
-                            byte[] pid = parent.getByteArrayProperty("device-id");
-                            if (pid != null && pid.length >= 2) {
-                                productIdMap.put(id, String.format(Locale.ROOT, "%02x%02x", pid[1], pid[0]));
-                                found = true;
-                            }
-                            parent.release();
-                        }
-                        matchingService.release();
-                        matchingService = serviceIterator.next();
-                    }
-                }
-            }
-        }, LOG, "Failed to retrieve controller vendor/product IDs for id {}");
+        @Override
+        public MacUsbDevice.RegistryEntry next() {
+            IORegistryEntry next = iter.next();
+            return next == null ? null : new FfmRegistryEntry(next);
+        }
+
+        @Override
+        public void release() {
+            iter.release();
+        }
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceJNA.java
@@ -4,13 +4,8 @@
  */
 package oshi.hardware.platform.mac;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 
 import com.sun.jna.platform.mac.CoreFoundation;
 import com.sun.jna.platform.mac.CoreFoundation.CFIndex;
@@ -25,16 +20,16 @@ import oshi.hardware.UsbDevice;
 import oshi.hardware.common.platform.mac.MacUsbDevice;
 
 /**
- * Mac USB device helper using JNA/IOKit. Instantiates {@link MacUsbDevice} objects.
+ * Enumerates Mac USB devices via JNA/IOKit, adapting the JNA registry-entry wrapper to {@link MacUsbDevice}'s
+ * backend-neutral view so the tree-building logic is shared.
  */
-public final class MacUsbDeviceJNA extends MacUsbDevice {
+public final class MacUsbDeviceJNA {
 
     private MacUsbDeviceJNA() {
     }
 
     private static final CoreFoundation CF = CoreFoundation.INSTANCE;
 
-    private static final String IOUSB = "IOUSB";
     private static final String IOSERVICE = "IOService";
 
     /**
@@ -43,189 +38,144 @@ public final class MacUsbDeviceJNA extends MacUsbDevice {
      * @return a list of USB controllers, each with its connected-device tree.
      */
     public static List<UsbDevice> getUsbDevices() {
-        return queryUsbDevices();
+        IORegistryEntry root = IOKitUtil.getRoot();
+        return MacUsbDevice.getUsbDevices(root == null ? null : new JnaRegistryEntry(root));
     }
 
-    private static List<UsbDevice> queryUsbDevices() {
-        // Maps to store information using RegistryEntryID as the key
-        Map<Long, String> nameMap = new HashMap<>();
-        Map<Long, String> vendorMap = new HashMap<>();
-        Map<Long, String> vendorIdMap = new HashMap<>();
-        Map<Long, String> productIdMap = new HashMap<>();
-        Map<Long, String> serialMap = new HashMap<>();
-        Map<Long, List<Long>> hubMap = new HashMap<>();
+    /**
+     * Adapts a JNA {@link IORegistryEntry} to {@link MacUsbDevice.RegistryEntry}.
+     */
+    private static final class JnaRegistryEntry implements MacUsbDevice.RegistryEntry {
+        private final IORegistryEntry entry;
 
-        Set<Long> usbControllers = new LinkedHashSet<>();
-        IORegistryEntry root = IOKitUtil.getRoot();
-        // Iterate over children of root in the IOUSB plane. This does not include
-        // controllers so we have to check their parents
-        IOIterator iter = root.getChildIterator(IOUSB);
-        if (iter != null) {
-            // Define keys
+        JnaRegistryEntry(IORegistryEntry entry) {
+            this.entry = entry;
+        }
+
+        @Override
+        public long getRegistryEntryID() {
+            return entry.getRegistryEntryID();
+        }
+
+        @Override
+        public String getName() {
+            return entry.getName();
+        }
+
+        @Override
+        public String getStringProperty(String key) {
+            return entry.getStringProperty(key);
+        }
+
+        @Override
+        public Long getLongProperty(String key) {
+            return entry.getLongProperty(key);
+        }
+
+        @Override
+        public MacUsbDevice.RegistryEntry getParentEntry(String plane) {
+            IORegistryEntry parent = entry.getParentEntry(plane);
+            return parent == null ? null : new JnaRegistryEntry(parent);
+        }
+
+        @Override
+        public MacUsbDevice.RegistryIterator getChildIterator(String plane) {
+            IOIterator iter = entry.getChildIterator(plane);
+            return iter == null ? null : new JnaRegistryIterator(iter);
+        }
+
+        @Override
+        public String[] lookupControllerVidPid() {
+            String[] result = new String[2];
             CFStringRef locationIDKey = CFStringRef.createCFString("locationID");
             CFStringRef ioPropertyMatchKey = CFStringRef.createCFString("IOPropertyMatch");
-
-            // Get the device directly under each controller
-            IORegistryEntry device = iter.next();
-            while (device != null) {
-                long id = 0L;
-                // The parent of this device in IOService plane is the controller
-                IORegistryEntry controller = device.getParentEntry(IOSERVICE);
-                if (controller != null) {
-                    // Unique global identifier for this controller
-                    id = controller.getRegistryEntryID();
-                    // Populate other data for the controller
-                    nameMap.put(id, controller.getName());
-                    // The only information we have in registry for this controller is
-                    // the locationID. Use that to search for matching PCI device to obtain
-                    // more information for the controller
-                    CFTypeRef ref = controller.createCFProperty(locationIDKey);
-                    if (ref != null) {
-                        getControllerIdByLocation(id, ref, locationIDKey, ioPropertyMatchKey, vendorIdMap,
-                                productIdMap);
-                        ref.release();
-                    }
-                    controller.release();
+            try {
+                CFTypeRef locationId = entry.createCFProperty(locationIDKey);
+                if (locationId == null) {
+                    return result;
                 }
-                // If controller is null, id remains 0L, acting as an anonymous catch-all
-                // controller so that devices whose parent cannot be identified are not lost.
-                usbControllers.add(id);
+                try {
+                    // Create a matching property dictionary from the locationId
+                    CFMutableDictionaryRef propertyDict = CF.CFDictionaryCreateMutable(CF.CFAllocatorGetDefault(),
+                            new CFIndex(0), null, null);
+                    propertyDict.setValue(locationIDKey, locationId);
+                    CFMutableDictionaryRef matchingDict = CF.CFDictionaryCreateMutable(CF.CFAllocatorGetDefault(),
+                            new CFIndex(0), null, null);
+                    matchingDict.setValue(ioPropertyMatchKey, propertyDict);
 
-                // Now recursively add this device and its children to the maps
-                // id is the controller ID and the first parent ID
-                addDeviceAndChildrenToMaps(device, id, nameMap, vendorMap, vendorIdMap, productIdMap, serialMap,
-                        hubMap);
-
-                device.release();
-                device = iter.next();
+                    // search for all IOServices that match the locationID; getMatchingServices releases matchingDict
+                    IOIterator serviceIterator = IOKitUtil.getMatchingServices(matchingDict);
+                    propertyDict.release();
+                    readVidPid(serviceIterator, result);
+                } finally {
+                    locationId.release();
+                }
+            } finally {
+                locationIDKey.release();
+                ioPropertyMatchKey.release();
             }
-            locationIDKey.release();
-            ioPropertyMatchKey.release();
-            iter.release();
-        }
-        root.release();
-
-        // Build tree and return
-        List<UsbDevice> controllerDevices = new ArrayList<>();
-        for (Long controller : usbControllers) {
-            controllerDevices.add(getDeviceAndChildren(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
-                    productIdMap, serialMap, hubMap));
-        }
-        return controllerDevices;
-    }
-
-    /**
-     * Recursively populate maps with information from a USB Device and its children
-     *
-     * @param device       The device which, along with its children, should be added
-     * @param parentId     The id of the device's parent.
-     * @param nameMap      the map of names
-     * @param vendorMap    the map of vendors
-     * @param vendorIdMap  the map of vendorIds
-     * @param productIdMap the map of productIds
-     * @param serialMap    the map of serial numbers
-     * @param hubMap       the map of hubs
-     */
-    private static void addDeviceAndChildrenToMaps(IORegistryEntry device, long parentId, Map<Long, String> nameMap,
-            Map<Long, String> vendorMap, Map<Long, String> vendorIdMap, Map<Long, String> productIdMap,
-            Map<Long, String> serialMap, Map<Long, List<Long>> hubMap) {
-
-        // Unique global identifier for this device
-        long id = device.getRegistryEntryID();
-        // Store id as a child of parent in hubmap
-        hubMap.computeIfAbsent(parentId, x -> new ArrayList<>()).add(id);
-        // Get device name and store in map
-        nameMap.put(id, device.getName().trim());
-        // Get vendor and store in map
-        String vendor = device.getStringProperty("USB Vendor Name");
-        if (vendor != null) {
-            vendorMap.put(id, vendor.trim());
-        }
-        // Get vendorId and store in map
-        Long vendorId = device.getLongProperty("idVendor");
-        if (vendorId != null) {
-            vendorIdMap.put(id, String.format(Locale.ROOT, "%04x", 0xffff & vendorId));
-        }
-        // Get productId and store in map
-        Long productId = device.getLongProperty("idProduct");
-        if (productId != null) {
-            productIdMap.put(id, String.format(Locale.ROOT, "%04x", 0xffff & productId));
-        }
-        // Get serial and store in map
-        String serial = device.getStringProperty("USB Serial Number");
-        if (serial != null) {
-            serialMap.put(id, serial.trim());
+            return result;
         }
 
-        // Now get this device's children (if any) and recurse
-        IOIterator childIter = device.getChildIterator(IOUSB);
-        if (childIter != null) {
-            IORegistryEntry childDevice = childIter.next();
-            while (childDevice != null) {
-                addDeviceAndChildrenToMaps(childDevice, id, nameMap, vendorMap, vendorIdMap, productIdMap, serialMap,
-                        hubMap);
-                childDevice.release();
-                childDevice = childIter.next();
+        /**
+         * Iterates matching services, reading vendor-id/device-id from the first parent that carries them.
+         *
+         * @param serviceIterator the iterator of matching services, or {@code null}
+         * @param result          the two-element {@code {vendorId, productId}} array to populate
+         */
+        private static void readVidPid(IOIterator serviceIterator, String[] result) {
+            if (serviceIterator == null) {
+                return;
             }
-            childIter.release();
-        }
-    }
-
-    /**
-     * Looks up vendor and product id information for a USB Host Controller by cross-referencing the location
-     *
-     * @param id                 The global unique ID for the host controller used as a key for maps
-     * @param locationId         The locationID of this controller returned from the registry
-     * @param locationIDKey      A pointer to the locationID string
-     * @param ioPropertyMatchKey A pointer to the IOPropertyMatch string
-     * @param productIdMap       the map of productIds
-     * @param vendorIdMap        the map of vendorIds
-     */
-    private static void getControllerIdByLocation(long id, CFTypeRef locationId, CFStringRef locationIDKey,
-            CFStringRef ioPropertyMatchKey, Map<Long, String> vendorIdMap, Map<Long, String> productIdMap) {
-        // Create a matching property dictionary from the locationId
-        CFMutableDictionaryRef propertyDict = CF.CFDictionaryCreateMutable(CF.CFAllocatorGetDefault(), new CFIndex(0),
-                null, null);
-        propertyDict.setValue(locationIDKey, locationId);
-        CFMutableDictionaryRef matchingDict = CF.CFDictionaryCreateMutable(CF.CFAllocatorGetDefault(), new CFIndex(0),
-                null, null);
-        matchingDict.setValue(ioPropertyMatchKey, propertyDict);
-
-        // search for all IOservices that match the locationID
-        IOIterator serviceIterator = IOKitUtil.getMatchingServices(matchingDict);
-        // getMatchingServices releases matchingDict
-        propertyDict.release();
-
-        // Iterate matching services looking for devices whose parents have the
-        // vendor and device ids
-        boolean found = false;
-        if (serviceIterator != null) {
+            boolean found = false;
             IORegistryEntry matchingService = serviceIterator.next();
             while (matchingService != null && !found) {
-                // Get the parent, which contains the keys we need
+                // The parent holds the vendor-id/device-id keys, each a 4-byte array
                 IORegistryEntry parent = matchingService.getParentEntry(IOSERVICE);
-                // look up the vendor-id by key
-                // vendor-id is a byte array of 4 bytes
                 if (parent != null) {
                     byte[] vid = parent.getByteArrayProperty("vendor-id");
                     if (vid != null && vid.length >= 2) {
-                        vendorIdMap.put(id, String.format(Locale.ROOT, "%02x%02x", vid[1], vid[0]));
+                        result[0] = String.format(Locale.ROOT, "%02x%02x", vid[1], vid[0]);
                         found = true;
                     }
-                    // look up the device-id by key
-                    // device-id is a byte array of 4 bytes
                     byte[] pid = parent.getByteArrayProperty("device-id");
                     if (pid != null && pid.length >= 2) {
-                        productIdMap.put(id, String.format(Locale.ROOT, "%02x%02x", pid[1], pid[0]));
+                        result[1] = String.format(Locale.ROOT, "%02x%02x", pid[1], pid[0]);
                         found = true;
                     }
                     parent.release();
                 }
-                // iterate
                 matchingService.release();
                 matchingService = serviceIterator.next();
             }
             serviceIterator.release();
+        }
+
+        @Override
+        public void release() {
+            entry.release();
+        }
+    }
+
+    /**
+     * Adapts a JNA {@link IOIterator} to {@link MacUsbDevice.RegistryIterator}.
+     */
+    private static final class JnaRegistryIterator implements MacUsbDevice.RegistryIterator {
+        private final IOIterator iter;
+
+        JnaRegistryIterator(IOIterator iter) {
+            this.iter = iter;
+        }
+
+        @Override
+        public MacUsbDevice.RegistryEntry next() {
+            IORegistryEntry next = iter.next();
+            return next == null ? null : new JnaRegistryEntry(next);
+        }
+
+        @Override
+        public void release() {
+            iter.release();
         }
     }
 }


### PR DESCRIPTION
## Summary

Part of the cross-OS USB consistency/dedup audit (follows the Linux udev PR #3448). `MacUsbDeviceJNA` and `MacUsbDeviceFFM` each carried a **verbatim copy** of the IORegistry walk — enumerate the root's IOUSB-plane children, resolve each device's controller via the IOService plane, look up the controller's vendor/product IDs by location-matching, and recurse the device subtree into lookup maps. The two differed only in the IOKit binding types (`com.sun.jna.platform.mac.IOKit` vs `oshi.ffm.platform.mac.IOKit`) and release style.

## Changes

- **`MacUsbDevice`** (oshi-common) gains two nested backend-neutral view interfaces, `RegistryEntry` / `RegistryIterator`, and now holds the **entire walk once** (`getUsbDevices(RegistryEntry root)` + `addDeviceAndChildrenToMaps` + the tree build), operating only on those views. The class is now `final`; the old no-arg "so subclasses compile" constructor is gone.
- **`MacUsbDeviceJNA` / `MacUsbDeviceFFM`** shrink to thin adapters over their native `IORegistryEntry`/`IOIterator`, plus the one genuinely backend-specific piece — `lookupControllerVidPid()`, which encapsulates the CoreFoundation dictionary matching. Neither extends `MacUsbDevice` anymore.
- HALs untouched — the `getUsbDevices()` entry point is unchanged.

The ~90 lines of *identical* walk/map-building that were duplicated across the two backends are now single-source; the only per-backend code left is native-binding delegation and the CF-matching hook, which can't be shared.

## Behavior

No user-facing change. Validated on Apple Silicon: **`NativeComparisonTest.usbDevices()`** — a recursive deep-equal of the JNA and FFM device trees — passes.

## Design note

Mac's IOKit is a tree-walk API (parent/children are live handles), so a view interface that lets the shared code drive the traversal is the right fit. This intentionally differs from the Linux udev PR (#3448), whose flat-enumeration API is better served by a carrier record. A follow-up will hoist the shared map/tree builder into `AbstractUsbDevice` so all platforms — regardless of producer shape — feed one tree-building consumer.

## Testing

- spotless / checkstyle / forbiddenapis / javadoc: clean
- Clean full-reactor `install`: BUILD SUCCESS, 0 tests failed
- `NativeComparisonTest.usbDevices()` (JNA vs FFM deep-equal): passes on macOS/Apple Silicon


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS USB device discovery and enumeration reliability.
  * Enhanced USB topology results with better hub/parent/controller relationships.
  * More consistent vendor/product and serial identification (including improved formatting and fallbacks).
  * Improved cleanup of native registry resources during enumeration.
* **Refactor**
  * Unified macOS USB enumeration behavior across runtime implementations for more consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->