### PR TITLE
Enable native-free JaCoCo coverage upload for Linux and NetBSD

### DIFF
--- a/.github/workflows/nativefree.yaml
+++ b/.github/workflows/nativefree.yaml
@@ -34,11 +34,21 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
       - name: Test oshi-common alone (native-free)
-        run: ./mvnw clean test -pl oshi-common -B -Djacoco.skip=true
+        run: ./mvnw clean test -pl oshi-common -B
+      - name: Upload Coverage
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: oshi-common/target/site/jacoco/jacoco.xml
+          flags: nativefree-linux
 
   # Builds and tests ONLY oshi-common on NetBSD WITHOUT the JNA native library
   # (java-jna not installed), exercising the fully command-line native-free path
-  # (sysctl/ps). No oshi-core or oshi-core-ffm on the classpath.
+  # (sysctl/ps). No oshi-core or oshi-core-ffm on the classpath. This is the only
+  # CI job that exercises the native-free NetBSD base classes, so its coverage is
+  # uploaded under the `nativefree-netbsd` flag. (The plain `netbsd` flag is reserved
+  # for a future JNA-NetBSD aggregate-coverage job.)
   testnativefreenetbsd:
     runs-on: ubuntu-24.04
     name: Native-Free JDK 21, NetBSD
@@ -52,6 +62,7 @@ jobs:
         with:
           release: "10.1"
           usesh: true
+          copyback: true
           prepare: |
             pkg_add curl
             pkg_add openjdk21
@@ -59,4 +70,11 @@ jobs:
             export JAVA_HOME=/usr/pkg/java/openjdk21
             export PATH=$JAVA_HOME/bin:$PATH
             mount -t procfs procfs /proc 2>/dev/null || true
-            ./mvnw clean test -pl oshi-common -B -Djacoco.skip=true
+            ./mvnw clean test -pl oshi-common -B
+      - name: Upload Coverage
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: oshi-common/target/site/jacoco/jacoco.xml
+          flags: nativefree-netbsd

--- a/pom.xml
+++ b/pom.xml
@@ -856,14 +856,21 @@
                         <exclude>**/jna/ByRef*</exclude>
                         <exclude>**/jna/Struct*</exclude>
                         <exclude>**/unix/dragonflybsd/**</exclude>
-                        <exclude>**/unix/netbsd/**</exclude>
+                        <!-- NetBSD: exclude only the oshi-core JNA classes (hardware/platform,
+                             software/os, util/platform). The oshi-common base classes under
+                             `*/common/*` are native-free and exercised on the native-free NetBSD CI
+                             job (codecov `nativefree-netbsd` flag), so they stay in coverage. `NetBsdLibc` in
+                             `jna/platform` is already covered by the `**/jna/platform/**` exclusion
+                             above. -->
+                        <exclude>**/hardware/platform/unix/netbsd/**</exclude>
+                        <exclude>**/software/os/unix/netbsd/**</exclude>
+                        <exclude>**/util/platform/unix/netbsd/**</exclude>
                         <!-- Narrow these `**/unix/<Name>*` patterns — JaCoCo agent globs let `*`
                              cross path separators, so `**/unix/*Bsd*` etc. would also exclude
                              `**/unix/<bsd-subpkg>/Free**Bsd**...`. OpenBSD and Solaris are exercised
                              on the permanent OpenBSD/OpenIndiana CI jobs, and AIX on the cfarm CI job,
                              all with aggregate coverage and codecov upload. -->
                         <exclude>**/unix/*DragonFlyBsd*</exclude>
-                        <exclude>**/unix/*NetBsd*</exclude>
                         <!-- Hardware-dependent: no GPU/sensors/battery on CI runners -->
                         <exclude>**/gpu/NvmlUtil*</exclude>
                         <exclude>**/gpu/AdlUtil*</exclude>


### PR DESCRIPTION
## Summary

The native-free CI jobs (added in #3507) ran with `-Djacoco.skip=true`, so `oshi-common`'s native-free classes were never measured. This enables JaCoCo on both jobs and uploads per-module coverage to Codecov.

## Changes

- **`nativefree.yaml`**: drop `-Djacoco.skip=true` from both jobs; add a Codecov upload of `oshi-common/target/site/jacoco/jacoco.xml` under new flags `nativefree-linux` and `nativefree-netbsd`. Add `copyback: true` to the NetBSD VM job so the report reaches the host runner before upload.
- **`pom.xml`** (JaCoCo excludes): the broad `**/unix/netbsd/**` and `**/unix/*NetBsd*` patterns also excluded the `oshi-common` native-free base classes — the agent glob's `*` crosses path separators. Replace them with three `oshi-core`-only paths (`hardware/platform/unix/netbsd`, `software/os/unix/netbsd`, `util/platform/unix/netbsd`) so the native-free base classes under `*/common/*` stay in coverage. `NetBsdLibc` remains excluded via the existing `**/jna/platform/**`.

The `oshi-core` JNA NetBSD classes stay excluded for now; adding them to an aggregate (JDK 25 `oshi-benchmark`) run is a follow-on. The plain `netbsd` flag is intentionally left free for that future JNA-NetBSD job.

## Testing

Verified on my fork (run exercising both jobs): JaCoCo `report` runs in the NetBSD VM, `copyback` lands `jacoco.xml` on the host runner, and the Codecov action resolves and uploads the file (upload itself only no-ops on the fork for lack of `CODECOV_TOKEN`; the token is present upstream). Confirmed the 16 `oshi-common` NetBSD base classes now appear in the report while all `oshi-core` JNA NetBSD classes remain excluded, by building `-pl oshi-common` and `-pl oshi-core` locally. `mvn sortpom:sort` is a no-op on the edited pom.

CI/coverage-only change — no CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Native-free Linux and NetBSD test runs now collect and upload JaCoCo coverage reports.
  * Coverage reporting now includes additional NetBSD platform code for more accurate results.

* **Chores**
  * Updated coverage configuration and CI reporting labels for native-free builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->