### PR TITLE
Registry access-flag fix, perf-counter filter casing, Mac power cleanup

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -40,7 +40,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     }
 
     // populated by initProcessorCounts called by the parent constructor
-    private volatile Map<String, Integer> numaNodeProcToLogicalProcMap;
+    private final AtomicReference<Map<String, Integer>> numaNodeProcToLogicalProcMap = new AtomicReference<>();
 
     /** Whether to use legacy Processor counters rather than Processor Information counters. */
     protected static final boolean USE_LEGACY_SYSTEM_COUNTERS = GlobalConfig
@@ -107,7 +107,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @return the map
      */
     protected Map<String, Integer> getNumaNodeProcToLogicalProcMap() {
-        return this.numaNodeProcToLogicalProcMap;
+        return this.numaNodeProcToLogicalProcMap.get();
     }
 
     /**
@@ -144,7 +144,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
             nextProcIndexByNode.put(node, procNum + 1);
         }
         // Publish the fully-built map as the final step so readers never observe a partial map
-        this.numaNodeProcToLogicalProcMap = map;
+        this.numaNodeProcToLogicalProcMap.set(map);
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -42,8 +42,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     // Populated by initProcessorCounts, which the parent constructor calls before this class's field initializers
     // run; that ordering rules out an AtomicReference holder (its initializer would not have run yet), so this stays
     // a volatile reference to a swap-published immutable snapshot, for which volatile publication is sufficient.
-    @SuppressWarnings("java:S3077")
-    private volatile Map<String, Integer> numaNodeProcToLogicalProcMap;
+    private volatile Map<String, Integer> numaNodeProcToLogicalProcMap; // NOSONAR squid:S3077
 
     /** Whether to use legacy Processor counters rather than Processor Information counters. */
     protected static final boolean USE_LEGACY_SYSTEM_COUNTERS = GlobalConfig

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -39,8 +39,11 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
         }
     }
 
-    // populated by initProcessorCounts called by the parent constructor
-    private final AtomicReference<Map<String, Integer>> numaNodeProcToLogicalProcMap = new AtomicReference<>();
+    // Populated by initProcessorCounts, which the parent constructor calls before this class's field initializers
+    // run; that ordering rules out an AtomicReference holder (its initializer would not have run yet), so this stays
+    // a volatile reference to a swap-published immutable snapshot, for which volatile publication is sufficient.
+    @SuppressWarnings("java:S3077")
+    private volatile Map<String, Integer> numaNodeProcToLogicalProcMap;
 
     /** Whether to use legacy Processor counters rather than Processor Information counters. */
     protected static final boolean USE_LEGACY_SYSTEM_COUNTERS = GlobalConfig
