### PR TITLE
Hoist the NetworkIF enumeration loop into AbstractNetworkIF

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -146,6 +146,41 @@ public abstract class AbstractNetworkIF implements NetworkIF {
     }
 
     /**
+     * Creates a platform-specific {@link NetworkIF} from a {@link NetworkInterface}.
+     */
+    @FunctionalInterface
+    protected interface NetworkIFFactory {
+        /**
+         * Creates the network interface.
+         *
+         * @param netint the underlying network interface
+         * @return the created {@link NetworkIF}
+         * @throws InstantiationException if the interface cannot be instantiated
+         */
+        NetworkIF create(NetworkInterface netint) throws InstantiationException;
+    }
+
+    /**
+     * Builds the list of network interfaces, constructing each with the given platform-specific factory. Interfaces
+     * that fail to instantiate are logged at debug and skipped.
+     *
+     * @param includeLocalInterfaces include local interfaces in the result
+     * @param factory                creates the platform-specific interface instances
+     * @return a list of {@link NetworkIF} objects representing the interfaces
+     */
+    protected static List<NetworkIF> getNetworks(boolean includeLocalInterfaces, NetworkIFFactory factory) {
+        List<NetworkIF> ifList = new ArrayList<>();
+        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
+            try {
+                ifList.add(factory.create(ni));
+            } catch (InstantiationException e) {
+                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
+            }
+        }
+        return ifList;
+    }
+
+    /**
      * Returns all network interfaces.
      *
      * @return A list of network interfaces

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxNetworkIfNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxNetworkIfNF.java
@@ -5,11 +5,7 @@
 package oshi.hardware.common.platform.linux.nativefree;
 
 import java.net.NetworkInterface;
-import java.util.ArrayList;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.NetworkIF;
@@ -20,8 +16,6 @@ import oshi.hardware.common.platform.linux.LinuxNetworkIF;
  */
 @ThreadSafe
 public final class LinuxNetworkIfNF extends LinuxNetworkIF {
-
-    private static final Logger LOG = LoggerFactory.getLogger(LinuxNetworkIfNF.class);
 
     LinuxNetworkIfNF(NetworkInterface netint) throws InstantiationException {
         super(netint, queryIfModelFromSysfs(netint.getName()));
@@ -34,14 +28,6 @@ public final class LinuxNetworkIfNF extends LinuxNetworkIF {
      * @return a list of {@link NetworkIF} objects
      */
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new LinuxNetworkIfNF(ni));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.toString());
-            }
-        }
-        return ifList;
+        return getNetworks(includeLocalInterfaces, LinuxNetworkIfNF::new);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdNetworkIF.java
@@ -5,11 +5,7 @@
 package oshi.hardware.common.platform.unix;
 
 import java.net.NetworkInterface;
-import java.util.ArrayList;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.NetworkIF;
@@ -23,8 +19,6 @@ import oshi.util.ParseUtil;
 @ThreadSafe
 public final class BsdNetworkIF extends AbstractNetworkIF {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BsdNetworkIF.class);
-
     public BsdNetworkIF(NetworkInterface netint) throws InstantiationException {
         super(netint);
         updateAttributes();
@@ -37,15 +31,7 @@ public final class BsdNetworkIF extends AbstractNetworkIF {
      * @return A list of {@link NetworkIF} objects representing the interfaces
      */
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new BsdNetworkIF(ni));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
-            }
-        }
-        return ifList;
+        return getNetworks(includeLocalInterfaces, BsdNetworkIF::new);
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
@@ -5,11 +5,7 @@
 package oshi.hardware.common.platform.unix.netbsd;
 
 import java.net.NetworkInterface;
