### PR TITLE
Hoist BSD/Mac OperatingSystem version, session, and boot-time queries into bases

### DIFF
--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -99,7 +99,7 @@
     <suppress checks="JavadocPackage" files=".*FFM\.java"/>
 
     <!-- Protected final fields initialized in constructor -->
-    <suppress checks="VisibilityModifier" files="MacOperatingSystem\.java" lines="54-61"/>
+    <suppress checks="VisibilityModifier" files="MacOperatingSystem\.java" lines="56-63"/>
 
     <!-- Imports for classes linked in javadocs -->
     <suppress checks="UnusedImports" files="(CentralProcessor|OSDesktopWindow|OSProcess)\.java"/>

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
@@ -28,12 +28,14 @@ import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.ApplicationInfo;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSService;
+import oshi.software.os.OSSession;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.Memoizer;
 import oshi.util.ParseUtil;
 import oshi.util.Util;
+import oshi.util.tuples.Pair;
 
 /**
  * macOS, previously Mac OS X and later OS X) is a series of proprietary graphical operating systems developed and
@@ -115,6 +117,36 @@ public abstract class MacOperatingSystem extends AbstractOperatingSystem {
         }
         return codeName;
     }
+
+    @Override
+    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
+        String family = this.major > 10 || (this.major == 10 && this.minor >= 12) ? "macOS"
+                : System.getProperty("os.name");
+        String codeName = parseCodeName();
+        String buildNumber = querySysctl("kern.osversion", "");
+        return new Pair<>(family, new OSVersionInfo(this.osXVersion, codeName, buildNumber));
+    }
+
+    @Override
+    public List<OSSession> getSessions() {
+        return USE_WHO_COMMAND ? super.getSessions() : queryWhoSessions();
+    }
+
+    /**
+     * Reads a string-valued sysctl by name.
+     *
+     * @param name the sysctl name (e.g. {@code "kern.osversion"})
+     * @param def  the default value if the sysctl can't be read
+     * @return the sysctl value, or {@code def}
+     */
+    protected abstract String querySysctl(String name, String def);
+
+    /**
+     * Reads the login sessions natively via {@code getutxent}.
+     *
+     * @return the sessions
+     */
+    protected abstract List<OSSession> queryWhoSessions();
 
     @Override
     protected int queryBitness(int jvmBitness) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOperatingSystem.java
@@ -25,6 +25,7 @@ import oshi.software.os.OSProcess;
 import oshi.software.os.OSService;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 
 /**
  * Abstract base shared by the BSD-family OperatingSystem implementations (FreeBSD, OpenBSD, DragonFly, NetBSD). Holds
@@ -141,6 +142,35 @@ public abstract class BsdOperatingSystem extends AbstractOperatingSystem {
             LOG.error("Directory: /etc/rc.d does not exist");
         }
         return services;
+    }
+
+    /**
+     * Builds the family/version info from the raw {@code kern.ostype}/{@code kern.osrelease}/{@code kern.version}
+     * sysctl values. Shared by the FreeBSD, DragonFly, and OpenBSD subclasses, which differ only in how those three
+     * strings are fetched (string-named vs. MIB-based sysctl).
+     *
+     * @param family      the {@code kern.ostype} value (e.g. {@code "FreeBSD"})
+     * @param version     the {@code kern.osrelease} value
+     * @param versionInfo the {@code kern.version} value
+     * @return the family name paired with the parsed version info
+     */
+    protected static Pair<String, OSVersionInfo> buildFamilyVersionInfo(String family, String version,
+            String versionInfo) {
+        String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
+        return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
+    }
+
+    /**
+     * Parses the boot time (seconds since the epoch) from the {@code sysctl -n kern.boottime} command output. Used as a
+     * fallback by the BSD subclasses when the native {@code kern.boottime} sysctl is unavailable.
+     *
+     * @return the boot time in seconds, or the current time if it can't be parsed
+     */
+    protected static long queryBootTimeFromCommand() {
+        // Boot time will be the first consecutive string of digits.
+        return ParseUtil.parseLongOrDefault(
+                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
+                System.currentTimeMillis() / 1000);
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOperatingSystem.java
@@ -15,9 +15,11 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.os.unix.bsd.BsdOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.os.OSProcess;
+import oshi.software.os.OSSession;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 
 /**
  * Abstract base shared by the DragonFly BSD OperatingSystem implementations (JNA and FFM). The cross-BSD-common pieces
@@ -56,6 +58,23 @@ public abstract class DragonFlyBsdOperatingSystem extends BsdOperatingSystem {
                 .orElse(new DragonFlyBsdOSThread(proc.getProcessID(), tid));
     }
 
+    @Override
+    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
+        return buildFamilyVersionInfo(querySysctl("kern.ostype", "DragonFly"), querySysctl("kern.osrelease", ""),
+                querySysctl("kern.version", ""));
+    }
+
+    @Override
+    public List<OSSession> getSessions() {
+        return USE_WHO_COMMAND ? super.getSessions() : queryWhoSessions();
+    }
+
+    @Override
+    protected long queryBootTime() {
+        long bootSeconds = queryKernBoottimeSeconds();
+        return bootSeconds > 0 ? bootSeconds : queryBootTimeFromCommand();
+    }
+
     /**
      * Creates a backend-specific {@link OSProcess} from a parsed {@code ps} row.
      *
@@ -64,4 +83,27 @@ public abstract class DragonFlyBsdOperatingSystem extends BsdOperatingSystem {
      * @return a new OSProcess
      */
     protected abstract OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap);
