### PR TITLE
Fix ADL GPU concurrency/overflow/OD6 gating and WMI handler thread-safety

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
@@ -271,7 +271,7 @@ public final class AdlUtilFFM {
             MemorySegment enabled = arena.allocate(JAVA_INT);
             MemorySegment version = arena.allocate(JAVA_INT);
             if ((int) ADL2_OVERDRIVE_CAPS.invokeExact(context, adapterIndex, supported, enabled, version) == ADL_OK) {
-                return version.get(JAVA_INT, 0) >= minVersion;
+                return supported.get(JAVA_INT, 0) != 0 && version.get(JAVA_INT, 0) >= minVersion;
             }
         } catch (Throwable t) {
             LOG.debug("ADL Overdrive_Caps failed: {}", t.getMessage());

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
@@ -38,6 +38,7 @@ public final class AdlUtilFFM {
 
     private static final int ADL_OK = 0;
     private static final int ADL_OVERDRIVE_VERSION_N = 8;
+    private static final int ADL_OVERDRIVE_VERSION_6 = 6;
     private static final int ADL_FAN_SPEED_MODE_PERCENT = 1;
     private static final int ADL_OVERDRIVE_TEMPERATURE_EDGE = 1;
 
@@ -147,6 +148,7 @@ public final class AdlUtilFFM {
     }
 
     // Lazy adapter enumeration
+    private static final Object ENUM_LOCK = new Object();
     private static volatile boolean adaptersEnumerated = false;
     private static final AtomicReference<Map<Integer, Integer>> BUS_TO_INDEX = new AtomicReference<>(
             Collections.emptyMap());
@@ -199,11 +201,17 @@ public final class AdlUtilFFM {
         if (adaptersEnumerated) {
             return;
         }
-        Map<Integer, Integer> result = enumerateAdapters(context, arena);
-        if (result != null) {
-            BUS_TO_INDEX.set(result);
-            adaptersEnumerated = true;
-            LOG.debug("ADL (FFM) enumerated {} adapter(s)", BUS_TO_INDEX.get().size());
+        // Double-checked locking so concurrent callers enumerate at most once
+        synchronized (ENUM_LOCK) {
+            if (adaptersEnumerated) {
+                return;
+            }
+            Map<Integer, Integer> result = enumerateAdapters(context, arena);
+            if (result != null) {
+                BUS_TO_INDEX.set(result);
+                adaptersEnumerated = true;
+                LOG.debug("ADL (FFM) enumerated {} adapter(s)", BUS_TO_INDEX.get().size());
+            }
         }
     }
 
@@ -215,6 +223,12 @@ public final class AdlUtilFFM {
             }
             int num = numRef.get(JAVA_INT, 0);
             if (num <= 0) {
+                return Collections.emptyMap();
+            }
+            // Guard against overflow: the buffer size is passed to the native call as a 32-bit int, so a huge
+            // adapter count could wrap. This is implausible in practice but keeps the int multiplication below safe.
+            if ((long) ADAPTER_INFO_SIZE * num > Integer.MAX_VALUE) {
+                LOG.warn("ADL reported an implausible adapter count {}; skipping enumeration", num);
                 return Collections.emptyMap();
             }
             MemorySegment infos = arena.allocate((long) ADAPTER_INFO_SIZE * num);
@@ -243,12 +257,21 @@ public final class AdlUtilFFM {
     }
 
     private static boolean supportsOverdriveN(MemorySegment context, int adapterIndex, Arena arena) {
+        return supportsOverdriveVersion(context, adapterIndex, arena, ADL_OVERDRIVE_VERSION_N);
+    }
+
+    private static boolean supportsOverdrive6(MemorySegment context, int adapterIndex, Arena arena) {
+        return supportsOverdriveVersion(context, adapterIndex, arena, ADL_OVERDRIVE_VERSION_6);
+    }
+
+    private static boolean supportsOverdriveVersion(MemorySegment context, int adapterIndex, Arena arena,
+            int minVersion) {
         try {
             MemorySegment supported = arena.allocate(JAVA_INT);
             MemorySegment enabled = arena.allocate(JAVA_INT);
             MemorySegment version = arena.allocate(JAVA_INT);
             if ((int) ADL2_OVERDRIVE_CAPS.invokeExact(context, adapterIndex, supported, enabled, version) == ADL_OK) {
-                return version.get(JAVA_INT, 0) >= ADL_OVERDRIVE_VERSION_N;
+                return version.get(JAVA_INT, 0) >= minVersion;
             }
         } catch (Throwable t) {
             LOG.debug("ADL Overdrive_Caps failed: {}", t.getMessage());
@@ -406,7 +429,9 @@ public final class AdlUtilFFM {
                 return -1d;
             }
             try {
-                if (!supportsOverdriveN(ctx, adapterIndex, arena)) {
+                // Power draw uses the Overdrive 6 API, so gate on OD6 (or newer) rather than Overdrive N. This
+                // no longer rejects OD6-only cards; the return code still guards cards that don't implement the call.
+                if (!supportsOverdrive6(ctx, adapterIndex, arena)) {
                     return -1d;
                 }
                 MemorySegment power = arena.allocate(JAVA_INT);

--- a/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryHandler.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryHandler.java
@@ -5,8 +5,9 @@
 package oshi.util.platform.windows;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 
 import org.slf4j.Logger;
@@ -41,10 +42,10 @@ public class WmiQueryHandler implements WmiQueryExecutor {
     }
 
     // Timeout for WMI queries
-    private int wmiTimeout = globalTimeout;
+    private volatile int wmiTimeout = globalTimeout;
 
     // Cache failed wmi classes
-    private final Set<String> failedWmiClassNames = new HashSet<>();
+    private final Set<String> failedWmiClassNames = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     // Preferred threading model
     private int comThreading = Ole32.COINIT_MULTITHREADED;


### PR DESCRIPTION
## Summary

Concurrency and correctness fixes surfaced by CodeQL/AI review in the AMD ADL GPU (FFM) path and the JNA WMI query handler.

### `AdlUtilFFM`
- **Adapter-enumeration race** — `ensureAdaptersEnumerated` did a check-then-act on the `volatile adaptersEnumerated` flag, so two threads could both run `enumerateAdapters` and reset `BUS_TO_INDEX`. Now guarded with double-checked locking so enumeration happens at most once.
- **Integer-overflow guard** — `enumerateAdapters` passed `ADAPTER_INFO_SIZE * num` (a plain `int`) to the native adapter-info call while allocating the buffer with a `long`. The native argument must stay 32-bit, so an overflow guard now rejects an implausibly large adapter count rather than letting the `int` multiplication wrap.
- **Overdrive-6 power gating** — `getPowerDraw` calls the Overdrive 6 power API but gated on Overdrive N (`version >= 8`), wrongly returning `-1` on OD6-only cards. It now gates on OD6 (`version >= 6`); the native return code still guards any card that doesn't implement the call. (AMD-hardware-specific; validated by code inspection, consistent with the rest of the best-effort Windows GPU path.)

### `WmiQueryHandler` (JNA)
The `@ThreadSafe` handler cached failed class names in a plain `HashSet` mutated without synchronization (concurrent `add`/`contains` can corrupt or spin), and `wmiTimeout` was a plain `int`. Brought to parity with the FFM twin: a `ConcurrentHashMap`-backed set and a `volatile wmiTimeout`. (`comThreading` stays plain — guarded by the existing `synchronized` accessors; `securityInitialized` was already `volatile`.)

## Testing

`./mvnw clean install` (full reactor) plus spotless, checkstyle, forbiddenapis, and javadoc all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AMD GPU adapter enumeration for better correctness and reliability under concurrent queries.
  - Added safeguards against invalid adapter counts that could lead to incorrect native buffer sizing.
  - Corrected AMD power-draw capability detection to align with newer Overdrive 6 support.
  - Improved capability checks for Overdrive versions to enhance compatibility.
  - Strengthened Windows WMI query handling with thread-safe caching of failed lookups and more consistent timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->