### PR TITLE
Extend native-free provider to NetBSD and add native-free CI

### DIFF
--- a/.github/workflows/nativefree.yaml
+++ b/.github/workflows/nativefree.yaml
@@ -1,0 +1,62 @@
+# CI for the native-free path: oshi-common alone (no oshi-core/JNA, no oshi-core-ffm).
+# Exercises oshi.nativefree.SystemInfo on the two platforms whose oshi-common base
+# classes are fully native-free: Linux (procfs/sysfs) and NetBSD (sysctl/ps).
+name: Native-Free CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+      - '**.yml'
+      - '**.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  # Builds and tests ONLY oshi-common on Linux, so neither oshi-core (JNA) nor
+  # oshi-core-ffm is on the classpath. Verifies the native-free provider is
+  # selected and works using procfs/sysfs alone.
+  testnativefreelinux:
+    runs-on: ubuntu-latest
+    name: Native-Free JDK 21, Linux
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: 21
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Test oshi-common alone (native-free)
+        run: ./mvnw clean test -pl oshi-common -B -Djacoco.skip=true
+
+  # Builds and tests ONLY oshi-common on NetBSD WITHOUT the JNA native library
+  # (java-jna not installed), exercising the fully command-line native-free path
+  # (sysctl/ps). No oshi-core or oshi-core-ffm on the classpath.
+  testnativefreenetbsd:
+    runs-on: ubuntu-24.04
+    name: Native-Free JDK 21, NetBSD
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Test in NetBSD
+        id: test-nativefree-netbsd
+        uses: vmactions/netbsd-vm@fac0a63f3e5244c600cb9ca532d27ee774ecdb4b # v1
+        with:
+          release: "10.1"
+          usesh: true
+          prepare: |
+            pkg_add curl
+            pkg_add openjdk21
+          run: |
+            export JAVA_HOME=/usr/pkg/java/openjdk21
+            export PATH=$JAVA_HOME/bin:$PATH
+            mount -t procfs procfs /proc 2>/dev/null || true
+            ./mvnw clean test -pl oshi-common -B -Djacoco.skip=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#3499](https://github.com/oshi/oshi/pull/3499): Fix FreeBSD, NetBSD, and OpenBSD `df -i` inode parsing to include ZFS, tmpfs, devfs, and mfs filesystems that do not start with `/` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3504](https://github.com/oshi/oshi/pull/3504): Fix AIX processor cache detection, which read the POWER generation from the hostname (`uname -n`) instead of `prtconf`'s `Processor Version` field, causing `getProcessorCaches()` to return an empty list - [@dbwiddis](https://github.com/dbwiddis).
 * [#3505](https://github.com/oshi/oshi/pull/3505): Fix the AIX FFM backend reading `perfstat_partition_config_t.processorMHz` at the wrong struct offset (344 instead of 340), which reported the processor's vendor frequency as unknown - [@dbwiddis](https://github.com/dbwiddis).
+* [#3507](https://github.com/oshi/oshi/pull/3507): Extend the native-free provider (`oshi-common` alone, no JNA or FFM) to NetBSD, so NetBSD users without the JNA native library can depend on `oshi-common` without `--enable-native-access`, as Linux already can - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18)
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ SystemInfoProvider si = SystemInfoFactory.create();
 | `oshi-core` only | 8+ | JNA (`oshi.SystemInfo`) |
 | `oshi-core-ffm` only | 25+ | FFM (`oshi.ffm.SystemInfo`) |
 | Both `oshi-core` and `oshi-core-ffm` | 8+ | FFM (JDK 25+), otherwise JNA |
-| `oshi-common` only | 8+ | No `--enable-native-access` required — Linux only (`oshi.nativefree.SystemInfo`) |
+| `oshi-common` only | 8+ | No `--enable-native-access` required — Linux and NetBSD only (`oshi.nativefree.SystemInfo`) |
 
 You can also instantiate directly:
 

--- a/oshi-common/src/main/java/oshi/nativefree/SystemInfo.java
+++ b/oshi-common/src/main/java/oshi/nativefree/SystemInfo.java
@@ -10,14 +10,21 @@ import java.util.function.Supplier;
 
 import oshi.hardware.HardwareAbstractionLayer;
 import oshi.hardware.common.platform.linux.nativefree.LinuxHardwareAbstractionLayerNF;
+import oshi.hardware.common.platform.unix.netbsd.NetBsdHardwareAbstractionLayer;
 import oshi.software.common.os.linux.nativefree.LinuxOperatingSystemNF;
+import oshi.software.common.os.unix.netbsd.NetBsdOperatingSystem;
 import oshi.software.os.OperatingSystem;
 import oshi.spi.SystemInfoProvider;
 import oshi.util.PlatformEnum;
 
 /**
- * Native-free {@link SystemInfoProvider} for Linux. Uses only procfs, sysfs, and standard Java APIs — no JNA, no FFM,
- * no {@code --enable-native-access} required.
+ * Native-free {@link SystemInfoProvider} for Linux and NetBSD. Uses only procfs, sysfs, {@code sysctl}, other
+ * command-line tools, and standard Java APIs — no JNA, no FFM, no {@code --enable-native-access} required.
+ * <p>
+ * On Linux this wires the native-free ({@code *NF}) subclasses that read {@code /proc} and {@code /sys}. On NetBSD the
+ * shared {@code oshi-common} base classes are already native-free (they query {@code sysctl} and {@code ps} via the
+ * command line), so they are used directly; the {@code oshi-core} JNA subclasses only swap in native process/thread
+ * identity and a JNA-based processor.
  * <p>
  * This provider is registered at priority 0 (lowest) and is only selected when no higher-priority provider (JNA or FFM)
  * is available on the classpath.
@@ -26,11 +33,11 @@ import oshi.util.PlatformEnum;
  */
 public class SystemInfo implements SystemInfoProvider {
 
-    private final Supplier<OperatingSystem> os = memoize(LinuxOperatingSystemNF::new);
-    private final Supplier<HardwareAbstractionLayer> hardware = memoize(LinuxHardwareAbstractionLayerNF::new);
+    private final Supplier<OperatingSystem> os = memoize(SystemInfo::createOperatingSystem);
+    private final Supplier<HardwareAbstractionLayer> hardware = memoize(SystemInfo::createHardware);
 
     /**
-     * Creates a new native-free Linux {@code SystemInfo} instance.
+     * Creates a new native-free {@code SystemInfo} instance.
      */
     public SystemInfo() {
     }
@@ -45,6 +52,30 @@ public class SystemInfo implements SystemInfoProvider {
         return hardware.get();
     }
 
+    private static OperatingSystem createOperatingSystem() {
+        switch (PlatformEnum.getCurrentPlatform()) {
+            case LINUX:
+                return new LinuxOperatingSystemNF();
+            case NETBSD:
+                return new NetBsdOperatingSystem();
+            default:
+                throw new UnsupportedOperationException(
+                        "Native-free operating system not supported: " + PlatformEnum.getCurrentPlatform().getName());
+        }
+    }
+
+    private static HardwareAbstractionLayer createHardware() {
+        switch (PlatformEnum.getCurrentPlatform()) {
+            case LINUX:
+                return new LinuxHardwareAbstractionLayerNF();
+            case NETBSD:
+                return new NetBsdHardwareAbstractionLayer();
+            default:
+                throw new UnsupportedOperationException(
+                        "Native-free hardware not supported: " + PlatformEnum.getCurrentPlatform().getName());
+        }
+    }
+
     @Override
     public int getPriority() {
         return 0;
@@ -52,6 +83,7 @@ public class SystemInfo implements SystemInfoProvider {
 
     @Override
     public boolean isAvailable() {
-        return PlatformEnum.getCurrentPlatform() == PlatformEnum.LINUX;
+        PlatformEnum platform = PlatformEnum.getCurrentPlatform();
+        return platform == PlatformEnum.LINUX || platform == PlatformEnum.NETBSD;
     }
 }

--- a/oshi-common/src/main/java/oshi/nativefree/package-info.java
+++ b/oshi-common/src/main/java/oshi/nativefree/package-info.java
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * Native-free OSHI entry point for Linux. See {@link oshi.nativefree.SystemInfo}.
+ * Native-free OSHI entry point for Linux and NetBSD. See {@link oshi.nativefree.SystemInfo}.
  */
 package oshi.nativefree;

--- a/oshi-common/src/main/java/oshi/spi/SystemInfoFactory.java
+++ b/oshi-common/src/main/java/oshi/spi/SystemInfoFactory.java
@@ -47,7 +47,7 @@ public final class SystemInfoFactory {
      *
      * @return a new instance of the best available {@link SystemInfoProvider}
      * @throws IllegalStateException if no available provider is found. Ensure {@code oshi-core}, {@code oshi-core-ffm},
-     *                               or (on Linux) {@code oshi-common} alone is on the classpath.
+     *                               or (on Linux or NetBSD) {@code oshi-common} alone is on the classpath.
      */
     public static SystemInfoProvider create() {
         SystemInfoProvider best = null;
@@ -65,7 +65,7 @@ public final class SystemInfoFactory {
         if (best == null) {
             throw new IllegalStateException(
                     "No SystemInfoProvider found. Add oshi-core or oshi-core-ffm as a dependency,"
-                            + " or use oshi-common alone if on Linux (native-free provider).");
+                            + " or use oshi-common alone if on Linux or NetBSD (native-free provider).");
         }
         return best;
     }

--- a/oshi-common/src/main/java/oshi/spi/SystemInfoProvider.java
+++ b/oshi-common/src/main/java/oshi/spi/SystemInfoProvider.java
@@ -38,7 +38,7 @@ public interface SystemInfoProvider {
      * Returns the priority of this provider. Higher values indicate higher priority. When multiple providers are
      * available, the one with the highest priority is selected.
      * <p>
-     * Priority 0 is reserved for a potential future no-native-access fallback. The JNA-based provider
+     * Priority 0 is the native-free fallback ({@code oshi-common} alone, on Linux or NetBSD). The JNA-based provider
      * ({@code oshi-core}) returns 10. The FFM-based provider ({@code oshi-core-ffm}) returns 20 (preferred when
      * available).
      *

--- a/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
+++ b/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
@@ -32,8 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
@@ -44,14 +43,25 @@ import oshi.software.os.OperatingSystem;
 import oshi.util.PlatformEnum;
 
 /**
- * Exercises the native-free Linux provider and logs human-readable output, mirroring the JNA and FFM SystemInfoTest
- * classes.
+ * Exercises the native-free provider (Linux and NetBSD) and logs human-readable output, mirroring the JNA and FFM
+ * SystemInfoTest classes.
  */
 @Execution(ExecutionMode.SAME_THREAD)
-@EnabledOnOs(OS.LINUX)
+@EnabledIf("isNativeFreePlatform")
 public class SystemInfoTest {
 
     private static final Logger logger = LoggerFactory.getLogger(SystemInfoTest.class);
+
+    /**
+     * Whether the native-free provider supports the current platform. Delegates to the production
+     * {@link SystemInfo#isAvailable()} so the test enablement cannot drift from the provider's own gating.
+     * ({@code @EnabledIf} requires a static method and cannot reference the instance method directly.)
+     *
+     * @return {@code true} on Linux or NetBSD
+     */
+    static boolean isNativeFreePlatform() {
+        return new SystemInfo().isAvailable();
+    }
 
     @Test
     void testPlatformEnum() {

--- a/oshi-common/src/test/java/oshi/spi/SystemInfoFactoryTest.java
+++ b/oshi-common/src/test/java/oshi/spi/SystemInfoFactoryTest.java
@@ -10,26 +10,36 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 /**
  * Validates SystemInfoFactory behavior when only oshi-common is on the classpath (no oshi-core or oshi-core-ffm).
  */
 class SystemInfoFactoryTest {
 
+    /**
+     * Whether the native-free provider supports the current platform. Delegates to the production
+     * {@code oshi.nativefree.SystemInfo#isAvailable()} so the test enablement cannot drift from the provider's own
+     * gating. ({@code @EnabledIf} requires a static method and cannot reference the instance method directly.)
+     *
+     * @return {@code true} on Linux or NetBSD
+     */
+    static boolean isNativeFreePlatform() {
+        return new oshi.nativefree.SystemInfo().isAvailable();
+    }
+
     @Test
-    @EnabledOnOs(OS.LINUX)
-    void factoryReturnsNativeFreeProviderOnLinux() {
+    @EnabledIf("isNativeFreePlatform")
+    void factoryReturnsNativeFreeProviderOnNativeFreePlatform() {
         SystemInfoProvider provider = SystemInfoFactory.create();
         assertThat(provider, is(instanceOf(oshi.nativefree.SystemInfo.class)));
         assertThat(provider.getPriority(), is(0));
     }
 
     @Test
-    @DisabledOnOs(OS.LINUX)
-    void factoryThrowsOnNonLinux() {
+    @DisabledIf("isNativeFreePlatform")
+    void factoryThrowsOnUnsupportedPlatform() {
         assertThrows(IllegalStateException.class, SystemInfoFactory::create);
     }
 }

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -77,7 +77,7 @@ SystemInfoProvider si = SystemInfoFactory.create();
 | `oshi-core` only | 8+ | JNA (`oshi.SystemInfo`) |
 | `oshi-core-ffm` only | 25+ | FFM (`oshi.ffm.SystemInfo`) |
 | Both `oshi-core` and `oshi-core-ffm` | 8+ | FFM (JDK 25+), otherwise JNA |
-| `oshi-common` only | 8+ | No `--enable-native-access` required — Linux only (`oshi.nativefree.SystemInfo`) |
+| `oshi-common` only | 8+ | No `--enable-native-access` required — Linux and NetBSD only (`oshi.nativefree.SystemInfo`) |
 
 You can also instantiate directly:
 


### PR DESCRIPTION
## Summary

Extends the native-free provider (`oshi-common` alone — no JNA, no FFM, no `--enable-native-access`) to **NetBSD**, so NetBSD users without the JNA native library can depend on `oshi-common` directly, as Linux already can.

NetBSD's `oshi-common` base classes (`NetBsdOperatingSystem`, `NetBsdHardwareAbstractionLayer`, `NetBsdCentralProcessor`) are already fully native-free — they query `sysctl`/`ps` via the command line. The `oshi-core` JNA subclasses only swap in a JNA processor and native pid/tid. So the native-free provider uses the base NetBSD classes directly (unlike Linux, which needs dedicated `*NF` subclasses).

## Changes

- **`oshi.nativefree.SystemInfo`**: selects Linux (`*NF` classes) or NetBSD (base classes) by `PlatformEnum`; `isAvailable()` now covers `LINUX` and `NETBSD`.
- **`SystemInfoFactory` / `SystemInfoProvider`**: refreshed the error message and priority-0 javadoc for the two-platform native-free fallback.
- **Tests**: `nativefree.SystemInfoTest` and `spi.SystemInfoFactoryTest` now gate on a shared `isNativeFreePlatform()` helper that uses the same `PlatformEnum` detection as `isAvailable()`, so the tests can't drift from production logic.
- **Docs**: README and `index.md` native-free row now reads "Linux and NetBSD only".
- **CI**: new `nativefree.yaml` builds/tests `oshi-common` in isolation (no `oshi-core`/JNA, no `oshi-core-ffm`) — Linux on ubuntu, NetBSD in a VM without `java-jna`.

## Testing

Both native-free CI jobs pass on my fork. The NetBSD job ran the full native-free `SystemInfoTest` end-to-end ("Using Native-Free (NF)", every hardware/OS check) with `oshi-common` alone. Local `spotless`, `checkstyle`, `install`, `forbiddenapis`, and `javadoc` all pass.

Not API-breaking (no interface changes; only a wider `isAvailable()` plus docs/CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended native-free support to NetBSD alongside Linux.
  * No `--enable-native-access` option is required when using the native-free implementation on supported platforms.

* **Documentation**
  * Updated usage guidance, compatibility tables, and API/changelog notes to reflect NetBSD native-free support.

* **Tests**
  * Added CI coverage validating native-free behavior on both Linux and NetBSD, including running the native-free test suite for `oshi-common`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->