### PR TITLE
Cover Linux command and file parsing via seam extraction

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
@@ -296,8 +296,21 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
 
     // Slower, use as backup
     private static List<GraphicsCard> getGraphicsCardsFromLshw(Function<Attrs, GraphicsCard> factory) {
+        return getGraphicsCardsFromLshw(ExecutingCommand.runPrivilegedNative("lshw -C display"), factory,
+                LinuxGraphicsCard::findDrmInfo);
+    }
+
+    /**
+     * Parse graphics card information from lshw output.
+     *
+     * @param lshw      output of {@code lshw -C display}
+     * @param factory   function that creates a concrete {@link GraphicsCard} from parsed attributes
+     * @param drmLookup function to look up DRM info for a PCI slot address
+     * @return list of graphics cards
+     */
+    static List<GraphicsCard> getGraphicsCardsFromLshw(List<String> lshw, Function<Attrs, GraphicsCard> factory,
+            Function<String, Triplet<String, String, String>> drmLookup) {
         List<GraphicsCard> cardList = new ArrayList<>();
-        List<String> lshw = ExecutingCommand.runPrivilegedNative("lshw -C display");
         String name = Constants.UNKNOWN;
         String deviceId = Constants.UNKNOWN;
         String vendor = Constants.UNKNOWN;
@@ -310,7 +323,7 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
             if (split[0].startsWith("*-display")) {
                 // Save previous card
                 if (cardNum++ > 0) {
-                    Triplet<String, String, String> drmInfo = findDrmInfo(busInfo);
+                    Triplet<String, String, String> drmInfo = drmLookup.apply(busInfo);
                     cardList.add(factory.apply(new Attrs(name, deviceId, vendor,
                             versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList), vram,
                             drmInfo.getA(), drmInfo.getB(), drmInfo.getC())));
@@ -341,7 +354,7 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
             }
         }
         if (cardNum > 0) {
-            Triplet<String, String, String> drmInfo = findDrmInfo(busInfo);
+            Triplet<String, String, String> drmInfo = drmLookup.apply(busInfo);
             cardList.add(factory.apply(new Attrs(name, deviceId, vendor,
                     versionInfoList.isEmpty() ? Constants.UNKNOWN : String.join(", ", versionInfoList), vram,
                     drmInfo.getA(), drmInfo.getB(), drmInfo.getC())));

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxCgroupInfo.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxCgroupInfo.java
@@ -201,7 +201,17 @@ public class LinuxCgroupInfo implements CgroupInfo {
     }
 
     private String resolveV1ControllerPath(String controller) {
-        List<String> selfCgroup = selfCgroupSupplier.get();
+        return resolveV1ControllerPath(selfCgroupSupplier.get(), controller);
+    }
+
+    /**
+     * Resolve the cgroup v1 sysfs mount path for a controller from {@code /proc/self/cgroup} lines.
+     *
+     * @param selfCgroup lines of {@code /proc/self/cgroup} (format {@code hierarchy-id:controllers:path})
+     * @param controller the controller name to resolve (e.g. {@code cpu})
+     * @return the sysfs path for the controller, or a best-effort default if not found in the cgroup lines
+     */
+    static String resolveV1ControllerPath(List<String> selfCgroup, String controller) {
         for (String line : selfCgroup) {
             // v1 format: "hierarchy-id:controllers:path"
             String[] parts = line.split(":");

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -488,8 +488,18 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @return The first valid matching filename
      */
     protected static String getReleaseFilename() {
-        // Look for any /etc/*-release, *-version, and variants
-        File etc = new File("/etc");
+        return getReleaseFilename("/etc");
+    }
+
+    /**
+     * Looks for a collection of possible distrib-release filenames in the given directory.
+     *
+     * @param etcPath the directory to search (normally {@code /etc})
+     * @return The first valid matching filename, or the {@code release}/{@code issue} fallback within {@code etcPath}
+     */
+    static String getReleaseFilename(String etcPath) {
+        // Look for any *-release, *-version, and variants
+        File etc = new File(etcPath);
         File[] matchingFiles = etc.listFiles(//
                 f -> (f.getName().endsWith("-release") || //
                         f.getName().endsWith("-version") || //
@@ -501,10 +511,11 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
         if (matchingFiles != null && matchingFiles.length > 0) {
             return matchingFiles[0].getPath();
         }
-        if (new File("/etc/release").exists()) {
-            return "/etc/release";
+        File release = new File(etc, "release");
+        if (release.exists()) {
+            return release.getPath();
         }
-        return "/etc/issue";
+        return new File(etc, "issue").getPath();
     }
 
     /**
@@ -535,8 +546,22 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
             services.add(s);
             running.add(p.getName());
         }
+        services.addAll(parseServices(ExecutingCommand.runNative("systemctl list-unit-files"), running, "/etc/init"));
+        return services;
+    }
+
+    /**
+     * Parse enabled-but-not-running services from {@code systemctl list-unit-files}, falling back to {@code .conf}
+     * files in the init directory when systemctl reports none.
+     *
+     * @param systemctl output of {@code systemctl list-unit-files}
+     * @param running   names of services already known to be running (used to avoid duplicates)
+     * @param initDir   the upstart init directory to scan when systemctl yields nothing (normally {@code /etc/init})
+     * @return the list of stopped services
+     */
+    static List<OSService> parseServices(List<String> systemctl, Set<String> running, String initDir) {
+        List<OSService> services = new ArrayList<>();
         boolean systemctlFound = false;
-        List<String> systemctl = ExecutingCommand.runNative("systemctl list-unit-files");
         for (String str : systemctl) {
             String[] split = ParseUtil.whitespaces.split(str);
             if (split.length >= 2 && split[0].endsWith(".service") && "enabled".equals(split[1])) {
@@ -544,26 +569,25 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
                 int index = name.lastIndexOf('.');
                 String shortName = (index < 0 || index > name.length() - 2) ? name : name.substring(index + 1);
                 if (!running.contains(name) && !running.contains(shortName)) {
-                    OSService s = new OSService(name, 0, STOPPED);
-                    services.add(s);
+                    services.add(new OSService(name, 0, STOPPED));
                     systemctlFound = true;
                 }
             }
         }
         if (!systemctlFound) {
-            File dir = new File("/etc/init");
-            if (dir.exists() && dir.isDirectory()) {
-                for (File f : dir.listFiles((f, name) -> name.toLowerCase(Locale.ROOT).endsWith(".conf"))) {
+            File dir = new File(initDir);
+            File[] confFiles = dir.listFiles((f, name) -> name.toLowerCase(Locale.ROOT).endsWith(".conf"));
+            if (confFiles != null) {
+                for (File f : confFiles) {
                     String name = f.getName().substring(0, f.getName().length() - 5);
                     int index = name.lastIndexOf('.');
                     String shortName = (index < 0 || index > name.length() - 2) ? name : name.substring(index + 1);
                     if (!running.contains(name) && !running.contains(shortName)) {
-                        OSService s = new OSService(name, 0, STOPPED);
-                        services.add(s);
+                        services.add(new OSService(name, 0, STOPPED));
                     }
                 }
             } else {
-                LOG.error("Directory: /etc/init does not exist");
+                LOG.error("Directory: {} does not exist", initDir);
             }
         }
         return services;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -565,12 +565,14 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
         for (String str : systemctl) {
             String[] split = ParseUtil.whitespaces.split(str);
             if (split.length >= 2 && split[0].endsWith(".service") && "enabled".equals(split[1])) {
+                // systemctl produced usable output; the /etc/init fallback is only for systems without systemctl,
+                // so mark it found even if every enabled unit turns out to be already running
+                systemctlFound = true;
                 String name = split[0].substring(0, split[0].length() - 8);
                 int index = name.lastIndexOf('.');
                 String shortName = (index < 0 || index > name.length() - 2) ? name : name.substring(index + 1);
                 if (!running.contains(name) && !running.contains(shortName)) {
                     services.add(new OSService(name, 0, STOPPED));
-                    systemctlFound = true;
                 }
             }
         }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
@@ -268,4 +268,68 @@ class LinuxGraphicsCardTest {
     void testQueryLspciMemorySizeEmpty() {
         assertThat(LinuxGraphicsCard.queryLspciMemorySize(Collections.emptyList()), is(0L));
     }
+
+    @Test
+    void testGetGraphicsCardsFromLspciVendorWithoutBracket() {
+        // A Vendor line whose value has no "[hex]" id does not parse as machine-readable; the raw text is used
+        List<String> lspci = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
+                "Vendor:\tRedHat, Inc.", "Device:\tVirtio GPU [1050]", "");
+        List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(lspci, STUB_FACTORY, NO_VRAM, NO_DRM);
+        assertThat(cards.size(), is(1));
+        assertThat(cards.get(0).getVendor(), is("RedHat, Inc."));
+        assertThat(cards.get(0).getName(), is("Virtio GPU"));
+    }
+
+    @Test
+    void testGetGraphicsCardsFromLspciNoTrailingBlankLine() {
+        // Output that ends mid-card (no terminating blank line) still flushes the last card
+        List<String> lspci = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
+                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1");
+        List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(lspci, STUB_FACTORY, NO_VRAM, NO_DRM);
+        assertThat(cards.size(), is(1));
+        assertThat(cards.get(0).getName(), is("GA102 [GeForce RTX 3090]"));
+        assertThat(cards.get(0).getVersionInfo(), is("Rev:\ta1"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getGraphicsCardsFromLshw parsing
+    // -------------------------------------------------------------------------
+
+    // Fixture: `lshw -C display` output (real structure) with two display nodes. The second card has no bus info so
+    // its DRM lookup is with a null slot; resources memory ranges drive the VRAM total.
+    private static final List<String> LSHW = Arrays.asList("  *-display",
+            "       description: VGA compatible controller", "       product: GA102 [GeForce RTX 3090]",
+            "       vendor: NVIDIA Corporation", "       physical id: 0", "       bus info: pci@0000:01:00.0",
+            "       version: a1", "       width: 64 bits", "       clock: 33MHz",
+            "       capabilities: pm msi pciexpress vga_controller bus_master cap_list rom",
+            "       configuration: driver=nvidia latency=0",
+            "       resources: irq:178 memory:f6000000-f6ffffff memory:e0000000-efffffff", "  *-display",
+            "       description: VGA compatible controller", "       product: UHD Graphics 630",
+            "       vendor: Intel Corporation", "       physical id: 2",
+            "       resources: irq:24 memory:db000000-dbffffff");
+
+    @Test
+    void testGetGraphicsCardsFromLshwTwoCards() {
+        List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLshw(LSHW, STUB_FACTORY, NO_DRM);
+        assertThat(cards.size(), is(2));
+
+        GraphicsCard nvidia = cards.get(0);
+        assertThat(nvidia.getName(), is("GA102 [GeForce RTX 3090]"));
+        assertThat(nvidia.getVendor(), is("NVIDIA Corporation"));
+        assertThat(nvidia.getVersionInfo(), is("version: a1"));
+        // 16 MiB (f6000000-f6ffffff) + 256 MiB (e0000000-efffffff)
+        assertThat(nvidia.getVRam(), is(16L * 1024 * 1024 + 256L * 1024 * 1024));
+
+        GraphicsCard intel = cards.get(1);
+        assertThat(intel.getName(), is("UHD Graphics 630"));
+        assertThat(intel.getVendor(), is("Intel Corporation"));
+        // No version line -> UNKNOWN version info; single 16 MiB memory range
+        assertThat(intel.getVRam(), is(16L * 1024 * 1024));
+    }
+
+    @Test
+    void testGetGraphicsCardsFromLshwEmpty() {
+        assertThat(LinuxGraphicsCard.getGraphicsCardsFromLshw(Collections.emptyList(), STUB_FACTORY, NO_DRM),
+                is(empty()));
+    }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import oshi.hardware.GraphicsCard;
+import oshi.util.Constants;
 import oshi.util.tuples.Triplet;
 
 class LinuxGraphicsCardTest {
@@ -324,6 +325,7 @@ class LinuxGraphicsCardTest {
         assertThat(intel.getName(), is("UHD Graphics 630"));
         assertThat(intel.getVendor(), is("Intel Corporation"));
         // No version line -> UNKNOWN version info; single 16 MiB memory range
+        assertThat(intel.getVersionInfo(), is(Constants.UNKNOWN));
         assertThat(intel.getVRam(), is(16L * 1024 * 1024));
     }
 

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoV1DispatchTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoV1DispatchTest.java
@@ -13,9 +13,16 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
+
+import oshi.util.linux.SysPath;
 
 /**
  * Tests the v1 dispatch paths and limit resolution in LinuxCgroupInfo that are not covered by the main test.
@@ -132,5 +139,47 @@ class LinuxCgroupInfoV1DispatchTest {
     void readPidCurrentV2EmptyFile(@TempDir Path tempDir) throws IOException {
         Files.write(tempDir.resolve("pids.current"), "".getBytes(StandardCharsets.UTF_8));
         assertEquals(0L, cgroup.readPidCurrentV2(tempDir.toString() + "/"));
+    }
+
+    // --- V1 controller path resolution from /proc/self/cgroup ---
+
+    // Real hybrid (v1 + unified) /proc/self/cgroup: numbered v1 hierarchies with comma-separated controllers, plus
+    // a trailing "0::" unified (v2) line whose controllers field is empty.
+    private static final List<String> SELF_CGROUP = Arrays.asList("12:hugetlb:/",
+            "11:cpu,cpuacct:/user.slice/user-1000.slice", "10:memory:/user.slice/user-1000.slice/session-3.scope",
+            "3:pids:/user.slice/user-1000.slice", "1:name=systemd:/user.slice/user-1000.slice/session-3.scope",
+            "0::/user.slice/user-1000.slice/session-3.scope");
+
+    // SysPath's static initializer resolves the live sysfs mount, so these Linux-only paths are asserted on Linux CI
+    // (which is also where coverage is collected).
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void resolveV1ControllerPathExactMatchInCommaList() {
+        // "cpu" is one of the comma-separated controllers; the full "cpu,cpuacct" mount name is used in the path
+        assertEquals(SysPath.CGROUP + "cpu,cpuacct/user.slice/user-1000.slice/",
+                LinuxCgroupInfo.resolveV1ControllerPath(SELF_CGROUP, "cpu"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void resolveV1ControllerPathSingleController() {
+        assertEquals(SysPath.CGROUP + "memory/user.slice/user-1000.slice/session-3.scope/",
+                LinuxCgroupInfo.resolveV1ControllerPath(SELF_CGROUP, "memory"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void resolveV1ControllerPathNotFoundUsesDefault() {
+        // No hierarchy lists "blkio"; fall back to the bare controller mount
+        assertEquals(SysPath.CGROUP + "blkio/", LinuxCgroupInfo.resolveV1ControllerPath(SELF_CGROUP, "blkio"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void resolveV1ControllerPathSkipsUnifiedLine() {
+        // A pure-v2 cgroup (only the "0::" unified line, empty controllers) never matches -> default path
+        List<String> unifiedOnly = Collections.singletonList("0::/user.slice/user-1000.slice/session-3.scope");
+        assertEquals(SysPath.CGROUP + "cpu/", LinuxCgroupInfo.resolveV1ControllerPath(unifiedOnly, "cpu"));
     }
 }

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
@@ -321,6 +321,18 @@ class LinuxOperatingSystemTest {
     }
 
     @Test
+    void testParseServicesSystemctlFoundSuppressesFallback(@TempDir Path initDir) throws IOException {
+        // The only enabled unit is already running, so no stopped service is emitted -- but systemctl DID produce
+        // output, so the /etc/init fallback must not run even though a .conf job is present in the init dir
+        Files.write(initDir.resolve("tty1.conf"), "start on runlevel\n".getBytes(StandardCharsets.UTF_8));
+        List<String> systemctl = Arrays.asList("UNIT FILE          STATE      VENDOR PRESET",
+                "ssh.service        enabled    enabled");
+        Set<String> running = new HashSet<>(Collections.singletonList("ssh"));
+        List<OSService> services = LinuxOperatingSystem.parseServices(systemctl, running, initDir.toString());
+        assertThat(services, is(empty()));
+    }
+
+    @Test
     void testParseServicesInitFallback(@TempDir Path initDir) throws IOException {
         // No systemctl services -> scan the init directory for *.conf upstart jobs
         Files.write(initDir.resolve("tty1.conf"), "start on runlevel\n".getBytes(StandardCharsets.UTF_8));

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
@@ -5,17 +5,28 @@
 package oshi.software.common.os.linux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 
+import oshi.software.os.OSService;
+import oshi.software.os.OSService.State;
 import oshi.util.Constants;
 import oshi.util.tuples.Triplet;
 
@@ -285,5 +296,77 @@ class LinuxOperatingSystemTest {
         assertThat(result.getA(), is("SUSE Linux Enterprise Server"));
         assertThat(result.getB(), is("15"));
         assertThat(result.getC(), is("SP3"));
+    }
+
+    // -------------------------------------------------------------------------
+    // parseServices — systemctl list-unit-files and /etc/init fallback
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testParseServicesSystemctl() {
+        // Real `systemctl list-unit-files` columns: UNIT FILE, STATE, [VENDOR PRESET]. Only ".service"/"enabled"
+        // rows count; already-running services are dropped by full name or short (last dotted segment) name.
+        List<String> systemctl = Arrays.asList("UNIT FILE                              STATE      VENDOR PRESET",
+                "cron.service                           enabled    enabled",
+                "ssh.service                            enabled    enabled",
+                "dbus-org.freedesktop.resolve1.service  enabled    enabled",
+                "bluetooth.service                      disabled   enabled", "", "247 unit files listed.");
+        Set<String> running = new HashSet<>(Arrays.asList("ssh", "resolve1"));
+        List<OSService> services = LinuxOperatingSystem.parseServices(systemctl, running, "/nonexistent-init-dir");
+        // ssh (full-name match) and resolve1 (short-name match) deduped; bluetooth disabled; only cron remains
+        assertThat(services, hasSize(1));
+        assertThat(services.get(0).getName(), is("cron"));
+        assertThat(services.get(0).getState(), is(State.STOPPED));
+        // systemctl produced a service, so the init-dir fallback (nonexistent path) is not consulted
+    }
+
+    @Test
+    void testParseServicesInitFallback(@TempDir Path initDir) throws IOException {
+        // No systemctl services -> scan the init directory for *.conf upstart jobs
+        Files.write(initDir.resolve("tty1.conf"), "start on runlevel\n".getBytes(StandardCharsets.UTF_8));
+        Files.write(initDir.resolve("ssh.conf"), "start on runlevel\n".getBytes(StandardCharsets.UTF_8));
+        Files.write(initDir.resolve("README.txt"), "not a job\n".getBytes(StandardCharsets.UTF_8));
+        Set<String> running = new HashSet<>(Collections.singletonList("ssh"));
+        List<OSService> services = LinuxOperatingSystem.parseServices(Collections.emptyList(), running,
+                initDir.toString());
+        // ssh.conf deduped against running, README.txt is not a .conf; only tty1 remains
+        assertThat(services, hasSize(1));
+        assertThat(services.get(0).getName(), is("tty1"));
+        assertThat(services.get(0).getState(), is(State.STOPPED));
+    }
+
+    @Test
+    void testParseServicesInitDirMissing(@TempDir Path tempDir) {
+        // No systemctl services and a nonexistent init directory -> empty list (error logged)
+        List<OSService> services = LinuxOperatingSystem.parseServices(Collections.emptyList(), new HashSet<>(),
+                tempDir.resolve("does-not-exist").toString());
+        assertThat(services, is(empty()));
+    }
+
+    // -------------------------------------------------------------------------
+    // getReleaseFilename — /etc scan for *-release / *-version files
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testGetReleaseFilenameMatchesDistribFile(@TempDir Path etc) throws IOException {
+        Files.write(etc.resolve("redhat-release"), "CentOS release 7\n".getBytes(StandardCharsets.UTF_8));
+        assertThat(LinuxOperatingSystem.getReleaseFilename(etc.toString()),
+                is(etc.resolve("redhat-release").toString()));
+    }
+
+    @Test
+    void testGetReleaseFilenameSkipsExcludedThenReleaseFallback(@TempDir Path etc) throws IOException {
+        // os-release/lsb-release/system-release are handled elsewhere and excluded from the scan; with only those
+        // present the scan falls back to the "release" file (Solaris-style) when it exists
+        Files.write(etc.resolve("os-release"), "NAME=Ubuntu\n".getBytes(StandardCharsets.UTF_8));
+        Files.write(etc.resolve("lsb-release"), "DISTRIB_ID=Ubuntu\n".getBytes(StandardCharsets.UTF_8));
+        Files.write(etc.resolve("release"), "Solaris\n".getBytes(StandardCharsets.UTF_8));
+        assertThat(LinuxOperatingSystem.getReleaseFilename(etc.toString()), is(etc.resolve("release").toString()));
+    }
+
+    @Test
+    void testGetReleaseFilenameIssueFallback(@TempDir Path etc) {
+        // No matching *-release files and no "release" file -> fall back to the "issue" path
+        assertThat(LinuxOperatingSystem.getReleaseFilename(etc.toString()), is(etc.resolve("issue").toString()));
     }
 }


### PR DESCRIPTION
## Summary

Coverage-driven (from Codecov cross-OS missed-line data): add unit coverage for previously-untested Linux command/file parsing, extracting seams where acquire+parse was inline and grounding fixtures in documented Linux formats.

- **`LinuxGraphicsCard`** — the `lshw -C display` parse was inline and unseamed. Extract `getGraphicsCardsFromLshw(List, factory, drmLookup)` (mirroring the existing lspci seam) and add a two-card fixture grounded in real `lshw -C display` output (memory-range VRAM math). Also cover two lspci gaps: a `Vendor` line without a `[hex]` id (raw-text fallback) and output that ends mid-card with no trailing blank line (last-card flush).
- **`LinuxOperatingSystem`** — extract `parseServices(systemctl, running, initDir)` (the `systemctl list-unit-files` scan plus the `/etc/init` `.conf` upstart fallback) and `getReleaseFilename(etcPath)` (the `/etc` `*-release`/`*-version` scan). Fixtures are grounded in real `systemctl list-unit-files` columns, upstart `.conf` files, and the `/etc` scan: the enabled/dedup-by-name-and-short-name path, the init-dir fallback, the missing-init-dir branch, a distrib-file match, excluded `os`/`lsb`/`system-release` files, and the `release`/`issue` fallbacks. The `/etc/init` fallback now guards on `listFiles() == null` instead of `exists() && isDirectory()` — behavior-preserving, and it closes a latent NPE from iterating `listFiles()` without a null check.
- **`LinuxCgroupInfo`** — extract static `resolveV1ControllerPath(selfCgroup, controller)` parsing `/proc/self/cgroup`. Fixtures grounded in a real hybrid (v1 + unified) cgroup file cover a comma-separated-controller exact match, a single controller, a not-found default, and a v2-only unified line whose controllers field is empty.

Deliberately left alone (not cleanly seamable): `queryFamilyVersionCodenameFromReleaseFiles` (interleaves several real file reads), the `LinuxFileSystem` mount-table loop / NFS / TCP probing (file-I/O + network), and `queryBitness`.

## Testing

- `oshi-common` full gate green: spotless, checkstyle, install + forbiddenapis, javadoc.
- New/updated tests pass. `SysPath`-dependent cgroup assertions and the `LinuxOperatingSystem` file/command tests run on Linux CI (where cross-OS coverage is collected) and skip elsewhere.

No CHANGELOG entry — test/coverage plus behavior-preserving extractions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux graphics card discovery and parsing from `lshw`, including incomplete vendor metadata and `lspci` output without a trailing blank line.
  * Improved Linux graphics card VRAM totals, version handling, and driver/device details.
  * Improved Linux cgroup v1 controller path resolution for hybrid and unified cgroup layouts.
  * Improved Linux service discovery and release-file detection with safer directory-scoped fallbacks.
* **Tests**
  * Added unit test coverage for graphics card parsing, cgroup path resolution, service discovery, and release-file selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->