-import java.util.ArrayList;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.NetworkIF;
@@ -23,8 +19,6 @@ import oshi.util.ParseUtil;
 @ThreadSafe
 public final class NetBsdNetworkIF extends AbstractNetworkIF {
 
-    private static final Logger LOG = LoggerFactory.getLogger(NetBsdNetworkIF.class);
-
     public NetBsdNetworkIF(NetworkInterface netint) throws InstantiationException {
         super(netint);
         updateAttributes();
@@ -37,15 +31,7 @@ public final class NetBsdNetworkIF extends AbstractNetworkIF {
      * @return A list of {@link NetworkIF} objects representing the interfaces
      */
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new NetBsdNetworkIF(ni));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
-            }
-        }
-        return ifList;
+        return getNetworks(includeLocalInterfaces, NetBsdNetworkIF::new);
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisNetworkIF.java
@@ -5,14 +5,8 @@
 package oshi.hardware.common.platform.unix.solaris;
 
 import java.net.NetworkInterface;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.hardware.NetworkIF;
 import oshi.hardware.common.AbstractNetworkIF;
 
 /**
@@ -21,8 +15,6 @@ import oshi.hardware.common.AbstractNetworkIF;
  */
 @ThreadSafe
 public abstract class SolarisNetworkIF extends AbstractNetworkIF {
-
-    private static final Logger LOG = LoggerFactory.getLogger(SolarisNetworkIF.class);
 
     /** Per-interface stats the Solaris HAL reads. Both JNA and FFM concrete subclasses populate this. */
     public static final class IfStats {
@@ -36,12 +28,6 @@ public abstract class SolarisNetworkIF extends AbstractNetworkIF {
         public long inDrops;
         public long speed;
         public long timeStamp;
-    }
-
-    /** Creates a concrete (JNA or FFM) Solaris network interface. */
-    @FunctionalInterface
-    protected interface NetworkIFFactory {
-        SolarisNetworkIF create(NetworkInterface netint) throws InstantiationException;
     }
 
     protected SolarisNetworkIF(NetworkInterface netint) throws InstantiationException {
@@ -67,25 +53,6 @@ public abstract class SolarisNetworkIF extends AbstractNetworkIF {
         this.speed = stats.speed;
         this.timeStamp = stats.timeStamp;
         return true;
-    }
-
-    /**
-     * Gets all network interfaces on this machine, building each with the given concrete factory.
-     *
-     * @param includeLocalInterfaces include local interfaces in the result
-     * @param factory                creates the platform-specific interface instances
-     * @return a list of {@link NetworkIF} objects representing the interfaces
-     */
-    protected static List<NetworkIF> getNetworks(boolean includeLocalInterfaces, NetworkIFFactory factory) {
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(factory.create(ni));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
-            }
-        }
-        return ifList;
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
@@ -10,7 +10,6 @@ import static oshi.software.os.linux.LinuxOperatingSystemFFM.HAS_UDEV;
 
 import java.lang.foreign.MemorySegment;
 import java.net.NetworkInterface;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -74,14 +73,6 @@ public final class LinuxNetworkIFFFM extends LinuxNetworkIF {
      * @return A list of {@link NetworkIF} objects representing the interfaces
      */
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new LinuxNetworkIFFFM(ni));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.toString());
-            }
-        }
-        return ifList;
+        return getNetworks(includeLocalInterfaces, LinuxNetworkIFFFM::new);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
@@ -10,7 +10,6 @@ import static oshi.ffm.platform.mac.SystemConfigurationFunctions.SCNetworkInterf
 
 import java.lang.foreign.MemorySegment;
 import java.net.NetworkInterface;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -66,16 +65,8 @@ public final class MacNetworkIfFFM extends MacNetworkIF {
     }
 
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
-        final Map<Integer, IFdata> data = NetStatFFM.queryIFdata(-1);
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new MacNetworkIfFFM(ni, data));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
-            }
-        }
-        return ifList;
+        Map<Integer, IFdata> data = NetStatFFM.queryIFdata(-1);
+        return getNetworks(includeLocalInterfaces, ni -> new MacNetworkIfFFM(ni, data));
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/aix/AixNetworkIFFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/aix/AixNetworkIFFFM.java
@@ -8,12 +8,8 @@ import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
 import java.net.NetworkInterface;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.aix.perfstat.PerfstatNetInterfaceFFM;
