### PR TITLE
FreeBSD: quiet dmesg.boot read and extract testable command parsers

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -20,6 +20,7 @@ import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 import oshi.util.tuples.Quartet;
 
 /**
@@ -151,26 +152,83 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
 
     @Override
     protected ProcessorIdentifier queryProcessorId() {
+        // Parsing dmesg.boot is apparently the only reliable source for processor identification in FreeBSD. Read
+        // quietly (reportError=false): its absence is tolerated (we fall back to sysctl), and warning on every
+        // CentralProcessor construction would spam callers that recreate one.
+        DmesgProcessorId id = parseProcessorIdFromDmesg(FileUtil.readFile("/var/run/dmesg.boot", false),
+                sysctlString("hw.model", ""));
+        long cpuFreq = sysctlLong("hw.clockrate", 0L) * 1_000_000L;
+        boolean cpu64bit = ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
+        String processorID = getProcessorIDfromDmiDecode(id.processorIdBits());
+        return new ProcessorIdentifier(id.vendor(), id.name(), id.family(), id.model(), id.stepping(), processorID,
+                cpu64bit, cpuFreq);
+    }
+
+    /** Immutable holder for the identifier fields parsed from {@code dmesg.boot}. Package-private for testing. */
+    static final class DmesgProcessorId {
+        private final String vendor;
+        private final String name;
+        private final String family;
+        private final String model;
+        private final String stepping;
+        private final long processorIdBits;
+
+        DmesgProcessorId(String vendor, String name, String family, String model, String stepping,
+                long processorIdBits) {
+            this.vendor = vendor;
+            this.name = name;
+            this.family = family;
+            this.model = model;
+            this.stepping = stepping;
+            this.processorIdBits = processorIdBits;
+        }
+
+        String vendor() {
+            return vendor;
+        }
+
+        String name() {
+            return name;
+        }
+
+        String family() {
+            return family;
+        }
+
+        String model() {
+            return model;
+        }
+
+        String stepping() {
+            return stepping;
+        }
+
+        long processorIdBits() {
+            return processorIdBits;
+        }
+    }
+
+    /**
+     * Parses the processor identifier fields from {@code dmesg.boot}. Uses {@code initialName} (from
+     * {@code sysctl hw.model}) unless the file supplies a {@code CPU:} line and the initial name is empty.
+     * Package-private for testing.
+     *
+     * @param dmesg       the lines of {@code dmesg.boot}
+     * @param initialName the CPU name from {@code sysctl hw.model}
+     * @return the parsed identifier fields
+     */
+    static DmesgProcessorId parseProcessorIdFromDmesg(List<String> dmesg, String initialName) {
         final Pattern identifierPattern = Pattern
                 .compile("Origin=\"([^\"]*)\".*Id=(\\S+).*Family=(\\S+).*Model=(\\S+).*Stepping=(\\S+).*");
         final Pattern featuresPattern = Pattern.compile("Features=(\\S+)<.*");
 
         String cpuVendor = "";
-        String cpuName = sysctlString("hw.model", "");
+        String cpuName = initialName;
         String cpuFamily = "";
         String cpuModel = "";
         String cpuStepping = "";
-        String processorID;
-        long cpuFreq = sysctlLong("hw.clockrate", 0L) * 1_000_000L;
-
-        boolean cpu64bit;
-
-        // Parsing dmesg.boot is apparently the only reliable source for processor
-        // identification in FreeBSD. Read quietly (reportError=false): its absence is tolerated (we fall back to
-        // sysctl below), and warning on every CentralProcessor construction would spam callers that recreate one.
         long processorIdBits = 0L;
-        List<String> cpuInfo = FileUtil.readFile("/var/run/dmesg.boot", false);
-        for (String line : cpuInfo) {
+        for (String line : dmesg) {
             line = line.trim();
             // Prefer hw.model to this one
             if (line.startsWith("CPU:") && cpuName.isEmpty()) {
@@ -193,11 +251,7 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
                 break;
             }
         }
-        cpu64bit = ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
-        processorID = getProcessorIDfromDmiDecode(processorIdBits);
-
-        return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,
-                cpuFreq);
+        return new DmesgProcessorId(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorIdBits);
     }
 
     @Override
@@ -207,25 +261,42 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
         if (logProcs.isEmpty()) {
             logProcs.add(new LogicalProcessor(0, 0, 0));
         }