+
+    /**
+     * Reads a string-valued sysctl by name.
+     *
+     * @param name the sysctl name (e.g. {@code "kern.ostype"})
+     * @param def  the default value if the sysctl can't be read
+     * @return the sysctl value, or {@code def}
+     */
+    protected abstract String querySysctl(String name, String def);
+
+    /**
+     * Reads the login sessions natively via {@code getutxent}.
+     *
+     * @return the sessions
+     */
+    protected abstract List<OSSession> queryWhoSessions();
+
+    /**
+     * Reads the boot time (seconds since the epoch) from the native {@code kern.boottime} sysctl.
+     *
+     * @return the boot time in seconds, or {@code 0} if the sysctl is unavailable
+     */
+    protected abstract long queryKernBoottimeSeconds();
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOperatingSystem.java
@@ -15,9 +15,11 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.os.unix.bsd.BsdOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.os.OSProcess;
+import oshi.software.os.OSSession;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 
 /**
  * Abstract base shared by the FreeBSD OperatingSystem implementations (JNA and FFM). The cross-BSD-common pieces live
@@ -54,6 +56,23 @@ public abstract class FreeBsdOperatingSystem extends BsdOperatingSystem {
                 .orElse(new FreeBsdOSThread(proc.getProcessID(), tid));
     }
 
+    @Override
+    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
+        return buildFamilyVersionInfo(querySysctl("kern.ostype", "FreeBSD"), querySysctl("kern.osrelease", ""),
+                querySysctl("kern.version", ""));
+    }
+
+    @Override
+    public List<OSSession> getSessions() {
+        return USE_WHO_COMMAND ? super.getSessions() : queryWhoSessions();
+    }
+
+    @Override
+    protected long queryBootTime() {
+        long bootSeconds = queryKernBoottimeSeconds();
+        return bootSeconds > 0 ? bootSeconds : queryBootTimeFromCommand();
+    }
+
     /**
      * Creates a backend-specific {@link OSProcess} from a parsed {@code ps} row.
      *
@@ -62,4 +81,27 @@ public abstract class FreeBsdOperatingSystem extends BsdOperatingSystem {
      * @return a new OSProcess
      */
     protected abstract OSProcess createProcess(int pid, Map<BsdPsKeyword, String> psMap);