@@ -107,7 +110,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @return the map
      */
     protected Map<String, Integer> getNumaNodeProcToLogicalProcMap() {
-        return this.numaNodeProcToLogicalProcMap.get();
+        return this.numaNodeProcToLogicalProcMap;
     }
 
     /**
@@ -144,7 +147,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
             nextProcIndexByNode.put(node, procNum + 1);
         }
         // Publish the fully-built map as the final step so readers never observe a partial map
-        this.numaNodeProcToLogicalProcMap.set(map);
+        this.numaNodeProcToLogicalProcMap = map;
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
@@ -85,12 +85,13 @@ public abstract class OpenBsdOSProcess extends BsdOSProcess {
     @Override
     protected void updateThreadCount() {
         List<String> threadList = ExecutingCommand.runNative("ps -axHo tid -p " + getProcessID());
+        int count = this.threadCount;
         if (!threadList.isEmpty()) {
             // Subtract 1 for header
-            this.threadCount = threadList.size() - 1;
+            count = threadList.size() - 1;
         }
         // A live process always has at least one thread
-        this.threadCount = Math.max(this.threadCount, 1);
+        this.threadCount = Math.max(count, 1);
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -62,7 +63,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     private final Supplier<List<String>> args = memoize(this::queryArguments);
     private final Supplier<Triplet<String, String, Map<String, String>>> cwdCmdEnv = memoize(
             this::queryCwdCommandlineEnvironment);
-    private volatile Map<Integer, ThreadPerfCounterBlock> tcb;
+    private final AtomicReference<Map<Integer, ThreadPerfCounterBlock>> tcb = new AtomicReference<>();
 
     private volatile long workingSetSize;
     private volatile long privateWorkingSetSize;
@@ -84,7 +85,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
         super(pid);
         this.os = os;
         this.bitness = os.getBitness();
-        this.tcb = threadMap;
+        this.tcb.set(threadMap);
         updateAttributes(processMap.get(pid), processWtsMap.get(pid));
     }
 
@@ -183,9 +184,10 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        Map<Integer, ThreadPerfCounterBlock> threads = tcb == null
-                ? queryMatchingThreads(Collections.singleton(this.getProcessID()))
-                : tcb;
+        Map<Integer, ThreadPerfCounterBlock> threads = this.tcb.get();
+        if (threads == null) {
+            threads = queryMatchingThreads(Collections.singleton(this.getProcessID()));
+        }
         if (threads == null) {
             threads = Collections.emptyMap();
         }
@@ -239,9 +241,10 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
         }
 
         this.state = RUNNING;
-        if (this.tcb != null) {
+        Map<Integer, ThreadPerfCounterBlock> threadBlocks = this.tcb.get();
+        if (threadBlocks != null) {
             int pid = this.getProcessID();
-            for (ThreadPerfCounterBlock tpd : this.tcb.values()) {
+            for (ThreadPerfCounterBlock tpd : threadBlocks.values()) {
                 if (tpd.getOwningProcessID() == pid) {
                     if (tpd.getThreadWaitReason() == 5) {
                         this.state = SUSPENDED;
@@ -298,7 +301,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
      * @param tcb the thread performance counter block map
      */
     protected void setTcb(Map<Integer, ThreadPerfCounterBlock> tcb) {
-        this.tcb = tcb;
+        this.tcb.set(tcb);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -110,20 +110,6 @@ public abstract class ForeignFunctions {
         boolean call(Arena arena) throws Throwable;
     }
 
-    /**
-     * Represents an operation that uses a confined {@link Arena} and does not return a value.
-     */
-    @FunctionalInterface
-    public interface ArenaRunnable {
-        /**
-         * Executes this operation with the provided arena.
-         *
-         * @param arena the confined arena scoped to this operation
-         * @throws Throwable if the operation fails
-         */
-        void run(Arena arena) throws Throwable;
-    }
-
     /** The native linker for the current platform. */
     protected static final Linker LINKER = Linker.nativeLinker();
 
@@ -270,26 +256,6 @@ public abstract class ForeignFunctions {
         } catch (Throwable t) {
             logThrowable(logger, level, message, t);
             return defaultValue;
-        }
-    }
-
-    /**
-     * Executes an operation in a confined arena, logging and swallowing any thrown failure.
-     * <p>
-     * This helper is intended for FFM operations whose useful result is a side effect. The provided arena is closed
-     * before this method returns.
-     *
-     * @param runnable the operation to execute
-     * @param logger   the logger for the calling class
-     * @param level    the level at which to log thrown failures
-     * @param message  the message to log if the operation throws
-     */
-    public static void runInArenaCatchingThrowable(ArenaRunnable runnable, Logger logger, Level level, String message) {
-        Objects.requireNonNull(runnable, "runnable");
-        try (Arena arena = Arena.ofConfined()) {
-            runnable.run(arena);
-        } catch (Throwable t) {
-            logThrowable(logger, level, message, t);
         }
     }
 

--- a/oshi-core-ffm/src/test/java/oshi/ffm/ForeignFunctionsTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/ForeignFunctionsTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.is;
 import static org.slf4j.event.Level.DEBUG;
 
 import java.lang.foreign.MemorySegment;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
@@ -118,24 +117,4 @@ class ForeignFunctionsTest {
         assertThat(result, is(false));
     }
 
-    @Test
-    void testRunInArenaCatchingThrowableRunsOperation() {
-        AtomicBoolean called = new AtomicBoolean();
-
-        ForeignFunctions.runInArenaCatchingThrowable(arena -> called.set(true), LOG, DEBUG, "void success");
-
-        assertThat(called.get(), is(true));
-    }
-
-    @Test
-    void testRunInArenaCatchingThrowableSwallowsThrowable() {
-        AtomicBoolean called = new AtomicBoolean();
-
-        ForeignFunctions.runInArenaCatchingThrowable(arena -> {
-            called.set(true);
-            throw new Throwable("void failure");
-        }, LOG, DEBUG, "void failure");
-
-        assertThat(called.get(), is(true));
-    }
 }

--- a/oshi-core/src/main/java/oshi/driver/unix/aix/PsInfoJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/aix/PsInfoJNA.java
@@ -13,9 +13,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.aix.AixPsInfo;
 import oshi.driver.common.unix.aix.PsInfo;
