### PR TITLE
Dedup Windows CentralProcessor frequency queries; fix JNA numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#3442](https://github.com/oshi/oshi/pull/3442): Convert static memoized suppliers to instance fields, allowing cached data to be reclaimed when users create new `SystemInfo` instances - [@dbwiddis](https://github.com/dbwiddis).
 * [#3443](https://github.com/oshi/oshi/pull/3443): Share memoized iostat supplier across disk instances; cache pluggable hardware lists (displays, USB, sound cards, graphics cards) in the HAL with a 3-second TTL - [@dbwiddis](https://github.com/dbwiddis).
 * [#3444](https://github.com/oshi/oshi/pull/3444): Consolidate try/catch-log-return-default patterns to use `ExceptionUtil` - [@dbwiddis](https://github.com/dbwiddis).
+* [#3459](https://github.com/oshi/oshi/pull/3459): Deduplicate the Windows `CentralProcessor` frequency queries into the shared base, and fix the JNA per-processor current-frequency numbering, which mis-assigned frequencies to logical processors on multi-processor-group/NUMA systems - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -6,6 +6,7 @@ package oshi.hardware.common.platform.windows;
 
 import static oshi.util.Memoizer.memoize;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -15,6 +16,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorFrequencyProperty;
+import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorPerformanceProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorTickCountProperty;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorUtilityTickCountProperty;
 import oshi.hardware.common.AbstractCentralProcessor;
@@ -61,20 +64,30 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
             : null;
 
     /**
-     * Checks whether the OS version is Windows 8 or greater using system property 'os.version'.
+     * Checks whether the OS version is at least the given Windows {@code major.minor} using system property
+     * 'os.version', without requiring native access.
+     *
+     * @param major the minimum major version
+     * @param minor the minimum minor version
+     * @return true if the OS version is at least {@code major.minor}
+     */
+    private static boolean isWindowsVersionOrGreater(int major, int minor) {
+        String[] parts = System.getProperty("os.version", "").split("\\.");
+        if (parts.length >= 2) {
+            int osMajor = ParseUtil.parseIntOrDefault(parts[0], 0);
+            int osMinor = ParseUtil.parseIntOrDefault(parts[1], 0);
+            return osMajor > major || (osMajor == major && osMinor >= minor);
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether the OS version is Windows 8 or greater.
      *
      * @return true if Windows 8 or greater
      */
     private static boolean isWindows8OrGreater() {
-        // Use system property check that works without native access
-        String osVersion = System.getProperty("os.version", "");
-        String[] parts = osVersion.split("\\.");
-        if (parts.length >= 2) {
-            int major = ParseUtil.parseIntOrDefault(parts[0], 0);
-            int minor = ParseUtil.parseIntOrDefault(parts[1], 0);
-            return major > 6 || (major == 6 && minor >= 2);
-        }
-        return false;
+        return isWindowsVersionOrGreater(6, 2);
     }
 
     /**
@@ -194,6 +207,99 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @return the instance names and processor tick counter values
      */
     protected abstract Pair<List<String>, Map<ProcessorTickCountProperty, List<Long>>> queryProcessorCounters();
+
+    /**
+     * Subclasses query the Processor Performance (% Processor Performance) counters via their JNA or FFM driver.
+     *
+     * @return the instance names and processor performance counter values
+     */
+    protected abstract Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> queryProcessorPerformanceCounters();
+
+    /**
+     * Subclasses query the Processor Frequency (% of Maximum Frequency) counters via their JNA or FFM driver.
+     *
+     * @return the instance names and processor frequency counter values
+     */
+    protected abstract Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> queryFrequencyCounters();
+
+    /**
+     * Subclasses call {@code CallNtPowerInformation} for Processor information, returning the requested field for each
+     * logical processor.
+     *
+     * @param fieldIndex the field index (1 = max MHz, 2 = current MHz)
+     * @return the array of frequency values, in Hz
+     */
+    protected abstract long[] queryNTPower(int fieldIndex);
+
+    /**
+     * Checks whether the OS version is Windows 7 or greater.
+     *
+     * @return true if Windows 7 or greater
+     */
+    private static boolean isWindows7OrGreater() {
+        return isWindowsVersionOrGreater(6, 1);
+    }
+
+    @Override
+    public long[] queryCurrentFreq() {
+        if (isWindows7OrGreater()) {
+            long maxFreq = this.getMaxFreq();
+            if (maxFreq > 0) {
+                // Prefer % Processor Performance from WMI formatted table (Win8+, reports >100% with turbo)
+                Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> perfPair = queryProcessorPerformanceCounters();
+                List<Long> perfList = perfPair.getB().get(ProcessorPerformanceProperty.PERCENTPROCESSORPERFORMANCE);
+                long[] freqs = mapPercentToFreqs(perfPair.getA(), perfList, maxFreq);
+                if (freqs != null) {
+                    return freqs;
+                }
+                // Fall back to % of Maximum Frequency (Win7, caps at 100%)
+                Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> freqPair = queryFrequencyCounters();
+                List<Long> percentMaxList = freqPair.getB().get(ProcessorFrequencyProperty.PERCENTOFMAXIMUMFREQUENCY);
+                freqs = mapPercentToFreqs(freqPair.getA(), percentMaxList, maxFreq);
+                if (freqs != null) {
+                    return freqs;
+                }
+            }
+        }
+        // If <Win7 or anything failed in PDH/WMI, use the native call
+        return queryNTPower(2); // Current is field index 2
+    }
+
+    private long[] mapPercentToFreqs(List<String> instances, List<Long> percentList, long maxFreq) {
+        if (instances.isEmpty() || percentList == null) {
+            return null;
+        }
+        long[] freqs = new long[getLogicalProcessorCount()];
+        boolean populated = false;
+        // instances and percentList are parallel lists; read by position i and map the instance name to the logical
+        // processor index the same way processTickData does (numa "group,proc" via the map, else the plain number).
+        for (int i = 0; i < instances.size(); i++) {
+            String instance = instances.get(i);
+            int cpu;
+            if (instance.contains(",")) {
+                if (!getNumaNodeProcToLogicalProcMap().containsKey(instance)) {
+                    continue;
+                }
+                cpu = getNumaNodeProcToLogicalProcMap().get(instance);
+            } else {
+                cpu = ParseUtil.parseIntOrDefault(instance, -1);
+            }
+            if (cpu < 0 || cpu >= getLogicalProcessorCount() || i >= percentList.size()) {
+                continue;
+            }
+            freqs[cpu] = percentList.get(i) * maxFreq / 100L;
+            if (freqs[cpu] > 0) {
+                populated = true;
+            }
+        }
+        return populated ? freqs : null;
+    }
+
+    @Override
+    public long queryMaxFreq() {
+        long[] freqs = queryNTPower(1); // Max is field index 1
+        return Arrays.stream(freqs).max().orElse(-1L);
+    }
 
     @Override
     public long[][] queryProcessorCpuLoadTicks() {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
@@ -33,12 +33,10 @@ import oshi.driver.windows.wmi.Win32ProcessorFFM;
 import oshi.ffm.NativeHandle;
 import oshi.ffm.platform.windows.Advapi32FFM;
 import oshi.ffm.platform.windows.Kernel32FFM;
-import oshi.ffm.platform.windows.VersionHelpersFFM;
 import oshi.ffm.platform.windows.WinNTFFM;
 import oshi.ffm.platform.windows.WinRegFFM;
 import oshi.ffm.platform.windows.WindowsForeignFunctions;
 import oshi.hardware.common.platform.windows.WindowsCentralProcessor;
-import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Quartet;
 import oshi.util.tuples.Triplet;
@@ -206,66 +204,17 @@ final class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
     }
 
     @Override
-    public long[] queryCurrentFreq() {
-        if (VersionHelpersFFM.IsWindows7OrGreater()) {
-            long maxFreq = this.getMaxFreq();
-            if (maxFreq > 0) {
-                // Prefer % Processor Performance from WMI formatted table (Win8+, reports >100% with turbo)
-                Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> perfPair = ProcessorInformationFFM
-                        .queryProcessorPerformanceCounters();
-                List<Long> perfList = perfPair.getB().get(ProcessorPerformanceProperty.PERCENTPROCESSORPERFORMANCE);
-                long[] freqs = mapPercentToFreqs(perfPair.getA(), perfList, maxFreq);
-                if (freqs != null) {
-                    return freqs;
-                }
-                // Fall back to % of Maximum Frequency (Win7, caps at 100%)
-                Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> freqPair = ProcessorInformationFFM
-                        .queryFrequencyCounters();
-                List<Long> percentMaxList = freqPair.getB().get(ProcessorFrequencyProperty.PERCENTOFMAXIMUMFREQUENCY);
-                freqs = mapPercentToFreqs(freqPair.getA(), percentMaxList, maxFreq);
-                if (freqs != null) {
-                    return freqs;
-                }
-            }
-        }
-        return queryNTPower(2);
-    }
-
-    private long[] mapPercentToFreqs(List<String> instances, List<Long> percentList, long maxFreq) {
-        if (instances.isEmpty() || percentList == null) {
-            return null;
-        }
-        long[] freqs = new long[getLogicalProcessorCount()];
-        boolean populated = false;
-        for (int i = 0; i < instances.size(); i++) {
-            String instance = instances.get(i);
-            int cpu;
-            if (instance.contains(",")) {
-                if (!getNumaNodeProcToLogicalProcMap().containsKey(instance)) {
-                    continue;
-                }
-                cpu = getNumaNodeProcToLogicalProcMap().get(instance);
-            } else {
-                cpu = ParseUtil.parseIntOrDefault(instance, -1);
-            }
-            if (cpu < 0 || cpu >= getLogicalProcessorCount() || i >= percentList.size()) {
-                continue;
-            }
-            freqs[cpu] = percentList.get(i) * maxFreq / 100L;
-            if (freqs[cpu] > 0) {
-                populated = true;
-            }
-        }
-        return populated ? freqs : null;
+    protected Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> queryProcessorPerformanceCounters() {
+        return ProcessorInformationFFM.queryProcessorPerformanceCounters();
     }
 
     @Override
-    public long queryMaxFreq() {
-        long[] freqs = queryNTPower(1);
-        return Arrays.stream(freqs).max().orElse(-1L);
+    protected Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> queryFrequencyCounters() {
+        return ProcessorInformationFFM.queryFrequencyCounters();
     }
 
-    private long[] queryNTPower(int fieldIndex) {
+    @Override
+    protected long[] queryNTPower(int fieldIndex) {
         long[] freqs = new long[getLogicalProcessorCount()];
         int totalSize = PPI_SIZE * freqs.length;
         try (Arena arena = Arena.ofConfined()) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorJNA.java
@@ -42,7 +42,6 @@ import oshi.jna.platform.windows.Kernel32;
 import oshi.jna.platform.windows.Kernel32.ProcessorFeature;
 import oshi.jna.platform.windows.PowrProf;
 import oshi.jna.platform.windows.PowrProf.ProcessorPowerInformation;
-import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Quartet;
 import oshi.util.tuples.Triplet;
@@ -181,65 +180,17 @@ final class WindowsCentralProcessorJNA extends WindowsCentralProcessor {
     }
 
     @Override
-    public long[] queryCurrentFreq() {
-        if (VersionHelpers.IsWindows7OrGreater()) {
-            long maxFreq = this.getMaxFreq();
-            if (maxFreq > 0) {
-                // Prefer % Processor Performance from WMI formatted table (Win8+, reports >100% with turbo)
-                Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> perfPair = ProcessorInformationJNA
-                        .queryProcessorPerformanceCounters();
-                List<Long> perfList = perfPair.getB().get(ProcessorPerformanceProperty.PERCENTPROCESSORPERFORMANCE);
-                long[] freqs = mapPercentToFreqs(perfPair.getA(), perfList, maxFreq);
-                if (freqs != null) {
-                    return freqs;
-                }
-                // Fall back to % of Maximum Frequency (Win7, caps at 100%)
-                Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> freqPair = ProcessorInformationJNA
-                        .queryFrequencyCounters();
-                List<Long> percentMaxList = freqPair.getB().get(ProcessorFrequencyProperty.PERCENTOFMAXIMUMFREQUENCY);
-                freqs = mapPercentToFreqs(freqPair.getA(), percentMaxList, maxFreq);
-                if (freqs != null) {
-                    return freqs;
-                }
-            }
-        }
-        // If <Win7 or anything failed in PDH/WMI, use the native call
-        return queryNTPower(2); // Current is field index 2
-    }
-
-    private long[] mapPercentToFreqs(List<String> instances, List<Long> percentList, long maxFreq) {
-        if (instances.isEmpty() || percentList == null) {
-            return null;
-        }
-        long[] freqs = new long[getLogicalProcessorCount()];
-        boolean populated = false;
-        for (String instance : instances) {
-            int cpu = instance.contains(",") ? getNumaNodeProcToLogicalProcMap().getOrDefault(instance, 0)
-                    : ParseUtil.parseIntOrDefault(instance, 0);
-            if (cpu >= getLogicalProcessorCount()) {
-                continue;
-            }
-            freqs[cpu] = percentList.get(cpu) * maxFreq / 100L;
-            if (freqs[cpu] > 0) {
-                populated = true;
-            }
-        }
-        return populated ? freqs : null;
+    protected Pair<List<String>, Map<ProcessorPerformanceProperty, List<Long>>> queryProcessorPerformanceCounters() {
+        return ProcessorInformationJNA.queryProcessorPerformanceCounters();
     }
 
     @Override
-    public long queryMaxFreq() {
-        long[] freqs = queryNTPower(1); // Max is field index 1
-        return Arrays.stream(freqs).max().orElse(-1L);
+    protected Pair<List<String>, Map<ProcessorFrequencyProperty, List<Long>>> queryFrequencyCounters() {
+        return ProcessorInformationJNA.queryFrequencyCounters();
     }
 
-    /**
-     * Call CallNTPowerInformation for Processor information and return an array of the specified index
-     *
-     * @param fieldIndex The field, in order as defined in the {@link PowrProf#PROCESSOR_INFORMATION} structure.
-     * @return The array of values.
-     */
-    private long[] queryNTPower(int fieldIndex) {
+    @Override
+    protected long[] queryNTPower(int fieldIndex) {
         ProcessorPowerInformation ppi = new ProcessorPowerInformation();
         ProcessorPowerInformation[] ppiArray = (ProcessorPowerInformation[]) ppi.toArray(getLogicalProcessorCount());
         long[] freqs = new long[getLogicalProcessorCount()];


### PR DESCRIPTION
## Summary

First slice of Item 7 (CentralProcessor) in the cross-OS dedup audit, kept small because it also fixes a bug.

`queryCurrentFreq()`, `mapPercentToFreqs()`, and `queryMaxFreq()` were duplicated across the Windows JNA and FFM `CentralProcessor` twins. Hoist them into the shared `WindowsCentralProcessor` base, with abstract hooks for the genuinely backend-specific pieces:
- `queryProcessorPerformanceCounters()` / `queryFrequencyCounters()` — the `ProcessorInformationJNA`/`FFM` PDH/WMI drivers
- `queryNTPower(int)` — the `PowrProf`/FFM `CallNtPowerInformation` native call

The Win7 version check moves to a native-free `isWindows7OrGreater()` (system-property based, matching the existing `isWindows8OrGreater()`).

## Bug fix (JNA per-processor frequency numbering)

The two twins' `mapPercentToFreqs` had **diverged**. The perfmon query returns `instances` and `percentList` as *parallel* lists, and the shared usage-tick mapper `processTickData()` (hardened during [#1373](https://github.com/oshi/oshi/issues/1373)) reads them by position and maps each instance name to a logical processor via the NUMA map. The FFM frequency code matched that; the **JNA** version (added in #3233) instead indexed `percentList` by the *computed CPU number* and defaulted unmapped NUMA instances to CPU 0.

On ordinary single-group systems (instances `"0".."N-1"` in order, no NUMA) the two are identical, which is why it went unnoticed. On **multi-processor-group / NUMA systems** (>64 logical processors, or multi-socket), the JNA path assigned current frequencies to the wrong logical processors (and could clobber CPU 0).

This unifies both backends on the positional numbering used by `processTickData` and the FFM code, **fixing the JNA path**. CHANGELOG updated.

## Behavior

FFM is unchanged; the JNA per-processor current-frequency numbering is corrected on NUMA/multi-group systems. Both backends now run identical frequency code, so `NativeComparisonTest.processorFrequencies()` compares like-for-like.

## Testing

- spotless / checkstyle / forbiddenapis / javadoc: clean
- Clean full-reactor `install`: BUILD SUCCESS, 0 tests failed
- Windows-frequency JNA==FFM parity runs on the Windows CI runner (developed on macOS)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows CPU frequency reporting by deduplicating CentralProcessor frequency queries.
  * Corrected per-processor current-frequency numbering on multi-processor-group/NUMA systems to align with JNA behavior.
  * Enhanced current and maximum CPU frequency detection on Windows 7+ using perf counter–based mapping with reliable fallbacks when counter data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->