### PR TITLE
Fix Windows JNA-backend divergences from the FFM backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#3444](https://github.com/oshi/oshi/pull/3444): Consolidate try/catch-log-return-default patterns to use `ExceptionUtil` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3459](https://github.com/oshi/oshi/pull/3459): Deduplicate the Windows `CentralProcessor` frequency queries into the shared base, and fix the JNA per-processor current-frequency numbering, which mis-assigned frequencies to logical processors on multi-processor-group/NUMA systems - [@dbwiddis](https://github.com/dbwiddis).
 * [#3473](https://github.com/oshi/oshi/pull/3473): Fix several macOS bugs in the default JNA backend to match the FFM backend: correct Intel Mac sensor temperatures that were under-reported by the SP78 fractional byte, decode process working directories and login sessions as UTF-8, and add missing null/bounds guards on native results - [@dbwiddis](https://github.com/dbwiddis).
+* [#3478](https://github.com/oshi/oshi/pull/3478): Fix several Windows bugs in the default JNA backend to match the FFM backend: stop reporting a UPS/non-system battery as the system battery, restore the WMI fallback (and avoid an NPE) when a PDH wildcard collection fails, drop phantom file stores for volumes that can't be queried, keep enumerating sound cards past an incomplete registry key, retain sessions without a client address, and include processors in NUMA nodes spanning more than 64 logical processors - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08)
 

--- a/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
@@ -121,27 +121,36 @@ public final class LogicalProcessorInformation {
 
         List<LogicalProcessor> logProcs = new ArrayList<>();
         Map<Integer, Integer> corePkgMap = new HashMap<>();
-        Map<Integer, String> pkgCpuidMap = new HashMap<>();
+        Map<Integer, String> coreCpuidMap = new HashMap<>();
         for (NUMA_NODE_RELATIONSHIP node : numaNodes) {
             int nodeNum = node.nodeNumber;
-            int group = node.groupMask.group;
-            long mask = node.groupMask.mask.longValue();
-            // Processor numbers are uniquely identified by processor group and processor
-            // number on that group, which matches the bitmask.
-            int lowBit = Long.numberOfTrailingZeros(mask);
-            int hiBit = 63 - Long.numberOfLeadingZeros(mask);
-            for (int lp = lowBit; lp <= hiBit; lp++) {
-                if ((mask & (1L << lp)) != 0) {
-                    int coreId = getMatchingCore(cores, group, lp);
-                    int pkgId = getMatchingPackage(packages, group, lp);
-                    corePkgMap.put(coreId, pkgId);
-                    pkgCpuidMap.put(coreId, processorIdMap.getOrDefault(pkgId, ""));
-                    LogicalProcessor logProc = new LogicalProcessor(lp, coreId, pkgId, nodeNum, group);
-                    logProcs.add(logProc);
+            // A NUMA node spanning more than 64 logical processors reports one GROUP_AFFINITY per group in
+            // groupMasks (with groupCount > 1); single-group nodes use the groupMask union member. Bound the
+            // iteration to groupCount because JNA may over-allocate groupMasks with padding entries, and fall back
+            // to the single groupMask when groupMasks is unpopulated. Matches LogicalProcessorInformationFFM.
+            boolean multiGroup = node.groupCount > 1 && node.groupMasks != null && node.groupMasks.length > 0;
+            int nodeGroupCount = multiGroup ? Math.min(node.groupCount, node.groupMasks.length) : 1;
+            for (int g = 0; g < nodeGroupCount; g++) {
+                GROUP_AFFINITY groupAffinity = multiGroup ? node.groupMasks[g] : node.groupMask;
+                int group = groupAffinity.group;
+                long mask = groupAffinity.mask.longValue();
+                // Processor numbers are uniquely identified by processor group and processor
+                // number on that group, which matches the bitmask.
+                int lowBit = Long.numberOfTrailingZeros(mask);
+                int hiBit = 63 - Long.numberOfLeadingZeros(mask);
+                for (int lp = lowBit; lp <= hiBit; lp++) {
+                    if ((mask & (1L << lp)) != 0) {
+                        int coreId = getMatchingCore(cores, group, lp);
+                        int pkgId = getMatchingPackage(packages, group, lp);
+                        corePkgMap.put(coreId, pkgId);
+                        coreCpuidMap.put(coreId, processorIdMap.getOrDefault(pkgId, ""));
+                        LogicalProcessor logProc = new LogicalProcessor(lp, coreId, pkgId, nodeNum, group);
+                        logProcs.add(logProc);
+                    }
                 }
             }
         }
-        List<PhysicalProcessor> physProcs = getPhysProcs(cores, coreEfficiencyMap, corePkgMap, pkgCpuidMap);
+        List<PhysicalProcessor> physProcs = getPhysProcs(cores, coreEfficiencyMap, corePkgMap, coreCpuidMap);
         return new Triplet<>(logProcs, physProcs, orderedProcCaches(caches));
     }
 

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilJNA.java
@@ -173,6 +173,13 @@ public final class HkeyPerformanceDataUtilJNA extends HkeyPerformanceDataUtil {
                 ret = Advapi32.INSTANCE.RegQueryValueEx(WinReg.HKEY_PERFORMANCE_DATA, objectIndexStr, 0, null,
                         pPerfData, lpcbData);
             }
+            // The buffer-grow retry can exit on a hard error rather than ERROR_SUCCESS; return null instead of an
+            // unvalidated buffer. Matches HkeyPerformanceDataUtilFFM.
+            if (ret != WinError.ERROR_SUCCESS) {
+                LOG.error("Error reading performance data from registry for {}.", objectName);
+                pPerfData.close();
+                return null;
+            }
             return pPerfData;
         }
     }

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/SessionWtsData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/SessionWtsData.java
@@ -102,13 +102,17 @@ public final class SessionWtsData {
                                         } finally {
                                             WTS.WTSFreeMemory(pBuffer);
                                         }
-                                        // HOST
+                                        // HOST. A session that can't report a client address (some service/console
+                                        // sessions) is still valid; record it with a "::" host rather than dropping
+                                        // it. Matches SessionWtsDataFFM.
                                         if (!WTS.WTSQuerySessionInformation(Wtsapi32.WTS_CURRENT_SERVER_HANDLE,
                                                 session.SessionId, WTS_CLIENTADDRESS, ppBuffer, pBytes)) {
+                                            sessions.add(new OSSession(userName, device, logonTime, "::"));
                                             continue;
                                         }
                                         pBuffer = ppBuffer.getValue();
                                         if (pBuffer == null) {
+                                            sessions.add(new OSSession(userName, device, logonTime, "::"));
                                             continue;
                                         }
                                         WTS_CLIENT_ADDRESS addr;

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
@@ -153,58 +153,59 @@ public final class WindowsPowerSourceJNA extends WindowsPowerSource {
                                                         if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
                                                                 IOCTL_BATTERY_QUERY_INFORMATION, bqi.getPointer(),
                                                                 bqi.size(), bi.getPointer(), bi.size(), dwOut, null)) {
-                                                            // Only non-UPS system batteries count
+                                                            // Only non-UPS system batteries count; skip UPS and
+                                                            // short-term batteries entirely so they don't terminate
+                                                            // the search with placeholder data.
                                                             bi.read();
+                                                            if (0 == (bi.Capabilities & BATTERY_SYSTEM_BATTERY)
+                                                                    || 0 != (bi.Capabilities & BATTERY_IS_SHORT_TERM)) {
+                                                                continue;
+                                                            }
                                                             int maxCapacitySafe = 1;
-                                                            if (0 != (bi.Capabilities & BATTERY_SYSTEM_BATTERY)
-                                                                    && 0 == (bi.Capabilities & BATTERY_IS_SHORT_TERM)) {
-                                                                // Capabilities flags non-mWh units
-                                                                if (0 == (bi.Capabilities
-                                                                        & BATTERY_CAPACITY_RELATIVE)) {
-                                                                    psCapacityUnits = CapacityUnits.MWH;
-                                                                }
-                                                                psChemistry = Native.toString(bi.Chemistry,
-                                                                        StandardCharsets.US_ASCII);
-                                                                psDesignCapacity = bi.DesignedCapacity;
-                                                                psMaxCapacity = bi.FullChargedCapacity;
-                                                                psCycleCount = bi.CycleCount;
-                                                                if (psMaxCapacity > 0) {
-                                                                    maxCapacitySafe = psMaxCapacity;
-                                                                } else if (psDesignCapacity > 0) {
-                                                                    maxCapacitySafe = psDesignCapacity;
-                                                                } else {
-                                                                    maxCapacitySafe = 1;
-                                                                }
+                                                            // Capabilities flags non-mWh units
+                                                            if (0 == (bi.Capabilities & BATTERY_CAPACITY_RELATIVE)) {
+                                                                psCapacityUnits = CapacityUnits.MWH;
+                                                            }
+                                                            psChemistry = Native.toString(bi.Chemistry,
+                                                                    StandardCharsets.US_ASCII);
+                                                            psDesignCapacity = bi.DesignedCapacity;
+                                                            psMaxCapacity = bi.FullChargedCapacity;
+                                                            psCycleCount = bi.CycleCount;
+                                                            if (psMaxCapacity > 0) {
+                                                                maxCapacitySafe = psMaxCapacity;
+                                                            } else if (psDesignCapacity > 0) {
+                                                                maxCapacitySafe = psDesignCapacity;
+                                                            } else {
+                                                                maxCapacitySafe = 1;
+                                                            }
 
-                                                                // Query the battery status.
-                                                                bws.BatteryTag = bqi.BatteryTag;
-                                                                bws.write();
-                                                                if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
-                                                                        IOCTL_BATTERY_QUERY_STATUS, bws.getPointer(),
-                                                                        bws.size(), bs.getPointer(), bs.size(), dwOut,
-                                                                        null)) {
-                                                                    bs.read();
-                                                                    if (0 != (bs.PowerState & BATTERY_POWER_ON_LINE)) {
-                                                                        psPowerOnLine = true;
-                                                                    }
-                                                                    if (0 != (bs.PowerState & BATTERY_DISCHARGING)) {
-                                                                        psDischarging = true;
-                                                                    }
-                                                                    if (0 != (bs.PowerState & BATTERY_CHARGING)) {
-                                                                        psCharging = true;
-                                                                        psTimeRemainingEstimated = -2d;
-                                                                    }
-                                                                    psCurrentCapacity = bs.Capacity;
-                                                                    psVoltage = bs.Voltage > 0 ? bs.Voltage / 1000d
-                                                                            : bs.Voltage;
-                                                                    psPowerUsageRate = bs.Rate;
-                                                                    if (psVoltage > 0) {
-                                                                        psAmperage = psPowerUsageRate / psVoltage;
-                                                                    }
-                                                                    psRemainingCapacityPercent = Math.min(1d,
-                                                                            (double) psCurrentCapacity
-                                                                                    / maxCapacitySafe);
+                                                            // Query the battery status.
+                                                            bws.BatteryTag = bqi.BatteryTag;
+                                                            bws.write();
+                                                            if (Kernel32.INSTANCE.DeviceIoControl(hBattery,
+                                                                    IOCTL_BATTERY_QUERY_STATUS, bws.getPointer(),
+                                                                    bws.size(), bs.getPointer(), bs.size(), dwOut,
+                                                                    null)) {
+                                                                bs.read();
+                                                                if (0 != (bs.PowerState & BATTERY_POWER_ON_LINE)) {
+                                                                    psPowerOnLine = true;
                                                                 }
+                                                                if (0 != (bs.PowerState & BATTERY_DISCHARGING)) {
+                                                                    psDischarging = true;
+                                                                }
+                                                                if (0 != (bs.PowerState & BATTERY_CHARGING)) {
+                                                                    psCharging = true;
+                                                                    psTimeRemainingEstimated = -2d;
+                                                                }
+                                                                psCurrentCapacity = bs.Capacity;
+                                                                psVoltage = bs.Voltage > 0 ? bs.Voltage / 1000d
+                                                                        : bs.Voltage;
+                                                                psPowerUsageRate = bs.Rate;
+                                                                if (psVoltage > 0) {
+                                                                    psAmperage = psPowerUsageRate / psVoltage;
+                                                                }
+                                                                psRemainingCapacityPercent = Math.min(1d,
+                                                                        (double) psCurrentCapacity / maxCapacitySafe);
                                                             }
 
                                                             try (Memory nameBuf = new Memory(1024)) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSoundCardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSoundCardJNA.java
@@ -51,15 +51,13 @@ final class WindowsSoundCardJNA extends AbstractSoundCard {
             String fullKey = REGISTRY_SOUNDCARDS + key;
             try {
                 if (Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, fullKey, "Driver")) {
+                    // Read each sub-value defensively; a driver key missing DriverVersion/ProviderName/DriverDesc
+                    // must not throw ERROR_FILE_NOT_FOUND and abort the whole enumeration. Matches
+                    // WindowsSoundCardFFM.
                     soundCards.add(new WindowsSoundCardJNA(
-                            Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, "Driver") + " "
-                                    + Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey,
-                                            "DriverVersion"),
-                            Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, "ProviderName")
-                                    + " "
-                                    + Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey,
-                                            "DriverDesc"),
-                            Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, fullKey, "DriverDesc")));
+                            getRegString(fullKey, "Driver") + " " + getRegString(fullKey, "DriverVersion"),
+                            getRegString(fullKey, "ProviderName") + " " + getRegString(fullKey, "DriverDesc"),
+                            getRegString(fullKey, "DriverDesc")));
                 }
             } catch (Win32Exception e) {
                 if (e.getErrorCode() != WinError.ERROR_ACCESS_DENIED) {
@@ -69,5 +67,13 @@ final class WindowsSoundCardJNA extends AbstractSoundCard {
             }
         }
         return soundCards;
+    }
+
+    private static String getRegString(String keyPath, String valueName) {
+        if (!Advapi32Util.registryValueExists(WinReg.HKEY_LOCAL_MACHINE, keyPath, valueName)) {
+            return "";
+        }
+        Object val = Advapi32Util.registryGetValue(WinReg.HKEY_LOCAL_MACHINE, keyPath, valueName);
+        return val instanceof String ? (String) val : "";
     }
 }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
