### PR TITLE
NetBSD/OpenBSD: extract testable parse methods from command readers

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
@@ -55,19 +55,11 @@ public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
 
     @Override
     protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
-        // Iterate dmesg, look for lines:
-        // cpu0: smt 0, core 0, package 0
-        // cpu1: smt 0, core 1, package 0
-        Map<Integer, Integer> coreMap = new HashMap<>();
-        Map<Integer, Integer> packageMap = new HashMap<>();
-        for (String line : ExecutingCommand.runNative("dmesg")) {
-            Matcher m = DMESG_CPU.matcher(line);
-            if (m.matches()) {
-                int cpu = ParseUtil.parseIntOrDefault(m.group(1), 0);
-                coreMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(3), 0));
-                packageMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(4), 0));
-            }
-        }
+        List<String> dmesg = ExecutingCommand.runNative("dmesg");
+        Pair<Map<Integer, Integer>, Map<Integer, Integer>> topology = parseTopology(dmesg);
+        Map<Integer, Integer> coreMap = topology.getA();
+        Map<Integer, Integer> packageMap = topology.getB();
+
         // native call seems to fail here, use fallback
         int logicalProcessorCount = sysctl("hw.ncpuonline", 1);
         // If we found more procs in dmesg, update
@@ -78,44 +70,47 @@ public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
         for (int i = 0; i < logicalProcessorCount; i++) {
             logProcs.add(new LogicalProcessor(i, coreMap.getOrDefault(i, 0), packageMap.getOrDefault(i, 0)));
         }
-        Map<Integer, String> cpuMap = new HashMap<>();
-        // cpu0 at mainbus0 mpidr 0: ARM Cortex-A7 r0p5
-        // but NOT: cpu0 at mainbus0: apid 0 (boot processor)
-        // cpu0: AMD GX-412TC SOC, 998.28 MHz, 16-30-01
-        // cpu0: AMD EPYC 7313P 16-Core Processor, 2994.74 MHz, 19-01-01
-        // cpu0: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01
-        Pattern p = Pattern.compile("cpu(\\d+).*: ((ARM|AMD|Intel|Apple).+)");
 
+        DmesgStrings parsed = parseDmesgModelsAndCaches(dmesg);
+        List<PhysicalProcessor> physProcs = parsed.getCpuMap().isEmpty() ? null
+                : createProcListFromDmesg(logProcs, parsed.getCpuMap());
+        return new Quartet<>(logProcs, physProcs, orderedProcCaches(parsed.getCaches()),
+                new ArrayList<>(parsed.getFeatureFlags()));
+    }
+
+    /**
+     * Parses topology lines from {@code dmesg} to extract per-CPU core and package mappings.
+     *
+     * @param dmesg the lines emitted by {@code dmesg}
+     * @return a {@link Pair} of (cpu-to-core map, cpu-to-package map)
+     */
+    static Pair<Map<Integer, Integer>, Map<Integer, Integer>> parseTopology(List<String> dmesg) {
+        Map<Integer, Integer> coreMap = new HashMap<>();
+        Map<Integer, Integer> packageMap = new HashMap<>();
+        for (String line : dmesg) {
+            Matcher m = DMESG_CPU.matcher(line);
+            if (m.matches()) {
+                int cpu = ParseUtil.parseIntOrDefault(m.group(1), 0);
+                coreMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(3), 0));
+                packageMap.put(cpu, ParseUtil.parseIntOrDefault(m.group(4), 0));
+            }
+        }
+        return new Pair<>(coreMap, packageMap);
+    }
+
+    /**
+     * Parses {@code dmesg} output for CPU model names, cache descriptions, and feature flags.
+     *
+     * @param dmesg the lines emitted by {@code dmesg}
+     * @return a {@link DmesgStrings} containing the parsed data
+     */
+    static DmesgStrings parseDmesgModelsAndCaches(List<String> dmesg) {
+        Map<Integer, String> cpuMap = new HashMap<>();
+        Pattern p = Pattern.compile("cpu(\\d+).*: ((ARM|AMD|Intel|Apple).+)");
         Set<ProcessorCache> caches = new HashSet<>();
-        // cpu0: 48KB 64b/line 12-way D-cache, 32KB 64b/line 8-way I-cache,
-        // ... 1MB 64b/line 10-way L2 cache, 24MB 64b/line 12-way L3 cache
-        // cpu0: 32KB 64b/line 8-way D-cache, 64KB 64b/line 4-way I-cache,
-        // ... 512KB 64b/line 8-way L2 cache, 4MB 64b/line 16-way L3 cache
-        // cpu0: 32KB 64b/line 2-way I-cache, 32KB 64b/line 8-way D-cache,
-        // ... 2MB 64b/line 16-way L2 cache
-        // cpu0: 32KB 64b/line 8-way I-cache, 32KB 64b/line 8-way D-cache,
-        // ... 512KB 64b/line 8-way L2 cache
-        // cpu0: 256KB 64b/line disabled L2 cache
-        // cpu0: 1MB 64b/line 16-way L2 cache
-        // --- Mac M1 example ---
-        // shows different for icestorm/firestrorm and multiple lines for L1 vs. L2
-        // cpu0 at mainbus0 mpidr 0: Apple Icestorm Pro r2p0
-        // cpu0: 128KB 64b/line 8-way L1 VIPT I-cache, 64KB 64b/line 8-way L1 D-cache
-        // cpu0: 4096KB 128b/line 16-way L2 cache
-        // cpu2 at mainbus0 mpidr 10100: Apple Firestorm Pro r2p0
-        // cpu2: 192KB 64b/line 6-way L1 VIPT I-cache, 128KB 64b/line 8-way L1 D-cache
-        // cpu2: 12288KB 128b/line 12-way L2 cache
-        // --- BIG:little example ---
-        // shows different for A53/A72 and multiple lines for L1 vs. L2
-        // cpu0 at mainbus0 mpidr 0: ARM Cortex-A53 r0p4
-        // cpu0: 32KB 64b/line 2-way L1 VIPT I-cache, 32KB 64b/line 4-way L1 D-cache
-        // cpu0: 512KB 64b/line 16-way L2 cache
-        // cpu4 at mainbus0 mpidr 100: ARM Cortex-A72 r0p2
-        // cpu4: 48KB 64b/line 3-way L1 PIPT I-cache, 32KB 64b/line 2-way L1 D-cache
-        // cpu4: 1024KB 64b/line 16-way L2 cache
         Pattern q = Pattern.compile("cpu(\\d+).*: (.+(I-|D-|L\\d+\\s)cache)");
         Set<String> featureFlags = new LinkedHashSet<>();
-        for (String s : ExecutingCommand.runNative("dmesg")) {
+        for (String s : dmesg) {
             Matcher m = p.matcher(s);
             if (m.matches()) {
                 int coreId = ParseUtil.parseIntOrDefault(m.group(1), 0);
@@ -138,11 +133,37 @@ public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
                 }
             }
         }
-        List<PhysicalProcessor> physProcs = cpuMap.isEmpty() ? null : createProcListFromDmesg(logProcs, cpuMap);
-        return new Quartet<>(logProcs, physProcs, orderedProcCaches(caches), new ArrayList<>(featureFlags));
+        return new DmesgStrings(cpuMap, caches, featureFlags);
     }
 
