### PR TITLE
Dedup Windows LoadAverage and Win32ProcessCached JNA/FFM twins

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/LoadAverage.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/LoadAverage.java
@@ -5,8 +5,12 @@
 package oshi.driver.common.windows.perfmon;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.perfmon.ProcessInformation.IdleProcessorTimeProperty;
+import oshi.driver.common.windows.perfmon.SystemInformation.ProcessorQueueLengthProperty;
 import oshi.util.tuples.Pair;
 
 /**
@@ -31,18 +35,59 @@ public abstract class LoadAverage {
             Math.exp(-5d / 60d), Math.exp(-5d / 300d), Math.exp(-5d / 900d) };
 
     /**
-     * Query the non-idle ticks from performance counters.
+     * Queries the raw idle-process performance counters. Implemented per-backend (JNA/FFM); the aggregation into
+     * non-idle ticks is shared in {@link #queryNonIdleTicks()}.
+     *
+     * @return a pair of (instance names, counter values keyed by property)
+     */
+    protected abstract Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> queryIdleProcessCounters();
+
+    /**
+     * Queries the raw processor-queue-length performance counter. Implemented per-backend (JNA/FFM).
+     *
+     * @return the counter values keyed by property
+     */
+    protected abstract Map<ProcessorQueueLengthProperty, Long> queryProcessorQueueLength();
+
+    /**
+     * Computes the non-idle ticks from the idle-process performance counters by summing the {@code _Total} instance and
+     * subtracting the {@code Idle} instance.
      *
      * @return A pair of (nonIdleTicks, nonIdleBase) values
      */
-    protected abstract Pair<Long, Long> queryNonIdleTicks();
+    protected Pair<Long, Long> queryNonIdleTicks() {
+        Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> idleValues = queryIdleProcessCounters();
+        List<String> instances = idleValues.getA();
+        Map<IdleProcessorTimeProperty, List<Long>> valueMap = idleValues.getB();
+        List<Long> proctimeTicks = valueMap.get(IdleProcessorTimeProperty.PERCENTPROCESSORTIME);
+        List<Long> proctimeBase = valueMap.get(IdleProcessorTimeProperty.ELAPSEDTIME);
+        if (proctimeTicks == null || proctimeBase == null) {
+            return new Pair<>(0L, 0L);
+        }
+        long nonIdleTicks = 0L;
+        long nonIdleBase = 0L;
+        for (int i = 0; i < instances.size(); i++) {
+            if (i >= proctimeTicks.size() || i >= proctimeBase.size()) {
+                break;
+            }
+            if ("_Total".equals(instances.get(i))) {
+                nonIdleTicks += proctimeTicks.get(i);
+                nonIdleBase += proctimeBase.get(i);
+            } else if ("Idle".equals(instances.get(i))) {
+                nonIdleTicks -= proctimeTicks.get(i);
+            }
+        }
+        return new Pair<>(nonIdleTicks, nonIdleBase);
+    }
 
     /**
-     * Query the processor queue length from performance counters.
+     * Returns the processor queue length from the raw performance counter.
      *
      * @return The processor queue length
      */
