### PR TITLE
Test the Windows legacy GetSystemTimes system-CPU-tick path (JNA and FFM)

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -91,6 +91,17 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     }
 
     /**
+     * Whether the legacy {@code GetSystemTimes} path is used for system CPU load ticks rather than the per-processor
+     * perfmon sum. Overridable so tests can force the legacy path independently of the
+     * {@link #USE_LEGACY_SYSTEM_COUNTERS} static capture.
+     *
+     * @return true to use the legacy {@code GetSystemTimes} path
+     */
+    protected boolean useLegacySystemCounters() {
+        return USE_LEGACY_SYSTEM_COUNTERS;
+    }
+
+    /**
      * Gets the numaNodeProcToLogicalProcMap.
      *
      * @return the map

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
@@ -44,8 +44,10 @@ import oshi.util.tuples.Triplet;
 /**
  * FFM-based Windows Central Processor implementation.
  */
+// Not final so tests can subclass it to force the useLegacySystemCounters() gate and exercise the legacy GetSystemTimes
+// path against the real system.
 @ThreadSafe
-final class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
+class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsCentralProcessorFFM.class);
 
@@ -167,7 +169,7 @@ final class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
     @Override
     public long[] querySystemCpuLoadTicks() {
         long[] ticks = new long[TickType.values().length];
-        if (USE_LEGACY_SYSTEM_COUNTERS) {
+        if (useLegacySystemCounters()) {
             try (Arena arena = Arena.ofConfined()) {
                 // FILETIME is 8 bytes (dwLowDateTime + dwHighDateTime)
                 MemorySegment lpIdleTime = arena.allocate(8);

--- a/oshi-core-ffm/src/test/java/module-info.test
+++ b/oshi-core-ffm/src/test/java/module-info.test
@@ -21,6 +21,8 @@
 --add-opens
   com.github.oshi.ffm/oshi.ffm.platform.windows.com=org.junit.platform.commons
 --add-opens
+  com.github.oshi.ffm/oshi.hardware.platform.windows=org.junit.platform.commons
+--add-opens
   com.github.oshi.ffm/oshi.driver.windows.perfmon=org.junit.platform.commons
 --add-opens
   com.github.oshi.ffm/oshi.driver.windows.registry=org.junit.platform.commons

--- a/oshi-core-ffm/src/test/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFMLegacyTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFMLegacyTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.stream.LongStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.hardware.CentralProcessor.TickType;
+
+/**
+ * Exercises the FFM legacy {@code GetSystemTimes} system-CPU-tick path against the real system by forcing the
+ * {@code useLegacySystemCounters()} gate. Only the gate is overridden, so the genuine native call runs; a rotted legacy
+ * binding (e.g. a broken {@code Kernel32FFM.GetSystemTimes} or FILETIME read) surfaces as all-zero ticks or a total
+ * wildly inconsistent with the modern per-processor sum rather than as a mere coverage number.
+ */
+@EnabledOnOs(OS.WINDOWS)
+class WindowsCentralProcessorFFMLegacyTest {
+
+    /** A real {@link WindowsCentralProcessorFFM} with only the legacy system-counter gate forced. */
+    private static final class ForcedLegacy extends WindowsCentralProcessorFFM {
+        private final boolean legacy;
+
+        ForcedLegacy(boolean legacy) {
+            this.legacy = legacy;
+        }
+
+        @Override
+        protected boolean useLegacySystemCounters() {
+            return legacy;
+        }
+    }
+
+    /**
+     * The legacy {@code GetSystemTimes} path and the modern per-processor perfmon sum both measure cumulative CPU time
+     * since boot, so their totals must agree closely. A broken legacy binding shows up here as zero idle/user ticks or
+     * a total far from the modern one.
+     */
+    @Test
+    void legacySystemCpuLoadTicksAreSaneAndMatchModernTotal() {
+        long[] legacy = new ForcedLegacy(true).querySystemCpuLoadTicks();
+        long[] modern = new ForcedLegacy(false).querySystemCpuLoadTicks();
+
+        assertThat("legacy ticks array length", legacy.length, is(TickType.values().length));
+        for (long tick : legacy) {
+            assertThat("legacy tick non-negative", tick, greaterThanOrEqualTo(0L));
+        }
+        // A successful GetSystemTimes yields non-zero idle and user time on any running system
+        assertThat("legacy idle ticks", legacy[TickType.IDLE.getIndex()], greaterThan(0L));
+        assertThat("legacy user ticks", legacy[TickType.USER.getIndex()], greaterThan(0L));
+
+        long legacyTotal = LongStream.of(legacy).sum();
+        long modernTotal = LongStream.of(modern).sum();
+        assertThat("legacy total ticks", legacyTotal, greaterThan(0L));
+        // Both measure cumulative CPU time since boot; a generous tolerance catches a rotted binding without flaking
+        assertThat((double) legacyTotal, closeTo(modernTotal, modernTotal * 0.5));
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorJNA.java
@@ -49,8 +49,10 @@ import oshi.util.tuples.Triplet;
 /**
  * A CPU, representing all of a system's processors. It may contain multiple individual Physical and Logical processors.
  */
+// Not final so tests can subclass it to force the useLegacySystemCounters() gate and exercise the legacy GetSystemTimes
+// path against the real system.
 @ThreadSafe
-final class WindowsCentralProcessorJNA extends WindowsCentralProcessor {
+class WindowsCentralProcessorJNA extends WindowsCentralProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsCentralProcessorJNA.class);
 
@@ -135,7 +137,7 @@ final class WindowsCentralProcessorJNA extends WindowsCentralProcessor {
     @Override
     public long[] querySystemCpuLoadTicks() {
         long[] ticks = new long[TickType.values().length];
-        if (USE_LEGACY_SYSTEM_COUNTERS) {
+        if (useLegacySystemCounters()) {
             WinBase.FILETIME lpIdleTime = new WinBase.FILETIME();
             WinBase.FILETIME lpKernelTime = new WinBase.FILETIME();
             WinBase.FILETIME lpUserTime = new WinBase.FILETIME();

--- a/oshi-core/src/test/java/oshi/hardware/platform/windows/WindowsCentralProcessorLegacyTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/windows/WindowsCentralProcessorLegacyTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.stream.LongStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.hardware.CentralProcessor.TickType;
+
+/**
+ * Exercises the legacy {@code GetSystemTimes} system-CPU-tick path against the real system by forcing the
+ * {@code useLegacySystemCounters()} gate. Only the gate is overridden, so the genuine native call runs; a rotted legacy
+ * binding (e.g. a broken native {@code GetSystemTimes}) surfaces as all-zero ticks or a total wildly inconsistent with
+ * the modern per-processor sum rather than as a mere coverage number.
+ */
+@EnabledOnOs(OS.WINDOWS)
+class WindowsCentralProcessorLegacyTest {
+
+    /** A real {@link WindowsCentralProcessorJNA} with only the legacy system-counter gate forced. */
+    private static final class ForcedLegacy extends WindowsCentralProcessorJNA {
+        private final boolean legacy;
+
+        ForcedLegacy(boolean legacy) {
+            this.legacy = legacy;
+        }
+
+        @Override
+        protected boolean useLegacySystemCounters() {
+            return legacy;
+        }
+    }
+
+    /**
+     * The legacy {@code GetSystemTimes} path and the modern per-processor perfmon sum both measure cumulative CPU time
+     * since boot, so their totals must agree closely. A broken legacy binding shows up here as zero idle/user ticks or
+     * a total far from the modern one.
+     */
+    @Test
+    void legacySystemCpuLoadTicksAreSaneAndMatchModernTotal() {
+        long[] legacy = new ForcedLegacy(true).querySystemCpuLoadTicks();
+        long[] modern = new ForcedLegacy(false).querySystemCpuLoadTicks();
+
+        assertThat("legacy ticks array length", legacy.length, is(TickType.values().length));
+        for (long tick : legacy) {
+            assertThat("legacy tick non-negative", tick, greaterThanOrEqualTo(0L));
+        }
+        // A successful GetSystemTimes yields non-zero idle and user time on any running system
+        assertThat("legacy idle ticks", legacy[TickType.IDLE.getIndex()], greaterThan(0L));
+        assertThat("legacy user ticks", legacy[TickType.USER.getIndex()], greaterThan(0L));
+
+        long legacyTotal = LongStream.of(legacy).sum();
+        long modernTotal = LongStream.of(modern).sum();
+        assertThat("legacy total ticks", legacyTotal, greaterThan(0L));
+        // Both measure cumulative CPU time since boot; a generous tolerance catches a rotted binding without flaking
+        assertThat((double) legacyTotal, closeTo(modernTotal, modernTotal * 0.5));
+    }
+}


### PR DESCRIPTION
Closes the last coverage gap from the CentralProcessor dedup arc: the Windows `USE_LEGACY_SYSTEM_COUNTERS=true` path.

### What

`querySystemCpuLoadTicks()` has a legacy branch that reads idle/kernel/user times via `GetSystemTimes` (`Kernel32` for JNA, `Kernel32FFM` for FFM). The IRQ/DPC half of that path (`querySystemCounters`) is already compared JNA==FFM, but the `GetSystemTimes` half — including how each backend interprets the raw `FILETIME` — had no test.

The flag is a `static final` capture, and the junit-platform plugin runs tests in-process (`<executor>JAVA</executor>`, no per-class fork), so a `@BeforeAll` config flip can't reliably force the path before the class loads. This follows the existing `WindowsGlobalMemoryLegacyTest` seam pattern instead:

- Add an overridable `useLegacySystemCounters()` gate (returns the static flag); both twins call it instead of the raw field.
- De-final `WindowsCentralProcessorJNA`/`FFM` so a test can subclass and force the gate.
- One `@EnabledOnOs(WINDOWS)` test per backend forces the legacy path and asserts the ticks are sane (non-negative, non-zero idle and user time) and that the legacy total is within a generous tolerance of the modern per-processor sum — both measure cumulative CPU time since boot. A rotted native `GetSystemTimes` or FILETIME read surfaces as all-zero ticks or a wildly inconsistent total.

Running both backends closes the JNA==FFM parity transitively (each legacy ≈ its own modern, and the moderns are already compared equal).

### Notes

No CHANGELOG — test-only plus an internal overridable seam; no behavior change. The assertions only run on the Windows CI runners; tolerances are kept generous since they can't be smoke-tested off-Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows CPU load tick collection by making the legacy system-counter approach selectable and more reliably exercised.
* **Tests**
  * Added Windows-only JUnit coverage for validating legacy CPU tick values, totals, and consistency against modern measurements (including both JNA and FFM paths).
* **Chores**
  * Updated test module JVM options to ensure required Windows FFM packages can be accessed during the test run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->