@@ -25,8 +21,6 @@ import oshi.hardware.common.platform.unix.aix.AixNetworkIF;
  */
 @ThreadSafe
 public final class AixNetworkIFFFM extends AixNetworkIF {
-
-    private static final Logger LOG = LoggerFactory.getLogger(AixNetworkIFFFM.class);
 
     private final Supplier<PerfstatNetInterfaceFFM.NetInterface[]> netstats;
 
@@ -46,15 +40,7 @@ public final class AixNetworkIFFFM extends AixNetworkIF {
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
         Supplier<PerfstatNetInterfaceFFM.NetInterface[]> netstats = memoize(PerfstatNetInterfaceFFM::queryNetInterfaces,
                 defaultExpiration());
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new AixNetworkIFFFM(ni, netstats));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
-            }
-        }
-        return ifList;
+        return getNetworks(includeLocalInterfaces, ni -> new AixNetworkIFFFM(ni, netstats));
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
@@ -11,7 +11,6 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.net.NetworkInterface;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -44,15 +43,7 @@ public final class WindowsNetworkIfFFM extends AbstractNetworkIF {
     }
 
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new WindowsNetworkIfFFM(ni));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
-            }
-        }
-        return ifList;
+        return getNetworks(includeLocalInterfaces, WindowsNetworkIfFFM::new);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFJNA.java
@@ -7,11 +7,7 @@ package oshi.hardware.platform.linux;
 import static oshi.software.os.linux.LinuxOperatingSystemJNA.HAS_UDEV;
 
 import java.net.NetworkInterface;
-import java.util.ArrayList;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.sun.jna.platform.linux.Udev;
 import com.sun.jna.platform.linux.Udev.UdevContext;
@@ -28,8 +24,6 @@ import oshi.util.linux.SysPath;
  */
 @ThreadSafe
 public final class LinuxNetworkIFJNA extends LinuxNetworkIF {
-
-    private static final Logger LOG = LoggerFactory.getLogger(LinuxNetworkIFJNA.class);
 
     LinuxNetworkIFJNA(NetworkInterface netint) throws InstantiationException {
         super(netint, queryIfModel(netint));
@@ -72,14 +66,6 @@ public final class LinuxNetworkIFJNA extends LinuxNetworkIF {
      * @return A list of {@link NetworkIF} objects representing the interfaces
      */
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new LinuxNetworkIFJNA(ni));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
-            }
-        }
-        return ifList;
+        return getNetworks(includeLocalInterfaces, LinuxNetworkIFJNA::new);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIfJNA.java
@@ -5,12 +5,8 @@
 package oshi.hardware.platform.mac;
 
 import java.net.NetworkInterface;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.mac.CoreFoundation.CFArrayRef;
@@ -29,8 +25,6 @@ import oshi.jna.platform.mac.SystemConfiguration.SCNetworkInterfaceRef;
  */
 @ThreadSafe
 public final class MacNetworkIfJNA extends MacNetworkIF {
-
-    private static final Logger LOG = LoggerFactory.getLogger(MacNetworkIfJNA.class);
 
     public MacNetworkIfJNA(NetworkInterface netint, Map<Integer, IFdata> data) throws InstantiationException {
         super(netint, queryIfDisplayName(netint));
@@ -67,16 +61,8 @@ public final class MacNetworkIfJNA extends MacNetworkIF {
      * @return A list of {@link NetworkIF} objects representing the interfaces
      */
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
-        final Map<Integer, IFdata> data = NetStat.queryIFdata(-1);
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new MacNetworkIfJNA(ni, data));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
-            }
-        }
-        return ifList;
+        Map<Integer, IFdata> data = NetStat.queryIFdata(-1);
+        return getNetworks(includeLocalInterfaces, ni -> new MacNetworkIfJNA(ni, data));
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixNetworkIFJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixNetworkIFJNA.java
@@ -8,12 +8,8 @@ import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
 import java.net.NetworkInterface;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.sun.jna.Native;
 import com.sun.jna.platform.unix.aix.Perfstat.perfstat_netinterface_t;