-    protected abstract long queryQueueLength();
+    protected long queryQueueLength() {
+        return queryProcessorQueueLength().getOrDefault(ProcessorQueueLengthProperty.PROCESSORQUEUELENGTH, 0L);
+    }
 
     /**
      * Queries the load average values.

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32ProcessCached.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32ProcessCached.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.wmi;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+
+import oshi.annotation.concurrent.GuardedBy;
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.wmi.Win32Process.CommandLineProperty;
+import oshi.util.tuples.Pair;
+
+/**
+ * Base for the cached {@code Win32_Process} command-line query. Holds the command-line cache and the lookup logic; the
+ * per-backend (JNA/FFM) WMI query is supplied by {@link #queryCommandLines()}.
+ */
+@ThreadSafe
+public abstract class Win32ProcessCached {
+
+    @GuardedBy("commandLineCacheLock")
+    private final Map<Integer, Pair<Long, String>> commandLineCache = new HashMap<>();
+    private final ReentrantLock commandLineCacheLock = new ReentrantLock();
+
+    /**
+     * Default constructor.
+     */
+    protected Win32ProcessCached() {
+    }
+
+    /**
+     * Queries the command lines of all running processes via WMI.
+     *
+     * @return the {@code Win32_Process} command-line WMI result
+     */
+    protected abstract WmiResult<CommandLineProperty> queryCommandLines();
+
+    /**
+     * Gets the process command line, while also querying and caching command lines for all running processes if the
+     * specified process is not in the cache.
+     *
+     * @param processId The process ID for which to return the command line.
+     * @param startTime The start time of the process, in milliseconds since the 1970 epoch.
+     * @return The command line of the specified process.
+     */
+    public String getCommandLine(int processId, long startTime) {
+        commandLineCacheLock.lock();
+        try {
+            Pair<Long, String> pair = commandLineCache.get(processId);
+            if (pair != null && startTime < pair.getA()) {
+                return pair.getB();
+            } else {
+                long now = System.currentTimeMillis();
+                WmiResult<CommandLineProperty> commandLineAllProcs = queryCommandLines();
+                if (commandLineCache.size() > commandLineAllProcs.getResultCount() * 2) {
+                    commandLineCache.clear();
+                }
+                String result = "";
+                for (int i = 0; i < commandLineAllProcs.getResultCount(); i++) {
+                    int pid = WmiUtil.getUint32(commandLineAllProcs, CommandLineProperty.PROCESSID, i);
+                    String cl = WmiUtil.getString(commandLineAllProcs, CommandLineProperty.COMMANDLINE, i);
+                    commandLineCache.put(pid, new Pair<>(now, cl));
+                    if (pid == processId) {
+                        result = cl;
+                    }
+                }
+                return result;
+            }
+        } finally {
+            commandLineCacheLock.unlock();
+        }
+    }
+}

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -45,6 +45,8 @@
 --add-opens
   com.github.oshi.common/oshi.driver.common.windows.wmi=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.driver.common.windows.perfmon=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.driver.common.windows.gpu=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.driver.common.unix.bsd=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/driver/common/windows/perfmon/LoadAverageTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/windows/perfmon/LoadAverageTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.perfmon;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.driver.common.windows.perfmon.ProcessInformation.IdleProcessorTimeProperty;
