### PR TITLE
Extract shared /proc/as address-space reader for AIX/Solaris PsInfo

### DIFF
--- a/oshi-core/src/main/java/oshi/driver/unix/ProcAddressSpaceReader.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/ProcAddressSpaceReader.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.unix;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.jna.Memory;
+import com.sun.jna.NativeLong;
+import com.sun.jna.platform.unix.LibCAPI.size_t;
+import com.sun.jna.platform.unix.LibCAPI.ssize_t;
+
+import oshi.annotation.concurrent.NotThreadSafe;
+import oshi.jna.platform.unix.CLibrary;
+
+/**
+ * Reads pointer-sized values and NUL-terminated strings out of a process's {@code /proc/<pid>/as} address space via
+ * libc {@code pread}, buffering one page at a time. Shared by the Solaris and AIX JNA {@code PsInfo} drivers, which
+ * read a process's argument and environment vectors this way.
+ * <p>
+ * Not thread-safe: each instance owns a single file descriptor and a reusable page buffer, so confine it to one thread
+ * and {@link #close()} it when done (it is {@link AutoCloseable}).
+ */
+@NotThreadSafe
+public final class ProcAddressSpaceReader implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProcAddressSpaceReader.class);
+
+    private final CLibrary libc;
+    private final int fd;
+    private final long pageSize;
+    private final Memory buffer;
+    private final size_t bufSize;
+    private long bufStart;
+
+    private ProcAddressSpaceReader(CLibrary libc, int fd, long pageSize) {
+        this.libc = libc;
+        this.fd = fd;
+        this.pageSize = pageSize;
+        this.buffer = new Memory(pageSize * 2);
+        this.bufSize = new size_t(this.buffer.size());
+        this.bufStart = 0L;
+    }
+
+    /**
+     * Opens {@code /proc/<pid>/as} for reading.
+     *
+     * @param libc     the platform C library providing {@code open}/{@code pread}/{@code close}
+     * @param pid      the process ID
+     * @param pageSize the memory page size in bytes
+     * @return a reader, or {@code null} if the address space could not be opened (e.g. insufficient permission)
+     */
+    public static ProcAddressSpaceReader open(CLibrary libc, int pid, long pageSize) {
+        String procas = "/proc/" + pid + "/as";
+        int fd = libc.open(procas, 0);
+        if (fd < 0) {
+            LOG.trace("No permission to read file: {} ", procas);
+            return null;
+        }
+        return new ProcAddressSpaceReader(libc, fd, pageSize);
+    }
+
+    /**
+     * Reads a pointer-sized value at {@code addr}.
+     *
+     * @param addr      the address to read
+     * @param increment the pointer size in bytes ({@code 8} for a 64-bit process, otherwise a 32-bit value)
+     * @return the pointer value, or {@code 0} if the page could not be read
+     */
+    public long readPointer(long addr, long increment) {
+        if (!ensurePage(addr)) {
+            return 0L;
+        }
+        return decodePointer(this.buffer, addr - this.bufStart, increment);
+    }
+
+    /**
+     * Reads a NUL-terminated string at {@code addr}.
+     *
+     * @param addr the address to read
+     * @return the string, or an empty string if the page could not be read
+     */
+    public String readString(long addr) {
+        if (!ensurePage(addr)) {
+            return "";
+        }
+        return this.buffer.getString(addr - this.bufStart);
+    }
+
+    /**
+     * Ensures the page containing {@code addr} is loaded in the buffer, reading it via {@code pread} if it is not
+     * already present.
+     *
+     * @param addr the address whose page must be buffered
+     * @return {@code true} if the page is available, {@code false} on read failure
+     */
+    private boolean ensurePage(long addr) {
+        // If we don't have the right page buffered, read it
+        if (addr < this.bufStart || addr - this.bufStart > this.pageSize) {
+            long newStart = Math.floorDiv(addr, this.pageSize) * this.pageSize;
+            ssize_t result = this.libc.pread(this.fd, this.buffer, this.bufSize, new NativeLong(newStart));
+            // May return less than asked but should be at least a full page
+            if (result.longValue() < this.pageSize) {
+                LOG.debug("Failed to read page from address space: {} bytes read", result.longValue());
+                return false;
+            }
+            this.bufStart = newStart;
+        }
+        return true;
+    }
+
+    /**
+     * Decodes a pointer-sized value from a buffer. For 32-bit pointers the value is read unsigned so high addresses
+     * ({@code >= 0x80000000}) are not sign-extended.
+     *
+     * @param buffer    the buffer to read from
+     * @param offset    the offset within the buffer
+     * @param increment the pointer size in bytes ({@code 8} for 64-bit, otherwise 32-bit)
+     * @return the decoded value
+     */
+    static long decodePointer(Memory buffer, long offset, long increment) {
+        return increment == 8 ? buffer.getLong(offset) : Integer.toUnsignedLong(buffer.getInt(offset));
+    }
+
+    @Override
+    public void close() {
+        this.libc.close(this.fd);
+        this.buffer.close();
+    }
+}

