### PR TITLE
Test macOS Bluetooth and installed-apps vendor parsing

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -58,25 +58,9 @@ public final class MacInstalledApps {
 
                 for (Map<String, String> dictValues : plistValues) {
                     try {
-                        String obtainedFrom = ParseUtil.getStringValueOrUnknown(dictValues.get("obtained_from"));
-                        if ("apple".equals(obtainedFrom)) {
-                            obtainedFrom = "Apple";
-                        } else if ("mac_app_store".equals(obtainedFrom)) {
-                            obtainedFrom = "App Store";
-                        }
-                        String signedBy = ParseUtil.getStringValueOrUnknown(dictValues.get("signed_by"));
-                        String vendor;
-                        if ("identified_developer".equals(obtainedFrom)) {
-                            if (signedBy.startsWith("Developer ID Application: ")) {
-                                vendor = signedBy.substring(26);
-                            } else {
-                                vendor = signedBy;
-                            }
-                        } else if (Constants.UNKNOWN.equals(obtainedFrom) && !Constants.UNKNOWN.equals(signedBy)) {
-                            vendor = signedBy;
-                        } else {
-                            vendor = obtainedFrom;
-                        }
+                        String vendor = resolveVendor(
+                                ParseUtil.getStringValueOrUnknown(dictValues.get("obtained_from")),
+                                ParseUtil.getStringValueOrUnknown(dictValues.get("signed_by")));
 
                         String version = dictValues.get("version");
 
@@ -139,6 +123,32 @@ public final class MacInstalledApps {
             }
             return buffer;
         }
+    }
+
+    /**
+     * Resolves the vendor/publisher name from an application's {@code obtained_from} and {@code signed_by} values (as
+     * reported by {@code system_profiler}). {@code apple}/{@code mac_app_store} map to display names; for an identified
+     * developer the {@code Developer ID Application:} prefix is stripped from the signer.
+     *
+     * @param obtainedFrom the {@code obtained_from} value ({@link Constants#UNKNOWN} if absent)
+     * @param signedBy     the {@code signed_by} value ({@link Constants#UNKNOWN} if absent)
+     * @return the resolved vendor name
+     */
+    static String resolveVendor(String obtainedFrom, String signedBy) {
+        if ("apple".equals(obtainedFrom)) {
+            obtainedFrom = "Apple";
+        } else if ("mac_app_store".equals(obtainedFrom)) {
+            obtainedFrom = "App Store";
+        }
+        if ("identified_developer".equals(obtainedFrom)) {
+            if (signedBy.startsWith("Developer ID Application: ")) {
+                return signedBy.substring(26);
+            }
+            return signedBy;
+        } else if (Constants.UNKNOWN.equals(obtainedFrom) && !Constants.UNKNOWN.equals(signedBy)) {
+            return signedBy;
+        }
+        return obtainedFrom;
     }
 
     static List<Map<String, String>> parseItems(String xml) {

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacBluetoothDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacBluetoothDeviceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.BluetoothDevice;
+
+class MacBluetoothDeviceTest {
+
+    // Representative `system_profiler SPBluetoothDataType` output (real structure, sanitized names/addresses): a
+    // controller block (ignored, not in a Connected/Not Connected section), then Connected and Not Connected device
+    // sections. Devices carry ignored fields (Vendor ID, Product ID, Services) plus the parsed Address/Minor Type/
+    // Battery Level.
+    private static final List<String> SPBLUETOOTH = Arrays.asList(//
+            "Bluetooth:", //
+            "", //
+            "      Bluetooth Controller:", //
+            "          Address: 5C:E9:1E:83:67:4F", //
+            "          State: On", //
+            "          Chipset: BCM_4388", //
+            "          Vendor ID: 0x004C (Apple)", //
+            "      Connected:", //
+            "          Wireless Keyboard:", //
+            "              Address: 11:22:33:aa:bb:cc", //
+            "              Vendor ID: 0x046D", //
+            "              Product ID: 0xB359", //
+            "              Minor Type: Keyboard", //
+            "              Battery Level: 80%", //
+            "              Services: 0x400000 < BLE >", //
+            "          Wireless Headphones:", //
+            "              Address: 22:33:44:55:66:77", //
+            "              Minor Type: Headphones", //
+            "      Not Connected:", //
+            "          Wireless Mouse:", //
+            "              Address: 33:44:55:66:77:88", //
+            "              Major Type: Peripheral");
+
+    @Test
+    void testParseSystemProfiler() {
+        List<BluetoothDevice> devices = MacBluetoothDevice.parseSystemProfiler(SPBLUETOOTH);
+        assertThat(devices, hasSize(3));
+
+        BluetoothDevice keyboard = devices.get(0);
+        assertThat(keyboard.getName(), is("Wireless Keyboard"));
+        // Address is upper-cased
+        assertThat(keyboard.getAddress(), is("11:22:33:AA:BB:CC"));
+        // Minor Type sets the majorDeviceClass field; ignored fields (Vendor/Product ID, Services) don't disturb it
+        assertThat(keyboard.getMajorDeviceClass(), is("Keyboard"));
+        assertThat(keyboard.isConnected(), is(true));
+        assertThat(keyboard.isPaired(), is(true));
+        assertThat(keyboard.getBatteryLevel(), is(80));
+
+        BluetoothDevice headphones = devices.get(1);
+        assertThat(headphones.getName(), is("Wireless Headphones"));
+        assertThat(headphones.isConnected(), is(true));
+        // No battery level line -> sentinel -1
+        assertThat(headphones.getBatteryLevel(), is(-1));
+
+        BluetoothDevice mouse = devices.get(2);
+        assertThat(mouse.getName(), is("Wireless Mouse"));
+        // In the Not Connected section
+        assertThat(mouse.isConnected(), is(false));
+        assertThat(mouse.getMajorDeviceClass(), is("Peripheral"));
+    }
+
+    @Test
+    void testParseSystemProfilerNoDevices() {
+        // Controller present but no Connected/Not Connected sections -> no devices
+        assertThat(MacBluetoothDevice.parseSystemProfiler(Arrays.asList("Bluetooth:", "      Bluetooth Controller:",
+                "          Address: AA:BB:CC:DD:EE:FF", "          State: On")), is(empty()));
+        assertThat(MacBluetoothDevice.parseSystemProfiler(Collections.emptyList()), is(empty()));
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
@@ -12,10 +12,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import oshi.hardware.CentralProcessor;
 import oshi.hardware.CentralProcessor.TickType;
 
 class MacCentralProcessorTest {
@@ -39,6 +41,33 @@ class MacCentralProcessorTest {
         StubMacCentralProcessor cpu = new StubMacCentralProcessor(new HashMap<>());
         List<String> flags = cpu.parseX86FeatureFlags();
         assertThat(flags, is(empty()));
+    }
+
+    @Test
+    void testQueryProcessorIdX86() {
+        // A non-Apple brand_string routes queryProcessorId into the x86 (Intel) identity branch, which reads
+        // machdep.cpu.* sysctls directly. Representative Intel values (Core 2 Duo, Penryn family 6 model 23).
+        Map<String, String> strings = new HashMap<>();
+        strings.put("machdep.cpu.brand_string", "Intel(R) Core(TM)2 Duo CPU L9400 @ 1.86GHz");
+        strings.put("machdep.cpu.vendor", "GenuineIntel");
+        Map<String, Integer> ints = new HashMap<>();
+        ints.put("machdep.cpu.family", 6);
+        ints.put("machdep.cpu.model", 23);
+        ints.put("machdep.cpu.stepping", 10);
+        ints.put("machdep.cpu.signature", 0x000106A5);
+        Map<String, Long> longs = new HashMap<>();
+        longs.put("machdep.cpu.feature_bits", 0xBFEBFBFFL);
+        StubMacCentralProcessor cpu = new StubMacCentralProcessor(strings, ints, longs);
+
+        CentralProcessor.ProcessorIdentifier id = cpu.queryProcessorId();
+        assertThat(id.getVendor(), is("GenuineIntel"));
+        assertThat(id.getName(), is("Intel(R) Core(TM)2 Duo CPU L9400 @ 1.86GHz"));
+        assertThat(id.getFamily(), is("6"));
+        assertThat(id.getModel(), is("23"));
+        assertThat(id.getStepping(), is("10"));
+        assertThat(id.isCpu64bit(), is(true));
+        // processorID packs the signature in the low word and the feature bits in the high word
+        assertThat(id.getProcessorID(), is(String.format(Locale.ROOT, "%016x", 0x000106A5L | (0xBFEBFBFFL << 32))));
     }
 
     @Test
@@ -138,6 +167,13 @@ class MacCentralProcessorTest {
 
         StubMacCentralProcessor(Map<String, String> extraStrings) {
             this(extraStrings, new int[0], new int[0], new double[0], 0);
+        }
+
+        StubMacCentralProcessor(Map<String, String> extraStrings, Map<String, Integer> extraInts,
+                Map<String, Long> extraLongs) {
+            this(extraStrings, new int[0], new int[0], new double[0], 0);
+            sysctlInts.putAll(extraInts);
+            sysctlLongs.putAll(extraLongs);
         }
 
         StubMacCentralProcessor(Map<String, String> extraStrings, int[] hostCpuTicks, int[] processorCpuTicks,

--- a/oshi-common/src/test/java/oshi/software/common/os/mac/MacInstalledAppsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/mac/MacInstalledAppsTest.java
@@ -16,6 +16,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import oshi.util.Constants;
+
 class MacInstalledAppsTest {
 
     // Fixture: minimal system_profiler -xml SPApplicationsDataType output
@@ -155,5 +157,35 @@ class MacInstalledAppsTest {
     @Test
     void testUnescapeMixed() {
         assertThat(MacInstalledApps.unescape("a &amp; b &lt; c"), is("a & b < c"));
+    }
+
+    // --- resolveVendor ---
+
+    @Test
+    void testResolveVendorAppleAndAppStore() {
+        assertThat(MacInstalledApps.resolveVendor("apple", "Software Signing"), is("Apple"));
+        assertThat(MacInstalledApps.resolveVendor("mac_app_store", "Apple Mac OS Application Signing"),
+                is("App Store"));
+    }
+
+    @Test
+    void testResolveVendorIdentifiedDeveloper() {
+        // The "Developer ID Application: " prefix is stripped
+        assertThat(
+                MacInstalledApps.resolveVendor("identified_developer", "Developer ID Application: Acme Corp (ABC123)"),
+                is("Acme Corp (ABC123)"));
+        // Without the prefix, the signer is returned as-is
+        assertThat(MacInstalledApps.resolveVendor("identified_developer", "Some Other Signer"),
+                is("Some Other Signer"));
+    }
+
+    @Test
+    void testResolveVendorUnknownAndFallthrough() {
+        // Unknown obtained_from but a known signer -> use the signer
+        assertThat(MacInstalledApps.resolveVendor(Constants.UNKNOWN, "A Signer"), is("A Signer"));
+        // Both unknown -> unknown
+        assertThat(MacInstalledApps.resolveVendor(Constants.UNKNOWN, Constants.UNKNOWN), is(Constants.UNKNOWN));
+        // Any other obtained_from is used verbatim
+        assertThat(MacInstalledApps.resolveVendor("web_download", "irrelevant"), is("web_download"));
     }
 }


### PR DESCRIPTION
## Summary

Coverage-driven (from Codecov cross-OS misses): cover previously-untested macOS command parsing, with fixtures grounded in real command output.

- **`MacBluetoothDevice`** — `parseSystemProfiler` (`system_profiler SPBluetoothDataType`) had no unit coverage. Adds a fixture test for the Connected / Not Connected sections, address upper-casing, Minor Type, Battery Level, and ignored fields. Structure grounded in real output; names/addresses sanitized (public repo).
- **`MacInstalledApps`** — its XML parse helpers were already tested, but the vendor-mapping logic in `queryInstalledApps` was branch-uncovered. Extract `resolveVendor(obtainedFrom, signedBy)` and cover every branch: `apple`/`mac_app_store` display names, `Developer ID Application:` prefix stripping, and the unknown/signer fallbacks. Grounded in the real `obtained_from` values and Developer ID signer format.
- **`MacCentralProcessor`** — the x86 (Intel) branch of `queryProcessorId` (`machdep.cpu.*` vendor/family/model/stepping/signature reads) never runs on Apple-Silicon CI, so it was uncovered. Extend `StubMacCentralProcessor` to inject int/long sysctls and add a test that routes through the x86 branch with a non-Apple brand string and representative Intel (Penryn) values, asserting the resulting `ProcessorIdentifier`. No Intel hardware needed — the stub makes the legacy x86 path deterministic. (The x86 *feature flags* were already stub-tested.)

## Testing

- `oshi-common` full gate green: spotless, checkstyle, install + forbiddenapis, javadoc.
- New/updated tests pass.

No CHANGELOG entry — test/coverage plus a behavior-preserving extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the vendor information displayed for installed macOS applications, including clearer Apple/App Store labeling and identified developer names.

* **Tests**
  * Added coverage for macOS Bluetooth device parsing, including connection status, pairing, device classes, addresses, and battery-level handling.
  * Added validation for installed-application vendor name resolution and fallback behavior.
  * Added coverage for macOS Central Processor identification on the x86/Intel path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
