### PR TITLE
Fix AIX processor-cache detection using the hostname as the POWER version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#3493](https://github.com/oshi/oshi/pull/3493): Document the CPU/memory trade-off of reusing versus recreating `SystemInfo` when polling, with supporting benchmarks - [@dbwiddis](https://github.com/dbwiddis).
 * [#3499](https://github.com/oshi/oshi/pull/3499): Fix FreeBSD, NetBSD, and OpenBSD `df -i` inode parsing to include ZFS, tmpfs, devfs, and mfs filesystems that do not start with `/` - [@dbwiddis](https://github.com/dbwiddis).
+* [#3504](https://github.com/oshi/oshi/pull/3504): Fix AIX processor cache detection, which read the POWER generation from the hostname (`uname -n`) instead of `prtconf`'s `Processor Version` field, causing `getProcessorCaches()` to return an empty list - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
@@ -145,13 +145,32 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
     }
 
     private static List<ProcessorCache> getCachesForModel(int cores) {
-        return cachesForPowerVersion(ParseUtil.getFirstIntValue(ExecutingCommand.getFirstAnswer("uname -n")), cores);
+        return cachesForPowerVersion(parsePowerVersion(ExecutingCommand.runNative("prtconf")), cores);
+    }
+
+    /**
+     * Parses the POWER generation from {@code prtconf}'s {@code Processor Version} line (e.g. {@code PV_8_Compat} -&gt;
+     * 8). This is the source used to select the cache topology; {@code uname -n} is the hostname and yields a
+     * meaningless number.
+     *
+     * @param prtconf the lines of {@code prtconf} output
+     * @return the POWER generation, or 0 if no {@code Processor Version} line is present
+     */
+    static int parsePowerVersion(List<String> prtconf) {
+        final String versionMarker = "Processor Version:";
+        for (String line : prtconf) {
+            if (line.startsWith(versionMarker)) {
+                return ParseUtil.getFirstIntValue(line.substring(versionMarker.length()));
+            }
+        }
+        return 0;
     }
 
     /**
      * Returns the known cache topology for a given POWER version.
      *
-     * @param powerVersion the POWER generation (e.g. 7, 8, 9), as parsed from {@code uname -n}
+     * @param powerVersion the POWER generation (e.g. 7, 8, 9), as parsed from {@code prtconf}'s {@code Processor
+     *                     Version} field
      * @param cores        the number of physical cores, used to size the shared L3 on POWER9
      * @return the processor caches for that generation, or an empty list if the version is unrecognized
      */

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessorTest.java
@@ -57,6 +57,24 @@ class AixCentralProcessorTest {
     }
 
     @Test
+    void testParsePowerVersion() {
+        // Real prtconf excerpt from a POWER8 box (IBM,8284-22A): the Processor Version line carries the generation
+        List<String> prtconf = Arrays.asList(//
+                "System Model: IBM,8284-22A", //
+                "Processor Type: PowerPC_POWER8", //
+                "Processor Implementation Mode: POWER 8", //
+                "Processor Version: PV_8_Compat", //
+                "Number Of Processors: 10", //
+                "CPU Type: 64-bit");
+        assertThat(AixCentralProcessor.parsePowerVersion(prtconf), is(8));
+        // POWER9 form
+        assertThat(AixCentralProcessor.parsePowerVersion(Collections.singletonList("Processor Version: PV_9_Compat")),
+                is(9));
+        // No Processor Version line -> 0 (selects no caches, same as an unknown generation)
+        assertThat(AixCentralProcessor.parsePowerVersion(Collections.emptyList()), is(0));
+    }
+
+    @Test
     void testParseCurrentFreq() {
         List<String> pmcycles = Arrays.asList("Cpu 0 runs at 3000 MHz", "Cpu 1 runs at 3000 MHz");
         // exactly two CPUs


### PR DESCRIPTION
## Summary

`AixCentralProcessor.getCachesForModel` selected the processor-cache topology from `ParseUtil.getFirstIntValue(runNative("uname -n"))` — but `uname -n` is the **network hostname**, not the processor version. On a POWER8 cfarm host named `gcc119`, that parses to `119`, matches no `switch` case, and `CentralProcessor.getProcessorCaches()` returns an **empty list**.

This reads the POWER generation from `prtconf`'s `Processor Version` line instead (e.g. `PV_8_Compat` → 8), via a new testable `parsePowerVersion(prtconf)` seam.

## Validation

Confirmed on the actual AIX box (`ssh` to cfarm `gcc119`, an `IBM,8284-22A` POWER8):

```
$ uname -n
gcc119                       # getFirstIntValue -> 119 -> no caches (the bug)
$ prtconf | grep Processor
Processor Type: PowerPC_POWER8
Processor Version: PV_8_Compat   # getFirstIntValue -> 8 -> POWER8 caches (the fix)
```

The new `parsePowerVersion` test is grounded in that exact `prtconf` output.

## Testing

- `oshi-common` full gate green: spotless, checkstyle, install + forbiddenapis, javadoc; clean full-reactor `install` green.
- `AixCentralProcessorTest` passes, including the new `testParsePowerVersion`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed processor cache detection on AIX systems using POWER processors.
  * Cache information is now correctly identified from the processor version, preventing empty cache results on supported systems.
* **Documentation**
  * Updated the changelog for version 7.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->