### PR TITLE
Assign volatile path field once in LinuxOSProcess (Coverity CID 1673009)

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -329,12 +329,14 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         String procPidExe = String.format(Locale.ROOT, ProcPath.PID_EXE, getProcessID());
         try {
             Path link = Paths.get(procPidExe);
-            this.path = Files.readSymbolicLink(link).toString();
+            String exePath = Files.readSymbolicLink(link).toString();
             // For some services the symbolic link process has terminated
-            int index = path.indexOf(" (deleted)");
+            int index = exePath.indexOf(" (deleted)");
             if (index != -1) {
-                path = path.substring(0, index);
+                exePath = exePath.substring(0, index);
             }
+            // Assign the volatile field once, after the value is fully computed
+            this.path = exePath;
         } catch (InvalidPathException | IOException | UnsupportedOperationException | SecurityException e) {
             LOG.debug("Unable to open symbolic link {}", procPidExe);
         }


### PR DESCRIPTION
Coverity CID 1673009 (VOLATILE_ATOMICITY, CWE-366): *Volatile not atomically updated*, in `LinuxOSProcess.updateAttributesFromProc()`.

The method wrote the volatile `path` field, then read it back twice to strip a trailing `" (deleted)"` suffix and wrote it again:

```java
this.path = Files.readSymbolicLink(link).toString();
int index = path.indexOf(" (deleted)");
if (index != -1) {
    path = path.substring(0, index);
}
```

That read-modify-write on a volatile is not atomic. A concurrent `updateAttributes()` on the same process object can interleave between the read and the second write, so an intervening update is overwritten by a substring computed from the stale value. It also leaves a window in which readers observe the untrimmed `... (deleted)` path.

Fix: compute the trimmed value in a local and assign the volatile exactly once.

No other behavior change — nothing between the old first write and the final value can throw, so the `catch` block still leaves the previous `path` in place on failure. This was the only occurrence of the pattern in the codebase.

No CHANGELOG entry: not user-observable behavior.

Pre-commit gate run on `oshi-common` (spotless, checkstyle, install, forbiddenapis, javadoc) — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRQiZ6VMVauZtarHrhnmhU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process path reporting for executables that have been deleted while still running.
  * Removed the trailing “(deleted)” marker from displayed executable paths for cleaner, more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->