### PR TITLE
Fix macOS JNA-backend divergences from the FFM backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#3443](https://github.com/oshi/oshi/pull/3443): Share memoized iostat supplier across disk instances; cache pluggable hardware lists (displays, USB, sound cards, graphics cards) in the HAL with a 3-second TTL - [@dbwiddis](https://github.com/dbwiddis).
 * [#3444](https://github.com/oshi/oshi/pull/3444): Consolidate try/catch-log-return-default patterns to use `ExceptionUtil` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3459](https://github.com/oshi/oshi/pull/3459): Deduplicate the Windows `CentralProcessor` frequency queries into the shared base, and fix the JNA per-processor current-frequency numbering, which mis-assigned frequencies to logical processors on multi-processor-group/NUMA systems - [@dbwiddis](https://github.com/dbwiddis).
+* [#3473](https://github.com/oshi/oshi/pull/3473): Fix several macOS bugs in the default JNA backend to match the FFM backend: correct Intel Mac sensor temperatures that were under-reported by the SP78 fractional byte, decode process working directories and login sessions as UTF-8, and add missing null/bounds guards on native results - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08)
 

--- a/oshi-core/src/main/java/oshi/driver/mac/Who.java
+++ b/oshi-core/src/main/java/oshi/driver/mac/Who.java
@@ -43,9 +43,9 @@ public final class Who {
         try { // Iterate
             while ((ut = SYS.getutxent()) != null) {
                 if (ut.ut_type == USER_PROCESS || ut.ut_type == LOGIN_PROCESS) {
-                    String user = Native.toString(ut.ut_user, StandardCharsets.US_ASCII);
-                    String device = Native.toString(ut.ut_line, StandardCharsets.US_ASCII);
-                    String host = Native.toString(ut.ut_host, StandardCharsets.US_ASCII);
+                    String user = Native.toString(ut.ut_user, StandardCharsets.UTF_8);
+                    String device = Native.toString(ut.ut_line, StandardCharsets.UTF_8);
+                    String host = Native.toString(ut.ut_host, StandardCharsets.UTF_8);
                     long loginTime = ut.ut_tv.tv_sec.longValue() * 1000L + ut.ut_tv.tv_usec / 1000L;
                     // Sanity check. If errors, default to who command line
                     if (!isSessionValid(user, device, loginTime)) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
@@ -114,7 +114,9 @@ final class MacDisplayJNA extends AbstractDisplay {
                                 // EDID is a byte array of 128 bytes (or more)
                                 int length = edid.getLength();
                                 Pointer p = edid.getBytePtr();
-                                displays.add(new MacDisplayJNA(p.getByteArray(0, length)));
+                                if (length > 0) {
+                                    displays.add(new MacDisplayJNA(p.getByteArray(0, length)));
+                                }
                             } finally {
                                 edid.release();
                             }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
@@ -5,7 +5,6 @@
 package oshi.hardware.platform.mac;
 
 import java.util.Locale;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -56,7 +55,8 @@ final class MacGpuStatsJNA implements GpuStats {
     private static final Pattern TRADEMARK_PATTERN = Pattern.compile("[®™]|\\([Rr]\\)|\\([Tt][Mm]\\)");
 
     private final boolean isAppleSilicon;
-    private final String cardName;
+    private final String normCardName;
+    private final Pattern cardNamePattern;
 
     // Non-null only on Apple Silicon
     private final IOReportClient ioReportClient;
@@ -65,7 +65,8 @@ final class MacGpuStatsJNA implements GpuStats {
 
     MacGpuStatsJNA(boolean isAppleSilicon, String cardName) {
         this.isAppleSilicon = isAppleSilicon;
-        this.cardName = cardName;
+        this.normCardName = TRADEMARK_PATTERN.matcher(cardName.toLowerCase(Locale.ROOT)).replaceAll("").trim();
+        this.cardNamePattern = Pattern.compile("\\b" + Pattern.quote(normCardName) + "\\b");
         this.ioReportClient = isAppleSilicon ? IOReportClient.create() : null;
         if (isAppleSilicon && ioReportClient == null) {
             LOG.warn("IOReport subscription failed for '{}'; GPU ticks and power will be unavailable."
@@ -281,11 +282,9 @@ final class MacGpuStatsJNA implements GpuStats {
             return false;
         }
         String normModel = TRADEMARK_PATTERN.matcher(model.toLowerCase(Locale.ROOT)).replaceAll("").trim();
-        String normName = TRADEMARK_PATTERN.matcher(cardName.toLowerCase(Locale.ROOT)).replaceAll("").trim();
-        if (normModel.equals(normName)) {
+        if (normModel.equals(normCardName)) {
             return true;
         }
-        Matcher m = Pattern.compile("\\b" + Pattern.quote(normName) + "\\b").matcher(normModel);
-        return m.find();
+        return cardNamePattern.matcher(normModel).find();
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
@@ -91,6 +91,7 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
             IOIterator driveListIter = IOKitUtil.getMatchingServices(matchingDict);
             if (driveListIter != null) {
                 // getMatchingServices releases matchingDict
+                boolean updated = false;
                 IORegistryEntry drive = driveListIter.next();
                 // Should only match one drive
                 if (drive != null) {
@@ -220,13 +221,14 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
                         if (parent != null) {
                             parent.release();
                         }
+                        updated = true;
                     } else {
                         LOG.error("Unable to find IOMedia device or parent for {}", bsdName);
                     }
                     drive.release();
                 }
                 driveListIter.release();
-                return true;
+                return updated;
             }
         }
         return false;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacNetworkIfJNA.java
@@ -44,7 +44,9 @@ public final class MacNetworkIfJNA extends MacNetworkIF {
                     if (cfName != null && name.equals(cfName.stringValue())) {
                         CFStringRef cfDisplayName = SystemConfiguration.INSTANCE
                                 .SCNetworkInterfaceGetLocalizedDisplayName(scNetIf);
-                        return cfDisplayName.stringValue();
+                        if (cfDisplayName != null) {
+                            return cfDisplayName.stringValue();
+                        }
                     }
                 }
             } finally {

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacPowerSourceJNA.java
@@ -6,6 +6,7 @@ package oshi.hardware.platform.mac;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.sun.jna.Pointer;
@@ -58,6 +59,12 @@ public final class MacPowerSourceJNA extends MacPowerSource {
         // Get the blob containing current power source state
         CFTypeRef powerSourcesInfo = IO.IOPSCopyPowerSourcesInfo();
         CFArrayRef powerSourcesList = IO.IOPSCopyPowerSourcesList(powerSourcesInfo);
+        if (powerSourcesList == null) {
+            if (powerSourcesInfo != null) {
+                powerSourcesInfo.release();
+            }
+            return Collections.emptyList();
+        }
         int powerSourcesCount = powerSourcesList.getCount();
 
         // Get time remaining

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
@@ -126,9 +126,11 @@ public class MacFileSystemJNA extends MacFileSystem {
                         if (disk != null) {
                             CFDictionaryRef diskInfo = DiskArbitration.INSTANCE.DADiskCopyDescription(disk);
                             if (diskInfo != null) {
-                                // get volume name from its key
+                                // get volume name from its key; keep the mount-derived name if absent
                                 Pointer result = diskInfo.getValue(daVolumeNameKey);
-                                name = CFUtil.cfPointerToString(result);
+                                if (result != null) {
+                                    name = CFUtil.cfPointerToString(result);
+                                }
                                 diskInfo.release();
                             }
                             disk.release();

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParamsJNA.java
@@ -54,7 +54,7 @@ final class MacNetworkParamsJNA extends MacNetworkParams {
                 return "";
             }
             try (Addrinfo info = new Addrinfo(ptr.getValue())) { // NOSONAR
-                String canonname = info.ai_canonname.trim();
+                String canonname = info.ai_canonname == null ? "" : info.ai_canonname.trim();
                 SYS.freeaddrinfo(ptr.getValue());
                 return canonname;
             }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
@@ -259,7 +259,7 @@ public class MacOSProcessJNA extends MacOSProcess {
         }
         try (CloseableVnodePathInfo vpi = new CloseableVnodePathInfo()) {
             if (0 < SystemB.INSTANCE.proc_pidinfo(getProcessID(), PROC_PIDVNODEPATHINFO, 0, vpi, vpi.size())) {
-                this.currentWorkingDirectory = Native.toString(vpi.pvi_cdir.vip_path, StandardCharsets.US_ASCII);
+                this.currentWorkingDirectory = Native.toString(vpi.pvi_cdir.vip_path, StandardCharsets.UTF_8);
             }
         }
         return true;

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -129,9 +129,9 @@ public final class SmcUtil {
             int result = smcReadKey(conn, key, val);
             if (result == 0 && val.dataSize > 0) {
                 if (Arrays.equals(val.dataType, DATATYPE_SP78) && val.dataSize == 2) {
-                    // First bit is sign, next 7 bits are integer portion, last 8 bits are
-                    // fractional portion
-                    return val.bytes[0] + val.bytes[1] / 256d;
+                    // First bit is sign, next 7 bits are integer portion, last 8 bits are the
+                    // (unsigned) fractional portion
+                    return val.bytes[0] + (val.bytes[1] & 0xFF) / 256d;
                 } else if (Arrays.equals(val.dataType, DATATYPE_FPE2) && val.dataSize == 2) {
                     // First E (14) bits are integer portion last 2 bits are fractional portion
                     return ParseUtil.byteArrayToFloat(val.bytes, val.dataSize, 2);


### PR DESCRIPTION
The default JNA backend had several macOS bugs where it behaved differently from (and less correctly than) the opt-in FFM backend. Found by an audit of every JNA/FFM twin pair; each fix aligns JNA to the existing FFM behavior. Validated live via `NativeComparisonTest -Pnative-comparison` (JNA==FFM) on Apple Silicon.

**Behavior fixes**
- **`SmcUtil` SP78** — read the fractional byte unsigned (`& 0xFF`); Intel Mac sensor temperatures were under-reported (and could go negative) whenever the fractional part was ≥ 0.5 °C.
- **`MacOSProcessJNA`** — decode the process working directory as UTF-8 instead of US-ASCII.
- **`Who`** — decode utmpx login-session user/line/host fields as UTF-8.
- **`MacHWDiskStoreJNA`** — return `false` from `updateDiskStats` when no matching IOMedia device is found (was reporting false success).
- **`MacFileSystemJNA`** — keep the mount-derived volume name when `DAVolumeName` is absent (was clobbering it to null).

**Null/bounds guards** (each would `NPE`/misbehave on an edge native result; FFM already guarded them)
- `MacNetworkIfJNA` null localized display name → fall back to the BSD interface name.
- `MacNetworkParamsJNA` null `ai_canonname` → empty domain name.
- `MacDisplayJNA` zero-length EDID → skip (was producing a bogus extra `Display`).
- `MacPowerSourceJNA` null power-source list → empty list.

Plus a non-behavioral tidy: `MacGpuStatsJNA` pre-computes the normalized card name in its constructor, mirroring the FFM twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS sensor temperature readings.
  - Corrected UTF-8 handling for process paths and login session details.
  - Added safeguards for missing or invalid hardware, network, power, filesystem, and display data.
  - Improved GPU identification and disk status reporting.
  - Prevented failures when macOS provides incomplete native system information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->