### PR TITLE
Fix SonarCloud test-binaries config and clear two code smells

### DIFF
--- a/oshi-common/src/test/java/oshi/driver/common/windows/registry/RegistryValueUtilTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/windows/registry/RegistryValueUtilTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.ZoneId;
 
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,8 @@ class RegistryValueUtilTest {
     @Test
     void testRegistryValueToLongDateString() {
         // yyyyMMdd is parsed at midnight in the system default zone
-        long expected = LocalDate.of(2020, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        long expected = LocalDate.of(2020, Month.JANUARY, 1).atStartOfDay(ZoneId.systemDefault()).toInstant()
+                .toEpochMilli();
         assertThat(RegistryValueUtil.registryValueToLong("20200101"), is(expected));
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
@@ -165,7 +165,7 @@ public final class AdlUtilFFM {
         try {
             // Allocate from the C heap (not a JVM Arena) so the pointer ADL later passes to free() is valid.
             return (MemorySegment) MALLOC.invokeExact((long) size);
-        } catch (Throwable t) {
+        } catch (Throwable _) {
             return MemorySegment.NULL;
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <!-- SonarCloud warned "Missing sonar.java.test.binaries" (less precise test-code analysis); declare each
+        module's compiled test classes explicitly. -->
+        <sonar.java.test.binaries>${project.build.testOutputDirectory}</sonar.java.test.binaries>
         <!-- native access enablement default -->
         <native.access.modules>ALL-UNNAMED</native.access.modules>
         <!-- internal, see https://issues.apache.org/jira/browse/MNG-7038 -->


### PR DESCRIPTION
Small pre-7.4.1 cleanup from a SonarCloud review. The analysis is otherwise clean — **0 bugs, 0 vulnerabilities, 0 reliability, 0 security issues**; the remaining code smells are pre-existing or covered by the accept-all cognitive-complexity policy.

### SonarCloud config
Declare `sonar.java.test.binaries` (each module's `target/test-classes`). SonarCloud was warning `Missing 'sonar.java.test.binaries' property. You might end up with less precise analysis results.` — the `sonar-maven-plugin` wasn't auto-detecting the compiled test classes (verified they compile: 221/60/23/8 classes). Resolves per-module via `${project.build.testOutputDirectory}`. *Validated on the next master SonarCloud run.*

### Two flagged code smells (introduced by the audit PRs)
- `AdlUtilFFM.adlMalloc` — `catch (Throwable t)` where `t` is unused → `catch (Throwable _)` (java:S7467), matching the unnamed-variable convention already used elsewhere.
- `RegistryValueUtilTest` — `LocalDate.of(2020, 1, 1)` → `LocalDate.of(2020, Month.JANUARY, 1)` (java:S8694).

No CHANGELOG entry — build config and code-smell cleanup with no user-observable change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Quality**
  * Improved SonarCloud analysis by explicitly identifying compiled test classes.
  * Updated date handling in automated test validation for clearer, more reliable expectations.

* **Bug Fixes**
  * Improved exception handling in graphics memory allocation without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->