### PR TITLE
Make @ThreadSafe HAL snapshot fields volatile/final for safe publication

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -41,16 +41,16 @@ public abstract class AbstractNetworkIF implements NetworkIF {
 
     private static final String OSHI_VM_MAC_ADDR_PROPERTIES = "oshi.vmmacaddr.properties";
 
-    private volatile NetworkInterface networkInterface;
-    private volatile String name;
-    private volatile String displayName;
-    private volatile int index;
-    private volatile long mtu;
-    private volatile String mac;
-    private volatile String[] ipv4;
-    private volatile Short[] subnetMasks;
-    private volatile String[] ipv6;
-    private volatile Short[] prefixLengths;
+    private final NetworkInterface networkInterface;
+    private final String name;
+    private final String displayName;
+    private final int index;
+    private final long mtu;
+    private final String mac;
+    private final String[] ipv4;
+    private final Short[] subnetMasks;
+    private final String[] ipv6;
+    private final Short[] prefixLengths;
 
     // Refreshed by each platform's updateNetworkStats(); protected so subclasses assign directly (see the
     // VisibilityModifier suppression for this file), matching the AbstractOSProcess model.

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -41,29 +41,29 @@ public abstract class AbstractNetworkIF implements NetworkIF {
 
     private static final String OSHI_VM_MAC_ADDR_PROPERTIES = "oshi.vmmacaddr.properties";
 
-    private NetworkInterface networkInterface;
-    private String name;
-    private String displayName;
-    private int index;
-    private long mtu;
-    private String mac;
-    private String[] ipv4;
-    private Short[] subnetMasks;
-    private String[] ipv6;
-    private Short[] prefixLengths;
+    private volatile NetworkInterface networkInterface;
+    private volatile String name;
+    private volatile String displayName;
+    private volatile int index;
+    private volatile long mtu;
+    private volatile String mac;
+    private volatile String[] ipv4;
+    private volatile Short[] subnetMasks;
+    private volatile String[] ipv6;
+    private volatile Short[] prefixLengths;
 
     // Refreshed by each platform's updateNetworkStats(); protected so subclasses assign directly (see the
     // VisibilityModifier suppression for this file), matching the AbstractOSProcess model.
-    protected long bytesRecv;
-    protected long bytesSent;
-    protected long packetsRecv;
-    protected long packetsSent;
-    protected long inErrors;
-    protected long outErrors;
-    protected long inDrops;
-    protected long collisions;
-    protected long speed;
-    protected long timeStamp;
+    protected volatile long bytesRecv;
+    protected volatile long bytesSent;
+    protected volatile long packetsRecv;
+    protected volatile long packetsSent;
+    protected volatile long inErrors;
+    protected volatile long outErrors;
+    protected volatile long inDrops;
+    protected volatile long collisions;
+    protected volatile long speed;
+    protected volatile long timeStamp;
 
     private final Supplier<Properties> vmMacAddrProps = memoize(AbstractNetworkIF::queryVmMacAddrProps);
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
@@ -20,10 +20,10 @@ import oshi.util.linux.SysPath;
 @ThreadSafe
 public abstract class LinuxNetworkIF extends AbstractNetworkIF {
 
-    private int ifType;
-    private boolean connectorPresent;
-    private String ifAlias = "";
-    private IfOperStatus ifOperStatus = IfOperStatus.UNKNOWN;
+    private volatile int ifType;
+    private volatile boolean connectorPresent;
+    private volatile String ifAlias = "";
+    private volatile IfOperStatus ifOperStatus = IfOperStatus.UNKNOWN;
 
     /**
      * Creates a LinuxNetworkIF.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
@@ -80,8 +80,8 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     private final Supplier<String> vendor = memoize(this::platformExpert);
     private final boolean isArmCpu = isArmCpu();
 
-    private long performanceCoreFrequency = DEFAULT_FREQUENCY;
-    private long efficiencyCoreFrequency = DEFAULT_FREQUENCY;
+    private volatile long performanceCoreFrequency = DEFAULT_FREQUENCY;
+    private volatile long efficiencyCoreFrequency = DEFAULT_FREQUENCY;
 
     /**
      * Returns the sysctl provider for this implementation.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacNetworkIF.java
@@ -18,7 +18,7 @@ import oshi.hardware.common.AbstractNetworkIF;
 @ThreadSafe
 public abstract class MacNetworkIF extends AbstractNetworkIF {
 
-    private int ifType;
+    private volatile int ifType;
 
     /**
      * Creates a MacNetworkIF.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -56,7 +56,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     // Previous sample for utility base multiplier calculation
     private final AtomicReference<Map<ProcessorUtilityTickCountProperty, List<Long>>> initialUtilityCounters = new AtomicReference<>();
     // Lazily initialized
-    private volatile Long utilityBaseMultiplier;
+    private Long utilityBaseMultiplier;
 
     // This tick query is memoized to enforce a minimum elapsed time for determining the capacity base multiplier
     private final Supplier<Pair<List<String>, Map<ProcessorUtilityTickCountProperty, List<Long>>>> processorUtilityCounters = USE_CPU_UTILITY
@@ -136,13 +136,15 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     protected void buildNumaNodeProcMap(List<LogicalProcessor> logProcs) {
         Map<Integer, Integer> nextProcIndexByNode = new HashMap<>();
         int lp = 0;
-        this.numaNodeProcToLogicalProcMap = new HashMap<>();
+        Map<String, Integer> map = new HashMap<>();
         for (LogicalProcessor logProc : logProcs) {
             int node = logProc.getNumaNode();
             int procNum = nextProcIndexByNode.getOrDefault(node, 0);
-            numaNodeProcToLogicalProcMap.put(String.format(Locale.ROOT, "%d,%d", node, procNum), lp++);
+            map.put(String.format(Locale.ROOT, "%d,%d", node, procNum), lp++);
             nextProcIndexByNode.put(node, procNum + 1);
         }
+        // Publish the fully-built map as the final step so readers never observe a partial map
+        this.numaNodeProcToLogicalProcMap = map;
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -40,7 +40,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     }
 
     // populated by initProcessorCounts called by the parent constructor
-    private Map<String, Integer> numaNodeProcToLogicalProcMap;
+    private volatile Map<String, Integer> numaNodeProcToLogicalProcMap;
 
     /** Whether to use legacy Processor counters rather than Processor Information counters. */
     protected static final boolean USE_LEGACY_SYSTEM_COUNTERS = GlobalConfig
@@ -56,7 +56,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     // Previous sample for utility base multiplier calculation
     private final AtomicReference<Map<ProcessorUtilityTickCountProperty, List<Long>>> initialUtilityCounters = new AtomicReference<>();
     // Lazily initialized
-    private Long utilityBaseMultiplier;
+    private volatile Long utilityBaseMultiplier;
 
     // This tick query is memoized to enforce a minimum elapsed time for determining the capacity base multiplier
     private final Supplier<Pair<List<String>, Map<ProcessorUtilityTickCountProperty, List<Long>>>> processorUtilityCounters = USE_CPU_UTILITY

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsNetworkIF.java
@@ -20,11 +20,11 @@ public abstract class WindowsNetworkIF extends AbstractNetworkIF {
     /** Bit in the interface flags indicating a connector is present. */
     protected static final byte CONNECTOR_PRESENT_BIT = 0b00000100;
 
-    private int ifType;
-    private int ndisPhysicalMediumType;
-    private boolean connectorPresent;
-    private String ifAlias = "";
-    private IfOperStatus ifOperStatus = IfOperStatus.UNKNOWN;
+    private volatile int ifType;
+    private volatile int ndisPhysicalMediumType;
+    private volatile boolean connectorPresent;
+    private volatile String ifAlias = "";
+    private volatile IfOperStatus ifOperStatus = IfOperStatus.UNKNOWN;
 
     /**
      * Creates a WindowsNetworkIF.

--- a/oshi-common/src/main/java/oshi/software/common/AbstractOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOSProcess.java
@@ -22,7 +22,7 @@ public abstract class AbstractOSProcess implements OSProcess {
 
     private final Supplier<Double> cumulativeCpuLoad = memoize(this::queryCumulativeCpuLoad, defaultExpiration());
 
-    private volatile int processID;
+    private final int processID;
 
     // Common attributes populated by each platform's updateAttributes(). Declared protected (rather than private with
     // setters) so the platform subclasses can assign them directly in their native refresh methods; see the

--- a/oshi-common/src/main/java/oshi/software/common/AbstractOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOSProcess.java
@@ -22,24 +22,24 @@ public abstract class AbstractOSProcess implements OSProcess {
 
     private final Supplier<Double> cumulativeCpuLoad = memoize(this::queryCumulativeCpuLoad, defaultExpiration());
 
-    private int processID;
+    private volatile int processID;
 
     // Common attributes populated by each platform's updateAttributes(). Declared protected (rather than private with
     // setters) so the platform subclasses can assign them directly in their native refresh methods; see the
     // VisibilityModifier suppression for this file.
-    protected String name;
-    protected String path = "";
-    protected State state = State.INVALID;
-    protected int parentProcessID;
-    protected int threadCount;
-    protected int priority;
-    protected long virtualSize;
-    protected long kernelTime;
-    protected long userTime;
-    protected long startTime;
-    protected long upTime;
-    protected long bytesRead;
-    protected long bytesWritten;
+    protected volatile String name;
+    protected volatile String path = "";
+    protected volatile State state = State.INVALID;
+    protected volatile int parentProcessID;
+    protected volatile int threadCount;
+    protected volatile int priority;
+    protected volatile long virtualSize;
+    protected volatile long kernelTime;
+    protected volatile long userTime;
+    protected volatile long startTime;
+    protected volatile long upTime;
+    protected volatile long bytesRead;
+    protected volatile long bytesWritten;
 
     /**
      * Creates an AbstractOSProcess for the given process ID.

--- a/oshi-common/src/main/java/oshi/software/common/AbstractOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOSThread.java
@@ -25,29 +25,29 @@ public abstract class AbstractOSThread implements OSThread {
     private final int owningProcessId;
 
     /** The thread id (OS-dependent meaning). */
-    protected int threadId;
+    protected volatile int threadId;
     /** The thread name; defaults to empty and is never returned as {@code null}. */
-    protected String name = "";
+    protected volatile String name = "";
     /** The thread execution state. */
-    protected OSProcess.State state = OSProcess.State.INVALID;
+    protected volatile OSProcess.State state = OSProcess.State.INVALID;
     /** Minor (soft) page faults; populated on Linux/BSD only. */
-    protected long minorFaults;
+    protected volatile long minorFaults;
     /** Major (hard) page faults; populated on Linux/BSD only. */
-    protected long majorFaults;
+    protected volatile long majorFaults;
     /** The start memory address. */
-    protected long startMemoryAddress;
+    protected volatile long startMemoryAddress;
     /** Voluntary + involuntary context switches. */
-    protected long contextSwitches;
+    protected volatile long contextSwitches;
     /** Kernel (privileged) time in milliseconds. */
-    protected long kernelTime;
+    protected volatile long kernelTime;
     /** User time in milliseconds. */
-    protected long userTime;
+    protected volatile long userTime;
     /** Start time in milliseconds since the epoch. */
-    protected long startTime;
+    protected volatile long startTime;
     /** Elapsed up-time in milliseconds. */
-    protected long upTime;
+    protected volatile long upTime;
     /** OS-dependent priority. */
-    protected int priority;
+    protected volatile int priority;
 
     /**
      * Creates an AbstractOSThread for the given owning process ID.

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -76,27 +76,27 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         return this.os;
     }
 
-    private Supplier<Integer> bitness = memoize(this::queryBitness);
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<List<String>> arguments = memoize(this::queryArguments);
-    private Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
-    private Supplier<String> user = memoize(this::queryUser);
-    private Supplier<String> group = memoize(this::queryGroup);
+    private final Supplier<Integer> bitness = memoize(this::queryBitness);
+    private final Supplier<String> commandLine = memoize(this::queryCommandLine);
+    private final Supplier<List<String>> arguments = memoize(this::queryArguments);
+    private final Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
+    private final Supplier<String> user = memoize(this::queryUser);
+    private final Supplier<String> group = memoize(this::queryGroup);
 
-    private String userID;
-    private String groupID;
-    private long residentSetSize;
-    private long privateResidentMemory;
-    private long minorFaults;
-    private long majorFaults;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
+    private volatile String userID;
+    private volatile String groupID;
+    private volatile long residentSetSize;
+    private volatile long privateResidentMemory;
+    private volatile long minorFaults;
+    private volatile long majorFaults;
+    private volatile long voluntaryContextSwitches;
+    private volatile long involuntaryContextSwitches;
 
     // Context-switch counts from getrusage for the current process, which are more accurate than the /proc values.
     // Populated by updateAttributes() via the queryContextSwitches() hook; the native-free build leaves these unset.
-    private boolean rusagePopulated;
-    private long cachedVoluntaryContextSwitches;
-    private long cachedInvoluntaryContextSwitches;
+    private volatile boolean rusagePopulated;
+    private volatile long cachedVoluntaryContextSwitches;
+    private volatile long cachedInvoluntaryContextSwitches;
 
     /**
      * Creates a LinuxOSProcess.

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSProcess.java
@@ -60,20 +60,20 @@ public abstract class MacOSProcess extends AbstractOSProcess {
     private final Supplier<Pair<List<String>, Map<String, String>>> argsEnviron = memoize(
             this::queryArgsAndEnvironment);
 
-    protected String currentWorkingDirectory;
-    protected String user;
-    protected String userID;
-    protected String group;
-    protected String groupID;
-    protected long residentSetSize;
-    protected long memoryFootprint;
-    protected long openFiles;
-    protected int bitness;
-    protected long minorFaults;
-    protected long majorFaults;
-    protected long contextSwitches;
-    protected long voluntaryContextSwitches;
-    protected long involuntaryContextSwitches;
+    protected volatile String currentWorkingDirectory;
+    protected volatile String user;
+    protected volatile String userID;
+    protected volatile String group;
+    protected volatile String groupID;
+    protected volatile long residentSetSize;
+    protected volatile long memoryFootprint;
+    protected volatile long openFiles;
+    protected volatile int bitness;
+    protected volatile long minorFaults;
+    protected volatile long majorFaults;
+    protected volatile long contextSwitches;
+    protected volatile long voluntaryContextSwitches;
+    protected volatile long involuntaryContextSwitches;
 
     protected MacOSProcess(int pid, int major, int minor, MacOperatingSystem os) {
         super(pid);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/AbstractProcOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/AbstractProcOSProcess.java
@@ -49,13 +49,13 @@ public abstract class AbstractProcOSProcess extends AbstractOSProcess {
     private final Supplier<Pair<List<String>, Map<String, String>>> cmdEnv = memoize(this::queryCommandlineEnvironment);
 
     // Populated by the subclass updateAttributes()
-    protected String commandLineBackup;
-    protected String user;
-    protected String userID;
-    protected String group;
-    protected String groupID;
-    protected long residentSetSize;
-    protected long privateResidentMemory;
+    protected volatile String commandLineBackup;
+    protected volatile String user;
+    protected volatile String userID;
+    protected volatile String group;
+    protected volatile String groupID;
+    protected volatile long residentSetSize;
+    protected volatile long privateResidentMemory;
 
     protected AbstractProcOSProcess(int pid) {
         super(pid);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
@@ -41,16 +41,16 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
     private final Supplier<List<String>> arguments = memoize(this::queryArguments);
     private final Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
 
-    protected String user;
-    protected String userID;
-    protected String group;
-    protected String groupID;
-    protected long residentSetSize;
-    protected long minorFaults;
-    protected long majorFaults;
-    protected long voluntaryContextSwitches;
-    protected long involuntaryContextSwitches;
-    protected String commandLineBackup;
+    protected volatile String user;
+    protected volatile String userID;
+    protected volatile String group;
+    protected volatile String groupID;
+    protected volatile long residentSetSize;
+    protected volatile long minorFaults;
+    protected volatile long majorFaults;
+    protected volatile long voluntaryContextSwitches;
+    protected volatile long involuntaryContextSwitches;
+    protected volatile String commandLineBackup;
 
     protected BsdOSProcess(int pid) {
         super(pid);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
@@ -39,10 +39,10 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
     private final Supplier<SolarisPsInfo> psinfo = memoize(this::queryPsInfo, defaultExpiration());
     private final Supplier<SolarisPrUsage> prusage = memoize(this::queryPrUsage, defaultExpiration());
 
-    private long minorFaults;
-    private long majorFaults;
-    private long voluntaryContextSwitches;
-    private long involuntaryContextSwitches;
+    private volatile long minorFaults;
+    private volatile long majorFaults;
+    private volatile long voluntaryContextSwitches;
+    private volatile long involuntaryContextSwitches;
 
     protected SolarisOSProcess(int pid) {
         super(pid);

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
@@ -55,20 +55,20 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
 
     private final OperatingSystem os;
 
-    private Supplier<Pair<String, String>> userInfo = memoize(this::queryUserInfo);
-    private Supplier<Pair<String, String>> groupInfo = memoize(this::queryGroupInfo);
-    private Supplier<String> currentWorkingDirectory = memoize(this::queryCwd);
-    private Supplier<String> commandLine = memoize(this::queryCommandLine);
-    private Supplier<List<String>> args = memoize(this::queryArguments);
-    private Supplier<Triplet<String, String, Map<String, String>>> cwdCmdEnv = memoize(
+    private final Supplier<Pair<String, String>> userInfo = memoize(this::queryUserInfo);
+    private final Supplier<Pair<String, String>> groupInfo = memoize(this::queryGroupInfo);
+    private final Supplier<String> currentWorkingDirectory = memoize(this::queryCwd);
+    private final Supplier<String> commandLine = memoize(this::queryCommandLine);
+    private final Supplier<List<String>> args = memoize(this::queryArguments);
+    private final Supplier<Triplet<String, String, Map<String, String>>> cwdCmdEnv = memoize(
             this::queryCwdCommandlineEnvironment);
-    private Map<Integer, ThreadPerfCounterBlock> tcb;
+    private volatile Map<Integer, ThreadPerfCounterBlock> tcb;
 
-    private long workingSetSize;
-    private long privateWorkingSetSize;
-    private long openFiles;
-    private int bitness;
-    private long pageFaults;
+    private volatile long workingSetSize;
+    private volatile long privateWorkingSetSize;
+    private volatile long openFiles;
+    private volatile int bitness;
+    private volatile long pageFaults;
 
     /**
      * Constructor.


### PR DESCRIPTION
## Summary

Honor the `@ThreadSafe` contract on OSHI's mutable-snapshot HAL classes by giving their fields proper cross-thread visibility and safe publication.

These classes (`OSProcess`, `OSThread`, and `NetworkIF` families, plus the dynamic `CentralProcessor` frequency/cache fields) are annotated `@ThreadSafe` but are populated at construction and refreshed by public `updateAttributes()` / `updateNetworkStats()` calls, then read via getters with no memory synchronization. A concurrent refresh and read could observe stale, torn, or half-updated values — violating the annotation's contract ("no caller synchronization required").

- `volatile` on 112 reassigned mutable stat fields — per-field visibility without locking the hot read path
- `final` on 12 write-once `memoize(...)` Supplier fields (matching e.g. `MacCentralProcessor.vendor`, which was already `final`)

No behavior change and no locks added; this is a pure visibility/publication hardening.

## CodeQL findings cleared

Clears three CodeQL Reliability categories for these classes in a single fix (`volatile` satisfies all three, `final` covers the write-once Suppliers):

- **Not thread-safe** — field access unprotected by a monitor
- **Safe publication** — non-`final`/non-`volatile` field not safely published
- **Escaping** — non-`final` `protected` field potentially escaping

The `WmiQueryHandlerFFM` findings in these categories are false positives (its state is a `ConcurrentHashMap`-backed set and `synchronized`/`volatile` primitives) and are dismissed separately.

## Testing

`./mvnw clean install` (full reactor) plus spotless, checkstyle, forbiddenapis, and javadoc all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of hardware, process, and thread details when accessed concurrently by ensuring updated values are reliably visible across threads (including network, CPU, and OS process/thread attributes).
* **Refactor**
  * Strengthened thread-safety guarantees by tightening internal state mutability/visibility (e.g., making stable identifiers immutable and using volatile for frequently refreshed metrics) without changing public APIs or expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->