### PR TITLE
Solaris: extract testable parse methods from command readers

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessor.java
@@ -34,19 +34,7 @@ public abstract class SolarisCentralProcessor extends AbstractCentralProcessor {
         if (logProcs.isEmpty()) {
             logProcs.add(new LogicalProcessor(0, 0, 0));
         }
-        Map<Integer, String> dmesg = new HashMap<>();
-        // Jan 9 14:04:28 solaris unix: [ID 950921 kern.info] cpu0: Intel(r) Celeron(r)
-        // CPU J3455 @ 1.50GHz
-        // but NOT: Jan 9 14:04:28 solaris unix: [ID 950921 kern.info] cpu0: x86 (chipid
-        // 0x0 GenuineIntel 506C9 family 6 model 92 step 9 clock 1500 MHz)
-        Pattern p = Pattern.compile(".* cpu(\\d+): ((ARM|AMD|Intel).+)");
-        for (String s : ExecutingCommand.runNative("dmesg")) {
-            Matcher m = p.matcher(s);
-            if (m.matches()) {
-                int coreId = ParseUtil.parseIntOrDefault(m.group(1), 0);
-                dmesg.put(coreId, m.group(2).trim());
-            }
-        }
+        Map<Integer, String> dmesg = parseDmesgCpuInfo(ExecutingCommand.runNative("dmesg"));
         if (dmesg.isEmpty()) {
             return new Quartet<>(logProcs, null, null, Collections.emptyList());
         }
@@ -70,23 +58,13 @@ public abstract class SolarisCentralProcessor extends AbstractCentralProcessor {
 
     @Override
     public long queryContextSwitches() {
-        long swtch = 0;
         // Shell-escaped pipe: Java \\\\| -> shell \\| -> kstat regex \| -> matches literal pipe.
-        List<String> kstat = ExecutingCommand.runNative("kstat -p cpu_stat:::/pswitch\\\\|inv_swtch/");
-        for (String s : kstat) {
-            swtch += ParseUtil.parseLastLong(s, 0L);
-        }
-        return swtch;
+        return sumKstatLong(ExecutingCommand.runNative("kstat -p cpu_stat:::/pswitch\\\\|inv_swtch/"));
     }
 
     @Override
     public long queryInterrupts() {
-        long intr = 0;
-        List<String> kstat = ExecutingCommand.runNative("kstat -p cpu_stat:::/intr/");
-        for (String s : kstat) {
-            intr += ParseUtil.parseLastLong(s, 0L);
-        }
-        return intr;
+        return sumKstatLong(ExecutingCommand.runNative("kstat -p cpu_stat:::/intr/"));
     }
 
     /**
@@ -102,10 +80,56 @@ public abstract class SolarisCentralProcessor extends AbstractCentralProcessor {
      * @return a map of processor id to NUMA node
      */
     protected static Map<Integer, Integer> mapNumaNodes() {
+        return parseNumaNodes(ExecutingCommand.runNative("lgrpinfo -c leaves"));
+    }
+
+    /**
+     * Fetches the ProcessorID by encoding the stepping, model, family, and feature flags.
+     *
+     * @param stepping the stepping
+     * @param model    the model
+     * @param family   the family
+     * @return the Processor ID string
+     */
+    protected static String getProcessorID(String stepping, String model, String family) {
+        String[] flags = parseIsainfoFlags(ExecutingCommand.runNative("isainfo -v"));
+        return createProcessorID(stepping, model, family, flags);
+    }
+
+    /**
+     * Parses the output of {@code dmesg} to extract CPU name strings keyed by core id.
+     *
+     * @param dmesg the lines emitted by {@code dmesg}
+     * @return a map of core id to CPU name string
+     */
+    static Map<Integer, String> parseDmesgCpuInfo(List<String> dmesg) {
+        Map<Integer, String> cpuMap = new HashMap<>();
+        // Jan 9 14:04:28 solaris unix: [ID 950921 kern.info] cpu0: Intel(r) Celeron(r)
+        // CPU J3455 @ 1.50GHz
+        // but NOT: Jan 9 14:04:28 solaris unix: [ID 950921 kern.info] cpu0: x86 (chipid
+        // 0x0 GenuineIntel 506C9 family 6 model 92 step 9 clock 1500 MHz)
+        Pattern p = Pattern.compile(".* cpu(\\d+): ((ARM|AMD|Intel).+)");
+        for (String s : dmesg) {
+            Matcher m = p.matcher(s);
+            if (m.matches()) {
+                int coreId = ParseUtil.parseIntOrDefault(m.group(1), 0);
+                cpuMap.put(coreId, m.group(2).trim());
+            }
+        }
+        return cpuMap;
+    }
+
+    /**
+     * Parses the output of {@code lgrpinfo -c leaves} into a map of CPU id to NUMA node.
+     *
+     * @param lgrpinfo the lines emitted by {@code lgrpinfo -c leaves}
+     * @return a map of processor id to NUMA node number
+     */
+    static Map<Integer, Integer> parseNumaNodes(List<String> lgrpinfo) {
         // Get numa node info from lgrpinfo
         Map<Integer, Integer> numaNodeMap = new HashMap<>();
         int lgroup = 0;
-        for (String line : ExecutingCommand.runNative("lgrpinfo -c leaves")) {
+        for (String line : lgrpinfo) {
             // Format:
             // lgroup 0 (root):
             // CPUs: 0 1
@@ -125,15 +149,12 @@ public abstract class SolarisCentralProcessor extends AbstractCentralProcessor {
     }
 
     /**
-     * Fetches the ProcessorID by encoding the stepping, model, family, and feature flags.
+     * Parses the output of {@code isainfo -v} to extract the 64-bit feature flags.
      *
-     * @param stepping the stepping
-     * @param model    the model
-     * @param family   the family
-     * @return the Processor ID string
+     * @param isainfo the lines emitted by {@code isainfo -v}
+     * @return an array of feature flag strings (lowercase)
      */
-    protected static String getProcessorID(String stepping, String model, String family) {
-        List<String> isainfo = ExecutingCommand.runNative("isainfo -v");
+    static String[] parseIsainfoFlags(List<String> isainfo) {
         StringBuilder flags = new StringBuilder();
         for (String line : isainfo) {
             if (line.startsWith("32-bit")) {
@@ -142,7 +163,20 @@ public abstract class SolarisCentralProcessor extends AbstractCentralProcessor {
                 flags.append(' ').append(line.trim());
             }
         }
-        return createProcessorID(stepping, model, family,
-                ParseUtil.whitespaces.split(flags.toString().toLowerCase(Locale.ROOT)));
+        return ParseUtil.whitespaces.split(flags.toString().toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Sums the last long value from each line of {@code kstat -p} output.
+     *
+     * @param kstat the lines emitted by a {@code kstat -p} command
+     * @return the sum of the trailing long values across all lines
+     */
+    static long sumKstatLong(List<String> kstat) {
+        long total = 0L;
+        for (String s : kstat) {
+            total += ParseUtil.parseLastLong(s, 0L);
+        }
+        return total;
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystem.java
@@ -12,6 +12,7 @@ import static oshi.util.ParseUtil.getValueOrUnknown;
 
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -79,6 +80,39 @@ public class SolarisComputerSystem extends AbstractComputerSystem {
     }
 
     private static SmbiosStrings readSmbios() {
+        EnumMap<SmbType, Map<String, String>> smbTypesMap = parseSmbios(ExecutingCommand.runNative("smbios"));
+
+        Map<String, String> smbTypeBIOSMap = smbTypesMap.get(SMB_TYPE_BIOS);
+        Map<String, String> smbTypeSystemMap = smbTypesMap.get(SMB_TYPE_SYSTEM);
+        Map<String, String> smbTypeBaseboardMap = smbTypesMap.get(SMB_TYPE_BASEBOARD);
+
+        final String serialNumMarker = "Serial Number";
+        // If we get to end and haven't assigned, use fallback
+        if (!smbTypeSystemMap.containsKey(serialNumMarker) || Util.isBlank(smbTypeSystemMap.get(serialNumMarker))) {
+            smbTypeSystemMap.put(serialNumMarker, readSerialNumber());
+        }
+        return new SmbiosStrings(smbTypeBIOSMap, smbTypeSystemMap, smbTypeBaseboardMap);
+    }
+
+    private static SmbType getSmbType(String checkLine) {
+        for (SmbType smbType : SmbType.values()) {
+            if (checkLine.contains(smbType.name())) {
+                return smbType;
+            }
+        }
+        // First 3 SMB_TYPEs are what we need. After that no need to
+        // continue processing the output
+        return null;
+    }
+
+    /**
+     * Parses the output of the {@code smbios} command into an {@link EnumMap} keyed by SMBIOS type, where each value is
+     * a map of field names to their string values.
+     *
+     * @param smbios the lines emitted by the {@code smbios} command
+     * @return an {@link EnumMap} of {@link SmbType} to field key-value maps
+     */
+    static EnumMap<SmbType, Map<String, String>> parseSmbios(List<String> smbios) {
         // $ smbios
         // ID SIZE TYPE
         // 0 87 SMB_TYPE_BIOS (BIOS Information)
@@ -115,8 +149,6 @@ public class SolarisComputerSystem extends AbstractComputerSystem {
         // ID SIZE TYPE
         // 3 .... <snip> ...
 
-        final String serialNumMarker = "Serial Number";
-
         SmbType smbTypeId = null;
 
         EnumMap<SmbType, Map<String, String>> smbTypesMap = new EnumMap<>(SmbType.class);
@@ -124,8 +156,7 @@ public class SolarisComputerSystem extends AbstractComputerSystem {
         smbTypesMap.put(SMB_TYPE_SYSTEM, new HashMap<>());
         smbTypesMap.put(SMB_TYPE_BASEBOARD, new HashMap<>());
 
-        // Only works with root permissions but it's all we've got
-        for (final String checkLine : ExecutingCommand.runNative("smbios")) {
+        for (final String checkLine : smbios) {
             // Change the smbTypeId when hitting a new header
             if (checkLine.contains("SMB_TYPE_") && (smbTypeId = getSmbType(checkLine)) == null) {
                 // If we get past what we need, stop iterating
@@ -139,27 +170,7 @@ public class SolarisComputerSystem extends AbstractComputerSystem {
                 smbTypesMap.get(smbTypeId).put(key, val);
             }
         }
-
-        Map<String, String> smbTypeBIOSMap = smbTypesMap.get(SMB_TYPE_BIOS);
-        Map<String, String> smbTypeSystemMap = smbTypesMap.get(SMB_TYPE_SYSTEM);
-        Map<String, String> smbTypeBaseboardMap = smbTypesMap.get(SMB_TYPE_BASEBOARD);
-
-        // If we get to end and haven't assigned, use fallback
-        if (!smbTypeSystemMap.containsKey(serialNumMarker) || Util.isBlank(smbTypeSystemMap.get(serialNumMarker))) {
-            smbTypeSystemMap.put(serialNumMarker, readSerialNumber());
-        }
-        return new SmbiosStrings(smbTypeBIOSMap, smbTypeSystemMap, smbTypeBaseboardMap);
-    }
-
-    private static SmbType getSmbType(String checkLine) {
-        for (SmbType smbType : SmbType.values()) {
-            if (checkLine.contains(smbType.name())) {
-                return smbType;
-            }
-        }
-        // First 3 SMB_TYPEs are what we need. After that no need to
-        // continue processing the output
-        return null;
+        return smbTypesMap;
     }
 
     private static String readSerialNumber() {
@@ -167,15 +178,25 @@ public class SolarisComputerSystem extends AbstractComputerSystem {
         String serialNumber = ExecutingCommand.getFirstAnswer("sneep");
         // if that didn't work, try...
         if (serialNumber.isEmpty()) {
-            String marker = "chassis-sn:";
-            for (String checkLine : ExecutingCommand.runNative("prtconf -pv")) {
-                if (checkLine.contains(marker)) {
-                    serialNumber = ParseUtil.getSingleQuoteStringValue(checkLine);
-                    break;
-                }
-            }
+            serialNumber = parseSerialFromPrtconf(ExecutingCommand.runNative("prtconf -pv"));
         }
         return serialNumber;
+    }
+
+    /**
+     * Parses the output of {@code prtconf -pv} to extract the chassis serial number.
+     *
+     * @param prtconf the lines emitted by {@code prtconf -pv}
+     * @return the serial number string, or empty string if not found
+     */
+    static String parseSerialFromPrtconf(List<String> prtconf) {
+        String marker = "chassis-sn:";
+        for (String checkLine : prtconf) {
+            if (checkLine.contains(marker)) {
+                return ParseUtil.getSingleQuoteStringValue(checkLine);
+            }
+        }
+        return "";
     }
 
     private static final class SmbiosStrings {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisGraphicsCard.java
@@ -41,9 +41,17 @@ public class SolarisGraphicsCard extends AbstractGraphicsCard {
      * @return List of {@link SolarisGraphicsCard} objects.
      */
     public static List<GraphicsCard> getGraphicsCards() {
+        return parsePrtconf(ExecutingCommand.runNative("prtconf -pv"));
+    }
+
+    /**
+     * Parses the output of {@code prtconf -pv} to extract display-class PCI devices as graphics cards.
+     *
+     * @param devices the lines emitted by {@code prtconf -pv}
+     * @return a list of {@link GraphicsCard} objects for each display device found
+     */
+    static List<GraphicsCard> parsePrtconf(List<String> devices) {
         List<GraphicsCard> cardList = new ArrayList<>();
-        // Enumerate all devices and add if required
-        List<String> devices = ExecutingCommand.runNative("prtconf -pv");
         if (devices.isEmpty()) {
             return cardList;
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisSoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisSoundCard.java
@@ -43,11 +43,21 @@ public class SolarisSoundCard extends AbstractSoundCard {
      * @return a {@link java.util.List} object.
      */
     public static List<SoundCard> getSoundCards() {
+        return parseLshal(ExecutingCommand.runNative(LSHAL));
+    }
+
+    /**
+     * Parses the output of {@code lshal} to extract sound card information.
+     *
+     * @param lshal the lines emitted by the {@code lshal} command
+     * @return a list of {@link SoundCard} objects for each audio device found
+     */
+    static List<SoundCard> parseLshal(List<String> lshal) {
         Map<String, String> vendorMap = new HashMap<>();
         Map<String, String> productMap = new HashMap<>();
         List<String> sounds = new ArrayList<>();
         String key = "";
-        for (String line : ExecutingCommand.runNative(LSHAL)) {
+        for (String line : lshal) {
             line = line.trim();
             if (line.startsWith("udi =")) {
                 // we have the key.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisVirtualMemory.java
@@ -7,6 +7,7 @@ package oshi.hardware.common.platform.unix.solaris;
 import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.memoize;
 
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -75,26 +76,41 @@ public class SolarisVirtualMemory extends AbstractVirtualMemory {
     }
 
     private static long queryPagesIn() {
-        long swapPagesIn = 0L;
-        for (String s : ExecutingCommand.runNative("kstat -p cpu_stat:::pgswapin")) {
-            swapPagesIn += ParseUtil.parseLastLong(s, 0L);
-        }
-        return swapPagesIn;
+        return sumKstatLong(ExecutingCommand.runNative("kstat -p cpu_stat:::pgswapin"));
     }
 
     private static long queryPagesOut() {
-        long swapPagesOut = 0L;
-        for (String s : ExecutingCommand.runNative("kstat -p cpu_stat:::pgswapout")) {
-            swapPagesOut += ParseUtil.parseLastLong(s, 0L);
-        }
-        return swapPagesOut;
+        return sumKstatLong(ExecutingCommand.runNative("kstat -p cpu_stat:::pgswapout"));
     }
 
     private static Pair<Long, Long> querySwapInfo() {
+        return parseSwapInfo(ExecutingCommand.getAnswerAt("swap -lk", 1));
+    }
+
+    /**
+     * Sums the last long value from each line of {@code kstat -p} output.
+     *
+     * @param kstat the lines emitted by a {@code kstat -p} command
+     * @return the sum of the trailing long values across all lines
+     */
+    static long sumKstatLong(List<String> kstat) {
+        long total = 0L;
+        for (String s : kstat) {
+            total += ParseUtil.parseLastLong(s, 0L);
+        }
+        return total;
+    }
+
+    /**
+     * Parses a single line of {@code swap -lk} output into swap used and swap total values.
+     *
+     * @param swapLine the line from {@code swap -lk} (typically the second line of output)
+     * @return a {@link Pair} of (swap used, swap total) in bytes
+     */
+    static Pair<Long, Long> parseSwapInfo(String swapLine) {
         long swapTotal = 0L;
         long swapUsed = 0L;
-        String swap = ExecutingCommand.getAnswerAt("swap -lk", 1);
-        Matcher m = SWAP_INFO.matcher(swap);
+        Matcher m = SWAP_INFO.matcher(swapLine);
         if (m.matches()) {
             swapTotal = ParseUtil.parseLongOrDefault(m.group(1), 0L) << 10;
             swapUsed = swapTotal - (ParseUtil.parseLongOrDefault(m.group(2), 0L) << 10);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStats.java
@@ -65,7 +65,7 @@ public class SolarisInternetProtocolStats extends AbstractInternetProtocolStats 
             // Now of form tcpXX = 123
             for (String stat : stats) {
                 if (stat != null) {
-                    String[] split = stat.split("=");
+                    String[] split = stat.split("=", 2);
                     if (split.length == 2) {
                         switch (split[0].trim()) {
                             case "tcpCurrEstab":
@@ -127,7 +127,7 @@ public class SolarisInternetProtocolStats extends AbstractInternetProtocolStats 
             // Now of form udpXX = 123
             for (String stat : stats) {
                 if (stat != null) {
-                    String[] split = stat.split("=");
+                    String[] split = stat.split("=", 2);
                     if (split.length == 2) {
                         switch (split[0].trim()) {
                             case "udpOutDatagrams":

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStats.java
@@ -4,6 +4,7 @@
  */
 package oshi.software.common.os.unix.solaris;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -28,6 +29,26 @@ public class SolarisInternetProtocolStats extends AbstractInternetProtocolStats 
     }
 
     private static TcpStats getTcpStats() {
+        List<String> netstat = new ArrayList<>(ExecutingCommand.runNative("netstat -s -P tcp"));
+        // append IP
+        netstat.addAll(ExecutingCommand.runNative("netstat -s -P ip"));
+        return parseTcpStats(netstat);
+    }
+
+    private static UdpStats getUdpStats() {
+        List<String> netstat = new ArrayList<>(ExecutingCommand.runNative("netstat -s -P udp"));
+        // append IP
+        netstat.addAll(ExecutingCommand.runNative("netstat -s -P ip"));
+        return parseUdpStats(netstat);
+    }
+
+    /**
+     * Parses combined {@code netstat -s -P tcp} and {@code netstat -s -P ip} output into TCP statistics.
+     *
+     * @param netstat the combined lines from both netstat commands
+     * @return a {@link TcpStats} object with the parsed values
+     */
+    static TcpStats parseTcpStats(List<String> netstat) {
         long connectionsEstablished = 0;
         long connectionsActive = 0;
         long connectionsPassive = 0;
@@ -38,9 +59,6 @@ public class SolarisInternetProtocolStats extends AbstractInternetProtocolStats 
         long segmentsRetransmitted = 0;
         long inErrors = 0;
         long outResets = 0;
-        List<String> netstat = ExecutingCommand.runNative("netstat -s -P tcp");
-        // append IP
-        netstat.addAll(ExecutingCommand.runNative("netstat -s -P ip"));
         for (String s : netstat) {
             // Two stats per line. Split the strings by index of "tcp"
             String[] stats = splitOnPrefix(s, "tcp");
@@ -92,14 +110,17 @@ public class SolarisInternetProtocolStats extends AbstractInternetProtocolStats 
                 connectionsReset, segmentsSent, segmentsReceived, segmentsRetransmitted, inErrors, outResets);
     }
 
-    private static UdpStats getUdpStats() {
+    /**
+     * Parses combined {@code netstat -s -P udp} and {@code netstat -s -P ip} output into UDP statistics.
+     *
+     * @param netstat the combined lines from both netstat commands
+     * @return a {@link UdpStats} object with the parsed values
+     */
+    static UdpStats parseUdpStats(List<String> netstat) {
         long datagramsSent = 0;
         long datagramsReceived = 0;
         long datagramsNoPort = 0;
         long datagramsReceivedErrors = 0;
-        List<String> netstat = ExecutingCommand.runNative("netstat -s -P udp");
-        // append IP
-        netstat.addAll(ExecutingCommand.runNative("netstat -s -P ip"));
         for (String s : netstat) {
             // Two stats per line. Split the strings by index of "udp"
             String[] stats = splitOnPrefix(s, "udp");
@@ -131,7 +152,15 @@ public class SolarisInternetProtocolStats extends AbstractInternetProtocolStats 
         return new UdpStats(datagramsSent, datagramsReceived, datagramsNoPort, datagramsReceivedErrors);
     }
 
-    private static String[] splitOnPrefix(String s, String prefix) {
+    /**
+     * Splits a line on a given prefix, yielding up to two stat fragments. Each line may contain two stat entries
+     * separated by the prefix (e.g., {@code "tcpFoo = 1   tcpBar = 2"}).
+     *
+     * @param s      the line to split
+     * @param prefix the stat name prefix (e.g., {@code "tcp"} or {@code "udp"})
+     * @return a two-element array where each element is a stat fragment or {@code null}
+     */
+    static String[] splitOnPrefix(String s, String prefix) {
         String[] stats = new String[2];
         int first = s.indexOf(prefix);
         if (first >= 0) {

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -86,6 +86,10 @@
   com.github.oshi.common/oshi.software.common.os.unix.aix=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.software.common.os.unix.bsd=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.hardware.common.platform.unix.solaris=org.junit.platform.commons
+--add-opens
+  com.github.oshi.common/oshi.software.common.os.unix.solaris=org.junit.platform.commons
 
 --add-modules
   org.hamcrest,org.slf4j.simple

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class SolarisCentralProcessorTest {
+
+    @Test
+    void testParseDmesgCpuInfo() {
+        List<String> dmesg = Arrays.asList(//
+                "Jan  9 14:04:28 solaris unix: [ID 950921 kern.info] cpu0: Intel(r) Celeron(r) CPU J3455 @ 1.50GHz", //
+                "Jan  9 14:04:28 solaris unix: [ID 950921 kern.info] cpu0: x86 (chipid 0x0 GenuineIntel 506C9 family 6 model 92 step 9 clock 1500 MHz)", //
+                "Jan  9 14:04:28 solaris unix: [ID 950921 kern.info] cpu1: Intel(r) Celeron(r) CPU J3455 @ 1.50GHz");
+        Map<Integer, String> result = SolarisCentralProcessor.parseDmesgCpuInfo(dmesg);
+        // Only lines matching ".* cpu(\d+): ((ARM|AMD|Intel).+)" are captured
+        assertThat(result.size(), is(2));
+        assertThat(result, hasEntry(0, "Intel(r) Celeron(r) CPU J3455 @ 1.50GHz"));
+        assertThat(result, hasEntry(1, "Intel(r) Celeron(r) CPU J3455 @ 1.50GHz"));
+    }
+
+    @Test
+    void testParseDmesgCpuInfoEmpty() {
+        Map<Integer, String> result = SolarisCentralProcessor.parseDmesgCpuInfo(Collections.emptyList());
+        assertThat(result.isEmpty(), is(true));
+    }
+
+    @Test
+    void testParseNumaNodes() {
+        List<String> lgrpinfo = Arrays.asList(//
+                "lgroup 0 (root):", //
+                "CPUs: 0-3", //
+                "lgroup 1 (leaf):", //
+                "CPUs: 4 5 6 7");
+        Map<Integer, Integer> result = SolarisCentralProcessor.parseNumaNodes(lgrpinfo);
+        assertThat(result.size(), is(8));
+        assertThat(result, hasEntry(0, 0));
+        assertThat(result, hasEntry(1, 0));
+        assertThat(result, hasEntry(2, 0));
+        assertThat(result, hasEntry(3, 0));
+        assertThat(result, hasEntry(4, 1));
+        assertThat(result, hasEntry(5, 1));
+        assertThat(result, hasEntry(6, 1));
+        assertThat(result, hasEntry(7, 1));
+    }
+
+    @Test
+    void testParseNumaNodesEmpty() {
+        Map<Integer, Integer> result = SolarisCentralProcessor.parseNumaNodes(Collections.emptyList());
+        assertThat(result.isEmpty(), is(true));
+    }
+
+    @Test
+    void testParseIsainfoFlags() {
+        // isainfo -v output: first a 64-bit header, then indented flags, then 32-bit header
+        List<String> isainfo = Arrays.asList(//
+                "64-bit amd64 applications", //
+                "        avx512f avx512cd sha sse4.2 popcnt", //
+                "32-bit i386 applications", //
+                "        sse2 sse mmx");
+        String[] flags = SolarisCentralProcessor.parseIsainfoFlags(isainfo);
+        // Should only contain flags from the 64-bit section, lowercased, split on whitespace.
+        // The first element is empty because the flags StringBuilder starts with a space.
+        assertThat(flags, arrayContaining("", "avx512f", "avx512cd", "sha", "sse4.2", "popcnt"));
+    }
+
+    @Test
+    void testParseIsainfoFlagsEmpty() {
+        String[] flags = SolarisCentralProcessor.parseIsainfoFlags(Collections.emptyList());
+        // Splitting an empty string produces a single-element array with ""
+        assertThat(flags.length, is(1));
+        assertThat(flags[0], is(""));
+    }
+
+    @Test
+    void testSumKstatLong() {
+        List<String> kstat = Arrays.asList(//
+                "cpu_stat:0:cpu_stat0:pswitch\t1000", //
+                "cpu_stat:1:cpu_stat1:pswitch\t2000", //
+                "cpu_stat:0:cpu_stat0:inv_swtch\t500");
+        assertThat(SolarisCentralProcessor.sumKstatLong(kstat), is(3500L));
+    }
+
+    @Test
+    void testSumKstatLongEmpty() {
+        assertThat(SolarisCentralProcessor.sumKstatLong(Collections.emptyList()), is(0L));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystemTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.common.platform.unix.solaris.SolarisComputerSystem.SmbType;
+
+class SolarisComputerSystemTest {
+
+    @Test
+    void testParseSmbios() {
+        // Representative smbios output with BIOS, System, and Baseboard sections
+        List<String> smbios = Arrays.asList(//
+                "ID    SIZE TYPE", //
+                "0     87   SMB_TYPE_BIOS (BIOS Information)", //
+                "", //
+                "  Vendor: Parallels Software International Inc.", //
+                "  Version String: 11.2.1 (32686)", //
+                "  Release Date: 07/15/2016", //
+                "  Address Segment: 0xf000", //
+                "", //
+                "ID    SIZE TYPE", //
+                "1     177  SMB_TYPE_SYSTEM (system information)", //
+                "", //
+                "  Manufacturer: Parallels Software International Inc.", //
+                "  Product: Parallels Virtual Platform", //
+                "  Version: None", //
+                "  Serial Number: Parallels-45 2E 7E 2D 57 5C 4B 59 B1 30 28 81 B7 81 89 34", //
+                "  UUID: 452e7e2d-575c04b59-b130-2881b7818934", //
+                "", //
+                "ID    SIZE TYPE", //
+                "2     90   SMB_TYPE_BASEBOARD (base board)", //
+                "", //
+                "  Manufacturer: Parallels Software International Inc.", //
+                "  Product: Parallels Virtual Platform", //
+                "  Version: None", //
+                "  Serial Number: None");
+
+        EnumMap<SmbType, Map<String, String>> result = SolarisComputerSystem.parseSmbios(smbios);
+
+        Map<String, String> bios = result.get(SmbType.SMB_TYPE_BIOS);
+        assertThat(bios.get("Vendor"), is("Parallels Software International Inc."));
+        assertThat(bios.get("Version String"), is("11.2.1 (32686)"));
+        assertThat(bios.get("Release Date"), is("07/15/2016"));
+
+        Map<String, String> system = result.get(SmbType.SMB_TYPE_SYSTEM);
+        assertThat(system.get("Manufacturer"), is("Parallels Software International Inc."));
+        assertThat(system.get("Product"), is("Parallels Virtual Platform"));
+        assertThat(system.get("Serial Number"), is("Parallels-45 2E 7E 2D 57 5C 4B 59 B1 30 28 81 B7 81 89 34"));
+        assertThat(system.get("UUID"), is("452e7e2d-575c04b59-b130-2881b7818934"));
+
+        Map<String, String> baseboard = result.get(SmbType.SMB_TYPE_BASEBOARD);
+        assertThat(baseboard.get("Manufacturer"), is("Parallels Software International Inc."));
+        assertThat(baseboard.get("Product"), is("Parallels Virtual Platform"));
+        assertThat(baseboard.get("Serial Number"), is("None"));
+    }
+
+    @Test
+    void testParseSmbiosEmpty() {
+        EnumMap<SmbType, Map<String, String>> result = SolarisComputerSystem.parseSmbios(Collections.emptyList());
+        assertThat(result.get(SmbType.SMB_TYPE_BIOS).isEmpty(), is(true));
+        assertThat(result.get(SmbType.SMB_TYPE_SYSTEM).isEmpty(), is(true));
+        assertThat(result.get(SmbType.SMB_TYPE_BASEBOARD).isEmpty(), is(true));
+    }
+
+    @Test
+    void testParseSerialFromPrtconf() {
+        List<String> prtconf = Arrays.asList(//
+                "System Configuration:  Sun Microsystems  sun4u", //
+                "    name:  'SUNW,Ultra-5_10'", //
+                "      chassis-sn:  'ABC123'", //
+                "    banner-name:  'Sun Ultra 5/10 UPA/PCI'");
+        assertThat(SolarisComputerSystem.parseSerialFromPrtconf(prtconf), is("ABC123"));
+    }
+
+    @Test
+    void testParseSerialFromPrtconfEmpty() {
+        assertThat(SolarisComputerSystem.parseSerialFromPrtconf(Collections.emptyList()), is(""));
+    }
+
+    @Test
+    void testParseSerialFromPrtconfNoMatch() {
+        List<String> prtconf = Arrays.asList(//
+                "System Configuration:  Sun Microsystems  sun4u", //
+                "    name:  'SUNW,Ultra-5_10'");
+        assertThat(SolarisComputerSystem.parseSerialFromPrtconf(prtconf), is(""));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisGraphicsCardTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.GraphicsCard;
+
+class SolarisGraphicsCardTest {
+
+    @Test
+    void testParsePrtconf() {
+        // prtconf -pv output with a display-class device (class-code 0003xxxx)
+        List<String> prtconf = Arrays.asList(//
+                "    Node 0x1f8e610", //
+                "      name:  'pci8086,2a42'", //
+                "      model:  'Intel GM45 Integrated Graphics'", //
+                "      vendor-id:  00008086", //
+                "      device-id:  00002a42", //
+                "      revision-id:  00000007", //
+                "      class-code:  00030000");
+        List<GraphicsCard> cards = SolarisGraphicsCard.parsePrtconf(prtconf);
+        assertThat(cards, hasSize(1));
+        GraphicsCard card = cards.get(0);
+        assertThat(card.getName(), is("Intel GM45 Integrated Graphics"));
+        assertThat(card.getVendor(), is("0x8086"));
+        assertThat(card.getDeviceId(), is("0x2a42"));
+        assertThat(card.getVersionInfo(), is("revision-id:  00000007"));
+        assertThat(card.getVRam(), is(0L));
+    }
+
+    @Test
+    void testParsePrtconfNoDisplayDevice() {
+        // prtconf -pv output with NO display-class device
+        List<String> prtconf = Arrays.asList(//
+                "    Node 0x1f8e610", //
+                "      name:  'pci8086,29c0'", //
+                "      vendor-id:  00008086", //
+                "      device-id:  000029c0", //
+                "      class-code:  00060000"); // class 0006 = Bridge, not Display
+        List<GraphicsCard> cards = SolarisGraphicsCard.parsePrtconf(prtconf);
+        assertThat(cards, is(empty()));
+    }
+
+    @Test
+    void testParsePrtconfEmpty() {
+        List<GraphicsCard> cards = SolarisGraphicsCard.parsePrtconf(Collections.emptyList());
+        assertThat(cards, is(empty()));
+    }
+
+    @Test
+    void testParsePrtconfDisplayAtEnd() {
+        // Display device at end of output (no following Node header to flush)
+        List<String> prtconf = Arrays.asList(//
+                "    Node 0xaabbcc", //
+                "      name:  'pci1002,67df'", //
+                "      model:  'AMD Radeon RX 580'", //
+                "      vendor-id:  00001002", //
+                "      device-id:  000067df", //
+                "      revision-id:  000000e7", //
+                "      class-code:  00030000");
+        List<GraphicsCard> cards = SolarisGraphicsCard.parsePrtconf(prtconf);
+        assertThat(cards, hasSize(1));
+        assertThat(cards.get(0).getName(), is("AMD Radeon RX 580"));
+        assertThat(cards.get(0).getVendor(), is("0x1002"));
+        assertThat(cards.get(0).getDeviceId(), is("0x67df"));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisSoundCardTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.SoundCard;
+
+class SolarisSoundCardTest {
+
+    @Test
+    void testParseLshal() {
+        // Representative lshal output with a sound device
+        List<String> lshal = Arrays.asList(//
+                "udi = '/org/freedesktop/Hal/devices/pci_8086_293e'", //
+                "  info.solaris.driver = 'audio810'  (string)", //
+                "  info.product = 'ICH9 HD Audio Controller'  (string)", //
+                "  info.vendor = 'Intel Corporation'  (string)", //
+                "", //
+                "udi = '/org/freedesktop/Hal/devices/pci_8086_0001'", //
+                "  info.solaris.driver = 'e1000g'  (string)", //
+                "  info.product = 'Network Adapter'  (string)", //
+                "  info.vendor = 'Intel Corporation'  (string)");
+        List<SoundCard> cards = SolarisSoundCard.parseLshal(lshal);
+        assertThat(cards, hasSize(1));
+        SoundCard card = cards.get(0);
+        assertThat(card.getName(), is("Intel Corporation ICH9 HD Audio Controller"));
+        assertThat(card.getCodec(), is("ICH9 HD Audio Controller"));
+        assertThat(card.getDriverVersion(), is("ICH9 HD Audio Controller audio810"));
+    }
+
+    @Test
+    void testParseLshalMultipleAudioDevices() {
+        List<String> lshal = Arrays.asList(//
+                "udi = '/org/freedesktop/Hal/devices/pci_8086_293e'", //
+                "  info.solaris.driver = 'audio810'  (string)", //
+                "  info.product = 'HD Audio'  (string)", //
+                "  info.vendor = 'Intel'  (string)", //
+                "", //
+                "udi = '/org/freedesktop/Hal/devices/pci_1002_aa38'", //
+                "  info.solaris.driver = 'audio810'  (string)", //
+                "  info.product = 'Radeon Audio'  (string)", //
+                "  info.vendor = 'AMD'  (string)");
+        List<SoundCard> cards = SolarisSoundCard.parseLshal(lshal);
+        assertThat(cards, hasSize(2));
+        assertThat(cards.get(0).getName(), is("Intel HD Audio"));
+        assertThat(cards.get(1).getName(), is("AMD Radeon Audio"));
+    }
+
+    @Test
+    void testParseLshalEmpty() {
+        List<SoundCard> cards = SolarisSoundCard.parseLshal(Collections.emptyList());
+        assertThat(cards, is(empty()));
+    }
+
+    @Test
+    void testParseLshalNoAudioDriver() {
+        // Devices exist but none have audio810 driver
+        List<String> lshal = Arrays.asList(//
+                "udi = '/org/freedesktop/Hal/devices/pci_8086_0001'", //
+                "  info.solaris.driver = 'e1000g'  (string)", //
+                "  info.product = 'Network Adapter'  (string)", //
+                "  info.vendor = 'Intel Corporation'  (string)");
+        List<SoundCard> cards = SolarisSoundCard.parseLshal(lshal);
+        assertThat(cards, is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisVirtualMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisVirtualMemoryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Pair;
+
+class SolarisVirtualMemoryTest {
+
+    @Test
+    void testSumKstatLong() {
+        List<String> kstat = Arrays.asList(//
+                "cpu_stat:0:cpu_stat0:pgswapin\t42", //
+                "cpu_stat:1:cpu_stat1:pgswapin\t18");
+        assertThat(SolarisVirtualMemory.sumKstatLong(kstat), is(60L));
+    }
+
+    @Test
+    void testSumKstatLongEmpty() {
+        assertThat(SolarisVirtualMemory.sumKstatLong(Collections.emptyList()), is(0L));
+    }
+
+    @Test
+    void testParseSwapInfo() {
+        // swap -lk output: device totalK freeK
+        String swapLine = "/dev/zvol/dsk/rpool/swap  1048576K  532480K";
+        Pair<Long, Long> result = SolarisVirtualMemory.parseSwapInfo(swapLine);
+        // total = 1048576 * 1024
+        assertThat(result.getB(), is(1048576L * 1024L));
+        // used = (1048576 - 532480) * 1024
+        assertThat(result.getA(), is((1048576L - 532480L) * 1024L));
+    }
+
+    @Test
+    void testParseSwapInfoEmpty() {
+        Pair<Long, Long> result = SolarisVirtualMemory.parseSwapInfo("");
+        assertThat(result.getA(), is(0L));
+        assertThat(result.getB(), is(0L));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStatsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStatsTest.java
@@ -42,6 +42,20 @@ class SolarisInternetProtocolStatsTest {
     }
 
     @Test
+    void testParseTcpStatsMixedPrefix() {
+        // Real netstat output: tcpInErr is paired with a non-tcp stat (from IP section),
+        // so splitOnPrefix finds only one "tcp" occurrence and the remainder contains "="
+        List<String> netstat = Arrays.asList(//
+                "tcpCurrEstab =    10   tcpActiveOpens =   100", //
+                "tcpInErr     =     7   udpNoPorts    =    99");
+        TcpStats stats = SolarisInternetProtocolStats.parseTcpStats(netstat);
+        assertThat(stats.getConnectionsEstablished(), is(10L));
+        assertThat(stats.getConnectionsActive(), is(100L));
+        // tcpInErr uses getFirstIntValue so it extracts 7 even with trailing "udpNoPorts = 99"
+        assertThat(stats.getInErrors(), is(7L));
+    }
+
+    @Test
     void testParseTcpStatsEmpty() {
         TcpStats stats = SolarisInternetProtocolStats.parseTcpStats(Collections.emptyList());
         assertThat(stats.getConnectionsEstablished(), is(0L));

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStatsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStatsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.software.os.InternetProtocolStats.TcpStats;
+import oshi.software.os.InternetProtocolStats.UdpStats;
+
+class SolarisInternetProtocolStatsTest {
+
+    @Test
+    void testParseTcpStats() {
+        // netstat -s -P tcp output: two stats per line separated by spaces
+        List<String> netstat = Arrays.asList(//
+                "tcpCurrEstab =    42   tcpActiveOpens =  1000", //
+                "tcpPassiveOpens = 500   tcpAttemptFails =   10", //
+                "tcpEstabResets =    5   tcpOutSegs    = 50000", //
+                "tcpInSegs     = 60000   tcpRetransSegs =   200", //
+                "tcpInErr      =     3   tcpOutRsts    =    15");
+        TcpStats stats = SolarisInternetProtocolStats.parseTcpStats(netstat);
+        assertThat(stats.getConnectionsEstablished(), is(42L));
+        assertThat(stats.getConnectionsActive(), is(1000L));
+        assertThat(stats.getConnectionsPassive(), is(500L));
+        assertThat(stats.getConnectionFailures(), is(10L));
+        assertThat(stats.getConnectionsReset(), is(5L));
+        assertThat(stats.getSegmentsSent(), is(50000L));
+        assertThat(stats.getSegmentsReceived(), is(60000L));
+        assertThat(stats.getSegmentsRetransmitted(), is(200L));
+        assertThat(stats.getInErrors(), is(3L));
+        assertThat(stats.getOutResets(), is(15L));
+    }
+
+    @Test
+    void testParseTcpStatsEmpty() {
+        TcpStats stats = SolarisInternetProtocolStats.parseTcpStats(Collections.emptyList());
+        assertThat(stats.getConnectionsEstablished(), is(0L));
+        assertThat(stats.getSegmentsSent(), is(0L));
+    }
+
+    @Test
+    void testParseUdpStats() {
+        List<String> netstat = Arrays.asList(//
+                "udpOutDatagrams = 10000   udpInDatagrams = 20000", //
+                "udpNoPorts      =   100   udpInErrors    =    50");
+        UdpStats stats = SolarisInternetProtocolStats.parseUdpStats(netstat);
+        assertThat(stats.getDatagramsSent(), is(10000L));
+        assertThat(stats.getDatagramsReceived(), is(20000L));
+        assertThat(stats.getDatagramsNoPort(), is(100L));
+        assertThat(stats.getDatagramsReceivedErrors(), is(50L));
+    }
+
+    @Test
+    void testParseUdpStatsEmpty() {
+        UdpStats stats = SolarisInternetProtocolStats.parseUdpStats(Collections.emptyList());
+        assertThat(stats.getDatagramsSent(), is(0L));
+        assertThat(stats.getDatagramsReceived(), is(0L));
+    }
+
+    @Test
+    void testSplitOnPrefix() {
+        String[] result = SolarisInternetProtocolStats.splitOnPrefix("tcpFoo = 1   tcpBar = 2", "tcp");
+        assertThat(result[0], is("tcpFoo = 1"));
+        assertThat(result[1], is("tcpBar = 2"));
+    }
+
+    @Test
+    void testSplitOnPrefixSingleStat() {
+        String[] result = SolarisInternetProtocolStats.splitOnPrefix("tcpFoo = 1", "tcp");
+        assertThat(result[0], is("tcpFoo = 1"));
+        assertThat(result[1], is(nullValue()));
+    }
+
+    @Test
+    void testSplitOnPrefixNoMatch() {
+        String[] result = SolarisInternetProtocolStats.splitOnPrefix("some random line", "tcp");
+        assertThat(result[0], is(nullValue()));
+        assertThat(result[1], is(nullValue()));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract inline command-output parsing into package-private static methods that accept `List<String>` (or `String`), mirroring the pattern from #3494 (Linux), #3495 (FreeBSD), and #3496 (NetBSD/OpenBSD)
- Allows fixture-based tests to exercise parse logic on every CI platform without requiring Solaris/OpenIndiana
- Covers 6 source files: CPU (dmesg, lgrpinfo, isainfo, kstat), ComputerSystem (smbios, prtconf), GraphicsCard (prtconf -pv), SoundCard (lshal), VirtualMemory (swap -lk, kstat), InternetProtocolStats (netstat -s -P tcp/udp/ip)

## Test plan
- [x] Full reactor build passes locally (`./mvnw clean install` — 1170 tests, 0 failures)
- [x] Unix CI passes on fork: https://github.com/dbwiddis/oshi/actions/runs/29776823523
- [x] 32 new fixture tests exercise all extracted parse methods with synthetic input grounded in real command output
- [x] No `@EnabledOnOs` gating on parse tests — they run on every platform
- [x] All pre-commit gates pass (spotless, checkstyle, forbiddenapis, javadoc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solaris parsing reliability for CPU/feature extraction, kstat rollups (context switches and interrupts), NUMA node mapping, SMBIOS/serial fallback, graphics and sound device discovery, and swap/virtual memory calculations.
  * Enhanced TCP/UDP netstat stats parsing consistency by separating command execution from parsing and tightening stat splitting.
* **Tests**
  * Added new Solaris-focused JUnit coverage for CPU, NUMA, SMBIOS/serial, graphics, sound, virtual memory, and TCP/UDP netstat parsing, including empty and edge-case outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->