-        Map<Integer, String> dmesg = new HashMap<>();
+        Pair<Map<Integer, String>, List<String>> modelsAndFlags = parseProcModelsAndFlags(
+                FileUtil.readFile("/var/run/dmesg.boot", false));
+        Map<Integer, String> dmesg = modelsAndFlags.getA();
+        List<String> featureFlags = modelsAndFlags.getB();
+        List<PhysicalProcessor> physProcs = dmesg.isEmpty() ? null : createProcListFromDmesg(logProcs, dmesg);
+        List<ProcessorCache> caches = getCacheInfoFromLscpu();
+        return new Quartet<>(logProcs, physProcs, caches, featureFlags);
+    }
+
+    /**
+     * Parses the per-core processor model strings and feature flags from {@code dmesg.boot}. Package-private for
+     * testing.
+     *
+     * @param dmesg the lines of {@code dmesg.boot}
+     * @return a pair of (core id to model-string map, feature-flag lines)
+     */
+    static Pair<Map<Integer, String>, List<String>> parseProcModelsAndFlags(List<String> dmesg) {
+        Map<Integer, String> models = new HashMap<>();
         // cpu0: <Open Firmware CPU> on cpulist0
         Pattern normal = Pattern.compile("cpu(\\d+): (.+) on .*");
         // CPU 0: ARM Cortex-A53 r0p4 affinity: 0 0
         Pattern hybrid = Pattern.compile("CPU\\s*(\\d+): (.+) affinity:.*");
         List<String> featureFlags = new ArrayList<>();
         boolean readingFlags = false;
-        for (String s : FileUtil.readFile("/var/run/dmesg.boot", false)) {
+        for (String s : dmesg) {
             Matcher h = hybrid.matcher(s);
             if (h.matches()) {
                 int coreId = ParseUtil.parseIntOrDefault(h.group(1), 0);
                 // This always takes priority, overwrite if needed
-                dmesg.put(coreId, h.group(2).trim());
+                models.put(coreId, h.group(2).trim());
             } else {
                 Matcher n = normal.matcher(s);
                 if (n.matches()) {
                     int coreId = ParseUtil.parseIntOrDefault(n.group(1), 0);
                     // Don't overwrite if h matched earlier
-                    dmesg.putIfAbsent(coreId, n.group(2).trim());
+                    models.putIfAbsent(coreId, n.group(2).trim());
                 }
             }
             if (s.contains("Origin=")) {
@@ -238,14 +309,22 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
                 }
             }
         }
-        List<PhysicalProcessor> physProcs = dmesg.isEmpty() ? null : createProcListFromDmesg(logProcs, dmesg);
-        List<ProcessorCache> caches = getCacheInfoFromLscpu();
-        return new Quartet<>(logProcs, physProcs, caches, featureFlags);
+        return new Pair<>(models, featureFlags);
     }
 
     private List<ProcessorCache> getCacheInfoFromLscpu() {
+        return parseCachesFromLscpu(ExecutingCommand.runNative("lscpu"));
+    }
+
+    /**
+     * Parses the CPU cache descriptions from {@code lscpu} output. Package-private for testing.
+     *
+     * @param lscpu the lines of {@code lscpu} output
+     * @return the ordered list of processor caches
+     */
+    static List<ProcessorCache> parseCachesFromLscpu(List<String> lscpu) {
         Set<ProcessorCache> caches = new HashSet<>();
-        for (String checkLine : ExecutingCommand.runNative("lscpu")) {
+        for (String checkLine : lscpu) {
             if (checkLine.contains("L1d cache:")) {
                 caches.add(new ProcessorCache(1, 0, 0,
                         ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.DATA));

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -166,9 +166,10 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
         boolean cpu64bit;
 
         // Parsing dmesg.boot is apparently the only reliable source for processor
-        // identification in FreeBSD
+        // identification in FreeBSD. Read quietly (reportError=false): its absence is tolerated (we fall back to
+        // sysctl below), and warning on every CentralProcessor construction would spam callers that recreate one.
         long processorIdBits = 0L;
-        List<String> cpuInfo = FileUtil.readFile("/var/run/dmesg.boot");
+        List<String> cpuInfo = FileUtil.readFile("/var/run/dmesg.boot", false);
         for (String line : cpuInfo) {
             line = line.trim();
             // Prefer hw.model to this one
@@ -213,7 +214,7 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
         Pattern hybrid = Pattern.compile("CPU\\s*(\\d+): (.+) affinity:.*");
         List<String> featureFlags = new ArrayList<>();
         boolean readingFlags = false;
-        for (String s : FileUtil.readFile("/var/run/dmesg.boot")) {
+        for (String s : FileUtil.readFile("/var/run/dmesg.boot", false)) {
             Matcher h = hybrid.matcher(s);
             if (h.matches()) {
                 int coreId = ParseUtil.parseIntOrDefault(h.group(1), 0);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystem.java
@@ -6,6 +6,7 @@ package oshi.hardware.common.platform.unix.freebsd;
 
 import static oshi.util.Memoizer.memoize;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.Immutable;
@@ -65,6 +66,35 @@ public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
     protected abstract String queryHostUuid();
 
     private Quintet<String, String, String, String, String> readDmiDecode() {
+        // Only works with root permissions but it's all we've got
+        Quintet<String, String, String, String, String> dmi = parseDmiDecode(
+                ExecutingCommand.runNative("dmidecode -t system"));
+        String manufacturer = dmi.getA();
+        String model = dmi.getB();
+        String serialNumber = dmi.getC();
+        String uuid = dmi.getD();
+        String version = dmi.getE();
+        // If we get to end and haven't assigned, use fallback
+        if (Util.isBlank(serialNumber)) {
+            serialNumber = querySystemSerialNumber();
+        }
+        if (Util.isBlank(uuid)) {
+            uuid = queryHostUuid();
+        }
+        return new Quintet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
+                Util.isBlank(model) ? Constants.UNKNOWN : model,
+                Util.isBlank(serialNumber) ? Constants.UNKNOWN : serialNumber,
+                Util.isBlank(uuid) ? Constants.UNKNOWN : uuid, Util.isBlank(version) ? Constants.UNKNOWN : version);
+    }
+
+    /**
+     * Parses the output of {@code dmidecode -t system} into its manufacturer, model, serial number, UUID, and version
+     * fields. Any field not present in the output is returned as {@code null}; the caller applies fallbacks.
+     *
+     * @param dmidecode the lines emitted by {@code dmidecode -t system}
+     * @return a {@link Quintet} of manufacturer, model, serial number, UUID, and version
+     */
+    static Quintet<String, String, String, String, String> parseDmiDecode(List<String> dmidecode) {
         String manufacturer = null;
         String model = null;
         String serialNumber = null;
@@ -77,8 +107,7 @@ public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
         final String uuidMarker = "UUID:";
         final String versionMarker = "Version:";
 
-        // Only works with root permissions but it's all we've got
-        for (final String checkLine : ExecutingCommand.runNative("dmidecode -t system")) {
+        for (final String checkLine : dmidecode) {
             if (checkLine.contains(manufacturerMarker)) {
                 manufacturer = checkLine.split(manufacturerMarker)[1].trim();
             } else if (checkLine.contains(productNameMarker)) {
@@ -91,17 +120,7 @@ public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
                 version = checkLine.split(versionMarker)[1].trim();
             }
         }
-        // If we get to end and haven't assigned, use fallback
-        if (Util.isBlank(serialNumber)) {
-            serialNumber = querySystemSerialNumber();
-        }
-        if (Util.isBlank(uuid)) {
-            uuid = queryHostUuid();
-        }
-        return new Quintet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
-                Util.isBlank(model) ? Constants.UNKNOWN : model,
-                Util.isBlank(serialNumber) ? Constants.UNKNOWN : serialNumber,
-                Util.isBlank(uuid) ? Constants.UNKNOWN : uuid, Util.isBlank(version) ? Constants.UNKNOWN : version);
+        return new Quintet<>(manufacturer, model, serialNumber, uuid, version);
     }
 
     private static String querySystemSerialNumber() {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmware.java
@@ -6,6 +6,7 @@ package oshi.hardware.common.platform.unix.freebsd;
 
 import static oshi.util.Memoizer.memoize;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.Immutable;
@@ -44,6 +45,17 @@ public class FreeBsdFirmware extends AbstractFirmware {
      */
 
     private static Triplet<String, String, String> readDmiDecode() {
+        // Only works with root permissions but it's all we've got
+        return parseDmiDecode(ExecutingCommand.runNative("dmidecode -t bios"));
+    }
+
+    /**
+     * Parses the output of {@code dmidecode -t bios} into its manufacturer, version, and release date fields.
+     *
+     * @param dmidecode the lines emitted by {@code dmidecode -t bios}
+     * @return a {@link Triplet} of manufacturer, version, and release date (each {@link Constants#UNKNOWN} if absent)
+     */
+    static Triplet<String, String, String> parseDmiDecode(List<String> dmidecode) {
         String manufacturer = null;
         String version = null;
         String releaseDate = "";
@@ -66,8 +78,7 @@ public class FreeBsdFirmware extends AbstractFirmware {
         final String versionMarker = "Version:";
         final String releaseDateMarker = "Release Date:";
 
-        // Only works with root permissions but it's all we've got
-        for (final String checkLine : ExecutingCommand.runNative("dmidecode -t bios")) {
+        for (final String checkLine : dmidecode) {
             if (checkLine.contains(manufacturerMarker)) {
                 manufacturer = checkLine.split(manufacturerMarker)[1].trim();
             } else if (checkLine.contains(versionMarker)) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmware.java
@@ -46,14 +46,21 @@ public class FreeBsdFirmware extends AbstractFirmware {
 
     private static Triplet<String, String, String> readDmiDecode() {
         // Only works with root permissions but it's all we've got
-        return parseDmiDecode(ExecutingCommand.runNative("dmidecode -t bios"));
+        Triplet<String, String, String> dmi = parseDmiDecode(ExecutingCommand.runNative("dmidecode -t bios"));
+        String manufacturer = dmi.getA();
+        String version = dmi.getB();
+        String releaseDate = dmi.getC();
+        return new Triplet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
+                Util.isBlank(version) ? Constants.UNKNOWN : version,
+                Util.isBlank(releaseDate) ? Constants.UNKNOWN : releaseDate);
     }
 
     /**
-     * Parses the output of {@code dmidecode -t bios} into its manufacturer, version, and release date fields.
+     * Parses the output of {@code dmidecode -t bios} into its manufacturer, version, and release date fields. Any field
+     * not present in the output is returned as {@code null} (or an empty date); the caller applies fallbacks.
      *
      * @param dmidecode the lines emitted by {@code dmidecode -t bios}
-     * @return a {@link Triplet} of manufacturer, version, and release date (each {@link Constants#UNKNOWN} if absent)
+     * @return a {@link Triplet} of manufacturer, version, and release date
      */
     static Triplet<String, String, String> parseDmiDecode(List<String> dmidecode) {
         String manufacturer = null;
@@ -88,8 +95,6 @@ public class FreeBsdFirmware extends AbstractFirmware {
             }
         }
         releaseDate = ParseUtil.parseMmDdYyyyToYyyyMmDD(releaseDate);
-        return new Triplet<>(Util.isBlank(manufacturer) ? Constants.UNKNOWN : manufacturer,
-                Util.isBlank(version) ? Constants.UNKNOWN : version,
-                Util.isBlank(releaseDate) ? Constants.UNKNOWN : releaseDate);
+        return new Triplet<>(manufacturer, version, releaseDate);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdSoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdSoundCard.java
@@ -43,13 +43,21 @@ public class FreeBsdSoundCard extends AbstractSoundCard {
      * @return a {@link java.util.List} object.
      */
     public static List<SoundCard> getSoundCards() {
+        return parseSoundCards(ExecutingCommand.runNative(LSHAL));
+    }
+
+    /**
+     * Parses {@code lshal} output into the list of sound cards (nodes driven by {@code pcm}).
+     *
+     * @param lshal the lines emitted by {@code lshal}
+     * @return a {@link java.util.List} of {@link SoundCard} objects.
+     */
+    static List<SoundCard> parseSoundCards(List<String> lshal) {
         Map<String, String> vendorMap = new HashMap<>();
         Map<String, String> productMap = new HashMap<>();
-        vendorMap.clear();
-        productMap.clear();
         List<String> sounds = new ArrayList<>();
         String key = "";
-        for (String line : ExecutingCommand.runNative(LSHAL)) {
+        for (String line : lshal) {
             line = line.trim();
             if (line.startsWith("udi =")) {
                 // we have the key.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdUsbDevice.java
@@ -36,6 +36,16 @@ public class FreeBsdUsbDevice extends AbstractUsbDevice {
      * @return a list of USB controllers, each with its connected-device tree.
      */
     public static List<UsbDevice> getUsbDevices() {
+        return parseUsbDevices(ExecutingCommand.runNative("lshal"));
+    }
+
+    /**
+     * Parses {@code lshal} output into the USB controller device tree.
+     *
+     * @param devices the lines emitted by {@code lshal}
+     * @return a list of USB controllers, each with its connected-device tree.
+     */
+    static List<UsbDevice> parseUsbDevices(List<String> devices) {
         // Maps to store information using node # as the key
         Map<String, String> nameMap = new HashMap<>();
         Map<String, String> vendorMap = new HashMap<>();
@@ -49,7 +59,6 @@ public class FreeBsdUsbDevice extends AbstractUsbDevice {
         // entire device tree; we will identify the controllers as the parents
         // of the usbus entries and eventually only populate the returned
         // results with those
-        List<String> devices = ExecutingCommand.runNative("lshal");
         if (devices.isEmpty()) {
             return emptyList();
         }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.freebsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.CentralProcessor.ProcessorCache;
+import oshi.hardware.common.platform.unix.freebsd.FreeBsdCentralProcessor.DmesgProcessorId;
+import oshi.util.tuples.Pair;
+
+class FreeBsdCentralProcessorTest {
+
+    // Representative dmesg.boot header (indented Origin/Features lines, as FreeBSD writes them)
+    private static final List<String> DMESG_ID = Arrays.asList(
+            "CPU: Intel(R) Xeon(R) CPU E5-2683 v3 @ 2.00GHz (2000.05-MHz K8-class CPU)",
+            "  Origin=\"GenuineIntel\"  Id=0x306f2  Family=0x6  Model=0x3f  Stepping=2",
+            "  Features=0xbfebfbff<FPU,VME,DE,PSE,TSC,MSR,PAE,MCE,CX8,APIC>",
+            "  Features2=0x7ffefbff<SSE3,PCLMULQDQ,DTES64>");
+
+    @Test
+    void testParseProcessorIdFromDmesg() {
+        DmesgProcessorId id = FreeBsdCentralProcessor.parseProcessorIdFromDmesg(DMESG_ID, "");
+        assertThat(id.vendor(), is("GenuineIntel"));
+        assertThat(id.name(), is("Intel(R) Xeon(R) CPU E5-2683 v3 @ 2.00GHz (2000.05-MHz K8-class CPU)"));
+        assertThat(id.family(), is("6"));
+        assertThat(id.model(), is("63"));
+        assertThat(id.stepping(), is("2"));
+        // low 32 bits from Id, high 32 bits from the first Features field
+        assertThat(id.processorIdBits(), is(0xbfebfbff000306f2L));
+    }
+
+    @Test
+    void testParseProcessorIdFromDmesgPrefersSysctlName() {
+        // A non-empty initial name (from sysctl hw.model) is kept over the CPU: line
+        DmesgProcessorId id = FreeBsdCentralProcessor.parseProcessorIdFromDmesg(DMESG_ID, "Preset Model");
+        assertThat(id.name(), is("Preset Model"));
+        assertThat(id.vendor(), is("GenuineIntel"));
+    }
+
+    @Test
+    void testParseProcessorIdFromDmesgEmpty() {
+        DmesgProcessorId id = FreeBsdCentralProcessor.parseProcessorIdFromDmesg(Collections.emptyList(), "");
+        assertThat(id.vendor(), is(""));
+        assertThat(id.name(), is(""));
+        assertThat(id.processorIdBits(), is(0L));
+    }
+
+    @Test
+    void testParseProcModelsAndFlags() {
+        List<String> dmesg = Arrays.asList("cpu0: <ACPI CPU> on acpi0", "cpu1: <ACPI CPU> on acpi0",
+                "  Origin=\"GenuineIntel\"  Id=0x306f2", "  Features=0xbfebfbff<FPU,VME>",
+                "  Features2=0x7ffefbff<SSE3>", "real memory  = 8589934592");
+        Pair<Map<Integer, String>, List<String>> r = FreeBsdCentralProcessor.parseProcModelsAndFlags(dmesg);
+        assertThat(r.getA().get(0), is("<ACPI CPU>"));
+        assertThat(r.getA().get(1), is("<ACPI CPU>"));
+        assertThat(r.getB(), contains("Features=0xbfebfbff<FPU,VME>", "Features2=0x7ffefbff<SSE3>"));
+    }
+
+    @Test
+    void testParseProcModelsAndFlagsArmHybrid() {
+        List<String> dmesg = Arrays.asList("CPU 0: ARM Cortex-A53 r0p4 affinity: 0 0",
+                "CPU 1: ARM Cortex-A72 r0p3 affinity: 0 1");
+        Pair<Map<Integer, String>, List<String>> r = FreeBsdCentralProcessor.parseProcModelsAndFlags(dmesg);
+        assertThat(r.getA().get(0), is("ARM Cortex-A53 r0p4"));
+        assertThat(r.getA().get(1), is("ARM Cortex-A72 r0p3"));
+        assertThat(r.getB(), is(empty()));
+    }
+
+    @Test
+    void testParseCachesFromLscpu() {
+        List<String> lscpu = Arrays.asList("L1d cache:                       32K",
+                "L1i cache:                       32K", "L2 cache:                        256K",
+                "L3 cache:                        8M");
+        List<ProcessorCache> caches = FreeBsdCentralProcessor.parseCachesFromLscpu(lscpu);
+        assertThat(caches, hasSize(4));
+        assertThat(caches.stream().anyMatch(c -> c.getLevel() == 3), is(true));
+        assertThat(caches.stream().anyMatch(c -> c.getLevel() == 1 && c.getType() == ProcessorCache.Type.DATA),
+                is(true));
+    }
+
+    @Test
+    void testParseCachesFromLscpuEmpty() {
+        assertThat(FreeBsdCentralProcessor.parseCachesFromLscpu(Collections.emptyList()), is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystemTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.freebsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Quintet;
+
+class FreeBsdComputerSystemTest {
+
+    @Test
+    void testParseDmiDecode() {
+        // Representative `dmidecode -t system` (DMI type 1) block.
+        List<String> dmidecode = Arrays.asList(//
+                "Handle 0x0001, DMI type 1, 27 bytes", //
+                "System Information", //
+                "\tManufacturer: Dell Inc.", //
+                "\tProduct Name: PowerEdge R640", //
+                "\tVersion: Not Specified", //
+                "\tSerial Number: 7XY1234", //
+                "\tUUID: 4c4c4544-0058-5910-8034-c4c04f313233", //
+                "\tWake-up Type: Power Switch", //
+                "\tSKU Number: SKU=NotProvided", //
+                "\tFamily: PowerEdge");
+        Quintet<String, String, String, String, String> dmi = FreeBsdComputerSystem.parseDmiDecode(dmidecode);
+        assertThat(dmi.getA(), is("Dell Inc."));
+        assertThat(dmi.getB(), is("PowerEdge R640"));
+        assertThat(dmi.getC(), is("7XY1234"));
+        assertThat(dmi.getD(), is("4c4c4544-0058-5910-8034-c4c04f313233"));
+        assertThat(dmi.getE(), is("Not Specified"));
+    }
+
+    @Test
+    void testParseDmiDecodeEmpty() {
+        // No output (e.g. dmidecode not available / not root): every field is null so the caller can fall back.
+        Quintet<String, String, String, String, String> dmi = FreeBsdComputerSystem
+                .parseDmiDecode(Collections.emptyList());
+        assertThat(dmi.getA(), is(nullValue()));
+        assertThat(dmi.getC(), is(nullValue()));
+        assertThat(dmi.getD(), is(nullValue()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmwareTest.java
@@ -5,7 +5,9 @@
 package oshi.hardware.common.platform.unix.freebsd;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -13,7 +15,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import oshi.util.Constants;
 import oshi.util.tuples.Triplet;
 
 class FreeBsdFirmwareTest {
@@ -37,10 +38,11 @@ class FreeBsdFirmwareTest {
 
     @Test
     void testParseDmiDecodeEmpty() {
-        // No output (e.g. dmidecode not available / not root): every field is UNKNOWN.
+        // No output (e.g. dmidecode not available / not root): the parser returns raw absent values (null
+        // manufacturer/version, empty date); readDmiDecode applies the Constants.UNKNOWN fallbacks.
         Triplet<String, String, String> fw = FreeBsdFirmware.parseDmiDecode(Collections.emptyList());
-        assertThat(fw.getA(), is(Constants.UNKNOWN));
-        assertThat(fw.getB(), is(Constants.UNKNOWN));
-        assertThat(fw.getC(), is(Constants.UNKNOWN));
+        assertThat(fw.getA(), is(nullValue()));
+        assertThat(fw.getB(), is(nullValue()));
+        assertThat(fw.getC(), is(emptyString()));
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmwareTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.freebsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.Constants;
+import oshi.util.tuples.Triplet;
+
+class FreeBsdFirmwareTest {
+
+    @Test
+    void testParseDmiDecode() {
+        // Representative `dmidecode -t bios` (DMI type 0) block; MM/DD/YYYY date is normalized to ISO.
+        List<String> dmidecode = Arrays.asList(//
+                "Handle 0x0000, DMI type 0, 24 bytes", //
+                "BIOS Information", //
+                "\tVendor: Parallels Software International Inc.", //
+                "\tVersion: 11.2.1 (32626)", //
+                "\tRelease Date: 07/15/2016", //
+                "\tBIOS Revision: 11.2", //
+                "\tFirmware Revision: 11.2");
+        Triplet<String, String, String> fw = FreeBsdFirmware.parseDmiDecode(dmidecode);
+        assertThat(fw.getA(), is("Parallels Software International Inc."));
+        assertThat(fw.getB(), is("11.2.1 (32626)"));
+        assertThat(fw.getC(), is("2016-07-15"));
+    }
+
+    @Test
+    void testParseDmiDecodeEmpty() {
+        // No output (e.g. dmidecode not available / not root): every field is UNKNOWN.
+        Triplet<String, String, String> fw = FreeBsdFirmware.parseDmiDecode(Collections.emptyList());
+        assertThat(fw.getA(), is(Constants.UNKNOWN));
+        assertThat(fw.getB(), is(Constants.UNKNOWN));
+        assertThat(fw.getC(), is(Constants.UNKNOWN));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdSoundCardTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.freebsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.SoundCard;
+
+class FreeBsdSoundCardTest {
+
+    @Test
+    void testParseSoundCards() {
+        // A pcm-driven node carries the product/vendor; other nodes (e.g. the parent hdac) are ignored.
+        List<String> lshal = Arrays.asList(//
+                "udi = '/org/freedesktop/Hal/devices/pci_8086_a348'", //
+                "  info.product = 'Cannon Lake PCH cAVS'  (string)", //
+                "udi = '/org/freedesktop/Hal/devices/pcm0'", //
+                "  info.product = 'Realtek ALC892 (Analog)'  (string)", //
+                "  info.vendor = 'Realtek'  (string)", //
+                "  freebsd.driver = 'pcm'  (string)");
+        List<SoundCard> cards = FreeBsdSoundCard.parseSoundCards(lshal);
+        assertThat(cards, hasSize(1));
+        SoundCard card = cards.get(0);
+        assertThat(card.getName(), is("Realtek Realtek ALC892 (Analog)"));
+        assertThat(card.getCodec(), is("Realtek ALC892 (Analog)"));
+    }
+
+    @Test
+    void testParseSoundCardsMissingVendor() {
+        // With no info.vendor, the name is just the product (leading space from the "vendor product" join).
+        List<String> lshal = Arrays.asList(//
+                "udi = '/org/freedesktop/Hal/devices/pcm0'", //
+                "  info.product = 'HDA Generic'  (string)", //
+                "  freebsd.driver = 'pcm'  (string)");
+        List<SoundCard> cards = FreeBsdSoundCard.parseSoundCards(lshal);
+        assertThat(cards, hasSize(1));
+        assertThat(cards.get(0).getCodec(), is("HDA Generic"));
+    }
+
+    @Test
+    void testParseSoundCardsEmpty() {
+        assertThat(FreeBsdSoundCard.parseSoundCards(Collections.emptyList()), is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdUsbDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdUsbDeviceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.freebsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.UsbDevice;
+
+class FreeBsdUsbDeviceTest {
+
+    // A minimal but real-shaped lshal tree: a host controller, its usbus, and one device beneath the usbus.
+    // getUsbDevices() promotes the usbus's children onto the controller and drops the usbus node itself.
+    private static final List<String> LSHAL = Arrays.asList(//
+            "udi = '/org/freedesktop/Hal/devices/pci_1022_43d5'", //
+            "  info.product = 'xHCI Host Controller'  (string)", //
+            "udi = '/org/freedesktop/Hal/devices/usb_device_0_0_usbus0'", //
+            "  freebsd.driver = 'usbus'  (string)", //
+            "  info.parent = '/org/freedesktop/Hal/devices/pci_1022_43d5'  (string)", //
+            "udi = '/org/freedesktop/Hal/devices/usb_device_781_5567'", //
+            "  info.parent = '/org/freedesktop/Hal/devices/usb_device_0_0_usbus0'  (string)", //
+            "  usb_device.product = 'Ultra USB 3.0'  (string)", //
+            "  usb_device.vendor = 'SanDisk'  (string)", //
+            "  usb_device.vendor_id = 1921  (0x781)  (int)", //
+            "  usb_device.product_id = 21863  (0x5567)  (int)", //
+            "  usb_device.serial = '4C530001120510117433'  (string)");
+
+    @Test
+    void testParseUsbDevices() {
+        List<UsbDevice> controllers = FreeBsdUsbDevice.parseUsbDevices(LSHAL);
+        assertThat(controllers, hasSize(1));
+
+        UsbDevice controller = controllers.get(0);
+        assertThat(controller.getName(), is("xHCI Host Controller"));
+        assertThat(controller.getUniqueDeviceId(), is("/org/freedesktop/Hal/devices/pci_1022_43d5"));
+        // The usbus node is skipped; its child is promoted directly onto the controller.
+        assertThat(controller.getConnectedDevices(), hasSize(1));
+
+        UsbDevice device = controller.getConnectedDevices().get(0);
+        assertThat(device.getName(), is("Ultra USB 3.0"));
+        assertThat(device.getVendor(), is("SanDisk"));
+        assertThat(device.getVendorId(), is("0781"));
+        assertThat(device.getProductId(), is("5567"));
+        assertThat(device.getSerialNumber(), is("4C530001120510117433"));
+    }
+
+    @Test
+    void testParseUsbDevicesHexSerial() {
+        // A 0x-prefixed serial is decoded from its hex byte string.
+        List<String> lshal = Arrays.asList(//
+                "udi = '/org/freedesktop/Hal/devices/pci_0'", //
+                "  info.product = 'Root Hub'  (string)", //
+                "udi = '/org/freedesktop/Hal/devices/usbus0'", //
+                "  freebsd.driver = 'usbus'  (string)", //
+                "  info.parent = '/org/freedesktop/Hal/devices/pci_0'  (string)", //
+                "udi = '/org/freedesktop/Hal/devices/dev0'", //
+                "  info.parent = '/org/freedesktop/Hal/devices/usbus0'  (string)", //
+                "  usb_device.serial = '0x41424344'  (string)");
+        List<UsbDevice> controllers = FreeBsdUsbDevice.parseUsbDevices(lshal);
+        assertThat(controllers, hasSize(1));
+        assertThat(controllers.get(0).getConnectedDevices(), hasSize(1));
+        // 0x41424344 -> "ABCD"
+        assertThat(controllers.get(0).getConnectedDevices().get(0).getSerialNumber(), is("ABCD"));
+    }
+
+    @Test
+    void testParseUsbDevicesSkipsInterfaceNodes() {
+        // An interface node's udi is "<device-udi>_ifN"; its .parent points at the device, so key.replace(parent)
+        // begins with "_if" and the node must be skipped rather than treated as a child device.
+        List<String> lshal = Arrays.asList(//
+                "udi = '/dev/pci0'", //
+                "  info.product = 'Root Hub'  (string)", //
+                "udi = '/dev/usbus0'", //
+                "  freebsd.driver = 'usbus'  (string)", //
+                "  info.parent = '/dev/pci0'  (string)", //
+                "udi = '/dev/dev0'", //
+                "  info.parent = '/dev/usbus0'  (string)", //
+                "  usb_device.product = 'Widget'  (string)", //
+                "udi = '/dev/dev0_if0'", //
+                "  info.parent = '/dev/dev0'  (string)", //
+                "  usb.interface.number = 0  (int)");
+        List<UsbDevice> controllers = FreeBsdUsbDevice.parseUsbDevices(lshal);
+        assertThat(controllers, hasSize(1));
+        // Only the real device hangs off the controller; the _if interface node is not a child.
+        assertThat(controllers.get(0).getConnectedDevices(), hasSize(1));
+        assertThat(controllers.get(0).getConnectedDevices().get(0).getName(), is("Widget"));
+    }
+
+    @Test
+    void testParseUsbDevicesEmpty() {
+        assertThat(FreeBsdUsbDevice.parseUsbDevices(Collections.emptyList()), is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/freebsd/ProcstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/freebsd/ProcstatUtilTest.java
@@ -9,7 +9,8 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 import java.lang.management.ManagementFactory;
 import java.util.Arrays;
@@ -74,7 +75,14 @@ class ProcstatUtilTest {
             int pid = ParseUtil.parseIntOrDefault(ManagementFactory.getRuntimeMXBean().getName().split("@", 2)[0], -1);
             assertThat("RuntimeMXBean#getName() should yield a positive PID, got " + pid, pid, is(greaterThan(0)));
             assertThat("Open files must be nonnegative", ProcstatUtil.getOpenFiles(pid), is(greaterThanOrEqualTo(0L)));
-            assertThat("Cwd should be nonempty", ProcstatUtil.getCwd(pid), is(not(emptyString())));
+            // procstat resolves cwd on a best-effort basis; on some CI filesystems (nullfs / memory-backed build
+            // dirs) the cwd vnode maps to no path and procstat returns it empty. Tolerate that, but when a path is
+            // returned it must be absolute.
+            String cwd = ProcstatUtil.getCwd(pid);
+            assertThat("getCwd must never return null", cwd, is(notNullValue()));
+            if (!cwd.isEmpty()) {
+                assertThat("A resolved cwd should be an absolute path", cwd, startsWith("/"));
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Improves FreeBSD testability/coverage and quiets a log-noise source, in three focused commits.

1. **Read `/var/run/dmesg.boot` quietly** — the file is often unreadable to non-root users; read it with `reportError=false` so a routine permission miss no longer logs an error.
2. **Extract testable parse methods from FreeBSD command readers** — separate acquisition (`runNative`/`readFile`) from parsing across the FreeBSD HAL, so the parsing logic is unit-testable with synthetic fixtures rather than only on a live FreeBSD host:
   - `FreeBsdCentralProcessor`: `parseProcessorIdFromDmesg` (+ `DmesgProcessorId` holder), `parseProcModelsAndFlags`, `parseCachesFromLscpu`
   - `FreeBsdUsbDevice`: `parseUsbDevices` (lshal device tree)
   - `FreeBsdSoundCard`: `parseSoundCards` (lshal pcm nodes)
   - `FreeBsdComputerSystem`: `parseDmiDecode` (`dmidecode -t system`)
   - `FreeBsdFirmware`: `parseDmiDecode` (`dmidecode -t bios`)

   New fixtures are grounded in real `dmesg.boot` / `lshal` / `lscpu` / `dmidecode` output; the tests run on every platform and cover each parse method's lines fully.
3. **Tolerate an unresolvable procstat cwd in the live FreeBSD test** — `procstat` resolves a process cwd on a best-effort basis; on some CI filesystems it returns empty. Accept that, and require an absolute path only when one is actually returned.

## Testing

- `oshi-common` full gate green: spotless, checkstyle, install + forbiddenapis, javadoc.
- `clean test` passes; new parse methods measured at ~100% line coverage locally via JaCoCo.

No CHANGELOG entry — test/coverage work plus a minor log-noise reduction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FreeBSD CPU identification (including precedence rules), cache parsing, and processor-model/feature extraction.
  * Refined FreeBSD `dmidecode` parsing for system and BIOS details with centralized fallbacks for missing fields.
  * Improved FreeBSD hardware parsing for sound cards and USB devices by reliably handling `lshal` output.
* **Tests**
  * Added/expanded JUnit coverage for FreeBSD CPU, cache, system, firmware, sound card, and USB parsing, including empty-input and edge cases.
  * Relaxed FreeBSD procstat cwd assertions to accept valid empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->