### PR TITLE
Slim the PR CI: carryforward coverage, trim matrix, path-gate Unix VMs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,10 @@ jobs:
   # the always-on ubuntu/mac/windows jobs, Codecov carryforward, and the authoritative
   # master run. A `full-coverage` label overrides the gate to force the VM jobs on.
   changes:
+    # On a `labeled` event only proceed for the full-coverage label, so adding an
+    # unrelated label doesn't re-run CI. opened/synchronize/reopened always run.
+    # The VM jobs inherit this via `needs: changes`.
+    if: github.event.action != 'labeled' || github.event.label.name == 'full-coverage'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -54,6 +58,7 @@ jobs:
   # Static analysis: formatting, style, API restrictions, and javadoc link validity.
   # Runs once on ubuntu/JDK 25 (javadoc for oshi-core-ffm requires JDK 25).
   lint:
+    if: github.event.action != 'labeled' || github.event.label.name == 'full-coverage'
     runs-on: ubuntu-latest
     name: Lint (Spotless, Checkstyle, ForbiddenAPIs, Javadoc)
     steps:
@@ -81,6 +86,7 @@ jobs:
         run: ./mvnw -Pverify-slf4j-17 clean compile
 
   test:
+    if: github.event.action != 'labeled' || github.event.label.name == 'full-coverage'
     runs-on: ${{ matrix.os }}
     strategy:
       # Latest LTS (JDK 25) across all three OSes — this is the coverage + JNA==FFM

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,6 +3,9 @@ name: Pull Request CI
 
 on:
   pull_request:
+    # `labeled` lets the `full-coverage` label trigger a run immediately (no re-push);
+    # the other types are the default set.
+    types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - '**.md'
       - '**.yml'
@@ -12,6 +15,42 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether this PR touches Unix-platform code or the build infrastructure.
+  # The nested-VM Unix coverage jobs (freebsd/openbsd/openindiana) are gated on this
+  # so an unrelated PR doesn't spin up slow VMs. Generic shared source is covered by
+  # the always-on ubuntu/mac/windows jobs, Codecov carryforward, and the authoritative
+  # master run. A `full-coverage` label overrides the gate to force the VM jobs on.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      unix: ${{ steps.filter.outputs.unix }}
+    steps:
+      - name: Detect Unix-relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! CHANGED=$(gh pr view "${{ github.event.pull_request.number }}" \
+              --repo "${{ github.repository }}" --json files --jq '.files[].path'); then
+            # Fail safe: if the file list can't be read, run the Unix jobs rather than
+            # silently skip them and drop coverage.
+            echo "Could not read changed files; defaulting to running the Unix jobs"
+            echo "unix=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changed files:"; echo "$CHANGED"
+          # Run the Unix VM jobs when Unix-platform code (any `unix/` path segment across
+          # oshi-common/oshi-core: hardware, software, driver, util, ffm, jna) or build
+          # infrastructure (any pom.xml, the Maven wrapper) changes.
+          if echo "$CHANGED" | grep -qE '(^|/)unix/|(^|/)pom\.xml$|^\.mvn/|^mvnw'; then
+            echo "unix=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "unix=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # Static analysis: formatting, style, API restrictions, and javadoc link validity.
   # Runs once on ubuntu/JDK 25 (javadoc for oshi-core-ffm requires JDK 25).
   lint:
@@ -44,15 +83,24 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      # Latest LTS (JDK 25) across all three OSes — this is the coverage + JNA==FFM
+      # row (uploads linux/macos/windows flags). The version floor/ceiling checks
+      # (JDK 21 and 26) run on ubuntu only; an OS-specific bug that is also
+      # JDK-version-specific in a way ubuntu wouldn't catch is vanishingly rare.
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [21, 25, 26]
         include:
           - os: ubuntu-latest
+            java: 21
+          - os: ubuntu-latest
+            java: 25
             coverage-flag: linux
+          - os: ubuntu-latest
+            java: 26
           - os: macos-latest
+            java: 25
             coverage-flag: macos
           - os: windows-latest
+            java: 25
             coverage-flag: windows
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}${{ contains(matrix.java, '25') && ' (+ JNA==FFM)' || '' }}
@@ -87,6 +135,10 @@ jobs:
   testfreebsd:
     runs-on: ubuntu-24.04
     name: Test JDK 25, FreeBSD (+ JNA==FFM)
