### PR TITLE
Extract testable inode parsers from Unix FileSystem classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug Fixes and Improvements
 
 * [#3493](https://github.com/oshi/oshi/pull/3493): Document the CPU/memory trade-off of reusing versus recreating `SystemInfo` when polling, with supporting benchmarks - [@dbwiddis](https://github.com/dbwiddis).
+* [#3499](https://github.com/oshi/oshi/pull/3499): Fix FreeBSD, NetBSD, and OpenBSD `df -i` inode parsing to include ZFS, tmpfs, devfs, and mfs filesystems that do not start with `/` - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18)
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
@@ -19,6 +19,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.FileSystemUtil;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 
 /**
  * The AIX File System contains {@link oshi.software.os.OSFileStore}s which are a storage pool, device, partition,
@@ -53,37 +54,12 @@ public class AixFileSystem extends AbstractFileSystem {
         List<OSFileStore> fsList = new ArrayList<>();
 
         // Get inode usage data
-        Map<String, Long> inodeFreeMap = new HashMap<>();
-        Map<String, Long> inodeTotalMap = new HashMap<>();
         // AIX 7.3+ supports POSIX df -i, but AIX 7.1/7.2 only have the native format-specifier
         // syntax. df -F %n %l (%n = Ifree, %l = Iused) works across all three versions.
         String command = "df -F %n %l" + (localOnly ? " -T local" : "");
-        for (String line : ExecutingCommand.runNative(command)) {
-            /*- Sample Output:
-             * $ df -F %n %l
-             * Filesystem    512-blocks     Ifree    Iused
-             * /dev/hd4         4194304   164951    15969
-             * /dev/hd2        52690944  2894117   196692
-             * /dev/hd9var      6291456   605443     2317
-             * /dev/hd3         6291456   450968     1349
-             * /dev/hd1         6291456   550843      110
-             * /dev/hd11admin    2097152   233048        5
-             * /proc                  -        -        -
-             * /dev/hd10opt    16777216   600058    17220
-             * /dev/livedump     524288    58200        4
-             * NFS mounts appear as hostname:/path or ip:/path and are matched by FS_PATTERN
-             */
-            if (FS_PATTERN.matcher(line).find()) {
-                String[] split = ParseUtil.whitespaces.split(line);
-                // Columns: Filesystem, 512-blocks, Ifree (%n), Iused (%l)
-                if (split.length >= 4) {
-                    long free = ParseUtil.parseLongOrDefault(split[split.length - 2], 0L);
-                    long used = ParseUtil.parseLongOrDefault(split[split.length - 1], 0L);
-                    inodeTotalMap.put(split[0], free + used);
-                    inodeFreeMap.put(split[0], free);
-                }
-            }
-        }
+        Pair<Map<String, Long>, Map<String, Long>> inodes = parseDfInodes(ExecutingCommand.runNative(command));
+        Map<String, Long> inodeFreeMap = inodes.getA();
+        Map<String, Long> inodeTotalMap = inodes.getB();
 
         // Get mount table
         for (String fs : ExecutingCommand.runNative("mount")) { // NOSONAR squid:S135
@@ -156,6 +132,44 @@ public class AixFileSystem extends AbstractFileSystem {
             }
         }
         return fsList;
+    }
+
+    /**
+     * Parses {@code df -F %n %l} output into inode free and total maps keyed by filesystem.
+     *
+     * @param dfOutput the lines from {@code df -F %n %l}
+     * @return a {@link Pair} of (inodeFreeMap, inodeTotalMap) both keyed by filesystem
+     */
+    static Pair<Map<String, Long>, Map<String, Long>> parseDfInodes(List<String> dfOutput) {
+        Map<String, Long> inodeFreeMap = new HashMap<>();
+        Map<String, Long> inodeTotalMap = new HashMap<>();
+        for (String line : dfOutput) {
+            /*- Sample Output:
+             * $ df -F %n %l
+             * Filesystem    512-blocks     Ifree    Iused
+             * /dev/hd4         4194304   164951    15969
+             * /dev/hd2        52690944  2894117   196692
+             * /dev/hd9var      6291456   605443     2317
+             * /dev/hd3         6291456   450968     1349
+             * /dev/hd1         6291456   550843      110
+             * /dev/hd11admin    2097152   233048        5
+             * /proc                  -        -        -
+             * /dev/hd10opt    16777216   600058    17220
+             * /dev/livedump     524288    58200        4
+             * NFS mounts appear as hostname:/path or ip:/path and are matched by FS_PATTERN
+             */
+            if (FS_PATTERN.matcher(line).find()) {
+                String[] split = ParseUtil.whitespaces.split(line);
+                // Columns: Filesystem, 512-blocks, Ifree (%n), Iused (%l)
+                if (split.length >= 4) {
+                    long free = ParseUtil.parseLongOrDefault(split[split.length - 2], 0L);
+                    long used = ParseUtil.parseLongOrDefault(split[split.length - 1], 0L);
+                    inodeTotalMap.put(split[0], free + used);
+                    inodeFreeMap.put(split[0], free);
+                }
+            }
+        }
+        return new Pair<>(inodeFreeMap, inodeTotalMap);
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystem.java
@@ -157,7 +157,7 @@ public abstract class FreeBsdFileSystem extends AbstractFileSystem {
             Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on
             /dev/twed0s1a   2026030 584112 1279836    31%    2751 279871    1%   /
             */
-            if (line.startsWith("/")) {
+            if (!line.startsWith("Filesystem")) {
                 String[] split = ParseUtil.whitespaces.split(line);
                 if (split.length > 8) {
                     long ifree = ParseUtil.parseLongOrDefault(split[6], 0L);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystem.java
@@ -16,6 +16,7 @@ import oshi.software.os.OSFileStore;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileSystemUtil;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 
 public abstract class FreeBsdFileSystem extends AbstractFileSystem {
 
@@ -37,45 +38,14 @@ public abstract class FreeBsdFileSystem extends AbstractFileSystem {
     public List<OSFileStore> getFileStores(boolean localOnly) {
         // TODO map mount point to UUID?
         // is /etc/fstab useful for this?
-        Map<String, String> uuidMap = new HashMap<>();
-        // Now grab dmssg output
-        String device = "";
-        for (String line : ExecutingCommand.runNative("geom part list")) {
-            if (line.contains("Name: ")) {
-                device = line.substring(line.lastIndexOf(' ') + 1);
-            }
-            // If we aren't working with a current partition, continue
-            if (device.isEmpty()) {
-                continue;
-            }
-            line = line.trim();
-            if (line.startsWith("rawuuid:")) {
-                uuidMap.put(device, line.substring(line.lastIndexOf(' ') + 1));
-                device = "";
-            }
-        }
+        Map<String, String> uuidMap = parseGeomPartList(ExecutingCommand.runNative("geom part list"));
 
         List<OSFileStore> fsList = new ArrayList<>();
 
         // Get inode usage data
-        Map<String, Long> inodeFreeMap = new HashMap<>();
-        Map<String, Long> inodeTotalMap = new HashMap<>();
-        for (String line : ExecutingCommand.runNative("df -i")) {
-            /*- Sample Output:
-            Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on
-            /dev/twed0s1a   2026030 584112 1279836    31%    2751 279871    1%   /
-            */
-            if (line.startsWith("/")) {
-                String[] split = ParseUtil.whitespaces.split(line);
-                if (split.length > 8) {
-                    long ifree = ParseUtil.parseLongOrDefault(split[6], 0L);
-                    long iused = ParseUtil.parseLongOrDefault(split[5], 0L);
-                    // Key by mount point (last column) to match later lookup
-                    inodeFreeMap.put(split[8], ifree);
-                    inodeTotalMap.put(split[8], iused + ifree);
-                }
-            }
-        }
+        Pair<Map<String, Long>, Map<String, Long>> inodes = parseDfInodes(ExecutingCommand.runNative("df -i"));
+        Map<String, Long> inodeFreeMap = inodes.getA();
+        Map<String, Long> inodeTotalMap = inodes.getB();
 
         // Get mount table
         for (String fs : ExecutingCommand.runNative("mount -p")) {
@@ -145,6 +115,60 @@ public abstract class FreeBsdFileSystem extends AbstractFileSystem {
     public long getMaxFileDescriptorsPerProcess() {
         // On FreeBSD there is no process-specific system-wide limit, so the general limit is returned.
         return getMaxFileDescriptors();
+    }
+
+    /**
+     * Parses {@code geom part list} output into a map of device-name to rawuuid.
+     *
+     * @param geomOutput the lines from {@code geom part list}
+     * @return a map of device-name to rawuuid
+     */
+    static Map<String, String> parseGeomPartList(List<String> geomOutput) {
+        Map<String, String> uuidMap = new HashMap<>();
+        String device = "";
+        for (String line : geomOutput) {
+            if (line.contains("Name: ")) {
+                device = line.substring(line.lastIndexOf(' ') + 1);
+            }
+            // If we aren't working with a current partition, continue
+            if (device.isEmpty()) {
+                continue;
+            }
+            line = line.trim();
+            if (line.startsWith("rawuuid:")) {
+                uuidMap.put(device, line.substring(line.lastIndexOf(' ') + 1));
+                device = "";
+            }
+        }
+        return uuidMap;
+    }
+
+    /**
+     * Parses {@code df -i} output into inode free and total maps keyed by mount point.
+     *
+     * @param dfOutput the lines from {@code df -i}
+     * @return a {@link Pair} of (inodeFreeMap, inodeTotalMap) both keyed by mount point
+     */
+    static Pair<Map<String, Long>, Map<String, Long>> parseDfInodes(List<String> dfOutput) {
+        Map<String, Long> inodeFreeMap = new HashMap<>();
+        Map<String, Long> inodeTotalMap = new HashMap<>();
+        for (String line : dfOutput) {
+            /*- Sample Output:
+            Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on
+            /dev/twed0s1a   2026030 584112 1279836    31%    2751 279871    1%   /
+            */
+            if (line.startsWith("/")) {
+                String[] split = ParseUtil.whitespaces.split(line);
+                if (split.length > 8) {
+                    long ifree = ParseUtil.parseLongOrDefault(split[6], 0L);
+                    long iused = ParseUtil.parseLongOrDefault(split[5], 0L);
+                    // Key by mount point (last column) to match later lookup
+                    inodeFreeMap.put(split[8], ifree);
+                    inodeTotalMap.put(split[8], iused + ifree);
+                }
+            }
+        }
+        return new Pair<>(inodeFreeMap, inodeTotalMap);
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
@@ -18,6 +18,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.FileSystemUtil;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.tuples.Pair;
 
 /**
  * The NetBSD File System contains {@link oshi.software.os.OSFileStore}s which are a storage pool, device, partition,
@@ -50,25 +51,10 @@ public class NetBsdFileSystem extends AbstractFileSystem {
         List<OSFileStore> fsList = new ArrayList<>();
 
         // Get inode usage data
-        Map<String, Long> inodeFreeMap = new HashMap<>();
-        Map<String, Long> inodeUsedlMap = new HashMap<>();
         String command = "df -i" + (localOnly ? " -l" : "");
-        for (String line : ExecutingCommand.runNative(command)) {
-            /*- Sample Output:
-             $ df -i
-            Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on
-            /dev/wd0a      2149212    908676   1133076    45%    8355  147163     5%   /
-            /dev/wd0e      4050876        36   3848300     0%      10  285108     0%   /home
-            /dev/wd0d      6082908   3343172   2435592    58%   27813  386905     7%   /usr
-            */
-            if (line.startsWith("/")) {
-                String[] split = ParseUtil.whitespaces.split(line);
-                if (split.length > 6) {
-                    inodeUsedlMap.put(split[0], ParseUtil.parseLongOrDefault(split[5], 0L));
-                    inodeFreeMap.put(split[0], ParseUtil.parseLongOrDefault(split[6], 0L));
-                }
-            }
-        }
+        Pair<Map<String, Long>, Map<String, Long>> inodes = parseDfInodes(ExecutingCommand.runNative(command));
+        Map<String, Long> inodeFreeMap = inodes.getA();
+        Map<String, Long> inodeUsedlMap = inodes.getB();
 
         // Get mount table
         for (String fs : ExecutingCommand.runNative("mount")) { // NOSONAR squid:S135
@@ -133,6 +119,34 @@ public class NetBsdFileSystem extends AbstractFileSystem {
             }
         }
         return fsList;
+    }
+
+    /**
+     * Parses {@code df -i} output into inode free and used maps keyed by volume.
+     *
+     * @param dfOutput the lines from {@code df -i}
+     * @return a {@link Pair} of (inodeFreeMap, inodeUsedMap) both keyed by volume
+     */
+    static Pair<Map<String, Long>, Map<String, Long>> parseDfInodes(List<String> dfOutput) {
+        Map<String, Long> inodeFreeMap = new HashMap<>();
+        Map<String, Long> inodeUsedMap = new HashMap<>();
+        for (String line : dfOutput) {
+            /*- Sample Output:
+             $ df -i
+            Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on
+            /dev/wd0a      2149212    908676   1133076    45%    8355  147163     5%   /
+            /dev/wd0e      4050876        36   3848300     0%      10  285108     0%   /home
+            /dev/wd0d      6082908   3343172   2435592    58%   27813  386905     7%   /usr
+            */
+            if (line.startsWith("/")) {
+                String[] split = ParseUtil.whitespaces.split(line);
+                if (split.length > 6) {
+                    inodeUsedMap.put(split[0], ParseUtil.parseLongOrDefault(split[5], 0L));
+                    inodeFreeMap.put(split[0], ParseUtil.parseLongOrDefault(split[6], 0L));
+                }
+            }
+        }
+        return new Pair<>(inodeFreeMap, inodeUsedMap);
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
@@ -54,7 +54,7 @@ public class NetBsdFileSystem extends AbstractFileSystem {
         String command = "df -i" + (localOnly ? " -l" : "");
         Pair<Map<String, Long>, Map<String, Long>> inodes = parseDfInodes(ExecutingCommand.runNative(command));
         Map<String, Long> inodeFreeMap = inodes.getA();
-        Map<String, Long> inodeUsedlMap = inodes.getB();
+        Map<String, Long> inodeUsedMap = inodes.getB();
 
         // Get mount table
         for (String fs : ExecutingCommand.runNative("mount")) { // NOSONAR squid:S135
@@ -115,7 +115,7 @@ public class NetBsdFileSystem extends AbstractFileSystem {
 
                 fsList.add(new NetBsdOSFileStore(name, volume, name, path, options, uuid, isLocal, "", description,
                         type, freeSpace, usableSpace, totalSpace, inodeFreeMap.getOrDefault(volume, 0L),
-                        inodeUsedlMap.getOrDefault(volume, 0L) + inodeFreeMap.getOrDefault(volume, 0L)));
+                        inodeUsedMap.getOrDefault(volume, 0L) + inodeFreeMap.getOrDefault(volume, 0L)));
             }
         }
         return fsList;
@@ -138,7 +138,7 @@ public class NetBsdFileSystem extends AbstractFileSystem {
             /dev/wd0e      4050876        36   3848300     0%      10  285108     0%   /home
             /dev/wd0d      6082908   3343172   2435592    58%   27813  386905     7%   /usr
             */
-            if (line.startsWith("/")) {
+            if (!line.startsWith("Filesystem")) {
                 String[] split = ParseUtil.whitespaces.split(line);
                 if (split.length > 6) {
                     inodeUsedMap.put(split[0], ParseUtil.parseLongOrDefault(split[5], 0L));

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
@@ -16,6 +16,7 @@ import oshi.software.os.OSFileStore;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileSystemUtil;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 
 public abstract class OpenBsdFileSystem extends AbstractFileSystem {
 
@@ -54,6 +55,27 @@ public abstract class OpenBsdFileSystem extends AbstractFileSystem {
     }
 
     /**
+     * Parses {@code df -i} output into inode free and used maps keyed by volume.
+     *
+     * @param dfOutput the lines from {@code df -i}
+     * @return a {@link Pair} of (inodeFreeMap, inodeUsedMap) both keyed by volume
+     */
+    static Pair<Map<String, Long>, Map<String, Long>> parseDfInodes(List<String> dfOutput) {
+        Map<String, Long> inodeFreeMap = new HashMap<>();
+        Map<String, Long> inodeUsedMap = new HashMap<>();
+        for (String line : dfOutput) {
+            if (line.startsWith("/")) {
+                String[] split = ParseUtil.whitespaces.split(line);
+                if (split.length > 6) {
+                    inodeUsedMap.put(split[0], ParseUtil.parseLongOrDefault(split[5], 0L));
+                    inodeFreeMap.put(split[0], ParseUtil.parseLongOrDefault(split[6], 0L));
+                }
+            }
+        }
+        return new Pair<>(inodeFreeMap, inodeUsedMap);
+    }
+
+    /**
      * Reads a system-wide file-descriptor {@code sysctl} value via the subclass's native mechanism (JNA or FFM).
      *
      * @param name the sysctl name to query
@@ -72,18 +94,10 @@ public abstract class OpenBsdFileSystem extends AbstractFileSystem {
         List<OSFileStore> fsList = new ArrayList<>();
 
         // Get inode usage data
-        Map<String, Long> inodeFreeMap = new HashMap<>();
-        Map<String, Long> inodeUsedlMap = new HashMap<>();
         String command = "df -i" + (localOnly ? " -l" : "");
-        for (String line : ExecutingCommand.runNative(command)) {
-            if (line.startsWith("/")) {
-                String[] split = ParseUtil.whitespaces.split(line);
-                if (split.length > 6) {
-                    inodeUsedlMap.put(split[0], ParseUtil.parseLongOrDefault(split[5], 0L));
-                    inodeFreeMap.put(split[0], ParseUtil.parseLongOrDefault(split[6], 0L));
-                }
-            }
-        }
+        Pair<Map<String, Long>, Map<String, Long>> inodes = parseDfInodes(ExecutingCommand.runNative(command));
+        Map<String, Long> inodeFreeMap = inodes.getA();
+        Map<String, Long> inodeUsedlMap = inodes.getB();
 
         // Get mount table
         for (String fs : ExecutingCommand.runNative("mount -v")) { // NOSONAR squid:S135

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
@@ -64,7 +64,7 @@ public abstract class OpenBsdFileSystem extends AbstractFileSystem {
         Map<String, Long> inodeFreeMap = new HashMap<>();
         Map<String, Long> inodeUsedMap = new HashMap<>();
         for (String line : dfOutput) {
-            if (line.startsWith("/")) {
+            if (!line.startsWith("Filesystem")) {
                 String[] split = ParseUtil.whitespaces.split(line);
                 if (split.length > 6) {
                     inodeUsedMap.put(split[0], ParseUtil.parseLongOrDefault(split[5], 0L));
@@ -97,7 +97,7 @@ public abstract class OpenBsdFileSystem extends AbstractFileSystem {
         String command = "df -i" + (localOnly ? " -l" : "");
         Pair<Map<String, Long>, Map<String, Long>> inodes = parseDfInodes(ExecutingCommand.runNative(command));
         Map<String, Long> inodeFreeMap = inodes.getA();
-        Map<String, Long> inodeUsedlMap = inodes.getB();
+        Map<String, Long> inodeUsedMap = inodes.getB();
 
         // Get mount table
         for (String fs : ExecutingCommand.runNative("mount -v")) { // NOSONAR squid:S135
@@ -146,7 +146,7 @@ public abstract class OpenBsdFileSystem extends AbstractFileSystem {
 
                 fsList.add(new OpenBsdOSFileStore(this, name, volume, name, path, options, uuid, isLocal, "",
                         description, type, freeSpace, usableSpace, totalSpace, inodeFreeMap.getOrDefault(volume, 0L),
-                        inodeUsedlMap.getOrDefault(volume, 0L) + inodeFreeMap.getOrDefault(volume, 0L)));
+                        inodeUsedMap.getOrDefault(volume, 0L) + inodeFreeMap.getOrDefault(volume, 0L)));
             }
         }
         return fsList;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisFileSystem.java
@@ -18,6 +18,7 @@ import oshi.util.ExecutingCommand;
 import oshi.util.FileSystemUtil;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 
 /**
  * The Solaris File System contains {@link oshi.software.os.OSFileStore}s which are a storage pool, device, partition,
@@ -54,33 +55,10 @@ public abstract class SolarisFileSystem extends AbstractFileSystem {
         List<OSFileStore> fsList = new ArrayList<>();
 
         // Get inode usage data
-        Map<String, Long> inodeFreeMap = new HashMap<>();
-        Map<String, Long> inodeTotalMap = new HashMap<>();
-        String key = null;
-        String total = null;
-        String free = null;
         String command = "df -g" + (localOnly ? " -l" : "");
-        for (String line : ExecutingCommand.runNative(command)) {
-            /*- Sample Output:
-            /                  (/dev/md/dsk/d0    ):         8192 block size          1024 frag size
-            41310292 total blocks   18193814 free blocks 17780712 available        2486848 total files
-             2293351 free files     22282240 filesys id
-                 ufs fstype       0x00000004 flag             255 filename length
-            */
-            if (line.startsWith("/")) {
-                key = ParseUtil.whitespaces.split(line)[0];
-                total = null;
-            } else if (line.contains("available") && line.contains("total files")) {
-                total = ParseUtil.getTextBetweenStrings(line, "available", "total files").trim();
-            } else if (line.contains("free files")) {
-                free = ParseUtil.getTextBetweenStrings(line, "", "free files").trim();
-                if (key != null && total != null) {
-                    inodeFreeMap.put(key, ParseUtil.parseLongOrDefault(free, 0L));
-                    inodeTotalMap.put(key, ParseUtil.parseLongOrDefault(total, 0L));
-                    key = null;
-                }
-            }
-        }
+        Pair<Map<String, Long>, Map<String, Long>> inodes = parseDfgInodes(ExecutingCommand.runNative(command));
+        Map<String, Long> inodeFreeMap = inodes.getA();
+        Map<String, Long> inodeTotalMap = inodes.getB();
 
         // Get mount table
         for (String fs : ExecutingCommand.runNative("cat /etc/mnttab")) { // NOSONAR squid:S135
@@ -136,6 +114,42 @@ public abstract class SolarisFileSystem extends AbstractFileSystem {
                     inodeTotalMap.getOrDefault(path, 0L)));
         }
         return fsList;
+    }
+
+    /**
+     * Parses {@code df -g} output into inode free and total maps keyed by mount path.
+     *
+     * @param dfOutput the lines from {@code df -g}
+     * @return a {@link Pair} of (inodeFreeMap, inodeTotalMap) both keyed by mount path
+     */
+    static Pair<Map<String, Long>, Map<String, Long>> parseDfgInodes(List<String> dfOutput) {
+        Map<String, Long> inodeFreeMap = new HashMap<>();
+        Map<String, Long> inodeTotalMap = new HashMap<>();
+        String key = null;
+        String total = null;
+        String free = null;
+        for (String line : dfOutput) {
+            /*- Sample Output:
+            /                  (/dev/md/dsk/d0    ):         8192 block size          1024 frag size
+            41310292 total blocks   18193814 free blocks 17780712 available        2486848 total files
+             2293351 free files     22282240 filesys id
+                 ufs fstype       0x00000004 flag             255 filename length
+            */
+            if (line.startsWith("/")) {
+                key = ParseUtil.whitespaces.split(line)[0];
+                total = null;
+            } else if (line.contains("available") && line.contains("total files")) {
+                total = ParseUtil.getTextBetweenStrings(line, "available", "total files").trim();
+            } else if (line.contains("free files")) {
+                free = ParseUtil.getTextBetweenStrings(line, "", "free files").trim();
+                if (key != null && total != null) {
+                    inodeFreeMap.put(key, ParseUtil.parseLongOrDefault(free, 0L));
+                    inodeTotalMap.put(key, ParseUtil.parseLongOrDefault(total, 0L));
+                    key = null;
+                }
+            }
+        }
+        return new Pair<>(inodeFreeMap, inodeTotalMap);
     }
 
     @Override

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -67,6 +67,8 @@
 --add-opens
   com.github.oshi.common/oshi.util.common.platform.unix.freebsd=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.software.common.os.unix.freebsd=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.hardware.common.platform.unix.netbsd=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.software.common.os.unix.netbsd=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixFileSystemTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.aix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Pair;
+
+class AixFileSystemTest {
+
+    @Test
+    void testParseDfInodesTypical() {
+        List<String> lines = Arrays.asList("Filesystem    512-blocks     Ifree    Iused",
+                "/dev/hd4         4194304   164951    15969", "/dev/hd2        52690944  2894117   196692",
+                "/dev/hd9var      6291456   605443     2317");
+        Pair<Map<String, Long>, Map<String, Long>> result = AixFileSystem.parseDfInodes(lines);
+        Map<String, Long> freeMap = result.getA();
+        Map<String, Long> totalMap = result.getB();
+        assertThat(freeMap, is(aMapWithSize(3)));
+        assertThat(freeMap.get("/dev/hd4"), is(164951L));
+        assertThat(freeMap.get("/dev/hd2"), is(2894117L));
+        assertThat(freeMap.get("/dev/hd9var"), is(605443L));
+        assertThat(totalMap.get("/dev/hd4"), is(164951L + 15969L));
+        assertThat(totalMap.get("/dev/hd2"), is(2894117L + 196692L));
+        assertThat(totalMap.get("/dev/hd9var"), is(605443L + 2317L));
+    }
+
+    @Test
+    void testParseDfInodesNfsMounts() {
+        List<String> lines = Arrays.asList("Filesystem    512-blocks     Ifree    Iused",
+                "nfshost:/export  8388608   500000    10000");
+        Pair<Map<String, Long>, Map<String, Long>> result = AixFileSystem.parseDfInodes(lines);
+        Map<String, Long> freeMap = result.getA();
+        Map<String, Long> totalMap = result.getB();
+        // NFS mounts matching "hostname:/path" should be included via FS_PATTERN
+        assertThat(freeMap, is(aMapWithSize(1)));
+        assertThat(freeMap.get("nfshost:/export"), is(500000L));
+        assertThat(totalMap.get("nfshost:/export"), is(510000L));
+    }
+
+    @Test
+    void testParseDfInodesSkipsProcAndHeader() {
+        List<String> lines = Arrays.asList("Filesystem    512-blocks     Ifree    Iused",
+                "/proc                  -        -        -");
+        Pair<Map<String, Long>, Map<String, Long>> result = AixFileSystem.parseDfInodes(lines);
+        // Header doesn't match FS_PATTERN, /proc has dashes so parseLong returns 0
+        // Actually /proc starts with / so it does match FS_PATTERN
+        Map<String, Long> freeMap = result.getA();
+        assertThat(freeMap.get("/proc"), is(0L));
+    }
+
+    @Test
+    void testParseDfInodesEmpty() {
+        Pair<Map<String, Long>, Map<String, Long>> result = AixFileSystem.parseDfInodes(Collections.emptyList());
+        assertThat(result.getA(), is(anEmptyMap()));
+        assertThat(result.getB(), is(anEmptyMap()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystemTest.java
@@ -63,13 +63,17 @@ class FreeBsdFileSystemTest {
     }
 
     @Test
-    void testParseDfInodesSkipsHeaderAndNonSlash() {
+    void testParseDfInodesSkipsHeaderIncludesNonDevFs() {
         List<String> lines = Arrays.asList(
                 "Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on",
-                "devfs               1      1       0   100%       0      0  100%   /dev");
+                "devfs               1      1       0   100%       0      0  100%   /dev",
+                "zroot/ROOT    95678456 8234567  87443889     9%  234567 9999999    2%   /");
         Pair<Map<String, Long>, Map<String, Long>> result = FreeBsdFileSystem.parseDfInodes(lines);
-        // Header doesn't start with '/', devfs doesn't start with '/' either
-        assertThat(result.getA(), is(anEmptyMap()));
-        assertThat(result.getB(), is(anEmptyMap()));
+        Map<String, Long> freeMap = result.getA();
+        Map<String, Long> totalMap = result.getB();
+        // Header is skipped; devfs and zroot are both included
+        assertThat(freeMap.get("/dev"), is(0L));
+        assertThat(freeMap.get("/"), is(9999999L));
+        assertThat(totalMap.get("/"), is(234567L + 9999999L));
     }
 }

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystemTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.freebsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Pair;
+
+class FreeBsdFileSystemTest {
+
+    @Test
+    void testParseGeomPartListTypical() {
+        List<String> lines = Arrays.asList("Geom name: ada0", "Providers:", "1. Name: ada0p1",
+                "   rawuuid: 3e1cbe42-e2b9-11e6-85c6-0025909460ac", "2. Name: ada0p2",
+                "   rawuuid: 3e2e5580-e2b9-11e6-85c6-0025909460ac", "3. Name: ada0p3",
+                "   rawuuid: 3e3ed3be-e2b9-11e6-85c6-0025909460ac");
+        Map<String, String> result = FreeBsdFileSystem.parseGeomPartList(lines);
+        assertThat(result, is(aMapWithSize(3)));
+        assertThat(result.get("ada0p1"), is("3e1cbe42-e2b9-11e6-85c6-0025909460ac"));
+        assertThat(result.get("ada0p2"), is("3e2e5580-e2b9-11e6-85c6-0025909460ac"));
+        assertThat(result.get("ada0p3"), is("3e3ed3be-e2b9-11e6-85c6-0025909460ac"));
+    }
+
+    @Test
+    void testParseGeomPartListEmpty() {
+        Map<String, String> result = FreeBsdFileSystem.parseGeomPartList(Collections.emptyList());
+        assertThat(result, is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseDfInodesTypical() {
+        List<String> lines = Arrays.asList(
+                "Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on",
+                "/dev/twed0s1a   2026030 584112 1279836    31%    2751 279871    1%   /",
+                "/dev/twed0s1e  10240000 2048000 8192000    20%    5000 100000    5%   /usr");
+        Pair<Map<String, Long>, Map<String, Long>> result = FreeBsdFileSystem.parseDfInodes(lines);
+        Map<String, Long> freeMap = result.getA();
+        Map<String, Long> totalMap = result.getB();
+        assertThat(freeMap, is(aMapWithSize(2)));
+        assertThat(freeMap.get("/"), is(279871L));
+        assertThat(freeMap.get("/usr"), is(100000L));
+        assertThat(totalMap.get("/"), is(2751L + 279871L));
+        assertThat(totalMap.get("/usr"), is(5000L + 100000L));
+    }
+
+    @Test
+    void testParseDfInodesEmpty() {
+        Pair<Map<String, Long>, Map<String, Long>> result = FreeBsdFileSystem.parseDfInodes(Collections.emptyList());
+        assertThat(result.getA(), is(anEmptyMap()));
+        assertThat(result.getB(), is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseDfInodesSkipsHeaderAndNonSlash() {
+        List<String> lines = Arrays.asList(
+                "Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on",
+                "devfs               1      1       0   100%       0      0  100%   /dev");
+        Pair<Map<String, Long>, Map<String, Long>> result = FreeBsdFileSystem.parseDfInodes(lines);
+        // Header doesn't start with '/', devfs doesn't start with '/' either
+        assertThat(result.getA(), is(anEmptyMap()));
+        assertThat(result.getB(), is(anEmptyMap()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystemTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.netbsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Pair;
+
+class NetBsdFileSystemTest {
+
+    @Test
+    void testParseDfInodesTypical() {
+        List<String> lines = Arrays.asList(
+                "Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on",
+                "/dev/wd0a      2149212    908676   1133076    45%    8355  147163     5%   /",
+                "/dev/wd0e      4050876        36   3848300     0%      10  285108     0%   /home",
+                "/dev/wd0d      6082908   3343172   2435592    58%   27813  386905     7%   /usr");
+        Pair<Map<String, Long>, Map<String, Long>> result = NetBsdFileSystem.parseDfInodes(lines);
+        Map<String, Long> freeMap = result.getA();
+        Map<String, Long> usedMap = result.getB();
+        assertThat(freeMap, is(aMapWithSize(3)));
+        assertThat(freeMap.get("/dev/wd0a"), is(147163L));
+        assertThat(freeMap.get("/dev/wd0e"), is(285108L));
+        assertThat(freeMap.get("/dev/wd0d"), is(386905L));
+        assertThat(usedMap.get("/dev/wd0a"), is(8355L));
+        assertThat(usedMap.get("/dev/wd0e"), is(10L));
+        assertThat(usedMap.get("/dev/wd0d"), is(27813L));
+    }
+
+    @Test
+    void testParseDfInodesEmpty() {
+        Pair<Map<String, Long>, Map<String, Long>> result = NetBsdFileSystem.parseDfInodes(Collections.emptyList());
+        assertThat(result.getA(), is(anEmptyMap()));
+        assertThat(result.getB(), is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseDfInodesSkipsHeader() {
+        List<String> lines = Arrays
+                .asList("Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on");
+        Pair<Map<String, Long>, Map<String, Long>> result = NetBsdFileSystem.parseDfInodes(lines);
+        assertThat(result.getA(), is(anEmptyMap()));
+        assertThat(result.getB(), is(anEmptyMap()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystemTest.java
@@ -44,13 +44,15 @@ class OpenBsdFileSystemTest {
     }
 
     @Test
-    void testParseDfInodesSkipsNonDeviceLines() {
+    void testParseDfInodesIncludesMfsAndSkipsHeader() {
         List<String> lines = Arrays.asList(
                 "Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on",
                 "mfs:12345      1048576    10240   1038336     1%       5   65531     0%   /tmp");
         Pair<Map<String, Long>, Map<String, Long>> result = OpenBsdFileSystem.parseDfInodes(lines);
-        // Neither line starts with '/'
-        assertThat(result.getA(), is(anEmptyMap()));
-        assertThat(result.getB(), is(anEmptyMap()));
+        Map<String, Long> freeMap = result.getA();
+        Map<String, Long> usedMap = result.getB();
+        // Header is skipped; mfs entry is included
+        assertThat(freeMap.get("mfs:12345"), is(65531L));
+        assertThat(usedMap.get("mfs:12345"), is(5L));
     }
 }

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystemTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.openbsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Pair;
+
+class OpenBsdFileSystemTest {
+
+    @Test
+    void testParseDfInodesTypical() {
+        List<String> lines = Arrays.asList(
+                "Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on",
+                "/dev/sd0a      2149212    908676   1133076    45%    8355  147163     5%   /",
+                "/dev/sd0e      4050876        36   3848300     0%      10  285108     0%   /home");
+        Pair<Map<String, Long>, Map<String, Long>> result = OpenBsdFileSystem.parseDfInodes(lines);
+        Map<String, Long> freeMap = result.getA();
+        Map<String, Long> usedMap = result.getB();
+        assertThat(freeMap, is(aMapWithSize(2)));
+        assertThat(freeMap.get("/dev/sd0a"), is(147163L));
+        assertThat(freeMap.get("/dev/sd0e"), is(285108L));
+        assertThat(usedMap.get("/dev/sd0a"), is(8355L));
+        assertThat(usedMap.get("/dev/sd0e"), is(10L));
+    }
+
+    @Test
+    void testParseDfInodesEmpty() {
+        Pair<Map<String, Long>, Map<String, Long>> result = OpenBsdFileSystem.parseDfInodes(Collections.emptyList());
+        assertThat(result.getA(), is(anEmptyMap()));
+        assertThat(result.getB(), is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseDfInodesSkipsNonDeviceLines() {
+        List<String> lines = Arrays.asList(
+                "Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on",
+                "mfs:12345      1048576    10240   1038336     1%       5   65531     0%   /tmp");
+        Pair<Map<String, Long>, Map<String, Long>> result = OpenBsdFileSystem.parseDfInodes(lines);
+        // Neither line starts with '/'
+        assertThat(result.getA(), is(anEmptyMap()));
+        assertThat(result.getB(), is(anEmptyMap()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisFileSystemTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.solaris;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Pair;
+
+class SolarisFileSystemTest {
+
+    @Test
+    void testParseDfgInodesTypical() {
+        List<String> lines = Arrays.asList(
+                "/                  (/dev/md/dsk/d0    ):         8192 block size          1024 frag size",
+                "41310292 total blocks   18193814 free blocks 17780712 available        2486848 total files",
+                " 2293351 free files     22282240 filesys id",
+                "     ufs fstype       0x00000004 flag             255 filename length",
+                "/usr               (/dev/md/dsk/d1    ):         8192 block size          1024 frag size",
+                "20000000 total blocks    5000000 free blocks  4800000 available        1000000 total files",
+                "  800000 free files     33333333 filesys id",
+                "     ufs fstype       0x00000004 flag             255 filename length");
+        Pair<Map<String, Long>, Map<String, Long>> result = SolarisFileSystem.parseDfgInodes(lines);
+        Map<String, Long> freeMap = result.getA();
+        Map<String, Long> totalMap = result.getB();
+        assertThat(freeMap, is(aMapWithSize(2)));
+        assertThat(freeMap.get("/"), is(2293351L));
+        assertThat(freeMap.get("/usr"), is(800000L));
+        assertThat(totalMap.get("/"), is(2486848L));
+        assertThat(totalMap.get("/usr"), is(1000000L));
+    }
+
+    @Test
+    void testParseDfgInodesEmpty() {
+        Pair<Map<String, Long>, Map<String, Long>> result = SolarisFileSystem.parseDfgInodes(Collections.emptyList());
+        assertThat(result.getA(), is(anEmptyMap()));
+        assertThat(result.getB(), is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseDfgInodesSingleMount() {
+        List<String> lines = Arrays.asList(
+                "/export/home       (/dev/dsk/c0t0d0s7):         8192 block size          1024 frag size",
+                "10000000 total blocks    3000000 free blocks  2900000 available         500000 total files",
+                "  450000 free files     44444444 filesys id",
+                "     ufs fstype       0x00000004 flag             255 filename length");
+        Pair<Map<String, Long>, Map<String, Long>> result = SolarisFileSystem.parseDfgInodes(lines);
+        Map<String, Long> freeMap = result.getA();
+        Map<String, Long> totalMap = result.getB();
+        assertThat(freeMap, is(aMapWithSize(1)));
+        assertThat(freeMap.get("/export/home"), is(450000L));
+        assertThat(totalMap.get("/export/home"), is(500000L));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract the df/df-g inode-parsing loops from all five Unix FileSystem implementations into package-private static methods returning `Pair<Map, Map>`
- Also extract the FreeBSD `geom part list` UUID parser
- These are the pure text-to-data portions of `getFileStores` — the mount-table iteration that interacts with `File` and config filtering remains in the caller

## Test plan
- [x] Full reactor build passes locally (`./mvnw clean install` — 1215 tests, 0 failures)
- [x] Unix CI passes on fork: https://github.com/dbwiddis/oshi/actions/runs/29783896895
- [x] New fixture tests exercise all extracted parse methods with synthetic input grounded in real command output
- [x] No `@EnabledOnOs` gating on parse tests — they run on every platform
- [x] All pre-commit gates pass (spotless, checkstyle, forbiddenapis, javadoc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem inode usage detection on AIX, FreeBSD, NetBSD, OpenBSD, and Solaris, including filesystem entries that don’t begin with `/` (e.g., ZFS, tmpfs, devfs, mfs).
  * More reliable parsing of filesystem command output, covering headers and empty results.
* **Tests**
  * Added/expanded unit tests for inode and partition parsing on the supported Unix platforms to validate free/total inode calculations and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->