### PR TITLE
Extract AixOperatingSystem base and shared perfstat process carrier

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -51,9 +51,10 @@
     <suppress checks="JavadocMethod" files="PerfstatFunctions\.java"/>
 
     <!-- AIX FFM driver POJOs mirror libperfstat struct field names verbatim (snake_case) so the
-         JNA and FFM consumer code reads identically. -->
-    <suppress checks="MemberName" files="Perfstat[a-zA-Z]+FFM\.java"/>
-    <suppress checks="VisibilityModifier" files="Perfstat[a-zA-Z]+FFM\.java"/>
+         JNA and FFM consumer code reads identically. AixPerfstatProcess is the shared (oshi-common)
+         carrier for those fields, populated by both the JNA and FFM perfstat drivers. -->
+    <suppress checks="MemberName" files="(Perfstat[a-zA-Z]+FFM|AixPerfstatProcess)\.java"/>
+    <suppress checks="VisibilityModifier" files="(Perfstat[a-zA-Z]+FFM|AixPerfstatProcess)\.java"/>
     <suppress checks="JavadocMethod" files="PsInfoFFM\.java"/>
 
     <!-- AIX shared HAL/OS abstract bases use public data POJOs (CpuTickRow, CpuTotalRow,

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/AixPerfstatProcess.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/AixPerfstatProcess.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.unix.aix;
+
+import oshi.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Backend-neutral carrier for the {@code perfstat_process_t} fields OSHI consumes. Populated by the JNA and FFM
+ * {@code PerfstatProcess} drivers so the AIX {@code OperatingSystem} and {@code OSProcess} logic can be shared.
+ */
+@NotThreadSafe
+public final class AixPerfstatProcess {
+    /** Process ID. */
+    public long pid;
+    /** Number of threads. */
+    public long num_threads;
+    /** Real memory used by the data section, in kilobytes. */
+    public long proc_real_mem_data;
+    /** Real memory used by the text section, in kilobytes. */
+    public long proc_real_mem_text;
+    /** Real memory in use, in kilobytes. */
+    public long real_inuse;
+    /** User-mode CPU time, in milliseconds. */
+    public double ucpu_time;
+    /** System-mode CPU time, in milliseconds. */
+    public double scpu_time;
+}

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.aix.AixLwpsInfo;
+import oshi.driver.common.unix.aix.AixPerfstatProcess;
 import oshi.driver.common.unix.aix.AixPsInfo;
 import oshi.driver.common.unix.aix.PsInfo;
 import oshi.software.common.os.unix.AbstractProcOSProcess;
@@ -36,9 +37,15 @@ import oshi.util.tuples.Quartet;
 public abstract class AixOSProcess extends AbstractProcOSProcess {
 
     private final Supplier<AixPsInfo> psinfo = memoize(this::queryPsInfoMemo, defaultExpiration());
+    private final Supplier<AixPerfstatProcess[]> procCpu;
+    private final AixOperatingSystem os;
 
-    protected AixOSProcess(int pid) {
+    protected AixOSProcess(int pid, Quartet<Long, Long, Long, Long> cpuMem, Supplier<AixPerfstatProcess[]> procCpu,
+            AixOperatingSystem os) {
         super(pid);
+        this.procCpu = procCpu;
+        this.os = os;
+        updateAttributes(cpuMem);
     }
 
     private AixPsInfo queryPsInfoMemo() {
@@ -50,17 +57,24 @@ public abstract class AixOSProcess extends AbstractProcOSProcess {
         return queryArgsEnv(getProcessID(), psinfo.get());
     }
 
-    /**
-     * Allows subclasses to set this process's state to {@link State#INVALID} when their perfstat lookup can't find the
-     * process. Mirrors the original pre-split {@code AixOSProcess.updateAttributes()} behavior so a stale
-     * {@code perfstat_process_t[]} array that briefly omits the pid leaves the OSProcess marked invalid rather than
-     * silently retaining whatever fields were last assigned.
-     *
-     * @param newState the new state
-     */
-    protected final void setState(State newState) {
-        this.state = newState;
+    @Override
+    public long getSoftOpenFileLimit() {
+        return getProcessID() == this.os.getProcessId() ? queryRlimitNofile(true) : -1L;
     }
+
+    @Override
+    public long getHardOpenFileLimit() {
+        return getProcessID() == this.os.getProcessId() ? queryRlimitNofile(false) : -1L;
+    }
+
+    /**
+     * Reads the current process's soft or hard open-file limit via {@code getrlimit(RLIMIT_NOFILE)}. Only called when
+     * this process is the current one.
+     *
+     * @param soft {@code true} for the soft limit, {@code false} for the hard limit
+     * @return the limit, or {@code -1} if unavailable
+     */
+    protected abstract long queryRlimitNofile(boolean soft);
 
     @Override
     protected OSThread createThread(int lwpid) {
@@ -84,6 +98,18 @@ public abstract class AixOSProcess extends AbstractProcOSProcess {
         }
         mask &= getCpuAffinityMask();
         return mask;
+    }
+
+    @Override
+    public boolean updateAttributes() {
+        for (AixPerfstatProcess stat : procCpu.get()) {
+            if ((int) stat.pid == getProcessID()) {
+                return updateAttributes(new Quartet<>((long) stat.ucpu_time, (long) stat.scpu_time,
+                        stat.real_inuse * 1024L, (stat.proc_real_mem_data + stat.proc_real_mem_text) * 1024L));
+            }
+        }
+        this.state = INVALID;
+        return false;
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOperatingSystem.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2020-2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.aix;
+
+import static oshi.software.os.OSProcess.State.INVALID;
+import static oshi.software.os.OSService.State.RUNNING;
+import static oshi.software.os.OSService.State.STOPPED;
+import static oshi.util.Memoizer.defaultExpiration;
+import static oshi.util.Memoizer.installedAppsExpiration;
+import static oshi.util.Memoizer.memoize;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.unix.aix.AixPerfstatProcess;
+import oshi.driver.common.unix.aix.Uptime;
+import oshi.driver.common.unix.aix.Who;
+import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.os.ApplicationInfo;
+import oshi.software.os.FileSystem;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OSService;
+import oshi.software.os.OSThread;
+import oshi.util.ExecutingCommand;
+import oshi.util.Memoizer;
+import oshi.util.ParseUtil;
+import oshi.util.Util;
+import oshi.util.tuples.Pair;
+import oshi.util.tuples.Quartet;
+
+/**
+ * Abstract base for the AIX OperatingSystem. Holds the command-line service/version logic, the perfstat-driven process
+ * and thread enumeration (operating on the backend-neutral {@link AixPerfstatProcess} carrier), and the boot-time and
+ * installed-application queries. The JNA and FFM subclasses supply the perfstat/partition-config reads, the native
+ * process/thread IDs, and the {@code OSProcess}/{@code InternetProtocolStats}/{@code NetworkParams} factories.
+ */
+@ThreadSafe
+public abstract class AixOperatingSystem extends AbstractOperatingSystem {
+
+    private final Supplier<AixPerfstatProcess[]> procCpu = memoize(this::queryPerfstatProcesses, defaultExpiration());
+    private final Supplier<List<ApplicationInfo>> installedAppsSupplier = Memoizer
+            .memoize(AixInstalledApps::queryInstalledApps, installedAppsExpiration());
+
+    private static final long BOOTTIME = querySystemBootTimeMillis() / 1000L;
+
+    @Override
+    public String queryManufacturer() {
+        return "IBM";
+    }
+
+    @Override
+    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
+        String systemName = System.getProperty("os.name");
+        String archName = System.getProperty("os.arch");
+        String versionNumber = System.getProperty("os.version");
+        if (Util.isBlank(versionNumber)) {
+            versionNumber = ExecutingCommand.getFirstAnswer("oslevel");
+        }
+        String releaseNumber = queryOsBuildRaw();
+        if (Util.isBlank(releaseNumber)) {
+            releaseNumber = ExecutingCommand.getFirstAnswer("oslevel -s");
+        } else {
+            int idx = releaseNumber.lastIndexOf(' ');
+            if (idx > 0 && idx < releaseNumber.length()) {
+                releaseNumber = releaseNumber.substring(idx + 1);
+            }
+        }
+        return new Pair<>(systemName, new OSVersionInfo(versionNumber, archName, releaseNumber));
+    }
+
+    @Override
+    protected int queryBitness(int jvmBitness) {
+        if (jvmBitness == 64) {
+            return 64;
+        }
+        return is64BitKernel() ? 64 : 32;
+    }
+
+    @Override
+    public FileSystem getFileSystem() {
+        return new AixFileSystem();
+    }
+
+    @Override
+    public List<OSProcess> queryAllProcesses() {
+        return getProcessListFromProcfs(-1);
+    }
+
+    @Override
+    public List<OSProcess> queryChildProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<OSProcess> queryDescendantProcesses(int parentPid) {
+        List<OSProcess> allProcs = queryAllProcesses();
+        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
+        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
+    }
+
+    @Override
+    public OSProcess getProcess(int pid) {
+        List<OSProcess> procs = getProcessListFromProcfs(pid);
+        return procs.isEmpty() ? null : procs.get(0);
+    }
+
+    private List<OSProcess> getProcessListFromProcfs(int pid) {
+        List<OSProcess> procs = new ArrayList<>();
+        AixPerfstatProcess[] perfstat = procCpu.get();
+        Map<Integer, Quartet<Long, Long, Long, Long>> cpuMemMap = new HashMap<>();
+        for (AixPerfstatProcess stat : perfstat) {
+            int statpid = (int) stat.pid;
+            if (pid < 0 || statpid == pid) {
+                cpuMemMap.put(statpid, new Quartet<>((long) stat.ucpu_time, (long) stat.scpu_time,
+                        stat.real_inuse * 1024L, (stat.proc_real_mem_data + stat.proc_real_mem_text) * 1024L));
+            }
+        }
+        for (Entry<Integer, Quartet<Long, Long, Long, Long>> entry : cpuMemMap.entrySet()) {
+            OSProcess proc = createProcess(entry.getKey(), entry.getValue(), procCpu);
+            if (proc.getState() != INVALID) {
+                procs.add(proc);
+            }
+        }
+        return procs;
+    }
+
+    @Override
+    public int getProcessCount() {
+        return procCpu.get().length;
+    }
+
+    @Override
+    public OSThread getCurrentThread() {
+        OSProcess proc = getCurrentProcess();
+        final int tid = getThreadId();
+        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
+                .orElse(new AixOSThread(proc.getProcessID(), tid));
+    }
+
+    @Override
+    public int getThreadCount() {
+        long tc = 0L;
+        for (AixPerfstatProcess proc : procCpu.get()) {
+            tc += proc.num_threads;
+        }
+        return (int) tc;
+    }
+
+    @Override
+    public long getSystemUptime() {
+        return System.currentTimeMillis() / 1000L - BOOTTIME;
+    }
+
+    @Override
+    public long getSystemBootTime() {
+        return BOOTTIME;
+    }
+
+    private static long querySystemBootTimeMillis() {
+        long bootTime = Who.queryBootTime();
+        if (bootTime >= 1000L) {
+            return bootTime;
+        }
+        return System.currentTimeMillis() - Uptime.queryUpTime();
+    }
+
+    @Override
+    public List<OSService> getServices() {
+        List<OSService> services = new ArrayList<>();
+        List<String> systemServicesInfoList = ExecutingCommand.runNative("lssrc -a");
+        if (systemServicesInfoList.size() > 1) {
+            systemServicesInfoList.remove(0);
+            for (String systemService : systemServicesInfoList) {
+                String[] serviceSplit = ParseUtil.whitespaces.split(systemService.trim());
+                if (systemService.contains("active")) {
+                    if (serviceSplit.length == 4) {
+                        services.add(new OSService(serviceSplit[0], ParseUtil.parseIntOrDefault(serviceSplit[2], 0),
+                                RUNNING));
+                    } else if (serviceSplit.length == 3) {
+                        services.add(new OSService(serviceSplit[0], ParseUtil.parseIntOrDefault(serviceSplit[1], 0),
+                                RUNNING));
+                    }
+                } else if (systemService.contains("inoperative")) {
+                    services.add(new OSService(serviceSplit[0], 0, STOPPED));
+                }
+            }
+        }
+        File dir = new File("/etc/rc.d/init.d");
+        File[] listFiles;
+        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
+            for (File file : listFiles) {
+                String installedService = ExecutingCommand.getFirstAnswer(file.getAbsolutePath() + " status");
+                if (installedService.contains("running")) {
+                    services.add(new OSService(file.getName(), ParseUtil.parseLastInt(installedService, 0), RUNNING));
+                } else {
+                    services.add(new OSService(file.getName(), 0, STOPPED));
+                }
+            }
+        }
+        return services;
+    }
+
+    @Override
+    public List<ApplicationInfo> getInstalledApplications() {
+        return installedAppsSupplier.get();
+    }
+
+    /**
+     * Queries per-process usage statistics via {@code perfstat_process}.
+     *
+     * @return one {@link AixPerfstatProcess} per process
+     */
+    protected abstract AixPerfstatProcess[] queryPerfstatProcesses();
+
+    /**
+     * Returns the raw {@code OSBuild} string from the partition configuration, or an empty string if unavailable.
+     *
+     * @return the raw OS build string
+     */
+    protected abstract String queryOsBuildRaw();
+
+    /**
+     * Returns whether the kernel is 64-bit, derived from the partition configuration {@code conf} flags.
+     *
+     * @return {@code true} for a 64-bit kernel
+     */
+    protected abstract boolean is64BitKernel();
+
+    /**
+     * Creates a platform-specific {@code OSProcess} for the given process.
+     *
+     * @param pid     the process ID
+     * @param cpuMem  the perfstat-derived (userTime, kernelTime, residentSetSize, privateResidentMemory) quartet
+     * @param procCpu the memoized perfstat process array, used by the process to refresh its own attributes
+     * @return the OSProcess
+     */
+    protected abstract OSProcess createProcess(int pid, Quartet<Long, Long, Long, Long> cpuMem,
+            Supplier<AixPerfstatProcess[]> procCpu);
+}

--- a/oshi-core-ffm/src/main/java/oshi/driver/unix/aix/perfstat/PerfstatProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/unix/aix/perfstat/PerfstatProcessFFM.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.unix.aix.AixPerfstatProcess;
 import oshi.ffm.ForeignFunctions;
 
 /**
@@ -35,17 +36,6 @@ public final class PerfstatProcessFFM {
     private PerfstatProcessFFM() {
     }
 
-    /** POJO mirror of the {@code perfstat_process_t} fields OSHI consumes. */
-    public static final class ProcessInfo {
-        public long pid;
-        public long num_threads;
-        public long proc_real_mem_data;
-        public long proc_real_mem_text;
-        public long real_inuse;
-        public double ucpu_time;
-        public double scpu_time;
-    }
-
     /** Slack added to the perfstat_process count to absorb new processes between count and fill calls. */
     private static final int PROC_COUNT_PAD = 10;
 
@@ -56,25 +46,25 @@ public final class PerfstatProcessFFM {
      * perfstat calls — mirrors {@code PerfstatProcessJNA} and the {@code MacOperatingSystemJNA.getThreadCount}
      * precedent (+10).
      *
-     * @return one {@link ProcessInfo} per process, or an empty array on error
+     * @return one {@link AixPerfstatProcess} per process, or an empty array on error
      */
-    public static ProcessInfo[] queryProcesses() {
+    public static AixPerfstatProcess[] queryProcesses() {
         return ForeignFunctions.callInArenaOrDefault(arena -> {
             int count = perfstat_process(MemorySegment.NULL, MemorySegment.NULL, PERFSTAT_PROCESS_T_SIZE, 0);
             if (count <= 0) {
-                return new ProcessInfo[0];
+                return new AixPerfstatProcess[0];
             }
             int padded = count + PROC_COUNT_PAD;
             MemorySegment buf = arena.allocate((long) PERFSTAT_PROCESS_T_SIZE * padded);
             MemorySegment firstName = arena.allocate(PERFSTAT_ID_T_SIZE);
             int ret = perfstat_process(firstName, buf, PERFSTAT_PROCESS_T_SIZE, padded);
             if (ret <= 0) {
-                return new ProcessInfo[0];
+                return new AixPerfstatProcess[0];
             }
-            ProcessInfo[] result = new ProcessInfo[ret];
+            AixPerfstatProcess[] result = new AixPerfstatProcess[ret];
             for (int i = 0; i < ret; i++) {
                 long off = (long) i * PERFSTAT_PROCESS_T_SIZE;
-                ProcessInfo p = new ProcessInfo();
+                AixPerfstatProcess p = new AixPerfstatProcess();
                 p.pid = procPid(buf, off);
                 p.num_threads = procNumThreads(buf, off);
                 p.proc_real_mem_data = procRealMemData(buf, off);
@@ -85,6 +75,6 @@ public final class PerfstatProcessFFM {
                 result[i] = p;
             }
             return result;
-        }, LOG, Level.TRACE, "Failed to query process statistics", new ProcessInfo[0]);
+        }, LOG, Level.TRACE, "Failed to query process statistics", new AixPerfstatProcess[0]);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOSProcessFFM.java
@@ -16,10 +16,10 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.unix.aix.AixPerfstatProcess;
 import oshi.driver.common.unix.aix.AixPsInfo;
 import oshi.driver.unix.aix.PsInfoFFM;
 import oshi.driver.unix.aix.perfstat.PerfstatCpuFFM;
-import oshi.driver.unix.aix.perfstat.PerfstatProcessFFM;
 import oshi.ffm.platform.unix.aix.AixLibcFunctions;
 import oshi.software.common.os.unix.aix.AixOSProcess;
 import oshi.util.tuples.Pair;
@@ -32,27 +32,10 @@ import oshi.util.tuples.Quartet;
 public final class AixOSProcessFFM extends AixOSProcess {
 
     private final Supplier<Long> affinityMask = memoize(PerfstatCpuFFM::queryCpuAffinityMask, defaultExpiration());
-    private final Supplier<PerfstatProcessFFM.ProcessInfo[]> procCpu;
-    private final AixOperatingSystemFFM os;
 
-    public AixOSProcessFFM(int pid, Quartet<Long, Long, Long, Long> cpuMem,
-            Supplier<PerfstatProcessFFM.ProcessInfo[]> procCpu, AixOperatingSystemFFM os) {
-        super(pid);
-        this.procCpu = procCpu;
-        this.os = os;
-        updateAttributes(cpuMem);
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        for (PerfstatProcessFFM.ProcessInfo stat : procCpu.get()) {
-            if ((int) stat.pid == getProcessID()) {
-                return updateAttributes(new Quartet<>((long) stat.ucpu_time, (long) stat.scpu_time,
-                        stat.real_inuse * 1024L, (stat.proc_real_mem_data + stat.proc_real_mem_text) * 1024L));
-            }
-        }
-        setState(State.INVALID);
-        return false;
+    public AixOSProcessFFM(int pid, Quartet<Long, Long, Long, Long> cpuMem, Supplier<AixPerfstatProcess[]> procCpu,
+            AixOperatingSystemFFM os) {
+        super(pid, cpuMem, procCpu, os);
     }
 
     @Override
@@ -66,31 +49,14 @@ public final class AixOSProcessFFM extends AixOSProcess {
     }
 
     @Override
-    public long getSoftOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment rlim = arena.allocate(RLIMIT_LAYOUT);
-                if (AixLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) == 0) {
-                    return AixLibcFunctions.rlimitCur(rlim);
-                }
-            } catch (Throwable _) {
-                // fall through
+    protected long queryRlimitNofile(boolean soft) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment rlim = arena.allocate(RLIMIT_LAYOUT);
+            if (AixLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) == 0) {
+                return soft ? AixLibcFunctions.rlimitCur(rlim) : AixLibcFunctions.rlimitMax(rlim);
             }
-        }
-        return -1L;
-    }
-
-    @Override
-    public long getHardOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment rlim = arena.allocate(RLIMIT_LAYOUT);
-                if (AixLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) == 0) {
-                    return AixLibcFunctions.rlimitMax(rlim);
-                }
-            } catch (Throwable _) {
-                // fall through
-            }
+        } catch (Throwable _) {
+            // fall through
         }
         return -1L;
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOperatingSystemFFM.java
@@ -4,147 +4,49 @@
  */
 package oshi.software.os.unix.aix;
 
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.installedAppsExpiration;
 import static oshi.util.Memoizer.memoize;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.common.unix.aix.Uptime;
-import oshi.driver.common.unix.aix.Who;
+import oshi.driver.common.unix.aix.AixPerfstatProcess;
 import oshi.driver.unix.aix.perfstat.PerfstatConfigFFM;
 import oshi.driver.unix.aix.perfstat.PerfstatProcessFFM;
 import oshi.ffm.platform.unix.aix.AixLibcFunctions;
-import oshi.software.common.AbstractOperatingSystem;
-import oshi.software.common.os.unix.aix.AixFileSystem;
-import oshi.software.common.os.unix.aix.AixInstalledApps;
-import oshi.software.common.os.unix.aix.AixOSThread;
-import oshi.software.os.ApplicationInfo;
-import oshi.software.os.FileSystem;
+import oshi.software.common.os.unix.aix.AixOperatingSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
-import oshi.software.os.OSThread;
-import oshi.util.ExecutingCommand;
-import oshi.util.Memoizer;
-import oshi.util.ParseUtil;
-import oshi.util.Util;
-import oshi.util.tuples.Pair;
 import oshi.util.tuples.Quartet;
 
 /**
  * FFM-backed AIX OperatingSystem.
  */
 @ThreadSafe
-public final class AixOperatingSystemFFM extends AbstractOperatingSystem {
+public final class AixOperatingSystemFFM extends AixOperatingSystem {
 
     private final Supplier<PerfstatConfigFFM.PartitionConfig> config = memoize(PerfstatConfigFFM::queryConfig);
-    private final Supplier<PerfstatProcessFFM.ProcessInfo[]> procCpu = memoize(PerfstatProcessFFM::queryProcesses,
-            defaultExpiration());
-    private final Supplier<List<ApplicationInfo>> installedAppsSupplier = Memoizer
-            .memoize(AixInstalledApps::queryInstalledApps, installedAppsExpiration());
-
-    private static final long BOOTTIME = querySystemBootTimeMillis() / 1000L;
 
     @Override
-    public String queryManufacturer() {
-        return "IBM";
+    protected AixPerfstatProcess[] queryPerfstatProcesses() {
+        return PerfstatProcessFFM.queryProcesses();
     }
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        PerfstatConfigFFM.PartitionConfig cfg = config.get();
-        String systemName = System.getProperty("os.name");
-        String archName = System.getProperty("os.arch");
-        String versionNumber = System.getProperty("os.version");
-        if (Util.isBlank(versionNumber)) {
-            versionNumber = ExecutingCommand.getFirstAnswer("oslevel");
-        }
-        String releaseNumber = cfg.OSBuild;
-        if (Util.isBlank(releaseNumber)) {
-            releaseNumber = ExecutingCommand.getFirstAnswer("oslevel -s");
-        } else {
-            int idx = releaseNumber.lastIndexOf(' ');
-            if (idx > 0 && idx < releaseNumber.length()) {
-                releaseNumber = releaseNumber.substring(idx + 1);
-            }
-        }
-        return new Pair<>(systemName, new OSVersionInfo(versionNumber, archName, releaseNumber));
+    protected String queryOsBuildRaw() {
+        return config.get().OSBuild;
     }
 
     @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness == 64) {
-            return 64;
-        }
-        return (config.get().conf & 0x0080_0000) > 0 ? 64 : 32;
+    protected boolean is64BitKernel() {
+        // 9th bit of conf is 64-bit kernel
+        return (config.get().conf & 0x0080_0000) > 0;
     }
 
     @Override
-    public FileSystem getFileSystem() {
-        return new AixFileSystem();
-    }
-
-    @Override
-    public InternetProtocolStats getInternetProtocolStats() {
-        return new AixInternetProtocolStatsFFM();
-    }
-
-    @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromProcfs(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).toList();
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromProcfs(pid);
-        return procs.isEmpty() ? null : procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromProcfs(int pid) {
-        List<OSProcess> procs = new ArrayList<>();
-        PerfstatProcessFFM.ProcessInfo[] perfstat = procCpu.get();
-        Map<Integer, Quartet<Long, Long, Long, Long>> cpuMemMap = new HashMap<>();
-        for (PerfstatProcessFFM.ProcessInfo stat : perfstat) {
-            int statpid = (int) stat.pid;
-            if (pid < 0 || statpid == pid) {
-                cpuMemMap.put(statpid, new Quartet<>((long) stat.ucpu_time, (long) stat.scpu_time,
-                        stat.real_inuse * 1024L, (stat.proc_real_mem_data + stat.proc_real_mem_text) * 1024L));
-            }
-        }
-        for (Entry<Integer, Quartet<Long, Long, Long, Long>> entry : cpuMemMap.entrySet()) {
-            OSProcess proc = new AixOSProcessFFM(entry.getKey(), entry.getValue(), procCpu, this);
-            if (proc.getState() != INVALID) {
-                procs.add(proc);
-            }
-        }
-        return procs;
+    protected OSProcess createProcess(int pid, Quartet<Long, Long, Long, Long> cpuMem,
+            Supplier<AixPerfstatProcess[]> procCpu) {
+        return new AixOSProcessFFM(pid, cpuMem, procCpu, this);
     }
 
     @Override
@@ -157,11 +59,6 @@ public final class AixOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     @Override
-    public int getProcessCount() {
-        return procCpu.get().length;
-    }
-
-    @Override
     public int getThreadId() {
         try {
             return AixLibcFunctions.thread_self();
@@ -171,83 +68,12 @@ public final class AixOperatingSystemFFM extends AbstractOperatingSystem {
     }
 
     @Override
-    public OSThread getCurrentThread() {
-        OSProcess proc = getCurrentProcess();
-        final int tid = getThreadId();
-        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
-                .orElse(new AixOSThread(proc.getProcessID(), tid));
-    }
-
-    @Override
-    public int getThreadCount() {
-        long tc = 0L;
-        for (PerfstatProcessFFM.ProcessInfo proc : procCpu.get()) {
-            tc += proc.num_threads;
-        }
-        return (int) tc;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000L - BOOTTIME;
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return BOOTTIME;
-    }
-
-    private static long querySystemBootTimeMillis() {
-        long bootTime = Who.queryBootTime();
-        if (bootTime >= 1000L) {
-            return bootTime;
-        }
-        return System.currentTimeMillis() - Uptime.queryUpTime();
+    public InternetProtocolStats getInternetProtocolStats() {
+        return new AixInternetProtocolStatsFFM();
     }
 
     @Override
     public NetworkParams getNetworkParams() {
         return new AixNetworkParamsFFM();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        List<OSService> services = new ArrayList<>();
-        List<String> systemServicesInfoList = ExecutingCommand.runNative("lssrc -a");
-        if (systemServicesInfoList.size() > 1) {
-            systemServicesInfoList.remove(0);
-            for (String systemService : systemServicesInfoList) {
-                String[] serviceSplit = ParseUtil.whitespaces.split(systemService.trim());
-                if (systemService.contains("active")) {
-                    if (serviceSplit.length == 4) {
-                        services.add(new OSService(serviceSplit[0], ParseUtil.parseIntOrDefault(serviceSplit[2], 0),
-                                RUNNING));
-                    } else if (serviceSplit.length == 3) {
-                        services.add(new OSService(serviceSplit[0], ParseUtil.parseIntOrDefault(serviceSplit[1], 0),
-                                RUNNING));
-                    }
-                } else if (systemService.contains("inoperative")) {
-                    services.add(new OSService(serviceSplit[0], 0, STOPPED));
-                }
-            }
-        }
-        File dir = new File("/etc/rc.d/init.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File file : listFiles) {
-                String installedService = ExecutingCommand.getFirstAnswer(file.getAbsolutePath() + " status");
-                if (installedService.contains("running")) {
-                    services.add(new OSService(file.getName(), ParseUtil.parseLastInt(installedService, 0), RUNNING));
-                } else {
-                    services.add(new OSService(file.getName(), 0, STOPPED));
-                }
-            }
-        }
-        return services;
-    }
-
-    @Override
-    public List<ApplicationInfo> getInstalledApplications() {
-        return installedAppsSupplier.get();
     }
 }

--- a/oshi-core/src/main/java/oshi/driver/unix/aix/perfstat/PerfstatProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/aix/perfstat/PerfstatProcessJNA.java
@@ -4,13 +4,12 @@
  */
 package oshi.driver.unix.aix.perfstat;
 
-import java.util.Arrays;
-
 import com.sun.jna.platform.unix.aix.Perfstat;
 import com.sun.jna.platform.unix.aix.Perfstat.perfstat_id_t;
 import com.sun.jna.platform.unix.aix.Perfstat.perfstat_process_t;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.unix.aix.AixPerfstatProcess;
 
 /**
  * Utility to query performance stats for processes
@@ -36,7 +35,7 @@ public final class PerfstatProcessJNA {
      *
      * @return an array of usage statistics
      */
-    public static perfstat_process_t[] queryProcesses() {
+    public static AixPerfstatProcess[] queryProcesses() {
         perfstat_process_t process = new perfstat_process_t();
         // With null, null, ..., 0, returns total # of elements
         int procCount = PERF.perfstat_process(null, null, process.size(), 0);
@@ -46,9 +45,22 @@ public final class PerfstatProcessJNA {
             perfstat_id_t firstprocess = new perfstat_id_t(); // name is ""
             int ret = PERF.perfstat_process(firstprocess, proct, process.size(), padded);
             if (ret > 0) {
-                return Arrays.copyOf(proct, ret);
+                AixPerfstatProcess[] result = new AixPerfstatProcess[ret];
+                for (int i = 0; i < ret; i++) {
+                    perfstat_process_t stat = proct[i];
+                    AixPerfstatProcess p = new AixPerfstatProcess();
+                    p.pid = stat.pid;
+                    p.num_threads = stat.num_threads;
+                    p.proc_real_mem_data = stat.proc_real_mem_data;
+                    p.proc_real_mem_text = stat.proc_real_mem_text;
+                    p.real_inuse = stat.real_inuse;
+                    p.ucpu_time = stat.ucpu_time;
+                    p.scpu_time = stat.scpu_time;
+                    result[i] = p;
+                }
+                return result;
             }
         }
-        return new perfstat_process_t[0];
+        return new AixPerfstatProcess[0];
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOSProcessJNA.java
@@ -13,9 +13,9 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import com.sun.jna.platform.unix.Resource;
-import com.sun.jna.platform.unix.aix.Perfstat.perfstat_process_t;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.unix.aix.AixPerfstatProcess;
 import oshi.driver.common.unix.aix.AixPsInfo;
 import oshi.driver.unix.aix.PsInfoJNA;
 import oshi.driver.unix.aix.perfstat.PerfstatCpuJNA;
@@ -31,27 +31,10 @@ import oshi.util.tuples.Quartet;
 public final class AixOSProcessJNA extends AixOSProcess {
 
     private final Supplier<Long> affinityMask = memoize(PerfstatCpuJNA::queryCpuAffinityMask, defaultExpiration());
-    private final Supplier<perfstat_process_t[]> procCpu;
-    private final AixOperatingSystemJNA os;
 
-    public AixOSProcessJNA(int pid, Quartet<Long, Long, Long, Long> cpuMem, Supplier<perfstat_process_t[]> procCpu,
+    public AixOSProcessJNA(int pid, Quartet<Long, Long, Long, Long> cpuMem, Supplier<AixPerfstatProcess[]> procCpu,
             AixOperatingSystemJNA os) {
-        super(pid);
-        this.procCpu = procCpu;
-        this.os = os;
-        updateAttributes(cpuMem);
-    }
-
-    @Override
-    public boolean updateAttributes() {
-        for (perfstat_process_t stat : procCpu.get()) {
-            if ((int) stat.pid == getProcessID()) {
-                return updateAttributes(new Quartet<>((long) stat.ucpu_time, (long) stat.scpu_time,
-                        stat.real_inuse * 1024L, (stat.proc_real_mem_data + stat.proc_real_mem_text) * 1024L));
-            }
-        }
-        setState(State.INVALID);
-        return false;
+        super(pid, cpuMem, procCpu, os);
     }
 
     @Override
@@ -65,23 +48,10 @@ public final class AixOSProcessJNA extends AixOSProcess {
     }
 
     @Override
-    public long getSoftOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            final Resource.Rlimit rlimit = new Resource.Rlimit();
-            if (AixLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit) == 0) {
-                return rlimit.rlim_cur;
-            }
-        }
-        return -1L;
-    }
-
-    @Override
-    public long getHardOpenFileLimit() {
-        if (getProcessID() == this.os.getProcessId()) {
-            final Resource.Rlimit rlimit = new Resource.Rlimit();
-            if (AixLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit) == 0) {
-                return rlimit.rlim_max;
-            }
+    protected long queryRlimitNofile(boolean soft) {
+        Resource.Rlimit rlimit = new Resource.Rlimit();
+        if (AixLibc.INSTANCE.getrlimit(RLIMIT_NOFILE, rlimit) == 0) {
+            return soft ? rlimit.rlim_cur : rlimit.rlim_max;
         }
         return -1L;
     }

--- a/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/aix/AixOperatingSystemJNA.java
@@ -4,156 +4,52 @@
  */
 package oshi.software.os.unix.aix;
 
-import static oshi.software.os.OSProcess.State.INVALID;
-import static oshi.software.os.OSService.State.RUNNING;
-import static oshi.software.os.OSService.State.STOPPED;
-import static oshi.util.Memoizer.defaultExpiration;
-import static oshi.util.Memoizer.installedAppsExpiration;
 import static oshi.util.Memoizer.memoize;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import com.sun.jna.Native;
 import com.sun.jna.platform.unix.aix.Perfstat.perfstat_partition_config_t;
-import com.sun.jna.platform.unix.aix.Perfstat.perfstat_process_t;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.driver.common.unix.aix.Uptime;
-import oshi.driver.common.unix.aix.Who;
+import oshi.driver.common.unix.aix.AixPerfstatProcess;
 import oshi.driver.unix.aix.perfstat.PerfstatConfigJNA;
 import oshi.driver.unix.aix.perfstat.PerfstatProcessJNA;
 import oshi.jna.platform.unix.AixLibc;
-import oshi.software.common.AbstractOperatingSystem;
-import oshi.software.common.os.unix.aix.AixFileSystem;
-import oshi.software.common.os.unix.aix.AixInstalledApps;
-import oshi.software.common.os.unix.aix.AixOSThread;
-import oshi.software.os.ApplicationInfo;
-import oshi.software.os.FileSystem;
+import oshi.software.common.os.unix.aix.AixOperatingSystem;
 import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
-import oshi.software.os.OSService;
-import oshi.software.os.OSThread;
-import oshi.util.ExecutingCommand;
-import oshi.util.Memoizer;
-import oshi.util.ParseUtil;
-import oshi.util.Util;
-import oshi.util.tuples.Pair;
 import oshi.util.tuples.Quartet;
 
 /**
  * JNA-backed AIX OperatingSystem.
  */
 @ThreadSafe
-public final class AixOperatingSystemJNA extends AbstractOperatingSystem {
+public final class AixOperatingSystemJNA extends AixOperatingSystem {
 
     private final Supplier<perfstat_partition_config_t> config = memoize(PerfstatConfigJNA::queryConfig);
-    private final Supplier<perfstat_process_t[]> procCpu = memoize(PerfstatProcessJNA::queryProcesses,
-            defaultExpiration());
-    private final Supplier<List<ApplicationInfo>> installedAppsSupplier = Memoizer
-            .memoize(AixInstalledApps::queryInstalledApps, installedAppsExpiration());
-
-    private static final long BOOTTIME = querySystemBootTimeMillis() / 1000L;
 
     @Override
-    public String queryManufacturer() {
-        return "IBM";
+    protected AixPerfstatProcess[] queryPerfstatProcesses() {
+        return PerfstatProcessJNA.queryProcesses();
     }
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        perfstat_partition_config_t cfg = config.get();
-        String systemName = System.getProperty("os.name");
-        String archName = System.getProperty("os.arch");
-        String versionNumber = System.getProperty("os.version");
-        if (Util.isBlank(versionNumber)) {
-            versionNumber = ExecutingCommand.getFirstAnswer("oslevel");
-        }
-        String releaseNumber = Native.toString(cfg.OSBuild);
-        if (Util.isBlank(releaseNumber)) {
-            releaseNumber = ExecutingCommand.getFirstAnswer("oslevel -s");
-        } else {
-            int idx = releaseNumber.lastIndexOf(' ');
-            if (idx > 0 && idx < releaseNumber.length()) {
-                releaseNumber = releaseNumber.substring(idx + 1);
-            }
-        }
-        return new Pair<>(systemName, new OSVersionInfo(versionNumber, archName, releaseNumber));
+    protected String queryOsBuildRaw() {
+        return Native.toString(config.get().OSBuild);
     }
 
     @Override
-    protected int queryBitness(int jvmBitness) {
-        if (jvmBitness == 64) {
-            return 64;
-        }
+    protected boolean is64BitKernel() {
         // 9th bit of conf is 64-bit kernel
-        return (config.get().conf & 0x0080_0000) > 0 ? 64 : 32;
+        return (config.get().conf & 0x0080_0000) > 0;
     }
 
     @Override
-    public FileSystem getFileSystem() {
-        return new AixFileSystem();
-    }
-
-    @Override
-    public InternetProtocolStats getInternetProtocolStats() {
-        return new AixInternetProtocolStatsJNA();
-    }
-
-    @Override
-    public List<OSProcess> queryAllProcesses() {
-        return getProcessListFromProcfs(-1);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, false);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        List<OSProcess> allProcs = queryAllProcesses();
-        Set<Integer> descendantPids = getChildrenOrDescendants(allProcs, parentPid, true);
-        return allProcs.stream().filter(p -> descendantPids.contains(p.getProcessID())).collect(Collectors.toList());
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procs = getProcessListFromProcfs(pid);
-        if (procs.isEmpty()) {
-            return null;
-        }
-        return procs.get(0);
-    }
-
-    private List<OSProcess> getProcessListFromProcfs(int pid) {
-        List<OSProcess> procs = new ArrayList<>();
-        perfstat_process_t[] perfstat = procCpu.get();
-        Map<Integer, Quartet<Long, Long, Long, Long>> cpuMemMap = new HashMap<>();
-        for (perfstat_process_t stat : perfstat) {
-            int statpid = (int) stat.pid;
-            if (pid < 0 || statpid == pid) {
-                cpuMemMap.put(statpid, new Quartet<>((long) stat.ucpu_time, (long) stat.scpu_time,
-                        stat.real_inuse * 1024L, (stat.proc_real_mem_data + stat.proc_real_mem_text) * 1024L));
-            }
-        }
-        for (Entry<Integer, Quartet<Long, Long, Long, Long>> entry : cpuMemMap.entrySet()) {
-            OSProcess proc = new AixOSProcessJNA(entry.getKey(), entry.getValue(), procCpu, this);
-            if (proc.getState() != INVALID) {
-                procs.add(proc);
-            }
-        }
-        return procs;
+    protected OSProcess createProcess(int pid, Quartet<Long, Long, Long, Long> cpuMem,
+            Supplier<AixPerfstatProcess[]> procCpu) {
+        return new AixOSProcessJNA(pid, cpuMem, procCpu, this);
     }
 
     @Override
@@ -162,93 +58,17 @@ public final class AixOperatingSystemJNA extends AbstractOperatingSystem {
     }
 
     @Override
-    public int getProcessCount() {
-        return procCpu.get().length;
-    }
-
-    @Override
     public int getThreadId() {
         return AixLibc.INSTANCE.thread_self();
     }
 
     @Override
-    public OSThread getCurrentThread() {
-        OSProcess proc = getCurrentProcess();
-        final int tid = getThreadId();
-        return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
-                .orElse(new AixOSThread(proc.getProcessID(), tid));
-    }
-
-    @Override
-    public int getThreadCount() {
-        long tc = 0L;
-        for (perfstat_process_t proc : procCpu.get()) {
-            tc += proc.num_threads;
-        }
-        return (int) tc;
-    }
-
-    @Override
-    public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000L - BOOTTIME;
-    }
-
-    @Override
-    public long getSystemBootTime() {
-        return BOOTTIME;
-    }
-
-    private static long querySystemBootTimeMillis() {
-        long bootTime = Who.queryBootTime();
-        if (bootTime >= 1000L) {
-            return bootTime;
-        }
-        return System.currentTimeMillis() - Uptime.queryUpTime();
+    public InternetProtocolStats getInternetProtocolStats() {
+        return new AixInternetProtocolStatsJNA();
     }
 
     @Override
     public NetworkParams getNetworkParams() {
         return new AixNetworkParamsJNA();
-    }
-
-    @Override
-    public List<OSService> getServices() {
-        List<OSService> services = new ArrayList<>();
-        List<String> systemServicesInfoList = ExecutingCommand.runNative("lssrc -a");
-        if (systemServicesInfoList.size() > 1) {
-            systemServicesInfoList.remove(0);
-            for (String systemService : systemServicesInfoList) {
-                String[] serviceSplit = ParseUtil.whitespaces.split(systemService.trim());
-                if (systemService.contains("active")) {
-                    if (serviceSplit.length == 4) {
-                        services.add(new OSService(serviceSplit[0], ParseUtil.parseIntOrDefault(serviceSplit[2], 0),
-                                RUNNING));
-                    } else if (serviceSplit.length == 3) {
-                        services.add(new OSService(serviceSplit[0], ParseUtil.parseIntOrDefault(serviceSplit[1], 0),
-                                RUNNING));
-                    }
-                } else if (systemService.contains("inoperative")) {
-                    services.add(new OSService(serviceSplit[0], 0, STOPPED));
-                }
-            }
-        }
-        File dir = new File("/etc/rc.d/init.d");
-        File[] listFiles;
-        if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
-            for (File file : listFiles) {
-                String installedService = ExecutingCommand.getFirstAnswer(file.getAbsolutePath() + " status");
-                if (installedService.contains("running")) {
-                    services.add(new OSService(file.getName(), ParseUtil.parseLastInt(installedService, 0), RUNNING));
-                } else {
-                    services.add(new OSService(file.getName(), 0, STOPPED));
-                }
-            }
-        }
-        return services;
-    }
-
-    @Override
-    public List<ApplicationInfo> getInstalledApplications() {
-        return installedAppsSupplier.get();
     }
 }

--- a/oshi-core/src/test/java/oshi/driver/unix/aix/perfstat/PerfstatJNATest.java
+++ b/oshi-core/src/test/java/oshi/driver/unix/aix/perfstat/PerfstatJNATest.java
@@ -25,8 +25,9 @@ import com.sun.jna.platform.unix.aix.Perfstat.perfstat_disk_t;
 import com.sun.jna.platform.unix.aix.Perfstat.perfstat_memory_total_t;
 import com.sun.jna.platform.unix.aix.Perfstat.perfstat_netinterface_t;
 import com.sun.jna.platform.unix.aix.Perfstat.perfstat_partition_config_t;
-import com.sun.jna.platform.unix.aix.Perfstat.perfstat_process_t;
 import com.sun.jna.platform.unix.aix.Perfstat.perfstat_protocol_t;
+
+import oshi.driver.common.unix.aix.AixPerfstatProcess;
 
 @EnabledOnOs(OS.AIX)
 class PerfstatJNATest {
@@ -82,9 +83,9 @@ class PerfstatJNATest {
 
     @Test
     void testQueryProcesses() {
-        perfstat_process_t[] procs = PerfstatProcessJNA.queryProcesses();
+        AixPerfstatProcess[] procs = PerfstatProcessJNA.queryProcesses();
         assertThat("Should have at least one process", procs.length, greaterThan(0));
-        for (perfstat_process_t proc : procs) {
+        for (AixPerfstatProcess proc : procs) {
             assertThat("Should have at least one thread", proc.num_threads, greaterThan(0L));
         }
     }


### PR DESCRIPTION
Part of the cross-OS consistency/dedup audit (OperatingSystem subsystem — AIX). AIX was the largest remaining single duplication hotspot: it is the only platform whose `OperatingSystem` JNA and FFM twins extend `AbstractOperatingSystem` directly, with no common base, so they duplicated ~200 lines.

## Shared perfstat carrier

New `oshi.driver.common.unix.aix.AixPerfstatProcess` (oshi-common) — a backend-neutral POJO holding the `perfstat_process_t` fields OSHI consumes. `PerfstatProcessJNA` now maps its JNA `Structure` array into this carrier, and `PerfstatProcessFFM` returns it in place of its own private `ProcessInfo` POJO. Both drivers therefore hand back the same type.

## AixOperatingSystem base

New abstract `AixOperatingSystem` (oshi-common) holds all the shared logic — `getServices`, version/manufacturer, boot time, installed applications, and the perfstat-driven `queryAllProcesses`/`getProcess`/`getProcessCount`/`getThreadCount`/`getCurrentThread` (operating on the carrier). The JNA and FFM twins collapse from ~254/253 lines to ~72/78, providing only hooks:

- `queryPerfstatProcesses()` — the perfstat array (via the driver),
- `queryOsBuildRaw()` / `is64BitKernel()` — the partition-config reads,
- `createProcess(...)` — the `OSProcess` factory,
- plus the native `getProcessId`/`getThreadId` and the `InternetProtocolStats`/`NetworkParams` factories.

The partition-config POJO is intentionally **not** promoted to a shared carrier — its other fields feed `AixCentralProcessor`/`AixGlobalMemory`, out of scope here — so config access stays as the two small hooks above.

## AixOSProcess

With the carrier in place, `AixOSProcess`'s duplicated `procCpu` iteration (`updateAttributes`) and its `getrlimit`-based open-file-limit skeleton move into the base (behind an `AixPerfstatProcess[]` supplier and a `queryRlimitNofile(boolean)` hook, matching the BsdOSProcess pattern). The twins keep only the native `getrlimit`, the affinity supplier, and the `queryArgsEnv` address-space read.

No CHANGELOG entry: behavior is identical.

Local gate: spotless, checkstyle (the carrier is added to the existing AIX perfstat-POJO suppression), forbiddenapis, javadoc, and a clean full-reactor build all pass; oshi-common and oshi-core tests pass (`PerfstatJNATest` updated for the new return type). AIX runtime, including JNA==FFM parity, is validated on the compile farm (dispatched separately, since cfarm does not run on pull requests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved AIX process monitoring with more consistent CPU, memory, and thread metrics across supported native access methods.
  * Enhanced AIX process handling to provide uniform behavior for CPU/memory reporting and open-file limit reporting.
* **Bug Fixes**
  * Processes that can’t be found in perfstat data are now correctly marked invalid.
* **Tests**
  * Updated AIX perfstat process query tests to validate against the shared AIX process representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->