--- a/oshi-core/src/main/java/oshi/driver/unix/ProcAddressSpaceReader.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/ProcAddressSpaceReader.java
@@ -34,6 +34,7 @@ public final class ProcAddressSpaceReader implements AutoCloseable {
     private final Memory buffer;
     private final size_t bufSize;
     private long bufStart;
+    private boolean bufValid;
 
     private ProcAddressSpaceReader(CLibrary libc, int fd, long pageSize) {
         this.libc = libc;
@@ -42,6 +43,7 @@ public final class ProcAddressSpaceReader implements AutoCloseable {
         this.buffer = new Memory(pageSize * 2);
         this.bufSize = new size_t(this.buffer.size());
         this.bufStart = 0L;
+        this.bufValid = false;
     }
 
     /**
@@ -97,17 +99,22 @@ public final class ProcAddressSpaceReader implements AutoCloseable {
      * @return {@code true} if the page is available, {@code false} on read failure
      */
     private boolean ensurePage(long addr) {
-        // If we don't have the right page buffered, read it
-        if (addr < this.bufStart || addr - this.bufStart > this.pageSize) {
-            long newStart = Math.floorDiv(addr, this.pageSize) * this.pageSize;
-            ssize_t result = this.libc.pread(this.fd, this.buffer, this.bufSize, new NativeLong(newStart));
-            // May return less than asked but should be at least a full page
-            if (result.longValue() < this.pageSize) {
-                LOG.debug("Failed to read page from address space: {} bytes read", result.longValue());
-                return false;
-            }
-            this.bufStart = newStart;
+        // Reuse the buffer only if it holds a valid page covering addr
+        if (this.bufValid && addr >= this.bufStart && addr - this.bufStart <= this.pageSize) {
+            return true;
         }
+        // pread overwrites the buffer, so invalidate the cached page before reading: a short read would otherwise
+        // leave bufStart pointing at a page the buffer no longer fully holds.
+        this.bufValid = false;
+        long newStart = Math.floorDiv(addr, this.pageSize) * this.pageSize;
+        ssize_t result = this.libc.pread(this.fd, this.buffer, this.bufSize, new NativeLong(newStart));
+        // May return less than asked but should be at least a full page
+        if (result.longValue() < this.pageSize) {
+            LOG.debug("Failed to read page from address space: {} bytes read", result.longValue());
+            return false;
+        }
+        this.bufStart = newStart;
+        this.bufValid = true;
         return true;
     }
 

--- a/oshi-core/src/main/java/oshi/driver/unix/aix/PsInfoJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/aix/PsInfoJNA.java
@@ -16,14 +16,10 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.Memory;
-import com.sun.jna.NativeLong;
-import com.sun.jna.platform.unix.LibCAPI.size_t;
-import com.sun.jna.platform.unix.LibCAPI.ssize_t;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.aix.AixPsInfo;
 import oshi.driver.common.unix.aix.PsInfo;
+import oshi.driver.unix.ProcAddressSpaceReader;
 import oshi.jna.platform.unix.AixLibc;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
@@ -60,14 +56,11 @@ public final class PsInfoJNA {
         // Get the arg count and list of env vars
         Triplet<Integer, Long, Long> addrs = PsInfo.queryArgsEnvAddrs(pid, psinfo);
         if (addrs != null) {
-            // Open a file descriptor to the address space
-            String procas = "/proc/" + pid + "/as";
-            int fd = LIBC.open(procas, 0);
-            if (fd < 0) {
-                LOG.trace("No permission to read file: {} ", procas);
-                return new Pair<>(args, env);
-            }
-            try {
+            // Open the address space for reading (buffered a page at a time)
+            try (ProcAddressSpaceReader reader = ProcAddressSpaceReader.open(LIBC, pid, PAGE_SIZE)) {
+                if (reader == null) {
+                    return new Pair<>(args, env);
+                }
                 // Non-null addrs means argc > 0
                 int argc = addrs.getA();
                 long argv = addrs.getB();
@@ -78,105 +71,53 @@ public final class PsInfoJNA {
                 Path p = Paths.get("/proc/" + pid + "/status");
                 try {
                     byte[] status = Files.readAllBytes(p);
-                    if (status[17] == 1) {
-                        increment = 8;
-                    } else {
-                        increment = 4;
-                    }
+                    increment = status[17] == 1 ? 8 : 4;
                 } catch (IOException e) {
                     return new Pair<>(args, env);
                 }
 
-                // Reusable buffer
-                try (Memory buffer = new Memory(PAGE_SIZE * 2)) {
-                    size_t bufSize = new size_t(buffer.size());
-
-                    // Read the pointers to the arg strings
-                    long bufStart = conditionallyReadBufferFromStartOfPage(fd, buffer, bufSize, 0, argv);
-                    long[] argPtr = new long[argc];
-                    long argp = bufStart == 0 ? 0 : getOffsetFromBuffer(buffer, argv - bufStart, increment);
-                    if (argp > 0) {
-                        for (int i = 0; i < argc; i++) {
-                            long offset = argp + i * increment;
-                            bufStart = conditionallyReadBufferFromStartOfPage(fd, buffer, bufSize, bufStart, offset);
-                            argPtr[i] = bufStart == 0 ? 0 : getOffsetFromBuffer(buffer, offset - bufStart, increment);
-                        }
-                    }
-
-                    // Also read the pointers to the env strings; the envp table is null-terminated,
-                    // so stop at the first null entry (with a 500-entry safety cap).
-                    bufStart = conditionallyReadBufferFromStartOfPage(fd, buffer, bufSize, bufStart, envp);
-                    List<Long> envPtrList = new ArrayList<>();
-                    long addr = bufStart == 0 ? 0 : getOffsetFromBuffer(buffer, envp - bufStart, increment);
-                    int limit = 500;
-                    long offset = addr;
-                    while (addr != 0 && --limit > 0) {
-                        bufStart = conditionallyReadBufferFromStartOfPage(fd, buffer, bufSize, bufStart, offset);
-                        long envPtr = bufStart == 0 ? 0 : getOffsetFromBuffer(buffer, offset - bufStart, increment);
-                        if (envPtr == 0) {
-                            break;
-                        }
-                        envPtrList.add(envPtr);
-                        offset += increment;
-                    }
-
-                    // Now read the arg strings from the buffer
-                    for (int i = 0; i < argPtr.length && argPtr[i] != 0; i++) {
-                        bufStart = conditionallyReadBufferFromStartOfPage(fd, buffer, bufSize, bufStart, argPtr[i]);
-                        if (bufStart != 0) {
-                            String argStr = buffer.getString(argPtr[i] - bufStart);
-                            if (!argStr.isEmpty()) {
-                                args.add(argStr);
-                            }
-                        }
-                    }
-
-                    // And now read the env strings from the buffer
-                    for (Long envPtr : envPtrList) {
-                        bufStart = conditionallyReadBufferFromStartOfPage(fd, buffer, bufSize, bufStart, envPtr);
-                        if (bufStart != 0) {
-                            String envStr = buffer.getString(envPtr - bufStart);
-                            int idx = envStr.indexOf('=');
-                            if (idx > 0) {
-                                env.put(envStr.substring(0, idx), envStr.substring(idx + 1));
-                            }
-                        }
+                // Read the pointers to the arg strings. On AIX argv points to the pointer array, so dereference once.
+                long[] argPtr = new long[argc];
+                long argp = reader.readPointer(argv, increment);
+                if (argp > 0) {
+                    for (int i = 0; i < argc; i++) {
+                        argPtr[i] = reader.readPointer(argp + i * increment, increment);
                     }
                 }
-            } finally {
-                LIBC.close(fd);
+
+                // Also read the pointers to the env strings; the envp table is null-terminated,
+                // so stop at the first null entry (with a 500-entry safety cap).
+                List<Long> envPtrList = new ArrayList<>();
+                long addr = reader.readPointer(envp, increment);
+                int limit = 500;
+                long offset = addr;
+                while (addr != 0 && --limit > 0) {
+                    long envPtr = reader.readPointer(offset, increment);
+                    if (envPtr == 0) {
+                        break;
+                    }
+                    envPtrList.add(envPtr);
+                    offset += increment;
+                }
+
+                // Now read the arg strings
+                for (int i = 0; i < argPtr.length && argPtr[i] != 0; i++) {
+                    String argStr = reader.readString(argPtr[i]);
+                    if (!argStr.isEmpty()) {
+                        args.add(argStr);
+                    }
+                }
+
+                // And now read the env strings
+                for (Long envPtr : envPtrList) {
+                    String envStr = reader.readString(envPtr);
+                    int idx = envStr.indexOf('=');
+                    if (idx > 0) {
+                        env.put(envStr.substring(0, idx), envStr.substring(idx + 1));
+                    }
+                }
             }
         }
         return new Pair<>(args, env);
-    }
-
-    /**
-     * Reads the page containing {@code addr} into {@code buffer}, unless the buffer already contains that page (as
-     * indicated by {@code bufStart}), in which case nothing is changed.
-     *
-     * @param fd       the file descriptor for the address space
-     * @param buffer   an allocated buffer
-     * @param bufSize  the size of the buffer
-     * @param bufStart the start of data currently in the buffer, or 0 if uninitialized
-     * @param addr     the address whose page to read into the buffer
-     * @return the new starting pointer for the buffer
-     */
-    private static long conditionallyReadBufferFromStartOfPage(int fd, Memory buffer, size_t bufSize, long bufStart,
-            long addr) {
-        if (addr < bufStart || addr - bufStart > PAGE_SIZE) {
-            long newStart = Math.floorDiv(addr, PAGE_SIZE) * PAGE_SIZE;
-            ssize_t result = LIBC.pread(fd, buffer, bufSize, new NativeLong(newStart));
-            // May return less than asked but should be at least a full page
-            if (result.longValue() < PAGE_SIZE) {
-                LOG.debug("Failed to read page from address space: {} bytes read", result.longValue());
-                return 0;
-            }
-            return newStart;
-        }
-        return bufStart;
-    }
-
-    private static long getOffsetFromBuffer(Memory buffer, long offset, long increment) {
-        return increment == 8 ? buffer.getLong(offset) : buffer.getInt(offset);
     }
 }

--- a/oshi-core/src/main/java/oshi/driver/unix/solaris/PsInfoJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/solaris/PsInfoJNA.java
@@ -12,13 +12,9 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.Memory;
-import com.sun.jna.NativeLong;
-import com.sun.jna.platform.unix.LibCAPI.size_t;
-import com.sun.jna.platform.unix.LibCAPI.ssize_t;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.solaris.SolarisPsInfo;
+import oshi.driver.unix.ProcAddressSpaceReader;
 import oshi.jna.platform.unix.SolarisLibc;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -89,109 +85,56 @@ public final class PsInfoJNA {
         // Get the arg count and list of env vars
         Quartet<Integer, Long, Long, Byte> addrs = queryArgsEnvAddrs(pid, psinfo);
         if (addrs != null) {
-            // Open a file descriptor to the address space
-            String procas = "/proc/" + pid + "/as";
-            int fd = LIBC.open(procas, 0);
-            if (fd < 0) {
-                LOG.trace("No permission to read file: {} ", procas);
-                return new Pair<>(args, env);
-            }
-            try {
+            // Open the address space for reading (buffered a page at a time)
+            try (ProcAddressSpaceReader reader = ProcAddressSpaceReader.open(LIBC, pid, PAGE_SIZE)) {
+                if (reader == null) {
+                    return new Pair<>(args, env);
+                }
                 // Non-null addrs means argc > 0
                 int argc = addrs.getA();
                 long argv = addrs.getB();
                 long envp = addrs.getC();
                 long increment = addrs.getD() * 4L;
 
-                // Reusable buffer
-                long bufStart = 0;
-                try (Memory buffer = new Memory(PAGE_SIZE * 2)) {
-                    size_t bufSize = new size_t(buffer.size());
+                // Read the pointers to the arg strings. We know argc so we can count them.
+                long[] argp = new long[argc];
+                long offset = argv;
+                for (int i = 0; i < argc; i++) {
+                    argp[i] = reader.readPointer(offset, increment);
+                    offset += increment;
+                }
 
-                    // Read the pointers to the arg strings
-                    // We know argc so we can count them
-                    long[] argp = new long[argc];
-                    long offset = argv;
-                    for (int i = 0; i < argc; i++) {
-                        bufStart = conditionallyReadBufferFromStartOfPage(fd, buffer, bufSize, bufStart, offset);
-                        argp[i] = bufStart == 0 ? 0 : getOffsetFromBuffer(buffer, offset - bufStart, increment);
-                        offset += increment;
+                // Also read the pointers to the env strings. We don't know how many, so stop at the null pointer.
+                List<Long> envPtrList = new ArrayList<>();
+                offset = envp;
+                long addr = 0;
+                int limit = 500; // sane max env strings to stop at
+                do {
+                    addr = reader.readPointer(offset, increment);
+                    if (addr != 0) {
+                        envPtrList.add(addr);
                     }
+                    offset += increment;
+                } while (addr != 0 && --limit > 0);
 
-                    // Also read the pointers to the env strings
-                    // We don't know how many, so stop when we get to null pointer
-                    List<Long> envPtrList = new ArrayList<>();
-                    offset = envp;
-                    long addr = 0;
-                    int limit = 500; // sane max env strings to stop at
-                    do {
-                        bufStart = conditionallyReadBufferFromStartOfPage(fd, buffer, bufSize, bufStart, offset);
-                        addr = bufStart == 0 ? 0 : getOffsetFromBuffer(buffer, offset - bufStart, increment);
-                        if (addr != 0) {
-                            envPtrList.add(addr);
-                        }
-                        offset += increment;
-                    } while (addr != 0 && --limit > 0);
-
-                    // Now read the arg strings from the buffer
-                    for (int i = 0; i < argp.length && argp[i] != 0; i++) {
-                        bufStart = conditionallyReadBufferFromStartOfPage(fd, buffer, bufSize, bufStart, argp[i]);
-                        if (bufStart != 0) {
-                            String argStr = buffer.getString(argp[i] - bufStart);
-                            if (!argStr.isEmpty()) {
-                                args.add(argStr);
-                            }
-                        }
-                    }
-
-                    // And now read the env strings from the buffer
-                    for (Long envPtr : envPtrList) {
-                        bufStart = conditionallyReadBufferFromStartOfPage(fd, buffer, bufSize, bufStart, envPtr);
-                        if (bufStart != 0) {
-                            String envStr = buffer.getString(envPtr - bufStart);
-                            int idx = envStr.indexOf('=');
-                            if (idx > 0) {
-                                env.put(envStr.substring(0, idx), envStr.substring(idx + 1));
-                            }
-                        }
+                // Now read the arg strings
+                for (int i = 0; i < argp.length && argp[i] != 0; i++) {
+                    String argStr = reader.readString(argp[i]);
+                    if (!argStr.isEmpty()) {
+                        args.add(argStr);
                     }
                 }
-            } finally {
-                LIBC.close(fd);
+
+                // And now read the env strings
+                for (Long envPtr : envPtrList) {
+                    String envStr = reader.readString(envPtr);
+                    int idx = envStr.indexOf('=');
+                    if (idx > 0) {
+                        env.put(envStr.substring(0, idx), envStr.substring(idx + 1));
+                    }
+                }
             }
         }
         return new Pair<>(args, env);
-    }
-
-    /**
-     * Reads the page containing addr into buffer, unless the buffer already contains that page (as indicated by the
-     * bufStart address), in which case nothing is changed.
-     *
-     * @param fd       The file descriptor for the address space
-     * @param buffer   An allocated buffer, possibly with data reread from bufStart
-     * @param bufSize  The size of the buffer
-     * @param bufStart The start of data currently in bufStart, or 0 if uninitialized
-     * @param addr     THe address whose page to read into the buffer
-     * @return The new starting pointer for the buffer
-     */
-    private static long conditionallyReadBufferFromStartOfPage(int fd, Memory buffer, size_t bufSize, long bufStart,
-            long addr) {
-        // If we don't have the right buffer, update it
-        if (addr < bufStart || addr - bufStart > PAGE_SIZE) {
-            long newStart = Math.floorDiv(addr, PAGE_SIZE) * PAGE_SIZE;
-            ssize_t result = LIBC.pread(fd, buffer, bufSize, new NativeLong(newStart));
-            // May return less than asked but should be at least a full page
-            if (result.longValue() < PAGE_SIZE) {
-                LOG.debug("Failed to read page from address space: {} bytes read", result.longValue());
-                return 0;
-            }
-            return newStart;
-        }
-        return bufStart;
-    }
-
-    private static long getOffsetFromBuffer(Memory buffer, long offset, long increment) {
-        // For 32-bit processes read the pointer as unsigned so high addresses (>= 0x80000000) aren't sign-extended
-        return increment == 8 ? buffer.getLong(offset) : Integer.toUnsignedLong(buffer.getInt(offset));
     }
 }

--- a/oshi-core/src/test/java/oshi/driver/unix/ProcAddressSpaceReaderTest.java
+++ b/oshi-core/src/test/java/oshi/driver/unix/ProcAddressSpaceReaderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.unix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.jna.Memory;
+
+/**
+ * Tests the pointer decoding shared by the Solaris and AIX JNA {@code PsInfo} address-space readers.
+ */
+class ProcAddressSpaceReaderTest {
+
+    @Test
+    void testDecodePointer64Bit() {
+        try (Memory buffer = new Memory(8)) {
+            buffer.setLong(0, 0x0000_1234_5678_9abcL);
+            assertThat(ProcAddressSpaceReader.decodePointer(buffer, 0, 8), is(0x0000_1234_5678_9abcL));
+        }
+    }
+
+    @Test
+    void testDecodePointer32BitLowAddress() {
+        try (Memory buffer = new Memory(4)) {
+            buffer.setInt(0, 0x0040_1000);
+            assertThat(ProcAddressSpaceReader.decodePointer(buffer, 0, 4), is(0x0040_1000L));
+        }
+    }
+
+    @Test
+    void testDecodePointer32BitHighAddressIsUnsigned() {
+        // A 32-bit pointer with the high bit set must be read unsigned, not sign-extended to a negative long.
+        try (Memory buffer = new Memory(4)) {
+            buffer.setInt(0, 0x8000_0000);
+            assertThat(ProcAddressSpaceReader.decodePointer(buffer, 0, 4), is(0x0000_0000_8000_0000L));
+        }
+    }
+
+    @Test
+    void testDecodePointer32BitMaxAddressIsUnsigned() {
+        try (Memory buffer = new Memory(4)) {
+            buffer.setInt(0, 0xFFFF_FFFF);
+            assertThat(ProcAddressSpaceReader.decodePointer(buffer, 0, 4), is(0x0000_0000_FFFF_FFFFL));
+        }
+    }
+}


### PR DESCRIPTION
Part of the cross-OS consistency/dedup audit (OSProcess subsystem, AIX/Solaris PsInfo drivers). This is the top remaining OSProcess duplication cluster per SonarCloud.

The Solaris and AIX JNA `PsInfo` drivers both read a process's argument and environment vectors out of `/proc/<pid>/as` using the same page-buffered `pread` logic. This hoists that plumbing into a shared reader without changing behavior:

- **New `oshi.driver.unix.ProcAddressSpaceReader`** — a `@NotThreadSafe`, `AutoCloseable` reader that owns the file descriptor and reusable page buffer and exposes `open(libc, pid, pageSize)` / `readPointer(addr, increment)` / `readString(addr)`. It is typed against `CLibrary`, which both `SolarisLibc` and `AixLibc` extend (declaring `open`/`pread`/`close`).
- **Solaris and AIX `PsInfoJNA`** now open the reader and keep only their genuinely-divergent pointer chase: Solaris reads the `argv` pointer array directly with the data model from `psinfo`; AIX dereferences `argv` once and reads the data model from `/proc/<pid>/status`. The identical open/close, page-buffer management, and arg/env string loops are gone.

The FFM side is intentionally untouched: Solaris `PsInfoFFM` uses `pargs -ae` (no `pread`), so only AIX `PsInfoFFM` does the address-space read, and it has nothing to share with.

**Pre-existing bug fixed:** AIX decoded 32-bit pointers with a raw signed `getInt`, sign-extending high addresses (`>= 0x80000000`) into negative longs that then miss the page lookup and drop those args/env entries. Solaris JNA and AIX FFM already read the pointer unsigned via `Integer.toUnsignedLong`; the shared `decodePointer` unifies on that, restoring AIX JNA==FFM parity on high addresses. No CHANGELOG entry: typical AIX 32-bit args/env live below `0x80000000`, so the bug is practically unreachable.

Adds a portable unit test for the unsigned pointer decode.

Local gate: spotless, checkstyle, forbiddenapis, javadoc, and a clean full-reactor build all pass; oshi-core tests including the new decode test pass. AIX/Solaris runtime is validated on the compile farm (`PsInfoJNATest` runs live on AIX; `NativeComparisonTest` covers AIX JNA==FFM parity), dispatched separately since cfarm does not run on pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a buffered address-space reader to support efficiently reading pointer-sized values and NUL-terminated strings from process memory.
  * Improved process argument and environment data retrieval on AIX and Solaris, with graceful handling when memory access isn’t available.
* **Refactor**
  * Switched AIX and Solaris address-space parsing to use the shared buffered reader for more consistent page-based reads.
* **Tests**
  * Added unit coverage for pointer decoding, including unsigned 32-bit values and 64-bit addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->