### PR TITLE
Aggregate coverage for NetBSD, DragonFly BSD, and Solaris SPARC

### DIFF
--- a/.github/workflows/cfarm.yaml
+++ b/.github/workflows/cfarm.yaml
@@ -42,6 +42,11 @@ jobs:
     concurrency: solaris_cfarm216
     runs-on: ubuntu-latest
     steps:
+    # Checkout on the runner so codecov-action can read the git context (commit,
+    # branch) for the report the Solaris box produces; the build itself runs remotely.
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
     - name: Test in Solaris SPARC
       uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
       env:
@@ -78,13 +83,38 @@ jobs:
           set +e
           # One wall-clock budget for both attempts, kept under command_timeout
           # so the box self-terminates first and leaves no orphan.
-          BUILD='./mvnw clean test -B -Djacoco.skip=true || { sleep 15; ./mvnw clean test -B -Djacoco.skip=true; }'
+          # jna-aggregate: JDK 17 aggregate report (oshi-common + oshi-core, no FFM) via oshi-demo;
+          # the oshi-benchmark aggregator needs JDK 25, unavailable on this SPARC box.
+          BUILD='./mvnw clean test -Pjna-aggregate -B || { sleep 15; ./mvnw clean test -Pjna-aggregate -B; }'
           if command -v timeout >/dev/null 2>&1; then
             timeout --kill-after=30s 20m sh -c "$BUILD"
           else
             sh -c "$BUILD"
           fi
           exit $?
+    # Pull the JDK 17 aggregate JaCoCo report (oshi-common + oshi-core, no FFM) off
+    # the shared box and upload it to Codecov under the `solaris-sparc` flag. Runs on
+    # test failure too, since JaCoCo still emits a report then.
+    - name: Copy back Solaris SPARC coverage
+      if: always()
+      env:
+        GCC_CI_KEY: ${{ secrets.GCC_CI_KEY }}
+      run: |
+        KEY=$(mktemp)
+        printf '%s\n' "$GCC_CI_KEY" > "$KEY"
+        chmod 600 "$KEY"
+        mkdir -p oshi-demo/target/site/jacoco-aggregate
+        scp -i "$KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+          oshi@cfarm216.cfarm.net:oshi/oshi-demo/target/site/jacoco-aggregate/jacoco.xml \
+          oshi-demo/target/site/jacoco-aggregate/jacoco.xml || echo "No Solaris SPARC coverage report to copy"
+        rm -f "$KEY"
+    - name: Upload Coverage
+      if: always()
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: oshi-demo/target/site/jacoco-aggregate/jacoco.xml
+        flags: solaris-sparc
 
   # Tests the triggering ref on AIX 7.3: master on push, or the dispatched
   # branch (possibly from a fork) on workflow_dispatch.

--- a/.github/workflows/unix.yaml
+++ b/.github/workflows/unix.yaml
@@ -138,6 +138,7 @@ jobs:
         with:
           release: "6.4.2"
           usesh: true
+          copyback: true
           prepare: |
             pkg install -y curl
             pkg install -y openjdk21
@@ -145,7 +146,15 @@ jobs:
             export JAVA_HOME=/usr/local/openjdk21
             export PATH=$JAVA_HOME/bin:$PATH
             mount -t procfs procfs /proc 2>/dev/null || true
-            ./mvnw clean test -B -Djacoco.skip=true
+            # jna-aggregate: JDK 21 aggregate report (oshi-common + oshi-core, no FFM) via oshi-demo.
+            ./mvnw clean test -Pjna-aggregate -B
+      - name: Upload Coverage
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: oshi-demo/target/site/jacoco-aggregate/jacoco.xml
+          flags: dragonflybsd
 
   # Runs on NetBSD 10.1 x86 VM WITHOUT the JNA native library (java-jna not installed), exercising the
   # command-line fallback path (NetBsdSysctlUtil.JNA_AVAILABLE == false).
@@ -162,6 +171,7 @@ jobs:
         with:
           release: "10.1"
           usesh: true
+          copyback: true
           prepare: |
             pkg_add curl
             pkg_add openjdk21
@@ -169,7 +179,15 @@ jobs:
             export JAVA_HOME=/usr/pkg/java/openjdk21
             export PATH=$JAVA_HOME/bin:$PATH
             mount -t procfs procfs /proc 2>/dev/null || true
-            ./mvnw clean test -B -Djacoco.skip=true
+            # jna-aggregate: JDK 21 aggregate report (oshi-common + oshi-core, no FFM) via oshi-demo.
+            ./mvnw clean test -Pjna-aggregate -B
+      - name: Upload Coverage
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: oshi-demo/target/site/jacoco-aggregate/jacoco.xml
+          flags: netbsd-nojna
 
   # Runs on NetBSD 10.1 x86 VM WITH the JNA native library (pkgsrc java-jna), exercising the native path
   # (NetBsdSysctlUtil.JNA_AVAILABLE == true). jna.boot.library.path points JNA at the pkgsrc libjnidispatch.