@@ -161,9 +161,15 @@ public class WindowsFileSystemJNA extends WindowsFileSystem {
                 systemFreeBytes = new WinNT.LARGE_INTEGER(0L);
 
                 volume = Native.toString(aVolume);
-                Kernel32.INSTANCE.GetVolumeInformation(volume, name, BUFSIZE, null, null, pFlags, fstype, 16);
+                // Skip the volume entirely if a native query fails, rather than emitting a phantom file store with a
+                // blank name and zero size. Matches WindowsFileSystemFFM.
+                if (!Kernel32.INSTANCE.GetVolumeInformation(volume, name, BUFSIZE, null, null, pFlags, fstype, 16)) {
+                    continue;
+                }
                 final int flags = pFlags.getValue();
-                Kernel32.INSTANCE.GetVolumePathNamesForVolumeName(volume, mount, BUFSIZE, null);
+                if (!Kernel32.INSTANCE.GetVolumePathNamesForVolumeName(volume, mount, BUFSIZE, null)) {
+                    continue;
+                }
 
                 strMount = Native.toString(mount);
                 if (!strMount.isEmpty() && (volumeToMatch == null || volumeToMatch.equals(volume))) {
@@ -176,7 +182,9 @@ public class WindowsFileSystemJNA extends WindowsFileSystem {
                     if (!moreOptions.isEmpty()) {
                         options.append(',').append(moreOptions);
                     }
-                    Kernel32.INSTANCE.GetDiskFreeSpaceEx(volume, userFreeBytes, totalBytes, systemFreeBytes);
+                    if (!Kernel32.INSTANCE.GetDiskFreeSpaceEx(volume, userFreeBytes, totalBytes, systemFreeBytes)) {
+                        continue;
+                    }
                     // Parse uuid from volume name
                     String uuid = ParseUtil.parseUuidOrDefault(volume, "");
 

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -189,6 +189,11 @@ public final class PerfCounterWildcardQuery {
                     }
                     valuesMap.put(prop, values);
                 }
+            } else {
+                // The PDH data collection failed. Return an empty pair (per this method's contract) so the caller
+                // falls back to WMI, rather than a populated instance list paired with an empty value map, which
+                // would NPE downstream consumers that index the value map by the returned instances.
+                return new Pair<>(Collections.emptyList(), Collections.emptyMap());
             }
         }
         return new Pair<>(instances, valuesMap);


