### PR TITLE
Dedup BSD OSProcess open-file-limit, cwd, and bitness logic

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
@@ -262,6 +262,71 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
         }
     }
 
+    @Override
+    public long getSoftOpenFileLimit() {
+        if (getProcessID() == queryOwnProcessId()) {
+            return queryRlimitNofile(true);
+        }
+        return otherProcessOpenFileLimit(1);
+    }
+
+    @Override
+    public long getHardOpenFileLimit() {
+        if (getProcessID() == queryOwnProcessId()) {
+            return queryRlimitNofile(false);
+        }
+        return otherProcessOpenFileLimit(2);
+    }
+
+    /**
+     * Returns the open-file limit for another (non-current) process. The default reads {@code /proc/<pid>/limits} where
+     * a procfs is available; platforms without one (OpenBSD) override this to return {@code -1}.
+     *
+     * @param index {@code 1} for the soft limit, {@code 2} for the hard limit
+     * @return the limit, or {@code -1} if unavailable
+     */
+    protected long otherProcessOpenFileLimit(int index) {
+        return getProcessOpenFileLimit(getProcessID(), index);
+    }
+
+    /**
+     * Returns the process ID of the current (JVM) process. {@code getrlimit} only reports the calling process, so the
+     * open-file-limit methods use this to decide whether they can query it natively. The default returns {@code -1} (so
+     * the process is never treated as the current one); the native subclasses override it with the operating system's
+     * own process ID.
+     *
+     * @return the current process ID, or {@code -1} if unknown
+     */
+    protected int queryOwnProcessId() {
+        return -1;
+    }
+
+    /**
+     * Reads the current process's soft or hard open-file limit via {@code getrlimit(RLIMIT_NOFILE)}. Only called when
+     * this process is the current one. The default returns {@code -1}; the native subclasses override it.
+     *
+     * @param soft {@code true} for the soft limit, {@code false} for the hard limit
+     * @return the limit, or {@code -1} if unavailable
+     */
+    protected long queryRlimitNofile(boolean soft) {
+        return -1L;
+    }
+
+    /**
+     * Derives process bitness from a {@code kern.proc.sv_name} system-call ABI string.
+     *
+     * @param svName the ABI name (e.g. {@code "FreeBSD ELF64"})
+     * @return {@code 32} or {@code 64}, or {@code 0} if not recognized
+     */
+    protected static int elfBitness(String svName) {
+        if (svName.contains("ELF32")) {
+            return 32;
+        } else if (svName.contains("ELF64")) {
+            return 64;
+        }
+        return 0;
+    }
+
     /**
      * Parses the soft or hard open-file limit for another process from {@code /proc/<pid>/limits}.
      *

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
@@ -38,6 +38,7 @@ import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.common.platform.unix.dragonflybsd.ProcstatUtil;
 
 public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
 
@@ -64,6 +65,16 @@ public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
     @Override
     protected String psCommandArgs() {
         return PS_COMMAND_ARGS;
+    }
+
+    @Override
+    public String getCurrentWorkingDirectory() {
+        return ProcstatUtil.getCwd(getProcessID());
+    }
+
+    @Override
+    public long getOpenFiles() {
+        return ProcstatUtil.getOpenFiles(getProcessID());
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSProcess.java
@@ -40,6 +40,7 @@ import oshi.software.common.os.unix.bsd.BsdPsThreadKeyword;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.common.platform.unix.freebsd.ProcstatUtil;
 
 public abstract class FreeBsdOSProcess extends BsdOSProcess {
 
@@ -66,6 +67,16 @@ public abstract class FreeBsdOSProcess extends BsdOSProcess {
     @Override
     protected String psCommandArgs() {
         return PS_COMMAND_ARGS;
+    }
+
+    @Override
+    public String getCurrentWorkingDirectory() {
+        return ProcstatUtil.getCwd(getProcessID());
+    }
+
+    @Override
+    public long getOpenFiles() {
+        return ProcstatUtil.getOpenFiles(getProcessID());
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
@@ -38,6 +38,7 @@ import oshi.software.common.os.unix.bsd.BsdPsThreadKeyword;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.common.platform.unix.openbsd.FstatUtil;
 
 public abstract class OpenBsdOSProcess extends BsdOSProcess {
 
@@ -63,6 +64,22 @@ public abstract class OpenBsdOSProcess extends BsdOSProcess {
     @Override
     protected String psCommandArgs() {
         return PS_COMMAND_ARGS;
+    }
+
+    @Override
+    public String getCurrentWorkingDirectory() {
+        return FstatUtil.getCwd(getProcessID());
+    }
+
+    @Override
+    public long getOpenFiles() {
+        return FstatUtil.getOpenFiles(getProcessID());
+    }
+
+    @Override
+    protected long otherProcessOpenFileLimit(int index) {
+        // OpenBSD has no procfs; open-file limits for other processes are unavailable
+        return -1L;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtil.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtil.java
@@ -8,9 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -24,24 +22,6 @@ import oshi.util.ParseUtil;
 public final class ProcstatUtil {
 
     private ProcstatUtil() {
-    }
-
-    /**
-     * Gets a map containing current working directory info
-     *
-     * @param pid a process ID, optional
-     * @return a map of process IDs to their current working directory. If {@code pid} is a negative number, all
-     *         processes are returned; otherwise the map may contain only a single element for {@code pid}
-     */
-    public static Map<Integer, String> getCwdMap(int pid) {
-        Map<Integer, String> cwdMap = new HashMap<>();
-        if (pid >= 0) {
-            String cwd = getCwd(pid);
-            if (!cwd.isEmpty()) {
-                cwdMap.put(pid, cwd);
-            }
-        }
-        return cwdMap;
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/freebsd/ProcstatUtil.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/freebsd/ProcstatUtil.java
@@ -4,50 +4,19 @@
  */
 package oshi.util.common.platform.unix.freebsd;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 /**
- * Reads from procstat into a map
+ * Reads process working-directory and open-file information from {@code procstat}.
  */
 @ThreadSafe
 public final class ProcstatUtil {
 
     private ProcstatUtil() {
-    }
-
-    /**
-     * Gets a map containing current working directory info
-     *
-     * @param pid a process ID, optional
-     * @return a map of process IDs to their current working directory. If {@code pid} is a negative number, all
-     *         processes are returned; otherwise the map may contain only a single element for {@code pid}
-     */
-    public static Map<Integer, String> getCwdMap(int pid) {
-        return parseCwdMap(ExecutingCommand.runNative("procstat -f " + (pid < 0 ? "-a" : pid)));
-    }
-
-    /**
-     * Parses {@code procstat -f} output into a map of PID to current working directory by selecting rows whose third
-     * column is {@code cwd}.
-     *
-     * @param procstatLines lines returned by {@code procstat -f}
-     * @return a map of PID to working directory
-     */
-    public static Map<Integer, String> parseCwdMap(List<String> procstatLines) {
-        Map<Integer, String> cwdMap = new HashMap<>();
-        for (String line : procstatLines) {
-            String[] split = ParseUtil.whitespaces.split(line.trim(), 10);
-            if (split.length == 10 && split[2].equals("cwd")) {
-                cwdMap.put(ParseUtil.parseIntOrDefault(split[0], -1), split[9]);
-            }
-        }
-        return cwdMap;
     }
 
     /**

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -80,6 +80,8 @@
   com.github.oshi.common/oshi.hardware.common.platform.unix.aix=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.software.common.os.unix.aix=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.software.common.os.unix.bsd=org.junit.platform.commons
 
 --add-modules
   org.hamcrest,org.slf4j.simple

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/bsd/BsdOSProcessTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/bsd/BsdOSProcessTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.bsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.software.os.OSThread;
+
+/**
+ * Tests the shared open-file-limit skeleton and ELF-bitness parsing hoisted into {@link BsdOSProcess}.
+ */
+class BsdOSProcessTest {
+
+    // Builds a minimal BSD process whose open-file-limit hooks return sentinel values so the base's routing (current
+    // process via getrlimit vs. other process via the fallback) can be observed.
+    private static BsdOSProcess stubProcess(int pid, int ownPid) {
+        return new BsdOSProcess(pid) {
+            @Override
+            protected List<BsdPsKeyword> psKeywords() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            protected String psCommandArgs() {
+                return "";
+            }
+
+            @Override
+            protected List<String> queryArguments() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            protected Map<String, String> queryEnvironmentVariables() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            protected int queryBitness() {
+                return 0;
+            }
+
+            @Override
+            protected int queryOwnProcessId() {
+                return ownPid;
+            }
+
+            @Override
+            protected long queryRlimitNofile(boolean soft) {
+                return soft ? 1024L : 4096L;
+            }
+
+            @Override
+            protected long otherProcessOpenFileLimit(int index) {
+                return index == 1 ? -11L : -22L;
+            }
+
+            @Override
+            public String getCurrentWorkingDirectory() {
+                return "";
+            }
+
+            @Override
+            public long getOpenFiles() {
+                return 0L;
+            }
+
+            @Override
+            public List<OSThread> getThreadDetails() {
+                return Collections.emptyList();
+            }
+        };
+    }
+
+    @Test
+    void testOpenFileLimitsForCurrentProcess() {
+        // pid matches the current process id, so getrlimit values are returned
+        BsdOSProcess self = stubProcess(42, 42);
+        assertThat(self.getSoftOpenFileLimit(), is(1024L));
+        assertThat(self.getHardOpenFileLimit(), is(4096L));
+    }
+
+    @Test
+    void testOpenFileLimitsForOtherProcess() {
+        // pid differs from the current process id, so the non-current fallback is used
+        BsdOSProcess other = stubProcess(42, 7);
+        assertThat(other.getSoftOpenFileLimit(), is(-11L));
+        assertThat(other.getHardOpenFileLimit(), is(-22L));
+    }
+
+    @Test
+    void testElfBitness() {
+        assertThat(BsdOSProcess.elfBitness("FreeBSD ELF64"), is(64));
+        assertThat(BsdOSProcess.elfBitness("FreeBSD ELF32"), is(32));
+        assertThat(BsdOSProcess.elfBitness("not an abi string"), is(0));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtilTest.java
@@ -79,12 +79,6 @@ class ProcstatUtilTest {
     }
 
     @Test
-    void testGetCwdMapNegativePidReturnsEmptyMap() {
-        // No live command is run for a negative pid; the map is empty.
-        assertThat(ProcstatUtil.getCwdMap(-1).size(), is(0));
-    }
-
-    @Test
     @EnabledIfSystemProperty(named = "os.name", matches = "(?i)dragonfly")
     void testProcstatLive() {
         // RuntimeMXBean#getName() returns "<pid>@<host>" — use it to avoid pulling oshi-core's SystemInfo into a

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/freebsd/ProcstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/freebsd/ProcstatUtilTest.java
@@ -5,7 +5,6 @@
 package oshi.util.common.platform.unix.freebsd;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -16,7 +15,6 @@ import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,27 +29,6 @@ class ProcstatUtilTest {
 
     // FreeBSD `procstat -f <pid>` columns (10 total):
     // PID COMM FD T V FLAGS REF OFFSET PRO NAME
-
-    @Test
-    void testParseCwdMapCollectsCwdRows() {
-        List<String> procstat = Arrays.asList("PID COMM             FD T V FLAGS    REF  OFFSET PRO NAME",
-                "1234 bash            text v r r---- 1 0 - /usr/local/bin/bash",
-                "1234 bash             cwd v d r---- 1 0 - /home/dan",
-                "5678 sshd             cwd v d r---- 1 0 - /var/empty",
-                "1234 bash               0 t s rw--- 1 0 - /dev/tty");
-        Map<Integer, String> map = ProcstatUtil.parseCwdMap(procstat);
-        assertThat(map.size(), is(2));
-        assertThat(map.get(1234), is("/home/dan"));
-        assertThat(map.get(5678), is("/var/empty"));
-    }
-
-    @Test
-    void testParseCwdMapNoCwd() {
-        assertThat(
-                ProcstatUtil.parseCwdMap(
-                        Collections.singletonList("PID COMM             FD T V FLAGS    REF  OFFSET PRO NAME")),
-                is(anEmptyMap()));
-    }
 
     @Test
     void testParseCwdReturnsFirstCwdPath() {
@@ -97,9 +74,6 @@ class ProcstatUtilTest {
             int pid = ParseUtil.parseIntOrDefault(ManagementFactory.getRuntimeMXBean().getName().split("@", 2)[0], -1);
             assertThat("RuntimeMXBean#getName() should yield a positive PID, got " + pid, pid, is(greaterThan(0)));
             assertThat("Open files must be nonnegative", ProcstatUtil.getOpenFiles(pid), is(greaterThanOrEqualTo(0L)));
-            assertThat("CwdMap should have at least one element", ProcstatUtil.getCwdMap(-1), is(not(anEmptyMap())));
-            assertThat("CwdMap with pid should have at least one element", ProcstatUtil.getCwdMap(pid),
-                    is(not(anEmptyMap())));
             assertThat("Cwd should be nonempty", ProcstatUtil.getCwd(pid), is(not(emptyString())));
         }
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
@@ -27,7 +27,6 @@ import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
-import oshi.util.common.platform.unix.dragonflybsd.ProcstatUtil;
 
 /**
  * FFM-backed DragonFly BSD OS process.
@@ -68,32 +67,12 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
     }
 
     @Override
-    public String getCurrentWorkingDirectory() {
-        return ProcstatUtil.getCwd(getProcessID());
+    protected int queryOwnProcessId() {
+        return this.os.getProcessId();
     }
 
     @Override
-    public long getOpenFiles() {
-        return ProcstatUtil.getOpenFiles(getProcessID());
-    }
-
-    @Override
-    public long getSoftOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            return queryRlimitNofile(true);
-        }
-        return getProcessOpenFileLimit(getProcessID(), 1);
-    }
-
-    @Override
-    public long getHardOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            return queryRlimitNofile(false);
-        }
-        return getProcessOpenFileLimit(getProcessID(), 2);
-    }
-
-    private long queryRlimitNofile(boolean soft) {
+    protected long queryRlimitNofile(boolean soft) {
         return callInArenaOrDefault(arena -> {
             MemorySegment rlim = arena.allocate(FreeBsdLibcFunctions.RLIMIT_LAYOUT);
             if (FreeBsdLibcFunctions.getrlimit(FreeBsdLibcFunctions.RLIMIT_NOFILE, rlim) != 0) {
@@ -117,13 +96,7 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
                 return 0;
             }
             byte[] bytes = buf.asSlice(0, Math.min(size.get(JAVA_LONG, 0), 32L)).toArray(JAVA_BYTE);
-            String elf = new String(bytes, StandardCharsets.UTF_8).trim();
-            if (elf.contains("ELF32")) {
-                return 32;
-            } else if (elf.contains("ELF64")) {
-                return 64;
-            }
-            return 0;
+            return elfBitness(new String(bytes, StandardCharsets.UTF_8).trim());
         }, LOG, Level.WARN, "queryBitness failed", 0);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
@@ -28,7 +28,6 @@ import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.freebsd.FreeBsdOSProcess;
 import oshi.util.ParseUtil;
-import oshi.util.common.platform.unix.freebsd.ProcstatUtil;
 
 /**
  * FFM-backed FreeBSD OSProcess.
@@ -102,32 +101,12 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
     }
 
     @Override
-    public String getCurrentWorkingDirectory() {
-        return ProcstatUtil.getCwd(getProcessID());
+    protected int queryOwnProcessId() {
+        return this.os.getProcessId();
     }
 
     @Override
-    public long getOpenFiles() {
-        return ProcstatUtil.getOpenFiles(getProcessID());
-    }
-
-    @Override
-    public long getSoftOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            return rlimitNofile(true);
-        }
-        return getProcessOpenFileLimit(getProcessID(), 1);
-    }
-
-    @Override
-    public long getHardOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            return rlimitNofile(false);
-        }
-        return getProcessOpenFileLimit(getProcessID(), 2);
-    }
-
-    private static long rlimitNofile(boolean soft) {
+    protected long queryRlimitNofile(boolean soft) {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment rlim = arena.allocate(RLIMIT_LAYOUT);
             if (FreeBsdLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) != 0) {
@@ -150,13 +129,7 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
             if (0 != FreeBsdLibcFunctions.sysctl(callState, mib, 4, buf, size, MemorySegment.NULL, 0L)) {
                 return 0;
             }
-            String elf = buf.getString(0);
-            if (elf.contains("ELF32")) {
-                return 32;
-            } else if (elf.contains("ELF64")) {
-                return 64;
-            }
-            return 0;
+            return elfBitness(buf.getString(0));
         }, LOG, org.slf4j.event.Level.WARN, "queryBitness failed", 0);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
@@ -32,7 +32,6 @@ import oshi.ffm.ForeignFunctions;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
-import oshi.util.common.platform.unix.openbsd.FstatUtil;
 
 @ThreadSafe
 public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.OpenBsdOSProcess {
@@ -132,32 +131,12 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
     }
 
     @Override
-    public String getCurrentWorkingDirectory() {
-        return FstatUtil.getCwd(getProcessID());
+    protected int queryOwnProcessId() {
+        return this.os.getProcessId();
     }
 
     @Override
-    public long getOpenFiles() {
-        return FstatUtil.getOpenFiles(getProcessID());
-    }
-
-    @Override
-    public long getSoftOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            return rlimitNofile(true);
-        }
-        return -1L;
-    }
-
-    @Override
-    public long getHardOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            return rlimitNofile(false);
-        }
-        return -1L;
-    }
-
-    private long rlimitNofile(boolean soft) {
+    protected long queryRlimitNofile(boolean soft) {
         return ForeignFunctions.callInArenaLongOrDefault(arena -> {
             MemorySegment rlim = arena.allocate(OpenBsdLibcFunctions.RLIMIT_LAYOUT);
             if (OpenBsdLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) != 0) {

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
@@ -21,7 +21,6 @@ import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
-import oshi.util.common.platform.unix.dragonflybsd.ProcstatUtil;
 
 /**
  * OSProcess implementation
@@ -58,35 +57,15 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
     }
 
     @Override
-    public String getCurrentWorkingDirectory() {
-        return ProcstatUtil.getCwd(getProcessID());
+    protected int queryOwnProcessId() {
+        return this.os.getProcessId();
     }
 
     @Override
-    public long getOpenFiles() {
-        return ProcstatUtil.getOpenFiles(getProcessID());
-    }
-
-    @Override
-    public long getSoftOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            final Resource.Rlimit rlimit = new Resource.Rlimit();
-            DragonFlyBsdLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit);
-            return rlimit.rlim_cur;
-        } else {
-            return getProcessOpenFileLimit(getProcessID(), 1);
-        }
-    }
-
-    @Override
-    public long getHardOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            final Resource.Rlimit rlimit = new Resource.Rlimit();
-            DragonFlyBsdLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit);
-            return rlimit.rlim_max;
-        } else {
-            return getProcessOpenFileLimit(getProcessID(), 2);
-        }
+    protected long queryRlimitNofile(boolean soft) {
+        Resource.Rlimit rlimit = new Resource.Rlimit();
+        DragonFlyBsdLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit);
+        return soft ? rlimit.rlim_cur : rlimit.rlim_max;
     }
 
     @Override
@@ -101,12 +80,7 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
         try (Memory abi = new Memory(32); CloseableSizeTByReference size = new CloseableSizeTByReference(32)) {
             // Fetch abi vector
             if (0 == DragonFlyBsdLibc.INSTANCE.sysctl(mib, mib.length, abi, size, null, size_t.ZERO)) {
-                String elf = abi.getString(0);
-                if (elf.contains("ELF32")) {
-                    return 32;
-                } else if (elf.contains("ELF64")) {
-                    return 64;
-                }
+                return elfBitness(abi.getString(0));
             }
         }
         return 0;

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessJNA.java
@@ -22,7 +22,6 @@ import oshi.jna.platform.unix.FreeBsdLibc;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.freebsd.FreeBsdOSProcess;
 import oshi.util.ParseUtil;
-import oshi.util.common.platform.unix.freebsd.ProcstatUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
 
 /**
@@ -96,35 +95,15 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
     }
 
     @Override
-    public String getCurrentWorkingDirectory() {
-        return ProcstatUtil.getCwd(getProcessID());
+    protected int queryOwnProcessId() {
+        return this.os.getProcessId();
     }
 
     @Override
-    public long getOpenFiles() {
-        return ProcstatUtil.getOpenFiles(getProcessID());
-    }
-
-    @Override
-    public long getSoftOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            final Resource.Rlimit rlimit = new Resource.Rlimit();
-            FreeBsdLibc.INSTANCE.getrlimit(FreeBsdLibc.RLIMIT_NOFILE, rlimit);
-            return rlimit.rlim_cur;
-        } else {
-            return getProcessOpenFileLimit(getProcessID(), 1);
-        }
-    }
-
-    @Override
-    public long getHardOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            final Resource.Rlimit rlimit = new Resource.Rlimit();
-            FreeBsdLibc.INSTANCE.getrlimit(FreeBsdLibc.RLIMIT_NOFILE, rlimit);
-            return rlimit.rlim_max;
-        } else {
-            return getProcessOpenFileLimit(getProcessID(), 2);
-        }
+    protected long queryRlimitNofile(boolean soft) {
+        Resource.Rlimit rlimit = new Resource.Rlimit();
+        FreeBsdLibc.INSTANCE.getrlimit(FreeBsdLibc.RLIMIT_NOFILE, rlimit);
+        return soft ? rlimit.rlim_cur : rlimit.rlim_max;
     }
 
     @Override
@@ -139,12 +118,7 @@ public class FreeBsdOSProcessJNA extends FreeBsdOSProcess {
         try (Memory abi = new Memory(32); CloseableSizeTByReference size = new CloseableSizeTByReference(32)) {
             // Fetch abi vector
             if (0 == FreeBsdLibc.INSTANCE.sysctl(mib, mib.length, abi, size, null, size_t.ZERO)) {
-                String elf = abi.getString(0);
-                if (elf.contains("ELF32")) {
-                    return 32;
-                } else if (elf.contains("ELF64")) {
-                    return 64;
-                }
+                return elfBitness(abi.getString(0));
             }
         }
         return 0;

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessJNA.java
@@ -24,7 +24,6 @@ import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.OpenBsdLibc;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.openbsd.OpenBsdOSProcess;
-import oshi.util.common.platform.unix.openbsd.FstatUtil;
 
 /**
  * OSProcess implementation
@@ -142,35 +141,15 @@ public class OpenBsdOSProcessJNA extends OpenBsdOSProcess {
     }
 
     @Override
-    public String getCurrentWorkingDirectory() {
-        return FstatUtil.getCwd(getProcessID());
+    protected int queryOwnProcessId() {
+        return this.os.getProcessId();
     }
 
     @Override
-    public long getOpenFiles() {
-        return FstatUtil.getOpenFiles(getProcessID());
-    }
-
-    @Override
-    public long getSoftOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            final Resource.Rlimit rlimit = new Resource.Rlimit();
-            OpenBsdLibc.INSTANCE.getrlimit(OpenBsdLibc.RLIMIT_NOFILE, rlimit);
-            return rlimit.rlim_cur;
-        } else {
-            return -1L; // not supported
-        }
-    }
-
-    @Override
-    public long getHardOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            final Resource.Rlimit rlimit = new Resource.Rlimit();
-            OpenBsdLibc.INSTANCE.getrlimit(OpenBsdLibc.RLIMIT_NOFILE, rlimit);
-            return rlimit.rlim_max;
-        } else {
-            return -1L; // not supported
-        }
+    protected long queryRlimitNofile(boolean soft) {
+        Resource.Rlimit rlimit = new Resource.Rlimit();
+        OpenBsdLibc.INSTANCE.getrlimit(OpenBsdLibc.RLIMIT_NOFILE, rlimit);
+        return soft ? rlimit.rlim_cur : rlimit.rlim_max;
     }
 
 }


### PR DESCRIPTION
Part of the cross-OS consistency/dedup audit (OSProcess subsystem, BSD family).

The BSD `OSProcess` JNA and FFM twins duplicated a lot of non-native logic. This hoists the shared pieces without changing behavior:

- **`BsdOSProcess`**: the `getSoftOpenFileLimit`/`getHardOpenFileLimit` skeleton (`if current process → getrlimit, else → fallback`) plus an `elfBitness(String)` helper, exposed via three overridable hooks (`queryOwnProcessId`, `queryRlimitNofile`, `otherProcessOpenFileLimit`). The hook defaults keep NetBSD — which overrides the limit methods directly — completely unaffected.
- **Per-platform bases** (FreeBSD/OpenBSD/DragonFly): the byte-identical `getCurrentWorkingDirectory`/`getOpenFiles` delegations move here (4 twin copies → 1 base each). These stay per-platform because each delegates to a different `procstat`/`fstat` util with a different output format. OpenBSD (no procfs) overrides the non-current-process fallback to `-1`.
- **The 6 twins** keep only their irreducible native bits: a `queryRlimitNofile` `getrlimit` hook, a one-line `queryOwnProcessId`, and the genuinely divergent argument/environment queries. FreeBSD and DragonFly bitness now reuse `elfBitness`.

Adds a portable `BsdOSProcessTest` (limit-routing skeleton + `elfBitness` parsing) and the `os.unix.bsd` opens line in `module-info.test`.

No CHANGELOG entry: pure dedup with identical observable behavior.

Local gate: spotless, checkstyle, forbiddenapis, javadoc, and a clean full-reactor build all pass; oshi-common tests including the new test pass. BSD native / JNA==FFM parity validated via the unix.yaml FreeBSD/OpenBSD/DragonFly VMs (dispatched manually, since unix.yaml does not trigger on pull requests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved soft/hard open-file limit reporting across BSD platforms, including more accurate results for the current process versus other processes.
  * Improved current working directory and open-file count reporting on DragonFlyBSD, FreeBSD, and OpenBSD.
  * Improved 32-bit vs 64-bit architecture detection for BSD process queries.
* **Tests**
  * Added BSD-focused unit coverage for open-file limits and architecture detection.
  * Updated existing procstat utility tests to match the current working-directory reading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->