@@ -186,6 +204,7 @@ jobs:
         with:
           release: "10.1"
           usesh: true
+          copyback: true
           prepare: |
             pkg_add curl
             pkg_add openjdk21
@@ -195,4 +214,12 @@ jobs:
             export PATH=$JAVA_HOME/bin:$PATH
             export JAVA_TOOL_OPTIONS="-Djna.boot.library.path=/usr/pkg/lib"
             mount -t procfs procfs /proc 2>/dev/null || true
-            ./mvnw clean test -B -Djacoco.skip=true
+            # jna-aggregate: JDK 21 aggregate report (oshi-common + oshi-core, no FFM) via oshi-demo.
+            ./mvnw clean test -Pjna-aggregate -B
+      - name: Upload Coverage
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: oshi-demo/target/site/jacoco-aggregate/jacoco.xml
+          flags: netbsd-jna

--- a/oshi-demo/pom.xml
+++ b/oshi-demo/pom.xml
@@ -21,6 +21,14 @@
     </properties>
 
     <dependencies>
+        <!-- oshi-common is transitive via oshi-core, but jacoco:report-aggregate only aggregates
+             DIRECT reactor dependencies, so declare it explicitly to include its coverage (native-free
+             base classes) in the jna-aggregate report. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>oshi-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>oshi-core</artifactId>
@@ -51,6 +59,27 @@
                 <configuration>
                     <skip>true</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <!-- JDK 17+/21 aggregate report for the JNA (oshi-core) + native-free (oshi-common)
+                         backends, without FFM. The oshi-benchmark aggregator requires JDK 25 (it depends
+                         on oshi-core-ffm), so platforms capped below 25 (NetBSD JDK 21, Solaris SPARC
+                         JDK 17) aggregate here instead. Gated behind the jna-aggregate profile so it does
+                         not run on the default build. -->
+                    <execution>
+                        <id>jna-aggregate-report</id>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <skip>${jna.aggregate.skip}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@
         <sonar.java.test.binaries>${project.build.testOutputDirectory}</sonar.java.test.binaries>
         <!-- native access enablement default -->
         <native.access.modules>ALL-UNNAMED</native.access.modules>
+        <!-- Skip the JDK 17+/21 JNA aggregate report (oshi-demo) by default; the jna-aggregate profile enables it. -->
+        <jna.aggregate.skip>true</jna.aggregate.skip>
         <!-- internal, see https://issues.apache.org/jira/browse/MNG-7038 -->
         <main.basedir>${maven.multiModuleProjectDirectory}</main.basedir>
         <!-- Dependency versions -->
@@ -855,22 +857,16 @@
                         <exclude>**/jna/platform/**</exclude>
                         <exclude>**/jna/ByRef*</exclude>
                         <exclude>**/jna/Struct*</exclude>
-                        <exclude>**/unix/dragonflybsd/**</exclude>
-                        <!-- NetBSD: exclude only the oshi-core JNA classes (hardware/platform,
-                             software/os, util/platform). The oshi-common base classes under
-                             `*/common/*` are native-free and exercised on the native-free NetBSD CI
-                             job (codecov `nativefree-netbsd` flag), so they stay in coverage. `NetBsdLibc` in
-                             `jna/platform` is already covered by the `**/jna/platform/**` exclusion
-                             above. -->
-                        <exclude>**/hardware/platform/unix/netbsd/**</exclude>
-                        <exclude>**/software/os/unix/netbsd/**</exclude>
-                        <exclude>**/util/platform/unix/netbsd/**</exclude>
-                        <!-- Narrow these `**/unix/<Name>*` patterns — JaCoCo agent globs let `*`
-                             cross path separators, so `**/unix/*Bsd*` etc. would also exclude
-                             `**/unix/<bsd-subpkg>/Free**Bsd**...`. OpenBSD and Solaris are exercised
-                             on the permanent OpenBSD/OpenIndiana CI jobs, and AIX on the cfarm CI job,
-                             all with aggregate coverage and codecov upload. -->
-                        <exclude>**/unix/*DragonFlyBsd*</exclude>
+                        <!-- All Unix platforms now have aggregate coverage + codecov upload: FreeBSD /
+                             OpenBSD / OpenIndiana (Solaris x86) on the permanent unix CI jobs (JDK 25,
+                             oshi-benchmark aggregator); AIX and Solaris SPARC on the cfarm CI jobs; and
+                             NetBSD and DragonFly BSD on their unix CI jobs. NetBSD, DragonFly, and Solaris
+                             SPARC are capped below JDK 25 (no FFM), so they aggregate via the oshi-demo
+                             `jna-aggregate` profile instead of oshi-benchmark. Their oshi-core JNA classes
+                             (hardware/platform, software/os, util/platform under unix/<os>) are therefore
+                             covered and not excluded; the oshi-common native-free base classes under
+                             `*/common/*` are covered on the native-free jobs. -->
+
                         <!-- Hardware-dependent: no GPU/sensors/battery on CI runners -->
                         <exclude>**/gpu/NvmlUtil*</exclude>
                         <exclude>**/gpu/AdlUtil*</exclude>
