### PR TITLE
Dedup NetworkIF native stats/model and test the Windows Vista legacy path

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -90,6 +90,10 @@
          for the kstat I/O, interface, and battery counters that the JNA and FFM subclasses populate. -->
     <suppress checks="VisibilityModifier" files="(SolarisHWDiskStore|SolarisNetworkIF|SolarisPowerSource)\.java"/>
 
+    <!-- Windows NetworkIF shared base uses a public IfStats data POJO for the IP Helper API counters that the JNA and
+         FFM subclasses populate. -->
+    <suppress checks="VisibilityModifier" files="WindowsNetworkIF\.java"/>
+
     <!-- Package-info is in other source tree -->
     <suppress checks="JavadocPackage" files=".*FFM\.java"/>
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
@@ -49,15 +49,25 @@ public abstract class LinuxNetworkIF extends AbstractNetworkIF {
 
     static String queryIfModelFromSysfs(String name, String netPath) {
         Map<String, String> uevent = FileUtil.getKeyValueMapFromFile(netPath + name + "/uevent", "=");
-        String devVendor = uevent.get("ID_VENDOR_FROM_DATABASE");
-        String devModel = uevent.get("ID_MODEL_FROM_DATABASE");
-        if (!Util.isBlank(devModel)) {
-            if (!Util.isBlank(devVendor)) {
-                return devVendor + " " + devModel;
+        return formatModel(uevent.get("ID_VENDOR_FROM_DATABASE"), uevent.get("ID_MODEL_FROM_DATABASE"), name);
+    }
+
+    /**
+     * Formats a vendor/model pair into a display string, falling back to the interface name when no model is present.
+     *
+     * @param vendor   the vendor string, may be {@code null} or blank
+     * @param model    the model string, may be {@code null} or blank
+     * @param fallback the value to return when {@code model} is blank (typically the interface name)
+     * @return {@code "vendor model"}, {@code "model"}, or {@code fallback}
+     */
+    protected static String formatModel(String vendor, String model, String fallback) {
+        if (!Util.isBlank(model)) {
+            if (!Util.isBlank(vendor)) {
+                return vendor + " " + model;
             }
-            return devModel;
+            return model;
         }
-        return name;
+        return fallback;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacNetworkIF.java
@@ -5,13 +5,15 @@
 package oshi.hardware.common.platform.mac;
 
 import java.net.NetworkInterface;
+import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.mac.IFdata;
 import oshi.hardware.common.AbstractNetworkIF;
 
 /**
- * Base class for macOS NetworkIF implementations. Subclasses provide platform-specific display name resolution and
- * network statistics updates.
+ * Base class for macOS NetworkIF implementations. The per-interface statistics come from a shared {@link IFdata} map;
+ * subclasses provide the native display-name resolution and the {@code IFdata} query (JNA or FFM).
  */
 @ThreadSafe
 public abstract class MacNetworkIF extends AbstractNetworkIF {
@@ -34,12 +36,42 @@ public abstract class MacNetworkIF extends AbstractNetworkIF {
         return this.ifType;
     }
 
-    /**
-     * Sets the interface type.
-     *
-     * @param ifType the interface type to set
-     */
-    protected void setIfType(int ifType) {
-        this.ifType = ifType;
+    @Override
+    public boolean updateAttributes() {
+        return updateNetworkStats(queryIFdata(queryNetworkInterface().getIndex()));
     }
+
+    /**
+     * Populates this interface's statistics from the given {@link IFdata} map.
+     *
+     * @param data map of interface index to {@link IFdata}
+     * @return {@code true} if this interface's index was present in the map
+     */
+    protected boolean updateNetworkStats(Map<Integer, IFdata> data) {
+        int index = queryNetworkInterface().getIndex();
+        if (data.containsKey(index)) {
+            IFdata ifData = data.get(index);
+            this.ifType = ifData.getIfType();
+            this.bytesSent = ifData.getOBytes();
+            this.bytesRecv = ifData.getIBytes();
+            this.packetsSent = ifData.getOPackets();
+            this.packetsRecv = ifData.getIPackets();
+            this.outErrors = ifData.getOErrors();
+            this.inErrors = ifData.getIErrors();
+            this.collisions = ifData.getCollisions();
+            this.inDrops = ifData.getIDrops();
+            this.speed = ifData.getSpeed();
+            this.timeStamp = ifData.getTimeStamp();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Queries interface statistics via the platform-specific (JNA or FFM) {@code getifaddrs} backend.
+     *
+     * @param index the interface index, or {@code -1} for all interfaces
+     * @return map of interface index to {@link IFdata}
+     */
+    protected abstract Map<Integer, IFdata> queryIFdata(int index);
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsNetworkIF.java
@@ -17,6 +17,9 @@ import oshi.hardware.common.AbstractNetworkIF;
 @ThreadSafe
 public abstract class WindowsNetworkIF extends AbstractNetworkIF {
 
+    /** Bit in the interface flags indicating a connector is present. */
+    protected static final byte CONNECTOR_PRESENT_BIT = 0b00000100;
+
     private int ifType;
     private int ndisPhysicalMediumType;
     private boolean connectorPresent;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsNetworkIF.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import java.net.NetworkInterface;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.common.AbstractNetworkIF;
+
+/**
+ * Common Windows NetworkIF logic shared between the JNA and FFM implementations. The per-interface statistics are
+ * gathered from the IP Helper API by the subclasses (JNA {@code MIB_IF_ROW2}/{@code MIB_IFROW} structures or FFM
+ * {@code GetIfEntry2} offsets) into an {@link IfStats} carrier; mapping those onto the interface fields lives here.
+ */
+@ThreadSafe
+public abstract class WindowsNetworkIF extends AbstractNetworkIF {
+
+    private int ifType;
+    private int ndisPhysicalMediumType;
+    private boolean connectorPresent;
+    private String ifAlias = "";
+    private IfOperStatus ifOperStatus = IfOperStatus.UNKNOWN;
+
+    /**
+     * Creates a WindowsNetworkIF.
+     *
+     * @param netint the network interface
+     * @throws InstantiationException if the interface cannot be instantiated
+     */
+    protected WindowsNetworkIF(NetworkInterface netint) throws InstantiationException {
+        super(netint);
+        updateAttributes();
+    }
+
+    /** Interface statistics gathered by a backend from the IP Helper API. */
+    public static final class IfStats {
+        public int ifType;
+        public int ndisPhysicalMediumType;
+        public boolean connectorPresent;
+        public long bytesSent;
+        public long bytesRecv;
+        public long packetsSent;
+        public long packetsRecv;
+        public long outErrors;
+        public long inErrors;
+        public long collisions;
+        public long inDrops;
+        public long speed;
+        public String ifAlias = "";
+        public IfOperStatus ifOperStatus = IfOperStatus.UNKNOWN;
+    }
+
+    @Override
+    public int getIfType() {
+        return this.ifType;
+    }
+
+    @Override
+    public int getNdisPhysicalMediumType() {
+        return this.ndisPhysicalMediumType;
+    }
+
+    @Override
+    public boolean isConnectorPresent() {
+        return this.connectorPresent;
+    }
+
+    @Override
+    public String getIfAlias() {
+        return ifAlias;
+    }
+
+    @Override
+    public IfOperStatus getIfOperStatus() {
+        return ifOperStatus;
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        IfStats stats = queryStats();
+        if (stats == null) {
+            return false;
+        }
+        this.ifType = stats.ifType;
+        this.ndisPhysicalMediumType = stats.ndisPhysicalMediumType;
+        this.connectorPresent = stats.connectorPresent;
+        this.bytesSent = stats.bytesSent;
+        this.bytesRecv = stats.bytesRecv;
+        this.packetsSent = stats.packetsSent;
+        this.packetsRecv = stats.packetsRecv;
+        this.outErrors = stats.outErrors;
+        this.inErrors = stats.inErrors;
+        this.collisions = stats.collisions;
+        this.inDrops = stats.inDrops;
+        this.speed = stats.speed;
+        this.ifAlias = stats.ifAlias;
+        this.ifOperStatus = stats.ifOperStatus;
+        this.timeStamp = System.currentTimeMillis();
+        return true;
+    }
+
+    /**
+     * Queries this interface's statistics from the native (JNA or FFM) IP Helper API.
+     *
+     * @return the stats, or {@code null} if the query failed
+     */
+    protected abstract IfStats queryStats();
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFFFM.java
@@ -20,7 +20,6 @@ import oshi.ffm.NativeHandle;
 import oshi.ffm.platform.linux.UdevFunctions;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.common.platform.linux.LinuxNetworkIF;
-import oshi.util.Util;
 import oshi.util.linux.SysPath;
 
 /**
@@ -53,12 +52,7 @@ public final class LinuxNetworkIFFFM extends LinuxNetworkIF {
                     try (var _ = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
                         String devVendor = UdevFunctions.getPropertyValue(device, "ID_VENDOR_FROM_DATABASE", arena);
                         String devModel = UdevFunctions.getPropertyValue(device, "ID_MODEL_FROM_DATABASE", arena);
-                        if (!Util.isBlank(devModel)) {
-                            if (!Util.isBlank(devVendor)) {
-                                return devVendor + " " + devModel;
-                            }
-                            return devModel;
-                        }
+                        return formatModel(devVendor, devModel, name);
                     }
                 }
             }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
@@ -70,28 +70,7 @@ public final class MacNetworkIfFFM extends MacNetworkIF {
     }
 
     @Override
-    public boolean updateAttributes() {
-        int index = queryNetworkInterface().getIndex();
-        return updateNetworkStats(NetStatFFM.queryIFdata(index));
-    }
-
-    private boolean updateNetworkStats(Map<Integer, IFdata> data) {
-        int index = queryNetworkInterface().getIndex();
-        if (data.containsKey(index)) {
-            IFdata ifData = data.get(index);
-            setIfType(ifData.getIfType());
-            this.bytesSent = ifData.getOBytes();
-            this.bytesRecv = ifData.getIBytes();
-            this.packetsSent = ifData.getOPackets();
-            this.packetsRecv = ifData.getIPackets();
-            this.outErrors = ifData.getOErrors();
-            this.inErrors = ifData.getIErrors();
-            this.collisions = ifData.getCollisions();
-            this.inDrops = ifData.getIDrops();
-            this.speed = ifData.getSpeed();
-            this.timeStamp = ifData.getTimeStamp();
-            return true;
-        }
-        return false;
+    protected Map<Integer, IFdata> queryIFdata(int index) {
+        return NetStatFFM.queryIFdata(index);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
@@ -5,7 +5,7 @@
 package oshi.hardware.platform.windows;
 
 import static org.slf4j.event.Level.ERROR;
-import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -19,62 +19,36 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.windows.IPHlpAPIFFM;
 import oshi.hardware.NetworkIF;
-import oshi.hardware.common.AbstractNetworkIF;
+import oshi.hardware.common.platform.windows.WindowsNetworkIF;
 
 /**
  * WindowsNetworks class using FFM.
  */
 @ThreadSafe
-public final class WindowsNetworkIfFFM extends AbstractNetworkIF {
+public final class WindowsNetworkIfFFM extends WindowsNetworkIF {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsNetworkIfFFM.class);
 
     private static final byte CONNECTOR_PRESENT_BIT = 0b00000100;
 
-    private int ifType;
-    private int ndisPhysicalMediumType;
-    private boolean connectorPresent;
-    private String ifAlias;
-    private IfOperStatus ifOperStatus;
-
     public WindowsNetworkIfFFM(NetworkInterface netint) throws InstantiationException {
         super(netint);
-        updateAttributes();
     }
 
+    /**
+     * Gets all network interfaces on this machine
+     *
+     * @param includeLocalInterfaces include local interfaces in the result
+     * @return A list of {@link NetworkIF} objects representing the interfaces
+     */
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {
         return getNetworks(includeLocalInterfaces, WindowsNetworkIfFFM::new);
     }
 
     @Override
-    public int getIfType() {
-        return this.ifType;
-    }
-
-    @Override
-    public int getNdisPhysicalMediumType() {
-        return this.ndisPhysicalMediumType;
-    }
-
-    @Override
-    public boolean isConnectorPresent() {
-        return this.connectorPresent;
-    }
-
-    @Override
-    public String getIfAlias() {
-        return ifAlias;
-    }
-
-    @Override
-    public IfOperStatus getIfOperStatus() {
-        return ifOperStatus;
-    }
-
-    @Override
-    public boolean updateAttributes() {
+    protected IfStats queryStats() {
         // FFM targets JDK 25+ which requires Vista+; use GetIfEntry2 directly
-        boolean success = callInArenaBooleanOrDefault(arena -> {
+        return callInArenaOrDefault(arena -> {
             MemorySegment ifRow = arena.allocate(IPHlpAPIFFM.MIB_IF_ROW2_SIZE);
             ifRow.fill((byte) 0);
             // Set InterfaceIndex at offset 8
@@ -82,33 +56,30 @@ public final class WindowsNetworkIfFFM extends AbstractNetworkIF {
             if (0 != IPHlpAPIFFM.GetIfEntry2(ifRow)) {
                 LOG.error("Failed to retrieve data for interface {}, {}", queryNetworkInterface().getIndex(),
                         getName());
-                return false;
+                return null;
             }
-            this.ifType = ifRow.get(ValueLayout.JAVA_INT, IPHlpAPIFFM.OFFSET_TYPE);
-            this.ndisPhysicalMediumType = ifRow.get(ValueLayout.JAVA_INT, IPHlpAPIFFM.OFFSET_PHYSICAL_MEDIUM_TYPE);
+            IfStats stats = new IfStats();
+            stats.ifType = ifRow.get(ValueLayout.JAVA_INT, IPHlpAPIFFM.OFFSET_TYPE);
+            stats.ndisPhysicalMediumType = ifRow.get(ValueLayout.JAVA_INT, IPHlpAPIFFM.OFFSET_PHYSICAL_MEDIUM_TYPE);
             byte flags = ifRow.get(ValueLayout.JAVA_BYTE, IPHlpAPIFFM.OFFSET_FLAGS);
-            this.connectorPresent = (flags & CONNECTOR_PRESENT_BIT) > 0;
-            this.speed = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_RECEIVE_LINK_SPEED);
-            this.bytesRecv = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_OCTETS);
-            this.packetsRecv = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_UCAST_PKTS);
-            this.inErrors = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_ERRORS);
-            this.inDrops = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_DISCARDS);
-            this.bytesSent = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_OCTETS);
-            this.packetsSent = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_UCAST_PKTS);
-            this.outErrors = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_ERRORS);
-            this.collisions = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_DISCARDS);
+            stats.connectorPresent = (flags & CONNECTOR_PRESENT_BIT) > 0;
+            stats.speed = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_RECEIVE_LINK_SPEED);
+            stats.bytesRecv = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_OCTETS);
+            stats.packetsRecv = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_UCAST_PKTS);
+            stats.inErrors = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_ERRORS);
+            stats.inDrops = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_IN_DISCARDS);
+            stats.bytesSent = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_OCTETS);
+            stats.packetsSent = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_UCAST_PKTS);
+            stats.outErrors = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_ERRORS);
+            stats.collisions = ifRow.get(ValueLayout.JAVA_LONG, IPHlpAPIFFM.OFFSET_OUT_DISCARDS);
             // Alias is WCHAR[257] at OFFSET_ALIAS
             MemorySegment aliasSlice = ifRow.asSlice(IPHlpAPIFFM.OFFSET_ALIAS, 257 * 2L);
-            this.ifAlias = readWideString(aliasSlice);
+            stats.ifAlias = readWideString(aliasSlice);
             int operStatus = ifRow.get(ValueLayout.JAVA_INT, IPHlpAPIFFM.OFFSET_OPER_STATUS);
-            this.ifOperStatus = IfOperStatus.byValue(operStatus);
-            return true;
+            stats.ifOperStatus = IfOperStatus.byValue(operStatus);
+            return stats;
         }, LOG, ERROR, "Failed to retrieve data for interface " + queryNetworkInterface().getIndex() + ", " + getName(),
