### PR TITLE
Dedup FreeBSD CentralProcessor tick/load queries into the base

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -30,6 +30,14 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
     private static final Pattern CPUMASK = Pattern
             .compile(".*<cpu\\s.*mask=\"(\\p{XDigit}+(,\\p{XDigit}+)*)\".*>.*</cpu>.*");
 
+    // FreeBSD CPU state indices into the kern.cp_time / kern.cp_times uint64 arrays
+    private static final int CP_USER = 0;
+    private static final int CP_NICE = 1;
+    private static final int CP_SYS = 2;
+    private static final int CP_INTR = 3;
+    private static final int CP_IDLE = 4;
+    private static final int CPUSTATES = 5;
+
     /**
      * Reads a string sysctl value.
      *
@@ -47,6 +55,99 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
      * @return the sysctl long value or the default
      */
     protected abstract long sysctlLong(String name, long def);
+
+    /**
+     * Reads an int sysctl value.
+     *
+     * @param name the sysctl name
+     * @param def  the default value
+     * @return the sysctl int value or the default
+     */
+    protected abstract int sysctlInt(String name, int def);
+
+    /**
+     * Reads a sysctl whose value is an array of {@code uint64} values, e.g. {@code kern.cp_time} (per-system) or
+     * {@code kern.cp_times} (per-CPU).
+     *
+     * @param name the sysctl name
+     * @return the values as a {@code long[]}, or {@code null} if the query failed
+     */
+    protected abstract long[] queryCpTimes(String name);
+
+    /**
+     * Native {@code getloadavg(3)} call, filling {@code loadavg} with up to {@code nelem} samples.
+     *
+     * @param loadavg the array to populate
+     * @param nelem   the number of elements requested
+     * @return the number of samples retrieved
+     */
+    protected abstract int getloadavgNative(double[] loadavg, int nelem);
+
+    /**
+     * Maps the five FreeBSD CPU-state values starting at {@code offset} in {@code cpTimeArray} to the corresponding
+     * {@link TickType} slots of {@code ticks}.
+     *
+     * @param ticks       the destination tick array
+     * @param cpTimeArray the source uint64 values
+     * @param offset      the starting index of this CPU's states within {@code cpTimeArray}
+     */
+    private static void fillTicks(long[] ticks, long[] cpTimeArray, int offset) {
+        ticks[TickType.USER.getIndex()] = cpTimeArray[offset + CP_USER];
+        ticks[TickType.NICE.getIndex()] = cpTimeArray[offset + CP_NICE];
+        ticks[TickType.SYSTEM.getIndex()] = cpTimeArray[offset + CP_SYS];
+        ticks[TickType.IRQ.getIndex()] = cpTimeArray[offset + CP_INTR];
+        ticks[TickType.IDLE.getIndex()] = cpTimeArray[offset + CP_IDLE];
+    }
+
+    @Override
+    public long[] querySystemCpuLoadTicks() {
+        long[] ticks = new long[TickType.values().length];
+        long[] cpTime = queryCpTimes("kern.cp_time");
+        if (cpTime == null || cpTime.length < CPUSTATES) {
+            return ticks;
+        }
+        fillTicks(ticks, cpTime, 0);
+        return ticks;
+    }
+
+    @Override
+    public long[][] queryProcessorCpuLoadTicks() {
+        long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
+        long[] cpTimes = queryCpTimes("kern.cp_times");
+        if (cpTimes == null) {
+            return ticks;
+        }
+        int cpus = Math.min(getLogicalProcessorCount(), cpTimes.length / CPUSTATES);
+        for (int cpu = 0; cpu < cpus; cpu++) {
+            fillTicks(ticks[cpu], cpTimes, cpu * CPUSTATES);
+        }
+        return ticks;
+    }
+
+    @Override
+    public double[] getSystemLoadAverage(int nelem) {
+        if (nelem < 1 || nelem > 3) {
+            throw new IllegalArgumentException("Must include from one to three elements.");
+        }
+        double[] average = new double[nelem];
+        int retval = getloadavgNative(average, nelem);
+        if (retval < nelem) {
+            for (int i = Math.max(retval, 0); i < average.length; i++) {
+                average[i] = -1d;
+            }
+        }
+        return average;
+    }
+
+    @Override
+    public long queryContextSwitches() {
+        return ParseUtil.unsignedIntToLong(sysctlInt("vm.stats.sys.v_swtch", 0));
+    }
+
+    @Override
+    public long queryInterrupts() {
+        return ParseUtil.unsignedIntToLong(sysctlInt("vm.stats.sys.v_intr", 0));
+    }
 
     @Override
     protected ProcessorIdentifier queryProcessorId() {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorFFM.java
@@ -6,9 +6,8 @@ package oshi.hardware.platform.unix.freebsd;
 
 import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
 import org.slf4j.Logger;
@@ -19,7 +18,6 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
 import oshi.hardware.common.platform.unix.freebsd.FreeBsdCentralProcessor;
-import oshi.util.ParseUtil;
 
 /**
  * FFM-backed FreeBSD central processor.
@@ -28,16 +26,6 @@ import oshi.util.ParseUtil;
 public class FreeBsdCentralProcessorFFM extends FreeBsdCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(FreeBsdCentralProcessorFFM.class);
-
-    // FreeBSD CPU state indices into kern.cp_time / kern.cp_times arrays
-    private static final int CP_USER = 0;
-    private static final int CP_NICE = 1;
-    private static final int CP_SYS = 2;
-    private static final int CP_INTR = 3;
-    private static final int CP_IDLE = 4;
-    private static final int CPUSTATES = 5;
-    private static final long UINT64_SIZE = Long.BYTES;
-    private static final long CPTIME_SIZE = CPUSTATES * UINT64_SIZE;
 
     @Override
     protected String sysctlString(String name, String def) {
@@ -50,72 +38,33 @@ public class FreeBsdCentralProcessorFFM extends FreeBsdCentralProcessor {
     }
 
     @Override
-    public long[] querySystemCpuLoadTicks() {
-        long[] ticks = new long[TickType.values().length];
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment cpTime = arena.allocate(CPTIME_SIZE);
-            if (BsdSysctlUtilFFM.sysctl("kern.cp_time", cpTime)) {
-                ticks[TickType.USER.getIndex()] = cpTime.getAtIndex(JAVA_LONG, CP_USER);
-                ticks[TickType.NICE.getIndex()] = cpTime.getAtIndex(JAVA_LONG, CP_NICE);
-                ticks[TickType.SYSTEM.getIndex()] = cpTime.getAtIndex(JAVA_LONG, CP_SYS);
-                ticks[TickType.IRQ.getIndex()] = cpTime.getAtIndex(JAVA_LONG, CP_INTR);
-                ticks[TickType.IDLE.getIndex()] = cpTime.getAtIndex(JAVA_LONG, CP_IDLE);
-            }
-        }
-        return ticks;
+    protected int sysctlInt(String name, int def) {
+        return BsdSysctlUtilFFM.sysctl(name, def);
     }
 
     @Override
-    public double[] getSystemLoadAverage(int nelem) {
-        if (nelem < 1 || nelem > 3) {
-            throw new IllegalArgumentException("Must include from one to three elements.");
-        }
-        final int n = nelem;
-        return callInArenaOrDefault(arena -> {
-            MemorySegment avg = arena.allocate(JAVA_DOUBLE, n);
-            int retval = FreeBsdLibcFunctions.getloadavg(avg, n);
-            double[] result = new double[n];
-            for (int i = 0; i < n; i++) {
-                result[i] = (i < retval) ? avg.getAtIndex(JAVA_DOUBLE, i) : -1d;
-            }
-            return result;
-        }, LOG, Level.WARN, "Failed to read load average", fillNegative(nelem));
-    }
-
-    private static double[] fillNegative(int nelem) {
-        double[] arr = new double[nelem];
-        for (int i = 0; i < nelem; i++) {
-            arr[i] = -1d;
-        }
-        return arr;
-    }
-
-    @Override
-    public long[][] queryProcessorCpuLoadTicks() {
-        int cpus = getLogicalProcessorCount();
-        long[][] ticks = new long[cpus][TickType.values().length];
-        MemorySegment buf = BsdSysctlUtilFFM.sysctl("kern.cp_times");
+    protected long[] queryCpTimes(String name) {
+        MemorySegment buf = BsdSysctlUtilFFM.sysctl(name);
         if (buf == null) {
-            return ticks;
+            return null;
         }
-        for (int cpu = 0; cpu < cpus; cpu++) {
-            long base = CPTIME_SIZE * cpu;
-            ticks[cpu][TickType.USER.getIndex()] = buf.get(JAVA_LONG, base + CP_USER * UINT64_SIZE);
-            ticks[cpu][TickType.NICE.getIndex()] = buf.get(JAVA_LONG, base + CP_NICE * UINT64_SIZE);
-            ticks[cpu][TickType.SYSTEM.getIndex()] = buf.get(JAVA_LONG, base + CP_SYS * UINT64_SIZE);
-            ticks[cpu][TickType.IRQ.getIndex()] = buf.get(JAVA_LONG, base + CP_INTR * UINT64_SIZE);
-            ticks[cpu][TickType.IDLE.getIndex()] = buf.get(JAVA_LONG, base + CP_IDLE * UINT64_SIZE);
+        int count = (int) (buf.byteSize() / Long.BYTES);
+        long[] result = new long[count];
+        for (int i = 0; i < count; i++) {
+            result[i] = buf.getAtIndex(JAVA_LONG, i);
         }
-        return ticks;
+        return result;
     }
 
     @Override
-    public long queryContextSwitches() {
-        return ParseUtil.unsignedIntToLong(BsdSysctlUtilFFM.sysctl("vm.stats.sys.v_swtch", 0));
-    }
-
-    @Override
-    public long queryInterrupts() {
-        return ParseUtil.unsignedIntToLong(BsdSysctlUtilFFM.sysctl("vm.stats.sys.v_intr", 0));
+    protected int getloadavgNative(double[] loadavg, int nelem) {
+        return callInArenaIntOrDefault(arena -> {
+            MemorySegment avg = arena.allocate(JAVA_DOUBLE, nelem);
+            int retval = FreeBsdLibcFunctions.getloadavg(avg, nelem);
+            for (int i = 0; i < nelem && i < retval; i++) {
+                loadavg[i] = avg.getAtIndex(JAVA_DOUBLE, i);
+            }
+            return retval;
+        }, LOG, Level.WARN, "Failed to read load average", 0);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdCentralProcessorJNA.java
@@ -4,19 +4,11 @@
  */
 package oshi.hardware.platform.unix.freebsd;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sun.jna.Memory;
-import com.sun.jna.Native;
-import com.sun.jna.platform.unix.LibCAPI.size_t;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.platform.unix.freebsd.FreeBsdCentralProcessor;
-import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.FreeBsdLibc;
-import oshi.jna.platform.unix.FreeBsdLibc.CpTime;
-import oshi.util.ParseUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
 
 /**
@@ -24,15 +16,6 @@ import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
  */
 @ThreadSafe
 public class FreeBsdCentralProcessorJNA extends FreeBsdCentralProcessor {
-
-    private static final Logger LOG = LoggerFactory.getLogger(FreeBsdCentralProcessorJNA.class);
-
-    private static final long CPTIME_SIZE;
-    static {
-        try (CpTime cpTime = new CpTime()) {
-            CPTIME_SIZE = cpTime.size();
-        }
-    }
 
     @Override
     protected String sysctlString(String name, String def) {
@@ -45,86 +28,27 @@ public class FreeBsdCentralProcessorJNA extends FreeBsdCentralProcessor {
     }
 
     @Override
-    public long[] querySystemCpuLoadTicks() {
-        long[] ticks = new long[TickType.values().length];
-        try (CpTime cpTime = new CpTime()) {
-            BsdSysctlUtil.sysctl("kern.cp_time", cpTime);
-            ticks[TickType.USER.getIndex()] = cpTime.cpu_ticks[FreeBsdLibc.CP_USER];
-            ticks[TickType.NICE.getIndex()] = cpTime.cpu_ticks[FreeBsdLibc.CP_NICE];
-            ticks[TickType.SYSTEM.getIndex()] = cpTime.cpu_ticks[FreeBsdLibc.CP_SYS];
-            ticks[TickType.IRQ.getIndex()] = cpTime.cpu_ticks[FreeBsdLibc.CP_INTR];
-            ticks[TickType.IDLE.getIndex()] = cpTime.cpu_ticks[FreeBsdLibc.CP_IDLE];
-        }
-        return ticks;
+    protected int sysctlInt(String name, int def) {
+        return BsdSysctlUtil.sysctl(name, def);
     }
 
     @Override
-    public double[] getSystemLoadAverage(int nelem) {
-        if (nelem < 1 || nelem > 3) {
-            throw new IllegalArgumentException("Must include from one to three elements.");
-        }
-        double[] average = new double[nelem];
-        int retval = FreeBsdLibc.INSTANCE.getloadavg(average, nelem);
-        if (retval < nelem) {
-            for (int i = Math.max(retval, 0); i < average.length; i++) {
-                average[i] = -1d;
+    protected long[] queryCpTimes(String name) {
+        try (Memory p = BsdSysctlUtil.sysctl(name)) {
+            if (p == null) {
+                return null;
             }
-        }
-        return average;
-    }
-
-    @Override
-    public long[][] queryProcessorCpuLoadTicks() {
-        long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
-
-        // Allocate memory for array of CPTime
-        long arraySize = CPTIME_SIZE * getLogicalProcessorCount();
-        try (Memory p = new Memory(arraySize);
-                CloseableSizeTByReference oldlenp = new CloseableSizeTByReference(arraySize)) {
-            String name = "kern.cp_times";
-            // Fetch
-            if (0 != FreeBsdLibc.INSTANCE.sysctlbyname(name, p, oldlenp, null, size_t.ZERO)) {
-                LOG.error("Failed sysctl call: {}, Error code: {}", name, Native.getLastError());
-                return ticks;
+            int count = (int) (p.size() / Long.BYTES);
+            long[] result = new long[count];
+            for (int i = 0; i < count; i++) {
+                result[i] = p.getLong((long) i * Long.BYTES);
             }
-            // p now points to the data; need to copy each element
-            for (int cpu = 0; cpu < getLogicalProcessorCount(); cpu++) {
-                ticks[cpu][TickType.USER.getIndex()] = p
-                        .getLong(CPTIME_SIZE * cpu + FreeBsdLibc.CP_USER * FreeBsdLibc.UINT64_SIZE); // lgtm
-                ticks[cpu][TickType.NICE.getIndex()] = p
-                        .getLong(CPTIME_SIZE * cpu + FreeBsdLibc.CP_NICE * FreeBsdLibc.UINT64_SIZE); // lgtm
-                ticks[cpu][TickType.SYSTEM.getIndex()] = p
-                        .getLong(CPTIME_SIZE * cpu + FreeBsdLibc.CP_SYS * FreeBsdLibc.UINT64_SIZE); // lgtm
-                ticks[cpu][TickType.IRQ.getIndex()] = p
-                        .getLong(CPTIME_SIZE * cpu + FreeBsdLibc.CP_INTR * FreeBsdLibc.UINT64_SIZE); // lgtm
-                ticks[cpu][TickType.IDLE.getIndex()] = p
-                        .getLong(CPTIME_SIZE * cpu + FreeBsdLibc.CP_IDLE * FreeBsdLibc.UINT64_SIZE); // lgtm
-            }
-        }
-        return ticks;
-    }
-
-    @Override
-    public long queryContextSwitches() {
-        String name = "vm.stats.sys.v_swtch";
-        size_t.ByReference size = new size_t.ByReference(new size_t(FreeBsdLibc.INT_SIZE));
-        try (Memory p = new Memory(size.longValue())) {
-            if (0 != FreeBsdLibc.INSTANCE.sysctlbyname(name, p, size, null, size_t.ZERO)) {
-                return 0L;
-            }
-            return ParseUtil.unsignedIntToLong(p.getInt(0));
+            return result;
         }
     }
 
     @Override
-    public long queryInterrupts() {
-        String name = "vm.stats.sys.v_intr";
-        size_t.ByReference size = new size_t.ByReference(new size_t(FreeBsdLibc.INT_SIZE));
-        try (Memory p = new Memory(size.longValue())) {
-            if (0 != FreeBsdLibc.INSTANCE.sysctlbyname(name, p, size, null, size_t.ZERO)) {
-                return 0L;
-            }
-            return ParseUtil.unsignedIntToLong(p.getInt(0));
-        }
+    protected int getloadavgNative(double[] loadavg, int nelem) {
+        return FreeBsdLibc.INSTANCE.getloadavg(loadavg, nelem);
     }
 }


### PR DESCRIPTION
## Summary

Continues Item 7 (CentralProcessor) in the cross-OS dedup audit. The FreeBSD JNA and FFM twins each carried a full copy of the CPU tick / load-average / context-switch / interrupt queries, differing only in native access (JNA `Memory`/`CpTime` struct vs FFM `MemorySegment`/`Arena`).

## Changes

Hoist all five methods — `querySystemCpuLoadTicks`, `queryProcessorCpuLoadTicks`, `getSystemLoadAverage`, `queryContextSwitches`, `queryInterrupts` — into `FreeBsdCentralProcessor`, with three small native hooks the twins implement:

- **`long[] queryCpTimes(String name)`** — reads a `uint64`-array sysctl into a `long[]`; covers both `kern.cp_time` (per-system, 5 values) and `kern.cp_times` (per-CPU, nCpu×5). The base does the `TickType` mapping once.
- **`int getloadavgNative(double[] out, int nelem)`** — the base keeps the shared nelem validation + fill-with-`-1`.
- **`int sysctlInt(String name, int def)`** — parallels the existing `sysctlLong`/`sysctlString` hooks; the base does the two `unsignedIntToLong` one-liners.

The twins drop to just the hooks (JNA 130→~55 lines, FFM 121→~72). Net −33 lines, tick mapping single-source.

**DragonFly** (its twins extend the FreeBSD ones) keeps its own `kern.cputime` tick overrides and inherits the shared load-average / context-switch / interrupt logic unchanged.

Small cleanup: JNA's `queryContextSwitches`/`queryInterrupts` hand-rolled a raw `sysctlbyname` even though `BsdSysctlUtil.sysctl(name, int)` already existed — the hook uses the simpler call.

## Behavior

No user-facing change — same sysctls, same tick mapping, only relocated behind hooks.

## Testing

- spotless / checkstyle / forbiddenapis / javadoc: clean
- Clean full-reactor `install`: BUILD SUCCESS, 0 tests failed
- FreeBSD (and DragonFly) runtime JNA==FFM parity — `processorCpuLoadTicks` / `getSystemLoadAverage` comparisons — runs on the FreeBSD CI VM (developed on macOS)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/standardized FreeBSD reporting for system and per-processor CPU usage, load averages, context switches, and interrupt counts.
* **Bug Fixes**
  * Improved consistency of CPU metrics across FreeBSD runtime implementations.
  * Load-average queries now validate requested sample counts and handle partial results; missing timing data is handled more safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->