### PR TITLE
Dedup Mac CentralProcessor CPU-tick and load-average logic

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
@@ -22,10 +22,14 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.ExecutingCommand;
+import oshi.util.FormatUtil;
 import oshi.util.ParseUtil;
 import oshi.util.Util;
 import oshi.util.tuples.Quartet;
@@ -36,6 +40,15 @@ import oshi.util.tuples.Quartet;
  */
 @ThreadSafe
 public abstract class MacCentralProcessor extends AbstractCentralProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MacCentralProcessor.class);
+
+    // Indices into the Mach cpu_ticks arrays (host_cpu_load_info / processor_cpu_load_info)
+    private static final int CPU_STATE_MAX = 4;
+    private static final int CPU_STATE_USER = 0;
+    private static final int CPU_STATE_SYSTEM = 1;
+    private static final int CPU_STATE_IDLE = 2;
+    private static final int CPU_STATE_NICE = 3;
 
     /**
      * Default constructor.
@@ -408,5 +421,77 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
             return ParseUtil.byteArrayToLong(freqData, 4, false);
         }
         return DEFAULT_FREQUENCY;
+    }
+
+    /**
+     * Reads the system-wide {@code host_cpu_load_info} CPU-tick counters.
+     *
+     * @return the {@code CPU_STATE_MAX} raw tick values, or a shorter/empty array on failure
+     */
+    protected abstract int[] queryHostCpuLoadTicks();
+
+    /**
+     * Reads the per-processor {@code processor_cpu_load_info} CPU-tick counters as a flat array of
+     * {@code processorCount * CPU_STATE_MAX} values. Implementations copy the values out of native memory and release
+     * the kernel-allocated buffer before returning.
+     *
+     * @return the flat per-processor tick values, or an empty array on failure
+     */
+    protected abstract int[] queryProcessorCpuTicks();
+
+    /**
+     * Native {@code getloadavg(3)} call, filling {@code loadavg} with up to {@code nelem} samples.
+     *
+     * @param loadavg the array to populate
+     * @param nelem   the number of elements requested
+     * @return the number of samples retrieved, or a negative value on failure
+     */
+    protected abstract int getloadavgNative(double[] loadavg, int nelem);
+
+    @Override
+    public long[] querySystemCpuLoadTicks() {
+        long[] ticks = new long[TickType.values().length];
+        int[] cpuTicks = queryHostCpuLoadTicks();
+        if (cpuTicks.length < CPU_STATE_MAX) {
+            return ticks;
+        }
+        ticks[TickType.USER.getIndex()] = FormatUtil.getUnsignedInt(cpuTicks[CPU_STATE_USER]);
+        ticks[TickType.NICE.getIndex()] = FormatUtil.getUnsignedInt(cpuTicks[CPU_STATE_NICE]);
+        ticks[TickType.SYSTEM.getIndex()] = FormatUtil.getUnsignedInt(cpuTicks[CPU_STATE_SYSTEM]);
+        ticks[TickType.IDLE.getIndex()] = FormatUtil.getUnsignedInt(cpuTicks[CPU_STATE_IDLE]);
+        return ticks;
+    }
+
+    @Override
+    public long[][] queryProcessorCpuLoadTicks() {
+        long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
+        int[] cpuTicks = queryProcessorCpuTicks();
+        int procCount = cpuTicks.length / CPU_STATE_MAX;
+        if (procCount > ticks.length) {
+            LOG.warn("processor_cpu_load_info returned {} CPUs but expected {}; capping iteration", procCount,
+                    ticks.length);
+        }
+        int cpuLimit = Math.min(procCount, ticks.length);
+        for (int cpu = 0; cpu < cpuLimit; cpu++) {
+            int offset = cpu * CPU_STATE_MAX;
+            ticks[cpu][TickType.USER.getIndex()] = FormatUtil.getUnsignedInt(cpuTicks[offset + CPU_STATE_USER]);
+            ticks[cpu][TickType.NICE.getIndex()] = FormatUtil.getUnsignedInt(cpuTicks[offset + CPU_STATE_NICE]);
+            ticks[cpu][TickType.SYSTEM.getIndex()] = FormatUtil.getUnsignedInt(cpuTicks[offset + CPU_STATE_SYSTEM]);
+            ticks[cpu][TickType.IDLE.getIndex()] = FormatUtil.getUnsignedInt(cpuTicks[offset + CPU_STATE_IDLE]);
+        }
+        return ticks;
+    }
+
+    @Override
+    public double[] getSystemLoadAverage(int nelem) {
+        if (nelem < 1 || nelem > 3) {
+            throw new IllegalArgumentException("Must include from one to three elements.");
+        }
+        double[] average = new double[nelem];
+        int retval = getloadavgNative(average, nelem);
+        if (retval < nelem) {
+            Arrays.fill(average, -1d);
+        }
+        return average;
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
@@ -8,12 +8,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+
+import oshi.hardware.CentralProcessor.TickType;
 
 class MacCentralProcessorTest {
 
@@ -38,16 +41,107 @@ class MacCentralProcessorTest {
         assertThat(flags, is(empty()));
     }
 
+    @Test
+    void testQuerySystemCpuLoadTicks() {
+        // Mach cpu_ticks order: user, system, idle, nice
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(new HashMap<>(), new int[] { 10, 30, 50, 20 },
+                new int[0], new double[0], 0);
+        long[] ticks = cpu.querySystemCpuLoadTicks();
+        assertThat(ticks[TickType.USER.getIndex()], is(10L));
+        assertThat(ticks[TickType.NICE.getIndex()], is(20L));
+        assertThat(ticks[TickType.SYSTEM.getIndex()], is(30L));
+        assertThat(ticks[TickType.IDLE.getIndex()], is(50L));
+    }
+
+    @Test
+    void testQuerySystemCpuLoadTicksShortArrayLeavesZeros() {
+        // Fewer than CPU_STATE_MAX values: mapping is skipped, ticks stay zero
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(new HashMap<>(), new int[] { 10, 30, 50 }, new int[0],
+                new double[0], 0);
+        long[] ticks = cpu.querySystemCpuLoadTicks();
+        for (long tick : ticks) {
+            assertThat(tick, is(0L));
+        }
+    }
+
+    @Test
+    void testQueryProcessorCpuLoadTicks() {
+        // One processor (the stub reports a single logical processor): user, system, idle, nice
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(new HashMap<>(), new int[0],
+                new int[] { 10, 30, 50, 20 }, new double[0], 0);
+        long[][] ticks = cpu.queryProcessorCpuLoadTicks();
+        assertThat(ticks.length, is(1));
+        assertThat(ticks[0][TickType.USER.getIndex()], is(10L));
+        assertThat(ticks[0][TickType.SYSTEM.getIndex()], is(30L));
+        assertThat(ticks[0][TickType.IDLE.getIndex()], is(50L));
+        assertThat(ticks[0][TickType.NICE.getIndex()], is(20L));
+    }
+
+    @Test
+    void testQueryProcessorCpuLoadTicksCapsExtraProcessors() {
+        // Native reports two processors but only one is expected: mapping caps to the expected count without error
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(new HashMap<>(), new int[0],
+                new int[] { 10, 30, 50, 20, 11, 31, 51, 21 }, new double[0], 0);
+        long[][] ticks = cpu.queryProcessorCpuLoadTicks();
+        assertThat(ticks.length, is(1));
+        assertThat(ticks[0][TickType.USER.getIndex()], is(10L));
+        assertThat(ticks[0][TickType.IDLE.getIndex()], is(50L));
+    }
+
+    @Test
+    void testLoadAverageRejectsBelowOne() {
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(new HashMap<>());
+        assertThrows(IllegalArgumentException.class, () -> cpu.getSystemLoadAverage(0));
+    }
+
+    @Test
+    void testLoadAverageRejectsAboveThree() {
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(new HashMap<>());
+        assertThrows(IllegalArgumentException.class, () -> cpu.getSystemLoadAverage(4));
+    }
+
+    @Test
+    void testLoadAveragePreservesFullResult() {
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(new HashMap<>(), new int[0], new int[0],
+                new double[] { 1.0, 5.0, 15.0 }, 3);
+        double[] avg = cpu.getSystemLoadAverage(3);
+        assertThat(avg[0], is(1.0));
+        assertThat(avg[1], is(5.0));
+        assertThat(avg[2], is(15.0));
+    }
+
+    @Test
+    void testLoadAveragePartialResultFillsNegative() {
+        // Native call returns fewer samples than requested: all-or-nothing, whole array becomes -1
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(new HashMap<>(), new int[0], new int[0],
+                new double[] { 1.0, 5.0, 15.0 }, 2);
+        double[] avg = cpu.getSystemLoadAverage(3);
+        assertThat(avg[0], is(-1.0));
+        assertThat(avg[1], is(-1.0));
+        assertThat(avg[2], is(-1.0));
+    }
+
     /**
-     * Minimal stub providing sysctl values without native calls.
+     * Minimal stub providing sysctl values and raw Mach CPU-tick / load-average values without native calls. The
+     * abstract superclass eagerly derives processor counts during construction, so the stub reports a single logical
+     * processor; per-processor tests are written against that.
      */
     static class StubMacCentralProcessor extends MacCentralProcessor {
 
         private final Map<String, Integer> sysctlInts = new HashMap<>();
         private final Map<String, Long> sysctlLongs = new HashMap<>();
         private final Map<String, String> sysctlStrings;
+        private final int[] hostCpuTicks;
+        private final int[] processorCpuTicks;
+        private final double[] loadavgValues;
+        private final int loadavgRetval;
 
         StubMacCentralProcessor(Map<String, String> extraStrings) {
+            this(extraStrings, new int[0], new int[0], new double[0], 0);
+        }
+
+        StubMacCentralProcessor(Map<String, String> extraStrings, int[] hostCpuTicks, int[] processorCpuTicks,
+                double[] loadavgValues, int loadavgRetval) {
             Map<String, String> defaults = new HashMap<>();
             defaults.put("machdep.cpu.brand_string", "Test CPU");
             defaults.putAll(extraStrings);
@@ -56,6 +150,10 @@ class MacCentralProcessorTest {
             sysctlInts.put("hw.physicalcpu", 1);
             sysctlInts.put("hw.packages", 1);
             sysctlInts.put("hw.cpu64bit_capable", 1);
+            this.hostCpuTicks = hostCpuTicks;
+            this.processorCpuTicks = processorCpuTicks;
+            this.loadavgValues = loadavgValues;
+            this.loadavgRetval = loadavgRetval;
         }
 
         @Override
@@ -108,13 +206,21 @@ class MacCentralProcessorTest {
         }
 
         @Override
-        protected long[] querySystemCpuLoadTicks() {
-            return new long[8];
+        protected int[] queryHostCpuLoadTicks() {
+            return hostCpuTicks;
         }
 
         @Override
-        protected long[][] queryProcessorCpuLoadTicks() {
-            return new long[1][8];
+        protected int[] queryProcessorCpuTicks() {
+            return processorCpuTicks;
+        }
+
+        @Override
+        protected int getloadavgNative(double[] loadavg, int nelem) {
+            for (int i = 0; i < nelem && i < loadavgValues.length; i++) {
+                loadavg[i] = loadavgValues[i];
+            }
+            return loadavgRetval;
         }
 
         @Override
@@ -135,11 +241,6 @@ class MacCentralProcessorTest {
         @Override
         public long queryInterrupts() {
             return 0L;
-        }
-
-        @Override
-        public double[] getSystemLoadAverage(int nelem) {
-            return new double[nelem];
         }
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
@@ -7,6 +7,7 @@ package oshi.hardware.platform.mac;
 import static org.slf4j.event.Level.DEBUG;
 import static org.slf4j.event.Level.ERROR;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.ForeignFunctions.getErrno;
 import static oshi.util.ExceptionUtil.runOrLog;
@@ -15,7 +16,6 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.util.Arrays;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +26,6 @@ import oshi.ffm.platform.mac.MacSystemFunctions;
 import oshi.hardware.common.platform.mac.IOKitProvider;
 import oshi.hardware.common.platform.mac.MacCentralProcessor;
 import oshi.hardware.common.platform.mac.SysctlProvider;
-import oshi.util.FormatUtil;
 
 /**
  * A CPU using FFM.
@@ -42,9 +41,8 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
     }
 
     @Override
-    public long[] querySystemCpuLoadTicks() {
+    protected int[] queryHostCpuLoadTicks() {
         return callInArenaOrDefault(arena -> {
-            long[] ticks = new long[TickType.values().length];
             MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
             MemorySegment cpuLoadInfo = arena.allocate(MacSystem.HOST_CPU_LOAD_INFO_DATA);
             MemorySegment count = arena.allocateFrom(ValueLayout.JAVA_INT,
@@ -53,42 +51,28 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
             if (0 != MacSystemFunctions.host_statistics(callState, machPort, MacSystem.HOST_CPU_LOAD_INFO, cpuLoadInfo,
                     count)) {
                 LOG.error("Failed to get System CPU ticks. Error code: {} ", getErrno(callState));
-                return ticks;
+                return new int[0];
             }
             var cpuTicksHandle = MacSystem.HOST_CPU_LOAD_INFO_DATA.varHandle(MacSystem.CPU_TICKS,
                     MemoryLayout.PathElement.sequenceElement());
-            ticks[TickType.USER.getIndex()] = Integer
-                    .toUnsignedLong((int) cpuTicksHandle.get(cpuLoadInfo, 0L, (long) MacSystem.CPU_STATE_USER));
-            ticks[TickType.NICE.getIndex()] = Integer
-                    .toUnsignedLong((int) cpuTicksHandle.get(cpuLoadInfo, 0L, (long) MacSystem.CPU_STATE_NICE));
-            ticks[TickType.SYSTEM.getIndex()] = Integer
-                    .toUnsignedLong((int) cpuTicksHandle.get(cpuLoadInfo, 0L, (long) MacSystem.CPU_STATE_SYSTEM));
-            ticks[TickType.IDLE.getIndex()] = Integer
-                    .toUnsignedLong((int) cpuTicksHandle.get(cpuLoadInfo, 0L, (long) MacSystem.CPU_STATE_IDLE));
-            return ticks;
-        }, LOG, ERROR, "Failed to get System CPU ticks", new long[TickType.values().length]);
+            int[] cpuTicks = new int[MacSystem.CPU_STATE_MAX];
+            for (int i = 0; i < cpuTicks.length; i++) {
+                cpuTicks[i] = (int) cpuTicksHandle.get(cpuLoadInfo, 0L, (long) i);
+            }
+            return cpuTicks;
+        }, LOG, ERROR, "Failed to get System CPU ticks", new int[0]);
     }
 
     @Override
-    public double[] getSystemLoadAverage(int nelem) {
-        if (nelem < 1 || nelem > 3) {
-            throw new IllegalArgumentException("Must include from one to three elements.");
-        }
-        double[] defaultAverage = new double[nelem];
-        Arrays.fill(defaultAverage, -1d);
-        return callInArenaOrDefault(arena -> {
-            double[] average = new double[nelem];
+    protected int getloadavgNative(double[] loadavg, int nelem) {
+        return callInArenaIntOrDefault(arena -> {
             MemorySegment loadavgSeg = arena.allocate(ValueLayout.JAVA_DOUBLE, nelem);
             int retval = MacSystemFunctions.getloadavg(loadavgSeg, nelem);
-            if (retval < nelem) {
-                Arrays.fill(average, -1d);
-            } else {
-                for (int i = 0; i < nelem; i++) {
-                    average[i] = loadavgSeg.getAtIndex(ValueLayout.JAVA_DOUBLE, i);
-                }
+            for (int i = 0; i < nelem && i < retval; i++) {
+                loadavg[i] = loadavgSeg.getAtIndex(ValueLayout.JAVA_DOUBLE, i);
             }
-            return average;
-        }, LOG, DEBUG, "Failed to query system load average", defaultAverage);
+            return retval;
+        }, LOG, DEBUG, "Failed to query system load average", -1);
     }
 
     @Override
@@ -97,8 +81,7 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
     }
 
     @Override
-    public long[][] queryProcessorCpuLoadTicks() {
-        long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
+    protected int[] queryProcessorCpuTicks() {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
             MemorySegment procCountSeg = arena.allocate(ValueLayout.JAVA_INT);
@@ -108,29 +91,17 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
             if (0 != MacSystemFunctions.host_processor_info(callState, machPort, MacSystem.PROCESSOR_CPU_LOAD_INFO,
                     procCountSeg, procInfoPtrSeg, procInfoCountSeg)) {
                 LOG.error("Failed to update CPU Load. Error code: {}", getErrno(callState));
-                return ticks;
+                return new int[0];
             }
-            int procCount = procCountSeg.get(ValueLayout.JAVA_INT, 0);
             int procInfoCount = procInfoCountSeg.get(ValueLayout.JAVA_INT, 0);
             MemorySegment rawProcInfoPtr = procInfoPtrSeg.get(ValueLayout.ADDRESS, 0);
             MemorySegment procInfoPtr = rawProcInfoPtr.reinterpret((long) procInfoCount * MacSystem.INT_SIZE);
             try {
-                if (procCount != ticks.length) {
-                    LOG.warn("host_processor_info returned {} CPUs but expected {}; capping iteration", procCount,
-                            ticks.length);
+                int[] cpuTicks = new int[procInfoCount];
+                for (int i = 0; i < procInfoCount; i++) {
+                    cpuTicks[i] = procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, i);
                 }
-                int cpuLimit = Math.min(procCount, ticks.length);
-                for (int cpu = 0; cpu < cpuLimit; cpu++) {
-                    int offset = cpu * MacSystem.CPU_STATE_MAX;
-                    ticks[cpu][TickType.USER.getIndex()] = FormatUtil.getUnsignedInt(
-                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, (long) offset + MacSystem.CPU_STATE_USER));
-                    ticks[cpu][TickType.NICE.getIndex()] = FormatUtil.getUnsignedInt(
-                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, (long) offset + MacSystem.CPU_STATE_NICE));
-                    ticks[cpu][TickType.SYSTEM.getIndex()] = FormatUtil.getUnsignedInt(
-                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, (long) offset + MacSystem.CPU_STATE_SYSTEM));
-                    ticks[cpu][TickType.IDLE.getIndex()] = FormatUtil.getUnsignedInt(
-                            procInfoPtr.getAtIndex(ValueLayout.JAVA_INT, (long) offset + MacSystem.CPU_STATE_IDLE));
-                }
+                return cpuTicks;
             } finally {
                 runOrLog(
                         () -> MacSystemFunctions.vm_deallocate(MacSystemFunctions.mach_task_self(),
@@ -140,7 +111,7 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
         } catch (Throwable e) {
             LOG.error("Failed to update CPU Load", e);
         }
-        return ticks;
+        return new int[0];
     }
 
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorJNA.java
@@ -4,8 +4,6 @@
  */
 package oshi.hardware.platform.mac;
 
-import java.util.Arrays;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +16,6 @@ import oshi.hardware.common.platform.mac.SysctlProvider;
 import oshi.jna.ByRef.CloseableIntByReference;
 import oshi.jna.ByRef.CloseablePointerByReference;
 import oshi.jna.Struct.CloseableHostCpuLoadInfo;
-import oshi.util.FormatUtil;
 
 /**
  * A CPU using JNA.
@@ -34,37 +31,22 @@ final class MacCentralProcessorJNA extends MacCentralProcessor {
     }
 
     @Override
-    public long[] querySystemCpuLoadTicks() {
-        long[] ticks = new long[TickType.values().length];
+    protected int[] queryHostCpuLoadTicks() {
         int machPort = SystemB.INSTANCE.mach_host_self();
         try (CloseableHostCpuLoadInfo cpuLoadInfo = new CloseableHostCpuLoadInfo();
                 CloseableIntByReference size = new CloseableIntByReference(cpuLoadInfo.size())) {
             int ret = SystemB.INSTANCE.host_statistics(machPort, SystemB.HOST_CPU_LOAD_INFO, cpuLoadInfo, size);
             if (0 != ret) {
                 LOG.error("Failed to get System CPU ticks. Error code: {} ", ret);
-                return ticks;
+                return new int[0];
             }
-
-            ticks[TickType.USER.getIndex()] = FormatUtil.getUnsignedInt(cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_USER]);
-            ticks[TickType.NICE.getIndex()] = FormatUtil.getUnsignedInt(cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_NICE]);
-            ticks[TickType.SYSTEM.getIndex()] = FormatUtil
-                    .getUnsignedInt(cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_SYSTEM]);
-            ticks[TickType.IDLE.getIndex()] = FormatUtil.getUnsignedInt(cpuLoadInfo.cpu_ticks[SystemB.CPU_STATE_IDLE]);
+            return cpuLoadInfo.cpu_ticks;
         }
-        return ticks;
     }
 
     @Override
-    public double[] getSystemLoadAverage(int nelem) {
-        if (nelem < 1 || nelem > 3) {
-            throw new IllegalArgumentException("Must include from one to three elements.");
-        }
-        double[] average = new double[nelem];
-        int retval = SystemB.INSTANCE.getloadavg(average, nelem);
-        if (retval < nelem) {
-            Arrays.fill(average, -1d);
-        }
-        return average;
+    protected int getloadavgNative(double[] loadavg, int nelem) {
+        return SystemB.INSTANCE.getloadavg(loadavg, nelem);
     }
 
     @Override
@@ -73,9 +55,7 @@ final class MacCentralProcessorJNA extends MacCentralProcessor {
     }
 
     @Override
-    public long[][] queryProcessorCpuLoadTicks() {
-        long[][] ticks = new long[getLogicalProcessorCount()][TickType.values().length];
-
+    protected int[] queryProcessorCpuTicks() {
         int machPort = SystemB.INSTANCE.mach_host_self();
         try (CloseableIntByReference procCount = new CloseableIntByReference();
                 CloseablePointerByReference procCpuLoadInfo = new CloseablePointerByReference();
@@ -84,21 +64,10 @@ final class MacCentralProcessorJNA extends MacCentralProcessor {
                     procCpuLoadInfo, procInfoCount);
             if (0 != ret) {
                 LOG.error("Failed to update CPU Load. Error code: {}", ret);
-                return ticks;
+                return new int[0];
             }
             try {
-                int[] cpuTicks = procCpuLoadInfo.getValue().getIntArray(0, procInfoCount.getValue());
-                for (int cpu = 0; cpu < procCount.getValue(); cpu++) {
-                    int offset = cpu * SystemB.CPU_STATE_MAX;
-                    ticks[cpu][TickType.USER.getIndex()] = FormatUtil
-                            .getUnsignedInt(cpuTicks[offset + SystemB.CPU_STATE_USER]);
-                    ticks[cpu][TickType.NICE.getIndex()] = FormatUtil
-                            .getUnsignedInt(cpuTicks[offset + SystemB.CPU_STATE_NICE]);
-                    ticks[cpu][TickType.SYSTEM.getIndex()] = FormatUtil
-                            .getUnsignedInt(cpuTicks[offset + SystemB.CPU_STATE_SYSTEM]);
-                    ticks[cpu][TickType.IDLE.getIndex()] = FormatUtil
-                            .getUnsignedInt(cpuTicks[offset + SystemB.CPU_STATE_IDLE]);
-                }
+                return procCpuLoadInfo.getValue().getIntArray(0, procInfoCount.getValue());
             } finally {
                 try {
                     SystemB.INSTANCE.vm_deallocate(SystemB.INSTANCE.mach_task_self(),
@@ -109,7 +78,6 @@ final class MacCentralProcessorJNA extends MacCentralProcessor {
                 }
             }
         }
-        return ticks;
     }
 
 }


### PR DESCRIPTION
Continues the CentralProcessor cross-OS consistency/dedup arc (after Windows #3459, FreeBSD/DragonFly #3460, and OpenBSD #3461), now for macOS.

### What

Hoist the shared Mach CPU-state mapping and load-average handling into the `MacCentralProcessor` common base, leaving each backend only its native read:

- **Base** gains the `CPU_STATE_*` indices and concrete `querySystemCpuLoadTicks` / `queryProcessorCpuLoadTicks` / `getSystemLoadAverage`, plus three hooks:
  - `queryHostCpuLoadTicks()` — `host_cpu_load_info`, returns the `CPU_STATE_MAX` raw ticks
  - `queryProcessorCpuTicks()` — `processor_cpu_load_info`, returns a flat `procCount * CPU_STATE_MAX` array copied out of native memory, with the kernel-allocated buffer released (`vm_deallocate`) inside the hook
  - `getloadavgNative()`
- **JNA** keeps its `SystemB` reads plus `getloadavg`; **FFM** keeps its `MacSystemFunctions` reads plus `getloadavg` via `callInArenaIntOrDefault`.

Twins shrink (JNA ~115→80, FFM ~146→115); the tick mapping and load-average logic now live once in the base.

### Latent JNA bug fixed

The per-processor mapping loop now lives in the base with a `min(procCount, logicalProcessorCount)` cap (and a warn on over-count). The JNA implementation previously looped over the raw native processor count **unguarded**, which could overrun the `ticks` array if `host_processor_info` ever reported more CPUs than `getLogicalProcessorCount()`. The FFM code already capped; hoisting the loop gives both backends the guard.

### Tests

`MacCentralProcessorTest` gains a stub that supplies raw Mach tick and load-average values without native calls, covering the system-tick mapping (`user/system/idle/nice` order + short-array guard), the per-processor mapping and its cap, and `getSystemLoadAverage` (bounds validation, full result preserved, partial result blanked).

Validated with a clean full build and live JNA==FFM parity (`NativeComparisonTest` `processorCpuLoadTicks()` / `processorLoadAverage()`) on Apple Silicon. No CHANGELOG — the AIOOBE fix is unreachable in practice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS system and per-processor CPU load reporting.
  * Added safer handling for incomplete or unexpected CPU metrics.
  * Improved system load-average results, including clear handling of unavailable samples.
  * Added validation for load-average requests to accept only 1–3 samples.
* **Tests**
  * Expanded coverage for CPU tick data, processor counts, incomplete results, and load-average behavior across supported macOS implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->