-                false);
-        if (success) {
-            this.timeStamp = System.currentTimeMillis();
-        }
-        return success;
+                null);
     }
 
     private static String readWideString(MemorySegment seg) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
@@ -29,8 +29,6 @@ public final class WindowsNetworkIfFFM extends WindowsNetworkIF {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsNetworkIfFFM.class);
 
-    private static final byte CONNECTOR_PRESENT_BIT = 0b00000100;
-
     public WindowsNetworkIfFFM(NetworkInterface netint) throws InstantiationException {
         super(netint);
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxNetworkIFJNA.java
@@ -16,7 +16,6 @@ import com.sun.jna.platform.linux.Udev.UdevDevice;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.NetworkIF;
 import oshi.hardware.common.platform.linux.LinuxNetworkIF;
-import oshi.util.Util;
 import oshi.util.linux.SysPath;
 
 /**
@@ -42,12 +41,7 @@ public final class LinuxNetworkIFJNA extends LinuxNetworkIF {
                     try {
                         String devVendor = device.getPropertyValue("ID_VENDOR_FROM_DATABASE");
                         String devModel = device.getPropertyValue("ID_MODEL_FROM_DATABASE");
-                        if (!Util.isBlank(devModel)) {
-                            if (!Util.isBlank(devVendor)) {
-                                return devVendor + " " + devModel;
-                            }
-                            return devModel;
-                        }
+                        return formatModel(devVendor, devModel, name);
                     } finally {
                         device.unref();
                     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIfJNA.java
@@ -66,28 +66,7 @@ public final class MacNetworkIfJNA extends MacNetworkIF {
     }
 
     @Override
-    public boolean updateAttributes() {
-        int index = queryNetworkInterface().getIndex();
-        return updateNetworkStats(NetStat.queryIFdata(index));
-    }
-
-    private boolean updateNetworkStats(Map<Integer, IFdata> data) {
-        int index = queryNetworkInterface().getIndex();
-        if (data.containsKey(index)) {
-            IFdata ifData = data.get(index);
-            setIfType(ifData.getIfType());
-            this.bytesSent = ifData.getOBytes();
-            this.bytesRecv = ifData.getIBytes();
-            this.packetsSent = ifData.getOPackets();
-            this.packetsRecv = ifData.getIPackets();
-            this.outErrors = ifData.getOErrors();
-            this.inErrors = ifData.getIErrors();
-            this.collisions = ifData.getCollisions();
-            this.inDrops = ifData.getIDrops();
-            this.speed = ifData.getSpeed();
-            this.timeStamp = ifData.getTimeStamp();
-            return true;
-        }
-        return false;
+    protected Map<Integer, IFdata> queryIFdata(int index) {
+        return NetStat.queryIFdata(index);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
@@ -33,7 +33,6 @@ public class WindowsNetworkIfJNA extends WindowsNetworkIF {
     private static final Logger LOG = LoggerFactory.getLogger(WindowsNetworkIfJNA.class);
 
     private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
-    private static final byte CONNECTOR_PRESENT_BIT = 0b00000100;
 
     public WindowsNetworkIfJNA(NetworkInterface netint) throws InstantiationException {
         super(netint);

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
@@ -16,31 +16,27 @@ import com.sun.jna.platform.win32.VersionHelpers;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.NetworkIF;
-import oshi.hardware.common.AbstractNetworkIF;
+import oshi.hardware.common.platform.windows.WindowsNetworkIF;
 import oshi.jna.Struct.CloseableMibIfRow;
 import oshi.jna.Struct.CloseableMibIfRow2;
 import oshi.util.ParseUtil;
 
 /**
  * WindowsNetworks class.
+ * <p>
+ * Not {@code final} so that tests can subclass it to force the {@link #isVistaOrGreater()} version gate and exercise
+ * the pre-Vista {@code MIB_IFROW} query path against the real system.
  */
 @ThreadSafe
-public final class WindowsNetworkIfJNA extends AbstractNetworkIF {
+public class WindowsNetworkIfJNA extends WindowsNetworkIF {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsNetworkIfJNA.class);
 
     private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
     private static final byte CONNECTOR_PRESENT_BIT = 0b00000100;
 
-    private int ifType;
-    private int ndisPhysicalMediumType;
-    private boolean connectorPresent;
-    private String ifAlias;
-    private IfOperStatus ifOperStatus;
-
     public WindowsNetworkIfJNA(NetworkInterface netint) throws InstantiationException {
         super(netint);
-        updateAttributes();
     }
 
     /**
@@ -53,85 +49,71 @@ public final class WindowsNetworkIfJNA extends AbstractNetworkIF {
         return getNetworks(includeLocalInterfaces, WindowsNetworkIfJNA::new);
     }
 
-    @Override
-    public int getIfType() {
-        return this.ifType;
+    /**
+     * Whether {@code MIB_IFROW2} (Vista+) is available. Overridable so tests can force the pre-Vista {@code MIB_IFROW}
+     * path.
+     *
+     * @return {@code true} on Windows Vista or later
+     */
+    protected boolean isVistaOrGreater() {
+        return IS_VISTA_OR_GREATER;
     }
 
     @Override
-    public int getNdisPhysicalMediumType() {
-        return this.ndisPhysicalMediumType;
+    protected IfStats queryStats() {
+        return isVistaOrGreater() ? queryStatsVista() : queryStatsLegacy();
     }
 
-    @Override
-    public boolean isConnectorPresent() {
-        return this.connectorPresent;
-    }
-
-    @Override
-    public String getIfAlias() {
-        return ifAlias;
-    }
-
-    @Override
-    public IfOperStatus getIfOperStatus() {
-        return ifOperStatus;
-    }
-
-    @Override
-    public boolean updateAttributes() {
+    private IfStats queryStatsVista() {
         // MIB_IFROW2 requires Vista (6.0) or later.
-        if (IS_VISTA_OR_GREATER) {
-            // Create new MIB_IFROW2 and set index to this interface index
-            try (CloseableMibIfRow2 ifRow = new CloseableMibIfRow2()) {
-                ifRow.InterfaceIndex = queryNetworkInterface().getIndex();
-                if (0 != IPHlpAPI.INSTANCE.GetIfEntry2(ifRow)) {
-                    // Error, abort
-                    LOG.error("Failed to retrieve data for interface {}, {}", queryNetworkInterface().getIndex(),
-                            getName());
-                    return false;
-                }
-                this.ifType = ifRow.Type;
-                this.ndisPhysicalMediumType = ifRow.PhysicalMediumType;
-                this.connectorPresent = (ifRow.InterfaceAndOperStatusFlags & CONNECTOR_PRESENT_BIT) > 0;
-                this.bytesSent = ifRow.OutOctets;
-                this.bytesRecv = ifRow.InOctets;
-                this.packetsSent = ifRow.OutUcastPkts;
-                this.packetsRecv = ifRow.InUcastPkts;
-                this.outErrors = ifRow.OutErrors;
-                this.inErrors = ifRow.InErrors;
-                this.collisions = ifRow.OutDiscards;
-                this.inDrops = ifRow.InDiscards;
-                this.speed = ifRow.ReceiveLinkSpeed;
-                this.ifAlias = Native.toString(ifRow.Alias);
-                this.ifOperStatus = IfOperStatus.byValue(ifRow.OperStatus);
+        try (CloseableMibIfRow2 ifRow = new CloseableMibIfRow2()) {
+            ifRow.InterfaceIndex = queryNetworkInterface().getIndex();
+            if (0 != IPHlpAPI.INSTANCE.GetIfEntry2(ifRow)) {
+                LOG.error("Failed to retrieve data for interface {}, {}", queryNetworkInterface().getIndex(),
+                        getName());
+                return null;
             }
-        } else {
-            // Create new MIB_IFROW and set index to this interface index
-            try (CloseableMibIfRow ifRow = new CloseableMibIfRow()) {
-                ifRow.dwIndex = queryNetworkInterface().getIndex();
-                if (0 != IPHlpAPI.INSTANCE.GetIfEntry(ifRow)) {
-                    // Error, abort
-                    LOG.error("Failed to retrieve data for interface {}, {}", queryNetworkInterface().getIndex(),
-                            getName());
-                    return false;
-                }
-                this.ifType = ifRow.dwType;
-                // These are unsigned ints. Widen them to longs.
-                this.bytesSent = ParseUtil.unsignedIntToLong(ifRow.dwOutOctets);
-                this.bytesRecv = ParseUtil.unsignedIntToLong(ifRow.dwInOctets);
-                this.packetsSent = ParseUtil.unsignedIntToLong(ifRow.dwOutUcastPkts);
-                this.packetsRecv = ParseUtil.unsignedIntToLong(ifRow.dwInUcastPkts);
-                this.outErrors = ParseUtil.unsignedIntToLong(ifRow.dwOutErrors);
-                this.inErrors = ParseUtil.unsignedIntToLong(ifRow.dwInErrors);
-                this.collisions = ParseUtil.unsignedIntToLong(ifRow.dwOutDiscards);
-                this.inDrops = ParseUtil.unsignedIntToLong(ifRow.dwInDiscards);
-                this.speed = ParseUtil.unsignedIntToLong(ifRow.dwSpeed);
-                this.ifAlias = ""; // not supported by MIB_IFROW
-                this.ifOperStatus = IfOperStatus.UNKNOWN; // not supported
-            }
+            IfStats stats = new IfStats();
+            stats.ifType = ifRow.Type;
+            stats.ndisPhysicalMediumType = ifRow.PhysicalMediumType;
+            stats.connectorPresent = (ifRow.InterfaceAndOperStatusFlags & CONNECTOR_PRESENT_BIT) > 0;
+            stats.bytesSent = ifRow.OutOctets;
+            stats.bytesRecv = ifRow.InOctets;
+            stats.packetsSent = ifRow.OutUcastPkts;
+            stats.packetsRecv = ifRow.InUcastPkts;
+            stats.outErrors = ifRow.OutErrors;
+            stats.inErrors = ifRow.InErrors;
+            stats.collisions = ifRow.OutDiscards;
+            stats.inDrops = ifRow.InDiscards;
+            stats.speed = ifRow.ReceiveLinkSpeed;
+            stats.ifAlias = Native.toString(ifRow.Alias);
+            stats.ifOperStatus = IfOperStatus.byValue(ifRow.OperStatus);
+            return stats;
         }
-        this.timeStamp = System.currentTimeMillis();
-        return true;
+    }
+
+    private IfStats queryStatsLegacy() {
+        // Pre-Vista MIB_IFROW: a narrower field set with unsigned 32-bit counters widened to long. Physical medium
+        // type, connector-present, alias, and oper-status are not available and keep their IfStats defaults.
+        try (CloseableMibIfRow ifRow = new CloseableMibIfRow()) {
+            ifRow.dwIndex = queryNetworkInterface().getIndex();
+            if (0 != IPHlpAPI.INSTANCE.GetIfEntry(ifRow)) {
+                LOG.error("Failed to retrieve data for interface {}, {}", queryNetworkInterface().getIndex(),
+                        getName());
+                return null;
+            }
+            IfStats stats = new IfStats();
+            stats.ifType = ifRow.dwType;
+            stats.bytesSent = ParseUtil.unsignedIntToLong(ifRow.dwOutOctets);
+            stats.bytesRecv = ParseUtil.unsignedIntToLong(ifRow.dwInOctets);
+            stats.packetsSent = ParseUtil.unsignedIntToLong(ifRow.dwOutUcastPkts);
+            stats.packetsRecv = ParseUtil.unsignedIntToLong(ifRow.dwInUcastPkts);
+            stats.outErrors = ParseUtil.unsignedIntToLong(ifRow.dwOutErrors);
+            stats.inErrors = ParseUtil.unsignedIntToLong(ifRow.dwInErrors);
+            stats.collisions = ParseUtil.unsignedIntToLong(ifRow.dwOutDiscards);
+            stats.inDrops = ParseUtil.unsignedIntToLong(ifRow.dwInDiscards);
+            stats.speed = ParseUtil.unsignedIntToLong(ifRow.dwSpeed);
+            return stats;
+        }
     }
 }

--- a/oshi-core/src/test/java/oshi/hardware/platform/windows/WindowsNetworkIfLegacyTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/windows/WindowsNetworkIfLegacyTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import java.net.NetworkInterface;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Exercises the pre-Vista {@code MIB_IFROW} fallback path against the real system by forcing the
+ * {@code isVistaOrGreater()} version gate. CI runners are all Vista+, so that branch is otherwise dead; running the
+ * genuine {@code GetIfEntry} query with only the version flag overridden catches a rotted legacy path (wrong struct
+ * offsets, failed query) as a divergence rather than a coverage number.
+ * <p>
+ * Only {@code ifType} is compared: the two APIs report the same IANA interface type, whereas the byte/packet counters
+ * legitimately differ (pre-Vista {@code MIB_IFROW} uses unsigned 32-bit counters that can wrap) and physical-medium
+ * type / alias / oper-status are simply unavailable in the legacy struct.
+ */
+@EnabledOnOs(OS.WINDOWS)
+class WindowsNetworkIfLegacyTest {
+
+    /** Forces the pre-Vista MIB_IFROW path; the constant override applies during super-construction. */
+    private static final class LegacyNetworkIf extends WindowsNetworkIfJNA {
+        LegacyNetworkIf(NetworkInterface netint) throws InstantiationException {
+            super(netint);
+        }
+
+        @Override
+        protected boolean isVistaOrGreater() {
+            return false;
+        }
+    }
+
+    @Test
+    void legacyMibIfRowPathMatchesModernType() throws Exception {
+        List<NetworkInterface> interfaces = Collections.list(NetworkInterface.getNetworkInterfaces());
+        int exercised = 0;
+        for (NetworkInterface ni : interfaces) {
+            WindowsNetworkIfJNA modern;
+            LegacyNetworkIf legacy;
+            try {
+                modern = new WindowsNetworkIfJNA(ni);
+                legacy = new LegacyNetworkIf(ni);
+            } catch (InstantiationException e) {
+                continue;
+            }
+            // updateAttributes() reports whether the pre-Vista GetIfEntry query succeeded on this real interface
+            if (legacy.updateAttributes()) {
+                exercised++;
+                assertThat("ifType for " + ni.getName(), legacy.getIfType(), is(modern.getIfType()));
+            }
+        }
+        assertThat("pre-Vista MIB_IFROW query succeeded for at least one interface", exercised, greaterThan(0));
+    }
+}


### PR DESCRIPTION
## Summary

Finishes the NetworkIF half of Item 6 — the per-platform native `updateAttributes`/model dedup that the enumeration-loop hoist (#3455) left behind.

## Changes

- **Mac**: `updateNetworkStats(Map<Integer,IFdata>)` was byte-identical across the JNA and FFM twins (both map the shared `IFdata` POJO to fields). Hoist it and `updateAttributes` into `MacNetworkIF` with a `queryIFdata(int)` hook; the twins keep only their native display-name lookup.
- **Linux**: the vendor/model formatting (`"vendor model"` / `"model"` / fallback) was triplicated across both udev twins and the sysfs reader. Extract a shared `formatModel(vendor, model, fallback)` helper into `LinuxNetworkIF`.
- **Windows**: introduce a `WindowsNetworkIF` base with an `IfStats` carrier and a `queryStats()` hook (the Solaris/AIX pattern), hoisting the five interface-detail getters, fields, and `updateAttributes` out of both twins. The JNA `MIB_IFROW2` (Vista+) vs pre-Vista `MIB_IFROW` selection becomes an overridable `isVistaOrGreater()` **seam**, and `WindowsNetworkIfJNA` is no longer `final` so a test can force the legacy path.
- Added `WindowsNetworkIF`'s public `IfStats` POJO to the checkstyle `VisibilityModifier` suppressions (same as Solaris/AIX `IfStats`).

## Vista legacy test

`WindowsNetworkIfLegacyTest` (Windows-only) forces `isVistaOrGreater()` off and runs the **real** `GetIfEntry` (`MIB_IFROW`) query against every interface, asserting the pre-Vista path succeeds for at least one and reports the same `ifType` as the modern `MIB_IFROW2` path. Only `ifType` is compared — the byte/packet counters legitimately differ (pre-Vista uses unsigned 32-bit counters that wrap) and physical-medium/alias/oper-status aren't in the legacy struct. This is the #3454 pattern applied to a branch that's been dead on CI for ~15 years; **a red result here means we found a real bug in that path.**

## Behavior

No user-facing change. Net raw LOC is up (+120) because the new Windows base scaffolding + the 65-line legacy test are additions; the *duplication* (Mac stats ×2, Linux format ×3, Windows getters/updateAttributes ×2) is collapsed to single-source.

## Testing

- spotless / checkstyle / forbiddenapis / javadoc: clean
- Clean full-reactor `install`: BUILD SUCCESS, 0 tests failed
- `NativeComparisonTest.networkIfUpdateAttributes()` JNA==FFM: passes on macOS
- The pre-Vista Windows path is validated by the Windows CI runners here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Windows network interface reporting with shared stats handling across modern and legacy querying paths.

* **Bug Fixes**
  * Improved vendor/model network interface display name formatting with consistent handling of blank values and fallbacks (Linux and FFM/JNA variants).
  * Refined macOS network statistics refresh so interface stats are populated consistently from shared per-interface data.
  * Updated Windows JNA/FFM network attribute collection to use the unified stats mechanism for more consistent results.

* **Tests**
  * Added legacy Windows network interface statistics coverage to validate legacy querying behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->