### PR TITLE
Dedup Linux context-switch caching and Windows token-account queries

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -92,6 +92,12 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
     private long voluntaryContextSwitches;
     private long involuntaryContextSwitches;
 
+    // Context-switch counts from getrusage for the current process, which are more accurate than the /proc values.
+    // Populated by updateAttributes() via the queryContextSwitches() hook; the native-free build leaves these unset.
+    private boolean rusagePopulated;
+    private long cachedVoluntaryContextSwitches;
+    private long cachedInvoluntaryContextSwitches;
+
     /**
      * Creates a LinuxOSProcess.
      *
@@ -206,12 +212,12 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
 
     @Override
     public long getVoluntaryContextSwitches() {
-        return this.voluntaryContextSwitches;
+        return this.rusagePopulated ? this.cachedVoluntaryContextSwitches : this.voluntaryContextSwitches;
     }
 
     @Override
     public long getInvoluntaryContextSwitches() {
-        return this.involuntaryContextSwitches;
+        return this.rusagePopulated ? this.cachedInvoluntaryContextSwitches : this.involuntaryContextSwitches;
     }
 
     @Override
@@ -292,6 +298,34 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
 
     @Override
     public boolean updateAttributes() {
+        boolean result = updateAttributesFromProc();
+        // getrusage reports more accurate context-switch counts than /proc, but only for the current process and only
+        // when its /proc attributes were read successfully
+        if (result && getProcessID() == getOs().getProcessId()) {
+            long[] contextSwitches = queryContextSwitches();
+            if (contextSwitches != null) {
+                this.cachedVoluntaryContextSwitches = contextSwitches[0];
+                this.cachedInvoluntaryContextSwitches = contextSwitches[1];
+                this.rusagePopulated = true;
+            } else {
+                this.rusagePopulated = false;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Reads this (current) process's voluntary and involuntary context-switch counts via native {@code getrusage}. The
+     * default returns {@code null} (the native-free build has no {@code getrusage}); the JNA and FFM subclasses
+     * override it.
+     *
+     * @return a two-element array {@code {voluntary, involuntary}}, or {@code null} if unavailable
+     */
+    protected long[] queryContextSwitches() {
+        return null;
+    }
+
+    private boolean updateAttributesFromProc() {
         String procPidExe = String.format(Locale.ROOT, ProcPath.PID_EXE, getProcessID());
         try {
             Path link = Paths.get(procPidExe);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
@@ -7,7 +7,7 @@ package oshi.software.os.linux;
 import static org.slf4j.event.Level.DEBUG;
 import static org.slf4j.event.Level.WARN;
 import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
-import static oshi.ffm.ForeignFunctions.runInArenaCatchingThrowable;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -28,47 +28,20 @@ public class LinuxOSProcessFFM extends LinuxOSProcess {
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxOSProcessFFM.class);
 
-    private boolean rusagePopulated;
-    private long cachedVoluntaryContextSwitches;
-    private long cachedInvoluntaryContextSwitches;
-
     public LinuxOSProcessFFM(int pid, LinuxOperatingSystem os) {
         super(pid, os);
     }
 
     @Override
-    public boolean updateAttributes() {
-        boolean result = super.updateAttributes();
-        if (getProcessID() == getOs().getProcessId()) {
-            this.rusagePopulated = false;
-            runInArenaCatchingThrowable(arena -> {
-                MemorySegment rusage = arena.allocate(LinuxLibcFunctions.RUSAGE_SIZE);
-                if (0 == LinuxLibcFunctions.getrusage(LinuxLibcFunctions.RUSAGE_SELF, rusage)) {
-                    this.cachedVoluntaryContextSwitches = rusage.get(ValueLayout.JAVA_LONG,
-                            LinuxLibcFunctions.RUSAGE_NVCSW_OFFSET);
-                    this.cachedInvoluntaryContextSwitches = rusage.get(ValueLayout.JAVA_LONG,
-                            LinuxLibcFunctions.RUSAGE_NIVCSW_OFFSET);
-                    this.rusagePopulated = true;
-                }
-            }, LOG, DEBUG, "FFM getrusage failed");
-        }
-        return result;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        if (rusagePopulated) {
-            return cachedVoluntaryContextSwitches;
-        }
-        return super.getVoluntaryContextSwitches();
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        if (rusagePopulated) {
-            return cachedInvoluntaryContextSwitches;
-        }
-        return super.getInvoluntaryContextSwitches();
+    protected long[] queryContextSwitches() {
+        return callInArenaOrDefault(arena -> {
+            MemorySegment rusage = arena.allocate(LinuxLibcFunctions.RUSAGE_SIZE);
+            if (0 == LinuxLibcFunctions.getrusage(LinuxLibcFunctions.RUSAGE_SELF, rusage)) {
+                return new long[] { rusage.get(ValueLayout.JAVA_LONG, LinuxLibcFunctions.RUSAGE_NVCSW_OFFSET),
+                        rusage.get(ValueLayout.JAVA_LONG, LinuxLibcFunctions.RUSAGE_NIVCSW_OFFSET) };
+            }
+            return null;
+        }, LOG, DEBUG, "FFM getrusage failed", null);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcessJNA.java
@@ -20,43 +20,17 @@ import oshi.software.common.os.linux.LinuxOperatingSystem;
 @ThreadSafe
 public class LinuxOSProcessJNA extends LinuxOSProcess {
 
-    private boolean rusagePopulated;
-    private long cachedVoluntaryContextSwitches;
-    private long cachedInvoluntaryContextSwitches;
-
     public LinuxOSProcessJNA(int pid, LinuxOperatingSystem os) {
         super(pid, os);
     }
 
     @Override
-    public boolean updateAttributes() {
-        boolean result = super.updateAttributes();
-        if (getProcessID() == getOs().getProcessId()) {
-            this.rusagePopulated = false;
-            LinuxLibc.Rusage rusage = new LinuxLibc.Rusage();
-            if (0 == LinuxLibc.INSTANCE.getrusage(RUSAGE_SELF, rusage)) {
-                this.cachedVoluntaryContextSwitches = rusage.ru_nvcsw.longValue();
-                this.cachedInvoluntaryContextSwitches = rusage.ru_nivcsw.longValue();
-                this.rusagePopulated = true;
-            }
+    protected long[] queryContextSwitches() {
+        LinuxLibc.Rusage rusage = new LinuxLibc.Rusage();
+        if (0 == LinuxLibc.INSTANCE.getrusage(RUSAGE_SELF, rusage)) {
+            return new long[] { rusage.ru_nvcsw.longValue(), rusage.ru_nivcsw.longValue() };
         }
-        return result;
-    }
-
-    @Override
-    public long getVoluntaryContextSwitches() {
-        if (rusagePopulated) {
-            return cachedVoluntaryContextSwitches;
-        }
-        return super.getVoluntaryContextSwitches();
-    }
-
-    @Override
-    public long getInvoluntaryContextSwitches() {
-        if (rusagePopulated) {
-            return cachedInvoluntaryContextSwitches;
-        }
-        return super.getInvoluntaryContextSwitches();
+        return null;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -177,63 +178,52 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
 
     @Override
     protected Pair<String, String> queryUserInfo() {
-        Pair<String, String> pair = null;
-        final HANDLE pHandle = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION, false, getProcessID());
-        if (pHandle != null) {
-            try (CloseableHANDLEByReference phToken = new CloseableHANDLEByReference()) {
-                try {
-                    if (Advapi32.INSTANCE.OpenProcessToken(pHandle, WinNT.TOKEN_QUERY, phToken)) {
-                        Account account = Advapi32Util.getTokenAccount(phToken.getValue());
-                        pair = new Pair<>(account.name, account.sidString);
-                    } else {
-                        int error = Kernel32.INSTANCE.GetLastError();
-                        // Access denied errors are common. Fail silently.
-                        if (error != WinError.ERROR_ACCESS_DENIED) {
-                            LOG.error("Failed to get process token for process {}: {}", getProcessID(), error);
-                        }
-                    }
-                } catch (Win32Exception e) {
-                    LOG.warn("Failed to query user info for process {} ({}): {}", getProcessID(), getName(),
-                            e.getMessage());
-                } finally {
-                    final HANDLE token = phToken.getValue();
-                    if (token != null) {
-                        Kernel32.INSTANCE.CloseHandle(token);
-                    }
-                    Kernel32.INSTANCE.CloseHandle(pHandle);
-                }
-            }
-        }
-        return pair != null ? pair : defaultPair();
+        return queryTokenAccount(Advapi32Util::getTokenAccount, "user");
     }
 
     @Override
     protected Pair<String, String> queryGroupInfo() {
+        return queryTokenAccount(Advapi32Util::getTokenPrimaryGroup, "group");
+    }
+
+    /**
+     * Opens this process's access token and resolves an account (name and SID) from it. Shared by the user- and
+     * group-info queries, which differ only in how the account is extracted from the token.
+     *
+     * @param accountFromToken extracts the {@link Account} from the process token (e.g. token user or primary group)
+     * @param infoType         a short label ({@code "user"}/{@code "group"}) for log messages
+     * @return a pair of (account name, SID string), or {@link #defaultPair()} if the token can't be read
+     */
+    private Pair<String, String> queryTokenAccount(Function<HANDLE, Account> accountFromToken, String infoType) {
         Pair<String, String> pair = null;
         final HANDLE pHandle = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION, false, getProcessID());
         if (pHandle != null) {
-            try (CloseableHANDLEByReference phToken = new CloseableHANDLEByReference()) {
-                try {
-                    if (Advapi32.INSTANCE.OpenProcessToken(pHandle, WinNT.TOKEN_QUERY, phToken)) {
-                        Account account = Advapi32Util.getTokenPrimaryGroup(phToken.getValue());
-                        pair = new Pair<>(account.name, account.sidString);
-                    } else {
-                        int error = Kernel32.INSTANCE.GetLastError();
-                        // Access denied errors are common. Fail silently.
-                        if (error != WinError.ERROR_ACCESS_DENIED) {
-                            LOG.error("Failed to get process token for process {}: {}", getProcessID(), error);
+            try {
+                try (CloseableHANDLEByReference phToken = new CloseableHANDLEByReference()) {
+                    try {
+                        if (Advapi32.INSTANCE.OpenProcessToken(pHandle, WinNT.TOKEN_QUERY, phToken)) {
+                            Account account = accountFromToken.apply(phToken.getValue());
+                            pair = new Pair<>(account.name, account.sidString);
+                        } else {
+                            int error = Kernel32.INSTANCE.GetLastError();
+                            // Access denied errors are common. Fail silently.
+                            if (error != WinError.ERROR_ACCESS_DENIED) {
+                                LOG.error("Failed to get process token for process {}: {}", getProcessID(), error);
+                            }
+                        }
+                    } catch (Win32Exception e) {
+                        LOG.warn("Failed to query {} info for process {} ({}): {}", infoType, getProcessID(), getName(),
+                                e.getMessage());
+                    } finally {
+                        final HANDLE token = phToken.getValue();
+                        if (token != null) {
+                            Kernel32.INSTANCE.CloseHandle(token);
                         }
                     }
-                } catch (Win32Exception e) {
-                    LOG.warn("Failed to query group info for process {} ({}): {}", getProcessID(), getName(),
-                            e.getMessage());
-                } finally {
-                    final HANDLE token = phToken.getValue();
-                    if (token != null) {
-                        Kernel32.INSTANCE.CloseHandle(token);
-                    }
-                    Kernel32.INSTANCE.CloseHandle(pHandle);
                 }
+            } finally {
+                // Close pHandle even if constructing the CloseableHANDLEByReference above fails
+                Kernel32.INSTANCE.CloseHandle(pHandle);
             }
         }
         return pair != null ? pair : defaultPair();


### PR DESCRIPTION
Part of the cross-OS consistency/dedup audit (OSProcess subsystem — Windows and Linux). Two independent, behavior-preserving dedups in the same PR.

## Linux

`LinuxOSProcessJNA` and `LinuxOSProcessFFM` both carried identical `getrusage` context-switch caching:
- the same three cache fields (`rusagePopulated`, `cachedVoluntary/InvoluntaryContextSwitches`),
- the same `getVoluntaryContextSwitches`/`getInvoluntaryContextSwitches` getters (prefer the cached `getrusage` value, fall back to the `/proc` value),
- an `updateAttributes` override that differed only in the native `getrusage` call.

All of that moves into `LinuxOSProcess`, which now owns the cache fields, the getters, and an `updateAttributes` that populates the cache for the current process via a new `queryContextSwitches()` hook returning `{voluntary, involuntary}` (or `null`). Each twin keeps only that native read (JNA `Rusage` struct / FFM `MemorySegment`). The native-free `LinuxOSProcessNF` inherits the `null` default, so it behaves exactly as before (no `getrusage`).

## Windows

`WindowsOSProcessJNA.queryUserInfo` and `queryGroupInfo` were copy-paste identical apart from `Advapi32Util.getTokenAccount` vs `getTokenPrimaryGroup` and one log word. They collapse into a shared `queryTokenAccount(Function<HANDLE, Account>, String)` helper — mirroring the `getTokenAccountInfo` helper the FFM twin (`WindowsOSProcessFFM`) already had, so the two backends are now structurally consistent.

No CHANGELOG entry: behavior is identical.

Local gate: spotless, checkstyle, forbiddenapis, javadoc, and a clean full-reactor build all pass; oshi-common and oshi-core tests pass (the Linux/Windows process tests are `@EnabledOnOs`-gated and run in CI). Linux (JNA/FFM/native-free) and Windows runtime, including `NativeComparisonTest` JNA==FFM parity, are exercised by the pull-request CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of voluntary/involuntary context-switch statistics for the current Linux process by using system `getrusage`, with automatic fallback when unavailable.
  * Prevents stale context-switch counters by refreshing values instead of relying on outdated cached results.

* **Refactor**
  * Updated Linux process context-switch collection for native integrations to use on-demand retrieval.
  * Refactored Windows process token account lookup to share common logic and produce clearer user-vs-group warning messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->