### PR TITLE
AIX: extract testable parse methods from command readers

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Ls.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Ls.java
@@ -5,6 +5,7 @@
 package oshi.driver.common.unix.aix;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -27,6 +28,16 @@ public final class Ls {
      * @return A map of device name to a major-minor pair
      */
     public static Map<String, Pair<Integer, Integer>> queryDeviceMajorMinor() {
+        return parseDeviceMajorMinor(ExecutingCommand.runNative("ls -l /dev"));
+    }
+
+    /**
+     * Parses {@code ls -l /dev} output into a map of block-device name to its major-minor number pair.
+     *
+     * @param ls the lines of {@code ls -l /dev} output
+     * @return A map of device name to a major-minor pair
+     */
+    public static Map<String, Pair<Integer, Integer>> parseDeviceMajorMinor(List<String> ls) {
         // Map major and minor from ls
         /*-
          $ ls -l /dev
@@ -34,7 +45,7 @@ public final class Ls {
         brw-------  1 root system 20,  0 Jun 28  1970 hdisk0
          */
         Map<String, Pair<Integer, Integer>> majMinMap = new HashMap<>();
-        for (String s : ExecutingCommand.runNative("ls -l /dev")) {
+        for (String s : ls) {
             // Filter to block devices
             if (!s.isEmpty() && s.charAt(0) == 'b') {
                 // Device name is last space-delim string

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lssrad.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lssrad.java
@@ -41,15 +41,26 @@ public final class Lssrad {
                        3        1992.00
                        4         249.00
          */
+        return parseNodesPackages(ExecutingCommand.runNative("lssrad -av"));
+    }
+
+    /**
+     * Parses {@code lssrad -av} output into a map of processor number to its (ref, srad) pair.
+     *
+     * @param lssrad the lines of {@code lssrad -av} output (including the header row)
+     * @return A map of processor number to a pair containing the ref (NUMA equivalent) and srad (package)
+     */
+    public static Map<Integer, Pair<Integer, Integer>> parseNodesPackages(List<String> lssrad) {
         int node = 0;
         int slot = 0;
         Map<Integer, Pair<Integer, Integer>> nodeMap = new HashMap<>();
-        List<String> lssrad = ExecutingCommand.runNative("lssrad -av");
-        // remove header
-        if (!lssrad.isEmpty()) {
-            lssrad.remove(0);
-        }
+        boolean header = true;
         for (String s : lssrad) {
+            // Skip the "REF1 SRAD MEM CPU" header row without mutating the input list
+            if (header) {
+                header = false;
+                continue;
+            }
             String t = s.trim();
             if (!t.isEmpty()) {
                 if (Character.isDigit(s.charAt(0))) {

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Uptime.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Uptime.java
@@ -36,7 +36,6 @@ public final class Uptime {
      * @return Up time in milliseconds
      */
     public static long queryUpTime() {
-        long uptime = 0L;
         String s = ExecutingCommand.getFirstAnswer("uptime");
         if (s.isEmpty()) {
             s = ExecutingCommand.getFirstAnswer("w");
@@ -44,6 +43,17 @@ public final class Uptime {
         if (s.isEmpty()) {
             s = ExecutingCommand.getFirstAnswer("/usr/bin/uptime");
         }
+        return parseUpTime(s);
+    }
+
+    /**
+     * Parses the {@code uptime} (or {@code w}) output line into an uptime in milliseconds.
+     *
+     * @param s a line of {@code uptime} output
+     * @return up time in milliseconds, or 0 if the line does not match the expected format
+     */
+    public static long parseUpTime(String s) {
+        long uptime = 0L;
         Matcher m = UPTIME_FORMAT_AIX.matcher(s);
         if (m.matches()) {
             if (m.group(2) != null) {

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Who.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Who.java
@@ -40,6 +40,16 @@ public final class Who {
         if (s.isEmpty()) {
             s = ExecutingCommand.getFirstAnswer("/usr/bin/who -b");
         }
+        return parseBootTime(s);
+    }
+
+    /**
+     * Parses the {@code who -b} output line into a boot time in milliseconds since the epoch.
+     *
+     * @param s a line of {@code who -b} output
+     * @return boot time in milliseconds since the epoch, or 0 if the line does not match the expected format
+     */
+    public static long parseBootTime(String s) {
         Matcher m = BOOT_FORMAT_AIX.matcher(s);
         if (m.matches()) {
             try {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixComputerSystem.java
@@ -63,6 +63,17 @@ public final class AixComputerSystem extends AbstractComputerSystem {
     }
 
     private static LsattrStrings readLsattr() {
+        return parseLsattr(ExecutingCommand.runNative("lsattr -El sys0"), ExecutingCommand.runNative("lsmcode -c"));
+    }
+
+    /**
+     * Parses {@code lsattr -El sys0} and {@code lsmcode -c} output into the system's firmware and identity strings.
+     *
+     * @param lsattr  the lines of {@code lsattr -El sys0} output
+     * @param lsmcode the lines of {@code lsmcode -c} output
+     * @return the parsed firmware and identity strings (blank fields defaulted to {@link Constants#UNKNOWN})
+     */
+    static LsattrStrings parseLsattr(List<String> lsattr, List<String> lsmcode) {
         String fwVendor = "IBM";
         String fwVersion = null;
         String fwPlatformVersion = null;
@@ -86,7 +97,7 @@ public final class AixComputerSystem extends AbstractComputerSystem {
         final String uuidMarker = "os_uuid";
         final String fwPlatformVersionMarker = "Platform Firmware level is";
 
-        for (final String checkLine : ExecutingCommand.runNative("lsattr -El sys0")) {
+        for (final String checkLine : lsattr) {
             if (checkLine.startsWith(fwVersionMarker)) {
                 fwVersion = checkLine.split(fwVersionMarker)[1].trim();
                 int comma = fwVersion.indexOf(',');
@@ -111,7 +122,7 @@ public final class AixComputerSystem extends AbstractComputerSystem {
                 uuid = ParseUtil.whitespaces.split(uuid)[0];
             }
         }
-        for (final String checkLine : ExecutingCommand.runNative("lsmcode -c")) {
+        for (final String checkLine : lsmcode) {
             /*-
              Platform Firmware level is 3F080425
              System Firmware level is RG080425_d79e22_regatta
@@ -124,7 +135,7 @@ public final class AixComputerSystem extends AbstractComputerSystem {
         return new LsattrStrings(fwVendor, fwPlatformVersion, fwVersion, manufacturer, model, serialNumber, uuid);
     }
 
-    private static final class LsattrStrings {
+    static final class LsattrStrings {
         private final String biosVendor;
         private final String biosPlatformVersion;
         private final String biosVersion;
@@ -144,6 +155,34 @@ public final class AixComputerSystem extends AbstractComputerSystem {
             this.model = Util.isBlank(model) ? Constants.UNKNOWN : model;
             this.serialNumber = Util.isBlank(serialNumber) ? Constants.UNKNOWN : serialNumber;
             this.uuid = Util.isBlank(uuid) ? Constants.UNKNOWN : uuid;
+        }
+
+        String biosVendor() {
+            return biosVendor;
+        }
+
+        String biosPlatformVersion() {
+            return biosPlatformVersion;
+        }
+
+        String biosVersion() {
+            return biosVersion;
+        }
+
+        String manufacturer() {
+            return manufacturer;
+        }
+
+        String model() {
+            return model;
+        }
+
+        String serialNumber() {
+            return serialNumber;
+        }
+
+        String uuid() {
+            return uuid;
         }
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixNetworkParams.java
@@ -4,6 +4,8 @@
  */
 package oshi.software.common.os.unix.aix;
 
+import java.util.List;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractNetworkParams;
 import oshi.util.Constants;
@@ -31,7 +33,17 @@ public abstract class AixNetworkParams extends AbstractNetworkParams {
     }
 
     private static String getDefaultGateway(String netstat) {
-        for (String line : ExecutingCommand.runNative(netstat)) {
+        return parseDefaultGateway(ExecutingCommand.runNative(netstat));
+    }
+
+    /**
+     * Parses {@code netstat -rnf inet[6]} output to find the gateway of the {@code default} route.
+     *
+     * @param netstat the lines of {@code netstat -rnf inet[6]} output
+     * @return the default gateway address, or {@link Constants#UNKNOWN} if no default route is present
+     */
+    static String parseDefaultGateway(List<String> netstat) {
+        for (String line : netstat) {
             String[] split = ParseUtil.whitespaces.split(line);
             if (split.length > 7 && "default".equals(split[0])) {
                 return split[1];

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LsDevicesTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LsDevicesTest.java
@@ -7,10 +7,14 @@ package oshi.driver.common.unix.aix;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -22,9 +26,30 @@ import oshi.hardware.HWPartition;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
-@EnabledOnOs(OS.AIX)
 class LsDevicesTest {
+
     @Test
+    void testParseDeviceMajorMinor() {
+        // ls -l /dev: block devices begin with 'b'; major,minor are the 2nd and 3rd integers, name is the last token
+        Map<String, Pair<Integer, Integer>> map = Ls.parseDeviceMajorMinor(Arrays.asList(//
+                "total 0", //
+                "crw-rw-rw-  1 root system  2,  2 Jun 28  1970 null", // not a block device, skipped
+                "brw-rw----  1 root system 10,  5 Sep 12  2017 hd2", //
+                "brw-------  1 root system 20,  0 Jun 28  1970 hdisk0"));
+        assertThat(map, not(hasKey("null")));
+        assertThat(map.get("hd2").getA(), is(10));
+        assertThat(map.get("hd2").getB(), is(5));
+        assertThat(map.get("hdisk0").getA(), is(20));
+        assertThat(map.get("hdisk0").getB(), is(0));
+    }
+
+    @Test
+    void testParseDeviceMajorMinorEmpty() {
+        assertThat(Ls.parseDeviceMajorMinor(Collections.emptyList()), is(anEmptyMap()));
+    }
+
+    @Test
+    @EnabledOnOs(OS.AIX)
     void testQueryLsDevices() {
         Map<String, Pair<Integer, Integer>> majMinMap = Ls.queryDeviceMajorMinor();
         assertThat("Device Major Minor Map shouldn't be empty", majMinMap, not(anEmptyMap()));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LssradTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LssradTest.java
@@ -6,8 +6,11 @@ package oshi.driver.common.unix.aix;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -16,9 +19,42 @@ import org.junit.jupiter.api.condition.OS;
 
 import oshi.util.tuples.Pair;
 
-@EnabledOnOs(OS.AIX)
 class LssradTest {
+
     @Test
+    void testParseNodesPackages() {
+        // lssrad -av: leading-digit lines set the REF (node); indented lines carry SRAD (slot) + CPU ranges.
+        // A range line without a decimal MEM column is a continuation that keeps the previous slot.
+        Map<Integer, Pair<Integer, Integer>> map = Lssrad.parseNodesPackages(Arrays.asList(//
+                "REF1        SRAD        MEM        CPU", //
+                "0", //
+                "               0       32749.12    0-63", //
+                "               1        9462.00    64-67 72-75", //
+                "                                   80-83 88-91", //
+                "1", //
+                "               2        2471.19    92-95"));
+        // node 0, slot 0
+        assertThat(map.get(0).getA(), is(0));
+        assertThat(map.get(0).getB(), is(0));
+        assertThat(map.get(63).getA(), is(0));
+        // node 0, slot 1
+        assertThat(map.get(64).getA(), is(0));
+        assertThat(map.get(64).getB(), is(1));
+        // continuation line keeps node 0, slot 1
+        assertThat(map.get(80).getA(), is(0));
+        assertThat(map.get(80).getB(), is(1));
+        // node 1, slot 2
+        assertThat(map.get(92).getA(), is(1));
+        assertThat(map.get(92).getB(), is(2));
+    }
+
+    @Test
+    void testParseNodesPackagesEmpty() {
+        assertThat(Lssrad.parseNodesPackages(Collections.emptyList()), is(anEmptyMap()));
+    }
+
+    @Test
+    @EnabledOnOs(OS.AIX)
     void testQueryLssrad() {
         Map<Integer, Pair<Integer, Integer>> nodeMap = Lssrad.queryNodesPackages();
         assertThat("Node Map shouldn't be empty", nodeMap, not(anEmptyMap()));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/UptimeAndBootTimeTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/UptimeAndBootTimeTest.java
@@ -7,16 +7,50 @@ package oshi.driver.common.unix.aix;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-@EnabledOnOs(OS.AIX)
 class UptimeAndBootTimeTest {
+
     @Test
+    void testParseUpTime() {
+        // 18:36pm up 10 days 8:11, 2 users, load average: 3.14, 2.74, 2.41
+        long ms = Uptime.parseUpTime("18:36pm up 10 days 8:11, 2 users, load average: 3.14, 2.74, 2.41");
+        assertThat(ms, is((10L * 86_400_000L) + (8L * 3_600_000L) + (11L * 60_000L)));
+        // minutes-only form
+        assertThat(Uptime.parseUpTime("12:00pm up 5 mins, 1 user, load average: 0.00, 0.00, 0.00"), is(5L * 60_000L));
+        // unparseable input yields 0
+        assertThat(Uptime.parseUpTime(""), is(0L));
+        assertThat(Uptime.parseUpTime("not an uptime line"), is(0L));
+    }
+
+    @Test
+    void testParseBootTime() {
+        // system boot 2020-06-16 09:12
+        long ms = Who.parseBootTime("   .        system boot 2020-06-16 09:12");
+        assertThat(ms, is(greaterThan(0L)));
+        // matches the same zone-aware conversion the parser performs
+        long expected = LocalDateTime
+                .parse("2020-06-16 09:12", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm", Locale.ROOT))
+                .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        assertThat(ms, is(expected));
+        // unparseable input yields 0
+        assertThat(Who.parseBootTime(""), is(0L));
+        assertThat(Who.parseBootTime("no timestamp here"), is(0L));
+    }
+
+    @Test
+    @EnabledOnOs(OS.AIX)
     void testQueryBootTime() {
         long msSinceEpoch = Who.queryBootTime();
         // Possible to return 0 if there is no year information in the command

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixComputerSystemTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.aix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.Constants;
+
+class AixComputerSystemTest {
+
+    // lsattr -El sys0: attr, value, description, user-settable columns (whitespace-separated)
+    private static final List<String> LSATTR = Arrays.asList(//
+            "fwversion       IBM,RG080425_d79e22_r                Firmware version and revision levels   False", //
+            "modelname       IBM,9114-275                         Machine name                           False", //
+            "os_uuid         789f930f-b15c-4639-b842-b42603862704 N/A                                     True", //
+            "systemid        IBM,0110ACFDE                        Hardware system identifier             False");
+
+    // lsmcode -c
+    private static final List<String> LSMCODE = Arrays.asList(//
+            "Platform Firmware level is 3F080425", //
+            "System Firmware level is RG080425_d79e22_regatta");
+
+    @Test
+    void testParseLsattr() {
+        AixComputerSystem.LsattrStrings s = AixComputerSystem.parseLsattr(LSATTR, LSMCODE);
+        // The "IBM," prefix is split off manufacturer/vendor; the remaining first token is model/version
+        assertThat(s.manufacturer(), is("IBM"));
+        assertThat(s.model(), is("9114-275"));
+        assertThat(s.serialNumber(), is("IBM,0110ACFDE"));
+        assertThat(s.uuid(), is("789f930f-b15c-4639-b842-b42603862704"));
+        assertThat(s.biosVendor(), is("IBM"));
+        assertThat(s.biosVersion(), is("RG080425_d79e22_r"));
+        assertThat(s.biosPlatformVersion(), is("3F080425"));
+    }
+
+    @Test
+    void testParseLsattrEmpty() {
+        // No lsattr/lsmcode output: vendor/manufacturer keep their IBM defaults, everything else is UNKNOWN
+        AixComputerSystem.LsattrStrings s = AixComputerSystem.parseLsattr(Collections.emptyList(),
+                Collections.emptyList());
+        assertThat(s.manufacturer(), is("IBM"));
+        assertThat(s.biosVendor(), is("IBM"));
+        assertThat(s.model(), is(Constants.UNKNOWN));
+        assertThat(s.serialNumber(), is(Constants.UNKNOWN));
+        assertThat(s.uuid(), is(Constants.UNKNOWN));
+        assertThat(s.biosVersion(), is(Constants.UNKNOWN));
+        assertThat(s.biosPlatformVersion(), is(Constants.UNKNOWN));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixNetworkParamsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixNetworkParamsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.aix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.Constants;
+
+class AixNetworkParamsTest {
+
+    @Test
+    void testParseDefaultGateway() {
+        // netstat -rnf inet: the "default" route's gateway is the second column
+        String gw = AixNetworkParams.parseDefaultGateway(Arrays.asList(//
+                "Routing tables", //
+                "Destination      Gateway         Flags  Refs   Use  If  Exp  Groups", //
+                "Route Tree for Protocol Family 2 (Internet):", //
+                "default          192.168.1.1     UG      1     123  en0   -    -", //
+                "127/8            127.0.0.1       U       3       0  lo0   -    -"));
+        assertThat(gw, is("192.168.1.1"));
+    }
+
+    @Test
+    void testParseDefaultGatewayNoDefaultRoute() {
+        String gw = AixNetworkParams.parseDefaultGateway(Arrays.asList(//
+                "Destination      Gateway         Flags  Refs   Use  If  Exp  Groups", //
+                "127/8            127.0.0.1       U       3       0  lo0   -    -"));
+        assertThat(gw, is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testParseDefaultGatewayEmpty() {
+        assertThat(AixNetworkParams.parseDefaultGateway(Collections.emptyList()), is(Constants.UNKNOWN));
+    }
+}


### PR DESCRIPTION
## Summary

Continues the parse-seam testability effort (after Linux #3494, FreeBSD #3495, NetBSD/OpenBSD #3496, Solaris #3497/#3498, FileSystem #3499, disk drivers #3500) with the AIX command readers. Each acquire-and-parse method keeps its acquisition and delegates to a package-private/`static` parse method taking the already-read input, so the parsing is unit-testable with synthetic fixtures instead of only on a live AIX host:

- `Uptime.parseUpTime(String)`, `Who.parseBootTime(String)`
- `Ls.parseDeviceMajorMinor(List<String>)`, `Lssrad.parseNodesPackages(List<String>)` (the latter no longer mutates its input to drop the header)
- `AixNetworkParams.parseDefaultGateway(List<String>)`
- `AixComputerSystem.parseLsattr(lsattr, lsmcode)` → `LsattrStrings` (now package-private with accessors)

Fixtures are grounded in the real `uptime`, `who -b`, `ls -l /dev`, `lssrad -av`, `netstat -rnf inet`, `lsattr -El sys0`, and `lsmcode -c` output documented in each source. The new parse tests run on **every** platform; the existing AIX-only live smoke tests keep their coverage via per-method `@EnabledOnOs(OS.AIX)`.

## Note on coverage

The AIX package is still JaCoCo-excluded (`**/unix/aix/**`), the same as NetBSD in #3496, so this lands as **testability / regression-safety groundwork** rather than an immediate coverage bump — un-excluding AIX is a separate follow-up (it needs its native/JNA paths measured, which the current CI aggregation doesn't do).

## Testing

- `oshi-common` full gate green: spotless, checkstyle, install + forbiddenapis, javadoc; clean full-reactor `install` green.
- All six AIX test classes pass; parse tests exercise each extracted method on the local (macOS) run.

No CHANGELOG entry — test/coverage refactor with no user-observable behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AIX hardware, network, device, processor-topology, uptime, and boot-time data parsing.
  - Increased resilience when command output is empty, incomplete, or formatted unexpectedly.
  - Improved detection of default network gateways and system identification details.

- **Tests**
  - Added broader coverage for AIX parsing scenarios, including empty and malformed inputs.
  - Expanded validation of device identifiers, boot times, hardware metadata, processor ranges, and gateway detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->