### PR TITLE
Skip the benchmark module in SonarCloud analysis

### DIFF
--- a/oshi-benchmark/pom.xml
+++ b/oshi-benchmark/pom.xml
@@ -22,6 +22,10 @@
         <native.access.modules>ALL-UNNAMED</native.access.modules>
         <shade.phase>none</shade.phase>
         <uberjar.name>benchmarks</uberjar.name>
+        <!-- Exclude this benchmark/comparison module from SonarCloud: it is not published, and its comparison tests
+        only compile under the native-comparison profile, so the default Sonar build has no test binaries for it (the
+        source of a "sonar.java.test.binaries" warning). -->
+        <sonar.skip>true</sonar.skip>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Follow-up to #3485. That PR declared `sonar.java.test.binaries` per module, which fixed the "Missing sonar.java.test.binaries" warning for the production modules (oshi-common/oshi-core/oshi-core-ffm) — but the post-merge master SonarCloud run showed the warning's real source was **oshi-benchmark**: it has comparison-test sources (`NativeComparisonTest`, etc.) but `maven.test.skip=true` by default (they only compile under `-Pnative-comparison`), so the default Sonar build has no test binaries for it, and my explicit path turned "Missing" into `Invalid value for 'sonar.java.test.binaries' … oshi-benchmark/target/test-classes`.

`oshi-benchmark` is a non-published benchmark/comparison module and contributes zero of the current findings, so exclude it from SonarCloud with `sonar.skip=true`. Production modules remain analyzed (verified `sonar.skip` resolves true only for oshi-benchmark).

Analysis itself is otherwise clean: **0 bugs, 0 vulnerabilities, 0 reliability, 0 security** (validated on the next master run). No CHANGELOG — build config only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark project configuration to exclude it from SonarCloud analysis.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->