### PR DESCRIPTION
The default JNA backend had several Windows bugs where it behaved differently from (and less correctly than) the opt-in FFM backend. Found by an audit of every Windows JNA/FFM twin pair; each fix aligns JNA to the existing FFM behavior. One commit per fix.

Windows runtime behavior is exercised only on CI (JDK 21/25/26 + the JNA/FFM comparison); these could not be validated locally on non-Windows hardware.

**Wrong-result / crash fixes**
- **`WindowsPowerSourceJNA`** — the `BATTERY_SYSTEM_BATTERY && !BATTERY_IS_SHORT_TERM` guard wrapped only the capacity/status block; device name, manufacture date, temperature, and `batteryFound = true` still ran for any battery. A non-system or short-term battery (e.g. a UPS) enumerated before the real system battery was returned with placeholder capacity and stopped the search. Skip such batteries with `continue`, matching the FFM backend.
- **`PerfCounterWildcardQuery`** — on a PDH collect failure the method returned a populated instance list paired with an empty value map, so the caller skipped the WMI fallback and downstream consumers keyed on the value map (e.g. `ProcessPerformanceData`) threw an NPE. Return an empty pair per the method's contract.
- **`WindowsFileSystemJNA`** — the results of `GetVolumeInformation`, `GetVolumePathNamesForVolumeName`, and `GetDiskFreeSpaceEx` were ignored, so a volume that could not be stat'd (e.g. an optical/removable drive with no media) was added as a phantom file store with a blank name and zero size. Skip the volume on any failed query.
- **`WindowsSoundCardJNA`** — a driver key missing `DriverVersion`/`ProviderName`/`DriverDesc` threw `ERROR_FILE_NOT_FOUND` (only `ERROR_ACCESS_DENIED` was swallowed), aborting the whole enumeration. Read each sub-value through a helper that returns an empty string when absent.

**Hardening (edge-path)**
- **`HkeyPerformanceDataUtilJNA`** — validate the result after the `ERROR_MORE_DATA` buffer-grow retry and return `null` on a hard error rather than an unvalidated buffer.
- **`SessionWtsData`** — a session whose client address can't be queried (some service/console sessions) is recorded with a `"::"` host instead of being dropped.
- **`LogicalProcessorInformation`** — iterate all group affinities of a NUMA node (`groupMasks` when `groupCount > 1`) so a node spanning more than 64 logical processors doesn't drop the processors beyond its first group on large multi-processor-group servers. Falls back to the single `groupMask` when `groupMasks` is unpopulated, so single-group systems are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows battery detection by skipping UPS and short-term battery devices.
  * Prevented invalid performance-data buffers by verifying success before returning results.
  * Improved Windows volume detection by skipping volumes when native queries fail, avoiding phantom file stores.
  * Fixed sound card enumeration to tolerate missing or non-string registry fields.
  * Improved session reporting by recording sessions with a placeholder host when client address lookup fails.
  * Corrected logical processor/NUMA reporting across multiple processor groups and ensured continued CPUID mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->