### PR TITLE
Share Windows GlobalMemory/VirtualMemory logic across JNA and FFM

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGlobalMemory.java
@@ -4,11 +4,27 @@
  */
 package oshi.hardware.common.platform.windows;
 
+import static oshi.util.Memoizer.defaultExpiration;
+import static oshi.util.Memoizer.memoize;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.wmi.Win32PhysicalMemory.PhysicalMemoryProperty;
+import oshi.driver.common.windows.wmi.Win32PhysicalMemory.PhysicalMemoryPropertyWin8;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.driver.common.windows.wmi.WmiUtil;
+import oshi.hardware.PhysicalMemory;
+import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.AbstractGlobalMemory;
+import oshi.util.tuples.Triplet;
 
 /**
- * Common Windows global memory logic shared between JNA and FFM implementations.
+ * Common Windows global memory logic shared between JNA and FFM implementations. Subclasses supply the native queries
+ * (performance info, WMI physical-memory banks, virtual memory) via the {@code protected abstract} hooks; the
+ * memoization and result assembly live here.
  */
 @ThreadSafe
 public abstract class WindowsGlobalMemory extends AbstractGlobalMemory {
@@ -16,6 +32,98 @@ public abstract class WindowsGlobalMemory extends AbstractGlobalMemory {
     /** Default constructor. */
     protected WindowsGlobalMemory() {
     }
+
+    private final Supplier<Triplet<Long, Long, Long>> availTotalSize = memoize(this::readPerfInfo, defaultExpiration());
+
+    private final Supplier<VirtualMemory> vm = memoize(this::createVirtualMemory);
+
+    @Override
+    public long getAvailable() {
+        return availTotalSize.get().getA();
+    }
+
+    @Override
+    public long getTotal() {
+        return availTotalSize.get().getB();
+    }
+
+    @Override
+    public long getPageSize() {
+        return availTotalSize.get().getC();
+    }
+
+    @Override
+    public VirtualMemory getVirtualMemory() {
+        return vm.get();
+    }
+
+    @Override
+    public List<PhysicalMemory> getPhysicalMemory() {
+        List<PhysicalMemory> physicalMemoryList = new ArrayList<>();
+        if (isWindows10OrGreater()) {
+            WmiResult<PhysicalMemoryProperty> bankMap = queryPhysicalMemory();
+            for (int index = 0; index < bankMap.getResultCount(); index++) {
+                String bankLabel = WmiUtil.getString(bankMap, PhysicalMemoryProperty.BANKLABEL, index);
+                long capacity = WmiUtil.getUint64(bankMap, PhysicalMemoryProperty.CAPACITY, index);
+                long speed = WmiUtil.getUint32(bankMap, PhysicalMemoryProperty.SPEED, index) * 1_000_000L;
+                String manufacturer = WmiUtil.getString(bankMap, PhysicalMemoryProperty.MANUFACTURER, index);
+                String memoryType = smBiosMemoryType(
+                        WmiUtil.getUint32(bankMap, PhysicalMemoryProperty.SMBIOSMEMORYTYPE, index));
+                String partNumber = WmiUtil.getString(bankMap, PhysicalMemoryProperty.PARTNUMBER, index);
+                String serialNumber = WmiUtil.getString(bankMap, PhysicalMemoryProperty.SERIALNUMBER, index);
+                physicalMemoryList.add(new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memoryType,
+                        partNumber, serialNumber));
+            }
+        } else {
+            WmiResult<PhysicalMemoryPropertyWin8> bankMap = queryPhysicalMemoryWin8();
+            for (int index = 0; index < bankMap.getResultCount(); index++) {
+                String bankLabel = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.BANKLABEL, index);
+                long capacity = WmiUtil.getUint64(bankMap, PhysicalMemoryPropertyWin8.CAPACITY, index);
+                long speed = WmiUtil.getUint32(bankMap, PhysicalMemoryPropertyWin8.SPEED, index) * 1_000_000L;
+                String manufacturer = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.MANUFACTURER, index);
+                String memoryType = memoryType(
+                        WmiUtil.getUint16(bankMap, PhysicalMemoryPropertyWin8.MEMORYTYPE, index));
+                String partNumber = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.PARTNUMBER, index);
+                String serialNumber = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.SERIALNUMBER, index);
+                physicalMemoryList.add(new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memoryType,
+                        partNumber, serialNumber));
+            }
+        }
+        return physicalMemoryList;
+    }
+
+    /**
+     * Queries performance info for the available, total, and page-size values.
+     *
+     * @return a triplet of (available bytes, total bytes, page size)
+     */
+    protected abstract Triplet<Long, Long, Long> readPerfInfo();
+
+    /**
+     * Creates the backend-specific virtual memory instance.
+     *
+     * @return the virtual memory
+     */
+    protected abstract VirtualMemory createVirtualMemory();
+
+    /**
+     * @return {@code true} if running on Windows 10 or greater
+     */
+    protected abstract boolean isWindows10OrGreater();
+
+    /**
+     * Queries the Win32_PhysicalMemory banks (Windows 10+ schema).
+     *
+     * @return the WMI result
+     */
+    protected abstract WmiResult<PhysicalMemoryProperty> queryPhysicalMemory();
+
+    /**
+     * Queries the Win32_PhysicalMemory banks (pre-Windows 10 schema).
+     *
+     * @return the WMI result
+     */
+    protected abstract WmiResult<PhysicalMemoryPropertyWin8> queryPhysicalMemoryWin8();
 
     /**
      * memoryType.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsVirtualMemory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static oshi.util.Memoizer.defaultExpiration;
+import static oshi.util.Memoizer.memoize;
+
+import java.util.function.Supplier;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.common.AbstractVirtualMemory;
+import oshi.util.tuples.Pair;
+import oshi.util.tuples.Triplet;
+
+/**
+ * Common Windows virtual memory logic shared between JNA and FFM implementations. Subclasses supply the native queries
+ * (paging usage, performance info, page swaps) via the {@code protected abstract} hooks; the memoization and page-size
+ * scaling live here.
+ */
+@ThreadSafe
+public abstract class WindowsVirtualMemory extends AbstractVirtualMemory {
+
+    private final WindowsGlobalMemory global;
+
+    private final Supplier<Long> used = memoize(this::querySwapUsed, defaultExpiration());
+
+    private final Supplier<Triplet<Long, Long, Long>> totalVmaxVused = memoize(this::querySwapTotalVirtMaxVirtUsed,
+            defaultExpiration());
+
+    private final Supplier<Pair<Long, Long>> swapInOut = memoize(this::queryPageSwaps, defaultExpiration());
+
+    /**
+     * Constructor.
+     *
+     * @param global the parent global memory instance, used to scale results by the page size
+     */
+    protected WindowsVirtualMemory(WindowsGlobalMemory global) {
+        this.global = global;
+    }
+
+    @Override
+    public long getSwapUsed() {
+        return this.global.getPageSize() * used.get();
+    }
+
+    @Override
+    public long getSwapTotal() {
+        return this.global.getPageSize() * totalVmaxVused.get().getA();
+    }
+
+    @Override
+    public long getVirtualMax() {
+        return this.global.getPageSize() * totalVmaxVused.get().getB();
+    }
+
+    @Override
+    public long getVirtualInUse() {
+        return this.global.getPageSize() * totalVmaxVused.get().getC();
+    }
+
+    @Override
+    public long getSwapPagesIn() {
+        return swapInOut.get().getA();
+    }
+
+    @Override
+    public long getSwapPagesOut() {
+        return swapInOut.get().getB();
+    }
+
+    /**
+     * Queries the swap (paging file) usage.
+     *
+     * @return the swap used, in pages
+     */
+    protected abstract long querySwapUsed();
+
+    /**
+     * Queries performance info for the swap total, virtual max, and virtual in-use values.
+     *
+     * @return a triplet of (swap total, virtual max, virtual in use), in pages
+     */
+    protected abstract Triplet<Long, Long, Long> querySwapTotalVirtMaxVirtUsed();
+
+    /**
+     * Queries the page swap-in and swap-out rates.
+     *
+     * @return a pair of (pages in, pages out)
+     */
+    protected abstract Pair<Long, Long> queryPageSwaps();
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGlobalMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGlobalMemoryFFM.java
@@ -6,15 +6,10 @@ package oshi.hardware.platform.windows;
 
 import static org.slf4j.event.Level.ERROR;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,12 +18,10 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.wmi.Win32PhysicalMemory.PhysicalMemoryProperty;
 import oshi.driver.common.windows.wmi.Win32PhysicalMemory.PhysicalMemoryPropertyWin8;
 import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.driver.windows.wmi.Win32PhysicalMemoryFFM;
 import oshi.ffm.platform.windows.Kernel32FFM;
 import oshi.ffm.platform.windows.PsapiFFM;
 import oshi.ffm.platform.windows.VersionHelpersFFM;
-import oshi.hardware.PhysicalMemory;
 import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.platform.windows.WindowsGlobalMemory;
 import oshi.util.tuples.Triplet;
@@ -43,70 +36,8 @@ final class WindowsGlobalMemoryFFM extends WindowsGlobalMemory {
 
     private static final boolean IS_WINDOWS10_OR_GREATER = VersionHelpersFFM.IsWindows10OrGreater();
 
-    private final Supplier<Triplet<Long, Long, Long>> availTotalSize = memoize(WindowsGlobalMemoryFFM::readPerfInfo,
-            defaultExpiration());
-
-    private final Supplier<VirtualMemory> vm = memoize(this::createVirtualMemory);
-
     @Override
-    public long getAvailable() {
-        return availTotalSize.get().getA();
-    }
-
-    @Override
-    public long getTotal() {
-        return availTotalSize.get().getB();
-    }
-
-    @Override
-    public long getPageSize() {
-        return availTotalSize.get().getC();
-    }
-
-    @Override
-    public VirtualMemory getVirtualMemory() {
-        return vm.get();
-    }
-
-    private VirtualMemory createVirtualMemory() {
-        return new WindowsVirtualMemoryFFM(this);
-    }
-
-    @Override
-    public List<PhysicalMemory> getPhysicalMemory() {
-        List<PhysicalMemory> physicalMemoryList = new ArrayList<>();
-        if (IS_WINDOWS10_OR_GREATER) {
-            WmiResult<PhysicalMemoryProperty> bankMap = Win32PhysicalMemoryFFM.queryPhysicalMemory();
-            for (int index = 0; index < bankMap.getResultCount(); index++) {
-                String bankLabel = WmiUtil.getString(bankMap, PhysicalMemoryProperty.BANKLABEL, index);
-                long capacity = WmiUtil.getUint64(bankMap, PhysicalMemoryProperty.CAPACITY, index);
-                long speed = WmiUtil.getUint32(bankMap, PhysicalMemoryProperty.SPEED, index) * 1_000_000L;
-                String manufacturer = WmiUtil.getString(bankMap, PhysicalMemoryProperty.MANUFACTURER, index);
-                String memType = smBiosMemoryType(
-                        WmiUtil.getUint32(bankMap, PhysicalMemoryProperty.SMBIOSMEMORYTYPE, index));
-                String partNumber = WmiUtil.getString(bankMap, PhysicalMemoryProperty.PARTNUMBER, index);
-                String serialNumber = WmiUtil.getString(bankMap, PhysicalMemoryProperty.SERIALNUMBER, index);
-                physicalMemoryList.add(new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memType, partNumber,
-                        serialNumber));
-            }
-        } else {
-            WmiResult<PhysicalMemoryPropertyWin8> bankMap = Win32PhysicalMemoryFFM.queryPhysicalMemoryWin8();
-            for (int index = 0; index < bankMap.getResultCount(); index++) {
-                String bankLabel = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.BANKLABEL, index);
-                long capacity = WmiUtil.getUint64(bankMap, PhysicalMemoryPropertyWin8.CAPACITY, index);
-                long speed = WmiUtil.getUint32(bankMap, PhysicalMemoryPropertyWin8.SPEED, index) * 1_000_000L;
-                String manufacturer = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.MANUFACTURER, index);
-                String memType = memoryType(WmiUtil.getUint16(bankMap, PhysicalMemoryPropertyWin8.MEMORYTYPE, index));
-                String partNumber = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.PARTNUMBER, index);
-                String serialNumber = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.SERIALNUMBER, index);
-                physicalMemoryList.add(new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memType, partNumber,
-                        serialNumber));
-            }
-        }
-        return physicalMemoryList;
-    }
-
-    private static Triplet<Long, Long, Long> readPerfInfo() {
+    protected Triplet<Long, Long, Long> readPerfInfo() {
         return callInArenaOrDefault(arena -> {
             MemorySegment perfInfo = arena.allocate(PsapiFFM.PERFORMANCE_INFORMATION_LAYOUT);
             int size = (int) PsapiFFM.PERFORMANCE_INFORMATION_LAYOUT.byteSize();
@@ -124,5 +55,25 @@ final class WindowsGlobalMemoryFFM extends WindowsGlobalMemory {
             long memTotal = pageSize * physTotal;
             return new Triplet<>(memAvailable, memTotal, pageSize);
         }, LOG, ERROR, "Failed to get Performance Info", new Triplet<>(0L, 0L, 4096L));
+    }
+
+    @Override
+    protected VirtualMemory createVirtualMemory() {
+        return new WindowsVirtualMemoryFFM(this);
+    }
+
+    @Override
+    protected boolean isWindows10OrGreater() {
+        return IS_WINDOWS10_OR_GREATER;
+    }
+
+    @Override
+    protected WmiResult<PhysicalMemoryProperty> queryPhysicalMemory() {
+        return Win32PhysicalMemoryFFM.queryPhysicalMemory();
+    }
+
+    @Override
+    protected WmiResult<PhysicalMemoryPropertyWin8> queryPhysicalMemoryWin8() {
+        return Win32PhysicalMemoryFFM.queryPhysicalMemoryWin8();
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsVirtualMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsVirtualMemoryFFM.java
@@ -6,14 +6,11 @@ package oshi.hardware.platform.windows;
 
 import static org.slf4j.event.Level.ERROR;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +22,7 @@ import oshi.driver.windows.perfmon.MemoryInformationFFM;
 import oshi.driver.windows.perfmon.PagingFileFFM;
 import oshi.ffm.platform.windows.Kernel32FFM;
 import oshi.ffm.platform.windows.PsapiFFM;
-import oshi.hardware.common.AbstractVirtualMemory;
+import oshi.hardware.common.platform.windows.WindowsVirtualMemory;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
@@ -33,59 +30,21 @@ import oshi.util.tuples.Triplet;
  * Virtual memory obtained from Performance Info using FFM.
  */
 @ThreadSafe
-final class WindowsVirtualMemoryFFM extends AbstractVirtualMemory {
+final class WindowsVirtualMemoryFFM extends WindowsVirtualMemory {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsVirtualMemoryFFM.class);
 
-    private final WindowsGlobalMemoryFFM global;
-
-    private final Supplier<Long> used = memoize(WindowsVirtualMemoryFFM::querySwapUsed, defaultExpiration());
-
-    private final Supplier<Triplet<Long, Long, Long>> totalVmaxVused = memoize(
-            WindowsVirtualMemoryFFM::querySwapTotalVirtMaxVirtUsed, defaultExpiration());
-
-    private final Supplier<Pair<Long, Long>> swapInOut = memoize(WindowsVirtualMemoryFFM::queryPageSwaps,
-            defaultExpiration());
-
     WindowsVirtualMemoryFFM(WindowsGlobalMemoryFFM windowsGlobalMemory) {
-        this.global = windowsGlobalMemory;
+        super(windowsGlobalMemory);
     }
 
     @Override
-    public long getSwapUsed() {
-        return this.global.getPageSize() * used.get();
-    }
-
-    @Override
-    public long getSwapTotal() {
-        return this.global.getPageSize() * totalVmaxVused.get().getA();
-    }
-
-    @Override
-    public long getVirtualMax() {
-        return this.global.getPageSize() * totalVmaxVused.get().getB();
-    }
-
-    @Override
-    public long getVirtualInUse() {
-        return this.global.getPageSize() * totalVmaxVused.get().getC();
-    }
-
-    @Override
-    public long getSwapPagesIn() {
-        return swapInOut.get().getA();
-    }
-
-    @Override
-    public long getSwapPagesOut() {
-        return swapInOut.get().getB();
-    }
-
-    private static long querySwapUsed() {
+    protected long querySwapUsed() {
         return PagingFileFFM.querySwapUsed().getOrDefault(PagingPercentProperty.PERCENTUSAGE, 0L);
     }
 
-    private static Triplet<Long, Long, Long> querySwapTotalVirtMaxVirtUsed() {
+    @Override
+    protected Triplet<Long, Long, Long> querySwapTotalVirtMaxVirtUsed() {
         return callInArenaOrDefault(arena -> {
             MemorySegment perfInfo = arena.allocate(PsapiFFM.PERFORMANCE_INFORMATION_LAYOUT);
             int size = (int) PsapiFFM.PERFORMANCE_INFORMATION_LAYOUT.byteSize();
@@ -103,7 +62,8 @@ final class WindowsVirtualMemoryFFM extends AbstractVirtualMemory {
         }, LOG, ERROR, "Failed to get Performance Info", new Triplet<>(0L, 0L, 0L));
     }
 
-    private static Pair<Long, Long> queryPageSwaps() {
+    @Override
+    protected Pair<Long, Long> queryPageSwaps() {
         Map<PageSwapProperty, Long> valueMap = MemoryInformationFFM.queryPageSwaps();
         return new Pair<>(valueMap.getOrDefault(PageSwapProperty.PAGESINPUTPERSEC, 0L),
                 valueMap.getOrDefault(PageSwapProperty.PAGESOUTPUTPERSEC, 0L));

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGlobalMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGlobalMemoryJNA.java
@@ -4,13 +4,6 @@
  */
 package oshi.hardware.platform.windows;
 
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Supplier;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,9 +15,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.wmi.Win32PhysicalMemory.PhysicalMemoryProperty;
 import oshi.driver.common.windows.wmi.Win32PhysicalMemory.PhysicalMemoryPropertyWin8;
 import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.driver.windows.wmi.Win32PhysicalMemoryJNA;
-import oshi.hardware.PhysicalMemory;
 import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.platform.windows.WindowsGlobalMemory;
 import oshi.jna.Struct.CloseablePerformanceInformation;
@@ -40,71 +31,8 @@ final class WindowsGlobalMemoryJNA extends WindowsGlobalMemory {
 
     private static final boolean IS_WINDOWS10_OR_GREATER = VersionHelpers.IsWindows10OrGreater();
 
-    private final Supplier<Triplet<Long, Long, Long>> availTotalSize = memoize(WindowsGlobalMemoryJNA::readPerfInfo,
-            defaultExpiration());
-
-    private final Supplier<VirtualMemory> vm = memoize(this::createVirtualMemory);
-
     @Override
-    public long getAvailable() {
-        return availTotalSize.get().getA();
-    }
-
-    @Override
-    public long getTotal() {
-        return availTotalSize.get().getB();
-    }
-
-    @Override
-    public long getPageSize() {
-        return availTotalSize.get().getC();
-    }
-
-    @Override
-    public VirtualMemory getVirtualMemory() {
-        return vm.get();
-    }
-
-    private VirtualMemory createVirtualMemory() {
-        return new WindowsVirtualMemoryJNA(this);
-    }
-
-    @Override
-    public List<PhysicalMemory> getPhysicalMemory() {
-        List<PhysicalMemory> physicalMemoryList = new ArrayList<>();
-        if (IS_WINDOWS10_OR_GREATER) {
-            WmiResult<PhysicalMemoryProperty> bankMap = Win32PhysicalMemoryJNA.queryPhysicalMemory();
-            for (int index = 0; index < bankMap.getResultCount(); index++) {
-                String bankLabel = WmiUtil.getString(bankMap, PhysicalMemoryProperty.BANKLABEL, index);
-                long capacity = WmiUtil.getUint64(bankMap, PhysicalMemoryProperty.CAPACITY, index);
-                long speed = WmiUtil.getUint32(bankMap, PhysicalMemoryProperty.SPEED, index) * 1_000_000L;
-                String manufacturer = WmiUtil.getString(bankMap, PhysicalMemoryProperty.MANUFACTURER, index);
-                String memoryType = smBiosMemoryType(
-                        WmiUtil.getUint32(bankMap, PhysicalMemoryProperty.SMBIOSMEMORYTYPE, index));
-                String partNumber = WmiUtil.getString(bankMap, PhysicalMemoryProperty.PARTNUMBER, index);
-                String serialNumber = WmiUtil.getString(bankMap, PhysicalMemoryProperty.SERIALNUMBER, index);
-                physicalMemoryList.add(new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memoryType,
-                        partNumber, serialNumber));
-            }
-        } else {
-            WmiResult<PhysicalMemoryPropertyWin8> bankMap = Win32PhysicalMemoryJNA.queryPhysicalMemoryWin8();
-            for (int index = 0; index < bankMap.getResultCount(); index++) {
-                String bankLabel = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.BANKLABEL, index);
-                long capacity = WmiUtil.getUint64(bankMap, PhysicalMemoryPropertyWin8.CAPACITY, index);
-                long speed = WmiUtil.getUint32(bankMap, PhysicalMemoryPropertyWin8.SPEED, index) * 1_000_000L;
-                String manufacturer = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.MANUFACTURER, index);
-                String memoryType = memoryType(
-                        WmiUtil.getUint16(bankMap, PhysicalMemoryPropertyWin8.MEMORYTYPE, index));
-                String partNumber = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.PARTNUMBER, index);
-                String serialNumber = WmiUtil.getString(bankMap, PhysicalMemoryPropertyWin8.SERIALNUMBER, index);
-                physicalMemoryList.add(new PhysicalMemory(bankLabel, capacity, speed, manufacturer, memoryType,
-                        partNumber, serialNumber));
-            }
-        }
-        return physicalMemoryList;
-    }
-
-    private static Triplet<Long, Long, Long> readPerfInfo() {
+    protected Triplet<Long, Long, Long> readPerfInfo() {
         try (CloseablePerformanceInformation performanceInfo = new CloseablePerformanceInformation()) {
             if (!Psapi.INSTANCE.GetPerformanceInfo(performanceInfo, performanceInfo.size())) {
                 LOG.error("Failed to get Performance Info. Error code: {}", Kernel32.INSTANCE.GetLastError());
@@ -115,5 +43,25 @@ final class WindowsGlobalMemoryJNA extends WindowsGlobalMemory {
             long memTotal = pageSize * performanceInfo.PhysicalTotal.longValue();
             return new Triplet<>(memAvailable, memTotal, pageSize);
         }
+    }
+
+    @Override
+    protected VirtualMemory createVirtualMemory() {
+        return new WindowsVirtualMemoryJNA(this);
+    }
+
+    @Override
+    protected boolean isWindows10OrGreater() {
+        return IS_WINDOWS10_OR_GREATER;
+    }
+
+    @Override
+    protected WmiResult<PhysicalMemoryProperty> queryPhysicalMemory() {
+        return Win32PhysicalMemoryJNA.queryPhysicalMemory();
+    }
+
+    @Override
+    protected WmiResult<PhysicalMemoryPropertyWin8> queryPhysicalMemoryWin8() {
+        return Win32PhysicalMemoryJNA.queryPhysicalMemoryWin8();
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsVirtualMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsVirtualMemoryJNA.java
@@ -4,11 +4,7 @@
  */
 package oshi.hardware.platform.windows;
 
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.memoize;
-
 import java.util.Map;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +17,7 @@ import oshi.driver.common.windows.perfmon.MemoryInformation.PageSwapProperty;
 import oshi.driver.common.windows.perfmon.PagingFile.PagingPercentProperty;
 import oshi.driver.windows.perfmon.MemoryInformationJNA;
 import oshi.driver.windows.perfmon.PagingFileJNA;
-import oshi.hardware.common.AbstractVirtualMemory;
+import oshi.hardware.common.platform.windows.WindowsVirtualMemory;
 import oshi.jna.Struct.CloseablePerformanceInformation;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
@@ -30,19 +26,9 @@ import oshi.util.tuples.Triplet;
  * Memory obtained from WMI
  */
 @ThreadSafe
-final class WindowsVirtualMemoryJNA extends AbstractVirtualMemory {
+final class WindowsVirtualMemoryJNA extends WindowsVirtualMemory {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsVirtualMemoryJNA.class);
-
-    private final WindowsGlobalMemoryJNA global;
-
-    private final Supplier<Long> used = memoize(WindowsVirtualMemoryJNA::querySwapUsed, defaultExpiration());
-
-    private final Supplier<Triplet<Long, Long, Long>> totalVmaxVused = memoize(
-            WindowsVirtualMemoryJNA::querySwapTotalVirtMaxVirtUsed, defaultExpiration());
-
-    private final Supplier<Pair<Long, Long>> swapInOut = memoize(WindowsVirtualMemoryJNA::queryPageSwaps,
-            defaultExpiration());
 
     /**
      * Constructor for WindowsVirtualMemoryJNA.
@@ -50,44 +36,16 @@ final class WindowsVirtualMemoryJNA extends AbstractVirtualMemory {
      * @param windowsGlobalMemory The parent global memory class instantiating this
      */
     WindowsVirtualMemoryJNA(WindowsGlobalMemoryJNA windowsGlobalMemory) {
-        this.global = windowsGlobalMemory;
+        super(windowsGlobalMemory);
     }
 
     @Override
-    public long getSwapUsed() {
-        return this.global.getPageSize() * used.get();
-    }
-
-    @Override
-    public long getSwapTotal() {
-        return this.global.getPageSize() * totalVmaxVused.get().getA();
-    }
-
-    @Override
-    public long getVirtualMax() {
-        return this.global.getPageSize() * totalVmaxVused.get().getB();
-    }
-
-    @Override
-    public long getVirtualInUse() {
-        return this.global.getPageSize() * totalVmaxVused.get().getC();
-    }
-
-    @Override
-    public long getSwapPagesIn() {
-        return swapInOut.get().getA();
-    }
-
-    @Override
-    public long getSwapPagesOut() {
-        return swapInOut.get().getB();
-    }
-
-    private static long querySwapUsed() {
+    protected long querySwapUsed() {
         return PagingFileJNA.querySwapUsed().getOrDefault(PagingPercentProperty.PERCENTUSAGE, 0L);
     }
 
-    private static Triplet<Long, Long, Long> querySwapTotalVirtMaxVirtUsed() {
+    @Override
+    protected Triplet<Long, Long, Long> querySwapTotalVirtMaxVirtUsed() {
         try (CloseablePerformanceInformation perfInfo = new CloseablePerformanceInformation()) {
             if (!Psapi.INSTANCE.GetPerformanceInfo(perfInfo, perfInfo.size())) {
                 LOG.error("Failed to get Performance Info. Error code: {}", Kernel32.INSTANCE.GetLastError());
@@ -98,7 +56,8 @@ final class WindowsVirtualMemoryJNA extends AbstractVirtualMemory {
         }
     }
 
-    private static Pair<Long, Long> queryPageSwaps() {
+    @Override
+    protected Pair<Long, Long> queryPageSwaps() {
         Map<PageSwapProperty, Long> valueMap = MemoryInformationJNA.queryPageSwaps();
         return new Pair<>(valueMap.getOrDefault(PageSwapProperty.PAGESINPUTPERSEC, 0L),
                 valueMap.getOrDefault(PageSwapProperty.PAGESOUTPUTPERSEC, 0L));


### PR DESCRIPTION
## Summary

Part of the cross-OS consistency/dedup audit (Item 5, memory). Every platform's `GlobalMemory`/`VirtualMemory` classes already follow the shared-base + thin-native-twin shape (done during the FFM ports) **except Windows**, whose JNA and FFM twins still carried the full logic in both backends. This brings Windows into line.

## Changes

**GlobalMemory** — `WindowsGlobalMemory` (existing base, previously just the memory-type lookup tables) now holds:
- the memoized `available`/`total`/`pageSize` suppliers + getters
- the memoized virtual-memory supplier + `getVirtualMemory()`
- the full `getPhysicalMemory()` WMI bank-assembly loop

with `protected abstract` hooks for the native pieces: `readPerfInfo()`, `createVirtualMemory()`, `isWindows10OrGreater()`, `queryPhysicalMemory()`, `queryPhysicalMemoryWin8()`.

**VirtualMemory** — `VirtualMemory` had no shared base, so **`WindowsVirtualMemory` is new**: it holds the parent-global reference, the memoized `used`/`totalVmaxVused`/`swapInOut` suppliers, and the six page-size-scaled getters, with hooks `querySwapUsed()`, `querySwapTotalVirtMaxVirtUsed()`, `queryPageSwaps()`.

The JNA and FFM twins shrink to just those native hooks:
- GlobalMemory: JNA 119 → 67, FFM 128 → 79
- VirtualMemory: JNA 106 → 65, FFM 111 → 71

~182 lines of duplicated twin logic eliminated. (Raw net LOC is roughly flat because `WindowsVirtualMemory` is a new file and `WindowsGlobalMemory` absorbs the loop that was duplicated in both twins — the win is single-source-of-truth / reduced duplication, matching every other platform.)

## Behavior

No user-facing change — the hoisted logic is identical to what both twins previously duplicated; only the native queries remain per-backend.

## Testing

- spotless / checkstyle / forbiddenapis / javadoc: clean
- Clean full-reactor `install`: BUILD SUCCESS, 0 tests failed (compiles the Windows JNA + FFM classes on all modules); `WindowsGlobalMemoryTest` passes
- Windows *runtime* memory values (perf-info, WMI banks, swap) are exercised only on the Windows CI runner — please confirm there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Windows memory reporting consistency across supported backends.
  * Improved caching and performance for global, virtual, and physical memory metrics.
  * Enhanced physical memory details, including capacity, speed, manufacturer, type, part number, and serial number.
  * Improved compatibility across Windows 10 and earlier Windows versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->