### PR TITLE
Extract Mac/Windows NetworkParams common bases

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacNetworkParams.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.mac;
+
+import java.util.List;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractNetworkParams;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+/**
+ * Common Mac NetworkParams logic shared between the JNA and FFM implementations. The default-gateway lookups are
+ * command-line based and live here; hostname/domain resolution is native and provided by the subclasses.
+ */
+@ThreadSafe
+public abstract class MacNetworkParams extends AbstractNetworkParams {
+
+    private static final String IPV6_ROUTE_HEADER = "Internet6:";
+
+    private static final String DEFAULT_GATEWAY = "default";
+
+    /** Default constructor. */
+    protected MacNetworkParams() {
+    }
+
+    @Override
+    public String getIpv4DefaultGateway() {
+        return searchGateway(ExecutingCommand.runNative("route -n get default"));
+    }
+
+    @Override
+    public String getIpv6DefaultGateway() {
+        List<String> lines = ExecutingCommand.runNative("netstat -nr");
+        boolean v6Table = false;
+        for (String line : lines) {
+            if (v6Table && line.startsWith(DEFAULT_GATEWAY)) {
+                String[] fields = ParseUtil.whitespaces.split(line);
+                if (fields.length > 2 && fields[2].contains("G")) {
+                    return fields[1].split("%")[0];
+                }
+            } else if (line.startsWith(IPV6_ROUTE_HEADER)) {
+                v6Table = true;
+            }
+        }
+        return "";
+    }
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsNetworkParams.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.windows;
+
+import java.util.List;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractNetworkParams;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+/**
+ * Common Windows NetworkParams logic shared between the JNA and FFM implementations. The default-gateway lookups parse
+ * {@code route print} output and live here; domain/host name and DNS-server resolution are native and provided by the
+ * subclasses.
+ */
+@ThreadSafe
+public abstract class WindowsNetworkParams extends AbstractNetworkParams {
+
+    /** Default constructor. */
+    protected WindowsNetworkParams() {
+    }
+
+    @Override
+    public String getIpv4DefaultGateway() {
+        return parseIpv4Route();
+    }
+
+    @Override
+    public String getIpv6DefaultGateway() {
+        return parseIpv6Route();
+    }
+
+    private static String parseIpv4Route() {
+        List<String> lines = ExecutingCommand.runNative("route print -4 0.0.0.0");
+        for (String line : lines) {
+            String[] fields = ParseUtil.whitespaces.split(line.trim());
+            if (fields.length > 2 && "0.0.0.0".equals(fields[0])) {
+                return fields[2];
+            }
+        }
+        return "";
+    }
+
+    private static String parseIpv6Route() {
+        List<String> lines = ExecutingCommand.runNative("route print -6 ::/0");
+        for (String line : lines) {
+            String[] fields = ParseUtil.whitespaces.split(line.trim());
+            if (fields.length > 3 && "::/0".equals(fields[2])) {
+                return fields[3];
+            }
+        }
+        return "";
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacNetworkParamsFFM.java
@@ -20,7 +20,6 @@ import static oshi.ffm.platform.mac.MacSystemFunctions.gethostname;
 import java.lang.foreign.MemorySegment;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,20 +27,15 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.NativeHandle;
 import oshi.ffm.platform.mac.MacSystemFunctions;
-import oshi.software.common.AbstractNetworkParams;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+import oshi.software.common.os.mac.MacNetworkParams;
 
 /**
  * MacNetworkParams implementation using FFM (no JNA dependency).
  */
 @ThreadSafe
-final class MacNetworkParamsFFM extends AbstractNetworkParams {
+final class MacNetworkParamsFFM extends MacNetworkParams {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacNetworkParamsFFM.class);
-
-    private static final String IPV6_ROUTE_HEADER = "Internet6:";
-    private static final String DEFAULT_GATEWAY = "default";
 
     @Override
     public String getDomainName() {
@@ -92,27 +86,5 @@ final class MacNetworkParamsFFM extends AbstractNetworkParams {
             return null;
         }, LOG, DEBUG, "Failed gethostname()", null);
         return hostname == null ? super.getHostName() : hostname;
-    }
-
-    @Override
-    public String getIpv4DefaultGateway() {
-        return searchGateway(ExecutingCommand.runNative("route -n get default"));
-    }
-
-    @Override
-    public String getIpv6DefaultGateway() {
-        List<String> lines = ExecutingCommand.runNative("netstat -nr");
-        boolean v6Table = false;
-        for (String line : lines) {
-            if (v6Table && line.startsWith(DEFAULT_GATEWAY)) {
-                String[] fields = ParseUtil.whitespaces.split(line);
-                if (fields.length > 2 && fields[2].contains("G")) {
-                    return fields[1].split("%")[0];
-                }
-            } else if (line.startsWith(IPV6_ROUTE_HEADER)) {
-                v6Table = true;
-            }
-        }
-        return "";
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsNetworkParamsFFM.java
@@ -4,15 +4,11 @@
  */
 package oshi.software.os.windows;
 
-import java.util.List;
-
 import oshi.ffm.util.platform.windows.IPHlpAPIUtilFFM;
 import oshi.ffm.util.platform.windows.Kernel32UtilFFM;
-import oshi.software.common.AbstractNetworkParams;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+import oshi.software.common.os.windows.WindowsNetworkParams;
 
-public final class WindowsNetworkParamsFFM extends AbstractNetworkParams {
+public final class WindowsNetworkParamsFFM extends WindowsNetworkParams {
 
     @Override
     public String[] getDnsServers() {
@@ -28,37 +24,5 @@ public final class WindowsNetworkParamsFFM extends AbstractNetworkParams {
     public String getHostName() {
         String name = Kernel32UtilFFM.getComputerName();
         return name.isEmpty() ? super.getHostName() : name;
-    }
-
-    @Override
-    public String getIpv4DefaultGateway() {
-        return parseIpv4Route();
-    }
-
-    @Override
-    public String getIpv6DefaultGateway() {
-        return parseIpv6Route();
-    }
-
-    private static String parseIpv4Route() {
-        List<String> lines = ExecutingCommand.runNative("route print -4 0.0.0.0");
-        for (String line : lines) {
-            String[] fields = ParseUtil.whitespaces.split(line.trim());
-            if (fields.length > 2 && "0.0.0.0".equals(fields[0])) {
-                return fields[2];
-            }
-        }
-        return "";
-    }
-
-    private static String parseIpv6Route() {
-        List<String> lines = ExecutingCommand.runNative("route print -6 ::/0");
-        for (String line : lines) {
-            String[] fields = ParseUtil.whitespaces.split(line.trim());
-            if (fields.length > 3 && "::/0".equals(fields[2])) {
-                return fields[3];
-            }
-        }
-        return "";
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParamsJNA.java
@@ -8,7 +8,6 @@ import static com.sun.jna.platform.unix.LibCAPI.HOST_NAME_MAX;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,23 +19,17 @@ import oshi.jna.ByRef.CloseablePointerByReference;
 import oshi.jna.platform.mac.SystemB;
 import oshi.jna.platform.unix.CLibrary;
 import oshi.jna.platform.unix.CLibrary.Addrinfo;
-import oshi.software.common.AbstractNetworkParams;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+import oshi.software.common.os.mac.MacNetworkParams;
 
 /**
  * MacNetworkParamsJNA class.
  */
 @ThreadSafe
-final class MacNetworkParamsJNA extends AbstractNetworkParams {
+final class MacNetworkParamsJNA extends MacNetworkParams {
 
     private static final Logger LOG = LoggerFactory.getLogger(MacNetworkParamsJNA.class);
 
     private static final SystemB SYS = SystemB.INSTANCE;
-
-    private static final String IPV6_ROUTE_HEADER = "Internet6:";
-
-    private static final String DEFAULT_GATEWAY = "default";
 
     @Override
     public String getDomainName() {
@@ -75,27 +68,5 @@ final class MacNetworkParamsJNA extends AbstractNetworkParams {
             return super.getHostName();
         }
         return Native.toString(hostnameBuffer);
-    }
-
-    @Override
-    public String getIpv4DefaultGateway() {
-        return searchGateway(ExecutingCommand.runNative("route -n get default"));
-    }
-
-    @Override
-    public String getIpv6DefaultGateway() {
-        List<String> lines = ExecutingCommand.runNative("netstat -nr");
-        boolean v6Table = false;
-        for (String line : lines) {
-            if (v6Table && line.startsWith(DEFAULT_GATEWAY)) {
-                String[] fields = ParseUtil.whitespaces.split(line);
-                if (fields.length > 2 && fields[2].contains("G")) {
-                    return fields[1].split("%")[0];
-                }
-            } else if (line.startsWith(IPV6_ROUTE_HEADER)) {
-                v6Table = true;
-            }
-        }
-        return "";
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParamsJNA.java
@@ -23,15 +23,13 @@ import com.sun.jna.platform.win32.WinError;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseableIntByReference;
-import oshi.software.common.AbstractNetworkParams;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
+import oshi.software.common.os.windows.WindowsNetworkParams;
 
 /**
  * WindowsNetworkParamsJNA class.
  */
 @ThreadSafe
-final class WindowsNetworkParamsJNA extends AbstractNetworkParams {
+final class WindowsNetworkParamsJNA extends WindowsNetworkParams {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsNetworkParamsJNA.class);
 
@@ -91,37 +89,5 @@ final class WindowsNetworkParamsJNA extends AbstractNetworkParams {
         } catch (Win32Exception e) {
             return super.getHostName();
         }
-    }
-
-    @Override
-    public String getIpv4DefaultGateway() {
-        return parseIpv4Route();
-    }
-
-    @Override
-    public String getIpv6DefaultGateway() {
-        return parseIpv6Route();
-    }
-
-    private static String parseIpv4Route() {
-        List<String> lines = ExecutingCommand.runNative("route print -4 0.0.0.0");
-        for (String line : lines) {
-            String[] fields = ParseUtil.whitespaces.split(line.trim());
-            if (fields.length > 2 && "0.0.0.0".equals(fields[0])) {
-                return fields[2];
-            }
-        }
-        return "";
-    }
-
-    private static String parseIpv6Route() {
-        List<String> lines = ExecutingCommand.runNative("route print -6 ::/0");
-        for (String line : lines) {
-            String[] fields = ParseUtil.whitespaces.split(line.trim());
-            if (fields.length > 3 && "::/0".equals(fields[2])) {
-                return fields[3];
-            }
-        }
-        return "";
     }
 }


### PR DESCRIPTION
## Summary

Continues Item 6 of the cross-OS dedup audit (NetworkParams half). Mac and Windows were the only platforms whose `NetworkParams` still lacked a common base — Linux/AIX/FreeBSD/NetBSD/OpenBSD/Solaris all have one — so their JNA and FFM twins each carried a full copy of the command-line default-gateway lookups. This adds the two missing bases, mirroring the Windows-memory dedup (#3453).

## Changes

- **New `MacNetworkParams`** (`software.common.os.mac`): holds `getIpv4DefaultGateway`/`getIpv6DefaultGateway` (the `route -n get default` and `netstat -nr` parsing) + the route constants. Mac JNA/FFM twins extend it and keep only their native `getDomainName`/`getHostName` (getaddrinfo/gethostname).
- **New `WindowsNetworkParams`** (`software.common.os.windows`): holds `getIpv4DefaultGateway`/`getIpv6DefaultGateway` (the `route print` parsing). Windows JNA/FFM twins extend it and keep native `getDomainName`/`getDnsServers`/`getHostName` (GetComputerNameEx/GetNetworkParams).
- The twins' `super.getHostName()` fallbacks still resolve to `AbstractNetworkParams` — the new bases don't override it.

Both target packages were already declared and exported in `module-info`, so no module changes were needed.

~96 lines of identical command-line gateway/route code collapsed from two copies each into one base (net raw count roughly flat since the two base files are new).

## Behavior

No user-facing change — same gateway/route parsing, only relocated; the native hostname/DNS calls stay per-backend.

## Testing

- spotless / checkstyle / forbiddenapis / javadoc: clean
- Clean full-reactor `install`: BUILD SUCCESS, 0 tests failed
- `NativeComparisonTest.networkParams()` JNA==FFM comparison: passes on macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of IPv4 and IPv6 default gateways on macOS and Windows.
  - Standardized gateway lookup across supported native integration options.
  - Improved IPv6 gateway parsing by removing interface suffixes from detected addresses.
  - Preserved existing hostname, domain, and DNS information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->