### PR TITLE
Fix AIX FFM perfstat processorMHz read at the wrong offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#3493](https://github.com/oshi/oshi/pull/3493): Document the CPU/memory trade-off of reusing versus recreating `SystemInfo` when polling, with supporting benchmarks - [@dbwiddis](https://github.com/dbwiddis).
 * [#3499](https://github.com/oshi/oshi/pull/3499): Fix FreeBSD, NetBSD, and OpenBSD `df -i` inode parsing to include ZFS, tmpfs, devfs, and mfs filesystems that do not start with `/` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3504](https://github.com/oshi/oshi/pull/3504): Fix AIX processor cache detection, which read the POWER generation from the hostname (`uname -n`) instead of `prtconf`'s `Processor Version` field, causing `getProcessorCaches()` to return an empty list - [@dbwiddis](https://github.com/dbwiddis).
+* [#3505](https://github.com/oshi/oshi/pull/3505): Fix the AIX FFM backend reading `perfstat_partition_config_t.processorMHz` at the wrong struct offset (344 instead of 340), which reported the processor's vendor frequency as unknown - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18)
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/aix/PerfstatFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/aix/PerfstatFunctions.java
@@ -7,6 +7,7 @@ package oshi.ffm.platform.unix.aix;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
+import static java.lang.foreign.ValueLayout.JAVA_DOUBLE_UNALIGNED;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
@@ -44,7 +45,7 @@ public final class PerfstatFunctions extends ForeignFunctions {
     public static final int PERFSTAT_MEMORY_TOTAL_T_SIZE = 352;
     public static final int PERFSTAT_PROCESS_T_SIZE = 288;
     public static final int PERFSTAT_DISK_T_SIZE = 496;
-    public static final int PERFSTAT_PARTITION_CONFIG_T_SIZE = 800;
+    public static final int PERFSTAT_PARTITION_CONFIG_T_SIZE = 808;
     public static final int PERFSTAT_NETINTERFACE_T_SIZE = 240;
     public static final int PERFSTAT_PROTOCOL_T_SIZE = 728;
 
@@ -393,9 +394,12 @@ public final class PerfstatFunctions extends ForeignFunctions {
         return readName(seg, 276);
     }
 
-    /** {@code processorMHz}: processor clock speed in MHz. */
+    /**
+     * {@code processorMHz}: processor clock speed in MHz. It follows {@code machineID[64]} (ending at 340) with no
+     * padding, so it is 4-byte- but not 8-byte-aligned and must be read unaligned.
+     */
     public static double configProcessorMHz(MemorySegment seg) {
-        return seg.get(JAVA_DOUBLE, 344);
+        return seg.get(JAVA_DOUBLE_UNALIGNED, 340);
     }
 
     /** {@code OSBuild[64]}: OS build string. */


### PR DESCRIPTION
## Summary

The FFM `perfstat_partition_config_t` reader (`PerfstatFunctions.configProcessorMHz`) read `processorMHz` at byte offset **344**, but the field sits immediately after `machineID[64]` (which ends at 340) with no padding — so it is at **340**, and only 4-byte aligned. Reading a `double` at 344 returned `0.0`, so the FFM backend reported the CPU max frequency (`ProcessorIdentifier` vendor frequency) as unknown (`-1`), while the JNA backend read it correctly. The two backends therefore disagreed on AIX.

The fix reads a `JAVA_DOUBLE_UNALIGNED` at 340, and also corrects `PERFSTAT_PARTITION_CONFIG_T_SIZE` from `800` to the actual `808`.

## How it was found

Enabling AIX coverage runs `NativeComparisonTest` on AIX for the first time (it lives in oshi-benchmark, previously `test.skip` on the cfarm job). It flagged:

```
NativeComparisonTest.processorIdentifier()  [X]
  field 'cpuVendorFreq' differ:  FFM = -1L,  JNA = 3425000000L   (3425 MHz)
```

## Validation

Confirmed on a cfarm AIX 7.3 POWER8 host (`IBM,8284-22A`) with a C probe against `/usr/include/libperfstat.h`:

```
offsetof(perfstat_partition_config_t, processorMHz) = 340   (FFM had 344)
sizeof(perfstat_partition_config_t)                 = 808   (FFM had 800)
live struct:  read@340 = 3425.0    read@344 = 0.0
```

`JAVA_DOUBLE_UNALIGNED` reads native (big-endian on AIX) byte order, matching the C read. The end-to-end `NativeComparisonTest` pass will be confirmed when AIX coverage is enabled (a follow-up that this fix unblocks).

## Testing

- Full-reactor `clean install` green (oshi-core-ffm compiles the change on JDK 25+).

CHANGELOG entry to follow once the PR number is assigned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an AIX issue that could incorrectly report the processor’s vendor frequency as unknown.
  - Improved compatibility with the native system layout to ensure processor frequency data is read accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->