+    needs: changes
+    if: >-
+      needs.changes.outputs.unix == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'full-coverage')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -116,6 +168,10 @@ jobs:
   testopenbsd:
     runs-on: ubuntu-24.04
     name: Test JDK 25, OpenBSD (+ JNA==FFM)
+    needs: changes
+    if: >-
+      needs.changes.outputs.unix == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'full-coverage')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -148,6 +204,10 @@ jobs:
   testopenindiana:
     runs-on: ubuntu-24.04
     name: Test JDK 25, OpenIndiana (+ JNA==FFM)
+    needs: changes
+    if: >-
+      needs.changes.outputs.unix == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'full-coverage')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,3 +13,13 @@ coverage:
     patch:
       default:
         target: 70%
+
+# Carry each per-OS flag's coverage forward when a commit doesn't upload it. Full
+# coverage (every flag) runs on pushes to master, so nothing is carried there. On
+# a PR only a subset of platforms runs, so the platforms that didn't run reuse their
+# last master value instead of reading as 0% — keeping the PR's project coverage
+# accurate. It is also a no-op-or-flake-smoother on master: an occasional missing
+# upload reuses the prior value rather than cratering that flag.
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
## Summary

Full authoritative coverage runs on pushes to master (every per-OS flag). PRs run only a subset, which made Codecov treat the un-run flags as 0% and post an inaccurate post-merge project-coverage number. This fixes that and trims the PR matrix, without losing any coverage.

### 1. Codecov carryforward (`codecov.yml`)
`flag_management.default_rules.carryforward: true`. When a commit doesn't upload a flag, Codecov reuses that flag's last value. On a PR, the platforms that didn't run reuse their last **master** value → **project coverage on the PR comment is accurate**. On master (which uploads every flag) it's a no-op, and if a master job flakes it smooths the gap rather than cratering that flag to 0%.

### 2. Trim the `test` matrix (9 → 5 jobs)
- **JDK 25 (latest LTS) × {ubuntu, macOS, Windows}** — the coverage + JNA==FFM row; keeps all three `linux`/`macos`/`windows` uploads.
- **JDK 21 + 26 × ubuntu only** — version floor/ceiling checks. (An OS-specific bug that's *also* JDK-version-specific in a way ubuntu wouldn't catch is vanishingly rare.)

### 3. Path-gate the nested-VM Unix jobs
A lightweight `changes` job (`gh pr view` + `grep`, fail-safe: runs the VMs if it can't read the file list) computes whether the PR touches Unix-platform code (`unix/` path segment) or build infra (`pom.xml`, `.mvn`, `mvnw`). `testfreebsd` / `testopenbsd` / `testopenindiana` gate on it, so an unrelated PR (Windows-only, a shared `ParseUtil` tweak, etc.) skips the slow VMs. The always-on ubuntu/macOS/Windows jobs + carryforward + the authoritative master run keep coverage honest. A skipped `if:`-gated job reports as passing for branch protection.

### 4. `full-coverage` label override
Adds `labeled` to the PR triggers; the Unix VM jobs' `if:` also fires when the `full-coverage` label is present. This overrides the path gate on demand — and unlike `workflow_dispatch`, it works for **external contributors' fork-branch PRs** (a maintainer just adds the label). Fork PRs get no secrets, so they lean on Codecov's tokenless/OIDC upload; **cfarm (AIX/SPARC) is intentionally not wired here** (it needs `GCC_CI_KEY`), staying master-push + `workflow_dispatch`.

## Notes
- Because this PR only changes `.yaml`/`.yml` (both in `paths-ignore`), `pr.yaml` won't run on it — the new behavior takes effect on merge and is exercised by the next code PR.
- No CHANGELOG entry — CI/coverage configuration, no user-observable behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded pull request validation to start when labels are added.
  * Improved platform-specific test execution by running Unix-related coverage only when relevant changes are detected or when the full-coverage label is present.
  * Updated the test matrix to use explicit OS/JDK coverage configurations for more reliable reporting.
* **Chores**
  * Improved coverage reporting continuity by enabling carry-forward for per-flag coverage when some platform uploads are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->