### PR TITLE
AIX: extract more testable parse methods from command readers

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lscfg.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lscfg.java
@@ -98,16 +98,13 @@ public final class Lscfg {
         String model = null;
         String serial = null;
         for (String s : lscfg) {
-            // Default model to description at end of first line
+            // Default model to description at end of first line. Locate the device literally (split would treat it
+            // as a regex); a device at the very end of the line leaves an empty remainder, so no model is derived.
             if (model == null && s.contains(device)) {
-                String[] locDescSplit = s.split(device);
-                // A device at the very end of the line splits to a single element; skip the fallback then
-                if (locDescSplit.length > 1) {
-                    String locDesc = locDescSplit[1].trim();
-                    int idx = locDesc.indexOf(' ');
-                    if (idx > 0) {
-                        model = locDesc.substring(idx).trim();
-                    }
+                String locDesc = s.substring(s.indexOf(device) + device.length()).trim();
+                int idx = locDesc.indexOf(' ');
+                if (idx > 0) {
+                    model = locDesc.substring(idx).trim();
                 }
             }
             if (s.contains(modelMarker)) {

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lscfg.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lscfg.java
@@ -82,11 +82,22 @@ public final class Lscfg {
      * @return A pair containing the model and serial number for the device, or null if not found
      */
     public static Pair<String, String> queryModelSerial(String device) {
+        return parseModelSerial(ExecutingCommand.runNative("lscfg -vl " + device), device);
+    }
+
+    /**
+     * Parse the output of {@code lscfg -vl device} to get the model and serial number
+     *
+     * @param lscfg  The output of a previous call to {@code lscfg -vl device}
+     * @param device The disk the output describes
+     * @return A pair containing the model and serial number for the device, either of which may be null if not found
+     */
+    public static Pair<String, String> parseModelSerial(List<String> lscfg, String device) {
         String modelMarker = "Machine Type and Model";
         String serialMarker = "Serial Number";
         String model = null;
         String serial = null;
-        for (String s : ExecutingCommand.runNative("lscfg -vl " + device)) {
+        for (String s : lscfg) {
             // Default model to description at end of first line
             if (model == null && s.contains(device)) {
                 String locDesc = s.split(device)[1].trim();

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lscfg.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lscfg.java
@@ -100,10 +100,14 @@ public final class Lscfg {
         for (String s : lscfg) {
             // Default model to description at end of first line
             if (model == null && s.contains(device)) {
-                String locDesc = s.split(device)[1].trim();
-                int idx = locDesc.indexOf(' ');
-                if (idx > 0) {
-                    model = locDesc.substring(idx).trim();
+                String[] locDescSplit = s.split(device);
+                // A device at the very end of the line splits to a single element; skip the fallback then
+                if (locDescSplit.length > 1) {
+                    String locDesc = locDescSplit[1].trim();
+                    int idx = locDesc.indexOf(' ');
+                    if (idx > 0) {
+                        model = locDesc.substring(idx).trim();
+                    }
                 }
             }
             if (s.contains(modelMarker)) {

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lspv.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lspv.java
@@ -52,7 +52,20 @@ public final class Lspv {
 
     private static List<HWPartition> computeLogicalVolumes(String device,
             Map<String, Pair<Integer, Integer>> majMinMap) {
-        List<HWPartition> partitions = new ArrayList<>();
+        long ppSize = parsePpSize(ExecutingCommand.runNative("lspv -L " + device));
+        if (ppSize == 0L) {
+            return new ArrayList<>();
+        }
+        return parsePartitions(ExecutingCommand.runNative("lspv -p " + device), ppSize, majMinMap);
+    }
+
+    /**
+     * Parses {@code lspv -L device} output to get the physical-partition size in bytes.
+     *
+     * @param lspvL the lines of {@code lspv -L device} output
+     * @return the physical-partition size in bytes, or 0 if the volume is not active or no PP size is reported
+     */
+    static long parsePpSize(List<String> lspvL) {
         /*-
          $ lspv -L hdisk0
         PHYSICAL VOLUME:    hdisk0                   VOLUME GROUP:     rootvg
@@ -69,20 +82,30 @@ public final class Lspv {
         String stateMarker = "PV STATE:";
         String sizeMarker = "PP SIZE:";
         long ppSize = 0L; // All physical partitions are the same size
-        for (String s : ExecutingCommand.runNative("lspv -L " + device)) {
+        for (String s : lspvL) {
             if (s.startsWith(stateMarker)) {
                 if (!s.contains("active")) {
-                    return partitions;
+                    return 0L;
                 }
             } else if (s.contains(sizeMarker)) {
                 ppSize = ParseUtil.getFirstIntValue(s);
             }
         }
-        if (ppSize == 0L) {
-            return partitions;
-        }
-        // Convert to megabytes
-        ppSize <<= 20;
+        // Convert megabytes to bytes
+        return ppSize << 20;
+    }
+
+    /**
+     * Parses {@code lspv -p device} output into the list of logical volumes (partitions) on the device.
+     *
+     * @param lspvP     the lines of {@code lspv -p device} output
+     * @param ppSize    the physical-partition size in bytes (from {@link #parsePpSize})
+     * @param majMinMap a map of device name to a pair with major and minor numbers
+     * @return a list of logical volumes (partitions)
+     */
+    static List<HWPartition> parsePartitions(List<String> lspvP, long ppSize,
+            Map<String, Pair<Integer, Integer>> majMinMap) {
+        List<HWPartition> partitions = new ArrayList<>();
         /*-
          $ lspv -p hdisk0
         hdisk0:
@@ -114,7 +137,7 @@ public final class Lspv {
         Map<String, String> mountMap = new HashMap<>();
         Map<String, String> typeMap = new HashMap<>();
         Map<String, Integer> ppMap = new HashMap<>();
-        for (String s : ExecutingCommand.runNative("lspv -p " + device)) {
+        for (String s : lspvP) {
             String[] split = ParseUtil.whitespaces.split(s.trim());
             if (split.length >= 6 && "used".equals(split[1])) {
                 // Region may have two words, so count from end

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
@@ -66,28 +66,11 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
     @Override
     protected ProcessorIdentifier queryProcessorId() {
         PartitionInfo info = queryPartitionInfo();
-        String cpuVendor = Constants.UNKNOWN;
-        String cpuName = "";
-        String cpuFamily = "";
-        boolean cpu64bit = false;
-
-        final String nameMarker = "Processor Type:";
-        final String familyMarker = "Processor Version:";
-        final String bitnessMarker = "CPU Type:";
-        for (final String checkLine : ExecutingCommand.runNative("prtconf")) {
-            if (checkLine.startsWith(nameMarker)) {
-                cpuName = checkLine.split(nameMarker)[1].trim();
-                if (cpuName.startsWith("P")) {
-                    cpuVendor = "IBM";
-                } else if (cpuName.startsWith("I")) {
-                    cpuVendor = "Intel";
-                }
-            } else if (checkLine.startsWith(familyMarker)) {
-                cpuFamily = checkLine.split(familyMarker)[1].trim();
-            } else if (checkLine.startsWith(bitnessMarker)) {
-                cpu64bit = checkLine.split(bitnessMarker)[1].contains("64");
-            }
-        }
+        Quartet<String, String, String, Boolean> id = parseProcessorId(ExecutingCommand.runNative("prtconf"));
+        String cpuVendor = id.getA();
+        String cpuName = id.getB();
+        String cpuFamily = id.getC();
+        boolean cpu64bit = id.getD();
 
         String cpuModel = "";
         String cpuStepping = "";
@@ -104,6 +87,39 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
 
         return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, machineId, cpu64bit,
                 (long) (info.processorMHz * 1_000_000L));
+    }
+
+    /**
+     * Parses {@code prtconf} output for the processor vendor, name, family, and 64-bit flag.
+     *
+     * @param prtconf the lines of {@code prtconf} output
+     * @return a {@link Quartet} of vendor, name, family, and 64-bit flag (vendor {@link Constants#UNKNOWN} if the
+     *         processor type is not recognized)
+     */
+    static Quartet<String, String, String, Boolean> parseProcessorId(List<String> prtconf) {
+        String cpuVendor = Constants.UNKNOWN;
+        String cpuName = "";
+        String cpuFamily = "";
+        boolean cpu64bit = false;
+
+        final String nameMarker = "Processor Type:";
+        final String familyMarker = "Processor Version:";
+        final String bitnessMarker = "CPU Type:";
+        for (final String checkLine : prtconf) {
+            if (checkLine.startsWith(nameMarker)) {
+                cpuName = checkLine.split(nameMarker)[1].trim();
+                if (cpuName.startsWith("P")) {
+                    cpuVendor = "IBM";
+                } else if (cpuName.startsWith("I")) {
+                    cpuVendor = "Intel";
+                }
+            } else if (checkLine.startsWith(familyMarker)) {
+                cpuFamily = checkLine.split(familyMarker)[1].trim();
+            } else if (checkLine.startsWith(bitnessMarker)) {
+                cpu64bit = checkLine.split(bitnessMarker)[1].contains("64");
+            }
+        }
+        return new Quartet<>(cpuVendor, cpuName, cpuFamily, cpu64bit);
     }
 
     @Override
@@ -128,8 +144,18 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
     }
 
     private static List<ProcessorCache> getCachesForModel(int cores) {
+        return cachesForPowerVersion(ParseUtil.getFirstIntValue(ExecutingCommand.getFirstAnswer("uname -n")), cores);
+    }
+
+    /**
+     * Returns the known cache topology for a given POWER version.
+     *
+     * @param powerVersion the POWER generation (e.g. 7, 8, 9), as parsed from {@code uname -n}
+     * @param cores        the number of physical cores, used to size the shared L3 on POWER9
+     * @return the processor caches for that generation, or an empty list if the version is unrecognized
+     */
+    static List<ProcessorCache> cachesForPowerVersion(int powerVersion, int cores) {
         List<ProcessorCache> caches = new ArrayList<>();
-        int powerVersion = ParseUtil.getFirstIntValue(ExecutingCommand.getFirstAnswer("uname -n"));
         switch (powerVersion) {
             case 7:
                 caches.add(new ProcessorCache(3, 8, 128, (2 * 32) << 20, Type.UNIFIED));
@@ -165,11 +191,22 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
     @Override
     public long[] queryCurrentFreq() {
         // pmcycles may require root; this is best-effort.
-        long[] freqs = new long[getLogicalProcessorCount()];
+        return parseCurrentFreq(ExecutingCommand.runNative("pmcycles -m"), getLogicalProcessorCount());
+    }
+
+    /**
+     * Parses {@code pmcycles -m} output into a per-logical-processor frequency array.
+     *
+     * @param pmcycles the lines of {@code pmcycles -m} output
+     * @param count    the number of logical processors (array length)
+     * @return an array of frequencies in Hz; entries with no corresponding output line remain -1
+     */
+    static long[] parseCurrentFreq(List<String> pmcycles, int count) {
+        long[] freqs = new long[count];
         Arrays.fill(freqs, -1);
         String freqMarker = "runs at";
         int idx = 0;
-        for (final String checkLine : ExecutingCommand.runNative("pmcycles -m")) {
+        for (final String checkLine : pmcycles) {
             if (checkLine.contains(freqMarker)) {
                 freqs[idx++] = ParseUtil.parseHertz(checkLine.split(freqMarker)[1].trim());
                 if (idx >= freqs.length) {
@@ -233,7 +270,17 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
     }
 
     private static int querySbits() {
-        for (String s : FileUtil.readFile("/usr/include/sys/proc.h")) {
+        return parseSbits(FileUtil.readFile("/usr/include/sys/proc.h"));
+    }
+
+    /**
+     * Parses the {@code SBITS} {@code #define} value from {@code /usr/include/sys/proc.h}, used to scale load averages.
+     *
+     * @param procH the lines of {@code /usr/include/sys/proc.h}
+     * @return the SBITS value, or 16 if not found
+     */
+    static int parseSbits(List<String> procH) {
+        for (String s : procH) {
             if (s.contains("SBITS") && s.contains("#define")) {
                 return ParseUtil.parseLastInt(s, 16);
             }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
@@ -106,17 +106,18 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
         final String familyMarker = "Processor Version:";
         final String bitnessMarker = "CPU Type:";
         for (final String checkLine : prtconf) {
+            // Each branch already confirmed the marker is a prefix, so substring is safe even when the value is empty
             if (checkLine.startsWith(nameMarker)) {
-                cpuName = checkLine.split(nameMarker)[1].trim();
+                cpuName = checkLine.substring(nameMarker.length()).trim();
                 if (cpuName.startsWith("P")) {
                     cpuVendor = "IBM";
                 } else if (cpuName.startsWith("I")) {
                     cpuVendor = "Intel";
                 }
             } else if (checkLine.startsWith(familyMarker)) {
-                cpuFamily = checkLine.split(familyMarker)[1].trim();
+                cpuFamily = checkLine.substring(familyMarker.length()).trim();
             } else if (checkLine.startsWith(bitnessMarker)) {
-                cpu64bit = checkLine.split(bitnessMarker)[1].contains("64");
+                cpu64bit = checkLine.substring(bitnessMarker.length()).contains("64");
             }
         }
         return new Quartet<>(cpuVendor, cpuName, cpuFamily, cpu64bit);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
@@ -174,9 +174,19 @@ public class AixFileSystem extends AbstractFileSystem {
 
     @Override
     public long getOpenFileDescriptors() {
+        return parseOpenFileDescriptors(ExecutingCommand.runNative("lsof -nl"));
+    }
+
+    /**
+     * Counts the open file descriptor rows in {@code lsof -nl} output (every row after the {@code COMMAND} header).
+     *
+     * @param lsof the lines of {@code lsof -nl} output
+     * @return the number of open file descriptors
+     */
+    static long parseOpenFileDescriptors(List<String> lsof) {
         boolean header = false;
         long openfiles = 0L;
-        for (String f : ExecutingCommand.runNative("lsof -nl")) {
+        for (String f : lsof) {
             if (!header) {
                 header = f.startsWith("COMMAND");
             } else {
@@ -193,8 +203,17 @@ public class AixFileSystem extends AbstractFileSystem {
 
     @Override
     public long getMaxFileDescriptorsPerProcess() {
-        final List<String> lines = FileUtil.readFile("/etc/security/limits");
-        for (final String line : lines) {
+        return parseMaxFileDescriptorsPerProcess(FileUtil.readFile("/etc/security/limits"));
+    }
+
+    /**
+     * Parses {@code /etc/security/limits} for the default per-process {@code nofiles} descriptor limit.
+     *
+     * @param limits the lines of {@code /etc/security/limits}
+     * @return the {@code nofiles} value, or {@link Long#MAX_VALUE} if not present
+     */
+    static long parseMaxFileDescriptorsPerProcess(List<String> limits) {
+        for (final String line : limits) {
             if (line.trim().startsWith("nofiles")) {
                 return ParseUtil.parseLastLong(line, Long.MAX_VALUE);
             }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOperatingSystem.java
@@ -178,25 +178,7 @@ public abstract class AixOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public List<OSService> getServices() {
-        List<OSService> services = new ArrayList<>();
-        List<String> systemServicesInfoList = ExecutingCommand.runNative("lssrc -a");
-        if (systemServicesInfoList.size() > 1) {
-            systemServicesInfoList.remove(0);
-            for (String systemService : systemServicesInfoList) {
-                String[] serviceSplit = ParseUtil.whitespaces.split(systemService.trim());
-                if (systemService.contains("active")) {
-                    if (serviceSplit.length == 4) {
-                        services.add(new OSService(serviceSplit[0], ParseUtil.parseIntOrDefault(serviceSplit[2], 0),
-                                RUNNING));
-                    } else if (serviceSplit.length == 3) {
-                        services.add(new OSService(serviceSplit[0], ParseUtil.parseIntOrDefault(serviceSplit[1], 0),
-                                RUNNING));
-                    }
-                } else if (systemService.contains("inoperative")) {
-                    services.add(new OSService(serviceSplit[0], 0, STOPPED));
-                }
-            }
-        }
+        List<OSService> services = parseServices(ExecutingCommand.runNative("lssrc -a"));
         File dir = new File("/etc/rc.d/init.d");
         File[] listFiles;
         if (dir.exists() && dir.isDirectory() && (listFiles = dir.listFiles()) != null) {
@@ -207,6 +189,37 @@ public abstract class AixOperatingSystem extends AbstractOperatingSystem {
                 } else {
                     services.add(new OSService(file.getName(), 0, STOPPED));
                 }
+            }
+        }
+        return services;
+    }
+
+    /**
+     * Parses {@code lssrc -a} output into the list of subsystem services. The first row is the column header.
+     *
+     * @param lssrc the lines of {@code lssrc -a} output
+     * @return the parsed services (active subsystems as {@code RUNNING}, inoperative as {@code STOPPED})
+     */
+    static List<OSService> parseServices(List<String> lssrc) {
+        List<OSService> services = new ArrayList<>();
+        boolean header = true;
+        for (String systemService : lssrc) {
+            // Skip the "Subsystem Group PID Status" header row without mutating the input list
+            if (header) {
+                header = false;
+                continue;
+            }
+            String[] serviceSplit = ParseUtil.whitespaces.split(systemService.trim());
+            if (systemService.contains("active")) {
+                if (serviceSplit.length == 4) {
+                    services.add(
+                            new OSService(serviceSplit[0], ParseUtil.parseIntOrDefault(serviceSplit[2], 0), RUNNING));
+                } else if (serviceSplit.length == 3) {
+                    services.add(
+                            new OSService(serviceSplit[0], ParseUtil.parseIntOrDefault(serviceSplit[1], 0), RUNNING));
+                }
+            } else if (systemService.contains("inoperative")) {
+                services.add(new OSService(serviceSplit[0], 0, STOPPED));
             }
         }
         return services;

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LscfgTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LscfgTest.java
@@ -40,6 +40,15 @@ class LscfgTest {
     }
 
     @Test
+    void testParseModelSerialDeviceAtEndOfLine() {
+        // A line ending in the device name splits to a single element; the fallback must be skipped, not crash
+        Pair<String, String> modSer = Lscfg.parseModelSerial(Collections.singletonList("  Adapter containing hdisk0"),
+                "hdisk0");
+        assertThat(modSer.getA(), is(nullValue()));
+        assertThat(modSer.getB(), is(nullValue()));
+    }
+
+    @Test
     void testParseModelSerialEmpty() {
         Pair<String, String> modSer = Lscfg.parseModelSerial(Collections.emptyList(), "hdisk0");
         assertThat(modSer.getA(), is(nullValue()));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LscfgTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LscfgTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.unix.aix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.tuples.Pair;
+
+class LscfgTest {
+
+    @Test
+    void testParseModelSerial() {
+        // lscfg -vl hdisk0: the "Machine Type and Model" line overrides the first-line description
+        Pair<String, String> modSer = Lscfg.parseModelSerial(Arrays.asList(//
+                "  hdisk0           U78CB.001.WZS00MP-P1-C2-T1-L0  MPIO IBM 2076 FC Disk", //
+                "        Manufacturer................IBM", //
+                "        Machine Type and Model......2076", //
+                "        Serial Number...............0123456789AB", //
+                "        EC Level....................D77161"), "hdisk0");
+        assertThat(modSer.getA(), is("2076"));
+        assertThat(modSer.getB(), is("0123456789AB"));
+    }
+
+    @Test
+    void testParseModelSerialFallsBackToDescription() {
+        // With no "Machine Type and Model" line, the model is the description after the location code
+        Pair<String, String> modSer = Lscfg.parseModelSerial(
+                Collections.singletonList("  cd0              U78CB.001.WZS00MP-P2-D1  SATA DVD-RAM Drive"), "cd0");
+        assertThat(modSer.getA(), is("SATA DVD-RAM Drive"));
+        assertThat(modSer.getB(), is(nullValue()));
+    }
+
+    @Test
+    void testParseModelSerialEmpty() {
+        Pair<String, String> modSer = Lscfg.parseModelSerial(Collections.emptyList(), "hdisk0");
+        assertThat(modSer.getA(), is(nullValue()));
+        assertThat(modSer.getB(), is(nullValue()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LspvTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LspvTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.unix.aix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.HWPartition;
+import oshi.util.tuples.Pair;
+
+class LspvTest {
+
+    @Test
+    void testParsePpSize() {
+        // lspv -L: an active volume with a 128 MB physical-partition size, returned in bytes
+        long ppSize = Lspv.parsePpSize(Arrays.asList(//
+                "PHYSICAL VOLUME:    hdisk0                   VOLUME GROUP:     rootvg", //
+                "PV STATE:           active", //
+                "PP SIZE:            128 megabyte(s)          LOGICAL VOLUMES:  12", //
+                "TOTAL PPs:          271 (34688 megabytes)    VG DESCRIPTORS:   2"));
+        assertThat(ppSize, is(128L << 20));
+    }
+
+    @Test
+    void testParsePpSizeInactiveOrEmpty() {
+        // A non-active PV yields 0 (no partitions to enumerate)
+        assertThat(
+                Lspv.parsePpSize(Arrays.asList("PV STATE:           missing", "PP SIZE:            128 megabyte(s)")),
+                is(0L));
+        assertThat(Lspv.parsePpSize(Collections.emptyList()), is(0L));
+    }
+
+    @Test
+    void testParsePartitions() {
+        List<String> lspvP = Arrays.asList(//
+                "hdisk0:", //
+                "PP RANGE  STATE   REGION        LV NAME             TYPE       MOUNT POINT", //
+                "1-1     used    outer edge    hd5                 boot       N/A", //
+                "2-55    free    outer edge", // free rows are skipped
+                "56-59    used    outer middle  hd6                 paging     N/A", //
+                "111-112   used    center        hd4                 jfs2       /");
+        Map<String, Pair<Integer, Integer>> majMin = Collections.singletonMap("hd5", new Pair<>(10, 5));
+        long ppSize = 128L << 20;
+        Map<String, HWPartition> byName = Lspv.parsePartitions(lspvP, ppSize, majMin).stream()
+                .collect(Collectors.toMap(HWPartition::getName, Function.identity()));
+
+        // hd5: 1 PP, type/mount from the row, major/minor from the supplied map
+        assertThat(byName.get("hd5").getType(), is("boot"));
+        assertThat(byName.get("hd5").getMountPoint(), is("")); // N/A is normalized to empty
+        assertThat(byName.get("hd5").getSize(), is(ppSize));
+        assertThat(byName.get("hd5").getMajor(), is(10));
+        assertThat(byName.get("hd5").getMinor(), is(5));
+        // hd6: 4 PPs (56-59); not in the map, so major/minor fall back to the first int in the name
+        assertThat(byName.get("hd6").getType(), is("paging"));
+        assertThat(byName.get("hd6").getSize(), is(ppSize * 4));
+        assertThat(byName.get("hd6").getMajor(), is(6));
+        // hd4: 2 PPs (111-112), mounted at /
+        assertThat(byName.get("hd4").getMountPoint(), is("/"));
+        assertThat(byName.get("hd4").getSize(), is(ppSize * 2));
+    }
+
+    @Test
+    void testParsePartitionsEmpty() {
+        assertThat(Lspv.parsePartitions(Collections.emptyList(), 128L << 20, Collections.emptyMap()), is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessorTest.java
@@ -46,6 +46,17 @@ class AixCentralProcessorTest {
     }
 
     @Test
+    void testParseProcessorIdEmptyMarkerValues() {
+        // Bare marker lines (no value after the colon) must not throw; they yield empty fields
+        Quartet<String, String, String, Boolean> id = AixCentralProcessor
+                .parseProcessorId(Arrays.asList("Processor Type:", "Processor Version:", "CPU Type:"));
+        assertThat(id.getA(), is(Constants.UNKNOWN));
+        assertThat(id.getB(), is(""));
+        assertThat(id.getC(), is(""));
+        assertThat(id.getD(), is(false));
+    }
+
+    @Test
     void testParseCurrentFreq() {
         List<String> pmcycles = Arrays.asList("Cpu 0 runs at 3000 MHz", "Cpu 1 runs at 3000 MHz");
         // exactly two CPUs

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix.aix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.CentralProcessor.ProcessorCache;
+import oshi.util.Constants;
+import oshi.util.tuples.Quartet;
+
+class AixCentralProcessorTest {
+
+    @Test
+    void testParseProcessorId() {
+        // prtconf excerpt
+        Quartet<String, String, String, Boolean> id = AixCentralProcessor.parseProcessorId(Arrays.asList(//
+                "System Model: IBM,9114-275", //
+                "Processor Type: PowerPC_POWER7", //
+                "Processor Version: PV_7_Compat", //
+                "Number Of Processors: 8", //
+                "CPU Type: 64-bit"));
+        assertThat(id.getA(), is("IBM"));
+        assertThat(id.getB(), is("PowerPC_POWER7"));
+        assertThat(id.getC(), is("PV_7_Compat"));
+        assertThat(id.getD(), is(true));
+    }
+
+    @Test
+    void testParseProcessorIdEmpty() {
+        Quartet<String, String, String, Boolean> id = AixCentralProcessor.parseProcessorId(Collections.emptyList());
+        assertThat(id.getA(), is(Constants.UNKNOWN));
+        assertThat(id.getB(), is(""));
+        assertThat(id.getC(), is(""));
+        assertThat(id.getD(), is(false));
+    }
+
+    @Test
+    void testParseCurrentFreq() {
+        List<String> pmcycles = Arrays.asList("Cpu 0 runs at 3000 MHz", "Cpu 1 runs at 3000 MHz");
+        // exactly two CPUs
+        assertThat(AixCentralProcessor.parseCurrentFreq(pmcycles, 2),
+                is(new long[] { 3_000_000_000L, 3_000_000_000L }));
+        // more logical processors than output lines: trailing entries stay -1
+        assertThat(AixCentralProcessor.parseCurrentFreq(pmcycles, 4),
+                is(new long[] { 3_000_000_000L, 3_000_000_000L, -1L, -1L }));
+        // no output: all -1
+        assertThat(AixCentralProcessor.parseCurrentFreq(Collections.emptyList(), 2), is(new long[] { -1L, -1L }));
+    }
+
+    @Test
+    void testParseSbits() {
+        assertThat(AixCentralProcessor.parseSbits(Collections.singletonList("#define SBITS 16")), is(16));
+        assertThat(AixCentralProcessor.parseSbits(Collections.singletonList("#define  SBITS  10")), is(10));
+        // default when not present
+        assertThat(AixCentralProcessor.parseSbits(Collections.singletonList("#define OTHER 5")), is(16));
+        assertThat(AixCentralProcessor.parseSbits(Collections.emptyList()), is(16));
+    }
+
+    @Test
+    void testCachesForPowerVersion() {
+        assertThat(AixCentralProcessor.cachesForPowerVersion(7, 4), hasSize(4));
+        assertThat(AixCentralProcessor.cachesForPowerVersion(8, 4), hasSize(5));
+        // POWER9 sizes its shared L3 by core count: (cores * 10) MiB
+        List<ProcessorCache> p9 = AixCentralProcessor.cachesForPowerVersion(9, 4);
+        assertThat(p9, hasSize(4));
+        ProcessorCache l3 = p9.stream().filter(c -> c.getLevel() == 3).findFirst().orElseThrow(AssertionError::new);
+        assertThat(l3.getCacheSize(), is((4 * 10) << 20));
+        // unknown version yields no caches
+        assertThat(AixCentralProcessor.cachesForPowerVersion(99, 4), is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixFileSystemTest.java
@@ -67,4 +67,35 @@ class AixFileSystemTest {
         assertThat(result.getA(), is(anEmptyMap()));
         assertThat(result.getB(), is(anEmptyMap()));
     }
+
+    @Test
+    void testParseOpenFileDescriptors() {
+        // lsof -nl: every row after the COMMAND header counts
+        List<String> lsof = Arrays.asList(//
+                "COMMAND     PID     USER   FD   TYPE             DEVICE  SIZE/OFF  NODE NAME", //
+                "init          1     root  cwd  VDIR              10,  5      256     2 /", //
+                "init          1     root  txt  VREG              10,  6    12345    17 /usr/sbin/init");
+        assertThat(AixFileSystem.parseOpenFileDescriptors(lsof), is(2L));
+    }
+
+    @Test
+    void testParseOpenFileDescriptorsNoHeaderOrEmpty() {
+        // No COMMAND header line: nothing is counted
+        assertThat(AixFileSystem.parseOpenFileDescriptors(Arrays.asList("garbage", "more garbage")), is(0L));
+        assertThat(AixFileSystem.parseOpenFileDescriptors(Collections.emptyList()), is(0L));
+    }
+
+    @Test
+    void testParseMaxFileDescriptorsPerProcess() {
+        List<String> limits = Arrays.asList("default:", "        fsize = -1", "        nofiles = 2000",
+                "        core = 2097151");
+        assertThat(AixFileSystem.parseMaxFileDescriptorsPerProcess(limits), is(2000L));
+    }
+
+    @Test
+    void testParseMaxFileDescriptorsPerProcessMissing() {
+        // No nofiles line: unlimited (Long.MAX_VALUE)
+        assertThat(AixFileSystem.parseMaxFileDescriptorsPerProcess(Arrays.asList("default:", "        fsize = -1")),
+                is(Long.MAX_VALUE));
+    }
 }

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixOperatingSystemTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.unix.aix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.software.os.OSService;
+
+class AixOperatingSystemTest {
+
+    @Test
+    void testParseServices() {
+        // lssrc -a: header row, active subsystems (with/without a Group column), and an inoperative one
+        List<OSService> services = AixOperatingSystem.parseServices(Arrays.asList(//
+                "Subsystem         Group            PID          Status", //
+                " syslogd          ras              4194320      active", //
+                " inetd            5218374          active", // 3-token active form (no group column)
+                " portmap          portmap                       inoperative"));
+        Map<String, OSService> byName = services.stream()
+                .collect(Collectors.toMap(OSService::getName, Function.identity()));
+
+        assertThat(byName.get("syslogd").getProcessID(), is(4194320));
+        assertThat(byName.get("syslogd").getState(), is(OSService.State.RUNNING));
+        assertThat(byName.get("inetd").getProcessID(), is(5218374));
+        assertThat(byName.get("inetd").getState(), is(OSService.State.RUNNING));
+        assertThat(byName.get("portmap").getProcessID(), is(0));
+        assertThat(byName.get("portmap").getState(), is(OSService.State.STOPPED));
+    }
+
+    @Test
+    void testParseServicesHeaderOnlyOrEmpty() {
+        assertThat(AixOperatingSystem.parseServices(Collections.singletonList("Subsystem Group PID Status")),
+                is(empty()));
+        assertThat(AixOperatingSystem.parseServices(Collections.emptyList()), is(empty()));
+    }
+}


### PR DESCRIPTION
## Summary

Second AIX batch in the parse-seam testability effort (after AIX #3501; and Linux #3494, FreeBSD #3495, NetBSD/OpenBSD #3496, Solaris #3497/#3498, FileSystem #3499, disk drivers #3500). Each acquire-and-parse method keeps its acquisition and delegates to a package-private/`static` parse method taking the already-read input, so the parsing is unit-testable with synthetic fixtures instead of only on a live AIX host:

- `Lspv.parsePpSize(List)` + `Lspv.parsePartitions(List, ppSize, majMinMap)` — splitting the two-command `computeLogicalVolumes`
- `Lscfg.parseModelSerial(List, device)`
- `AixCentralProcessor`: `parseProcessorId(prtconf)` → `Quartet`, `parseCurrentFreq(pmcycles, count)`, `parseSbits(proc.h)`, `cachesForPowerVersion(version, cores)`
- `AixOperatingSystem.parseServices(lssrc)` (no longer mutates its input to drop the header)
- `AixFileSystem.parseOpenFileDescriptors(lsof)` + `parseMaxFileDescriptorsPerProcess(limits)`

Fixtures are grounded in the real `lspv -L`/`-p`, `lscfg -vl`, `prtconf`, `pmcycles -m`, `/usr/include/sys/proc.h`, `lssrc -a`, `lsof -nl`, and `/etc/security/limits` output. New parse tests run on **every** platform; the existing AIX-only `@EnabledOnOs(OS.AIX)` live smoke tests are unaffected.

## Note on coverage

As with #3501, the AIX package is still JaCoCo-excluded (`**/unix/aix/**`), so this lands as **testability / regression-safety groundwork** rather than an immediate coverage bump — un-excluding AIX is a separate follow-up.

## Testing

- `oshi-common` full gate green: spotless, checkstyle, install + forbiddenapis, javadoc; clean full-reactor `install` green.
- All five AIX test classes pass; parse tests exercise each extracted method on the local (macOS) run.

No CHANGELOG entry — test/coverage refactor with no user-observable behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AIX CPU, including vendor/model details, per-processor current frequency, and SBITS extraction, with more reliable cache sizing.
  * More robust AIX storage reporting by refining physical-to-logical volume/partition parsing, including inactive/missing physical volume handling.
  * Improved AIX model/serial extraction from system configuration output, plus safer parsing of file descriptor limits and service runtime states.
* **Tests**
  * Added/expanded unit tests covering AIX model/serial, physical volume sizing and partition parsing, CPU parsing/frequency/SBITS/cache sizing, filesystem limits, and service parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->