### PR TITLE
Document the reuse-vs-recreate CPU/memory trade-off with a monitoring benchmark

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -36,8 +36,13 @@ jobs:
           cache: 'maven'
       - name: Build benchmark jar
         run: ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
+      # Longer settings than the VM jobs below: native runners give stable numbers, so this on-demand run
+      # invests ~30 min for accuracy. -prof gc adds per-op allocation (bytes/op) for the memory columns.
       - name: Run JMH benchmarks
-        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 5 -i 10 -f 3 -prof gc
+      # Retained-memory dimension of the reuse-vs-recreate trade-off (not a per-op JMH quantity)
+      - name: Report monitoring footprint
+        run: java --enable-native-access=ALL-UNNAMED -cp oshi-benchmark/target/benchmarks.jar oshi.benchmark.MonitoringFootprintReport
 
   benchmacos:
     name: JMH benchmarks, macOS
@@ -56,8 +61,13 @@ jobs:
           cache: 'maven'
       - name: Build benchmark jar
         run: ./mvnw package -pl oshi-benchmark -am -DskipTests -Dshade.phase=package -q
+      # Longer settings than the VM jobs below: native runners give stable numbers, so this on-demand run
+      # invests ~30 min for accuracy. -prof gc adds per-op allocation (bytes/op) for the memory columns.
       - name: Run JMH benchmarks
-        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 5 -i 10 -f 3 -prof gc
+      # Retained-memory dimension of the reuse-vs-recreate trade-off (not a per-op JMH quantity)
+      - name: Report monitoring footprint
+        run: java --enable-native-access=ALL-UNNAMED -cp oshi-benchmark/target/benchmarks.jar oshi.benchmark.MonitoringFootprintReport
 
   benchwindows:
     name: JMH benchmarks, Windows
@@ -76,8 +86,13 @@ jobs:
           cache: 'maven'
       - name: Build benchmark jar
         run: ./mvnw package -pl oshi-benchmark -am "-DskipTests" "-Dshade.phase=package" -q
+      # Longer settings than the VM jobs below: native runners give stable numbers, so this on-demand run
+      # invests ~30 min for accuracy. -prof gc adds per-op allocation (bytes/op) for the memory columns.
       - name: Run JMH benchmarks
-        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 1 -i 3 -f 1
+        run: java -jar oshi-benchmark/target/benchmarks.jar -wi 5 -i 10 -f 3 -prof gc
+      # Retained-memory dimension of the reuse-vs-recreate trade-off (not a per-op JMH quantity)
+      - name: Report monitoring footprint
+        run: java --enable-native-access=ALL-UNNAMED -cp oshi-benchmark/target/benchmarks.jar oshi.benchmark.MonitoringFootprintReport
 
   benchfreebsd:
     name: JMH benchmarks, FreeBSD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 7.4.2 (in progress)
 