+
+    /**
+     * Reads a string-valued sysctl by name.
+     *
+     * @param name the sysctl name (e.g. {@code "kern.ostype"})
+     * @param def  the default value if the sysctl can't be read
+     * @return the sysctl value, or {@code def}
+     */
+    protected abstract String querySysctl(String name, String def);
+
+    /**
+     * Reads the login sessions natively via {@code getutxent}.
+     *
+     * @return the sessions
+     */
+    protected abstract List<OSSession> queryWhoSessions();
+
+    /**
+     * Reads the boot time (seconds since the epoch) from the native {@code kern.boottime} sysctl.
+     *
+     * @return the boot time in seconds, or {@code 0} if the sysctl is unavailable
+     */
+    protected abstract long queryKernBoottimeSeconds();
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
@@ -17,6 +17,7 @@ import oshi.software.os.OSProcess;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 
 /**
  * Abstract base shared by the OpenBSD OperatingSystem implementations (JNA and FFM). The cross-BSD-common pieces live
@@ -27,6 +28,28 @@ import oshi.util.ParseUtil;
  */
 @ThreadSafe
 public abstract class OpenBsdOperatingSystem extends BsdOperatingSystem {
+
+    // OpenBSD sysctl(2) MIB identifiers (from <sys/sysctl.h>)
+    private static final int CTL_KERN = 1;
+    private static final int KERN_OSTYPE = 1;
+    private static final int KERN_OSRELEASE = 2;
+    private static final int KERN_VERSION = 4;
+
+    @Override
+    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
+        return buildFamilyVersionInfo(querySysctl(new int[] { CTL_KERN, KERN_OSTYPE }, "OpenBSD"),
+                querySysctl(new int[] { CTL_KERN, KERN_OSRELEASE }, ""),
+                querySysctl(new int[] { CTL_KERN, KERN_VERSION }, ""));
+    }
+
+    /**
+     * Reads a string-valued sysctl by its MIB identifier array.
+     *
+     * @param mib the sysctl MIB (e.g. {@code {CTL_KERN, KERN_OSTYPE}})
+     * @param def the default value if the sysctl can't be read
+     * @return the sysctl value, or {@code def}
+     */
+    protected abstract String querySysctl(int[] mib, String def);
 
     @Override
     public InternetProtocolStats getInternetProtocolStats() {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
@@ -45,7 +45,6 @@ import oshi.software.os.OSProcess.State;
 import oshi.software.os.OSSession;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.tuples.Pair;
 
 /**
  * macOS, previously Mac OS X and later OS X) is a series of proprietary graphical operating systems developed and
@@ -92,17 +91,13 @@ public class MacOperatingSystemFFM extends MacOperatingSystem {
     }
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        String family = this.major > 10 || (this.major == 10 && this.minor >= 12) ? "macOS"
-                : System.getProperty("os.name");
-        String codeName = parseCodeName();
-        String buildNumber = SysctlUtilFFM.sysctl("kern.osversion", "");
-        return new Pair<>(family, new OSVersionInfo(this.osXVersion, codeName, buildNumber));
+    protected String querySysctl(String name, String def) {
+        return SysctlUtilFFM.sysctl(name, def);
     }
 
     @Override
-    public List<OSSession> getSessions() {
-        return USE_WHO_COMMAND ? super.getSessions() : WhoFFM.queryUtxent();
+    protected List<OSSession> queryWhoSessions() {
+        return WhoFFM.queryUtxent();
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
@@ -31,9 +31,6 @@ import oshi.software.os.OSSession;
 import oshi.software.os.unix.freebsd.FreeBsdFileSystemFFM;
 import oshi.software.os.unix.freebsd.FreeBsdInternetProtocolStatsFFM;
 import oshi.software.os.unix.freebsd.FreeBsdNetworkParamsFFM;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
-import oshi.util.tuples.Pair;
 
 /**
  * FFM-backed DragonFly BSD operating system.
@@ -44,14 +41,8 @@ public class DragonFlyBsdOperatingSystemFFM extends DragonFlyBsdOperatingSystem 
     private static final Logger LOG = LoggerFactory.getLogger(DragonFlyBsdOperatingSystemFFM.class);
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        String family = BsdSysctlUtilFFM.sysctl("kern.ostype", "DragonFly");
-
-        String version = BsdSysctlUtilFFM.sysctl("kern.osrelease", "");
-        String versionInfo = BsdSysctlUtilFFM.sysctl("kern.version", "");
-        String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
-
-        return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
+    protected String querySysctl(String name, String def) {
+        return BsdSysctlUtilFFM.sysctl(name, def);
     }
 
     @Override
@@ -70,8 +61,8 @@ public class DragonFlyBsdOperatingSystemFFM extends DragonFlyBsdOperatingSystem 
     }
 
     @Override
-    public List<OSSession> getSessions() {
-        return USE_WHO_COMMAND ? super.getSessions() : WhoFFM.queryUtxent();
+    protected List<OSSession> queryWhoSessions() {
+        return WhoFFM.queryUtxent();
     }
 
     @Override
@@ -92,7 +83,7 @@ public class DragonFlyBsdOperatingSystemFFM extends DragonFlyBsdOperatingSystem 
     }
 
     @Override
-    protected long queryBootTime() {
+    protected long queryKernBoottimeSeconds() {
         try (Arena arena = Arena.ofConfined()) {
             // struct timeval: two longs (tv_sec, tv_usec) = 16 bytes on LP64 BSD.
             MemorySegment tv = arena.allocate(JAVA_LONG.byteSize() * 2);
@@ -100,9 +91,6 @@ public class DragonFlyBsdOperatingSystemFFM extends DragonFlyBsdOperatingSystem 
                 return tv.get(JAVA_LONG, 0);
             }
         }
-        // Fall back to text parsing: "{ sec = 1779823319, nsec = 0 } ..."
-        return ParseUtil.parseLongOrDefault(
-                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
-                System.currentTimeMillis() / 1000);
+        return 0L;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemFFM.java
@@ -27,9 +27,6 @@ import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSSession;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
-import oshi.util.tuples.Pair;
 
 /**
  * FFM-backed FreeBSD operating system.
@@ -40,14 +37,8 @@ public class FreeBsdOperatingSystemFFM extends FreeBsdOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(FreeBsdOperatingSystemFFM.class);
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        String family = BsdSysctlUtilFFM.sysctl("kern.ostype", "FreeBSD");
-
-        String version = BsdSysctlUtilFFM.sysctl("kern.osrelease", "");
-        String versionInfo = BsdSysctlUtilFFM.sysctl("kern.version", "");
-        String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
-
-        return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
+    protected String querySysctl(String name, String def) {
+        return BsdSysctlUtilFFM.sysctl(name, def);
     }
 
     @Override
@@ -66,8 +57,8 @@ public class FreeBsdOperatingSystemFFM extends FreeBsdOperatingSystem {
     }
 
     @Override
-    public List<OSSession> getSessions() {
-        return USE_WHO_COMMAND ? super.getSessions() : WhoFFM.queryUtxent();
+    protected List<OSSession> queryWhoSessions() {
+        return WhoFFM.queryUtxent();
     }
 
     @Override
@@ -92,7 +83,7 @@ public class FreeBsdOperatingSystemFFM extends FreeBsdOperatingSystem {
     }
 
     @Override
-    protected long queryBootTime() {
+    protected long queryKernBoottimeSeconds() {
         try (Arena arena = Arena.ofConfined()) {
             // struct timeval: two longs (tv_sec, tv_usec) = 16 bytes on LP64 FreeBSD.
             MemorySegment tv = arena.allocate(JAVA_LONG.byteSize() * 2);
@@ -100,9 +91,6 @@ public class FreeBsdOperatingSystemFFM extends FreeBsdOperatingSystem {
                 return tv.get(JAVA_LONG, 0);
             }
         }
-        // Fall back to text parsing if sysctl fails or returns zero.
-        return ParseUtil.parseLongOrDefault(
-                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
-                System.currentTimeMillis() / 1000);
+        return 0L;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
@@ -4,11 +4,6 @@
  */
 package oshi.software.os.unix.openbsd;
 
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CTL_KERN;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_OSRELEASE;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_OSTYPE;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_VERSION;
-
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -23,7 +18,6 @@ import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.openbsd.OpenBsdOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.OSProcess;
-import oshi.util.tuples.Pair;
 
 /**
  * FFM-backed OpenBSD operating system.
@@ -34,18 +28,8 @@ public class OpenBsdOperatingSystemFFM extends OpenBsdOperatingSystem {
     private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOperatingSystemFFM.class);
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        int[] mibType = { CTL_KERN, KERN_OSTYPE };
-        String family = OpenBsdSysctlUtilFFM.sysctl(mibType, "OpenBSD");
-
-        int[] mibRelease = { CTL_KERN, KERN_OSRELEASE };
-        String version = OpenBsdSysctlUtilFFM.sysctl(mibRelease, "");
-
-        int[] mibVersion = { CTL_KERN, KERN_VERSION };
-        String versionInfo = OpenBsdSysctlUtilFFM.sysctl(mibVersion, "");
-        String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
-
-        return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
+    protected String querySysctl(int[] mib, String def) {
+        return OpenBsdSysctlUtilFFM.sysctl(mib, def);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystemJNA.java
@@ -25,7 +25,6 @@ import oshi.software.os.OSSession;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.platform.mac.SysctlUtil;
-import oshi.util.tuples.Pair;
 
 /**
  * macOS, previously Mac OS X and later OS X) is a series of proprietary graphical operating systems developed and
@@ -76,17 +75,13 @@ public class MacOperatingSystemJNA extends MacOperatingSystem {
     }
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        String family = this.major > 10 || (this.major == 10 && this.minor >= 12) ? "macOS"
-                : System.getProperty("os.name");
-        String codeName = parseCodeName();
-        String buildNumber = SysctlUtil.sysctl("kern.osversion", "");
-        return new Pair<>(family, new OSVersionInfo(this.osXVersion, codeName, buildNumber));
+    protected String querySysctl(String name, String def) {
+        return SysctlUtil.sysctl(name, def);
     }
 
     @Override
-    public List<OSSession> getSessions() {
-        return USE_WHO_COMMAND ? super.getSessions() : Who.queryUtxent();
+    protected List<OSSession> queryWhoSessions() {
+        return Who.queryUtxent();
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemJNA.java
@@ -21,10 +21,7 @@ import oshi.software.os.OSSession;
 import oshi.software.os.unix.freebsd.FreeBsdFileSystemJNA;
 import oshi.software.os.unix.freebsd.FreeBsdInternetProtocolStatsJNA;
 import oshi.software.os.unix.freebsd.FreeBsdNetworkParamsJNA;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
-import oshi.util.tuples.Pair;
 
 /**
  * JNA-backed DragonFly BSD operating system.
@@ -33,14 +30,8 @@ import oshi.util.tuples.Pair;
 public class DragonFlyBsdOperatingSystemJNA extends DragonFlyBsdOperatingSystem {
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        String family = BsdSysctlUtil.sysctl("kern.ostype", "DragonFly");
-
-        String version = BsdSysctlUtil.sysctl("kern.osrelease", "");
-        String versionInfo = BsdSysctlUtil.sysctl("kern.version", "");
-        String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
-
-        return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
+    protected String querySysctl(String name, String def) {
+        return BsdSysctlUtil.sysctl(name, def);
     }
 
     @Override
@@ -59,8 +50,8 @@ public class DragonFlyBsdOperatingSystemJNA extends DragonFlyBsdOperatingSystem 
     }
 
     @Override
-    public List<OSSession> getSessions() {
-        return USE_WHO_COMMAND ? super.getSessions() : Who.queryUtxent();
+    protected List<OSSession> queryWhoSessions() {
+        return Who.queryUtxent();
     }
 
     @Override
@@ -80,13 +71,10 @@ public class DragonFlyBsdOperatingSystemJNA extends DragonFlyBsdOperatingSystem 
     }
 
     @Override
-    protected long queryBootTime() {
+    protected long queryKernBoottimeSeconds() {
         FreeBsdLibc.Timeval tv = new FreeBsdLibc.Timeval();
         if (!BsdSysctlUtil.sysctl("kern.boottime", tv) || tv.tv_sec == 0) {
-            // Fall back to text parsing: "{ sec = 1779823319, nsec = 0 } ..."
-            return ParseUtil.parseLongOrDefault(
-                    ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
-                    System.currentTimeMillis() / 1000);
+            return 0L;
         }
         return tv.tv_sec;
     }

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemJNA.java
@@ -20,10 +20,7 @@ import oshi.software.os.InternetProtocolStats;
 import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSSession;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
 import oshi.util.platform.unix.freebsd.BsdSysctlUtil;
-import oshi.util.tuples.Pair;
 
 /**
  * JNA-backed FreeBSD operating system.
@@ -32,14 +29,8 @@ import oshi.util.tuples.Pair;
 public class FreeBsdOperatingSystemJNA extends FreeBsdOperatingSystem {
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        String family = BsdSysctlUtil.sysctl("kern.ostype", "FreeBSD");
-
-        String version = BsdSysctlUtil.sysctl("kern.osrelease", "");
-        String versionInfo = BsdSysctlUtil.sysctl("kern.version", "");
-        String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
-
-        return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
+    protected String querySysctl(String name, String def) {
+        return BsdSysctlUtil.sysctl(name, def);
     }
 
     @Override
@@ -58,8 +49,8 @@ public class FreeBsdOperatingSystemJNA extends FreeBsdOperatingSystem {
     }
 
     @Override
-    public List<OSSession> getSessions() {
-        return USE_WHO_COMMAND ? super.getSessions() : Who.queryUtxent();
+    protected List<OSSession> queryWhoSessions() {
+        return Who.queryUtxent();
     }
 
     @Override
@@ -82,14 +73,10 @@ public class FreeBsdOperatingSystemJNA extends FreeBsdOperatingSystem {
     }
 
     @Override
-    protected long queryBootTime() {
+    protected long queryKernBoottimeSeconds() {
         Timeval tv = new Timeval();
         if (!BsdSysctlUtil.sysctl("kern.boottime", tv) || tv.tv_sec == 0) {
-            // Usually this works. If it doesn't, fall back to text parsing.
-            // Boot time will be the first consecutive string of digits.
-            return ParseUtil.parseLongOrDefault(
-                    ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
-                    System.currentTimeMillis() / 1000);
+            return 0L;
         }
         // tv now points to a 128-bit timeval structure for boot time.
         // First 8 bytes are seconds, second 8 bytes are microseconds (we ignore)

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemJNA.java
@@ -4,11 +4,6 @@
  */
 package oshi.software.os.unix.openbsd;
 
-import static oshi.jna.platform.unix.OpenBsdLibc.CTL_KERN;
-import static oshi.jna.platform.unix.OpenBsdLibc.KERN_OSRELEASE;
-import static oshi.jna.platform.unix.OpenBsdLibc.KERN_OSTYPE;
-import static oshi.jna.platform.unix.OpenBsdLibc.KERN_VERSION;
-
 import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -18,7 +13,6 @@ import oshi.software.common.os.unix.openbsd.OpenBsdOperatingSystem;
 import oshi.software.os.FileSystem;
 import oshi.software.os.OSProcess;
 import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
-import oshi.util.tuples.Pair;
 
 /**
  * JNA-backed OpenBSD operating system.
@@ -27,18 +21,8 @@ import oshi.util.tuples.Pair;
 public class OpenBsdOperatingSystemJNA extends OpenBsdOperatingSystem {
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        int[] mib = new int[2];
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_OSTYPE;
-        String family = OpenBsdSysctlUtil.sysctl(mib, "OpenBSD");
-        mib[1] = KERN_OSRELEASE;
-        String version = OpenBsdSysctlUtil.sysctl(mib, "");
-        mib[1] = KERN_VERSION;
-        String versionInfo = OpenBsdSysctlUtil.sysctl(mib, "");
-        String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
-
-        return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
+    protected String querySysctl(int[] mib, String def) {
+        return OpenBsdSysctlUtil.sysctl(mib, def);
     }
 
     @Override


### PR DESCRIPTION
Part of the cross-OS consistency/dedup audit (OperatingSystem subsystem, follow-on to the AIX base extraction #3469). The FreeBSD, DragonFly, OpenBSD, and Mac `OperatingSystem` JNA/FFM twins duplicated three methods whose logic is identical and differs only in the native backend.

## What's hoisted

- **`queryFamilyVersionInfo`** — the `kern.ostype`/`kern.osrelease`/`kern.version` (Mac: `kern.osversion`) sysctl reads plus the shared buildNumber parse.
- **`getSessions`** — the `USE_WHO_COMMAND ? super : who.getutxent()` selection.
- **boot time** — the `kern.boottime` sysctl read plus the `sysctl -n kern.boottime` command fallback (FreeBSD/DragonFly).

These move into the per-platform bases behind small native hooks — `querySysctl`, `queryWhoSessions`, `queryKernBoottimeSeconds` — and each twin now provides only those hook implementations plus the irreducible `FileSystem`/`NetworkParams`/`InternetProtocolStats`/`OSProcess` factories and `getpid`/`getThreadId`.

The shared version-info parse (`buildFamilyVersionInfo`) and boot-time command fallback (`queryBootTimeFromCommand`) live as **static helpers** on `BsdOperatingSystem` — no new abstract methods — so the command-line NetBSD implementation is untouched. OpenBSD's mib-based sysctl is handled by a `querySysctl(int[], String)` hook with the MIB identifiers defined on the OpenBSD base.

## Left as-is (deliberate)

The Solaris (`HAS_KSTAT2` kstat2 probing), Linux (`HAS_UDEV`/`HAS_GETTID` auxv/udev/gettid detection), and Windows (registry perf-counter suppliers) twins diverge in genuine native capability detection, not shareable logic — the same hard axis as the COM/PDH and Mac struct-reading cases.

No CHANGELOG entry: behavior is identical.

Local gate: spotless, checkstyle, forbiddenapis, javadoc, and a clean full-reactor build all pass; oshi-common and oshi-core tests pass. Mac runtime is validated locally — `NativeComparisonTest.operatingSystemInfo()` and `sessions()` (JNA==FFM) pass on Apple Silicon. FreeBSD and OpenBSD run on the pull-request CI; DragonFly is validated via a manual `unix.yaml` dispatch (it isn't part of the PR workflow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved operating system version and build identification across macOS, FreeBSD, DragonFly BSD, and OpenBSD.
  * Added more reliable session discovery using native system data where available.
  * Improved boot-time detection with fallback handling when native values are unavailable.

* **Bug Fixes**
  * Corrected static analysis suppression coverage for macOS operating-system code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->