-    private ProcessorCache parseCacheStr(String cacheStr) {
+    /**
+     * Holds the results of parsing {@code dmesg} output for CPU models, caches, and feature flags.
+     */
+    static final class DmesgStrings {
+        private final Map<Integer, String> cpuMap;
+        private final Set<ProcessorCache> caches;
+        private final Set<String> featureFlags;
+
+        DmesgStrings(Map<Integer, String> cpuMap, Set<ProcessorCache> caches, Set<String> featureFlags) {
+            this.cpuMap = cpuMap;
+            this.caches = caches;
+            this.featureFlags = featureFlags;
+        }
+
+        Map<Integer, String> getCpuMap() {
+            return cpuMap;
+        }
+
+        Set<ProcessorCache> getCaches() {
+            return caches;
+        }
+
+        Set<String> getFeatureFlags() {
+            return featureFlags;
+        }
+    }
+
+    static ProcessorCache parseCacheStr(String cacheStr) {
         String[] split = ParseUtil.whitespaces.split(cacheStr.trim());
         if (split.length > 3) {
             switch (split[split.length - 1]) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdGraphicsCard.java
@@ -36,8 +36,17 @@ public final class BsdGraphicsCard extends AbstractGraphicsCard {
      * @return List of {@link GraphicsCard} objects.
      */
     public static List<GraphicsCard> getGraphicsCards() {
+        return parsePciDump(ExecutingCommand.runNative("pcidump -v"));
+    }
+
+    /**
+     * Parses the output of {@code pcidump -v} to extract display-class PCI devices.
+     *
+     * @param devices the lines emitted by {@code pcidump -v}
+     * @return a list of {@link GraphicsCard} objects for each display device found
+     */
+    static List<GraphicsCard> parsePciDump(List<String> devices) {
         List<GraphicsCard> cardList = new ArrayList<>();
-        List<String> devices = ExecutingCommand.runNative("pcidump -v");
         if (devices.isEmpty()) {
             return Collections.emptyList();
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdSoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdSoundCard.java
@@ -39,7 +39,17 @@ public final class BsdSoundCard extends AbstractSoundCard {
      * @return a {@link java.util.List} object.
      */
     public static List<SoundCard> getSoundCards() {
-        List<String> dmesg = ExecutingCommand.runNative("dmesg");
+        return parseDmesg(ExecutingCommand.runNative("dmesg"));
+    }
+
+    /**
+     * Parses {@code dmesg} output to extract sound card information. The parser performs two passes: the first collects
+     * audio device attachment names, the second matches those names against PCI device entries and their codecs.
+     *
+     * @param dmesg the lines emitted by {@code dmesg}
+     * @return a list of {@link SoundCard} objects
+     */
+    static List<SoundCard> parseDmesg(List<String> dmesg) {
         Set<String> names = new HashSet<>();
         for (String line : dmesg) {
             Matcher m = AUDIO_AT.matcher(line);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdUsbDevice.java
@@ -31,6 +31,17 @@ public final class BsdUsbDevice extends AbstractUsbDevice {
      * @return a list of USB controllers, each with its connected-device tree.
      */
     public static List<UsbDevice> getUsbDevices() {
+        return parseUsbDevices(ExecutingCommand.runNative("usbdevs -v"));
+    }
+
+    /**
+     * Parses the output of {@code usbdevs -v} into a USB controller device tree. Each controller becomes a root device
+     * whose children are the attached USB devices, building a hierarchy from the "Controller" and "addr" lines.
+     *
+     * @param usbdevs the lines emitted by {@code usbdevs -v}
+     * @return a list of USB controller devices, each with its connected-device tree
+     */
+    static List<UsbDevice> parseUsbDevices(List<String> usbdevs) {
         Map<String, String> nameMap = new HashMap<>();
         Map<String, String> vendorMap = new HashMap<>();
         Map<String, String> vendorIdMap = new HashMap<>();
@@ -41,7 +52,7 @@ public final class BsdUsbDevice extends AbstractUsbDevice {
         List<String> rootHubs = new ArrayList<>();
         String key = "";
         String parent = "";
-        for (String line : ExecutingCommand.runNative("usbdevs -v")) {
+        for (String line : usbdevs) {
             if (line.startsWith("Controller ")) {
                 parent = line.substring(11);
             } else if (line.startsWith("addr ")) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -44,29 +44,11 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
         if (cpuName.isEmpty()) {
             cpuName = NetBsdSysctlUtil.sysctl("hw.model", "");
         }
-        // NetBSD provides family/model/stepping via dmesg
-        // e.g., "cpu0: Intel(R) ... 06-7a-01" or from machdep
-        String cpuFamily = "";
-        String cpuModel = "";
-        String cpuStepping = "";
+        String[] fms = parseFamilyModelStepping(ExecutingCommand.runNative("dmesg"));
+        String cpuFamily = fms[0];
+        String cpuModel = fms[1];
+        String cpuStepping = fms[2];
         String processorID = "";
-        // Try to parse from dmesg "cpu0: ... XX-YY-ZZ"
-        for (String line : ExecutingCommand.runNative("dmesg")) {
-            if (line.startsWith("cpu0:") && line.matches(".*\\d+-[\\da-fA-F]+-[\\da-fA-F]+.*")) {
-                String[] parts = line.split(",");
-                for (String part : parts) {
-                    String trimmed = part.trim();
-                    if (trimmed.matches("[\\da-fA-F]+-[\\da-fA-F]+-[\\da-fA-F]+")) {
-                        String[] fms = trimmed.split("-");
-                        cpuFamily = fms[0];
-                        cpuModel = fms[1];
-                        cpuStepping = fms[2];
-                        break;
-                    }
-                }
-                break;
-            }
-        }
         long cpuFreq = NetBsdSysctlUtil.sysctl("machdep.tsc_freq", 0L);
         if (cpuFreq == 0L) {
             cpuFreq = ParseUtil.parseHertz(cpuName);
@@ -96,9 +78,18 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
 
     @Override
     protected Pair<Long, Long> queryVmStats() {
+        return parseVmStats(ExecutingCommand.runNative("vmstat -s"));
+    }
+
+    /**
+     * Parses the output of {@code vmstat -s} to extract context switch and interrupt counts.
+     *
+     * @param vmstat the lines emitted by {@code vmstat -s}
+     * @return a {@link Pair} of (context switches, interrupts)
+     */
+    static Pair<Long, Long> parseVmStats(List<String> vmstat) {
         long contextSwitches = 0L;
         long interrupts = 0L;
-        List<String> vmstat = ExecutingCommand.runNative("vmstat -s");
         for (String line : vmstat) {
             if (line.endsWith("CPU context switches")) {
                 contextSwitches = ParseUtil.parseLongOrDefault(line.trim().split("\\s+")[0], 0L);
@@ -107,6 +98,28 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
             }
         }
         return new Pair<>(contextSwitches, interrupts);
+    }
+
+    /**
+     * Parses family, model, and stepping from {@code dmesg} output. Looks for lines starting with {@code "cpu0:"} that
+     * contain a hyphen-separated triple like {@code "06-7a-01"}.
+     *
+     * @param dmesg the lines emitted by {@code dmesg}
+     * @return a 3-element array of [family, model, stepping], each empty string if not found
+     */
+    static String[] parseFamilyModelStepping(List<String> dmesg) {
+        for (String line : dmesg) {
+            if (line.startsWith("cpu0:") && line.matches(".*\\d+-[\\da-fA-F]+-[\\da-fA-F]+.*")) {
+                String[] parts = line.split(",");
+                for (String part : parts) {
+                    String trimmed = part.trim();
+                    if (trimmed.matches("[\\da-fA-F]+-[\\da-fA-F]+-[\\da-fA-F]+")) {
+                        return trimmed.split("-");
+                    }
+                }
+            }
+        }
+        return new String[] { "", "", "" };
     }
 
     /**
@@ -159,7 +172,7 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
      * @param cpTimeStr the sysctl output string
      * @return array of [user, nice, sys, intr, idle] tick values
      */
-    private static long[] parseCpTime(String cpTimeStr) {
+    static long[] parseCpTime(String cpTimeStr) {
         long[] ticks = new long[CPUSTATES];
         if (cpTimeStr == null || cpTimeStr.isEmpty()) {
             return ticks;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdFirmware.java
@@ -70,7 +70,8 @@ public class NetBsdFirmware extends AbstractFirmware {
                 version = ParseUtil.getStringBetween(line, '"');
                 releaseDate = ParseUtil.parseMmDdYyyyToYyyyMmDD(ParseUtil.parseLastString(line));
                 String afterVendor = line.split("vendor")[1].trim();
-                vendor = afterVendor.split("\\s+")[0];
+                int versionIdx = afterVendor.indexOf(" version ");
+                vendor = versionIdx > 0 ? afterVendor.substring(0, versionIdx) : afterVendor.split("\\s+")[0];
             }
         }
         return new Triplet<>(vendor, version, releaseDate);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdFirmware.java
@@ -40,15 +40,32 @@ public class NetBsdFirmware extends AbstractFirmware {
     }
 
     private static Triplet<String, String, String> readDmesg() {
+        Triplet<String, String, String> dmi = parseDmesg(ExecutingCommand.runNative("dmesg"));
+        String vendor = dmi.getA();
+        String version = dmi.getB();
+        String releaseDate = dmi.getC();
+        return new Triplet<>(Util.isBlank(vendor) ? Constants.UNKNOWN : vendor,
+                Util.isBlank(version) ? Constants.UNKNOWN : version,
+                Util.isBlank(releaseDate) ? Constants.UNKNOWN : releaseDate);
+    }
+
+    /**
+     * Parses the output of {@code dmesg} for BIOS firmware information. Looks for lines starting with
+     * {@code "bios0: vendor"} to extract manufacturer, version, and release date. Any field not present in the output
+     * is returned as {@code null} (or an empty date); the caller applies fallbacks.
+     *
+     * @param dmesg the lines emitted by {@code dmesg}
+     * @return a {@link Triplet} of vendor, version, and release date
+     */
+    static Triplet<String, String, String> parseDmesg(List<String> dmesg) {
         String version = null;
         String vendor = null;
         String releaseDate = "";
 
-        List<String> dmesg = ExecutingCommand.runNative("dmesg");
+        // bios0 at mainbus0: SMBIOS rev. 2.7 @ 0xdcc0e000 (67 entries)
+        // bios0: vendor LENOVO version "GLET90WW (2.44 )" date 09/13/2017
+        // bios0: LENOVO 20AWA08J00
         for (String line : dmesg) {
-            // bios0 at mainbus0: SMBIOS rev. 2.7 @ 0xdcc0e000 (67 entries)
-            // bios0: vendor LENOVO version "GLET90WW (2.44 )" date 09/13/2017
-            // bios0: LENOVO 20AWA08J00
             if (line.startsWith("bios0: vendor")) {
                 version = ParseUtil.getStringBetween(line, '"');
                 releaseDate = ParseUtil.parseMmDdYyyyToYyyyMmDD(ParseUtil.parseLastString(line));
@@ -56,8 +73,6 @@ public class NetBsdFirmware extends AbstractFirmware {
                 vendor = afterVendor.split("\\s+")[0];
             }
         }
-        return new Triplet<>(Util.isBlank(vendor) ? Constants.UNKNOWN : vendor,
-                Util.isBlank(version) ? Constants.UNKNOWN : version,
-                Util.isBlank(releaseDate) ? Constants.UNKNOWN : releaseDate);
+        return new Triplet<>(vendor, version, releaseDate);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
@@ -87,7 +87,7 @@ public abstract class OpenBsdCentralProcessor extends BsdCentralProcessor {
                 cpuFreq);
     }
 
-    private static Triplet<Integer, Integer, Integer> cpuidToFamilyModelStepping(int cpuid) {
+    static Triplet<Integer, Integer, Integer> cpuidToFamilyModelStepping(int cpuid) {
         // family is bits 27:20 | 11:8
         int family = cpuid >> 16 & 0xff0 | cpuid >> 8 & 0xf;
         // model is bits 19:16 | 7:4
@@ -107,9 +107,18 @@ public abstract class OpenBsdCentralProcessor extends BsdCentralProcessor {
 
     @Override
     protected Pair<Long, Long> queryVmStats() {
+        return parseVmStats(ExecutingCommand.runNative("vmstat -s"));
+    }
+
+    /**
+     * Parses the output of {@code vmstat -s} to extract context switch and interrupt counts.
+     *
+     * @param vmstat the lines emitted by {@code vmstat -s}
+     * @return a {@link Pair} of (context switches, interrupts)
+     */
+    static Pair<Long, Long> parseVmStats(List<String> vmstat) {
         long contextSwitches = 0L;
         long interrupts = 0L;
-        List<String> vmstat = ExecutingCommand.runNative("vmstat -s");
         for (String line : vmstat) {
             if (line.endsWith("cpu context switches")) {
                 contextSwitches = ParseUtil.parseLongOrDefault(line.trim().split("\\s+")[0], 0L);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdFirmware.java
@@ -40,11 +40,28 @@ public class OpenBsdFirmware extends AbstractFirmware {
     }
 
     private static Triplet<String, String, String> readDmesg() {
+        Triplet<String, String, String> dmi = parseDmesg(ExecutingCommand.runNative("dmesg"));
+        String vendor = dmi.getA();
+        String version = dmi.getB();
+        String releaseDate = dmi.getC();
+        return new Triplet<>(Util.isBlank(vendor) ? Constants.UNKNOWN : vendor,
+                Util.isBlank(version) ? Constants.UNKNOWN : version,
+                Util.isBlank(releaseDate) ? Constants.UNKNOWN : releaseDate);
+    }
+
+    /**
+     * Parses the output of {@code dmesg} for BIOS firmware information. Looks for lines starting with
+     * {@code "bios0: vendor"} to extract manufacturer, version, and release date. Any field not present in the output
+     * is returned as {@code null} (or an empty date); the caller applies fallbacks.
+     *
+     * @param dmesg the lines emitted by {@code dmesg}
+     * @return a {@link Triplet} of vendor, version, and release date
+     */
+    static Triplet<String, String, String> parseDmesg(List<String> dmesg) {
         String version = null;
         String vendor = null;
         String releaseDate = "";
 
-        List<String> dmesg = ExecutingCommand.runNative("dmesg");
         for (String line : dmesg) {
             if (line.startsWith("bios0: vendor")) {
                 version = ParseUtil.getStringBetween(line, '"');
@@ -52,8 +69,6 @@ public class OpenBsdFirmware extends AbstractFirmware {
                 vendor = line.split("vendor")[1].trim();
             }
         }
-        return new Triplet<>(Util.isBlank(vendor) ? Constants.UNKNOWN : vendor,
-                Util.isBlank(version) ? Constants.UNKNOWN : version,
-                Util.isBlank(releaseDate) ? Constants.UNKNOWN : releaseDate);
+        return new Triplet<>(vendor, version, releaseDate);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdFirmware.java
@@ -66,7 +66,9 @@ public class OpenBsdFirmware extends AbstractFirmware {
             if (line.startsWith("bios0: vendor")) {
                 version = ParseUtil.getStringBetween(line, '"');
                 releaseDate = ParseUtil.parseMmDdYyyyToYyyyMmDD(ParseUtil.parseLastString(line));
-                vendor = line.split("vendor")[1].trim();
+                String afterVendor = line.split("vendor")[1].trim();
+                int versionIdx = afterVendor.indexOf(" version ");
+                vendor = versionIdx > 0 ? afterVendor.substring(0, versionIdx) : afterVendor.split("\\s+")[0];
             }
         }
         return new Triplet<>(vendor, version, releaseDate);

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdCentralProcessorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.CentralProcessor.ProcessorCache;
+import oshi.hardware.CentralProcessor.ProcessorCache.Type;
+import oshi.hardware.common.platform.unix.BsdCentralProcessor.DmesgStrings;
+import oshi.util.tuples.Pair;
+
+class BsdCentralProcessorTest {
+
+    // Representative OpenBSD/NetBSD dmesg topology lines
+    private static final List<String> DMESG_TOPOLOGY = Arrays.asList(//
+            "cpu0: smt 0, core 0, package 0", //
+            "cpu1: smt 0, core 1, package 0", //
+            "cpu2: smt 0, core 0, package 1", //
+            "cpu3: smt 0, core 1, package 1");
+
+    @Test
+    void testParseTopology() {
+        Pair<Map<Integer, Integer>, Map<Integer, Integer>> result = BsdCentralProcessor.parseTopology(DMESG_TOPOLOGY);
+        Map<Integer, Integer> coreMap = result.getA();
+        Map<Integer, Integer> packageMap = result.getB();
+        assertThat(coreMap.size(), is(4));
+        assertThat(coreMap.get(0), is(0));
+        assertThat(coreMap.get(1), is(1));
+        assertThat(coreMap.get(2), is(0));
+        assertThat(coreMap.get(3), is(1));
+        assertThat(packageMap.get(0), is(0));
+        assertThat(packageMap.get(2), is(1));
+    }
+
+    @Test
+    void testParseTopologyEmpty() {
+        Pair<Map<Integer, Integer>, Map<Integer, Integer>> result = BsdCentralProcessor
+                .parseTopology(Collections.emptyList());
+        assertThat(result.getA().isEmpty(), is(true));
+        assertThat(result.getB().isEmpty(), is(true));
+    }
+
+    @Test
+    void testParseDmesgModelsAndCachesIntel() {
+        // Representative x86 dmesg — cache entries are split across separate lines but each line ends with "cache"
+        List<String> dmesg = Arrays.asList(//
+                "cpu0: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01", //
+                "cpu0: 32KB 64b/line 8-way D-cache, 32KB 64b/line 8-way I-cache", //
+                "cpu0: 4MB 64b/line 16-way L2 cache", //
+                "cpu0: FPU,VME,DE,PSE,TSC,MSR,PAE,MCE");
+        DmesgStrings result = BsdCentralProcessor.parseDmesgModelsAndCaches(dmesg);
+        assertThat(result.getCpuMap().get(0), is("Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01"));
+        assertThat(result.getCaches(), is(not(empty())));
+        // D-cache, I-cache (from first cache line), L2 cache (from second)
+        assertThat(result.getCaches().size(), is(3));
+    }
+
+    @Test
+    void testParseDmesgModelsAndCachesArm() {
+        // Representative ARM big.LITTLE dmesg
+        List<String> dmesg = Arrays.asList(//
+                "cpu0 at mainbus0 mpidr 0: ARM Cortex-A53 r0p4", //
+                "cpu0: 32KB 64b/line 2-way L1 VIPT I-cache, 32KB 64b/line 4-way L1 D-cache", //
+                "cpu0: 512KB 64b/line 16-way L2 cache", //
+                "cpu4 at mainbus0 mpidr 100: ARM Cortex-A72 r0p2", //
+                "cpu4: 48KB 64b/line 3-way L1 PIPT I-cache, 32KB 64b/line 2-way L1 D-cache", //
+                "cpu4: 1024KB 64b/line 16-way L2 cache");
+        DmesgStrings result = BsdCentralProcessor.parseDmesgModelsAndCaches(dmesg);
+        assertThat(result.getCpuMap().get(0), is("ARM Cortex-A53 r0p4"));
+        assertThat(result.getCpuMap().get(4), is("ARM Cortex-A72 r0p2"));
+        // Should have L1 I-cache, L1 D-cache, L2 from each CPU type (unique by cache params)
+        assertThat(result.getCaches().size(), is(6));
+    }
+
+    @Test
+    void testParseDmesgModelsAndCachesFeatureFlags() {
+        // Feature flags are lines starting with "cpu" having ": " with 4+ comma-delimited items
+        List<String> dmesg = Arrays.asList(//
+                "cpu0: FPU,VME,DE,PSE,TSC,MSR,PAE,MCE", //
+                "cpu0: SSE3,PCLMULQDQ,DTES64,MONITOR");
+        DmesgStrings result = BsdCentralProcessor.parseDmesgModelsAndCaches(dmesg);
+        assertThat(result.getFeatureFlags().size(), is(2));
+    }
+
+    @Test
+    void testParseDmesgModelsAndCachesEmpty() {
+        DmesgStrings result = BsdCentralProcessor.parseDmesgModelsAndCaches(Collections.emptyList());
+        assertThat(result.getCpuMap().isEmpty(), is(true));
+        assertThat(result.getCaches(), is(empty()));
+        assertThat(result.getFeatureFlags(), is(empty()));
+    }
+
+    @Test
+    void testParseCacheStrDCache() {
+        ProcessorCache cache = BsdCentralProcessor.parseCacheStr("32KB 64b/line 8-way D-cache");
+        assertThat(cache, is(not(nullValue())));
+        assertThat(cache.getType(), is(Type.DATA));
+        assertThat(cache.getLevel(), is((byte) 1));
+        assertThat(cache.getAssociativity(), is((byte) 8));
+        assertThat(cache.getLineSize(), is((short) 64));
+        assertThat(cache.getCacheSize(), is(32768));
+    }
+
+    @Test
+    void testParseCacheStrICache() {
+        ProcessorCache cache = BsdCentralProcessor.parseCacheStr("48KB 64b/line 3-way L1 PIPT I-cache");
+        assertThat(cache, is(not(nullValue())));
+        assertThat(cache.getType(), is(Type.INSTRUCTION));
+        assertThat(cache.getLevel(), is((byte) 1));
+        assertThat(cache.getAssociativity(), is((byte) 3));
+    }
+
+    @Test
+    void testParseCacheStrL2Unified() {
+        ProcessorCache cache = BsdCentralProcessor.parseCacheStr("4MB 64b/line 16-way L2 cache");
+        assertThat(cache, is(not(nullValue())));
+        assertThat(cache.getType(), is(Type.UNIFIED));
+        assertThat(cache.getLevel(), is((byte) 2));
+        assertThat(cache.getAssociativity(), is((byte) 16));
+        assertThat(cache.getLineSize(), is((short) 64));
+        assertThat(cache.getCacheSize(), is(4 * 1024 * 1024));
+    }
+
+    @Test
+    void testParseCacheStrL3Unified() {
+        ProcessorCache cache = BsdCentralProcessor.parseCacheStr("24MB 64b/line 12-way L3 cache");
+        assertThat(cache, is(not(nullValue())));
+        assertThat(cache.getType(), is(Type.UNIFIED));
+        assertThat(cache.getLevel(), is((byte) 3));
+        assertThat(cache.getAssociativity(), is((byte) 12));
+    }
+
+    @Test
+    void testParseCacheStrTooShort() {
+        ProcessorCache cache = BsdCentralProcessor.parseCacheStr("disabled");
+        assertThat(cache, is(nullValue()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdGraphicsCardTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.GraphicsCard;
+
+class BsdGraphicsCardTest {
+
+    // Representative pcidump -v output from OpenBSD with one display and one network device
+    private static final List<String> PCIDUMP = Arrays.asList(//
+            " 0:0:0: Intel 82G33/G31/P35/P31 DRAM Controller", //
+            "\tVendor ID: 8086", //
+            "\tProduct ID: 29c0", //
+            "\tClass: 06 Bridge, Host", //
+            " 0:2:0: Intel 82G33/G31 Integrated Graphics Controller", //
+            "\tVendor ID: 8086", //
+            "\tProduct ID: 29c2", //
+            "\tClass: 03 Display, VGA", //
+            "\tRevision: 02", //
+            " 0:25:0: Intel 82801I (ICH9) LAN Controller", //
+            "\tVendor ID: 8086", //
+            "\tProduct ID: 10f0", //
+            "\tClass: 02 Network, Ethernet");
+
+    @Test
+    void testParsePciDump() {
+        List<GraphicsCard> cards = BsdGraphicsCard.parsePciDump(PCIDUMP);
+        assertThat(cards, hasSize(1));
+        GraphicsCard card = cards.get(0);
+        assertThat(card.getName(), is("Intel 82G33/G31 Integrated Graphics Controller"));
+        assertThat(card.getDeviceId(), is("0x29c2"));
+        assertThat(card.getVendor(), is("0x8086"));
+        assertThat(card.getVersionInfo(), is("Revision: 02"));
+        assertThat(card.getVRam(), is(0L));
+    }
+
+    @Test
+    void testParsePciDumpMultipleDisplayDevices() {
+        List<String> pcidump = Arrays.asList(//
+                " 0:2:0: NVIDIA GeForce GTX 1080", //
+                "\tVendor ID: 10de", //
+                "\tProduct ID: 1b80", //
+                "\tClass: 03 Display, VGA", //
+                "\tRevision: a1", //
+                " 0:3:0: NVIDIA GeForce GTX 1080 Audio", //
+                "\tVendor ID: 10de", //
+                "\tProduct ID: 10f0", //
+                "\tClass: 04 Multimedia, Audio", //
+                " 0:5:0: AMD Radeon RX 580", //
+                "\tVendor ID: 1002", //
+                "\tProduct ID: 67df", //
+                "\tClass: 03 Display, VGA", //
+                "\tRevision: e7");
+        List<GraphicsCard> cards = BsdGraphicsCard.parsePciDump(pcidump);
+        assertThat(cards, hasSize(2));
+        assertThat(cards.get(0).getName(), is("NVIDIA GeForce GTX 1080"));
+        assertThat(cards.get(0).getDeviceId(), is("0x1b80"));
+        assertThat(cards.get(1).getName(), is("AMD Radeon RX 580"));
+        assertThat(cards.get(1).getDeviceId(), is("0x67df"));
+        assertThat(cards.get(1).getVersionInfo(), is("Revision: e7"));
+    }
+
+    @Test
+    void testParsePciDumpNoDisplayDevices() {
+        List<String> pcidump = Arrays.asList(//
+                " 0:0:0: Intel Host Bridge", //
+                "\tVendor ID: 8086", //
+                "\tProduct ID: 0001", //
+                "\tClass: 06 Bridge, Host");
+        List<GraphicsCard> cards = BsdGraphicsCard.parsePciDump(pcidump);
+        assertThat(cards, is(empty()));
+    }
+
+    @Test
+    void testParsePciDumpEmpty() {
+        List<GraphicsCard> cards = BsdGraphicsCard.parsePciDump(Collections.emptyList());
+        assertThat(cards, is(empty()));
+    }
+
+    @Test
+    void testParsePciDumpDisplayAtEndOfOutput() {
+        // Display device is the last entry (no following header to flush it)
+        List<String> pcidump = Arrays.asList(//
+                " 0:2:0: VGA Compatible Controller", //
+                "\tVendor ID: abcd", //
+                "\tProduct ID: 1234", //
+                "\tClass: 03 Display, VGA", //
+                "\tRevision: ff");
+        List<GraphicsCard> cards = BsdGraphicsCard.parsePciDump(pcidump);
+        assertThat(cards, hasSize(1));
+        assertThat(cards.get(0).getVendor(), is("0xabcd"));
+        assertThat(cards.get(0).getDeviceId(), is("0x1234"));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdSoundCardTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.SoundCard;
+
+class BsdSoundCardTest {
+
+    // Representative NetBSD/OpenBSD dmesg output with audio devices
+    private static final List<String> DMESG = Arrays.asList(//
+            "azalia0 at pci0 dev 27 function 0 \"Intel 82801I HD Audio\" rev 0x03: msi", //
+            "azalia0: codec[0]: Realtek ALC888", //
+            "audio0 at azalia0", //
+            "hdaudio0 at pci0 dev 3 function 0 \"Intel HD Graphics Audio\" rev 0x05: msi", //
+            "hdaudio0: codec[0]: Intel Haswell HDMI", //
+            "audio1 at hdaudio0");
+
+    @Test
+    void testParseDmesg() {
+        List<SoundCard> cards = BsdSoundCard.parseDmesg(DMESG);
+        assertThat(cards, hasSize(2));
+        // Find the azalia card
+        SoundCard azalia = cards.stream().filter(c -> c.getName().contains("82801I")).findFirst().orElse(null);
+        assertThat(azalia != null, is(true));
+        assertThat(azalia.getName(), is("Intel 82801I HD Audio"));
+        // Parser uses indexOf(':') to split — captures everything after the first colon in the codec line
+        assertThat(azalia.getCodec(), is("codec[0]: Realtek ALC888"));
+        assertThat(azalia.getDriverVersion(), is("rev 0x03"));
+    }
+
+    @Test
+    void testParseDmesgNoAudio() {
+        List<String> dmesg = Arrays.asList(//
+                "azalia0 at pci0 dev 27 function 0 \"Intel Audio\" rev 0x03: msi", //
+                "azalia0: codec[0]: Realtek ALC888");
+        // No "audio0 at azalia0" line means azalia0 is not in the names set
+        List<SoundCard> cards = BsdSoundCard.parseDmesg(dmesg);
+        assertThat(cards, is(empty()));
+    }
+
+    @Test
+    void testParseDmesgEmpty() {
+        List<SoundCard> cards = BsdSoundCard.parseDmesg(Collections.emptyList());
+        assertThat(cards, is(empty()));
+    }
+
+    @Test
+    void testParseDmesgNoCodec() {
+        // Audio device is present but no codec line follows the PCI match
+        List<String> dmesg = Arrays.asList(//
+                "audio0 at azalia0", //
+                "azalia0 at pci0 dev 27 function 0 \"Intel Audio\" rev 0x01: msi", //
+                "unrelated line here");
+        List<SoundCard> cards = BsdSoundCard.parseDmesg(dmesg);
+        assertThat(cards, hasSize(1));
+        assertThat(cards.get(0).getName(), is("Intel Audio"));
+        // No codec line found, map.get returns null
+        assertThat(cards.get(0).getCodec(), is((String) null));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdUsbDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdUsbDeviceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.UsbDevice;
+
+class BsdUsbDeviceTest {
+
+    // Representative usbdevs -v output from OpenBSD/NetBSD
+    // Format: "addr NN: VVVV:PPPP VendorName, ProductName" (colon at pos 7, comma separates vendor from product)
+    private static final List<String> USBDEVS = Arrays.asList(//
+            "Controller /dev/usb0:", //
+            "addr 01: 0000:0000 UHCI, root hub", //
+            "  iSerial 12345", //
+            "addr 02: 8087:0024 Intel, Rate Matching Hub", //
+            "addr 03: 046d:c52b Logitech, Unifying Receiver");
+
+    @Test
+    void testParseUsbDevices() {
+        List<UsbDevice> devices = BsdUsbDevice.parseUsbDevices(USBDEVS);
+        // Should have one root hub controller
+        assertThat(devices, hasSize(1));
+        UsbDevice root = devices.get(0);
+        assertThat(root.getName(), is("root hub"));
+        assertThat(root.getSerialNumber(), is("12345"));
+        assertThat(root.getVendorId(), is("0000"));
+        assertThat(root.getProductId(), is("0000"));
+    }
+
+    @Test
+    void testParseUsbDevicesMultipleControllers() {
+        List<String> usbdevs = Arrays.asList(//
+                "Controller /dev/usb0:", //
+                "addr 01: 0000:0000 UHCI, root hub 0", //
+                "Controller /dev/usb1:", //
+                "addr 01: 0000:0000 EHCI, root hub 1");
+        List<UsbDevice> devices = BsdUsbDevice.parseUsbDevices(usbdevs);
+        assertThat(devices, hasSize(2));
+        assertThat(devices.get(0).getName(), is("root hub 0"));
+        assertThat(devices.get(1).getName(), is("root hub 1"));
+    }
+
+    @Test
+    void testParseUsbDevicesEmpty() {
+        List<UsbDevice> devices = BsdUsbDevice.parseUsbDevices(Collections.emptyList());
+        assertThat(devices, is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.netbsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Pair;
+
+class NetBsdCentralProcessorTest {
+
+    @Test
+    void testParseVmStats() {
+        List<String> vmstat = Arrays.asList(//
+                "       42983 CPU context switches", //
+                "        8301 device interrupts", //
+                "           0 software interrupts", //
+                "       12345 some other stat");
+        Pair<Long, Long> result = NetBsdCentralProcessor.parseVmStats(vmstat);
+        assertThat(result.getA(), is(42983L));
+        assertThat(result.getB(), is(8301L));
+    }
+
+    @Test
+    void testParseVmStatsEmpty() {
+        Pair<Long, Long> result = NetBsdCentralProcessor.parseVmStats(Collections.emptyList());
+        assertThat(result.getA(), is(0L));
+        assertThat(result.getB(), is(0L));
+    }
+
+    @Test
+    void testParseFamilyModelStepping() {
+        List<String> dmesg = Arrays.asList(//
+                "cpu0: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01", //
+                "cpu1: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01");
+        String[] fms = NetBsdCentralProcessor.parseFamilyModelStepping(dmesg);
+        assertThat(fms, is(arrayContaining("06", "7a", "01")));
+    }
+
+    @Test
+    void testParseFamilyModelSteppingAmd() {
+        List<String> dmesg = Arrays.asList(//
+                "cpu0: AMD EPYC 7313P 16-Core Processor, 2994.74 MHz, 19-01-01");
+        String[] fms = NetBsdCentralProcessor.parseFamilyModelStepping(dmesg);
+        assertThat(fms, is(arrayContaining("19", "01", "01")));
+    }
+
+    @Test
+    void testParseFamilyModelSteppingEmpty() {
+        String[] fms = NetBsdCentralProcessor.parseFamilyModelStepping(Collections.emptyList());
+        assertThat(fms, is(arrayContaining("", "", "")));
+    }
+
+    @Test
+    void testParseFamilyModelSteppingNoMatch() {
+        List<String> dmesg = Arrays.asList(//
+                "cpu0 at mainbus0 mpidr 0: ARM Cortex-A53 r0p4", //
+                "cpu0: 32KB 64b/line 2-way L1 VIPT I-cache");
+        String[] fms = NetBsdCentralProcessor.parseFamilyModelStepping(dmesg);
+        assertThat(fms, is(arrayContaining("", "", "")));
+    }
+
+    @Test
+    void testParseCpTime() {
+        long[] ticks = NetBsdCentralProcessor
+                .parseCpTime("kern.cp_time: user = 2930, nice = 42, sys = 1334, intr = 1877, idle = 46354");
+        assertThat(ticks[0], is(2930L));
+        assertThat(ticks[1], is(42L));
+        assertThat(ticks[2], is(1334L));
+        assertThat(ticks[3], is(1877L));
+        assertThat(ticks[4], is(46354L));
+    }
+
+    @Test
+    void testParseCpTimeEmpty() {
+        long[] ticks = NetBsdCentralProcessor.parseCpTime("");
+        assertThat(ticks.length, is(5));
+        for (long tick : ticks) {
+            assertThat(tick, is(0L));
+        }
+    }
+
+    @Test
+    void testParseCpTimeNull() {
+        long[] ticks = NetBsdCentralProcessor.parseCpTime(null);
+        assertThat(ticks.length, is(5));
+        for (long tick : ticks) {
+            assertThat(tick, is(0L));
+        }
+    }
+
+    @Test
+    void testParseCpTimePerCpu() {
+        long[] ticks = NetBsdCentralProcessor
+                .parseCpTime("kern.cp_time.0: user = 100, nice = 0, sys = 50, intr = 10, idle = 840");
+        assertThat(ticks[0], is(100L));
+        assertThat(ticks[1], is(0L));
+        assertThat(ticks[2], is(50L));
+        assertThat(ticks[3], is(10L));
+        assertThat(ticks[4], is(840L));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/netbsd/NetBsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/netbsd/NetBsdFirmwareTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.netbsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Triplet;
+
+class NetBsdFirmwareTest {
+
+    @Test
+    void testParseDmesg() {
+        // Representative NetBSD dmesg bios0 output
+        List<String> dmesg = Arrays.asList(//
+                "bios0 at mainbus0: SMBIOS rev. 2.7 @ 0xdcc0e000 (67 entries)", //
+                "bios0: vendor LENOVO version \"GLET90WW (2.44 )\" date 09/13/2017", //
+                "bios0: LENOVO 20AWA08J00");
+        Triplet<String, String, String> fw = NetBsdFirmware.parseDmesg(dmesg);
+        assertThat(fw.getA(), is("LENOVO"));
+        assertThat(fw.getB(), is("GLET90WW (2.44 )"));
+        assertThat(fw.getC(), is("2017-09-13"));
+    }
+
+    @Test
+    void testParseDmesgEmpty() {
+        Triplet<String, String, String> fw = NetBsdFirmware.parseDmesg(Collections.emptyList());
+        assertThat(fw.getA(), is(nullValue()));
+        assertThat(fw.getB(), is(nullValue()));
+        assertThat(fw.getC(), is(emptyString()));
+    }
+
+    @Test
+    void testParseDmesgNoMatch() {
+        List<String> dmesg = Arrays.asList(//
+                "cpu0 at mainbus0: AMD EPYC 7313P", //
+                "some other line");
+        Triplet<String, String, String> fw = NetBsdFirmware.parseDmesg(dmesg);
+        assertThat(fw.getA(), is(nullValue()));
+        assertThat(fw.getB(), is(nullValue()));
+        assertThat(fw.getC(), is(emptyString()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/netbsd/NetBsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/netbsd/NetBsdFirmwareTest.java
@@ -41,6 +41,16 @@ class NetBsdFirmwareTest {
     }
 
     @Test
+    void testParseDmesgMultiWordVendor() {
+        List<String> dmesg = Arrays.asList(//
+                "bios0: vendor Phoenix Technologies LTD version \"6.00\" date 04/14/2014");
+        Triplet<String, String, String> fw = NetBsdFirmware.parseDmesg(dmesg);
+        assertThat(fw.getA(), is("Phoenix Technologies LTD"));
+        assertThat(fw.getB(), is("6.00"));
+        assertThat(fw.getC(), is("2014-04-14"));
+    }
+
+    @Test
     void testParseDmesgNoMatch() {
         List<String> dmesg = Arrays.asList(//
                 "cpu0 at mainbus0: AMD EPYC 7313P", //

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessorTest.java
@@ -8,10 +8,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import oshi.hardware.CentralProcessor.TickType;
 import oshi.util.tuples.Pair;
+import oshi.util.tuples.Triplet;
 
 /**
  * Tests the native-free tick-mapping and load-average logic hoisted into {@link OpenBsdCentralProcessor}, using a stub
@@ -86,6 +91,56 @@ class OpenBsdCentralProcessorTest {
         assertThat(avg[0], is(-1.0));
         assertThat(avg[1], is(-1.0));
         assertThat(avg[2], is(-1.0));
+    }
+
+    @Test
+    void testParseVmStats() {
+        // Real OpenBSD vmstat -s: "software interrupts" appears before bare "interrupts"
+        List<String> vmstat = Arrays.asList(//
+                "      142983 cpu context switches", //
+                "           0 software interrupts", //
+                "       28301 interrupts", //
+                "       50000 some other stat");
+        Pair<Long, Long> result = OpenBsdCentralProcessor.parseVmStats(vmstat);
+        assertThat(result.getA(), is(142983L));
+        assertThat(result.getB(), is(28301L));
+    }
+
+    @Test
+    void testParseVmStatsEmpty() {
+        Pair<Long, Long> result = OpenBsdCentralProcessor.parseVmStats(Collections.emptyList());
+        assertThat(result.getA(), is(0L));
+        assertThat(result.getB(), is(0L));
+    }
+
+    @Test
+    void testCpuidToFamilyModelStepping() {
+        // Intel Core i7-8700K: CPUID = 0x000906EA → family=6, model=158, stepping=10
+        Triplet<Integer, Integer, Integer> fms = OpenBsdCentralProcessor.cpuidToFamilyModelStepping(0x000906EA);
+        assertThat(fms.getA(), is(6));
+        assertThat(fms.getB(), is(158));
+        assertThat(fms.getC(), is(10));
+    }
+
+    @Test
+    void testCpuidToFamilyModelSteppingAmd() {
+        // AMD Zen 2 (Ryzen 3600): CPUID = 0x00800F12 → family=143 (0x8F), model=1, stepping=2
+        // formula: family = (cpuid >> 16 & 0xff0) | (cpuid >> 8 & 0xf)
+        // model = (cpuid >> 12 & 0xf0) | (cpuid >> 4 & 0xf)
+        // 0x00800F12 >> 16 = 0x0080, & 0xff0 = 0x80; >> 8 = 0x00800F, & 0xf = 0xF; family = 0x80|0xF = 0x8F = 143
+        // 0x00800F12 >> 12 = 0x00800, & 0xf0 = 0x00; >> 4 = 0x0080_0F1, & 0xf = 0x1; model = 0|1 = 1
+        Triplet<Integer, Integer, Integer> fms = OpenBsdCentralProcessor.cpuidToFamilyModelStepping(0x00800F12);
+        assertThat(fms.getA(), is(143));
+        assertThat(fms.getB(), is(1));
+        assertThat(fms.getC(), is(2));
+    }
+
+    @Test
+    void testCpuidToFamilyModelSteppingZero() {
+        Triplet<Integer, Integer, Integer> fms = OpenBsdCentralProcessor.cpuidToFamilyModelStepping(0);
+        assertThat(fms.getA(), is(0));
+        assertThat(fms.getB(), is(0));
+        assertThat(fms.getC(), is(0));
     }
 
     /**

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdFirmwareTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.openbsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Triplet;
+
+class OpenBsdFirmwareTest {
+
+    @Test
+    void testParseDmesg() {
+        // Representative OpenBSD dmesg bios0 output
+        List<String> dmesg = Arrays.asList(//
+                "bios0 at mainbus0: SMBIOS rev. 2.8 @ 0xe9cb0 (53 entries)", //
+                "bios0: vendor American Megatrends Inc. version \"F5\" date 03/18/2016");
+        Triplet<String, String, String> fw = OpenBsdFirmware.parseDmesg(dmesg);
+        // The full remainder after "vendor" is captured — existing behavior preserved
+        assertThat(fw.getA(), is("American Megatrends Inc. version \"F5\" date 03/18/2016"));
+        assertThat(fw.getB(), is("F5"));
+        assertThat(fw.getC(), is("2016-03-18"));
+    }
+
+    @Test
+    void testParseDmesgEmpty() {
+        Triplet<String, String, String> fw = OpenBsdFirmware.parseDmesg(Collections.emptyList());
+        assertThat(fw.getA(), is(nullValue()));
+        assertThat(fw.getB(), is(nullValue()));
+        assertThat(fw.getC(), is(emptyString()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdFirmwareTest.java
@@ -21,13 +21,12 @@ class OpenBsdFirmwareTest {
 
     @Test
     void testParseDmesg() {
-        // Representative OpenBSD dmesg bios0 output
+        // Representative OpenBSD dmesg bios0 output with multi-word vendor
         List<String> dmesg = Arrays.asList(//
                 "bios0 at mainbus0: SMBIOS rev. 2.8 @ 0xe9cb0 (53 entries)", //
                 "bios0: vendor American Megatrends Inc. version \"F5\" date 03/18/2016");
         Triplet<String, String, String> fw = OpenBsdFirmware.parseDmesg(dmesg);
-        // The full remainder after "vendor" is captured — existing behavior preserved
-        assertThat(fw.getA(), is("American Megatrends Inc. version \"F5\" date 03/18/2016"));
+        assertThat(fw.getA(), is("American Megatrends Inc."));
         assertThat(fw.getB(), is("F5"));
         assertThat(fw.getC(), is("2016-03-18"));
     }


### PR DESCRIPTION
## Summary
- Extract inline command-output parsing into package-private static methods that accept `List<String>`, mirroring the pattern from #3494 (Linux) and #3495 (FreeBSD)
- Allows fixture-based tests to exercise parse logic on every CI platform without requiring the target OS
- Covers 8 source files shared by NetBSD and OpenBSD: firmware (dmesg bios0), CPU topology/caches/feature-flags, vmstat counters, processor identification, graphics cards (pcidump), sound cards (dmesg audio/pci), and USB devices (usbdevs)

## Test plan
- [x] Full reactor build passes locally (`./mvnw clean install` — 1137 tests, 0 failures)
- [x] Unix CI passes on fork: https://github.com/dbwiddis/oshi/actions/runs/29767455079
- [x] New fixture tests exercise parse methods with synthetic input grounded in real command output (man pages / captures)
- [x] No `@EnabledOnOs` gating on parse tests — they run on every platform
- [x] Existing OpenBSD tick-mapping/load-average stub tests still pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BSD hardware detection and parsing for CPU topology/model/caches, firmware, graphics, sound, and USB devices.
  * Enhanced NetBSD and OpenBSD processor, system statistics, and firmware extraction accuracy, including more resilient dmesg parsing.
  * Reduced repeated system-output collection during hardware discovery to improve consistency and efficiency.
* **Tests**
  * Added/expanded unit test coverage for BSD, NetBSD, and OpenBSD parsing of CPU, firmware, graphics, sound, USB, and system statistics outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->