### PR TITLE
Solaris: extract prtpicl, prtconf USB, svcs, and plimit/pbind parsers

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisSensors.java
@@ -60,17 +60,12 @@ public final class SolarisSensors extends AbstractSensors {
      */
     static int[] parseFanSpeeds(List<String> prtpicl) {
         List<Integer> speedList = new ArrayList<>();
-        // Return max found temp
         for (String line : prtpicl) {
             if (line.trim().startsWith("Speed:")) {
                 speedList.add(ParseUtil.parseLastInt(line, 0));
             }
         }
-        int[] fans = new int[speedList.size()];
-        for (int i = 0; i < speedList.size(); i++) {
-            fans[i] = speedList.get(i);
-        }
-        return fans;
+        return speedList.stream().mapToInt(Integer::intValue).toArray();
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisSensors.java
@@ -20,9 +20,19 @@ public final class SolarisSensors extends AbstractSensors {
 
     @Override
     public double queryCpuTemperature() {
+        return parseCpuTemperature(ExecutingCommand.runNative("/usr/sbin/prtpicl -v -c temperature-sensor"));
+    }
+
+    /**
+     * Parses the output of {@code prtpicl -v -c temperature-sensor} to find the maximum CPU temperature.
+     *
+     * @param prtpicl the lines emitted by {@code prtpicl -v -c temperature-sensor}
+     * @return the maximum temperature found (divided by 1000 if in millidegrees), or 0 if none
+     */
+    static double parseCpuTemperature(List<String> prtpicl) {
         double maxTemp = 0d;
         // Return max found temp
-        for (String line : ExecutingCommand.runNative("/usr/sbin/prtpicl -v -c temperature-sensor")) {
+        for (String line : prtpicl) {
             if (line.trim().startsWith("Temperature:")) {
                 int temp = ParseUtil.parseLastInt(line, 0);
                 if (temp > maxTemp) {
@@ -39,9 +49,19 @@ public final class SolarisSensors extends AbstractSensors {
 
     @Override
     public int[] queryFanSpeeds() {
+        return parseFanSpeeds(ExecutingCommand.runNative("/usr/sbin/prtpicl -v -c fan"));
+    }
+
+    /**
+     * Parses the output of {@code prtpicl -v -c fan} to extract fan speeds.
+     *
+     * @param prtpicl the lines emitted by {@code prtpicl -v -c fan}
+     * @return an array of fan speeds
+     */
+    static int[] parseFanSpeeds(List<String> prtpicl) {
         List<Integer> speedList = new ArrayList<>();
         // Return max found temp
-        for (String line : ExecutingCommand.runNative("/usr/sbin/prtpicl -v -c fan")) {
+        for (String line : prtpicl) {
             if (line.trim().startsWith("Speed:")) {
                 speedList.add(ParseUtil.parseLastInt(line, 0));
             }
@@ -55,8 +75,18 @@ public final class SolarisSensors extends AbstractSensors {
 
     @Override
     public double queryCpuVoltage() {
+        return parseVoltage(ExecutingCommand.runNative("/usr/sbin/prtpicl -v -c voltage-sensor"));
+    }
+
+    /**
+     * Parses the output of {@code prtpicl -v -c voltage-sensor} to find the first voltage reading.
+     *
+     * @param prtpicl the lines emitted by {@code prtpicl -v -c voltage-sensor}
+     * @return the first voltage found, or 0 if none
+     */
+    static double parseVoltage(List<String> prtpicl) {
         double voltage = 0d;
-        for (String line : ExecutingCommand.runNative("/usr/sbin/prtpicl -v -c voltage-sensor")) {
+        for (String line : prtpicl) {
             if (line.trim().startsWith("Voltage:")) {
                 voltage = ParseUtil.parseDoubleOrDefault(line.replace("Voltage:", "").trim(), 0d);
                 break;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisUsbDevice.java
@@ -37,14 +37,22 @@ public class SolarisUsbDevice extends AbstractUsbDevice {
      * @return a list of USB controllers, each with its connected-device tree.
      */
     public static List<UsbDevice> getUsbDevices() {
+        return parsePrtconf(ExecutingCommand.runNative("prtconf -pv"));
+    }
+
+    /**
+     * Parses the output of {@code prtconf -pv} to build the USB device tree.
+     *
+     * @param devices the lines emitted by {@code prtconf -pv}
+     * @return a list of USB controller devices, each with its connected-device tree
+     */
+    static List<UsbDevice> parsePrtconf(List<String> devices) {
         Map<String, String> nameMap = new HashMap<>();
         Map<String, String> vendorIdMap = new HashMap<>();
         Map<String, String> productIdMap = new HashMap<>();
         Map<String, List<String>> hubMap = new HashMap<>();
         Map<String, String> deviceTypeMap = new HashMap<>();
 
-        // Enumerate all usb devices and build information maps
-        List<String> devices = ExecutingCommand.runNative("prtconf -pv");
         if (devices.isEmpty()) {
             return emptyList();
         }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
@@ -92,21 +92,23 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
 
     @Override
     public long getAffinityMask() {
+        long mask = parsePbindOutput(ExecutingCommand.getFirstAnswer("pbind -q " + getProcessID()));
+        return mask != 0L ? mask : parsePsrinfo(ExecutingCommand.runNative("psrinfo"));
+    }
+
+    /**
+     * Parses the output of {@code pbind -q <pid>} to determine the processor affinity bitmask.
+     *
+     * @param cpuset the single-line output from {@code pbind -q}
+     * @return the bitmask of bound processors, or 0 if not bound or empty
+     */
+    static long parsePbindOutput(String cpuset) {
         long bitMask = 0L;
-        String cpuset = ExecutingCommand.getFirstAnswer("pbind -q " + getProcessID());
         // Sample output:
         // <empty string if no binding>
         // pid 101048 strongly bound to processor(s) 0 1 2 3.
         if (cpuset.isEmpty()) {
-            List<String> allProcs = ExecutingCommand.runNative("psrinfo");
-            for (String proc : allProcs) {
-                String[] split = ParseUtil.whitespaces.split(proc);
-                int bitToSet = ParseUtil.parseIntOrDefault(split[0], -1);
-                if (bitToSet >= 0) {
-                    bitMask |= 1L << bitToSet;
-                }
-            }
-            return bitMask;
+            return 0L;
         } else if (cpuset.endsWith(".") && cpuset.contains("strongly bound to processor(s)")) {
             String parse = cpuset.substring(0, cpuset.length() - 1);
             String[] split = ParseUtil.whitespaces.split(parse);
@@ -118,6 +120,24 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
                     // Once we run into the word processor(s) we're done
                     break;
                 }
+            }
+        }
+        return bitMask;
+    }
+
+    /**
+     * Parses the output of {@code psrinfo} to build a bitmask of all available processors.
+     *
+     * @param psrinfo the lines emitted by {@code psrinfo}
+     * @return a bitmask with a bit set for each processor listed
+     */
+    static long parsePsrinfo(List<String> psrinfo) {
+        long bitMask = 0L;
+        for (String proc : psrinfo) {
+            String[] split = ParseUtil.whitespaces.split(proc);
+            int bitToSet = ParseUtil.parseIntOrDefault(split[0], -1);
+            if (bitToSet >= 0) {
+                bitMask |= 1L << bitToSet;
             }
         }
         return bitMask;
@@ -207,11 +227,21 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
      * @return the limit, or {@code -1} if unavailable
      */
     protected static long getProcessOpenFileLimit(long processId, int index) {
-        final List<String> output = ExecutingCommand.runNative("plimit " + processId);
-        if (output.isEmpty()) {
+        return parseOpenFileLimit(ExecutingCommand.runNative("plimit " + processId), index);
+    }
+
+    /**
+     * Parses the output of {@code plimit <pid>} to extract the open-file limit.
+     *
+     * @param plimitOutput the lines emitted by {@code plimit <pid>}
+     * @param index        {@code 1} for the soft limit, {@code 2} for the hard limit
+     * @return the limit value, or {@code -1} if unavailable
+     */
+    static long parseOpenFileLimit(List<String> plimitOutput, int index) {
+        if (plimitOutput.isEmpty()) {
             return -1; // not supported
         }
-        final Optional<String> nofilesLine = output.stream().filter(line -> line.trim().startsWith("nofiles"))
+        final Optional<String> nofilesLine = plimitOutput.stream().filter(line -> line.trim().startsWith("nofiles"))
                 .findFirst();
         if (!nofilesLine.isPresent()) {
             return -1;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystem.java
@@ -143,7 +143,6 @@ public abstract class SolarisOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public List<OSService> getServices() {
-        List<OSService> services = new ArrayList<>();
         // Get legacy RC service name possibilities
         List<String> legacySvcs = new ArrayList<>();
         File dir = new File("/etc/init.d");
@@ -155,6 +154,18 @@ public abstract class SolarisOperatingSystem extends AbstractOperatingSystem {
         }
         // Iterate service list
         List<String> svcs = ExecutingCommand.runNative("svcs -p");
+        return parseSvcs(svcs, legacySvcs);
+    }
+
+    /**
+     * Parses the output of {@code svcs -p} to build a list of OS services.
+     *
+     * @param svcs       the lines emitted by {@code svcs -p}
+     * @param legacySvcs the list of legacy service names from {@code /etc/init.d}
+     * @return a list of {@link OSService} objects
+     */
+    static List<OSService> parseSvcs(List<String> svcs, List<String> legacySvcs) {
+        List<OSService> services = new ArrayList<>();
         /*-
          Output:
          STATE          STIME    FRMI

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisSensorsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisSensorsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+class SolarisSensorsTest {
+
+    @Test
+    void testParseCpuTemperature() {
+        assertThat(
+                SolarisSensors.parseCpuTemperature(
+                        Arrays.asList("  :Temperature  42", "    Temperature:  36", "    Temperature:  42")),
+                is(closeTo(42.0, 0.001)));
+    }
+
+    @Test
+    void testParseCpuTemperatureMillidegrees() {
+        assertThat(
+                SolarisSensors.parseCpuTemperature(Arrays.asList("    Temperature:  45000", "    Temperature:  42000")),
+                is(closeTo(45.0, 0.001)));
+    }
+
+    @Test
+    void testParseCpuTemperatureEmpty() {
+        assertThat(SolarisSensors.parseCpuTemperature(Collections.emptyList()), is(closeTo(0.0, 0.001)));
+    }
+
+    @Test
+    void testParseFanSpeeds() {
+        int[] speeds = SolarisSensors
+                .parseFanSpeeds(Arrays.asList("    Speed:  1200", "    Speed:  1500", "    Speed:  900"));
+        assertThat(speeds.length, is(3));
+        assertThat(speeds[0], is(1200));
+        assertThat(speeds[1], is(1500));
+        assertThat(speeds[2], is(900));
+    }
+
+    @Test
+    void testParseFanSpeedsEmpty() {
+        int[] speeds = SolarisSensors.parseFanSpeeds(Collections.emptyList());
+        assertThat(speeds.length, is(0));
+    }
+
+    @Test
+    void testParseVoltage() {
+        assertThat(SolarisSensors.parseVoltage(Arrays.asList("    Voltage:  1.200", "    Voltage:  3.300")),
+                is(closeTo(1.2, 0.001)));
+    }
+
+    @Test
+    void testParseVoltageEmpty() {
+        assertThat(SolarisSensors.parseVoltage(Collections.emptyList()), is(closeTo(0.0, 0.001)));
+    }
+
+    @Test
+    void testParseVoltageNoMatch() {
+        assertThat(SolarisSensors.parseVoltage(Arrays.asList("  Other:  1.200", "  Something:  3.300")),
+                is(closeTo(0.0, 0.001)));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisUsbDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisUsbDeviceTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.UsbDevice;
+
+class SolarisUsbDeviceTest {
+
+    @Test
+    void testParsePrtconfEmpty() {
+        List<UsbDevice> devices = SolarisUsbDevice.parsePrtconf(Collections.emptyList());
+        assertThat(devices, is(empty()));
+    }
+
+    @Test
+    void testParsePrtconfUsbController() {
+        // A USB controller (class-code 000c) with one child device
+        List<String> prtconf = Arrays.asList("    Node 0xf0a8b0", //
+                "      name:  'usb-controller'", //
+                "      model:  'EHCI Host Controller'", //
+                "      vendor-id:  00008086", //
+                "      device-id:  00002934", //
+                "      class-code:  000c0320", //
+                "        Node 0xf0a900", //
+                "          name:  'storage'", //
+                "          model:  'USB Flash Drive'", //
+                "          vendor-id:  00000781", //
+                "          device-id:  00005567");
+        List<UsbDevice> devices = SolarisUsbDevice.parsePrtconf(prtconf);
+        assertThat(devices, hasSize(1));
+        UsbDevice controller = devices.get(0);
+        assertThat(controller.getName(), is("EHCI Host Controller"));
+        assertThat(controller.getVendor(), is(""));
+        assertThat(controller.getVendorId(), is("8086"));
+        assertThat(controller.getProductId(), is("2934"));
+        // Child device
+        assertThat(controller.getConnectedDevices(), hasSize(1));
+        UsbDevice child = controller.getConnectedDevices().get(0);
+        assertThat(child.getName(), is("USB Flash Drive"));
+        assertThat(child.getVendorId(), is("0781"));
+        assertThat(child.getProductId(), is("5567"));
+    }
+
+    @Test
+    void testParsePrtconfDeviceTypeUsb() {
+        // A controller identified by device_type 'usb' rather than class-code
+        List<String> prtconf = Arrays.asList("    Node 0xaabb00", //
+                "      name:  'usb'", //
+                "      device_type:  'usb'", //
+                "      vendor-id:  00001033", //
+                "      device-id:  00000194");
+        List<UsbDevice> devices = SolarisUsbDevice.parsePrtconf(prtconf);
+        assertThat(devices, hasSize(1));
+        assertThat(devices.get(0).getName(), is("usb"));
+    }
+
+    @Test
+    void testParsePrtconfNonUsbController() {
+        // A non-USB controller (class-code 0006 = bridge)
+        List<String> prtconf = Arrays.asList("    Node 0xdead00", //
+                "      name:  'pci-bridge'", //
+                "      vendor-id:  00008086", //
+                "      device-id:  0000244e", //
+                "      class-code:  00060400");
+        List<UsbDevice> devices = SolarisUsbDevice.parsePrtconf(prtconf);
+        assertThat(devices, is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOSProcessTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOSProcessTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class SolarisOSProcessTest {
+
+    @Test
+    void testParseOpenFileLimitSoft() {
+        List<String> plimit = Arrays.asList("1234:", "   coredumpsize      0           unlimited",
+                "   nofiles(descriptors)  256         65536", "   vmemorysize       unlimited   unlimited");
+        assertThat(SolarisOSProcess.parseOpenFileLimit(plimit, 1), is(256L));
+    }
+
+    @Test
+    void testParseOpenFileLimitHard() {
+        List<String> plimit = Arrays.asList("1234:", "   nofiles(descriptors)  256         65536");
+        assertThat(SolarisOSProcess.parseOpenFileLimit(plimit, 2), is(65536L));
+    }
+
+    @Test
+    void testParseOpenFileLimitEmpty() {
+        assertThat(SolarisOSProcess.parseOpenFileLimit(Collections.emptyList(), 1), is(-1L));
+    }
+
+    @Test
+    void testParseOpenFileLimitNoNofilesLine() {
+        List<String> plimit = Arrays.asList("1234:", "   coredumpsize      0           unlimited");
+        assertThat(SolarisOSProcess.parseOpenFileLimit(plimit, 1), is(-1L));
+    }
+
+    @Test
+    void testParseOpenFileLimitIndexOutOfBounds() {
+        List<String> plimit = Arrays.asList("   nofiles(descriptors)  256         unlimited");
+        // "unlimited" is non-numeric, so split yields only ["", "256"]
+        assertThat(SolarisOSProcess.parseOpenFileLimit(plimit, 2), is(-1L));
+    }
+
+    @Test
+    void testParsePbindOutputBound() {
+        String cpuset = "pid 101048 strongly bound to processor(s) 0 1 2 3.";
+        long mask = SolarisOSProcess.parsePbindOutput(cpuset);
+        // bits 0,1,2,3 set = 0b1111 = 15
+        assertThat(mask, is(15L));
+    }
+
+    @Test
+    void testParsePbindOutputEmpty() {
+        assertThat(SolarisOSProcess.parsePbindOutput(""), is(0L));
+    }
+
+    @Test
+    void testParsePbindOutputNotBound() {
+        // Some unexpected format that doesn't match the pattern
+        assertThat(SolarisOSProcess.parsePbindOutput("pid 1234 not bound"), is(0L));
+    }
+
+    @Test
+    void testParsePsrinfo() {
+        List<String> psrinfo = Arrays.asList("0       on-line   since 01/01/2020 00:00:00",
+                "1       on-line   since 01/01/2020 00:00:00", "4       on-line   since 01/01/2020 00:00:00");
+        long mask = SolarisOSProcess.parsePsrinfo(psrinfo);
+        // bits 0, 1, 4 set = 0b10011 = 19
+        assertThat(mask, is(19L));
+    }
+
+    @Test
+    void testParsePsrinfoEmpty() {
+        assertThat(SolarisOSProcess.parsePsrinfo(Collections.emptyList()), is(0L));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystemTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.software.os.OSService;
+import oshi.software.os.OSService.State;
+
+class SolarisOperatingSystemTest {
+
+    @Test
+    void testParseSvcsTypical() {
+        List<String> svcs = Arrays.asList("online         23:56:25 svc:/system/svc/restarter:default",
+                "                        23:56:24       13 svc.startd",
+                "legacy_run     23:56:49 lrc:/etc/rc2_d/S47pppd",
+                "online         23:56:25 svc:/network/loopback:default");
+        List<String> legacySvcs = Arrays.asList("S47pppd", "S89PRESERVE");
+
+        List<OSService> services = SolarisOperatingSystem.parseSvcs(svcs, legacySvcs);
+
+        // "online" lines produce STOPPED services (named from svc path)
+        // lines starting with space produce RUNNING services (with PID)
+        // "legacy_run" lines matching legacySvcs produce STOPPED services
+        assertThat(services, hasSize(4));
+
+        // First: online svc:/system/svc/restarter:default -> name "/system/svc/restarter", state STOPPED
+        assertThat(services.get(0).getName(), is("/system/svc/restarter"));
+        assertThat(services.get(0).getState(), is(State.STOPPED));
+
+        // Second: space-prefixed line with pid 13
+        assertThat(services.get(1).getName(), is("svc.startd"));
+        assertThat(services.get(1).getProcessID(), is(13));
+        assertThat(services.get(1).getState(), is(State.RUNNING));
+
+        // Third: legacy_run matching S47pppd
+        assertThat(services.get(2).getName(), is("S47pppd"));
+        assertThat(services.get(2).getState(), is(State.STOPPED));
+
+        // Fourth: online svc:/network/loopback:default -> name "/network/loopback"
+        assertThat(services.get(3).getName(), is("/network/loopback"));
+        assertThat(services.get(3).getState(), is(State.STOPPED));
+    }
+
+    @Test
+    void testParseSvcsEmpty() {
+        List<OSService> services = SolarisOperatingSystem.parseSvcs(Collections.emptyList(), Collections.emptyList());
+        assertThat(services, is(empty()));
+    }
+
+    @Test
+    void testParseSvcsLegacyNoMatch() {
+        List<String> svcs = Arrays.asList("legacy_run     23:56:49 lrc:/etc/rc2_d/S47pppd");
+        List<String> legacySvcs = Arrays.asList("S89PRESERVE");
+
+        List<OSService> services = SolarisOperatingSystem.parseSvcs(svcs, legacySvcs);
+        assertThat(services, is(empty()));
+    }
+
+    @Test
+    void testParseSvcsOnlineWithoutDefaultSuffix() {
+        List<String> svcs = Arrays.asList("online         23:56:25 svc:/system/manifest-import:refresh");
+        List<OSService> services = SolarisOperatingSystem.parseSvcs(svcs, Collections.emptyList());
+        assertThat(services, hasSize(1));
+        // No :default suffix, so name includes everything after the last :/
+        assertThat(services.get(0).getName(), is("/system/manifest-import:refresh"));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract remaining Solaris-specific command parsers into testable static methods, continuing the coverage work from #3497
- Covers prtpicl (sensors), prtconf -pv (USB device tree), svcs -p (services), plimit (file descriptor limits), and pbind/psrinfo (process affinity)
- Cross-OS commands (df/mount, iostat, route) deferred to their respective sweeps

## Test plan
- [x] Full reactor build passes locally (`./mvnw clean install` — 1197 tests, 0 failures)
- [x] Unix CI passes on fork: https://github.com/dbwiddis/oshi/actions/runs/29780509404
- [x] New fixture tests exercise all extracted parse methods with synthetic input grounded in real command output
- [x] No `@EnabledOnOs` gating on parse tests — they run on every platform
- [x] All pre-commit gates pass (spotless, checkstyle, forbiddenapis, javadoc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced Solaris hardware monitoring for CPU temperature, fan speeds, voltage, and USB device details with more robust output parsing.
  * Improved Solaris process reporting for CPU affinity and open-file limits, including better handling of empty or unexpected command output.
  * Improved Solaris service detection and status reporting via clearer parsing of `svcs` output and legacy service mappings.
* **Tests**
  * Added/expanded JUnit coverage for Solaris sensor, USB, process, and service parsing, including empty, alternate formatting, and malformed output cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->