+import oshi.driver.common.windows.perfmon.SystemInformation.ProcessorQueueLengthProperty;
+import oshi.util.tuples.Pair;
+
+/**
+ * Tests the non-idle-tick and queue-length aggregation hoisted into {@link LoadAverage}.
+ */
+class LoadAverageTest {
+
+    // Builds a LoadAverage whose raw-counter hooks return the supplied fixtures, so the shared aggregation can be
+    // exercised without the platform-specific perfmon drivers.
+    private static LoadAverage stub(Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> idleCounters,
+            Map<ProcessorQueueLengthProperty, Long> queueLength) {
+        return new LoadAverage() {
+            @Override
+            protected Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> queryIdleProcessCounters() {
+                return idleCounters;
+            }
+
+            @Override
+            protected Map<ProcessorQueueLengthProperty, Long> queryProcessorQueueLength() {
+                return queueLength;
+            }
+        };
+    }
+
+    @Test
+    void testQueryNonIdleTicksSumsTotalMinusIdle() {
+        Map<IdleProcessorTimeProperty, List<Long>> valueMap = new EnumMap<>(IdleProcessorTimeProperty.class);
+        valueMap.put(IdleProcessorTimeProperty.PERCENTPROCESSORTIME, Arrays.asList(1000L, 300L));
+        valueMap.put(IdleProcessorTimeProperty.ELAPSEDTIME, Arrays.asList(5000L, 4000L));
+        Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> counters = new Pair<>(
+                Arrays.asList("_Total", "Idle"), valueMap);
+
+        Pair<Long, Long> ticks = stub(counters, Collections.emptyMap()).queryNonIdleTicks();
+        // _Total contributes ticks 1000 and base 5000; Idle subtracts its 300 ticks and leaves base untouched
+        assertThat(ticks.getA(), is(700L));
+        assertThat(ticks.getB(), is(5000L));
+    }
+
+    @Test
+    void testQueryNonIdleTicksMissingCountersReturnsZero() {
+        Pair<Long, Long> ticks = stub(new Pair<>(Collections.singletonList("_Total"),
+                Collections.<IdleProcessorTimeProperty, List<Long>>emptyMap()), Collections.emptyMap())
+                        .queryNonIdleTicks();
+        assertThat(ticks.getA(), is(0L));
+        assertThat(ticks.getB(), is(0L));
+    }
+
+    @Test
+    void testQueryQueueLength() {
+        assertThat(stub(null, Collections.singletonMap(ProcessorQueueLengthProperty.PROCESSORQUEUELENGTH, 3L))
+                .queryQueueLength(), is(3L));
+        assertThat(stub(null, Collections.emptyMap()).queryQueueLength(), is(0L));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/perfmon/LoadAverageFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/perfmon/LoadAverageFFM.java
@@ -29,35 +29,12 @@ public final class LoadAverageFFM extends LoadAverage {
     }
 
     @Override
-    protected Pair<Long, Long> queryNonIdleTicks() {
-        Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> idleValues = ProcessInformationFFM
-                .queryIdleProcessCounters();
-        List<String> instances = idleValues.getA();
-        Map<IdleProcessorTimeProperty, List<Long>> valueMap = idleValues.getB();
-        List<Long> proctimeTicks = valueMap.get(IdleProcessorTimeProperty.PERCENTPROCESSORTIME);
-        List<Long> proctimeBase = valueMap.get(IdleProcessorTimeProperty.ELAPSEDTIME);
-        if (proctimeTicks == null || proctimeBase == null) {
-            return new Pair<>(0L, 0L);
-        }
-        long nonIdleTicks = 0L;
-        long nonIdleBase = 0L;
-        for (int i = 0; i < instances.size(); i++) {
-            if (i >= proctimeTicks.size() || i >= proctimeBase.size()) {
-                break;
-            }
-            if ("_Total".equals(instances.get(i))) {
-                nonIdleTicks += proctimeTicks.get(i);
-                nonIdleBase += proctimeBase.get(i);
-            } else if ("Idle".equals(instances.get(i))) {
-                nonIdleTicks -= proctimeTicks.get(i);
-            }
-        }
-        return new Pair<>(nonIdleTicks, nonIdleBase);
+    protected Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> queryIdleProcessCounters() {
+        return ProcessInformationFFM.queryIdleProcessCounters();
     }
 
     @Override
-    protected long queryQueueLength() {
-        return SystemInformationFFM.queryProcessorQueueLength()
-                .getOrDefault(ProcessorQueueLengthProperty.PROCESSORQUEUELENGTH, 0L);
+    protected Map<ProcessorQueueLengthProperty, Long> queryProcessorQueueLength() {
+        return SystemInformationFFM.queryProcessorQueueLength();
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/wmi/Win32ProcessCachedFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/wmi/Win32ProcessCachedFFM.java
@@ -6,29 +6,20 @@ package oshi.driver.windows.wmi;
 
 import static oshi.util.Memoizer.memoize;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
-import oshi.annotation.concurrent.GuardedBy;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.wmi.Win32Process.CommandLineProperty;
+import oshi.driver.common.windows.wmi.Win32ProcessCached;
 import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
-import oshi.util.tuples.Pair;
 
 /**
  * Utility to query WMI class {@code Win32_Process} using cache (FFM).
  */
 @ThreadSafe
-public final class Win32ProcessCachedFFM {
+public final class Win32ProcessCachedFFM extends Win32ProcessCached {
 
     private static final Supplier<Win32ProcessCachedFFM> INSTANCE = memoize(Win32ProcessCachedFFM::createInstance);
-
-    @GuardedBy("commandLineCacheLock")
-    private final Map<Integer, Pair<Long, String>> commandLineCache = new HashMap<>();
-    private final ReentrantLock commandLineCacheLock = new ReentrantLock();
 
     private Win32ProcessCachedFFM() {
     }
@@ -46,39 +37,8 @@ public final class Win32ProcessCachedFFM {
         return new Win32ProcessCachedFFM();
     }
 
-    /**
-     * Gets the process command line, while also querying and caching command lines for all running processes if the
-     * specified process is not in the cache.
-     *
-     * @param processId The process ID for which to return the command line.
-     * @param startTime The start time of the process, in milliseconds since the 1970 epoch.
-     * @return The command line of the specified process.
-     */
-    public String getCommandLine(int processId, long startTime) {
-        commandLineCacheLock.lock();
-        try {
-            Pair<Long, String> pair = commandLineCache.get(processId);
-            if (pair != null && startTime < pair.getA()) {
-                return pair.getB();
-            } else {
-                long now = System.currentTimeMillis();
-                WmiResult<CommandLineProperty> commandLineAllProcs = Win32ProcessFFM.queryCommandLines(null);
-                if (commandLineCache.size() > commandLineAllProcs.getResultCount() * 2) {
-                    commandLineCache.clear();
-                }
-                String result = "";
-                for (int i = 0; i < commandLineAllProcs.getResultCount(); i++) {
-                    int pid = WmiUtil.getUint32(commandLineAllProcs, CommandLineProperty.PROCESSID, i);
-                    String cl = WmiUtil.getString(commandLineAllProcs, CommandLineProperty.COMMANDLINE, i);
-                    commandLineCache.put(pid, new Pair<>(now, cl));
-                    if (pid == processId) {
-                        result = cl;
-                    }
-                }
-                return result;
-            }
-        } finally {
-            commandLineCacheLock.unlock();
-        }
+    @Override
+    protected WmiResult<CommandLineProperty> queryCommandLines() {
+        return Win32ProcessFFM.queryCommandLines(null);
     }
 }

--- a/oshi-core/src/main/java/oshi/driver/windows/perfmon/LoadAverageJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/perfmon/LoadAverageJNA.java
@@ -29,35 +29,12 @@ public final class LoadAverageJNA extends LoadAverage {
     }
 
     @Override
-    protected Pair<Long, Long> queryNonIdleTicks() {
-        Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> idleValues = ProcessInformationJNA
-                .queryIdleProcessCounters();
-        List<String> instances = idleValues.getA();
-        Map<IdleProcessorTimeProperty, List<Long>> valueMap = idleValues.getB();
-        List<Long> proctimeTicks = valueMap.get(IdleProcessorTimeProperty.PERCENTPROCESSORTIME);
-        List<Long> proctimeBase = valueMap.get(IdleProcessorTimeProperty.ELAPSEDTIME);
-        if (proctimeTicks == null || proctimeBase == null) {
-            return new Pair<>(0L, 0L);
-        }
-        long nonIdleTicks = 0L;
-        long nonIdleBase = 0L;
-        for (int i = 0; i < instances.size(); i++) {
-            if (i >= proctimeTicks.size() || i >= proctimeBase.size()) {
-                break;
-            }
-            if ("_Total".equals(instances.get(i))) {
-                nonIdleTicks += proctimeTicks.get(i);
-                nonIdleBase += proctimeBase.get(i);
-            } else if ("Idle".equals(instances.get(i))) {
-                nonIdleTicks -= proctimeTicks.get(i);
-            }
-        }
-        return new Pair<>(nonIdleTicks, nonIdleBase);
+    protected Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> queryIdleProcessCounters() {
+        return ProcessInformationJNA.queryIdleProcessCounters();
     }
 
     @Override
-    protected long queryQueueLength() {
-        return SystemInformationJNA.queryProcessorQueueLength()
-                .getOrDefault(ProcessorQueueLengthProperty.PROCESSORQUEUELENGTH, 0L);
+    protected Map<ProcessorQueueLengthProperty, Long> queryProcessorQueueLength() {
+        return SystemInformationJNA.queryProcessorQueueLength();
     }
 }

--- a/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32ProcessCachedJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32ProcessCachedJNA.java
@@ -6,29 +6,20 @@ package oshi.driver.windows.wmi;
 
 import static oshi.util.Memoizer.memoize;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
-import oshi.annotation.concurrent.GuardedBy;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.wmi.Win32Process.CommandLineProperty;
+import oshi.driver.common.windows.wmi.Win32ProcessCached;
 import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
-import oshi.util.tuples.Pair;
 
 /**
  * Utility to query WMI class {@code Win32_Process} using cache (JNA).
  */
 @ThreadSafe
-public final class Win32ProcessCachedJNA {
+public final class Win32ProcessCachedJNA extends Win32ProcessCached {
 
     private static final Supplier<Win32ProcessCachedJNA> INSTANCE = memoize(Win32ProcessCachedJNA::createInstance);
-
-    @GuardedBy("commandLineCacheLock")
-    private final Map<Integer, Pair<Long, String>> commandLineCache = new HashMap<>();
-    private final ReentrantLock commandLineCacheLock = new ReentrantLock();
 
     private Win32ProcessCachedJNA() {
     }
@@ -46,39 +37,8 @@ public final class Win32ProcessCachedJNA {
         return new Win32ProcessCachedJNA();
     }
 
-    /**
-     * Gets the process command line, while also querying and caching command lines for all running processes if the
-     * specified process is not in the cache.
-     *
-     * @param processId The process ID for which to return the command line.
-     * @param startTime The start time of the process, in milliseconds since the 1970 epoch.
-     * @return The command line of the specified process.
-     */
-    public String getCommandLine(int processId, long startTime) {
-        commandLineCacheLock.lock();
-        try {
-            Pair<Long, String> pair = commandLineCache.get(processId);
-            if (pair != null && startTime < pair.getA()) {
-                return pair.getB();
-            } else {
-                long now = System.currentTimeMillis();
-                WmiResult<CommandLineProperty> commandLineAllProcs = Win32ProcessJNA.queryCommandLines(null);
-                if (commandLineCache.size() > commandLineAllProcs.getResultCount() * 2) {
-                    commandLineCache.clear();
-                }
-                String result = "";
-                for (int i = 0; i < commandLineAllProcs.getResultCount(); i++) {
-                    int pid = WmiUtil.getUint32(commandLineAllProcs, CommandLineProperty.PROCESSID, i);
-                    String cl = WmiUtil.getString(commandLineAllProcs, CommandLineProperty.COMMANDLINE, i);
-                    commandLineCache.put(pid, new Pair<>(now, cl));
-                    if (pid == processId) {
-                        result = cl;
-                    }
-                }
-                return result;
-            }
-        } finally {
-            commandLineCacheLock.unlock();
-        }
+    @Override
+    protected WmiResult<CommandLineProperty> queryCommandLines() {
+        return Win32ProcessJNA.queryCommandLines(null);
     }
 }


### PR DESCRIPTION
Part of the cross-OS consistency/dedup audit (Windows WMI/Perf subsystem). Most of this subsystem's JNA/FFM twins are irreducible — they're built on different native COM/PDH type systems — but two pairs differed *only* in which driver class they called, with identical surrounding logic. This deduplicates those two.

## LoadAverage

`LoadAverageJNA` and `LoadAverageFFM` had an identical 25-line non-idle-tick aggregation (sum the `_Total` perfmon instance, subtract `Idle`) plus a queue-length lookup, differing only in `ProcessInformationJNA`/`SystemInformationJNA` vs the FFM equivalents. That logic moves into the existing `LoadAverage` base behind two raw-counter hooks — `queryIdleProcessCounters()` and `queryProcessorQueueLength()` — and each twin becomes just its singleton plus two one-line delegations.

## Win32ProcessCached

`Win32ProcessCachedJNA` and `Win32ProcessCachedFFM` had an identical command-line cache and lookup method, differing only in `Win32ProcessJNA.queryCommandLines` vs `Win32ProcessFFM.queryCommandLines`. Extract a new `Win32ProcessCached` base (oshi-common) holding the cache and the lookup, with a `queryCommandLines()` hook. The twins keep only their singleton and the backend-specific query; the public `getInstance()` / `getCommandLine(...)` API is unchanged.

## Left as-is (deliberate)

The `WmiQueryHandler`, `PerfCounterQuery`, and `WmiQueryExecutor` twins are the harder axis: identical *structure* but built on genuinely different native type systems (JNA `WbemcliUtil`/`Wbemcli`/`PdhUtil` vs FFM `WbemcliUtilFFM`/`PerfDataUtilFFM`/COM FFM). Deduping them would require abstracting over both native type systems for little benefit, so they stay separate.

Adds a portable `LoadAverageTest` for the hoisted tick-summing and queue-length logic (runs on all platforms). `Win32ProcessCached.getCommandLine` remains covered by the existing `WMIDriversTest`/`WMIDriversFFMTest` on Windows CI.

No CHANGELOG entry: behavior is identical.

Local gate: spotless, checkstyle, forbiddenapis, javadoc, and a clean full-reactor build all pass; oshi-common (including the new test) and oshi-core tests pass. Windows runtime is exercised by the pull-request CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows load-average calculations, including safer handling of missing or incomplete performance-counter data.
  * Processor queue length now reliably defaults to zero when unavailable.
  * Improved Windows process command-line retrieval through shared, thread-safe caching.

* **Tests**
  * Added coverage for load-average calculations, missing counter data, and processor queue-length fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->