### PR TITLE
Dedup OpenBSD CentralProcessor CPU-tick and load-average logic

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -5,6 +5,7 @@
 package oshi.hardware.common.platform.unix.freebsd;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -132,9 +133,8 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
         double[] average = new double[nelem];
         int retval = getloadavgNative(average, nelem);
         if (retval < nelem) {
-            for (int i = Math.max(retval, 0); i < average.length; i++) {
-                average[i] = -1d;
-            }
+            // All-or-nothing: a partial result is more likely a misread than a real load average
+            Arrays.fill(average, -1d);
         }
         return average;
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
@@ -4,6 +4,7 @@
  */
 package oshi.hardware.common.platform.unix.openbsd;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -25,6 +26,14 @@ public abstract class OpenBsdCentralProcessor extends BsdCentralProcessor {
     private static final int HW_MACHINE = 1;
     private static final int HW_MODEL = 2;
     private static final int HW_CPUSPEED = 12;
+
+    // OpenBSD CPU state indices into the kern.cptime / kern.cptime2 arrays
+    private static final int CP_USER = 0;
+    private static final int CP_NICE = 1;
+    private static final int CP_SYS = 2;
+    private static final int CP_INTR = 3;
+    private static final int CP_IDLE = 4;
+    private static final int CPUSTATES = 5;
 
     /**
      * Reads a string sysctl value by name.
@@ -109,5 +118,77 @@ public abstract class OpenBsdCentralProcessor extends BsdCentralProcessor {
             }
         }
         return new Pair<>(contextSwitches, interrupts);
+    }
+
+    /**
+     * Reads the system-wide CPU time counters ({@code kern.cptime}) as an array of 5 or 6 {@code long} values.
+     *
+     * @return the CPU state ticks, or a shorter/empty array if unavailable
+     */
+    protected abstract long[] querySystemCpTime();
+
+    /**
+     * Reads a single processor's CPU time counters ({@code kern.cptime2}) as an array of 5 or 6 {@code long} values.
+     *
+     * @param cpu the logical processor index
+     * @return the CPU state ticks, or a shorter/empty array if unavailable
+     */
+    protected abstract long[] queryProcessorCpTime(int cpu);
+
+    /**
+     * Native {@code getloadavg(3)} call, filling {@code loadavg} with up to {@code nelem} samples.
+     *
+     * @param loadavg the array to populate
+     * @param nelem   the number of elements requested
+     * @return the number of samples retrieved
+     */
+    protected abstract int getloadavgNative(double[] loadavg, int nelem);
+
+    /**
+     * Maps a 5- or 6-element OpenBSD CPU-state array to the corresponding {@link TickType} slots of {@code ticks}.
+     * OpenBSD 6.4+ adds a spin-time element, giving a 6-element array; the extra element shifts IRQ and IDLE by one.
+     *
+     * @param ticks   the destination tick array
+     * @param cpTicks the source CPU-state values (5 or 6 longs)
+     */
+    private static void fillTicks(long[] ticks, long[] cpTicks) {
+        if (cpTicks.length < CPUSTATES) {
+            return;
+        }
+        ticks[TickType.USER.getIndex()] = cpTicks[CP_USER];
+        ticks[TickType.NICE.getIndex()] = cpTicks[CP_NICE];
+        ticks[TickType.SYSTEM.getIndex()] = cpTicks[CP_SYS];
+        int offset = cpTicks.length > CPUSTATES ? 1 : 0;
+        ticks[TickType.IRQ.getIndex()] = cpTicks[CP_INTR + offset];
+        ticks[TickType.IDLE.getIndex()] = cpTicks[CP_IDLE + offset];
+    }
+
+    @Override
+    protected long[] querySystemCpuLoadTicks() {
+        long[] ticks = new long[TickType.values().length];
+        fillTicks(ticks, querySystemCpTime());
+        return ticks;
+    }
+
+    @Override
+    protected long[][] queryProcessorCpuLoadTicks() {
+        long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
+        for (int cpu = 0; cpu < getLogicalProcessorCount(); cpu++) {
+            fillTicks(ticks[cpu], queryProcessorCpTime(cpu));
+        }
+        return ticks;
+    }
+
+    @Override
+    public double[] getSystemLoadAverage(int nelem) {
+        if (nelem < 1 || nelem > 3) {
+            throw new IllegalArgumentException("Must include from one to three elements.");
+        }
+        double[] average = new double[nelem];
+        int retval = getloadavgNative(average, nelem);
+        if (retval < nelem) {
+            Arrays.fill(average, -1d);
+        }
+        return average;
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.openbsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.CentralProcessor.TickType;
+import oshi.util.tuples.Pair;
+
+/**
+ * Tests the native-free tick-mapping and load-average logic hoisted into {@link OpenBsdCentralProcessor}, using a stub
+ * that supplies raw CPU-state and load-average values without native calls.
+ */
+class OpenBsdCentralProcessorTest {
+
+    @Test
+    void testFillTicksFiveElement() {
+        // Pre-6.4 layout: user, nice, sys, intr, idle
+        StubOpenBsdCentralProcessor cpu = new StubOpenBsdCentralProcessor(new long[] { 10L, 20L, 30L, 40L, 50L },
+                new double[0], 0);
+        long[] ticks = cpu.querySystemCpuLoadTicks();
+        assertThat(ticks[TickType.USER.getIndex()], is(10L));
+        assertThat(ticks[TickType.NICE.getIndex()], is(20L));
+        assertThat(ticks[TickType.SYSTEM.getIndex()], is(30L));
+        assertThat(ticks[TickType.IRQ.getIndex()], is(40L));
+        assertThat(ticks[TickType.IDLE.getIndex()], is(50L));
+    }
+
+    @Test
+    void testFillTicksSixElement() {
+        // OpenBSD 6.4+ inserts a spin element (99) between sys and intr, shifting IRQ and IDLE by one
+        StubOpenBsdCentralProcessor cpu = new StubOpenBsdCentralProcessor(new long[] { 10L, 20L, 30L, 99L, 40L, 50L },
+                new double[0], 0);
+        long[] ticks = cpu.querySystemCpuLoadTicks();
+        assertThat(ticks[TickType.USER.getIndex()], is(10L));
+        assertThat(ticks[TickType.NICE.getIndex()], is(20L));
+        assertThat(ticks[TickType.SYSTEM.getIndex()], is(30L));
+        assertThat(ticks[TickType.IRQ.getIndex()], is(40L));
+        assertThat(ticks[TickType.IDLE.getIndex()], is(50L));
+    }
+
+    @Test
+    void testFillTicksShortArrayLeavesZeros() {
+        // Fewer than CPUSTATES elements: mapping is skipped, ticks stay zero
+        StubOpenBsdCentralProcessor cpu = new StubOpenBsdCentralProcessor(new long[] { 1L, 2L, 3L }, new double[0], 0);
+        long[] ticks = cpu.querySystemCpuLoadTicks();
+        for (long tick : ticks) {
+            assertThat(tick, is(0L));
+        }
+    }
+
+    @Test
+    void testLoadAverageRejectsBelowOne() {
+        StubOpenBsdCentralProcessor cpu = new StubOpenBsdCentralProcessor(new long[0], new double[0], 0);
+        assertThrows(IllegalArgumentException.class, () -> cpu.getSystemLoadAverage(0));
+    }
+
+    @Test
+    void testLoadAverageRejectsAboveThree() {
+        StubOpenBsdCentralProcessor cpu = new StubOpenBsdCentralProcessor(new long[0], new double[0], 0);
+        assertThrows(IllegalArgumentException.class, () -> cpu.getSystemLoadAverage(4));
+    }
+
+    @Test
+    void testLoadAveragePreservesFullResult() {
+        StubOpenBsdCentralProcessor cpu = new StubOpenBsdCentralProcessor(new long[0], new double[] { 1.0, 5.0, 15.0 },
+                3);
+        double[] avg = cpu.getSystemLoadAverage(3);
+        assertThat(avg[0], is(1.0));
+        assertThat(avg[1], is(5.0));
+        assertThat(avg[2], is(15.0));
+    }
+
+    @Test
+    void testLoadAveragePartialResultFillsNegative() {
+        // Native call returns fewer samples than requested: all-or-nothing, whole array becomes -1
+        StubOpenBsdCentralProcessor cpu = new StubOpenBsdCentralProcessor(new long[0], new double[] { 1.0, 5.0, 15.0 },
+                2);
+        double[] avg = cpu.getSystemLoadAverage(3);
+        assertThat(avg[0], is(-1.0));
+        assertThat(avg[1], is(-1.0));
+        assertThat(avg[2], is(-1.0));
+    }
+
+    /**
+     * Minimal stub supplying raw CPU-state and load-average values without native calls.
+     */
+    static class StubOpenBsdCentralProcessor extends OpenBsdCentralProcessor {
+
+        private final long[] systemCpTime;
+        private final double[] loadavgValues;
+        private final int loadavgRetval;
+
+        StubOpenBsdCentralProcessor(long[] systemCpTime, double[] loadavgValues, int loadavgRetval) {
+            this.systemCpTime = systemCpTime;
+            this.loadavgValues = loadavgValues;
+            this.loadavgRetval = loadavgRetval;
+        }
+
+        @Override
+        protected int sysctl(String name, int def) {
+            return def;
+        }
+
+        @Override
+        protected String sysctl(String name, String def) {
+            return def;
+        }
+
+        @Override
+        protected String sysctl(int[] mib, String def) {
+            return def;
+        }
+
+        @Override
+        protected int sysctl(int[] mib, int def) {
+            return def;
+        }
+
+        @Override
+        protected Pair<Long, Long> queryVmStats() {
+            return new Pair<>(0L, 0L);
+        }
+
+        @Override
+        protected long[] querySystemCpTime() {
+            return systemCpTime;
+        }
+
+        @Override
+        protected long[] queryProcessorCpTime(int cpu) {
+            return systemCpTime;
+        }
+
+        @Override
+        protected int getloadavgNative(double[] loadavg, int nelem) {
+            for (int i = 0; i < nelem && i < loadavgValues.length; i++) {
+                loadavg[i] = loadavgValues[i];
+            }
+            return loadavgRetval;
+        }
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorFFM.java
@@ -6,25 +6,18 @@ package oshi.hardware.platform.unix.openbsd;
 
 import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CPUSTATES;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CP_IDLE;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CP_INTR;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CP_NICE;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CP_SYS;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CP_USER;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CTL_KERN;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_CPTIME;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_CPTIME2;
 
 import java.lang.foreign.MemorySegment;
-import java.util.Arrays;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.ffm.ForeignFunctions;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.hardware.common.platform.unix.openbsd.OpenBsdCentralProcessor;
@@ -58,60 +51,37 @@ public class OpenBsdCentralProcessorFFM extends OpenBsdCentralProcessor {
     }
 
     @Override
-    protected long[] querySystemCpuLoadTicks() {
-        long[] ticks = new long[TickType.values().length];
-        int[] mib = { CTL_KERN, KERN_CPTIME };
+    protected long[] querySystemCpTime() {
+        return readCpTime(new int[] { CTL_KERN, KERN_CPTIME });
+    }
+
+    @Override
+    protected long[] queryProcessorCpTime(int cpu) {
+        return readCpTime(new int[] { CTL_KERN, KERN_CPTIME2, cpu });
+    }
+
+    private static long[] readCpTime(int[] mib) {
         MemorySegment buf = OpenBsdSysctlUtilFFM.sysctl(mib);
-        if (buf != null) {
-            int arraySize = (int) (buf.byteSize() / JAVA_LONG.byteSize());
-            if (arraySize >= CPUSTATES) {
-                ticks[TickType.USER.getIndex()] = buf.getAtIndex(JAVA_LONG, CP_USER);
-                ticks[TickType.NICE.getIndex()] = buf.getAtIndex(JAVA_LONG, CP_NICE);
-                ticks[TickType.SYSTEM.getIndex()] = buf.getAtIndex(JAVA_LONG, CP_SYS);
-                int offset = arraySize > CPUSTATES ? 1 : 0;
-                ticks[TickType.IRQ.getIndex()] = buf.getAtIndex(JAVA_LONG, (long) CP_INTR + offset);
-                ticks[TickType.IDLE.getIndex()] = buf.getAtIndex(JAVA_LONG, (long) CP_IDLE + offset);
-            }
+        if (buf == null) {
+            return new long[0];
         }
-        return ticks;
+        int arraySize = (int) (buf.byteSize() / JAVA_LONG.byteSize());
+        long[] result = new long[arraySize];
+        for (int i = 0; i < arraySize; i++) {
+            result[i] = buf.getAtIndex(JAVA_LONG, i);
+        }
+        return result;
     }
 
     @Override
-    protected long[][] queryProcessorCpuLoadTicks() {
-        long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
-        for (int cpu = 0; cpu < getLogicalProcessorCount(); cpu++) {
-            int[] mib = { CTL_KERN, KERN_CPTIME2, cpu };
-            MemorySegment buf = OpenBsdSysctlUtilFFM.sysctl(mib);
-            if (buf != null) {
-                int arraySize = (int) (buf.byteSize() / JAVA_LONG.byteSize());
-                if (arraySize >= CPUSTATES) {
-                    ticks[cpu][TickType.USER.getIndex()] = buf.getAtIndex(JAVA_LONG, CP_USER);
-                    ticks[cpu][TickType.NICE.getIndex()] = buf.getAtIndex(JAVA_LONG, CP_NICE);
-                    ticks[cpu][TickType.SYSTEM.getIndex()] = buf.getAtIndex(JAVA_LONG, CP_SYS);
-                    int offset = arraySize > CPUSTATES ? 1 : 0;
-                    ticks[cpu][TickType.IRQ.getIndex()] = buf.getAtIndex(JAVA_LONG, (long) CP_INTR + offset);
-                    ticks[cpu][TickType.IDLE.getIndex()] = buf.getAtIndex(JAVA_LONG, (long) CP_IDLE + offset);
-                }
-            }
-        }
-        return ticks;
-    }
-
-    @Override
-    public double[] getSystemLoadAverage(int nelem) {
-        if (nelem < 1 || nelem > 3) {
-            throw new IllegalArgumentException("Must include from one to three elements.");
-        }
-        double[] average = new double[nelem];
-        Arrays.fill(average, -1d);
-        return ForeignFunctions.callInArenaOrDefault(arena -> {
+    protected int getloadavgNative(double[] loadavg, int nelem) {
+        return callInArenaIntOrDefault(arena -> {
             MemorySegment avg = arena.allocate(JAVA_DOUBLE, nelem);
             int retval = OpenBsdLibcFunctions.getloadavg(avg, nelem);
-            double[] result = new double[nelem];
-            for (int i = 0; i < nelem; i++) {
-                result[i] = (i < retval) ? avg.getAtIndex(JAVA_DOUBLE, i) : -1d;
+            for (int i = 0; i < nelem && i < retval; i++) {
+                loadavg[i] = avg.getAtIndex(JAVA_DOUBLE, i);
             }
-            return result;
-        }, LOG, Level.WARN, "Failed to read load average", average);
+            return retval;
+        }, LOG, Level.WARN, "Failed to read load average", 0);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorJNA.java
@@ -4,16 +4,9 @@
  */
 package oshi.hardware.platform.unix.openbsd;
 
-import static oshi.jna.platform.unix.OpenBsdLibc.CP_IDLE;
-import static oshi.jna.platform.unix.OpenBsdLibc.CP_INTR;
-import static oshi.jna.platform.unix.OpenBsdLibc.CP_NICE;
-import static oshi.jna.platform.unix.OpenBsdLibc.CP_SYS;
-import static oshi.jna.platform.unix.OpenBsdLibc.CP_USER;
 import static oshi.jna.platform.unix.OpenBsdLibc.CTL_KERN;
 import static oshi.jna.platform.unix.OpenBsdLibc.KERN_CPTIME;
 import static oshi.jna.platform.unix.OpenBsdLibc.KERN_CPTIME2;
-
-import java.util.Arrays;
 
 import com.sun.jna.Memory;
 import com.sun.jna.Native;
@@ -49,59 +42,20 @@ public class OpenBsdCentralProcessorJNA extends OpenBsdCentralProcessor {
         return OpenBsdSysctlUtil.sysctl(mib, def);
     }
 
-    /**
-     * Get the system CPU load ticks
-     *
-     * @return The system CPU load ticks
-     */
     @Override
-    protected long[] querySystemCpuLoadTicks() {
-        long[] ticks = new long[TickType.values().length];
-        int[] mib = new int[2];
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_CPTIME;
+    protected long[] querySystemCpTime() {
+        int[] mib = { CTL_KERN, KERN_CPTIME };
         try (Memory m = OpenBsdSysctlUtil.sysctl(mib)) {
-            // array of 5 or 6 native longs
-            long[] cpuTicks = cpTimeToTicks(m, false);
-            if (cpuTicks.length >= 5) {
-                ticks[TickType.USER.getIndex()] = cpuTicks[CP_USER];
-                ticks[TickType.NICE.getIndex()] = cpuTicks[CP_NICE];
-                ticks[TickType.SYSTEM.getIndex()] = cpuTicks[CP_SYS];
-                int offset = cpuTicks.length > 5 ? 1 : 0;
-                ticks[TickType.IRQ.getIndex()] = cpuTicks[CP_INTR + offset];
-                ticks[TickType.IDLE.getIndex()] = cpuTicks[CP_IDLE + offset];
-            }
+            return cpTimeToTicks(m, false);
         }
-        return ticks;
     }
 
-    /**
-     * Get the processor CPU load ticks
-     *
-     * @return The processor CPU load ticks
-     */
     @Override
-    protected long[][] queryProcessorCpuLoadTicks() {
-        long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
-        int[] mib = new int[3];
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_CPTIME2;
-        for (int cpu = 0; cpu < getLogicalProcessorCount(); cpu++) {
-            mib[2] = cpu;
-            try (Memory m = OpenBsdSysctlUtil.sysctl(mib)) {
-                // array of 5 or 6 longs
-                long[] cpuTicks = cpTimeToTicks(m, true);
-                if (cpuTicks.length >= 5) {
-                    ticks[cpu][TickType.USER.getIndex()] = cpuTicks[CP_USER];
-                    ticks[cpu][TickType.NICE.getIndex()] = cpuTicks[CP_NICE];
-                    ticks[cpu][TickType.SYSTEM.getIndex()] = cpuTicks[CP_SYS];
-                    int offset = cpuTicks.length > 5 ? 1 : 0;
-                    ticks[cpu][TickType.IRQ.getIndex()] = cpuTicks[CP_INTR + offset];
-                    ticks[cpu][TickType.IDLE.getIndex()] = cpuTicks[CP_IDLE + offset];
-                }
-            }
+    protected long[] queryProcessorCpTime(int cpu) {
+        int[] mib = { CTL_KERN, KERN_CPTIME2, cpu };
+        try (Memory m = OpenBsdSysctlUtil.sysctl(mib)) {
+            return cpTimeToTicks(m, true);
         }
-        return ticks;
     }
 
     /**
@@ -128,31 +82,8 @@ public class OpenBsdCentralProcessorJNA extends OpenBsdCentralProcessor {
         return ticks;
     }
 
-    /**
-     * Returns the system load average for the number of elements specified, up to 3, representing 1, 5, and 15 minutes.
-     * The system load average is the sum of the number of runnable entities queued to the available processors and the
-     * number of runnable entities running on the available processors averaged over a period of time. The way in which
-     * the load average is calculated is operating system specific but is typically a damped time-dependent average. If
-     * the load average is not available, a negative value is returned. This method is designed to provide a hint about
-     * the system load and may be queried frequently.
-     * <p>
-     * The load average may be unavailable on some platforms (e.g., Windows) where it is expensive to implement this
-     * method.
-     *
-     * @param nelem Number of elements to return.
-     * @return an array of the system load averages for 1, 5, and 15 minutes with the size of the array specified by
-     *         nelem; or negative values if not available.
-     */
     @Override
-    public double[] getSystemLoadAverage(int nelem) {
-        if (nelem < 1 || nelem > 3) {
-            throw new IllegalArgumentException("Must include from one to three elements.");
-        }
-        double[] average = new double[nelem];
-        int retval = OpenBsdLibc.INSTANCE.getloadavg(average, nelem);
-        if (retval < nelem) {
-            Arrays.fill(average, -1d);
-        }
-        return average;
+    protected int getloadavgNative(double[] loadavg, int nelem) {
+        return OpenBsdLibc.INSTANCE.getloadavg(loadavg, nelem);
     }
 }


### PR DESCRIPTION
Continues the CentralProcessor cross-OS consistency/dedup arc (after Windows #3459 and FreeBSD/DragonFly #3460), now for OpenBSD.

### What

Hoist the shared OpenBSD CPU-state mapping and load-average handling into the `OpenBsdCentralProcessor` common base, leaving each backend only its native read:

- **Base** gains `fillTicks` — the 5-vs-6-element `kern.cptime`/`kern.cptime2` → `TickType` mapping, handling the OpenBSD 6.4+ spin-time element that shifts IRQ/IDLE by one — plus concrete `querySystemCpuLoadTicks` / `queryProcessorCpuLoadTicks` / `getSystemLoadAverage`, and three new hooks: `querySystemCpTime`, `queryProcessorCpTime`, `getloadavgNative`.
- **JNA** keeps its native-long-aware cp-time parse (native size for `kern.cptime`, forced 64-bit for `kern.cptime2`) and `getloadavg` via `OpenBsdLibc`.
- **FFM** keeps its 64-bit cp-time read and `getloadavg` via `callInArenaIntOrDefault`.

Net **113 insertions / 131 deletions** across 3 files; the tick-mapping and load-average logic now lives once in the base.

### Behavior note

`getSystemLoadAverage` is now **all-or-nothing**: if the native `getloadavg` returns fewer samples than requested, the whole array is filled with `-1`. `getloadavg(loadavg, nelem)` returns the requested count on success or `-1` on error, and the kernel tracks exactly three averages — so a partial result is more likely a misread than a genuine load average. This matches the prior JNA behavior; it changes FFM only in the practically-impossible partial-`getloadavg` case, so no CHANGELOG entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenBSD CPU usage reporting by standardizing how raw CPU time data is collected and converted into CPU load ticks across native interfaces.
  * Improved system and per-processor CPU load tick collection, including correct handling of OpenBSD CPU-state array layouts.
  * Improved system load average reporting: validates requested sample count (1–3), and when fewer samples are available it now returns `-1.0` for all entries instead of only the missing tail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->