### PR TITLE
Extract testable parse methods from FreeBSD and Solaris disk drivers

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/GeomDiskList.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/GeomDiskList.java
@@ -31,6 +31,16 @@ public final class GeomDiskList {
      * @return A map with disk name as the key and a Triplet of model, serial, and size as the value
      */
     public static Map<String, Triplet<String, String, Long>> queryDisks() {
+        return parseGeomDiskList(ExecutingCommand.runNative(GEOM_DISK_LIST));
+    }
+
+    /**
+     * Parses the output of {@code geom disk list} into a map of disk parameters.
+     *
+     * @param geom the lines of output from {@code geom disk list}
+     * @return A map with disk name as the key and a Triplet of model, serial, and size as the value
+     */
+    static Map<String, Triplet<String, String, Long>> parseGeomDiskList(List<String> geom) {
         // Map of device name to disk, to be returned
         Map<String, Triplet<String, String, Long>> diskMap = new HashMap<>();
         // Parameters needed.
@@ -39,7 +49,6 @@ public final class GeomDiskList {
         String ident = Constants.UNKNOWN;
         long mediaSize = 0L;
 
-        List<String> geom = ExecutingCommand.runNative(GEOM_DISK_LIST);
         for (String line : geom) {
             line = line.trim();
             // Marks the DiskStore device

--- a/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/Mount.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/Mount.java
@@ -5,6 +5,7 @@
 package oshi.driver.common.unix.freebsd.disk;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -30,9 +31,18 @@ public final class Mount {
      * @return A map with partitions as the key and mount points as the value
      */
     public static Map<String, String> queryPartitionToMountMap() {
-        // Parse 'mount' to map partitions to mount point
+        return parseMountOutput(ExecutingCommand.runNative(MOUNT_CMD));
+    }
+
+    /**
+     * Parses the output of the {@code mount} command into a partition-to-mount-point map.
+     *
+     * @param mountOutput the lines of output from {@code mount}
+     * @return A map with partitions as the key and mount points as the value
+     */
+    static Map<String, String> parseMountOutput(List<String> mountOutput) {
         Map<String, String> mountMap = new HashMap<>();
-        for (String mnt : ExecutingCommand.runNative(MOUNT_CMD)) {
+        for (String mnt : mountOutput) {
             Matcher m = MOUNT_PATTERN.matcher(mnt);
             if (m.matches()) {
                 mountMap.put(m.group(1), m.group(2));

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Iostat.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Iostat.java
@@ -50,14 +50,24 @@ public final class Iostat {
      * @return A map with partitions as the key and mount points as the value
      */
     public static Map<String, String> queryPartitionToMountMap() {
-        // Create map to correlate disk name with block device mount point for
-        // later use in partition info
-        Map<String, String> deviceMap = new HashMap<>();
-
         // First, run iostat -er to enumerate disks by name.
         List<String> mountNames = ExecutingCommand.runNative(IOSTAT_ER);
         // Also run iostat -ern to get the same list by mount point.
         List<String> mountPoints = ExecutingCommand.runNative(IOSTAT_ERN);
+        return parsePartitionToMountMap(mountNames, mountPoints);
+    }
+
+    /**
+     * Parses the output of {@code iostat -er} and {@code iostat -ern} into a partition-to-mount-point map.
+     *
+     * @param mountNames  the lines of output from {@code iostat -er} (device name in first column)
+     * @param mountPoints the lines of output from {@code iostat -ern} (device name in last column)
+     * @return A map with partitions as the key and mount points as the value
+     */
+    static Map<String, String> parsePartitionToMountMap(List<String> mountNames, List<String> mountPoints) {
+        // Create map to correlate disk name with block device mount point for
+        // later use in partition info
+        Map<String, String> deviceMap = new HashMap<>();
 
         String disk;
         for (int i = 0; i < mountNames.size() && i < mountPoints.size(); i++) {
@@ -82,9 +92,19 @@ public final class Iostat {
      * @return A map with disk name as the key and a quintet of model, vendor, product, serial, size as the value
      */
     public static Map<String, Quintet<String, String, String, String, Long>> queryDeviceStrings(Set<String> diskSet) {
+        return parseDeviceStrings(ExecutingCommand.runNative(IOSTAT_ER_DETAIL), diskSet);
+    }
+
+    /**
+     * Parses the output of {@code iostat -Er} into a map of detailed drive information.
+     *
+     * @param iostat  the lines of output from {@code iostat -Er}
+     * @param diskSet A set of valid disk names; others will be ignored
+     * @return A map with disk name as the key and a quintet of model, vendor, product, serial, size as the value
+     */
+    static Map<String, Quintet<String, String, String, String, Long>> parseDeviceStrings(List<String> iostat,
+            Set<String> diskSet) {
         Map<String, Quintet<String, String, String, String, Long>> deviceParamMap = new HashMap<>();
-        // Run iostat -Er to get model, etc.
-        List<String> iostat = ExecutingCommand.runNative(IOSTAT_ER_DETAIL);
         // We'll use Model if available, otherwise Vendor+Product
         String diskName = null;
         String model = "";

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Lshal.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Lshal.java
@@ -30,8 +30,17 @@ public final class Lshal {
      *         otherwise
      */
     public static Map<String, Integer> queryDiskToMajorMap() {
+        return parseLshal(ExecutingCommand.runNative(LSHAL_CMD));
+    }
+
+    /**
+     * Parses the output of {@code lshal} into a map of disk names to block device major numbers.
+     *
+     * @param lshal the lines of output from {@code lshal}
+     * @return A map with disk names as the key and block device major as the value
+     */
+    static Map<String, Integer> parseLshal(List<String> lshal) {
         Map<String, Integer> majorMap = new HashMap<>();
-        List<String> lshal = ExecutingCommand.runNative(LSHAL_CMD);
         String diskName = null;
         for (String line : lshal) {
             if (line.startsWith("udi ")) {

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Prtvtoc.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Prtvtoc.java
@@ -24,18 +24,36 @@ public final class Prtvtoc {
     private Prtvtoc() {
     }
 
+    /**
+     * Query prtvtoc to get partition information for a disk.
+     *
+     * @param mount the mount point identifier for the disk
+     * @param major the block device major number
+     * @return A list of partitions for the specified disk
+     */
     public static List<HWPartition> queryPartitions(String mount, int major) {
-        List<HWPartition> partList = new ArrayList<>();
         // This requires sudo permissions; will result in "permission denied"
         // otherwise in which case we return empty partition list
-        List<String> prtvotc = ExecutingCommand.runNative(PRTVTOC_DEV_DSK + mount);
+        return parsePrtvtoc(ExecutingCommand.runNative(PRTVTOC_DEV_DSK + mount), mount, major);
+    }
+
+    /**
+     * Parses the output of {@code prtvtoc} into a list of partitions.
+     *
+     * @param prtvtoc the lines of output from {@code prtvtoc /dev/dsk/<mount>}
+     * @param mount   the mount point identifier for the disk
+     * @param major   the block device major number
+     * @return A list of partitions parsed from the prtvtoc output
+     */
+    static List<HWPartition> parsePrtvtoc(List<String> prtvtoc, String mount, int major) {
+        List<HWPartition> partList = new ArrayList<>();
         // Sample output - see man prtvtoc
-        if (prtvotc.size() > 1) {
+        if (prtvtoc.size() > 1) {
             int bytesPerSector = 0;
             String volumeName = "";
             String[] split;
             // We have a result, parse partition table
-            for (String line : prtvotc) {
+            for (String line : prtvtoc) {
                 // If line starts with asterisk we ignore except for the one
                 // specifying bytes per sector
                 if (line.startsWith("*")) {

--- a/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/GeomDiskListTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/GeomDiskListTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.unix.freebsd.disk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.Constants;
+import oshi.util.tuples.Triplet;
+
+class GeomDiskListTest {
+
+    @Test
+    void testParseGeomDiskListTypicalOutput() {
+        List<String> geom = Arrays.asList("Geom name: ada0", "Providers:", "1. Name: ada0",
+                "   Mediasize: 500107862016 (465G)", "   Sectorsize: 512", "   Mode: r2w2e3",
+                "   descr: Samsung SSD 860 EVO 500GB", "   ident: S3Z2NB0K123456X", "   rotationrate: 0", "",
+                "Geom name: da0", "Providers:", "1. Name: da0", "   Mediasize: 8053063680 (7.5G)", "   Sectorsize: 512",
+                "   Mode: r0w0e0", "   descr: USB Flash Drive", "   ident: (null)", "   rotationrate: unknown");
+
+        Map<String, Triplet<String, String, Long>> result = GeomDiskList.parseGeomDiskList(geom);
+
+        assertThat(result.size(), is(2));
+
+        Triplet<String, String, Long> ada0 = result.get("ada0");
+        assertThat(ada0.getA(), is("Samsung SSD 860 EVO 500GB"));
+        assertThat(ada0.getB(), is("S3Z2NB0K123456X"));
+        assertThat(ada0.getC(), is(500107862016L));
+
+        Triplet<String, String, Long> da0 = result.get("da0");
+        assertThat(da0.getA(), is("USB Flash Drive"));
+        assertThat(da0.getB(), is(""));
+        assertThat(da0.getC(), is(8053063680L));
+    }
+
+    @Test
+    void testParseGeomDiskListEmptyInput() {
+        Map<String, Triplet<String, String, Long>> result = GeomDiskList.parseGeomDiskList(Collections.emptyList());
+        assertThat(result, is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseGeomDiskListNoMediasizeDefaultsToZero() {
+        List<String> geom = Arrays.asList("Geom name: vtbd0", "   descr: VirtIO Block Device", "   ident: serial123");
+
+        Map<String, Triplet<String, String, Long>> result = GeomDiskList.parseGeomDiskList(geom);
+
+        assertThat(result.size(), is(1));
+        Triplet<String, String, Long> vtbd0 = result.get("vtbd0");
+        assertThat(vtbd0.getA(), is("VirtIO Block Device"));
+        assertThat(vtbd0.getB(), is("serial123"));
+        assertThat(vtbd0.getC(), is(0L));
+    }
+
+    @Test
+    void testParseGeomDiskListMissingFieldsDefaultToUnknown() {
+        List<String> geom = Arrays.asList("Geom name: nvd0", "   Mediasize: 1024000000000 (953G)");
+
+        Map<String, Triplet<String, String, Long>> result = GeomDiskList.parseGeomDiskList(geom);
+
+        assertThat(result.size(), is(1));
+        Triplet<String, String, Long> nvd0 = result.get("nvd0");
+        assertThat(nvd0.getA(), is(Constants.UNKNOWN));
+        assertThat(nvd0.getB(), is(Constants.UNKNOWN));
+        assertThat(nvd0.getC(), is(1024000000000L));
+    }
+}

--- a/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/MountTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/MountTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.unix.freebsd.disk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class MountTest {
+
+    @Test
+    void testParseMountOutputTypicalOutput() {
+        List<String> mountOutput = Arrays.asList("/dev/ada0p2 on / (ufs, local, journaled, soft-updates)",
+                "devfs on /dev (devfs)", "/dev/ada0p3 on /usr (ufs, local, journaled, soft-updates)",
+                "/dev/da0p1 on /mnt/usb (msdosfs, local)");
+
+        Map<String, String> result = Mount.parseMountOutput(mountOutput);
+
+        assertThat(result.size(), is(3));
+        assertThat(result.get("ada0p2"), is("/"));
+        assertThat(result.get("ada0p3"), is("/usr"));
+        assertThat(result.get("da0p1"), is("/mnt/usb"));
+    }
+
+    @Test
+    void testParseMountOutputEmptyInput() {
+        Map<String, String> result = Mount.parseMountOutput(Collections.emptyList());
+        assertThat(result, is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseMountOutputNonMatchingLinesIgnored() {
+        List<String> mountOutput = Arrays.asList("devfs on /dev (devfs)", "procfs on /proc (procfs, local)",
+                "tmpfs on /tmp (tmpfs, local)");
+
+        Map<String, String> result = Mount.parseMountOutput(mountOutput);
+        assertThat(result, is(anEmptyMap()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/IostatTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/IostatTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.unix.solaris.disk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Quintet;
+
+class IostatTest {
+
+    @Test
+    void testParsePartitionToMountMapTypicalOutput() {
+        // iostat -er output: errors with device name in first column
+        List<String> mountNames = Arrays.asList("errors", "device,s/w,h/w,trn,tot", "cmdk0,0,0,0,0", "sd0,0,0,0,0");
+        // iostat -ern output: errors with device name in last column
+        List<String> mountPoints = Arrays.asList("errors", "s/w,h/w,trn,tot,device", "0,0,0,0,c1d0", "0,0,0,0,c1t1d0");
+
+        Map<String, String> result = Iostat.parsePartitionToMountMap(mountNames, mountPoints);
+
+        assertThat(result.size(), is(2));
+        assertThat(result.get("cmdk0"), is("c1d0"));
+        assertThat(result.get("sd0"), is("c1t1d0"));
+    }
+
+    @Test
+    void testParsePartitionToMountMapEmptyInput() {
+        Map<String, String> result = Iostat.parsePartitionToMountMap(Collections.emptyList(), Collections.emptyList());
+        assertThat(result, is(anEmptyMap()));
+    }
+
+    @Test
+    void testParsePartitionToMountMapHeaderOnly() {
+        List<String> mountNames = Arrays.asList("errors", "device,s/w,h/w,trn,tot");
+        List<String> mountPoints = Arrays.asList("errors", "s/w,h/w,trn,tot,device");
+
+        Map<String, String> result = Iostat.parsePartitionToMountMap(mountNames, mountPoints);
+        assertThat(result, is(anEmptyMap()));
+    }
+
+    @Test
+    void testParsePartitionToMountMapMismatchedLengths() {
+        // mountNames has more entries than mountPoints - only paired entries are processed
+        List<String> mountNames = Arrays.asList("errors", "device,s/w,h/w,trn,tot", "cmdk0,0,0,0,0", "sd0,0,0,0,0");
+        List<String> mountPoints = Arrays.asList("errors", "s/w,h/w,trn,tot,device", "0,0,0,0,c1d0");
+
+        Map<String, String> result = Iostat.parsePartitionToMountMap(mountNames, mountPoints);
+
+        assertThat(result.size(), is(1));
+        assertThat(result.get("cmdk0"), is("c1d0"));
+    }
+
+    @Test
+    void testParseDeviceStringsTypicalOutput() {
+        List<String> iostat = Arrays.asList("cmdk0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0",
+                "Model: VBOX HARDDISK,Serial No: VB12345678-abcdefgh,Size: 21.47GB <21474836480 bytes>",
+                "sd0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0",
+                "Vendor: ATA,Product: Samsung SSD 860,Serial No: S3Z2NB0K999999,Size: 500.11GB <500107862016 bytes>");
+
+        Set<String> diskSet = new HashSet<>(Arrays.asList("cmdk0", "sd0"));
+
+        Map<String, Quintet<String, String, String, String, Long>> result = Iostat.parseDeviceStrings(iostat, diskSet);
+
+        assertThat(result.size(), is(2));
+
+        Quintet<String, String, String, String, Long> cmdk0 = result.get("cmdk0");
+        assertThat(cmdk0.getA(), is("VBOX HARDDISK"));
+        assertThat(cmdk0.getB(), is(""));
+        assertThat(cmdk0.getC(), is(""));
+        assertThat(cmdk0.getD(), is("VB12345678-abcdefgh"));
+        assertThat(cmdk0.getE(), is(21474836480L));
+
+        Quintet<String, String, String, String, Long> sd0 = result.get("sd0");
+        assertThat(sd0.getA(), is(""));
+        assertThat(sd0.getB(), is("ATA"));
+        assertThat(sd0.getC(), is("Samsung SSD 860"));
+        assertThat(sd0.getD(), is("S3Z2NB0K999999"));
+        assertThat(sd0.getE(), is(500107862016L));
+    }
+
+    @Test
+    void testParseDeviceStringsFiltersByDiskSet() {
+        List<String> iostat = Arrays.asList("cmdk0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0",
+                "Model: VBOX HARDDISK,Serial No: VB12345,Size: 21.47GB <21474836480 bytes>",
+                "sd0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0",
+                "Vendor: ATA,Product: Test,Serial No: SN999,Size: 100GB <100000000000 bytes>");
+
+        // Only include cmdk0 in the disk set
+        Set<String> diskSet = new HashSet<>(Arrays.asList("cmdk0"));
+
+        Map<String, Quintet<String, String, String, String, Long>> result = Iostat.parseDeviceStrings(iostat, diskSet);
+
+        assertThat(result.size(), is(1));
+        assertThat(result.containsKey("cmdk0"), is(true));
+        assertThat(result.containsKey("sd0"), is(false));
+    }
+
+    @Test
+    void testParseDeviceStringsEmptyInput() {
+        Set<String> diskSet = new HashSet<>(Arrays.asList("cmdk0"));
+        Map<String, Quintet<String, String, String, String, Long>> result = Iostat
+                .parseDeviceStrings(Collections.emptyList(), diskSet);
+        assertThat(result, is(anEmptyMap()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/LshalTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/LshalTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.unix.solaris.disk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class LshalTest {
+
+    @Test
+    void testParseLshalTypicalOutput() {
+        List<String> lshal = Arrays.asList("udi = '/org/freedesktop/Hal/devices/storage_serial_VBOX_HARDDISK_VB12345'",
+                "  block.major = 102  (0x66)  (int)", "  block.minor = 0  (0x0)  (int)",
+                "  info.category = 'storage'  (string)", "",
+                "udi = '/org/freedesktop/Hal/devices/storage_serial_disk1'", "  block.major = 91  (0x5b)  (int)",
+                "  block.minor = 1  (0x1)  (int)");
+
+        Map<String, Integer> result = Lshal.parseLshal(lshal);
+
+        assertThat(result.size(), is(2));
+        assertThat(result.get("storage_serial_VBOX_HARDDISK_VB12345"), is(102));
+        assertThat(result.get("storage_serial_disk1"), is(91));
+    }
+
+    @Test
+    void testParseLshalEmptyInput() {
+        Map<String, Integer> result = Lshal.parseLshal(Collections.emptyList());
+        assertThat(result, is(anEmptyMap()));
+    }
+
+    @Test
+    void testParseLshalNoBlockMajorLine() {
+        List<String> lshal = Arrays.asList("udi = '/org/freedesktop/Hal/devices/computer'",
+                "  info.category = 'computer'  (string)", "  info.product = 'Computer'  (string)");
+
+        Map<String, Integer> result = Lshal.parseLshal(lshal);
+        assertThat(result, is(anEmptyMap()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/PrtvtocTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/PrtvtocTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.unix.solaris.disk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.HWPartition;
+import oshi.util.Constants;
+
+class PrtvtocTest {
+
+    @Test
+    void testParsePrtvtocTypicalOutput() {
+        // Typical prtvtoc output for a Solaris disk
+        List<String> prtvtoc = Arrays.asList("* /dev/dsk/c1t0d0s0 partition map", "*", "* Dimensions:",
+                "*     512 bytes/sector", "*      63 sectors/track", "*      16 tracks/cylinder",
+                "*    1008 sectors/cylinder", "*   16384 cylinders", "*   16382 accessible cylinders", "*", "* Flags:",
+                "*   1: unmountable", "*  10: read-only", "*", "* Volume Name: MyVolume", "*",
+                "*          First     Sector    Last",
+                "* Partition  Tag  Flags  Sector     Count    Sector  Mount Directory",
+                "       0      2    00       1008   14329440   14330447   /",
+                "       1      3    01    14330448    2097648   16428095",
+                "       2      5    00           0   16515072   16515071",
+                "       3      7    00    16428096      86976   16515071   /var");
+
+        List<HWPartition> result = Prtvtoc.parsePrtvtoc(prtvtoc, "c1t0d0", 102);
+
+        // Partition 2 (backup/whole disk) is always skipped
+        assertThat(result.size(), is(3));
+
+        // Partition 0: tag=2 (root), flags=00 (wm)
+        HWPartition p0 = result.get(0);
+        assertThat(p0.getIdentification(), is("c1t0d0s0"));
+        assertThat(p0.getName(), is("root"));
+        assertThat(p0.getType(), is("wm"));
+        assertThat(p0.getSize(), is(512L * 14329440L));
+        assertThat(p0.getMajor(), is(102));
+        assertThat(p0.getMinor(), is(0));
+        assertThat(p0.getMountPoint(), is("/"));
+        assertThat(p0.getLabel(), is("MyVolume"));
+
+        // Partition 1: tag=3 (swap), flags=01 (wu)
+        HWPartition p1 = result.get(1);
+        assertThat(p1.getIdentification(), is("c1t0d0s1"));
+        assertThat(p1.getName(), is("swap"));
+        assertThat(p1.getType(), is("wu"));
+        assertThat(p1.getSize(), is(512L * 2097648L));
+        assertThat(p1.getMajor(), is(102));
+        assertThat(p1.getMinor(), is(1));
+        assertThat(p1.getMountPoint(), is(""));
+
+        // Partition 3: tag=7 (var), flags=00 (wm)
+        HWPartition p3 = result.get(2);
+        assertThat(p3.getIdentification(), is("c1t0d0s3"));
+        assertThat(p3.getName(), is("var"));
+        assertThat(p3.getType(), is("wm"));
+        assertThat(p3.getSize(), is(512L * 86976L));
+        assertThat(p3.getMajor(), is(102));
+        assertThat(p3.getMinor(), is(3));
+        assertThat(p3.getMountPoint(), is("/var"));
+    }
+
+    @Test
+    void testParsePrtvtocTagMappings() {
+        // Test various tag values to verify name mappings
+        List<String> prtvtoc = Arrays.asList("* header line", "*     512 bytes/sector",
+                "       0      1    00       0   1000    999", "       1     24    00       0   1000    999",
+                "       3      4    10       0   1000    999", "       4      6    00       0   1000    999",
+                "       5      8    00       0   1000    999", "       6      9    00       0   1000    999",
+                "       7     10    00       0   1000    999", "       8     11    00       0   1000    999",
+                "       9     12    00       0   1000    999", "      10     14    00       0   1000    999",
+                "      11     15    00       0   1000    999", "      12     99    00       0   1000    999");
+
+        List<HWPartition> result = Prtvtoc.parsePrtvtoc(prtvtoc, "c0d0", 10);
+
+        assertThat(result.size(), is(12));
+        // tag 0x01 -> boot
+        assertThat(result.get(0).getName(), is("boot"));
+        // tag 0x18 (24) -> boot
+        assertThat(result.get(1).getName(), is("boot"));
+        // tag 0x04 -> usr
+        assertThat(result.get(2).getName(), is("usr"));
+        // tag 0x06 -> stand
+        assertThat(result.get(3).getName(), is("stand"));
+        // tag 0x08 -> home
+        assertThat(result.get(4).getName(), is("home"));
+        // tag 0x09 -> altsctr
+        assertThat(result.get(5).getName(), is("altsctr"));
+        // tag 0x0a (10) -> cache
+        assertThat(result.get(6).getName(), is("cache"));
+        // tag 0x0b (11) -> reserved
+        assertThat(result.get(7).getName(), is("reserved"));
+        // tag 0x0c (12) -> system
+        assertThat(result.get(8).getName(), is("system"));
+        // tag 0x0e (14) -> public region
+        assertThat(result.get(9).getName(), is("public region"));
+        // tag 0x0f (15) -> private region
+        assertThat(result.get(10).getName(), is("private region"));
+        // tag 99 -> unknown
+        assertThat(result.get(11).getName(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testParsePrtvtocFlagMappings() {
+        // Test flag values: 00=wm, 10=rm, 01=wu, other=ru
+        List<String> prtvtoc = Arrays.asList("* header", "*     512 bytes/sector",
+                "       0      2    00       0   1000    999", "       1      2    10       0   1000    999",
+                "       3      2    01       0   1000    999", "       4      2    11       0   1000    999");
+
+        List<HWPartition> result = Prtvtoc.parsePrtvtoc(prtvtoc, "c0d0", 5);
+
+        assertThat(result.size(), is(4));
+        assertThat(result.get(0).getType(), is("wm"));
+        assertThat(result.get(1).getType(), is("rm"));
+        assertThat(result.get(2).getType(), is("wu"));
+        assertThat(result.get(3).getType(), is("ru"));
+    }
+
+    @Test
+    void testParsePrtvtocEmptyInput() {
+        List<HWPartition> result = Prtvtoc.parsePrtvtoc(Collections.emptyList(), "c0d0", 10);
+        assertThat(result, is(empty()));
+    }
+
+    @Test
+    void testParsePrtvtocSingleLineInput() {
+        // size <= 1 returns empty
+        List<HWPartition> result = Prtvtoc.parsePrtvtoc(Collections.singletonList("* header"), "c0d0", 10);
+        assertThat(result, is(empty()));
+    }
+
+    @Test
+    void testParsePrtvtocNoBytesPerSectorIgnoresPartitions() {
+        // If bytes/sector is never set, partition lines are ignored
+        List<String> prtvtoc = Arrays.asList("* header line without bytes/sector info", "* another comment",
+                "       0      2    00       0   1000    999");
+
+        List<HWPartition> result = Prtvtoc.parsePrtvtoc(prtvtoc, "c0d0", 10);
+        assertThat(result, is(empty()));
+    }
+
+    @Test
+    void testParsePrtvtocVolumeNameUsedAsLabel() {
+        List<String> prtvtoc = Arrays.asList("* header", "*     512 bytes/sector", "* Volume Name: TestLabel",
+                "       0      2    00       0   2048    2047   /");
+
+        List<HWPartition> result = Prtvtoc.parsePrtvtoc(prtvtoc, "c0d0", 5);
+
+        assertThat(result.size(), is(1));
+        // Volume name goes into the uuid/label field
+        assertThat(result.get(0).getLabel(), is("TestLabel"));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract inline command-output parsing into package-private static methods in the FreeBSD and Solaris disk driver classes
- Enables fixture-based tests that run on every CI platform without requiring the target OS
- Covers 5 driver files with 7 new parse methods

## Test plan
- [x] Full reactor build passes locally (`./mvnw clean install` — 1239 tests, 0 failures)
- [x] Unix CI passes on fork (retry): https://github.com/dbwiddis/oshi/actions/runs/29786081843
- [x] New fixture tests exercise all extracted parse methods with synthetic input grounded in real command output
- [x] No `@EnabledOnOs` gating on parse tests — they run on every platform
- [x] All pre-commit gates pass (spotless, checkstyle, forbiddenapis, javadoc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of FreeBSD and Solaris disk, mount, partition, and device information parsing.
  * Corrected parsing workflows to consistently process command output and handle missing or incomplete data safely.

* **Tests**
  * Added comprehensive coverage for typical output, empty results, malformed input, missing fields, filtering, and platform-specific edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->