@@ -1160,6 +1156,18 @@
                  The profile is defined here as a placeholder; oshi-benchmark
                  overrides maven.test.skip to enable its comparison tests. -->
             <id>aggregate-coverage</id>
+        </profile>
+        <profile>
+            <!-- JDK 17+/21 aggregate JaCoCo report over oshi-common + oshi-core (JNA), without FFM.
+                 Use: mvnw test -Pjna-aggregate
+                 For platforms capped below JDK 25 that cannot build oshi-core-ffm/oshi-benchmark
+                 (NetBSD JDK 21, Solaris SPARC JDK 17). Enables the report-aggregate execution in
+                 oshi-demo (which depends on oshi-core); the aggregate lands at
+                 oshi-demo/target/site/jacoco-aggregate/jacoco.xml. -->
+            <id>jna-aggregate</id>
+            <properties>
+                <jna.aggregate.skip>false</jna.aggregate.skip>
+            </properties>
         </profile>
         <profile>
             <id>checks</id>


### PR DESCRIPTION
## Summary

NetBSD (JDK 21), DragonFly BSD (JDK 21), and Solaris SPARC (JDK 17) are capped below JDK 25 and cannot build `oshi-core-ffm`, so they could not use the `oshi-benchmark` `aggregate-coverage` report (which requires JDK 25). They ran with `-Djacoco.skip=true` and contributed no coverage — leaving their `oshi-core` JNA classes excluded from JaCoCo.

This adds a JDK 17+ aggregate report hosted in `oshi-demo` (depends on `oshi-core`, no FFM) behind a new `jna-aggregate` profile, and wires the CI jobs to produce and upload it.

## Changes

- **`oshi-demo/pom.xml`**: add a `report-aggregate` execution (skipped by default via `jna.aggregate.skip`, flipped `false` by the `jna-aggregate` profile). Declare `oshi-common` as an explicit **direct** dependency — `report-aggregate` only aggregates direct reactor dependencies, so without this the native-free base classes are dropped.
- **`pom.xml`**: add the `jna-aggregate` profile and the default `jna.aggregate.skip=true` property. Remove the NetBSD and DragonFly BSD JaCoCo excludes so their `oshi-core` JNA classes are measured on their platform runs (as FreeBSD/OpenBSD/Solaris already are); `NetBsdLibc`/`DragonFlyBsdLibc` remain covered by `**/jna/platform/**`.
- **`unix.yaml`**: NetBSD (JNA + command-line fallback) and DragonFly BSD jobs now run `-Pjna-aggregate` with `copyback: true`, uploading `oshi-demo/target/site/jacoco-aggregate/jacoco.xml` under flags `netbsd-jna`, `netbsd-nojna`, `dragonflybsd`.
- **`cfarm.yaml`**: Solaris SPARC job runs `-Pjna-aggregate`, gains a runner checkout (for codecov git context) + scp-copyback of the aggregate report, uploaded under flag `solaris-sparc`.

The JNA classes now also appear (as 0%) in the JDK 25 `oshi-benchmark` aggregate on non-NetBSD/DragonFly runs; codecov unions across flags, so the platform runs supply the real coverage — consistent with how the other platform JNA classes already behave.

## Testing

Verified on my fork (Unix CI run, all 6 jobs green): NetBSD JNA, NetBSD no-JNA, and DragonFly BSD each produce the `oshi-demo` aggregate (bundles `oshi-common` + `oshi-core`), `copyback` lands `jacoco.xml` on the host runner, and the codecov action resolves and uploads it (upload no-ops on the fork for lack of `CODECOV_TOKEN`; the token is present upstream). The existing JDK 25 `aggregate-coverage` path and the default build are unaffected; `mvn sortpom:sort` is a no-op on the edited poms.

**Not fork-testable:** the Solaris SPARC cfarm job runs only on the upstream repo (shared physical host, `GCC_CI_KEY` secret, and its `if:` gates out fork pushes), so its scp-copyback path and codecov upload will first exercise on upstream master. The scp source mirrors the proven AIX-job pattern, adjusted for Solaris's `~/oshi` working directory.

CI/coverage-only change — no CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Unix platform test coverage reporting, including Solaris SPARC, DragonFlyBSD, and NetBSD environments.
  * Added aggregate JaCoCo reports covering both JNA and native-free backends.
  * Improved test environment setup where `/proc` is required.

* **Chores**
  * Updated automated workflows to upload platform-specific coverage reports to Codecov.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->