@@ -28,8 +24,6 @@ import oshi.hardware.common.platform.unix.aix.AixNetworkIF;
  */
 @ThreadSafe
 public final class AixNetworkIFJNA extends AixNetworkIF {
-
-    private static final Logger LOG = LoggerFactory.getLogger(AixNetworkIFJNA.class);
 
     private final Supplier<perfstat_netinterface_t[]> netstats;
 
@@ -49,15 +43,7 @@ public final class AixNetworkIFJNA extends AixNetworkIF {
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
         Supplier<perfstat_netinterface_t[]> netstats = memoize(PerfstatNetInterfaceJNA::queryNetInterfaces,
                 defaultExpiration());
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new AixNetworkIFJNA(ni, netstats));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
-            }
-        }
-        return ifList;
+        return getNetworks(includeLocalInterfaces, ni -> new AixNetworkIFJNA(ni, netstats));
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
@@ -5,7 +5,6 @@
 package oshi.hardware.platform.windows;
 
 import java.net.NetworkInterface;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -51,15 +50,7 @@ public final class WindowsNetworkIfJNA extends AbstractNetworkIF {
      * @return A list of {@link NetworkIF} objects representing the interfaces
      */
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
-        List<NetworkIF> ifList = new ArrayList<>();
-        for (NetworkInterface ni : getNetworkInterfaces(includeLocalInterfaces)) {
-            try {
-                ifList.add(new WindowsNetworkIfJNA(ni));
-            } catch (InstantiationException e) {
-                LOG.debug("Network Interface Instantiation failed: {}", e.getMessage());
-            }
-        }
-        return ifList;
+        return getNetworks(includeLocalInterfaces, WindowsNetworkIfJNA::new);
     }
 
     @Override


### PR DESCRIPTION
## Summary

First slice of Item 6 (NetworkIF) in the cross-OS dedup audit. Every platform's `getNetworks(boolean)` hand-rolled the identical enumeration loop — walk `getNetworkInterfaces(includeLocal)`, construct the platform-specific `NetworkIF` for each, and log+skip any that throw `InstantiationException`. Only the constructed type differed (and, for Mac/AIX, some pre-queried bulk data).

`SolarisNetworkIF` already proved the fix with a *local* `NetworkIFFactory` + `getNetworks(boolean, factory)` helper. This promotes that helper up to `AbstractNetworkIF` and adopts it across all ~14 implementations.

## Changes

- **`AbstractNetworkIF`**: add the `NetworkIFFactory` functional interface + shared `getNetworks(boolean, factory)` (using the existing `LOG` and `getNetworkInterfaces`).
- **Simple platforms** (Linux, Windows, BSD, NetBSD, native-free) delegate with a constructor ref: `return getNetworks(includeLocal, LinuxNetworkIFJNA::new);`
- **Bulk-data platforms** (Mac, AIX) query once and capture it in the factory lambda: `return getNetworks(includeLocal, ni -> new MacNetworkIfJNA(ni, data));`
- **Solaris**: local factory/helper removed; inherits the hoisted one (JNA/FFM callers unchanged).
- **Consistency fix**: `LinuxNetworkIFFFM` and `LinuxNetworkIfNF` logged `e.toString()` while everyone else logged `e.getMessage()`; the shared helper uses `getMessage()` for all. Now-orphaned `LOG` fields dropped.

Net **−132 lines** (13 files); ~14 copies of the loop → one helper.

## Behavior

No user-facing change — same enumeration, same skip-on-failure semantics; only that one debug-log line is unified.

## Testing

- spotless / checkstyle / forbiddenapis / javadoc: clean
- Clean full-reactor `install`: BUILD SUCCESS, 0 tests failed
- `NativeComparisonTest` NetworkIF JNA==FFM comparison: passes on macOS

## Follow-ups (queued, separate PRs)

The fatter per-platform native `updateAttributes`/model logic is left for follow-ups (they need native-call abstraction, not a mechanical hoist): the Linux udev model lookup, and the Mac/Windows/AIX stat queries. Note `WindowsNetworkIfJNA.updateAttributes` has a **Vista-gated legacy path** (`MIB_IFROW2` vs `MIB_IFROW`) — a target for the seam + differential-legacy-test pattern (cf. #3454) when that PR lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Simplified network-interface discovery across supported platforms.
  - Network interfaces that cannot be initialized are now skipped gracefully, allowing other available interfaces to be returned.
  - Local-interface inclusion behavior remains supported.
- **Maintenance**
  - Standardized network-interface handling and reduced duplicated processing across platform implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->