### PR TITLE
Differentially test the pre-Windows-10 physical-memory fallback path

### DIFF
--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGlobalMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGlobalMemoryJNA.java
@@ -23,9 +23,12 @@ import oshi.util.tuples.Triplet;
 
 /**
  * Memory obtained by Performance Info.
+ * <p>
+ * Not {@code final} so that tests can subclass it to force the {@link #isWindows10OrGreater()} version gate and
+ * exercise the pre-Windows-10 fallback query path against the real system.
  */
 @ThreadSafe
-final class WindowsGlobalMemoryJNA extends WindowsGlobalMemory {
+class WindowsGlobalMemoryJNA extends WindowsGlobalMemory {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsGlobalMemoryJNA.class);
 

--- a/oshi-core/src/test/java/oshi/hardware/platform/windows/WindowsGlobalMemoryLegacyTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/windows/WindowsGlobalMemoryLegacyTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.hardware.PhysicalMemory;
+
+/**
+ * Exercises the pre-Windows-10 physical-memory fallback path against the real system by forcing the
+ * {@code isWindows10OrGreater()} version gate. Only the version flag is overridden, so the genuine WMI query runs; a
+ * rotted legacy path surfaces as a divergence from the modern path rather than as a mere coverage number.
+ */
+@EnabledOnOs(OS.WINDOWS)
+class WindowsGlobalMemoryLegacyTest {
+
+    // Stable ordering on fields that must agree between the two schemas, so the comparison can't flake on WMI row order
+    private static final Comparator<PhysicalMemory> BY_BANK = Comparator.comparing(PhysicalMemory::getBankLabel)
+            .thenComparing(PhysicalMemory::getSerialNumber).thenComparingLong(PhysicalMemory::getCapacity);
+
+    /** A real {@link WindowsGlobalMemoryJNA} with only the Windows-version gate forced. */
+    private static final class ForcedVersion extends WindowsGlobalMemoryJNA {
+        private final boolean windows10OrGreater;
+
+        ForcedVersion(boolean windows10OrGreater) {
+            this.windows10OrGreater = windows10OrGreater;
+        }
+
+        @Override
+        protected boolean isWindows10OrGreater() {
+            return windows10OrGreater;
+        }
+    }
+
+    /**
+     * The legacy (pre-Win10) and modern physical-memory queries hit the same {@code Win32_PhysicalMemory} class and
+     * differ only in how they resolve the memory-type string, so every other field must agree bank-for-bank. A broken
+     * legacy query (wrong field, wrong parse) shows up here as a mismatch. When the runner reports no banks both lists
+     * are empty and the legacy branch is still exercised.
+     */
+    @Test
+    void legacyPhysicalMemoryMatchesModernExceptType() {
+        List<PhysicalMemory> legacy = new ArrayList<>(new ForcedVersion(false).getPhysicalMemory());
+        List<PhysicalMemory> modern = new ArrayList<>(new ForcedVersion(true).getPhysicalMemory());
+        legacy.sort(BY_BANK);
+        modern.sort(BY_BANK);
+
+        assertThat("legacy and modern must report the same bank count", legacy, hasSize(modern.size()));
+        for (int i = 0; i < modern.size(); i++) {
+            PhysicalMemory l = legacy.get(i);
+            PhysicalMemory m = modern.get(i);
+            assertThat(l.getBankLabel(), is(m.getBankLabel()));
+            assertThat(l.getCapacity(), is(m.getCapacity()));
+            assertThat(l.getClockSpeed(), is(m.getClockSpeed()));
+            assertThat(l.getManufacturer(), is(m.getManufacturer()));
+            assertThat(l.getPartNumber(), is(m.getPartNumber()));
+            assertThat(l.getSerialNumber(), is(m.getSerialNumber()));
+            // memoryType is intentionally not compared: legacy resolves Win32 MemoryType, modern SMBIOSMemoryType
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The pre-Windows-10 branch of `WindowsGlobalMemory.getPhysicalMemory()` (the `Win32_PhysicalMemory` query with the pre-10 `MemoryType` field, resolved via `memoryType()` instead of `smBiosMemoryType()`) has **never executed on CI** — the runners are all Windows 10+, so that `else` branch is dead on CI and its legacy query/field-mapping has drifted through several refactors untested since it was written on a Win7 VM years ago.

The recent memory dedup (#3453) incidentally made this testable: the version check is now an overridable `protected isWindows10OrGreater()` hook rather than an inlined static `VersionHelpers` read, so the legacy path can be forced **against the real system** without mocking a static native call.

## Changes

- **`WindowsGlobalMemoryJNA`**: dropped `final` (one word + a javadoc note) so a test can subclass it and override only the version gate, inheriting the genuine query hooks.
- **`WindowsGlobalMemoryLegacyTest`** (new, `@EnabledOnOs(WINDOWS)`): builds the real class twice with `isWindows10OrGreater()` forced `false` and `true`, runs the real WMI query both ways, and asserts the legacy and modern results agree **bank-for-bank** on every schema-independent field — bank label, capacity, clock speed, manufacturer, part number, serial number. `memoryType` is intentionally excluded (the two schemas legitimately resolve it differently). Lists are sorted before comparison so WMI row order can't flake it; a runner reporting no banks still exercises the legacy branch.

## Why differential (not fabricated tables)

The goal isn't coverage for its own sake — it's to exercise the **real** legacy query/parse on real hardware and catch a rotted path. Feeding canned `WmiResult` tables would only test the parser. Forcing the gate and diffing legacy-vs-modern on the same machine catches a broken legacy query (wrong field, wrong parse) as a concrete divergence.

**A red result on the Windows runner is the intended signal** that the legacy path diverged and needs a fix (either the path itself, or narrowing the comparison if some field legitimately differs pre-10).

## Testing

- Compiles clean; correctly skipped on non-Windows (`[S] Disabled`)
- spotless / checkstyle / forbiddenapis / javadoc: clean; clean full-reactor build, 0 tests failed
- The legacy path itself is validated by the Windows CI runners here

## Pattern

Establishes a reusable approach for the consistency arc: **seam the version/capability gate, then differential-test the legacy path against real data** — to reapply on the Windows CPU counter-set selection (`Processor` vs `ProcessorInformation`) and the 32-bit uptime wrap when those subsystems are touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility validation for Windows systems by verifying that legacy and modern memory detection paths report consistent physical memory details.

* **Tests**
  * Added Windows-specific coverage for comparing memory bank information across supported operating system versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->