+* [#3493](https://github.com/oshi/oshi/pull/3493): Document the CPU/memory trade-off of reusing versus recreating `SystemInfo` when polling, with supporting benchmarks - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here!
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 7.4.2 (in progress)
 
+##### Bug Fixes and Improvements
+
 * [#3493](https://github.com/oshi/oshi/pull/3493): Document the CPU/memory trade-off of reusing versus recreating `SystemInfo` when polling, with supporting benchmarks - [@dbwiddis](https://github.com/dbwiddis).
-* Your contribution here!
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18)
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -111,6 +111,21 @@ OSHI avoids caching large amount of information, leaving caching to the user.  L
 
 Users with memory constraints can ensure the existing cached information is disposed of by using a new instance of `SystemInfo` and the subordinate classes when collecting data.
 
+### Reusing vs. recreating `SystemInfo` when polling
+
+A monitoring agent that samples the same metrics repeatedly (e.g., once per second) should **hold a single `SystemInfo` and its subordinate objects** rather than constructing a new `SystemInfo` for each poll. Realistic poll intervals are far longer than the sub-second memoizer TTL, so the memoizer never helps *across* polls; the real trade-off is the memory retained by the held object graph versus the CPU to reconstruct it each time.
+
+`ReuseVsRecreateBenchmark` (CPU time, with `-prof gc` for per-poll allocation) and `MonitoringFootprintReport` (retained memory of the held graph) measure this with memoization disabled so every poll is a real query. Illustrative numbers (macOS, JDK 25):
+
+| Polled metric | Reuse / poll | Recreate / poll | Retained (held) | Alloc / poll (reuse) |
+|---------------|-------------:|----------------:|----------------:|---------------------:|
+| CPU load ticks    | ~4 µs   | ~5 ms   | ~10 KB | ~2 KB   |
+| Available memory  | ~4 µs   | ~6 µs   | ~1 KB  | ~1 KB   |
+| Process list      | ~29 ms  | ~29 ms  | —      | ~490 KB |
+
+- **CPU ticks / memory:** recreating a `SystemInfo` rebuilds the `CentralProcessor` (CPU topology and identifier queries) on every poll — about 5 ms — versus ~4 µs to read from a held instance, a ~1000× difference, while the retained object graph is only ~10 KB (recreating also churns ~130 KB/poll of allocation instead of ~2 KB). Reusing is almost pure win: negligible retained memory for a large CPU saving.
+- **Process list:** `getProcesses()` is a live full query, so reusing `SystemInfo` saves nothing (~29 ms either way) and the ~490 KB result — plus ~20 MB of transient parsing garbage — is allocated on every poll regardless. To monitor specific processes, hold the individual `OSProcess` objects and call `updateAttributes()` rather than re-querying the whole list (see below).
+
 ## Updating statistics on objects in a list
 
 Many of the individual objects returned by lists, such as `OSProcess`, `NetworkIF`, `OSFileStore`, and others, have an `updateAttributes()` method that operates only on that object. These are intended for use primarily if that individual process is the only one being monitored/updated.  In many cases, the entire list must be queried to provide the information, so users updating multiple objects in a list should simply re-query the entire list once and then correlate the new set of results to the old ones in their own application.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -113,18 +113,22 @@ Users with memory constraints can ensure the existing cached information is disp
 
 ### Reusing vs. recreating `SystemInfo` when polling
 
-A monitoring agent that samples the same metrics repeatedly (e.g., once per second) should **hold a single `SystemInfo` and its subordinate objects** rather than constructing a new `SystemInfo` for each poll. Realistic poll intervals are far longer than the sub-second memoizer TTL, so the memoizer never helps *across* polls; the real trade-off is the memory retained by the held object graph versus the CPU to reconstruct it each time.
+A monitoring agent that samples the same metrics repeatedly should **hold a single `SystemInfo` and its subordinate objects** rather than constructing a new `SystemInfo` for each poll. Realistic poll intervals are far longer than the sub-second memoizer TTL, so the memoizer does not help *across* polls; the trade-off is the CPU to reconstruct the object graph each poll versus the memory retained by holding it.
 
-`ReuseVsRecreateBenchmark` (CPU time, with `-prof gc` for per-poll allocation) and `MonitoringFootprintReport` (retained memory of the held graph) measure this with memoization disabled so every poll is a real query. Illustrative numbers (macOS, JDK 25):
+The dominant reconstruction cost is the `CentralProcessor` (CPU topology and identifier queries). Reading CPU load ticks once per poll, measured by `ReuseVsRecreateBenchmark` with memoization disabled (`-f 3`):
 
-| Polled metric | Reuse / poll | Recreate / poll | Retained (held) | Alloc / poll (reuse) |
-|---------------|-------------:|----------------:|----------------:|---------------------:|
-| CPU load ticks    | ~4 µs   | ~5 ms   | ~10 KB | ~2 KB   |
-| Available memory  | ~4 µs   | ~6 µs   | ~1 KB  | ~1 KB   |
-| Process list      | ~29 ms  | ~29 ms  | —      | ~490 KB |
+| Platform | Recreate per poll | Reuse (held) per poll | Retained if held |
+|----------|------------------:|----------------------:|-----------------:|
+| Windows  | 10.7 ms | 632 µs  | 3.9 KB |
+| macOS    | 3.8 ms  | 2.4 µs  | 8.5 KB |
+| Linux    | 2.4 ms  | 19.5 µs | 5.0 KB |
 
-- **CPU ticks / memory:** recreating a `SystemInfo` rebuilds the `CentralProcessor` (CPU topology and identifier queries) on every poll — about 5 ms — versus ~4 µs to read from a held instance, a ~1000× difference, while the retained object graph is only ~10 KB (recreating also churns ~130 KB/poll of allocation instead of ~2 KB). Reusing is almost pure win: negligible retained memory for a large CPU saving.
-- **Process list:** `getProcesses()` is a live full query, so reusing `SystemInfo` saves nothing (~29 ms either way) and the ~490 KB result — plus ~20 MB of transient parsing garbage — is allocated on every poll regardless. To monitor specific processes, hold the individual `OSProcess` objects and call `updateAttributes()` rather than re-querying the whole list (see below).
+Reconstructing costs milliseconds per poll (most on Windows, where CPU identity comes from WMI/registry) for a few KB of retained memory saved — a strongly favorable trade for CPU-derived metrics. Two caveats:
+
+- **Available memory does not benefit:** recreate ≈ reuse on all platforms (`GlobalMemory` is cheap to construct), so the win is specific to the `CentralProcessor`.
+- **The process list does not benefit:** `getProcesses()` is a live full query (~10 ms and 1–15 MB allocated per poll on every platform, reused or not). To track specific processes, hold the individual `OSProcess` objects and call `updateAttributes()` rather than re-querying the whole list (see below).
+
+Holding a `SystemInfo` and one snapshot of *every* subsystem it returns (measured by `MonitoringFootprintReport`) retains roughly **0.65 MB**, dominated by the process-list snapshot; the persistent hardware/OS caches alone are under ~150 KB. Applications with tight memory constraints can release even that by discarding the `SystemInfo` between collections, paying the reconstruction cost above.
 
 ## Updating statistics on objects in a list
 

--- a/oshi-benchmark/README.md
+++ b/oshi-benchmark/README.md
@@ -33,6 +33,15 @@ Pass a regex matching the benchmark class or method name:
 | `FileStoreBenchmark` | `getFileStores()` — filesystem enumeration and stats |
 | `NetworkIFBenchmark` | `getNetworkIFs()` — network interface enumeration |
 | `ProcessesBenchmark` | `getProcesses()` — process list retrieval |
+| `ReuseVsRecreateBenchmark` | Reusing a held `SystemInfo` vs. constructing a new one for every poll (CPU ticks, memory, process list). Unlike the others, this measures the reuse-vs-recreate trade-off, not JNA vs. FFM; pair it with `-prof gc` for per-poll allocation. |
+
+The non-JMH `MonitoringFootprintReport` reports the retained memory of the held object graph (the memory dimension of `ReuseVsRecreateBenchmark`, which JMH cannot measure per-operation):
+
+```sh
+java -cp oshi-benchmark/target/benchmarks.jar oshi.benchmark.MonitoringFootprintReport
+```
+
+Both feed the "CPU/memory trade-offs" section of [`PERFORMANCE.md`](../PERFORMANCE.md).
 
 ## Custom JMH Options
 

--- a/oshi-benchmark/src/main/java/oshi/benchmark/MonitoringFootprintReport.java
+++ b/oshi-benchmark/src/main/java/oshi/benchmark/MonitoringFootprintReport.java
@@ -71,6 +71,7 @@ public final class MonitoringFootprintReport {
     // Retained bytes of `copies` poll results held from a single reused SystemInfo
     private static double resultKb(Function<SystemInfo, Object> read) {
         SystemInfo si = new SystemInfo();
+        read.apply(si); // realize the subsystem graph so only per-result allocations are measured below
         Object[] hold = new Object[RESULT_COPIES];
         long before = usedBytes();
         for (int i = 0; i < RESULT_COPIES; i++) {
@@ -124,7 +125,8 @@ public final class MonitoringFootprintReport {
     // Retained bytes when holding a SystemInfo and one snapshot of every subsystem it exposes (upper bound of "cache
     // everything"); dominated by the process-list snapshot.
     private static double cacheEverythingKb() {
-        List<Object> hold = new ArrayList<>();
+        // 18 snapshots held per iteration; pre-size so the backing array is in the baseline, not the measured delta
+        List<Object> hold = new ArrayList<>(GRAPH_COPIES * 18);
         long before = usedBytes();
         for (int i = 0; i < GRAPH_COPIES; i++) {
             SystemInfo si = new SystemInfo();

--- a/oshi-benchmark/src/main/java/oshi/benchmark/MonitoringFootprintReport.java
+++ b/oshi-benchmark/src/main/java/oshi/benchmark/MonitoringFootprintReport.java
@@ -4,10 +4,14 @@
  */
 package oshi.benchmark;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import oshi.SystemInfo;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.software.os.OperatingSystem;
 import oshi.util.GlobalConfig;
 
 /**
@@ -111,5 +115,44 @@ public final class MonitoringFootprintReport {
             double result = resultKb(m.read());
             System.out.printf("%-14s %22.1f %18.1f%n", m.name(), graph, result);
         }
+
+        double all = cacheEverythingKb();
+        System.out.printf("%nHolding everything a SystemInfo returns (all subsystems + one snapshot each): %.0f KB%n",
+                all);
+    }
+
+    // Retained bytes when holding a SystemInfo and one snapshot of every subsystem it exposes (upper bound of "cache
+    // everything"); dominated by the process-list snapshot.
+    private static double cacheEverythingKb() {
+        List<Object> hold = new ArrayList<>();
+        long before = usedBytes();
+        for (int i = 0; i < GRAPH_COPIES; i++) {
+            SystemInfo si = new SystemInfo();
+            HardwareAbstractionLayer hw = si.getHardware();
+            OperatingSystem os = si.getOperatingSystem();
+            hold.add(si);
+            hold.add(hw.getComputerSystem());
+            hold.add(hw.getProcessor().getSystemCpuLoadTicks());
+            hold.add(hw.getMemory());
+            hold.add(hw.getSensors());
+            hold.add(hw.getPowerSources());
+            hold.add(hw.getDisplays());
+            hold.add(hw.getDiskStores());
+            hold.add(hw.getUsbDevices(true));
+            hold.add(hw.getSoundCards());
+            hold.add(hw.getGraphicsCards());
+            hold.add(hw.getNetworkIFs());
+            hold.add(os.getFileSystem().getFileStores());
+            hold.add(os.getNetworkParams());
+            hold.add(os.getInternetProtocolStats());
+            hold.add(os.getServices());
+            hold.add(os.getSessions());
+            hold.add(os.getProcesses());
+        }
+        long after = usedBytes();
+        if (hold.isEmpty()) {
+            throw new IllegalStateException();
+        }
+        return (after - before) / 1024.0 / GRAPH_COPIES;
     }
 }

--- a/oshi-benchmark/src/main/java/oshi/benchmark/MonitoringFootprintReport.java
+++ b/oshi-benchmark/src/main/java/oshi/benchmark/MonitoringFootprintReport.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.benchmark;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import oshi.SystemInfo;
+import oshi.util.GlobalConfig;
+
+/**
+ * Reports the memory dimension of the reuse-vs-recreate trade-off (see {@link ReuseVsRecreateBenchmark} for the CPU
+ * dimension): for each metric a monitoring agent polls, the retained size of the held object graph (what a reused
+ * {@link SystemInfo} keeps alive and does not release to GC) and the size of one poll's result.
+ *
+ * <p>
+ * This is a rough heap-differencing measurement (hold N copies, force GC, divide), not a precise object-graph walk, but
+ * it is stable enough to show the order-of-magnitude contrast documented in {@code PERFORMANCE.md}. It is a plain
+ * {@code main} rather than a JMH benchmark because retained footprint is not a per-operation quantity.
+ *
+ * <pre>
+ *   java -cp oshi-benchmark/target/benchmarks.jar oshi.benchmark.MonitoringFootprintReport
+ * </pre>
+ */
+public final class MonitoringFootprintReport {
+
+    private static final int WARMUP = 20;
+    private static final int GRAPH_COPIES = 50;
+    private static final int RESULT_COPIES = 20;
+
+    private MonitoringFootprintReport() {
+    }
+
+    private static long usedBytes() {
+        Runtime r = Runtime.getRuntime();
+        long used = Long.MAX_VALUE;
+        // Settle: GC repeatedly until the used-memory reading stops shrinking
+        for (int i = 0; i < 8; i++) {
+            System.gc();
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            used = Math.min(used, r.totalMemory() - r.freeMemory());
+        }
+        return used;
+    }
+
+    // Retained bytes of `copies` reused SystemInfo instances, each with the monitored subsystem realized
+    private static double retainedGraphKb(Consumer<SystemInfo> realize) {
+        SystemInfo[] hold = new SystemInfo[GRAPH_COPIES];
+        long before = usedBytes();
+        for (int i = 0; i < GRAPH_COPIES; i++) {
+            hold[i] = new SystemInfo();
+            realize.accept(hold[i]);
+        }
+        long after = usedBytes();
+        if (hold[GRAPH_COPIES - 1] == null) {
+            throw new IllegalStateException();
+        }
+        return (after - before) / 1024.0 / GRAPH_COPIES;
+    }
+
+    // Retained bytes of `copies` poll results held from a single reused SystemInfo
+    private static double resultKb(Function<SystemInfo, Object> read) {
+        SystemInfo si = new SystemInfo();
+        Object[] hold = new Object[RESULT_COPIES];
+        long before = usedBytes();
+        for (int i = 0; i < RESULT_COPIES; i++) {
+            hold[i] = read.apply(si);
+        }
+        long after = usedBytes();
+        if (hold[RESULT_COPIES - 1] == null) {
+            throw new IllegalStateException();
+        }
+        return (after - before) / 1024.0 / RESULT_COPIES;
+    }
+
+    /**
+     * Prints the footprint table.
+     *
+     * @param args unused
+     */
+    public static void main(String[] args) {
+        // Match the benchmark: realistic polling always misses the sub-second memoizer TTL.
+        GlobalConfig.set(GlobalConfig.OSHI_UTIL_MEMOIZER_EXPIRATION, 0);
+
+        record Metric(String name, Function<SystemInfo, Object> read) {
+            Consumer<SystemInfo> realize() {
+                return read::apply;
+            }
+        }
+        Metric[] metrics = { new Metric("cpuTicks", si -> si.getHardware().getProcessor().getSystemCpuLoadTicks()),
+                new Metric("memAvailable", si -> si.getHardware().getMemory().getAvailable()),
+                new Metric("processes", si -> si.getOperatingSystem().getProcesses()) };
+
+        // Warm up class loading, native libraries, and JIT before measuring (see PERFORMANCE.md cold-start note)
+        for (int i = 0; i < WARMUP; i++) {
+            for (Metric m : metrics) {
+                m.read().apply(new SystemInfo());
+            }
+        }
+
+        System.out.printf("%-14s %22s %18s%n", "metric", "retained held-graph(KB)", "poll result(KB)");
+        System.out.printf("%-14s %22s %18s%n", "------", "----------------------", "---------------");
+        for (Metric m : metrics) {
+            double graph = retainedGraphKb(m.realize());
+            double result = resultKb(m.read());
+            System.out.printf("%-14s %22.1f %18.1f%n", m.name(), graph, result);
+        }
+    }
+}

--- a/oshi-benchmark/src/main/java/oshi/benchmark/ReuseVsRecreateBenchmark.java
+++ b/oshi-benchmark/src/main/java/oshi/benchmark/ReuseVsRecreateBenchmark.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.benchmark;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import oshi.SystemInfo;
+import oshi.util.GlobalConfig;
+
+/**
+ * Measures the CPU cost of reusing a {@link SystemInfo} (holding the constructed object graph) versus creating a new
+ * one for every poll, for the metrics a monitoring agent samples repeatedly (CPU ticks, available memory, process
+ * list).
+ *
+ * <p>
+ * The memoizer is <strong>disabled</strong> ({@code oshi.util.memoizer.expiration = 0}) in {@link #setup()} because
+ * real monitoring polls (e.g. once per second) always fall outside the memoizer's sub-second TTL — so every poll is a
+ * cache miss, and the honest question is the cost of <em>reconstructing the objects</em>, not of a cache hit.
+ *
+ * <p>
+ * Pair this with {@code -prof gc} (allocation per poll) and {@link MonitoringFootprintReport} (retained memory of the
+ * held object graph) for the full CPU-vs-memory picture documented in {@code PERFORMANCE.md}.
+ *
+ * <pre>
+ *   java -jar oshi-benchmark/target/benchmarks.jar ReuseVsRecreateBenchmark -prof gc
+ * </pre>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(value = 1, jvmArgsPrepend = "--enable-native-access=ALL-UNNAMED")
+public class ReuseVsRecreateBenchmark {
+
+    /** The monitored metric to sample. */
+    @Param({ "cpuTicks", "memAvailable", "processes" })
+    public String metric;
+
+    private SystemInfo reused;
+
+    /** Creates a new benchmark instance. Required by JMH for {@code @State} classes. */
+    public ReuseVsRecreateBenchmark() {
+    }
+
+    /**
+     * Disables memoization (so each poll is a real query, as it would be at realistic poll intervals) and builds the
+     * reusable {@link SystemInfo}, realizing the subsystem under test.
+     */
+    @Setup
+    public void setup() {
+        GlobalConfig.set(GlobalConfig.OSHI_UTIL_MEMOIZER_EXPIRATION, 0);
+        reused = new SystemInfo();
+        read(reused);
+    }
+
+    private Object read(SystemInfo si) {
+        switch (metric) {
+            case "cpuTicks":
+                return si.getHardware().getProcessor().getSystemCpuLoadTicks();
+            case "memAvailable":
+                return si.getHardware().getMemory().getAvailable();
+            case "processes":
+                return si.getOperatingSystem().getProcesses();
+            default:
+                throw new IllegalArgumentException("Unknown metric: " + metric);
+        }
+    }
+
+    /**
+     * Polls the metric from a reused {@link SystemInfo}, so the constructed object graph is not rebuilt.
+     *
+     * @return the metric result
+     */
+    @Benchmark
+    public Object reuse() {
+        return read(reused);
+    }
+
+    /**
+     * Polls the metric from a freshly constructed {@link SystemInfo}, rebuilding the object graph on every poll.
+     *
+     * @return the metric result
+     */
+    @Benchmark
+    public Object recreate() {
+        return read(new SystemInfo());
+    }
+
+    /**
+     * Standalone entry point.
+     *
+     * @param args unused
+     * @throws RunnerException if the benchmark fails to run
+     */
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(ReuseVsRecreateBenchmark.class.getSimpleName()).build();
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
## Summary

Expands the "CPU/memory trade-offs" section of `PERFORMANCE.md` with measured numbers for the choice a monitoring agent faces: **hold one `SystemInfo` and poll it, or construct a new one each poll.** At realistic poll intervals every call falls outside the sub-second memoizer TTL, so the real trade-off is the CPU to reconstruct the object graph versus the memory retained by holding it.

The docs are the point of this PR; the benchmark additions are how the numbers are generated (and re-generated).

### Findings (measured on the manual benchmarks workflow, 3 forks)

Reading CPU load ticks once per poll:

| Platform | Recreate per poll | Reuse (held) per poll | Retained if held |
|----------|------------------:|----------------------:|-----------------:|
| Windows  | 10.7 ms | 632 µs  | 3.9 KB |
| macOS    | 3.8 ms  | 2.4 µs  | 8.5 KB |
| Linux    | 2.4 ms  | 19.5 µs | 5.0 KB |

- The dominant reconstruction cost is the `CentralProcessor` (CPU topology + identifier queries — priciest on Windows via WMI/registry). Reuse trades a few KB retained for milliseconds saved per poll.
- **Available memory** does not benefit (recreate ≈ reuse; `GlobalMemory` is cheap to build).
- **The process list** does not benefit — `getProcesses()` is a live full query (~10 ms and 1–15 MB allocated per poll regardless of reuse).
- Holding a `SystemInfo` plus one snapshot of every subsystem retains ~0.65 MB (dominated by the process list); the persistent caches alone are under ~150 KB.

### Changes

- **`ReuseVsRecreateBenchmark`** (JMH): `reuse()` vs `recreate()` over `@Param{cpuTicks, memAvailable, processes}`, with memoization disabled in `@Setup` so every poll is a real query (not a cache hit). Pair with `-prof gc` for per-poll allocation.
- **`MonitoringFootprintReport`** (plain `main`): retained memory of the held object graph and the cache-everything bound — the memory dimension JMH cannot measure per-operation.
- **`benchmarks.yaml`**: native runners (Linux/macOS/Windows) now run longer settings (`-wi 5 -i 10 -f 3 -prof gc`, ~30 min) plus the footprint report; the noisier VM jobs keep their quick settings.
- `PERFORMANCE.md` and `oshi-benchmark/README.md` updated.

## Testing

`./mvnw clean install` (full reactor); spotless, checkstyle, forbiddenapis, javadoc pass. The manual `benchmarks.yaml` workflow was run on a fork across all platforms (Linux/macOS/Windows/FreeBSD/OpenBSD/OpenIndiana/AIX) to capture the numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JMH benchmarks comparing reuse vs recreation of monitoring components.
  * Added a standalone monitoring footprint reporting utility to quantify polling-related heap retention.

* **Documentation**
  * Added guidance on reusing vs recreating `SystemInfo` during repeated polling, including scenario-specific caveats.
  * Updated benchmark listings and documented the new footprint reporting output.

* **Bug Fixes / Improvements**
  * Updated the upcoming release notes entry to reflect the added benchmark improvements.

* **CI / Benchmarks**
  * Expanded benchmark runs with longer JMH settings and added garbage-collection profiling plus footprint reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->