### PR TITLE
Dedup Linux CentralProcessor topology, frequency, and load-average logic

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
@@ -204,42 +204,73 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     /**
-     * Reads processor topology using udev.
+     * Reads processor topology, using udev to enumerate CPUs when available and falling back to a sysfs directory scan.
      *
      * @return a quartet of logical processors, caches, efficiency map, and modalias map
      */
-    protected abstract Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyWithUdev();
+    protected Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyWithUdev() {
+        return buildTopology(cpuSyspaths());
+    }
 
     /**
-     * Reads processor topology from sysfs using the default CPU path.
+     * Enumerates the sysfs paths of all CPUs (e.g. {@code /sys/devices/system/cpu/cpuN}) via udev, or returns
+     * {@code null} if udev is unavailable so the caller can fall back to a sysfs directory scan.
      *
-     * @return a quartet of logical processors, caches, efficiency map, and modalias map
+     * @return the CPU syspaths from udev, or {@code null} if udev is unavailable
      */
-    protected static Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyFromSysfs() {
-        return readTopologyFromSysfs(SysPath.CPU);
+    protected abstract List<String> enumerateCpuSyspathsViaUdev();
+
+    /**
+     * Enumerates the sysfs paths of all CPUs, preferring udev and falling back to a sysfs directory scan.
+     *
+     * @return the CPU syspaths
+     */
+    private List<String> cpuSyspaths() {
+        List<String> viaUdev = enumerateCpuSyspathsViaUdev();
+        return viaUdev != null ? viaUdev : cpuSyspathsFromSysfs(SysPath.CPU);
+    }
+
+    /**
+     * Enumerates the sysfs paths of all CPUs by scanning a sysfs cpu directory for {@code cpuN} entries.
+     *
+     * @param cpuPath the sysfs cpu directory to scan
+     * @return the CPU syspaths, or an empty list if the path cannot be read
+     */
+    protected static List<String> cpuSyspathsFromSysfs(String cpuPath) {
+        List<String> syspaths = new ArrayList<>();
+        // Only immediate children (the cpuN entries); avoid walking each CPU's topology/cache/cpufreq subtree
+        try (Stream<Path> cpuFiles = Files.find(Paths.get(cpuPath), 1,
+                (path, basicFileAttributes) -> path.toFile().getName().matches("cpu\\d+"))) {
+            cpuFiles.forEach(cpu -> syspaths.add(cpu.toString()));
+        } catch (IOException e) {
+            // No udev and no cpu info in sysfs? Bad.
+            LOG.warn("Unable to find CPU information in sysfs at path {}", cpuPath);
+        }
+        return syspaths;
     }
 
     static Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyFromSysfs(
             String cpuPath) {
+        return buildTopology(cpuSyspathsFromSysfs(cpuPath));
+    }
+
+    /**
+     * Builds processor topology from a list of CPU syspaths, reading each CPU's MODALIAS from its {@code uevent} file.
+     *
+     * @param syspaths the CPU syspaths (e.g. {@code /sys/devices/system/cpu/cpuN})
+     * @return a quartet of logical processors, caches, efficiency map, and modalias map
+     */
+    static Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> buildTopology(
+            List<String> syspaths) {
         List<LogicalProcessor> logProcs = new ArrayList<>();
         Set<ProcessorCache> caches = new HashSet<>();
         Map<Integer, Integer> coreEfficiencyMap = new HashMap<>();
         Map<Integer, String> modAliasMap = new HashMap<>();
-        try {
-            try (Stream<Path> cpuFiles = Files.find(Paths.get(cpuPath), Integer.MAX_VALUE,
-                    (path, basicFileAttributes) -> path.toFile().getName().matches("cpu\\d+"))) {
-                cpuFiles.forEach(cpu -> {
-                    String syspath = cpu.toString(); // /sys/devices/system/cpu/cpuX
-                    Map<String, String> uevent = FileUtil.getKeyValueMapFromFile(syspath + "/uevent", "=");
-                    String modAlias = uevent.get("MODALIAS");
-                    // updates caches as a side-effect
-                    logProcs.add(
-                            getLogicalProcessorFromSyspath(syspath, caches, modAlias, coreEfficiencyMap, modAliasMap));
-                });
-            }
-        } catch (IOException e) {
-            // No udev and no cpu info in sysfs? Bad.
-            LOG.warn("Unable to find CPU information in sysfs at path {}", cpuPath);
+        for (String syspath : syspaths) {
+            Map<String, String> uevent = FileUtil.getKeyValueMapFromFile(syspath + "/uevent", "=");
+            String modAlias = uevent.get("MODALIAS");
+            // updates caches as a side-effect
+            logProcs.add(getLogicalProcessorFromSyspath(syspath, caches, modAlias, coreEfficiencyMap, modAliasMap));
         }
         return new Quartet<>(logProcs, orderedProcCaches(caches), coreEfficiencyMap, modAliasMap);
     }
@@ -468,39 +499,25 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     /**
-     * Fills the freqs array from udev cpu-freq source. Returns true if successful (max > 0). Subclasses provide the
-     * implementation.
+     * Fills the freqs array with per-logical-processor current frequencies in Hz, reading each CPU's cpufreq sysfs
+     * files. CPUs are enumerated via udev when available, otherwise via a sysfs directory scan.
      *
      * @param freqs array to fill with per-logical-processor frequencies in Hz
-     * @return true if frequencies were successfully read
+     * @return true if frequencies were successfully read (max &gt; 0)
      */
-    protected abstract boolean queryCurrentFreqFromUdev(long[] freqs);
-
-    /**
-     * queryCurrentFreqFromSysfs.
-     *
-     * @param freqs the freqs
-     * @return the result
-     */
-    protected static boolean queryCurrentFreqFromSysfs(long[] freqs) {
+    protected boolean queryCurrentFreqFromUdev(long[] freqs) {
         long max = 0L;
-        try (Stream<Path> cpuFiles = Files.find(Paths.get(SysPath.CPU), 1,
-                (path, attr) -> path.toFile().getName().matches("cpu\\d+"))) {
-            for (Path cpu : (Iterable<Path>) cpuFiles::iterator) {
-                String syspath = cpu.toString();
-                int cpuIdx = ParseUtil.getFirstIntValue(syspath);
-                if (cpuIdx >= 0 && cpuIdx < freqs.length) {
-                    freqs[cpuIdx] = FileUtil.getLongFromFile(syspath + "/cpufreq/scaling_cur_freq");
-                    if (freqs[cpuIdx] == 0) {
-                        freqs[cpuIdx] = FileUtil.getLongFromFile(syspath + "/cpufreq/cpuinfo_cur_freq");
-                    }
-                    if (max < freqs[cpuIdx]) {
-                        max = freqs[cpuIdx];
-                    }
+        for (String syspath : cpuSyspaths()) {
+            int cpuIdx = ParseUtil.getFirstIntValue(syspath);
+            if (cpuIdx >= 0 && cpuIdx < freqs.length) {
+                freqs[cpuIdx] = FileUtil.getLongFromFile(syspath + "/cpufreq/scaling_cur_freq");
+                if (freqs[cpuIdx] == 0) {
+                    freqs[cpuIdx] = FileUtil.getLongFromFile(syspath + "/cpufreq/cpuinfo_cur_freq");
+                }
+                if (max < freqs[cpuIdx]) {
+                    max = freqs[cpuIdx];
                 }
             }
-        } catch (IOException e) {
-            // ignore
         }
         if (max > 0L) {
             for (int i = 0; i < freqs.length; i++) {
@@ -520,19 +537,18 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     /**
-     * Queries the maximum frequency from udev.
+     * Queries the maximum (policy) frequency from the cpufreq sysfs tree, enumerating CPUs via udev when available and
+     * otherwise via a sysfs directory scan.
      *
      * @return the maximum frequency in Hz
      */
-    protected abstract long queryMaxFreqFromUdev();
-
-    /**
-     * Queries the maximum frequency from sysfs.
-     *
-     * @return the maximum frequency in Hz
-     */
-    protected static long queryMaxFreqFromSysfs() {
-        return queryMaxFreqFromCpuFreqPath(SysPath.CPU.substring(0, SysPath.CPU.length() - 1) + "/cpufreq");
+    protected long queryMaxFreqFromUdev() {
+        List<String> syspaths = cpuSyspaths();
+        if (!syspaths.isEmpty()) {
+            String syspath = syspaths.get(0);
+            return queryMaxFreqFromCpuFreqPath(syspath.substring(0, syspath.lastIndexOf('/')) + "/cpufreq");
+        }
+        return -1L;
     }
 
     /**
@@ -562,7 +578,20 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
 
     @Override
     public double[] getSystemLoadAverage(int nelem) {
-        return getSystemLoadAverage(nelem, FileUtil.getStringFromFile(LOADAVG));
+        if (nelem < 1 || nelem > 3) {
+            throw new IllegalArgumentException("Must include from one to three elements.");
+        }
+        double[] average = new double[nelem];
+        int retval = getloadavgNative(average, nelem);
+        if (retval < 0) {
+            // Native call unavailable or failed; fall back to /proc/loadavg
+            return getSystemLoadAverage(nelem, FileUtil.getStringFromFile(LOADAVG));
+        }
+        if (retval < nelem) {
+            // All-or-nothing: a partial result is more likely a misread than a real load average
+            Arrays.fill(average, -1d);
+        }
+        return average;
     }
 
     static double[] getSystemLoadAverage(int nelem, String loadavgContent) {
@@ -576,6 +605,15 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
         }
         return average;
     }
+
+    /**
+     * Native {@code getloadavg(3)} call, filling {@code loadavg} with up to {@code nelem} samples.
+     *
+     * @param loadavg the array to populate
+     * @param nelem   the number of elements requested
+     * @return the number of samples retrieved, or a negative value if the native call is unavailable or failed
+     */
+    protected abstract int getloadavgNative(double[] loadavg, int nelem);
 
     @Override
     public long[][] queryProcessorCpuLoadTicks() {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxCentralProcessorNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxCentralProcessorNF.java
@@ -5,17 +5,16 @@
 package oshi.hardware.common.platform.linux.nativefree;
 
 import java.util.List;
-import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.platform.linux.LinuxCentralProcessor;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.tuples.Quartet;
 
 /**
- * Native-free Linux central processor implementation. Extends {@link LinuxCentralProcessor}, overriding udev-dependent
- * methods with sysfs-based alternatives.
+ * Native-free Linux central processor implementation. Extends {@link LinuxCentralProcessor}, using only sysfs and
+ * {@code /proc} sources: it has no udev enumeration and no native {@code getloadavg}, so the base falls back to a sysfs
+ * directory scan and {@code /proc/loadavg} respectively.
  */
 @ThreadSafe
 public final class LinuxCentralProcessorNF extends LinuxCentralProcessor {
@@ -35,17 +34,14 @@ public final class LinuxCentralProcessorNF extends LinuxCentralProcessor {
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyWithUdev() {
-        return readTopologyFromSysfs();
+    protected List<String> enumerateCpuSyspathsViaUdev() {
+        // No udev; the base falls back to a sysfs directory scan
+        return null;
     }
 
     @Override
-    protected boolean queryCurrentFreqFromUdev(long[] freqs) {
-        return queryCurrentFreqFromSysfs(freqs);
-    }
-
-    @Override
-    protected long queryMaxFreqFromUdev() {
-        return queryMaxFreqFromSysfs();
+    protected int getloadavgNative(double[] loadavg, int nelem) {
+        // No native getloadavg; the base falls back to /proc/loadavg
+        return -1;
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import oshi.hardware.CentralProcessor.LogicalProcessor;
@@ -136,6 +138,55 @@ class LinuxCentralProcessorTest {
     void testGetSystemLoadAverageInvalidNelem() {
         assertThrows(IllegalArgumentException.class, () -> LinuxCentralProcessor.getSystemLoadAverage(0, "1 2 3"));
         assertThrows(IllegalArgumentException.class, () -> LinuxCentralProcessor.getSystemLoadAverage(4, "1 2 3"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX) // constructing a LinuxCentralProcessor initializes Linux-only SysPath
+    void testGetSystemLoadAverageNativeFullResult() {
+        StubLinuxCentralProcessor cpu = new StubLinuxCentralProcessor(new double[] { 1.0, 5.0, 15.0 }, 3);
+        double[] avg = cpu.getSystemLoadAverage(3);
+        assertThat(avg[0], closeTo(1.0, EPS));
+        assertThat(avg[1], closeTo(5.0, EPS));
+        assertThat(avg[2], closeTo(15.0, EPS));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX) // constructing a LinuxCentralProcessor initializes Linux-only SysPath
+    void testGetSystemLoadAverageNativePartialResultFillsNegative() {
+        // Native call returns fewer samples than requested: all-or-nothing, whole array becomes -1
+        StubLinuxCentralProcessor cpu = new StubLinuxCentralProcessor(new double[] { 1.0, 5.0, 15.0 }, 2);
+        double[] avg = cpu.getSystemLoadAverage(3);
+        assertThat(avg[0], closeTo(-1d, EPS));
+        assertThat(avg[1], closeTo(-1d, EPS));
+        assertThat(avg[2], closeTo(-1d, EPS));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX) // constructing a LinuxCentralProcessor initializes Linux-only SysPath
+    void testGetSystemLoadAverageNativeInvalidNelem() {
+        StubLinuxCentralProcessor cpu = new StubLinuxCentralProcessor(new double[0], 0);
+        assertThrows(IllegalArgumentException.class, () -> cpu.getSystemLoadAverage(0));
+        assertThrows(IllegalArgumentException.class, () -> cpu.getSystemLoadAverage(4));
+    }
+
+    // -------------------------------------------------------------------------
+    // cpuSyspathsFromSysfs
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testCpuSyspathsFromSysfs(@TempDir Path tempDir) throws IOException {
+        Files.createDirectories(tempDir.resolve("cpu0"));
+        Files.createDirectories(tempDir.resolve("cpu1"));
+        Files.createDirectories(tempDir.resolve("cpufreq")); // not a cpuN entry
+        List<String> syspaths = LinuxCentralProcessor.cpuSyspathsFromSysfs(tempDir.toString());
+        assertThat(syspaths, hasSize(2));
+        assertThat(syspaths.stream().anyMatch(p -> p.endsWith("cpu0")), is(true));
+        assertThat(syspaths.stream().anyMatch(p -> p.endsWith("cpu1")), is(true));
+    }
+
+    @Test
+    void testCpuSyspathsFromSysfsNonexistentPath(@TempDir Path tempDir) {
+        assertThat(LinuxCentralProcessor.cpuSyspathsFromSysfs(tempDir.resolve("missing").toString()), is(empty()));
     }
 
     // -------------------------------------------------------------------------
@@ -447,5 +498,33 @@ class LinuxCentralProcessorTest {
     void testMapCachesFromLscpuEmpty() {
         Set<ProcessorCache> result = LinuxCentralProcessor.mapCachesFromLscpu(Collections.emptyList());
         assertThat(result, is(empty()));
+    }
+
+    /**
+     * Minimal stub supplying native load-average samples without native calls and no udev enumeration.
+     */
+    static class StubLinuxCentralProcessor extends LinuxCentralProcessor {
+
+        private final double[] loadavgValues;
+        private final int loadavgRetval;
+
+        StubLinuxCentralProcessor(double[] loadavgValues, int loadavgRetval) {
+            super(100L);
+            this.loadavgValues = loadavgValues;
+            this.loadavgRetval = loadavgRetval;
+        }
+
+        @Override
+        protected List<String> enumerateCpuSyspathsViaUdev() {
+            return null;
+        }
+
+        @Override
+        protected int getloadavgNative(double[] loadavg, int nelem) {
+            for (int i = 0; i < nelem && i < loadavgValues.length; i++) {
+                loadavg[i] = loadavgValues[i];
+            }
+            return loadavgRetval;
+        }
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
@@ -5,19 +5,14 @@
 package oshi.hardware.platform.linux;
 
 import static org.slf4j.event.Level.WARN;
-import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
-import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.software.os.linux.LinuxOperatingSystemFFM.HAS_UDEV;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,14 +24,11 @@ import oshi.ffm.platform.linux.LinuxLibcFunctions;
 import oshi.ffm.platform.linux.UdevFunctions;
 import oshi.hardware.common.platform.linux.LinuxCentralProcessor;
 import oshi.software.os.linux.LinuxOperatingSystemFFM;
-import oshi.util.FileUtil;
-import oshi.util.ParseUtil;
 import oshi.util.driver.linux.proc.Auxv;
-import oshi.util.tuples.Quartet;
 
 /**
- * FFM-based Linux central processor implementation. Extends {@link LinuxCentralProcessor}, overriding udev-dependent
- * methods with FFM implementations via {@link UdevFunctions}.
+ * FFM-based Linux central processor implementation. Extends {@link LinuxCentralProcessor}, supplying the udev CPU
+ * enumeration via {@link UdevFunctions} and native library calls.
  */
 @ThreadSafe
 public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
@@ -48,153 +40,51 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
     }
 
     @Override
+    protected List<String> enumerateCpuSyspathsViaUdev() {
+        if (!HAS_UDEV) {
+            return null;
+        }
+        return callInArenaOrDefault(arena -> {
+            MemorySegment udev = UdevFunctions.udev_new();
+            if (MemorySegment.NULL.equals(udev)) {
+                return null;
+            }
+            List<String> syspaths = new ArrayList<>();
+            // wrapped only to release the native handle on close
+            try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
+                MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
+                // wrapped only to release the native handle on close
+                try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
+                    UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
+                    UdevFunctions.udev_enumerate_scan_devices(enumerate);
+                    for (MemorySegment entry = UdevFunctions
+                            .udev_enumerate_get_list_entry(enumerate); !MemorySegment.NULL
+                                    .equals(entry); entry = UdevFunctions.udev_list_entry_get_next(entry)) {
+                        String syspath = UdevFunctions.getString(UdevFunctions.udev_list_entry_get_name(entry), arena);
+                        if (syspath != null) {
+                            syspaths.add(syspath);
+                        }
+                    }
+                }
+            }
+            return syspaths;
+        }, LOG, WARN, "Error enumerating CPUs via udev, falling back to sysfs", null);
+    }
+
+    @Override
     protected long queryHwcap() {
         return AuxvFFM.queryAuxv().getOrDefault(Auxv.AT_HWCAP, 0L);
     }
 
     @Override
-    public double[] getSystemLoadAverage(int nelem) {
-        if (nelem < 1 || nelem > 3) {
-            throw new IllegalArgumentException("Must include from one to three elements.");
-        }
-        double[] average = callInArenaOrDefault(arena -> {
-            MemorySegment loadavg = arena.allocate(ValueLayout.JAVA_DOUBLE, nelem);
-            int retval = LinuxLibcFunctions.getloadavg(loadavg, nelem);
-            double[] result = new double[nelem];
-            for (int i = 0; i < nelem; i++) {
-                result[i] = retval > i ? loadavg.getAtIndex(ValueLayout.JAVA_DOUBLE, i) : -1d;
+    protected int getloadavgNative(double[] loadavg, int nelem) {
+        return callInArenaIntOrDefault(arena -> {
+            MemorySegment seg = arena.allocate(ValueLayout.JAVA_DOUBLE, nelem);
+            int retval = LinuxLibcFunctions.getloadavg(seg, nelem);
+            for (int i = 0; i < nelem && i < retval; i++) {
+                loadavg[i] = seg.getAtIndex(ValueLayout.JAVA_DOUBLE, i);
             }
-            return result;
-        }, LOG, WARN, "FFM getloadavg failed", null);
-        return average == null ? super.getSystemLoadAverage(nelem) : average;
-    }
-
-    @Override
-    protected Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyWithUdev() {
-        if (!HAS_UDEV) {
-            return readTopologyFromSysfs();
-        }
-        List<LogicalProcessor> logProcs = new ArrayList<>();
-        Set<ProcessorCache> caches = new HashSet<>();
-        Map<Integer, Integer> coreEfficiencyMap = new HashMap<>();
-        Map<Integer, String> modAliasMap = new HashMap<>();
-        Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> topology = callInArenaOrDefault(
-                arena -> {
-                    MemorySegment udev = UdevFunctions.udev_new();
-                    if (MemorySegment.NULL.equals(udev)) {
-                        return readTopologyFromSysfs();
-                    }
-                    // wrapped only to release the native handle on close
-                    try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
-                        MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                        // wrapped only to release the native handle on close
-                        try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
-                            UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
-                            UdevFunctions.udev_enumerate_scan_devices(enumerate);
-                            for (MemorySegment entry = UdevFunctions
-                                    .udev_enumerate_get_list_entry(enumerate); !MemorySegment.NULL
-                                            .equals(entry); entry = UdevFunctions.udev_list_entry_get_next(entry)) {
-                                String syspath = UdevFunctions.getString(UdevFunctions.udev_list_entry_get_name(entry),
-                                        arena);
-                                if (syspath == null) {
-                                    continue;
-                                }
-                                MemorySegment device = UdevFunctions.deviceNewFromSyspath(udev, syspath, arena);
-                                String modAlias = null;
-                                if (!MemorySegment.NULL.equals(device)) {
-                                    // wrapped only to release the native handle on close
-                                    try (var _ = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
-                                        modAlias = UdevFunctions.getPropertyValue(device, "MODALIAS", arena);
-                                    }
-                                }
-                                logProcs.add(getLogicalProcessorFromSyspath(syspath, caches, modAlias,
-                                        coreEfficiencyMap, modAliasMap));
-                            }
-                        }
-                    }
-                    return new Quartet<>(logProcs, orderedProcCaches(caches), coreEfficiencyMap, modAliasMap);
-                }, LOG, WARN, "Error reading CPU topology via udev, falling back to sysfs", null);
-        return topology == null ? readTopologyFromSysfs() : topology;
-    }
-
-    @Override
-    protected boolean queryCurrentFreqFromUdev(long[] freqs) {
-        if (!HAS_UDEV) {
-            return queryCurrentFreqFromSysfs(freqs);
-        }
-        boolean success = callInArenaBooleanOrDefault(arena -> {
-            MemorySegment udev = UdevFunctions.udev_new();
-            if (MemorySegment.NULL.equals(udev)) {
-                return false;
-            }
-            // wrapped only to release the native handle on close
-            try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
-                MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                // wrapped only to release the native handle on close
-                try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
-                    UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
-                    UdevFunctions.udev_enumerate_scan_devices(enumerate);
-                    long max = 0L;
-                    for (MemorySegment entry = UdevFunctions
-                            .udev_enumerate_get_list_entry(enumerate); !MemorySegment.NULL
-                                    .equals(entry); entry = UdevFunctions.udev_list_entry_get_next(entry)) {
-                        String syspath = UdevFunctions.getString(UdevFunctions.udev_list_entry_get_name(entry), arena);
-                        if (syspath == null) {
-                            continue;
-                        }
-                        int cpu = ParseUtil.getFirstIntValue(syspath);
-                        if (cpu >= 0 && cpu < freqs.length) {
-                            freqs[cpu] = FileUtil.getLongFromFile(syspath + "/cpufreq/scaling_cur_freq");
-                            if (freqs[cpu] == 0) {
-                                freqs[cpu] = FileUtil.getLongFromFile(syspath + "/cpufreq/cpuinfo_cur_freq");
-                            }
-                            if (max < freqs[cpu]) {
-                                max = freqs[cpu];
-                            }
-                        }
-                    }
-                    if (max > 0L) {
-                        for (int i = 0; i < freqs.length; i++) {
-                            freqs[i] *= 1000L;
-                        }
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }, LOG, WARN, "Error reading CPU frequencies via udev", false);
-        return success || queryCurrentFreqFromSysfs(freqs);
-    }
-
-    @Override
-    protected long queryMaxFreqFromUdev() {
-        if (!HAS_UDEV) {
-            return queryMaxFreqFromSysfs();
-        }
-        long maxFreq = callInArenaLongOrDefault(arena -> {
-            MemorySegment udev = UdevFunctions.udev_new();
-            if (MemorySegment.NULL.equals(udev)) {
-                return -1L;
-            }
-            // wrapped only to release the native handle on close
-            try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
-                MemorySegment enumerate = UdevFunctions.udev_enumerate_new(udev);
-                // wrapped only to release the native handle on close
-                try (var _ = NativeHandle.of(enumerate, UdevFunctions::udev_enumerate_unref)) {
-                    UdevFunctions.addMatchSubsystem(enumerate, "cpu", arena);
-                    UdevFunctions.udev_enumerate_scan_devices(enumerate);
-                    MemorySegment entry = UdevFunctions.udev_enumerate_get_list_entry(enumerate);
-                    if (!MemorySegment.NULL.equals(entry)) {
-                        String syspath = UdevFunctions.getString(UdevFunctions.udev_list_entry_get_name(entry), arena);
-                        if (syspath != null) {
-                            return queryMaxFreqFromCpuFreqPath(
-                                    syspath.substring(0, syspath.lastIndexOf('/')) + "/cpufreq");
-                        }
-                    }
-                }
-            }
-            return -1L;
-        }, LOG, WARN, "Error reading max CPU frequency via udev", -1L);
-        return maxFreq < 0L ? queryMaxFreqFromSysfs() : maxFreq;
+            return retval;
+        }, LOG, WARN, "FFM getloadavg failed", -1);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorJNA.java
@@ -7,15 +7,13 @@ package oshi.hardware.platform.linux;
 import static oshi.software.os.linux.LinuxOperatingSystemJNA.HAS_UDEV;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sun.jna.platform.linux.Udev;
 import com.sun.jna.platform.linux.Udev.UdevContext;
-import com.sun.jna.platform.linux.Udev.UdevDevice;
 import com.sun.jna.platform.linux.Udev.UdevEnumerate;
 import com.sun.jna.platform.linux.Udev.UdevListEntry;
 
@@ -24,128 +22,53 @@ import oshi.driver.linux.proc.AuxvJNA;
 import oshi.hardware.common.platform.linux.LinuxCentralProcessor;
 import oshi.jna.platform.linux.LinuxLibc;
 import oshi.software.os.linux.LinuxOperatingSystemJNA;
-import oshi.util.FileUtil;
-import oshi.util.ParseUtil;
 import oshi.util.driver.linux.proc.Auxv;
-import oshi.util.tuples.Quartet;
 
 /**
- * JNA-based Linux central processor implementation. Extends {@link LinuxCentralProcessor}, overriding udev-dependent
- * methods with JNA implementations.
+ * JNA-based Linux central processor implementation. Extends {@link LinuxCentralProcessor}, supplying the udev CPU
+ * enumeration and native library calls.
  */
 @ThreadSafe
 final class LinuxCentralProcessorJNA extends LinuxCentralProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxCentralProcessorJNA.class);
 
     LinuxCentralProcessorJNA() {
         super(LinuxOperatingSystemJNA.hz());
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyWithUdev() {
+    protected List<String> enumerateCpuSyspathsViaUdev() {
         if (!HAS_UDEV) {
-            return readTopologyFromSysfs();
+            return null;
         }
         UdevContext udev = Udev.INSTANCE.udev_new();
         if (udev == null) {
-            return readTopologyFromSysfs();
+            return null;
         }
         try {
-            return readTopologyFromUdev(udev);
-        } finally {
-            udev.unref();
-        }
-    }
-
-    @Override
-    protected boolean queryCurrentFreqFromUdev(long[] freqs) {
-        if (!HAS_UDEV) {
-            return queryCurrentFreqFromSysfs(freqs);
-        }
-        UdevContext udev = Udev.INSTANCE.udev_new();
-        if (udev == null) {
-            return queryCurrentFreqFromSysfs(freqs);
-        }
-        try {
-            return readCurrentFreqFromUdev(udev, freqs);
-        } finally {
-            udev.unref();
-        }
-    }
-
-    @Override
-    protected long queryMaxFreqFromUdev() {
-        if (!HAS_UDEV) {
-            return queryMaxFreqFromSysfs();
-        }
-        UdevContext udev = Udev.INSTANCE.udev_new();
-        if (udev == null) {
-            return queryMaxFreqFromSysfs();
-        }
-        try {
-            return readMaxFreqFromUdev(udev);
-        } finally {
-            udev.unref();
-        }
-    }
-
-    private static Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> readTopologyFromUdev(
-            UdevContext udev) {
-        List<LogicalProcessor> logProcs = new ArrayList<>();
-        Set<ProcessorCache> caches = new HashSet<>();
-        Map<Integer, Integer> coreEfficiencyMap = new HashMap<>();
-        Map<Integer, String> modAliasMap = new HashMap<>();
-        UdevEnumerate enumerate = udev.enumerateNew();
-        try {
-            enumerate.addMatchSubsystem("cpu");
-            enumerate.scanDevices();
-            for (UdevListEntry entry = enumerate.getListEntry(); entry != null; entry = entry.getNext()) {
-                String syspath = entry.getName(); // /sys/devices/system/cpu/cpuX
-                UdevDevice device = udev.deviceNewFromSyspath(syspath);
-                String modAlias = null;
-                if (device != null) {
-                    try {
-                        modAlias = device.getPropertyValue("MODALIAS");
-                    } finally {
-                        device.unref();
-                    }
+            List<String> syspaths = new ArrayList<>();
+            UdevEnumerate enumerate = udev.enumerateNew();
+            if (enumerate == null) {
+                return null;
+            }
+            try {
+                enumerate.addMatchSubsystem("cpu");
+                enumerate.scanDevices();
+                for (UdevListEntry entry = enumerate.getListEntry(); entry != null; entry = entry.getNext()) {
+                    syspaths.add(entry.getName());
                 }
-                logProcs.add(getLogicalProcessorFromSyspath(syspath, caches, modAlias, coreEfficiencyMap, modAliasMap));
+            } finally {
+                enumerate.unref();
             }
+            return syspaths;
+        } catch (RuntimeException e) {
+            // Any udev failure falls back to the shared sysfs scan
+            LOG.warn("Error enumerating CPUs via udev, falling back to sysfs", e);
+            return null;
         } finally {
-            enumerate.unref();
+            udev.unref();
         }
-        return new Quartet<>(logProcs, orderedProcCaches(caches), coreEfficiencyMap, modAliasMap);
-    }
-
-    private static boolean readCurrentFreqFromUdev(UdevContext udev, long[] freqs) {
-        long max = 0L;
-        UdevEnumerate enumerate = udev.enumerateNew();
-        try {
-            enumerate.addMatchSubsystem("cpu");
-            enumerate.scanDevices();
-            for (UdevListEntry entry = enumerate.getListEntry(); entry != null; entry = entry.getNext()) {
-                String syspath = entry.getName();
-                int cpu = ParseUtil.getFirstIntValue(syspath);
-                if (cpu >= 0 && cpu < freqs.length) {
-                    freqs[cpu] = FileUtil.getLongFromFile(syspath + "/cpufreq/scaling_cur_freq");
-                    if (freqs[cpu] == 0) {
-                        freqs[cpu] = FileUtil.getLongFromFile(syspath + "/cpufreq/cpuinfo_cur_freq");
-                    }
-                    if (max < freqs[cpu]) {
-                        max = freqs[cpu];
-                    }
-                }
-            }
-        } finally {
-            enumerate.unref();
-        }
-        if (max > 0L) {
-            for (int i = 0; i < freqs.length; i++) {
-                freqs[i] *= 1000L;
-            }
-            return true;
-        }
-        return false;
     }
 
     @Override
@@ -154,34 +77,7 @@ final class LinuxCentralProcessorJNA extends LinuxCentralProcessor {
     }
 
     @Override
-    public double[] getSystemLoadAverage(int nelem) {
-        if (nelem < 1 || nelem > 3) {
-            throw new IllegalArgumentException("Must include from one to three elements.");
-        }
-        double[] average = new double[nelem];
-        int retval = LinuxLibc.INSTANCE.getloadavg(average, nelem);
-        if (retval < 0) {
-            return super.getSystemLoadAverage(nelem);
-        }
-        for (int i = retval; i < nelem; i++) {
-            average[i] = -1d;
-        }
-        return average;
-    }
-
-    private static long readMaxFreqFromUdev(UdevContext udev) {
-        UdevEnumerate enumerate = udev.enumerateNew();
-        try {
-            enumerate.addMatchSubsystem("cpu");
-            enumerate.scanDevices();
-            UdevListEntry entry = enumerate.getListEntry();
-            if (entry != null) {
-                String syspath = entry.getName();
-                return queryMaxFreqFromCpuFreqPath(syspath.substring(0, syspath.lastIndexOf('/')) + "/cpufreq");
-            }
-        } finally {
-            enumerate.unref();
-        }
-        return -1L;
+    protected int getloadavgNative(double[] loadavg, int nelem) {
+        return LinuxLibc.INSTANCE.getloadavg(loadavg, nelem);
     }
 }


### PR DESCRIPTION
Completes the CentralProcessor cross-OS consistency/dedup arc (after Windows #3459, FreeBSD/DragonFly #3460, OpenBSD #3461, and macOS #3462), now for Linux.

### What

The Linux central processor's JNA/FFM/native-free backends duplicated ~130 lines of near-identical udev topology and frequency logic, plus separate `getSystemLoadAverage` overrides. The only part that genuinely differs between JNA and FFM is the udev enumeration itself; everything downstream (syspath parsing, cpufreq file reads, topology building, MODALIAS) is plain Java. So the entire divergence collapses to **two hooks**:

- **`enumerateCpuSyspathsViaUdev()`** — returns the CPU syspaths via udev, or `null` when udev is unavailable so the base falls back to a sysfs directory scan. JNA (`UdevContext`), FFM (`UdevFunctions`), native-free (`null`).
- **`getloadavgNative()`** — native `getloadavg`; the native-free backend returns `-1` so the base falls back to `/proc/loadavg`.

The base `LinuxCentralProcessor` now implements topology, current-frequency, max-frequency, and load-average once. `getSystemLoadAverage` is **all-or-nothing** (a partial native result blanks the whole array — a partial read is more likely a misread than a real load average), consistent with the other platforms, with a `/proc/loadavg` fallback.

Twins shrink: **JNA 187→70, FFM 200→95, NF 51→48** (net −114 lines).

### Behavior notes (both preserve observable output)

1. Topology MODALIAS is now read from the cpu `uevent` file — the source the sysfs path already used and that udev itself derives the property from — rather than the udev device property.
2. The no-udev frequency path now enumerates CPUs with the same sysfs scan used for topology.

### Tests

Added stub-based `getSystemLoadAverage` coverage (full result, all-or-nothing partial, bounds), gated `@EnabledOnOs(LINUX)` because constructing a `LinuxCentralProcessor` initializes the Linux-only `SysPath`; plus `cpuSyspathsFromSysfs` enumeration tests that run everywhere. The existing topology tests pass unchanged through the new shared `buildTopology`.

Validated with a clean full build on macOS; the Linux runtime paths (udev/freq/topology) are exercised by the Linux CI matrix (JNA + FFM + native-free). No CHANGELOG — no user-facing behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Linux CPU topology discovery, with better handling when udev is unavailable.
  * Centralized CPU frequency reporting with improved fallbacks for current/max values.
  * Enhanced system load-average retrieval using native support when available, otherwise `/proc`, including stricter handling of partial/invalid results.
  * Native-free Linux now relies solely on sysfs and `/proc` for these metrics.
* **Tests**
  * Added OS-conditional and stubbed test coverage for load-average edge cases and CPU syspath scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->