@@ -30,8 +27,6 @@ import oshi.util.tuples.Triplet;
  */
 @ThreadSafe
 public final class PsInfoJNA {
-
-    private static final Logger LOG = LoggerFactory.getLogger(PsInfoJNA.class);
 
     private static final AixLibc LIBC = AixLibc.INSTANCE;
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacPowerSourceJNA.java
@@ -65,59 +65,78 @@ public final class MacPowerSourceJNA extends MacPowerSource {
             }
             return Collections.emptyList();
         }
-        int powerSourcesCount = powerSourcesList.getCount();
+        // Keys start null so the finally block releases only what was actually created, even if an exception
+        // is thrown partway through, so the CF references above are never leaked.
+        CFStringRef nameKey = null;
+        CFStringRef isPresentKey = null;
+        CFStringRef currentCapacityKey = null;
+        CFStringRef maxCapacityKey = null;
+        try {
+            int powerSourcesCount = powerSourcesList.getCount();
 
-        // Get time remaining
-        // -1 = unknown, -2 = unlimited
-        double psTimeRemainingEstimated = IO.IOPSGetTimeRemainingEstimate();
+            // Get time remaining
+            // -1 = unknown, -2 = unlimited
+            double psTimeRemainingEstimated = IO.IOPSGetTimeRemainingEstimate();
 
-        CFStringRef nameKey = CFStringRef.createCFString("Name");
-        CFStringRef isPresentKey = CFStringRef.createCFString("Is Present");
-        CFStringRef currentCapacityKey = CFStringRef.createCFString("Current Capacity");
-        CFStringRef maxCapacityKey = CFStringRef.createCFString("Max Capacity");
-        // For each power source, capture the present ones for the shared computation
-        List<PowerSourceData> sources = new ArrayList<>(powerSourcesCount);
-        for (int ps = 0; ps < powerSourcesCount; ps++) {
-            // Get the dictionary for that Power Source
-            Pointer pwrSrcPtr = powerSourcesList.getValueAtIndex(ps);
-            CFTypeRef powerSource = new CFTypeRef();
-            powerSource.setPointer(pwrSrcPtr);
-            CFDictionaryRef dictionary = IO.IOPSGetPowerSourceDescription(powerSourcesInfo, powerSource);
+            nameKey = CFStringRef.createCFString("Name");
+            isPresentKey = CFStringRef.createCFString("Is Present");
+            currentCapacityKey = CFStringRef.createCFString("Current Capacity");
+            maxCapacityKey = CFStringRef.createCFString("Max Capacity");
+            // For each power source, capture the present ones for the shared computation
+            List<PowerSourceData> sources = new ArrayList<>(powerSourcesCount);
+            for (int ps = 0; ps < powerSourcesCount; ps++) {
+                // Get the dictionary for that Power Source
+                Pointer pwrSrcPtr = powerSourcesList.getValueAtIndex(ps);
+                CFTypeRef powerSource = new CFTypeRef();
+                powerSource.setPointer(pwrSrcPtr);
+                CFDictionaryRef dictionary = IO.IOPSGetPowerSourceDescription(powerSourcesInfo, powerSource);
 
-            // Get values from dictionary (See IOPSKeys.h)
-            // Skip if not present
-            Pointer result = dictionary.getValue(isPresentKey);
-            if (result != null) {
-                CFBooleanRef isPresentRef = new CFBooleanRef(result);
-                if (0 != CF.CFBooleanGetValue(isPresentRef)) {
-                    // Get name
-                    result = dictionary.getValue(nameKey);
-                    String psName = CFUtil.cfPointerToString(result);
-                    // Remaining Capacity = current / max
-                    double currentCapacity = 0d;
-                    if (dictionary.getValueIfPresent(currentCapacityKey, null)) {
-                        result = dictionary.getValue(currentCapacityKey);
-                        CFNumberRef cap = new CFNumberRef(result);
-                        currentCapacity = cap.intValue();
+                // Get values from dictionary (See IOPSKeys.h)
+                // Skip if not present
+                Pointer result = dictionary.getValue(isPresentKey);
+                if (result != null) {
+                    CFBooleanRef isPresentRef = new CFBooleanRef(result);
+                    if (0 != CF.CFBooleanGetValue(isPresentRef)) {
+                        // Get name
+                        result = dictionary.getValue(nameKey);
+                        String psName = CFUtil.cfPointerToString(result);
+                        // Remaining Capacity = current / max
+                        double currentCapacity = 0d;
+                        if (dictionary.getValueIfPresent(currentCapacityKey, null)) {
+                            result = dictionary.getValue(currentCapacityKey);
+                            CFNumberRef cap = new CFNumberRef(result);
+                            currentCapacity = cap.intValue();
+                        }
+                        double maxCapacity = 1d;
+                        if (dictionary.getValueIfPresent(maxCapacityKey, null)) {
+                            result = dictionary.getValue(maxCapacityKey);
+                            CFNumberRef cap = new CFNumberRef(result);
+                            maxCapacity = cap.intValue();
+                        }
+                        sources.add(new PowerSourceData(psName, currentCapacity, maxCapacity));
                     }
-                    double maxCapacity = 1d;
-                    if (dictionary.getValueIfPresent(maxCapacityKey, null)) {
-                        result = dictionary.getValue(maxCapacityKey);
-                        CFNumberRef cap = new CFNumberRef(result);
-                        maxCapacity = cap.intValue();
-                    }
-                    sources.add(new PowerSourceData(psName, currentCapacity, maxCapacity));
                 }
             }
+            return buildPowerSources(IOKitProviderJNA.INSTANCE, psTimeRemainingEstimated, sources,
+                    MacPowerSourceJNA::new);
+        } finally {
+            if (isPresentKey != null) {
+                isPresentKey.release();
+            }
+            if (nameKey != null) {
+                nameKey.release();
+            }
+            if (currentCapacityKey != null) {
+                currentCapacityKey.release();
+            }
+            if (maxCapacityKey != null) {
+                maxCapacityKey.release();
+            }
+            // Release the blob
+            powerSourcesList.release();
+            if (powerSourcesInfo != null) {
+                powerSourcesInfo.release();
+            }
         }
-        isPresentKey.release();
-        nameKey.release();
-        currentCapacityKey.release();
-        maxCapacityKey.release();
-        // Release the blob
-        powerSourcesList.release();
-        powerSourcesInfo.release();
-
-        return buildPowerSources(IOKitProviderJNA.INSTANCE, psTimeRemainingEstimated, sources, MacPowerSourceJNA::new);
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -135,10 +135,11 @@ public final class PerfCounterWildcardQuery {
             throw new IllegalArgumentException("Enum " + propertyEnum.getName()
                     + " must have at least two elements, an instance filter and a counter.");
         }
-        String instanceFilter = Util.isBlank(customFilter)
+        // Lowercase the filter (matching the built-in default below) since instance names are compared
+        // case-insensitively via toLowerCase at the wildcardMatch call.
+        String instanceFilter = (Util.isBlank(customFilter)
                 ? ((PdhCounterWildcardProperty) propertyEnum.getEnumConstants()[0]).getCounter()
-                        .toLowerCase(Locale.ROOT)
-                : customFilter;
+                : customFilter).toLowerCase(Locale.ROOT);
         // Localize the perfObject using different variable for the EnumObjectItems
         // Will still use unlocalized perfObject for the query
         String perfObjectLocalized = PerfCounterQuery.localizeIfNeeded(perfObject, true);

--- a/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
@@ -4,6 +4,8 @@
  */
 package oshi.util.platform.windows;
 
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +54,19 @@ public final class RegistryUtil {
             // registryGetValues opens the key with KEY_READ | accessFlag, so the WOW64 access flag (e.g.
             // KEY_WOW64_32KEY/KEY_WOW64_64KEY) is honored when reading the value. Reading the value separately via
             // registryGetValue(root, path, key) re-opened the key with the default view, ignoring accessFlag.
-            return Advapi32Util.registryGetValues(root, path, accessFlag).get(key);
+            Map<String, Object> values = Advapi32Util.registryGetValues(root, path, accessFlag);
+            // A null key requests the (Default) value, which registryGetValues stores under the empty name.
+            String valueName = key == null ? "" : key;
+            Object value = values.get(valueName);
+            if (value == null) {
+                // Registry value names are case-insensitive; fall back to a case-insensitive match.
+                for (Map.Entry<String, Object> entry : values.entrySet()) {
+                    if (entry.getKey().equalsIgnoreCase(valueName)) {
+                        return entry.getValue();
+                    }
+                }
+            }
+            return value;
         } catch (Win32Exception e) {
             LOG.trace("Unable to access {} with flag {}: {}", path, accessFlag, e.getMessage());
         }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
@@ -4,15 +4,9 @@
  */
 package oshi.util.platform.windows;
 
-import static com.sun.jna.platform.win32.WinError.ERROR_SUCCESS;
-import static com.sun.jna.platform.win32.WinNT.KEY_READ;
-
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.platform.win32.Advapi32;
 import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.Win32Exception;
 import com.sun.jna.platform.win32.WinReg;
@@ -26,8 +20,6 @@ import oshi.driver.common.windows.registry.RegistryValueUtil;
 public final class RegistryUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(RegistryUtil.class);
-
-    private static final Advapi32 ADV = Advapi32.INSTANCE;
 
     private RegistryUtil() {
     }
@@ -56,20 +48,13 @@ public final class RegistryUtil {
      * @return the registry value or null
      */
     public static Object getRegistryValueOrNull(HKEY root, String path, String key, int accessFlag) {
-        HKEY hKey = null;
         try {
-            hKey = Advapi32Util.registryGetKey(root, path, KEY_READ | accessFlag).getValue();
-            Object value = Advapi32Util.registryGetValue(root, path, key);
-            return Objects.isNull(value) ? null : value;
+            // registryGetValues opens the key with KEY_READ | accessFlag, so the WOW64 access flag (e.g.
+            // KEY_WOW64_32KEY/KEY_WOW64_64KEY) is honored when reading the value. Reading the value separately via
+            // registryGetValue(root, path, key) re-opened the key with the default view, ignoring accessFlag.
+            return Advapi32Util.registryGetValues(root, path, accessFlag).get(key);
         } catch (Win32Exception e) {
             LOG.trace("Unable to access {} with flag {}: {}", path, accessFlag, e.getMessage());
-        } finally {
-            if (hKey != null) {
-                int rc = ADV.RegCloseKey(hKey);
-                if (rc != ERROR_SUCCESS) {
-                    LOG.trace("Unable to close registry key {}: {}", path, rc);
-                }
-            }
         }
         return null;
     }


### PR DESCRIPTION
## Summary

Cleanup batch from the CodeQL/AI review pass — a functional Windows registry bug plus smaller correctness/robustness fixes.

### `RegistryUtil` — WOW64 access flag was ignored (functional bug)
`getRegistryValueOrNull` opened the key with the requested access flag (`Advapi32Util.registryGetKey(root, path, KEY_READ | accessFlag)`) but then read the value with `Advapi32Util.registryGetValue(root, path, key)`, which re-opens the key internally with the **default** registry view — so `accessFlag` was never applied to the read. The only caller passing a non-zero flag is the installed-applications enumeration, which iterates `{KEY_WOW64_64KEY, KEY_WOW64_32KEY}`; the bug meant the 32-bit view read the 64-bit hive on 64-bit Windows, so 32-bit apps could be missed or mis-read. Now reads via `registryGetValues(root, path, accessFlag)`, which opens with `KEY_READ | accessFlag`. Also drops a no-op `Objects.isNull(value) ? null : value` ternary and the now-unused manual key handle. Brings the JNA path in line with the already-correct FFM backend.

### `PerfCounterWildcardQuery` — customFilter casing
A caller-supplied `customFilter` was used as-is, while the built-in default is lowercased and instance names are compared lowercased at the `wildcardMatch` call — so a mixed-case `customFilter` silently matched nothing. It is now lowercased to match.

### `MacPowerSourceJNA` — exception-safe cleanup
`getPowerSources` released its CoreFoundation references only at the end of the method, so a throw partway through (e.g. in a dictionary read) leaked them. Cleanup now runs in a `finally` block, and the possibly-null `powerSourcesInfo` release is guarded.

### Remove unused `ArenaRunnable` helper
`ForeignFunctions.ArenaRunnable` and `runInArenaCatchingThrowable` had no production callers (only their own unit tests, which ignored the arena). Removed both and the two tests.

## Testing

`./mvnw clean install` (full reactor); `oshi-core-ffm` tests pass (`ForeignFunctionsTest` included); spotless, checkstyle, forbiddenapis, and javadoc all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS power-source monitoring by ensuring native resources are reliably released on all paths.
  - Improved Windows performance-counter instance filtering with consistent case-insensitive matching.
  - Improved OpenBSD and Windows process/thread reporting to reduce stale or incomplete thread data.
  - Improved Windows Registry value reads to handle missing values more safely.
- **Refactor**
  - Removed the foreign-function “runnable in confined arena” helper and its related tests.
  - Switched Windows thread-performance-counter cache to an atomic reference to improve safe updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->