### PR TITLE
Upload AIX code coverage from the cfarm CI job

### DIFF
--- a/.github/workflows/cfarm.yaml
+++ b/.github/workflows/cfarm.yaml
@@ -98,6 +98,11 @@ jobs:
     concurrency: aix_cfarm119
     runs-on: ubuntu-latest
     steps:
+    # Checkout on the runner so codecov-action can read the git context (commit,
+    # branch) for the report the AIX box produces; the build itself runs remotely.
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
     - name: Test in AIX
       uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
       env:
@@ -108,7 +113,7 @@ jobs:
         username: oshi
         key: ${{ secrets.GCC_CI_KEY }}
         port: 22
-        command_timeout: 15m
+        command_timeout: 25m
         envs: REPO_URL,BRANCH
         script: |
           # Backup reaper: kill stale JVMs from a previously killed run (older
@@ -117,7 +122,7 @@ jobs:
           for pid in $(ps -u oshi -o pid=,etime=,comm= 2>/dev/null | awk '$3 ~ /java/ {
                 et=$2; n=split(et,a,/[-:]/);
                 m=(et ~ /-/)?999:(n==3?a[1]*60+a[2]:a[1]);
-                if (m>=13) print $1 }'); do
+                if (m>=21) print $1 }'); do
             kill -9 "$pid" 2>/dev/null || true
           done
           rm -fR ~/javashared*
@@ -175,10 +180,33 @@ jobs:
           trap 'ec=$?; trap "" TERM; kill 0 2>/dev/null; exit $ec' EXIT
           # One wall-clock budget for both attempts, kept under command_timeout
           # so the box self-terminates first and leaves no orphan.
-          BUILD='mvn clean test -B -Djacoco.skip=true || { sleep 15; mvn clean test -B -Djacoco.skip=true; }'
+          BUILD='mvn clean test -Paggregate-coverage -B || { sleep 15; mvn clean test -Paggregate-coverage -B; }'
           if command -v timeout >/dev/null 2>&1; then
-            timeout --kill-after=30s 12m sh -c "$BUILD"
+            timeout --kill-after=30s 20m sh -c "$BUILD"
           else
             sh -c "$BUILD"
           fi
           exit $?
+    # Pull the aggregate JaCoCo report off the shared box (produced under JDK 25
+    # so the FFM backend is included) and upload it to Codecov under the `aix`
+    # flag. Runs on test failure too, since JaCoCo still emits a report then.
+    - name: Copy back AIX coverage
+      if: always()
+      env:
+        GCC_CI_KEY: ${{ secrets.GCC_CI_KEY }}
+      run: |
+        KEY=$(mktemp)
+        printf '%s\n' "$GCC_CI_KEY" > "$KEY"
+        chmod 600 "$KEY"
+        mkdir -p oshi-benchmark/target/site/jacoco-aggregate
+        scp -i "$KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+          oshi@cfarm119.cfarm.net:git/oshi/oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml \
+          oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml || echo "No AIX coverage report to copy"
+        rm -f "$KEY"
+    - name: Upload Coverage
+      if: always()
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
+        flags: aix

--- a/pom.xml
+++ b/pom.xml
@@ -855,15 +855,13 @@
                         <exclude>**/jna/platform/**</exclude>
                         <exclude>**/jna/ByRef*</exclude>
                         <exclude>**/jna/Struct*</exclude>
-                        <exclude>**/unix/aix/**</exclude>
                         <exclude>**/unix/dragonflybsd/**</exclude>
                         <exclude>**/unix/netbsd/**</exclude>
                         <!-- Narrow these `**/unix/<Name>*` patterns — JaCoCo agent globs let `*`
                              cross path separators, so `**/unix/*Bsd*` etc. would also exclude
-                             `**/unix/<bsd-subpkg>/Free**Bsd**...`. OpenBSD and Solaris are now
-                             exercised on the permanent OpenBSD/OpenIndiana CI jobs (with aggregate
-                             coverage and codecov upload) that landed with the FFM ports. -->
-                        <exclude>**/unix/*Aix*</exclude>
+                             `**/unix/<bsd-subpkg>/Free**Bsd**...`. OpenBSD and Solaris are exercised
+                             on the permanent OpenBSD/OpenIndiana CI jobs, and AIX on the cfarm CI job,
+                             all with aggregate coverage and codecov upload. -->
                         <exclude>**/unix/*DragonFlyBsd*</exclude>
                         <exclude>**/unix/*NetBsd*</exclude>
                         <!-- Hardware-dependent: no GPU/sensors/battery on CI runners -->


### PR DESCRIPTION
## Summary

The cfarm AIX job runs on JDK 25 (so the FFM backend is exercised) and the box has proven stable enough to use for coverage. This wires AIX into Codecov the same way OpenBSD/Solaris already are:

- Run the AIX tests under `-Paggregate-coverage`.
- `scp` the aggregate JaCoCo report back to the runner and upload it to Codecov under a new **`aix`** flag (a runner-side `actions/checkout` gives `codecov-action` the git context, since the build itself runs remotely over SSH).
- Raise the build budget (`command_timeout` 15m→25m, `timeout` 12m→20m, stale-JVM reaper 13→21 min) to fit the slower instrumented build, matching the Solaris SPARC job.
- Drop the `**/unix/aix/**` and `**/unix/*Aix*` JaCoCo excludes so AIX code is measured.

Enabling coverage runs `NativeComparisonTest` on AIX for the first time; the JNA↔FFM `processorMHz` bug it surfaced was fixed separately in #3505, which this depends on.

## Validation

Dispatched `cfarm.yaml` on the fork against this branch — **AIX green**:
- `NativeComparisonTest.processorIdentifier() [OK]` (JNA == FFM after #3505).
- Copy-back retrieved `jacoco-aggregate/jacoco.xml`; `codecov upload-coverage --flag aix` ran on it.
- Fits the 20-minute budget.

(An earlier fork run failed with `cannot find symbol` in unrelated disk-driver tests — that was a shared-box workspace clobber from a concurrent upstream cfarm run on cfarm119, not a code issue; Solaris SPARC on cfarm216 was unaffected. Re-run clean once the box was free. Once merged, the upstream master run is the only thing on cfarm119, so it won't race itself.)

No CHANGELOG entry — CI/coverage configuration, no user-observable behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved AIX test coverage reporting and reliability.
  - Aggregate coverage results are now generated and uploaded automatically after AIX test runs.
  - Extended test execution time limits to better support longer-running builds.

- **Chores**
  - Refined platform-specific coverage tracking for Unix environments, producing more accurate coverage results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->