### PR TITLE
Consolidate sysctl utilities into shared helpers and fix int-width sysctl misread (#3517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#3504](https://github.com/oshi/oshi/pull/3504): Fix AIX processor cache detection, which read the POWER generation from the hostname (`uname -n`) instead of `prtconf`'s `Processor Version` field, causing `getProcessorCaches()` to return an empty list - [@dbwiddis](https://github.com/dbwiddis).
 * [#3505](https://github.com/oshi/oshi/pull/3505): Fix the AIX FFM backend reading `perfstat_partition_config_t.processorMHz` at the wrong struct offset (344 instead of 340), which reported the processor's vendor frequency as unknown - [@dbwiddis](https://github.com/dbwiddis).
 * [#3507](https://github.com/oshi/oshi/pull/3507): Extend the native-free provider (`oshi-common` alone, no JNA or FFM) to NetBSD, so NetBSD users without the JNA native library can depend on `oshi-common` without `--enable-native-access`, as Linux already can - [@dbwiddis](https://github.com/dbwiddis).
+* [#3518](https://github.com/oshi/oshi/pull/3518): Consolidate the duplicated `sysctl` utility code into shared command-line (`BsdSysctlUtil`), JNA (`SysctlUtilJNA`), and FFM (`SysctlFFM`) helpers, and fix a latent bug where reading an int-width sysctl (e.g. FreeBSD `hw.clockrate`) through the `long` API returned uninitialized bytes, intermittently reporting an absurd CPU vendor frequency such as 6.2 EHz - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18)
 

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -58,6 +58,7 @@ module com.github.oshi.common {
     exports oshi.software.os;
     exports oshi.spi;
     exports oshi.util;
+    exports oshi.util.common.platform.unix.bsd;
     exports oshi.util.common.platform.unix.dragonflybsd;
     exports oshi.util.common.platform.unix.freebsd;
     exports oshi.util.common.platform.unix.netbsd;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -11,7 +11,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.platform.unix.BsdCentralProcessor;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 import oshi.util.tuples.Pair;
 
 /**
@@ -31,32 +31,32 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
 
     @Override
     protected int sysctl(String name, int def) {
-        return NetBsdSysctlUtil.sysctl(name, def);
+        return BsdSysctlUtil.sysctl(name, def);
     }
 
     @Override
     protected ProcessorIdentifier queryProcessorId() {
-        String cpuVendor = NetBsdSysctlUtil.sysctl("machdep.cpu_vendor", "");
+        String cpuVendor = BsdSysctlUtil.sysctl("machdep.cpu_vendor", "");
         if (cpuVendor.isEmpty()) {
             cpuVendor = ExecutingCommand.getFirstAnswer("sysctl -n machdep.dmi.processor-vendor").trim();
         }
-        String cpuName = NetBsdSysctlUtil.sysctl("machdep.cpu_brand", "");
+        String cpuName = BsdSysctlUtil.sysctl("machdep.cpu_brand", "");
         if (cpuName.isEmpty()) {
-            cpuName = NetBsdSysctlUtil.sysctl("hw.model", "");
+            cpuName = BsdSysctlUtil.sysctl("hw.model", "");
         }
         String[] fms = parseFamilyModelStepping(ExecutingCommand.runNative("dmesg"));
         String cpuFamily = fms[0];
         String cpuModel = fms[1];
         String cpuStepping = fms[2];
         String processorID = "";
-        long cpuFreq = NetBsdSysctlUtil.sysctl("machdep.tsc_freq", 0L);
+        long cpuFreq = BsdSysctlUtil.sysctl("machdep.tsc_freq", 0L);
         if (cpuFreq == 0L) {
             cpuFreq = ParseUtil.parseHertz(cpuName);
             if (cpuFreq < 0) {
                 cpuFreq = queryMaxFreq();
             }
         }
-        String machine = NetBsdSysctlUtil.sysctl("hw.machine", "");
+        String machine = BsdSysctlUtil.sysctl("hw.machine", "");
         boolean cpu64bit = machine != null && machine.contains("64")
                 || ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
 
@@ -68,7 +68,7 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
     protected long[] queryCurrentFreq() {
         long[] freq = new long[1];
         // machdep.tsc_freq gives frequency in Hz on x86
-        freq[0] = NetBsdSysctlUtil.sysctl("machdep.tsc_freq", 0L);
+        freq[0] = BsdSysctlUtil.sysctl("machdep.tsc_freq", 0L);
         if (freq[0] == 0L) {
             // Fallback: parse from cpu name (e.g., "Intel ... @ 2.10GHz")
             freq[0] = queryMaxFreq();

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdComputerSystem.java
@@ -14,7 +14,7 @@ import oshi.hardware.Firmware;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.hardware.common.platform.unix.UnixBaseboard;
 import oshi.util.Constants;
-import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 
 /**
  * NetBSD ComputerSystem implementation
@@ -58,22 +58,22 @@ public class NetBsdComputerSystem extends AbstractComputerSystem {
     @Override
     protected Baseboard createBaseboard() {
         return new UnixBaseboard(manufacturer.get(), model.get(), serialNumber.get(),
-                NetBsdSysctlUtil.sysctl("hw.product", Constants.UNKNOWN));
+                BsdSysctlUtil.sysctl("hw.product", Constants.UNKNOWN));
     }
 
     private static String queryManufacturer() {
-        return NetBsdSysctlUtil.sysctl("hw.vendor", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.vendor", Constants.UNKNOWN);
     }
 
     private static String queryModel() {
-        return NetBsdSysctlUtil.sysctl("hw.version", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.version", Constants.UNKNOWN);
     }
 
     private static String querySerialNumber() {
-        return NetBsdSysctlUtil.sysctl("hw.serialno", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.serialno", Constants.UNKNOWN);
     }
 
     private static String queryUUID() {
-        return NetBsdSysctlUtil.sysctl("hw.uuid", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.uuid", Constants.UNKNOWN);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdGlobalMemory.java
@@ -14,7 +14,7 @@ import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.AbstractGlobalMemory;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 
 /**
  * Memory obtained by sysctl and vmstat
@@ -64,11 +64,11 @@ final class NetBsdGlobalMemory extends AbstractGlobalMemory {
     }
 
     private static long queryPhysMem() {
-        return NetBsdSysctlUtil.sysctl("hw.physmem64", 0L);
+        return BsdSysctlUtil.sysctl("hw.physmem64", 0L);
     }
 
     private static long queryPageSize() {
-        return NetBsdSysctlUtil.sysctl("hw.pagesize", 4096L);
+        return BsdSysctlUtil.sysctl("hw.pagesize", 4096L);
     }
 
     private VirtualMemory createVirtualMemory() {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
@@ -20,7 +20,7 @@ import oshi.hardware.HWPartition;
 import oshi.hardware.common.AbstractHWDiskStore;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 import oshi.util.tuples.Quartet;
 
 /**
@@ -49,7 +49,7 @@ public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
 
         // Get list of disks from sysctl
         // NetBSD: hw.disknames = ld0 fd0 dk0 dk1 cd0 (space-separated, no colon suffix)
-        String[] devices = NetBsdSysctlUtil.sysctl("hw.disknames", "").trim().split("\\s+");
+        String[] devices = BsdSysctlUtil.sysctl("hw.disknames", "").trim().split("\\s+");
         NetBsdHWDiskStore store;
         for (String diskName : devices) {
             // Try disklabel first (works for physical disks, not wedges)

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
@@ -17,7 +17,7 @@ import oshi.software.os.OSFileStore;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileSystemUtil;
 import oshi.util.ParseUtil;
-import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 import oshi.util.tuples.Pair;
 
 /**
@@ -151,16 +151,16 @@ public class NetBsdFileSystem extends AbstractFileSystem {
 
     @Override
     public long getOpenFileDescriptors() {
-        return NetBsdSysctlUtil.sysctl("kern.nfiles", 0);
+        return BsdSysctlUtil.sysctl("kern.nfiles", 0);
     }
 
     @Override
     public long getMaxFileDescriptors() {
-        return NetBsdSysctlUtil.sysctl("kern.maxfiles", 0);
+        return BsdSysctlUtil.sysctl("kern.maxfiles", 0);
     }
 
     @Override
     public long getMaxFileDescriptorsPerProcess() {
-        return NetBsdSysctlUtil.sysctl("kern.maxfilesperproc", 0);
+        return BsdSysctlUtil.sysctl("kern.maxfilesperproc", 0);
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -40,8 +40,8 @@ import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 import oshi.util.common.platform.unix.netbsd.FstatUtil;
-import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
 
 /**
  * OSProcess implementation
@@ -110,9 +110,9 @@ public class NetBsdOSProcess extends BsdOSProcess {
     @Override
     public long getSoftOpenFileLimit() {
         if (getProcessID() == this.os.getProcessId()) {
-            long limit = NetBsdSysctlUtil.sysctl("kern.maxfilesperproc", 0L);
+            long limit = BsdSysctlUtil.sysctl("kern.maxfilesperproc", 0L);
             if (limit <= 0) {
-                limit = NetBsdSysctlUtil.sysctl("kern.maxfiles", 0L);
+                limit = BsdSysctlUtil.sysctl("kern.maxfiles", 0L);
             }
             return limit > 0 ? limit : -1L;
         }
@@ -122,7 +122,7 @@ public class NetBsdOSProcess extends BsdOSProcess {
     @Override
     public long getHardOpenFileLimit() {
         if (getProcessID() == this.os.getProcessId()) {
-            long limit = NetBsdSysctlUtil.sysctl("kern.maxfiles", 0L);
+            long limit = BsdSysctlUtil.sysctl("kern.maxfiles", 0L);
             return limit > 0 ? limit : -1L;
         }
         return -1L;
@@ -154,7 +154,7 @@ public class NetBsdOSProcess extends BsdOSProcess {
             }
         }
         // Not bound — return all CPUs
-        int ncpu = NetBsdSysctlUtil.sysctl("hw.ncpuonline", 1);
+        int ncpu = BsdSysctlUtil.sysctl("hw.ncpuonline", 1);
         return ncpu < 64 ? (1L << ncpu) - 1 : -1L;
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
@@ -19,7 +19,7 @@ import oshi.software.os.OSProcess;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 import oshi.util.tuples.Pair;
 
 /**
@@ -35,9 +35,9 @@ public class NetBsdOperatingSystem extends BsdOperatingSystem {
 
     @Override
     public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        String family = NetBsdSysctlUtil.sysctl("kern.ostype", "NetBSD");
-        String version = NetBsdSysctlUtil.sysctl("kern.osrelease", "");
-        String versionInfo = NetBsdSysctlUtil.sysctl("kern.version", "");
+        String family = BsdSysctlUtil.sysctl("kern.ostype", "NetBSD");
+        String version = BsdSysctlUtil.sysctl("kern.osrelease", "");
+        String versionInfo = BsdSysctlUtil.sysctl("kern.version", "");
         String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
 
         return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/bsd/BsdSysctlUtil.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/bsd/BsdSysctlUtil.java
@@ -2,22 +2,23 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.util.common.platform.unix.netbsd;
+package oshi.util.common.platform.unix.bsd;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 /**
- * Provides access to sysctl calls on NetBSD via command-line execution. This implementation does not require JNA native
- * library support.
+ * Provides access to sysctl calls on BSD-family operating systems (FreeBSD, OpenBSD, NetBSD, macOS) via command-line
+ * execution of {@code sysctl -n}. This implementation does not require JNA or FFM native library support and serves as
+ * the native-free implementation as well as the fallback path for the JNA and FFM implementations.
  */
 @ThreadSafe
-public final class NetBsdSysctlUtil {
+public final class BsdSysctlUtil {
 
     private static final String SYSCTL_N = "sysctl -n ";
 
-    private NetBsdSysctlUtil() {
+    private BsdSysctlUtil() {
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/bsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/bsd/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides utilities shared across BSD-family operating systems
+ */
+package oshi.util.common.platform.unix.bsd;

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -59,6 +59,8 @@
 --add-opens
   com.github.oshi.common/oshi.software.common.os.unix.dragonflybsd=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.util.common.platform.unix.bsd=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.util.common.platform.unix.dragonflybsd=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.driver.common.unix.solaris.disk=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/bsd/BsdSysctlUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/bsd/BsdSysctlUtilTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.common.platform.unix.bsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import oshi.util.PlatformEnum;
+
+/**
+ * Tests the command-line {@code sysctl -n} implementation shared across all BSD-family operating systems. Enabled on
+ * every platform that ships a {@code sysctl} command so both the success and failure paths of all three overloads are
+ * exercised.
+ */
+class BsdSysctlUtilTest {
+
+    /** Platforms that provide a {@code sysctl} command whose {@code -n} flag prints a bare value. */
+    private static final Set<PlatformEnum> SYSCTL_PLATFORMS = EnumSet.of(PlatformEnum.MACOS, PlatformEnum.FREEBSD,
+            PlatformEnum.OPENBSD, PlatformEnum.NETBSD, PlatformEnum.DRAGONFLYBSD);
+
+    /**
+     * Condition method for {@link EnabledIf}: true when the current platform ships {@code sysctl}.
+     *
+     * @return whether the sysctl command-line tests should run
+     */
+    static boolean hasSysctlCommand() {
+        return SYSCTL_PLATFORMS.contains(PlatformEnum.getCurrentPlatform());
+    }
+
+    @Test
+    @EnabledIf("hasSysctlCommand")
+    void testSysctlStringSuccess() {
+        // kern.ostype is present on macOS and every BSD; its value is the kernel name.
+        assertThat("kern.ostype should not be empty", BsdSysctlUtil.sysctl("kern.ostype", ""), is(not("")));
+    }
+
+    @Test
+    @EnabledIf("hasSysctlCommand")
+    void testSysctlStringFailureReturnsDefault() {
+        assertThat(BsdSysctlUtil.sysctl("invalid.bogus.name", "mydefault"), is("mydefault"));
+    }
+
+    @Test
+    @EnabledIf("hasSysctlCommand")
+    void testSysctlIntSuccess() {
+        // hw.pagesize is a positive int on macOS and every BSD.
+        assertThat("hw.pagesize should be positive", BsdSysctlUtil.sysctl("hw.pagesize", 0), greaterThan(0));
+    }
+
+    @Test
+    @EnabledIf("hasSysctlCommand")
+    void testSysctlIntFailureReturnsDefault() {
+        assertThat(BsdSysctlUtil.sysctl("invalid.bogus.name", -99), is(-99));
+    }
+
+    @Test
+    @EnabledIf("hasSysctlCommand")
+    void testSysctlLongSuccess() {
+        // hw.pagesize also parses as a positive long.
+        assertThat("hw.pagesize should be positive", BsdSysctlUtil.sysctl("hw.pagesize", 0L), greaterThan(0L));
+    }
+
+    @Test
+    @EnabledIf("hasSysctlCommand")
+    void testSysctlLongFailureReturnsDefault() {
+        assertThat(BsdSysctlUtil.sysctl("invalid.bogus.name", -123L), is(-123L));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/SysctlFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/SysctlFFM.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.util;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.ParseUtil;
+
+/**
+ * Shared implementation of the FFM {@code sysctl} result handling used by the per-platform utility classes. The only
+ * per-platform difference is the native call itself (macOS and FreeBSD use {@code sysctlbyname(String)}; OpenBSD uses
+ * {@code sysctl(int[])}); callers supply that call as a {@link SysctlOp} so the arena management, buffer sizing, and
+ * result decoding live in one place. The {@code SysctlOp} is responsible for allocating its own name/MIB segment,
+ * invoking the native function, and logging any errno on failure.
+ */
+@ThreadSafe
+public final class SysctlFFM {
+
+    /** All supported platforms define {@code size_t} as an unsigned 64-bit value. */
+    public static final ValueLayout.OfLong SIZE_T = JAVA_LONG;
+
+    private SysctlFFM() {
+    }
+
+    /**
+     * A single native {@code sysctl}/{@code sysctlbyname} invocation. Implementations allocate their name or MIB
+     * segment from the supplied arena, invoke the native function, log any errno on failure, and report success.
+     */
+    @FunctionalInterface
+    public interface SysctlOp {
+        /**
+         * Invokes the bound native sysctl call.
+         *
+         * @param arena   the confined arena for any scratch allocations
+         * @param oldp    buffer to receive the result, or {@link MemorySegment#NULL} to query the required size
+         * @param oldlenp in/out size of {@code oldp}
+         * @return {@code true} on success; {@code false} on failure
+         * @throws Throwable on FFM invocation error
+         */
+        boolean invoke(Arena arena, MemorySegment oldp, MemorySegment oldlenp) throws Throwable;
+    }
+
+    /**
+     * Executes a sysctl call with an int result.
+     *
+     * @param op   the bound native sysctl call
+     * @param def  default int value
+     * @param log  logger for the calling class
+     * @param name name of the sysctl, for logging
+     * @return The int result of the call if successful; the default otherwise
+     */
+    public static int sysctl(SysctlOp op, int def, Logger log, Object name) {
+        return callInArenaIntOrDefault(arena -> {
+            MemorySegment valueSeg = arena.allocate(JAVA_INT);
+            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_INT.byteSize());
+            if (!op.invoke(arena, valueSeg, sizeSeg)) {
+                return def;
+            }
+            return valueSeg.get(JAVA_INT, 0);
+        }, log, Level.WARN, "Failed to get sysctl value for " + name, def);
+    }
+
+    /**
+     * Executes a sysctl call with a long result.
+     *
+     * @param op   the bound native sysctl call
+     * @param def  default long value
+     * @param log  logger for the calling class
+     * @param name name of the sysctl, for logging
+     * @return The long result of the call if successful; the default otherwise
+     */
+    public static long sysctl(SysctlOp op, long def, Logger log, Object name) {
+        return callInArenaLongOrDefault(arena -> {
+            MemorySegment valueSeg = arena.allocate(JAVA_LONG);
+            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_LONG.byteSize());
+            if (!op.invoke(arena, valueSeg, sizeSeg)) {
+                return def;
+            }
+            // Some OIDs exposed as a "long" are actually kernel ints (e.g. FreeBSD hw.clockrate is a 4-byte int).
+            // sysctl updates oldlenp in place with the number of bytes actually written, so read only that many,
+            // widening a 4-byte int as unsigned.
+            return sizeSeg.get(SIZE_T, 0) == JAVA_INT.byteSize()
+                    ? ParseUtil.unsignedIntToLong(valueSeg.get(JAVA_INT, 0))
+                    : valueSeg.get(JAVA_LONG, 0);
+        }, log, Level.WARN, "Failed to get sysctl value for " + name, def);
+    }
+
+    /**
+     * Executes a sysctl call with a String result.
+     *
+     * @param op   the bound native sysctl call
+     * @param def  default String value
+     * @param log  logger for the calling class
+     * @param name name of the sysctl, for logging
+     * @return The String result of the call if successful; the default otherwise
+     */
+    public static String sysctl(SysctlOp op, String def, Logger log, Object name) {
+        return callInArenaOrDefault(arena -> {
+            MemorySegment sizeSeg = arena.allocate(SIZE_T);
+            if (!op.invoke(arena, MemorySegment.NULL, sizeSeg)) {
+                return def;
+            }
+            long size = sizeSeg.get(SIZE_T, 0);
+            MemorySegment valueSeg = arena.allocate(size + 1);
+            if (!op.invoke(arena, valueSeg, sizeSeg)) {
+                return def;
+            }
+            return valueSeg.getString(0);
+        }, log, Level.WARN, "Failed to get sysctl value for " + name, def);
+    }
+
+    /**
+     * Executes a sysctl call that populates a caller-provided struct segment.
+     *
+     * @param op     the bound native sysctl call
+     * @param struct segment sized to the expected struct layout
+     * @param log    logger for the calling class
+     * @param name   name of the sysctl, for logging
+     * @return {@code true} if the struct was populated, {@code false} otherwise
+     */
+    public static boolean sysctl(SysctlOp op, MemorySegment struct, Logger log, Object name) {
+        return callInArenaBooleanOrDefault(arena -> {
+            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, struct.byteSize());
+            return op.invoke(arena, struct, sizeSeg);
+        }, log, Level.WARN, "Failed to get sysctl value for " + name, false);
+    }
+
+    /**
+     * Executes a sysctl call returning a freshly allocated buffer of the natural size.
+     *
+     * @param op   the bound native sysctl call
+     * @param log  logger for the calling class
+     * @param name name of the sysctl, for logging
+     * @return an auto-arena {@link MemorySegment} containing the result on success; {@code null} otherwise
+     */
+    public static MemorySegment sysctl(SysctlOp op, Logger log, Object name) {
+        return callInArenaOrDefault(arena -> {
+            MemorySegment sizeSeg = arena.allocate(SIZE_T);
+            if (!op.invoke(arena, MemorySegment.NULL, sizeSeg)) {
+                return null;
+            }
+            long size = sizeSeg.get(SIZE_T, 0);
+            MemorySegment valueSeg = arena.allocate(size);
+            if (!op.invoke(arena, valueSeg, sizeSeg)) {
+                return null;
+            }
+            MemorySegment returnSeg = Arena.ofAuto().allocate(size);
+            returnSeg.copyFrom(valueSeg);
+            return returnSeg;
+        }, log, Level.WARN, "Failed to get sysctl value for " + name, null);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SysctlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SysctlUtilFFM.java
@@ -5,14 +5,10 @@
 package oshi.ffm.util.platform.mac;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
-import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
-import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
-import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.ForeignFunctions.getErrno;
-import static oshi.ffm.platform.mac.MacSystemFunctions.SIZE_T;
+import static oshi.ffm.util.SysctlFFM.SIZE_T;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -24,6 +20,7 @@ import org.slf4j.event.Level;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.mac.MacSystemFunctions;
+import oshi.ffm.util.SysctlFFM;
 
 /**
  * Provides access to sysctl calls on macOS
@@ -58,15 +55,8 @@ public final class SysctlUtilFFM {
      * @return The int result of the call if successful; the default otherwise
      */
     public static int sysctl(String name, int def, boolean logWarning) {
-        return callInArenaIntOrDefault(arena -> {
-            MemorySegment nameSeg = arena.allocateFrom(name);
-            MemorySegment valueSeg = arena.allocate(JAVA_INT);
-            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_INT.byteSize());
-            if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg, logWarning)) {
-                return def;
-            }
-            return valueSeg.get(JAVA_INT, 0);
-        }, LOG, logWarning ? Level.WARN : Level.DEBUG, "Failed to get sysctl value for " + name, def);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlbyname(arena, name, oldp, oldlenp, logWarning), def,
+                LOG, name);
     }
 
     /**
@@ -77,15 +67,8 @@ public final class SysctlUtilFFM {
      * @return The long result of the call if successful; the default otherwise
      */
     public static long sysctl(String name, long def) {
-        return callInArenaLongOrDefault(arena -> {
-            MemorySegment nameSeg = arena.allocateFrom(name);
-            MemorySegment valueSeg = arena.allocate(JAVA_LONG);
-            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_LONG.byteSize());
-            if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg, true)) {
-                return def;
-            }
-            return valueSeg.get(JAVA_LONG, 0);
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, def);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlbyname(arena, name, oldp, oldlenp, true), def, LOG,
+                name);
     }
 
     /**
@@ -108,19 +91,8 @@ public final class SysctlUtilFFM {
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(String name, String def, boolean logWarning) {
-        return callInArenaOrDefault(arena -> {
-            MemorySegment nameSeg = arena.allocateFrom(name);
-            MemorySegment sizeSeg = arena.allocate(SIZE_T);
-            if (!sysctlbyname(arena, nameSeg, MemorySegment.NULL, sizeSeg, logWarning)) {
-                return def;
-            }
-            long size = sizeSeg.get(SIZE_T, 0);
-            MemorySegment valueSeg = arena.allocate(size + 1);
-            if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg, logWarning)) {
-                return def;
-            }
-            return valueSeg.getString(0);
-        }, LOG, logWarning ? Level.WARN : Level.DEBUG, "Failed to get sysctl value for " + name, def);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlbyname(arena, name, oldp, oldlenp, logWarning), def,
+                LOG, name);
     }
 
     /**
@@ -131,11 +103,8 @@ public final class SysctlUtilFFM {
      * @return True if structure is successfuly populated, false otherwise
      */
     public static boolean sysctl(String name, MemorySegment struct) {
-        return callInArenaBooleanOrDefault(arena -> {
-            MemorySegment nameSeg = arena.allocateFrom(name);
-            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, struct.byteSize());
-            return sysctlbyname(arena, nameSeg, struct, sizeSeg, true);
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, false);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlbyname(arena, name, oldp, oldlenp, true), struct, LOG,
+                name);
     }
 
     /**
@@ -146,21 +115,7 @@ public final class SysctlUtilFFM {
      *         undefined.
      */
     public static MemorySegment sysctl(String name) {
-        return callInArenaOrDefault(arena -> {
-            MemorySegment nameSeg = arena.allocateFrom(name);
-            MemorySegment sizeSeg = arena.allocate(SIZE_T);
-            if (!sysctlbyname(arena, nameSeg, MemorySegment.NULL, sizeSeg, true)) {
-                return null;
-            }
-            long size = sizeSeg.get(SIZE_T, 0);
-            MemorySegment valueSeg = arena.allocate(size);
-            if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg, true)) {
-                return null;
-            }
-            MemorySegment returnSeg = Arena.ofAuto().allocate(size);
-            returnSeg.copyFrom(valueSeg);
-            return returnSeg;
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, null);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlbyname(arena, name, oldp, oldlenp, true), LOG, name);
     }
 
     /**
@@ -186,10 +141,11 @@ public final class SysctlUtilFFM {
         }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), -1L);
     }
 
-    private static boolean sysctlbyname(Arena arena, MemorySegment name, MemorySegment oldp, MemorySegment oldlenp,
+    private static boolean sysctlbyname(Arena arena, String name, MemorySegment oldp, MemorySegment oldlenp,
             boolean logWarning) throws Throwable {
+        MemorySegment nameSeg = arena.allocateFrom(name);
         MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
-        var result = MacSystemFunctions.sysctlbyname(callState, name, oldp, oldlenp, MemorySegment.NULL, 0L);
+        int result = MacSystemFunctions.sysctlbyname(callState, nameSeg, oldp, oldlenp, MemorySegment.NULL, 0L);
         if (result != 0) {
             if (logWarning) {
                 LOG.warn(SYSCTL_FAIL, name, getErrno(callState));

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/freebsd/BsdSysctlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/freebsd/BsdSysctlUtilFFM.java
@@ -4,25 +4,18 @@
  */
 package oshi.ffm.util.platform.unix.freebsd;
 
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
-import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
-import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
-import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
-import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.ForeignFunctions.getErrno;
-import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.SIZE_T;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
+import oshi.ffm.util.SysctlFFM;
 
 /**
  * Provides access to sysctl calls on FreeBSD via the FFM API.
@@ -48,15 +41,7 @@ public final class BsdSysctlUtilFFM {
      * @return The int result of the call if successful; the default otherwise
      */
     public static int sysctl(String name, int def) {
-        return callInArenaIntOrDefault(arena -> {
-            MemorySegment nameSeg = arena.allocateFrom(name);
-            MemorySegment valueSeg = arena.allocate(JAVA_INT);
-            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_INT.byteSize());
-            if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg)) {
-                return def;
-            }
-            return valueSeg.get(JAVA_INT, 0);
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, def);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlbyname(arena, name, oldp, oldlenp), def, LOG, name);
     }
 
     /**
@@ -67,15 +52,7 @@ public final class BsdSysctlUtilFFM {
      * @return The long result of the call if successful; the default otherwise
      */
     public static long sysctl(String name, long def) {
-        return callInArenaLongOrDefault(arena -> {
-            MemorySegment nameSeg = arena.allocateFrom(name);
-            MemorySegment valueSeg = arena.allocate(JAVA_LONG);
-            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_LONG.byteSize());
-            if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg)) {
-                return def;
-            }
-            return valueSeg.get(JAVA_LONG, 0);
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, def);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlbyname(arena, name, oldp, oldlenp), def, LOG, name);
     }
 
     /**
@@ -86,19 +63,7 @@ public final class BsdSysctlUtilFFM {
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(String name, String def) {
-        return callInArenaOrDefault(arena -> {
-            MemorySegment nameSeg = arena.allocateFrom(name);
-            MemorySegment sizeSeg = arena.allocate(SIZE_T);
-            if (!sysctlbyname(arena, nameSeg, MemorySegment.NULL, sizeSeg)) {
-                return def;
-            }
-            long size = sizeSeg.get(SIZE_T, 0);
-            MemorySegment valueSeg = arena.allocate(size + 1);
-            if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg)) {
-                return def;
-            }
-            return valueSeg.getString(0);
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, def);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlbyname(arena, name, oldp, oldlenp), def, LOG, name);
     }
 
     /**
@@ -109,11 +74,7 @@ public final class BsdSysctlUtilFFM {
      * @return {@code true} if the struct was populated, {@code false} otherwise
      */
     public static boolean sysctl(String name, MemorySegment struct) {
-        return callInArenaBooleanOrDefault(arena -> {
-            MemorySegment nameSeg = arena.allocateFrom(name);
-            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, struct.byteSize());
-            return sysctlbyname(arena, nameSeg, struct, sizeSeg);
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, false);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlbyname(arena, name, oldp, oldlenp), struct, LOG, name);
     }
 
     /**
@@ -123,31 +84,18 @@ public final class BsdSysctlUtilFFM {
      * @return an auto-arena {@link MemorySegment} containing the result on success; {@code null} otherwise
      */
     public static MemorySegment sysctl(String name) {
-        return callInArenaOrDefault(arena -> {
-            MemorySegment nameSeg = arena.allocateFrom(name);
-            MemorySegment sizeSeg = arena.allocate(SIZE_T);
-            if (!sysctlbyname(arena, nameSeg, MemorySegment.NULL, sizeSeg)) {
-                return null;
-            }
-            long size = sizeSeg.get(SIZE_T, 0);
-            MemorySegment valueSeg = arena.allocate(size);
-            if (!sysctlbyname(arena, nameSeg, valueSeg, sizeSeg)) {
-                return null;
-            }
-            MemorySegment returnSeg = Arena.ofAuto().allocate(size);
-            returnSeg.copyFrom(valueSeg);
-            return returnSeg;
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + name, null);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlbyname(arena, name, oldp, oldlenp), LOG, name);
     }
 
-    private static boolean sysctlbyname(Arena arena, MemorySegment name, MemorySegment oldp, MemorySegment oldlenp)
+    private static boolean sysctlbyname(Arena arena, String name, MemorySegment oldp, MemorySegment oldlenp)
             throws Throwable {
+        MemorySegment nameSeg = arena.allocateFrom(name);
         MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
-        int result = FreeBsdLibcFunctions.sysctlbyname(callState, name, oldp, oldlenp, MemorySegment.NULL, 0L);
+        int result = FreeBsdLibcFunctions.sysctlbyname(callState, nameSeg, oldp, oldlenp, MemorySegment.NULL, 0L);
         if (result != 0) {
             // Guard so the native getErrno read is skipped when WARN is disabled
             if (LOG.isWarnEnabled()) {
-                LOG.warn(SYSCTL_FAIL, name.getString(0), getErrno(callState));
+                LOG.warn(SYSCTL_FAIL, name, getErrno(callState));
             }
             return false;
         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFM.java
@@ -24,8 +24,6 @@ import org.slf4j.event.Level;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
 
 /**
  * Provides access to sysctl calls on OpenBSD via the FFM API.
@@ -35,8 +33,6 @@ import oshi.util.ParseUtil;
  */
 @ThreadSafe
 public final class OpenBsdSysctlUtilFFM {
-
-    private static final String SYSCTL_N = "sysctl -n ";
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenBsdSysctlUtilFFM.class);
 
@@ -138,47 +134,6 @@ public final class OpenBsdSysctlUtilFFM {
             returnSeg.copyFrom(valueSeg);
             return returnSeg;
         }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), null);
-    }
-
-    /*
-     * Backup versions with command parsing
-     */
-
-    /**
-     * Executes a sysctl call with an int result via command line.
-     *
-     * @param name name of the sysctl
-     * @param def  default int value
-     * @return The int result of the call if successful; the default otherwise
-     */
-    public static int sysctl(String name, int def) {
-        return ParseUtil.parseIntOrDefault(ExecutingCommand.getFirstAnswer(SYSCTL_N + name), def);
-    }
-
-    /**
-     * Executes a sysctl call with a long result via command line.
-     *
-     * @param name name of the sysctl
-     * @param def  default long value
-     * @return The long result of the call if successful; the default otherwise
-     */
-    public static long sysctl(String name, long def) {
-        return ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer(SYSCTL_N + name), def);
-    }
-
-    /**
-     * Executes a sysctl call with a String result via command line.
-     *
-     * @param name name of the sysctl
-     * @param def  default String value
-     * @return The String result of the call if successful; the default otherwise
-     */
-    public static String sysctl(String name, String def) {
-        String v = ExecutingCommand.getFirstAnswer(SYSCTL_N + name);
-        if (null == v || v.isEmpty()) {
-            return def;
-        }
-        return v;
     }
 
     private static boolean sysctlMib(Arena arena, int[] mib, MemorySegment oldp, MemorySegment oldlenp)

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFM.java
@@ -5,14 +5,8 @@
 package oshi.ffm.util.platform.unix.openbsd;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
-import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
-import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
-import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
-import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.ForeignFunctions.getErrno;
-import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.SIZE_T;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -20,10 +14,10 @@ import java.util.Arrays;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
+import oshi.ffm.util.SysctlFFM;
 
 /**
  * Provides access to sysctl calls on OpenBSD via the FFM API.
@@ -49,14 +43,8 @@ public final class OpenBsdSysctlUtilFFM {
      * @return The int result of the call if successful; the default otherwise
      */
     public static int sysctl(int[] mib, int def) {
-        return callInArenaIntOrDefault(arena -> {
-            MemorySegment valueSeg = arena.allocate(JAVA_INT);
-            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_INT.byteSize());
-            if (!sysctlMib(arena, mib, valueSeg, sizeSeg)) {
-                return def;
-            }
-            return valueSeg.get(JAVA_INT, 0);
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), def);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlMib(arena, mib, oldp, oldlenp), def, LOG,
+                Arrays.toString(mib));
     }
 
     /**
@@ -67,14 +55,8 @@ public final class OpenBsdSysctlUtilFFM {
      * @return The long result of the call if successful; the default otherwise
      */
     public static long sysctl(int[] mib, long def) {
-        return callInArenaLongOrDefault(arena -> {
-            MemorySegment valueSeg = arena.allocate(JAVA_LONG);
-            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, JAVA_LONG.byteSize());
-            if (!sysctlMib(arena, mib, valueSeg, sizeSeg)) {
-                return def;
-            }
-            return valueSeg.get(JAVA_LONG, 0);
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), def);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlMib(arena, mib, oldp, oldlenp), def, LOG,
+                Arrays.toString(mib));
     }
 
     /**
@@ -85,18 +67,8 @@ public final class OpenBsdSysctlUtilFFM {
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(int[] mib, String def) {
-        return callInArenaOrDefault(arena -> {
-            MemorySegment sizeSeg = arena.allocate(SIZE_T);
-            if (!sysctlMib(arena, mib, MemorySegment.NULL, sizeSeg)) {
-                return def;
-            }
-            long size = sizeSeg.get(SIZE_T, 0);
-            MemorySegment valueSeg = arena.allocate(size + 1);
-            if (!sysctlMib(arena, mib, valueSeg, sizeSeg)) {
-                return def;
-            }
-            return valueSeg.getString(0);
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), def);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlMib(arena, mib, oldp, oldlenp), def, LOG,
+                Arrays.toString(mib));
     }
 
     /**
@@ -107,10 +79,8 @@ public final class OpenBsdSysctlUtilFFM {
      * @return {@code true} if the struct was populated, {@code false} otherwise
      */
     public static boolean sysctl(int[] mib, MemorySegment struct) {
-        return callInArenaBooleanOrDefault(arena -> {
-            MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, struct.byteSize());
-            return sysctlMib(arena, mib, struct, sizeSeg);
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), false);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlMib(arena, mib, oldp, oldlenp), struct, LOG,
+                Arrays.toString(mib));
     }
 
     /**
@@ -120,28 +90,13 @@ public final class OpenBsdSysctlUtilFFM {
      * @return an auto-arena {@link MemorySegment} containing the result on success; {@code null} otherwise
      */
     public static MemorySegment sysctl(int[] mib) {
-        return callInArenaOrDefault(arena -> {
-            MemorySegment sizeSeg = arena.allocate(SIZE_T);
-            if (!sysctlMib(arena, mib, MemorySegment.NULL, sizeSeg)) {
-                return null;
-            }
-            long size = sizeSeg.get(SIZE_T, 0);
-            MemorySegment valueSeg = arena.allocate(size);
-            if (!sysctlMib(arena, mib, valueSeg, sizeSeg)) {
-                return null;
-            }
-            MemorySegment returnSeg = Arena.ofAuto().allocate(size);
-            returnSeg.copyFrom(valueSeg);
-            return returnSeg;
-        }, LOG, Level.WARN, "Failed to get sysctl value for " + Arrays.toString(mib), null);
+        return SysctlFFM.sysctl((arena, oldp, oldlenp) -> sysctlMib(arena, mib, oldp, oldlenp), LOG,
+                Arrays.toString(mib));
     }
 
     private static boolean sysctlMib(Arena arena, int[] mib, MemorySegment oldp, MemorySegment oldlenp)
             throws Throwable {
-        MemorySegment mibSeg = arena.allocate(JAVA_INT, mib.length);
-        for (int i = 0; i < mib.length; i++) {
-            mibSeg.setAtIndex(JAVA_INT, i, mib[i]);
-        }
+        MemorySegment mibSeg = arena.allocateFrom(JAVA_INT, mib);
         MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
         int result = OpenBsdLibcFunctions.sysctl(callState, mibSeg, mib.length, oldp, oldlenp, MemorySegment.NULL, 0L);
         if (result != 0) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorFFM.java
@@ -21,6 +21,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.hardware.common.platform.unix.openbsd.OpenBsdCentralProcessor;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 
 /**
  * OpenBSD Central Processor implementation, backed by FFM sysctl and native library calls.
@@ -32,12 +33,12 @@ public class OpenBsdCentralProcessorFFM extends OpenBsdCentralProcessor {
 
     @Override
     protected int sysctl(String name, int def) {
-        return OpenBsdSysctlUtilFFM.sysctl(name, def);
+        return BsdSysctlUtil.sysctl(name, def);
     }
 
     @Override
     protected String sysctl(String name, String def) {
-        return OpenBsdSysctlUtilFFM.sysctl(name, def);
+        return BsdSysctlUtil.sysctl(name, def);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdComputerSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdComputerSystemFFM.java
@@ -9,13 +9,13 @@ import static oshi.util.Memoizer.memoize;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.Immutable;
-import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.hardware.Baseboard;
 import oshi.hardware.Firmware;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.hardware.common.platform.unix.UnixBaseboard;
 import oshi.hardware.common.platform.unix.openbsd.OpenBsdFirmware;
 import oshi.util.Constants;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 
 /**
  * FFM-backed OpenBSD ComputerSystem implementation.
@@ -59,22 +59,22 @@ public class OpenBsdComputerSystemFFM extends AbstractComputerSystem {
     @Override
     protected Baseboard createBaseboard() {
         return new UnixBaseboard(manufacturer.get(), model.get(), serialNumber.get(),
-                OpenBsdSysctlUtilFFM.sysctl("hw.product", Constants.UNKNOWN));
+                BsdSysctlUtil.sysctl("hw.product", Constants.UNKNOWN));
     }
 
     private static String queryManufacturer() {
-        return OpenBsdSysctlUtilFFM.sysctl("hw.vendor", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.vendor", Constants.UNKNOWN);
     }
 
     private static String queryModel() {
-        return OpenBsdSysctlUtilFFM.sysctl("hw.version", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.version", Constants.UNKNOWN);
     }
 
     private static String querySerialNumber() {
-        return OpenBsdSysctlUtilFFM.sysctl("hw.serialno", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.serialno", Constants.UNKNOWN);
     }
 
     private static String queryUUID() {
-        return OpenBsdSysctlUtilFFM.sysctl("hw.uuid", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.uuid", Constants.UNKNOWN);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdGlobalMemoryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdGlobalMemoryFFM.java
@@ -18,6 +18,7 @@ import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.platform.unix.openbsd.OpenBsdVirtualMemory;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 
 @ThreadSafe
 final class OpenBsdGlobalMemoryFFM extends oshi.hardware.common.platform.unix.openbsd.OpenBsdGlobalMemory {
@@ -46,12 +47,12 @@ final class OpenBsdGlobalMemoryFFM extends oshi.hardware.common.platform.unix.op
 
     @Override
     protected long queryPhysMem() {
-        return OpenBsdSysctlUtilFFM.sysctl("hw.physmem", 0L);
+        return BsdSysctlUtil.sysctl("hw.physmem", 0L);
     }
 
     @Override
     protected long queryPageSize() {
-        return OpenBsdSysctlUtilFFM.sysctl("hw.pagesize", 4096L);
+        return BsdSysctlUtil.sysctl("hw.pagesize", 4096L);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreFFM.java
@@ -8,9 +8,9 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.common.platform.unix.openbsd.OpenBsdHWDiskStore;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 
 /**
  * FFM-backed OpenBSD hard disk implementation.
@@ -29,6 +29,6 @@ public final class OpenBsdHWDiskStoreFFM extends OpenBsdHWDiskStore {
      * @return a list of {@link HWDiskStore} objects representing the disks
      */
     public static List<HWDiskStore> getDisks() {
-        return OpenBsdHWDiskStore.getDisks(OpenBsdSysctlUtilFFM::sysctl, OpenBsdHWDiskStoreFFM::new);
+        return OpenBsdHWDiskStore.getDisks(BsdSysctlUtil::sysctl, OpenBsdHWDiskStoreFFM::new);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdFileSystemFFM.java
@@ -5,8 +5,8 @@
 package oshi.software.os.unix.openbsd;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.software.common.os.unix.openbsd.OpenBsdFileSystem;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 
 /**
  * FFM-backed OpenBSD file system. All file-store enumeration (mount/df parsing) lives on {@link OpenBsdFileSystem};
@@ -17,6 +17,6 @@ public final class OpenBsdFileSystemFFM extends OpenBsdFileSystem {
 
     @Override
     protected long querySysctl(String name) {
-        return OpenBsdSysctlUtilFFM.sysctl(name, 0);
+        return BsdSysctlUtil.sysctl(name, 0);
     }
 }

--- a/oshi-core-ffm/src/test/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/util/platform/unix/openbsd/OpenBsdSysctlUtilFFMTest.java
@@ -87,24 +87,6 @@ class OpenBsdSysctlUtilFFMTest {
     }
 
     @Test
-    void testSysctlCommandLineString() {
-        String osType = OpenBsdSysctlUtilFFM.sysctl("kern.ostype", "");
-        assertThat("Command-line kern.ostype should be OpenBSD", osType, is("OpenBSD"));
-    }
-
-    @Test
-    void testSysctlCommandLineInt() {
-        int pageSize = OpenBsdSysctlUtilFFM.sysctl("hw.pagesize", 0);
-        assertThat("Command-line hw.pagesize should be positive", pageSize, greaterThan(0));
-    }
-
-    @Test
-    void testSysctlCommandLineLong() {
-        long physmem = OpenBsdSysctlUtilFFM.sysctl("hw.physmem", 0L);
-        assertThat("Command-line hw.physmem should be positive", physmem, greaterThan(0L));
-    }
-
-    @Test
     void testGetrlimit() throws Throwable {
         java.lang.foreign.Arena arena = java.lang.foreign.Arena.ofConfined();
         java.lang.foreign.MemorySegment rlim = arena.allocate(OpenBsdLibcFunctions.RLIMIT_LAYOUT);

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdCentralProcessorJNA.java
@@ -14,6 +14,7 @@ import com.sun.jna.Native;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.platform.unix.openbsd.OpenBsdCentralProcessor;
 import oshi.jna.platform.unix.OpenBsdLibc;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
 
 /**
@@ -24,12 +25,12 @@ public class OpenBsdCentralProcessorJNA extends OpenBsdCentralProcessor {
 
     @Override
     protected int sysctl(String name, int def) {
-        return OpenBsdSysctlUtil.sysctl(name, def);
+        return BsdSysctlUtil.sysctl(name, def);
     }
 
     @Override
     protected String sysctl(String name, String def) {
-        return OpenBsdSysctlUtil.sysctl(name, def);
+        return BsdSysctlUtil.sysctl(name, def);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdComputerSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdComputerSystemJNA.java
@@ -15,7 +15,7 @@ import oshi.hardware.common.AbstractComputerSystem;
 import oshi.hardware.common.platform.unix.UnixBaseboard;
 import oshi.hardware.common.platform.unix.openbsd.OpenBsdFirmware;
 import oshi.util.Constants;
-import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 
 /**
  * OpenBSD ComputerSystem implementation
@@ -59,22 +59,22 @@ public class OpenBsdComputerSystemJNA extends AbstractComputerSystem {
     @Override
     protected Baseboard createBaseboard() {
         return new UnixBaseboard(manufacturer.get(), model.get(), serialNumber.get(),
-                OpenBsdSysctlUtil.sysctl("hw.product", Constants.UNKNOWN));
+                BsdSysctlUtil.sysctl("hw.product", Constants.UNKNOWN));
     }
 
     private static String queryManufacturer() {
-        return OpenBsdSysctlUtil.sysctl("hw.vendor", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.vendor", Constants.UNKNOWN);
     }
 
     private static String queryModel() {
-        return OpenBsdSysctlUtil.sysctl("hw.version", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.version", Constants.UNKNOWN);
     }
 
     private static String querySerialNumber() {
-        return OpenBsdSysctlUtil.sysctl("hw.serialno", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.serialno", Constants.UNKNOWN);
     }
 
     private static String queryUUID() {
-        return OpenBsdSysctlUtil.sysctl("hw.uuid", Constants.UNKNOWN);
+        return BsdSysctlUtil.sysctl("hw.uuid", Constants.UNKNOWN);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdGlobalMemoryJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdGlobalMemoryJNA.java
@@ -17,6 +17,7 @@ import oshi.hardware.common.platform.unix.openbsd.OpenBsdVirtualMemory;
 import oshi.jna.platform.unix.OpenBsdLibc.Bcachestats;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
 
 /**
@@ -48,12 +49,12 @@ final class OpenBsdGlobalMemoryJNA extends OpenBsdGlobalMemory {
 
     @Override
     protected long queryPhysMem() {
-        return OpenBsdSysctlUtil.sysctl("hw.physmem", 0L);
+        return BsdSysctlUtil.sysctl("hw.physmem", 0L);
     }
 
     @Override
     protected long queryPageSize() {
-        return OpenBsdSysctlUtil.sysctl("hw.pagesize", 4096L);
+        return BsdSysctlUtil.sysctl("hw.pagesize", 4096L);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/openbsd/OpenBsdHWDiskStoreJNA.java
@@ -10,7 +10,7 @@ import java.util.function.Supplier;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.common.platform.unix.openbsd.OpenBsdHWDiskStore;
-import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 
 /**
  * OpenBSD hard disk implementation.
@@ -29,6 +29,6 @@ public final class OpenBsdHWDiskStoreJNA extends OpenBsdHWDiskStore {
      * @return a list of {@link HWDiskStore} objects representing the disks
      */
     public static List<HWDiskStore> getDisks() {
-        return OpenBsdHWDiskStore.getDisks(OpenBsdSysctlUtil::sysctl, OpenBsdHWDiskStoreJNA::new);
+        return OpenBsdHWDiskStore.getDisks(BsdSysctlUtil::sysctl, OpenBsdHWDiskStoreJNA::new);
     }
 }

--- a/oshi-core/src/main/java/oshi/jna/util/SysctlUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/jna/util/SysctlUtilJNA.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.jna.util;
+
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.platform.unix.LibCAPI.size_t;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.jna.ByRef.CloseableSizeTByReference;
+import oshi.util.ParseUtil;
+
+/**
+ * Shared implementation of the JNA {@code sysctl} result handling used by the per-platform utility classes. The only
+ * per-platform difference is the native call itself (macOS and FreeBSD use {@code sysctlbyname(String)}; NetBSD and
+ * OpenBSD use {@code sysctl(int[])}); callers supply that call as a {@link SysctlCall} so the buffer sizing, error
+ * logging, and result decoding live in one place.
+ */
+@ThreadSafe
+public final class SysctlUtilJNA {
+
+    private static final String SYSCTL_FAIL = "Failed sysctl call: {}, Error code: {}";
+
+    private static final int INT_SIZE = Native.getNativeSize(int.class);
+
+    private static final int UINT64_SIZE = Native.getNativeSize(long.class);
+
+    private SysctlUtilJNA() {
+    }
+
+    /**
+     * A single native {@code sysctl}/{@code sysctlbyname} invocation with the name (String or MIB array) already bound
+     * by the caller.
+     */
+    @FunctionalInterface
+    public interface SysctlCall {
+        /**
+         * Invokes the bound native sysctl call.
+         *
+         * @param oldp    buffer to receive the result, or {@code null} to query the required size
+         * @param oldlenp in/out size of {@code oldp}
+         * @return 0 on success; nonzero on failure (with {@code errno} set)
+         */
+        int call(Pointer oldp, size_t.ByReference oldlenp);
+    }
+
+    /**
+     * Executes a sysctl call with an int result.
+     *
+     * @param call       the bound native sysctl call
+     * @param name       name of the sysctl, for logging
+     * @param def        default int value
+     * @param log        logger for the calling class
+     * @param logWarning whether to log a warning if the call fails
+     * @return The int result of the call if successful; the default otherwise
+     */
+    public static int sysctl(SysctlCall call, Object name, int def, Logger log, boolean logWarning) {
+        try (Memory p = new Memory(INT_SIZE);
+                CloseableSizeTByReference size = new CloseableSizeTByReference(INT_SIZE)) {
+            if (0 != call.call(p, size)) {
+                if (logWarning) {
+                    log.warn(SYSCTL_FAIL, name, Native.getLastError());
+                }
+                return def;
+            }
+            return p.getInt(0);
+        }
+    }
+
+    /**
+     * Executes a sysctl call with a long result.
+     *
+     * @param call the bound native sysctl call
+     * @param name name of the sysctl, for logging
+     * @param def  default long value
+     * @param log  logger for the calling class
+     * @return The long result of the call if successful; the default otherwise
+     */
+    public static long sysctl(SysctlCall call, Object name, long def, Logger log) {
+        try (Memory p = new Memory(UINT64_SIZE);
+                CloseableSizeTByReference size = new CloseableSizeTByReference(UINT64_SIZE)) {
+            if (0 != call.call(p, size)) {
+                log.warn(SYSCTL_FAIL, name, Native.getLastError());
+                return def;
+            }
+            // Some OIDs exposed as a "long" are actually kernel ints (e.g. FreeBSD hw.clockrate is a 4-byte int). The
+            // kernel then writes only 4 bytes into the 8-byte buffer, and reading getLong(0) would combine the 4 valid
+            // bytes with 4 uninitialized ones. sysctl updates oldlenp in place with the number of bytes actually
+            // written, so read only that many, widening a 4-byte int as unsigned (matching an over-wide read of a
+            // zeroed buffer).
+            return size.longValue() == INT_SIZE ? ParseUtil.unsignedIntToLong(p.getInt(0)) : p.getLong(0);
+        }
+    }
+
+    /**
+     * Executes a sysctl call with a String result.
+     *
+     * @param call       the bound native sysctl call
+     * @param name       name of the sysctl, for logging
+     * @param def        default String value
+     * @param log        logger for the calling class
+     * @param logWarning whether to log a warning if the call fails
+     * @return The String result of the call if successful; the default otherwise
+     */
+    public static String sysctl(SysctlCall call, Object name, String def, Logger log, boolean logWarning) {
+        // Call first time with null pointer to get value of size
+        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
+            if (0 != call.call(null, size)) {
+                if (logWarning) {
+                    log.warn(SYSCTL_FAIL, name, Native.getLastError());
+                }
+                return def;
+            }
+            // Add 1 to size for null terminated string
+            try (Memory p = new Memory(size.longValue() + 1L)) {
+                if (0 != call.call(p, size)) {
+                    if (logWarning) {
+                        log.warn(SYSCTL_FAIL, name, Native.getLastError());
+                    }
+                    return def;
+                }
+                return p.getString(0);
+            }
+        }
+    }
+
+    /**
+     * Executes a sysctl call that populates a caller-provided {@link Structure}.
+     *
+     * @param call   the bound native sysctl call
+     * @param name   name of the sysctl, for logging
+     * @param struct structure for the result
+     * @param log    logger for the calling class
+     * @param level  level at which to log a failure
+     * @return {@code true} if the structure was successfully populated, {@code false} otherwise
+     */
+    public static boolean sysctl(SysctlCall call, Object name, Structure struct, Logger log, Level level) {
+        try (CloseableSizeTByReference size = new CloseableSizeTByReference(struct.size())) {
+            if (0 != call.call(struct.getPointer(), size)) {
+                logFailure(log, level, name);
+                return false;
+            }
+        }
+        struct.read();
+        return true;
+    }
+
+    /**
+     * Executes a sysctl call returning a freshly allocated buffer of the natural size.
+     *
+     * @param call  the bound native sysctl call
+     * @param name  name of the sysctl, for logging
+     * @param log   logger for the calling class
+     * @param level level at which to log a failure
+     * @return An allocated memory buffer containing the result on success, {@code null} otherwise. Its value on failure
+     *         is undefined.
+     */
+    public static Memory sysctl(SysctlCall call, Object name, Logger log, Level level) {
+        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
+            if (0 != call.call(null, size)) {
+                logFailure(log, level, name);
+                return null;
+            }
+            Memory m = new Memory(size.longValue());
+            if (0 != call.call(m, size)) {
+                logFailure(log, level, name);
+                m.close();
+                return null;
+            }
+            return m;
+        }
+    }
+
+    private static void logFailure(Logger log, Level level, Object name) {
+        if (level == Level.ERROR) {
+            log.error(SYSCTL_FAIL, name, Native.getLastError());
+        } else {
+            log.warn(SYSCTL_FAIL, name, Native.getLastError());
+        }
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdFileSystemJNA.java
@@ -6,7 +6,7 @@ package oshi.software.os.unix.openbsd;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.os.unix.openbsd.OpenBsdFileSystem;
-import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
+import oshi.util.common.platform.unix.bsd.BsdSysctlUtil;
 
 /**
  * The OpenBSD File System contains {@link oshi.software.os.OSFileStore}s which are a storage pool, device, partition,
@@ -17,6 +17,6 @@ public class OpenBsdFileSystemJNA extends OpenBsdFileSystem {
 
     @Override
     protected long querySysctl(String name) {
-        return OpenBsdSysctlUtil.sysctl(name, 0);
+        return BsdSysctlUtil.sysctl(name, 0);
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SysctlUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SysctlUtil.java
@@ -1,20 +1,20 @@
 /*
- * Copyright 2016-2024 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.mac;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import com.sun.jna.Memory;
-import com.sun.jna.Native;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.unix.LibCAPI.size_t;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.mac.SystemB;
+import oshi.jna.util.SysctlUtilJNA;
 
 /**
  * Provides access to sysctl calls on macOS
@@ -23,8 +23,6 @@ import oshi.jna.platform.mac.SystemB;
 public final class SysctlUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(SysctlUtil.class);
-
-    private static final String SYSCTL_FAIL = "Failed sysctl call: {}, Error code: {}";
 
     private SysctlUtil() {
     }
@@ -49,16 +47,9 @@ public final class SysctlUtil {
      * @return The int result of the call if successful; the default otherwise
      */
     public static int sysctl(String name, int def, boolean logWarning) {
-        int intSize = com.sun.jna.platform.mac.SystemB.INT_SIZE;
-        try (Memory p = new Memory(intSize); CloseableSizeTByReference size = new CloseableSizeTByReference(intSize)) {
-            if (0 != SystemB.INSTANCE.sysctlbyname(name, p, size, null, size_t.ZERO)) {
-                if (logWarning) {
-                    LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                }
-                return def;
-            }
-            return p.getInt(0);
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> SystemB.INSTANCE.sysctlbyname(name, oldp, oldlenp, null, size_t.ZERO), name, def,
+                LOG, logWarning);
     }
 
     /**
@@ -69,15 +60,9 @@ public final class SysctlUtil {
      * @return The long result of the call if successful; the default otherwise
      */
     public static long sysctl(String name, long def) {
-        int uint64Size = com.sun.jna.platform.mac.SystemB.UINT64_SIZE;
-        try (Memory p = new Memory(uint64Size);
-                CloseableSizeTByReference size = new CloseableSizeTByReference(uint64Size)) {
-            if (0 != SystemB.INSTANCE.sysctlbyname(name, p, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            return p.getLong(0);
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> SystemB.INSTANCE.sysctlbyname(name, oldp, oldlenp, null, size_t.ZERO), name, def,
+                LOG);
     }
 
     /**
@@ -100,25 +85,9 @@ public final class SysctlUtil {
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(String name, String def, boolean logWarning) {
-        // Call first time with null pointer to get value of size
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
-            if (0 != SystemB.INSTANCE.sysctlbyname(name, null, size, null, size_t.ZERO)) {
-                if (logWarning) {
-                    LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                }
-                return def;
-            }
-            // Add 1 to size for null terminated string
-            try (Memory p = new Memory(size.longValue() + 1L)) {
-                if (0 != SystemB.INSTANCE.sysctlbyname(name, p, size, null, size_t.ZERO)) {
-                    if (logWarning) {
-                        LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                    }
-                    return def;
-                }
-                return p.getString(0);
-            }
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> SystemB.INSTANCE.sysctlbyname(name, oldp, oldlenp, null, size_t.ZERO), name, def,
+                LOG, logWarning);
     }
 
     /**
@@ -129,14 +98,9 @@ public final class SysctlUtil {
      * @return True if structure is successfuly populated, false otherwise
      */
     public static boolean sysctl(String name, Structure struct) {
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference(struct.size())) {
-            if (0 != SystemB.INSTANCE.sysctlbyname(name, struct.getPointer(), size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return false;
-            }
-        }
-        struct.read();
-        return true;
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> SystemB.INSTANCE.sysctlbyname(name, oldp, oldlenp, null, size_t.ZERO), name, struct,
+                LOG, Level.WARN);
     }
 
     /**
@@ -147,18 +111,8 @@ public final class SysctlUtil {
      *         undefined.
      */
     public static Memory sysctl(String name) {
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
-            if (0 != SystemB.INSTANCE.sysctlbyname(name, null, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return null;
-            }
-            Memory m = new Memory(size.longValue());
-            if (0 != SystemB.INSTANCE.sysctlbyname(name, m, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                m.close();
-                return null;
-            }
-            return m;
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> SystemB.INSTANCE.sysctlbyname(name, oldp, oldlenp, null, size_t.ZERO), name, LOG,
+                Level.WARN);
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/unix/freebsd/BsdSysctlUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/freebsd/BsdSysctlUtil.java
@@ -1,20 +1,20 @@
 /*
- * Copyright 2016-2022 The OSHI Project Contributors
+ * Copyright 2016-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.unix.freebsd;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import com.sun.jna.Memory;
-import com.sun.jna.Native;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.unix.LibCAPI.size_t;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.FreeBsdLibc;
+import oshi.jna.util.SysctlUtilJNA;
 
 /**
  * Provides access to sysctl calls on FreeBSD
@@ -23,8 +23,6 @@ import oshi.jna.platform.unix.FreeBsdLibc;
 public final class BsdSysctlUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(BsdSysctlUtil.class);
-
-    private static final String SYSCTL_FAIL = "Failed sysctl call: {}, Error code: {}";
 
     private BsdSysctlUtil() {
     }
@@ -37,14 +35,9 @@ public final class BsdSysctlUtil {
      * @return The int result of the call if successful; the default otherwise
      */
     public static int sysctl(String name, int def) {
-        int intSize = FreeBsdLibc.INT_SIZE;
-        try (Memory p = new Memory(intSize); CloseableSizeTByReference size = new CloseableSizeTByReference(intSize)) {
-            if (0 != FreeBsdLibc.INSTANCE.sysctlbyname(name, p, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            return p.getInt(0);
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> FreeBsdLibc.INSTANCE.sysctlbyname(name, oldp, oldlenp, null, size_t.ZERO), name, def,
+                LOG, true);
     }
 
     /**
@@ -55,15 +48,9 @@ public final class BsdSysctlUtil {
      * @return The long result of the call if successful; the default otherwise
      */
     public static long sysctl(String name, long def) {
-        int uint64Size = FreeBsdLibc.UINT64_SIZE;
-        try (Memory p = new Memory(uint64Size);
-                CloseableSizeTByReference size = new CloseableSizeTByReference(uint64Size)) {
-            if (0 != FreeBsdLibc.INSTANCE.sysctlbyname(name, p, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            return p.getLong(0);
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> FreeBsdLibc.INSTANCE.sysctlbyname(name, oldp, oldlenp, null, size_t.ZERO), name, def,
+                LOG);
     }
 
     /**
@@ -74,21 +61,9 @@ public final class BsdSysctlUtil {
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(String name, String def) {
-        // Call first time with null pointer to get value of size
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
-            if (0 != FreeBsdLibc.INSTANCE.sysctlbyname(name, null, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            // Add 1 to size for null terminated string
-            try (Memory p = new Memory(size.longValue() + 1L)) {
-                if (0 != FreeBsdLibc.INSTANCE.sysctlbyname(name, p, size, null, size_t.ZERO)) {
-                    LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                    return def;
-                }
-                return p.getString(0);
-            }
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> FreeBsdLibc.INSTANCE.sysctlbyname(name, oldp, oldlenp, null, size_t.ZERO), name, def,
+                LOG, true);
     }
 
     /**
@@ -99,14 +74,9 @@ public final class BsdSysctlUtil {
      * @return True if structure is successfuly populated, false otherwise
      */
     public static boolean sysctl(String name, Structure struct) {
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference(struct.size())) {
-            if (0 != FreeBsdLibc.INSTANCE.sysctlbyname(name, struct.getPointer(), size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                return false;
-            }
-        }
-        struct.read();
-        return true;
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> FreeBsdLibc.INSTANCE.sysctlbyname(name, oldp, oldlenp, null, size_t.ZERO), name,
+                struct, LOG, Level.ERROR);
     }
 
     /**
@@ -117,18 +87,8 @@ public final class BsdSysctlUtil {
      *         undefined.
      */
     public static Memory sysctl(String name) {
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
-            if (0 != FreeBsdLibc.INSTANCE.sysctlbyname(name, null, size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                return null;
-            }
-            Memory m = new Memory(size.longValue());
-            if (0 != FreeBsdLibc.INSTANCE.sysctlbyname(name, m, size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                m.close();
-                return null;
-            }
-            return m;
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> FreeBsdLibc.INSTANCE.sysctlbyname(name, oldp, oldlenp, null, size_t.ZERO), name, LOG,
+                Level.ERROR);
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/NetBsdSysctlUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/NetBsdSysctlUtil.java
@@ -4,17 +4,19 @@
  */
 package oshi.util.platform.unix.netbsd;
 
+import java.util.Arrays;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import com.sun.jna.Memory;
-import com.sun.jna.Native;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.unix.LibCAPI.size_t;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.NetBsdLibc;
+import oshi.jna.util.SysctlUtilJNA;
 
 /**
  * Provides access to native sysctl calls on NetBSD via JNA.
@@ -28,8 +30,6 @@ import oshi.jna.platform.unix.NetBsdLibc;
 public final class NetBsdSysctlUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(NetBsdSysctlUtil.class);
-
-    private static final String SYSCTL_FAIL = "Failed sysctl call: {}, Error code: {}";
 
     /**
      * Whether the JNA native library is available on this system. When {@code false}, the native methods in this class
@@ -61,14 +61,9 @@ public final class NetBsdSysctlUtil {
      * @return The int result of the call if successful; the default otherwise
      */
     public static int sysctl(int[] name, int def) {
-        int intSize = NetBsdLibc.INT_SIZE;
-        try (Memory p = new Memory(intSize); CloseableSizeTByReference size = new CloseableSizeTByReference(intSize)) {
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            return p.getInt(0);
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> NetBsdLibc.INSTANCE.sysctl(name, name.length, oldp, oldlenp, null, size_t.ZERO),
+                Arrays.toString(name), def, LOG, true);
     }
 
     /**
@@ -79,15 +74,9 @@ public final class NetBsdSysctlUtil {
      * @return The long result of the call if successful; the default otherwise
      */
     public static long sysctl(int[] name, long def) {
-        int uint64Size = NetBsdLibc.UINT64_SIZE;
-        try (Memory p = new Memory(uint64Size);
-                CloseableSizeTByReference size = new CloseableSizeTByReference(uint64Size)) {
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            return p.getLong(0);
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> NetBsdLibc.INSTANCE.sysctl(name, name.length, oldp, oldlenp, null, size_t.ZERO),
+                Arrays.toString(name), def, LOG);
     }
 
     /**
@@ -98,21 +87,9 @@ public final class NetBsdSysctlUtil {
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(int[] name, String def) {
-        // Call first time with null pointer to get value of size
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, null, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            // Add 1 to size for null terminated string
-            try (Memory p = new Memory(size.longValue() + 1L)) {
-                if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
-                    LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                    return def;
-                }
-                return p.getString(0);
-            }
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> NetBsdLibc.INSTANCE.sysctl(name, name.length, oldp, oldlenp, null, size_t.ZERO),
+                Arrays.toString(name), def, LOG, true);
     }
 
     /**
@@ -123,14 +100,9 @@ public final class NetBsdSysctlUtil {
      * @return True if structure is successfully populated, false otherwise
      */
     public static boolean sysctl(int[] name, Structure struct) {
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference(struct.size())) {
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, struct.getPointer(), size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                return false;
-            }
-        }
-        struct.read();
-        return true;
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> NetBsdLibc.INSTANCE.sysctl(name, name.length, oldp, oldlenp, null, size_t.ZERO),
+                Arrays.toString(name), struct, LOG, Level.ERROR);
     }
 
     /**
@@ -141,18 +113,8 @@ public final class NetBsdSysctlUtil {
      *         undefined.
      */
     public static Memory sysctl(int[] name) {
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, null, size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                return null;
-            }
-            Memory m = new Memory(size.longValue());
-            if (0 != NetBsdLibc.INSTANCE.sysctl(name, name.length, m, size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                m.close();
-                return null;
-            }
-            return m;
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> NetBsdLibc.INSTANCE.sysctl(name, name.length, oldp, oldlenp, null, size_t.ZERO),
+                Arrays.toString(name), LOG, Level.ERROR);
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/NetBsdSysctlUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/NetBsdSysctlUtil.java
@@ -22,7 +22,7 @@ import oshi.jna.platform.unix.NetBsdLibc;
  * JNA does not distribute a native binary for NetBSD; it is only available as an optional pkgsrc package
  * ({@code java-jna}), and OSHI does not require it to be installed. Callers must therefore gate every native call on
  * {@link #JNA_AVAILABLE} and fall back to the command-line implementations in
- * {@code oshi.util.common.platform.unix.netbsd.NetBsdSysctlUtil} when it is {@code false}.
+ * {@code oshi.util.common.platform.unix.bsd.BsdSysctlUtil} when it is {@code false}.
  */
 @ThreadSafe
 public final class NetBsdSysctlUtil {

--- a/oshi-core/src/main/java/oshi/util/platform/unix/openbsd/OpenBsdSysctlUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/openbsd/OpenBsdSysctlUtil.java
@@ -4,17 +4,19 @@
  */
 package oshi.util.platform.unix.openbsd;
 
+import java.util.Arrays;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import com.sun.jna.Memory;
-import com.sun.jna.Native;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.unix.LibCAPI.size_t;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.OpenBsdLibc;
+import oshi.jna.util.SysctlUtilJNA;
 
 /**
  * Provides access to sysctl calls on OpenBSD
@@ -24,111 +26,71 @@ public final class OpenBsdSysctlUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenBsdSysctlUtil.class);
 
-    private static final String SYSCTL_FAIL = "Failed sysctl call: {}, Error code: {}";
-
     private OpenBsdSysctlUtil() {
     }
 
     /**
      * Executes a sysctl call with an int result
      *
-     * @param name name of the sysctl
+     * @param name MIB array identifying the sysctl
      * @param def  default int value
      * @return The int result of the call if successful; the default otherwise
      */
     public static int sysctl(int[] name, int def) {
-        int intSize = OpenBsdLibc.INT_SIZE;
-        try (Memory p = new Memory(intSize); CloseableSizeTByReference size = new CloseableSizeTByReference(intSize)) {
-            if (0 != OpenBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            return p.getInt(0);
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> OpenBsdLibc.INSTANCE.sysctl(name, name.length, oldp, oldlenp, null, size_t.ZERO),
+                Arrays.toString(name), def, LOG, true);
     }
 
     /**
      * Executes a sysctl call with a long result
      *
-     * @param name name of the sysctl
+     * @param name MIB array identifying the sysctl
      * @param def  default long value
      * @return The long result of the call if successful; the default otherwise
      */
     public static long sysctl(int[] name, long def) {
-        int uint64Size = OpenBsdLibc.UINT64_SIZE;
-        try (Memory p = new Memory(uint64Size);
-                CloseableSizeTByReference size = new CloseableSizeTByReference(uint64Size)) {
-            if (0 != OpenBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            return p.getLong(0);
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> OpenBsdLibc.INSTANCE.sysctl(name, name.length, oldp, oldlenp, null, size_t.ZERO),
+                Arrays.toString(name), def, LOG);
     }
 
     /**
      * Executes a sysctl call with a String result
      *
-     * @param name name of the sysctl
+     * @param name MIB array identifying the sysctl
      * @param def  default String value
      * @return The String result of the call if successful; the default otherwise
      */
     public static String sysctl(int[] name, String def) {
-        // First call with null oldp to query the needed size
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
-            if (0 != OpenBsdLibc.INSTANCE.sysctl(name, name.length, null, size, null, size_t.ZERO)) {
-                LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                return def;
-            }
-            // Add 1 to buffer for null terminated string; size passed to kernel is unchanged
-            try (Memory p = new Memory(size.longValue() + 1L)) {
-                if (0 != OpenBsdLibc.INSTANCE.sysctl(name, name.length, p, size, null, size_t.ZERO)) {
-                    LOG.warn(SYSCTL_FAIL, name, Native.getLastError());
-                    return def;
-                }
-                return p.getString(0);
-            }
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> OpenBsdLibc.INSTANCE.sysctl(name, name.length, oldp, oldlenp, null, size_t.ZERO),
+                Arrays.toString(name), def, LOG, true);
     }
 
     /**
      * Executes a sysctl call with a Structure result
      *
-     * @param name   name of the sysctl
+     * @param name   MIB array identifying the sysctl
      * @param struct structure for the result
      * @return True if structure is successfuly populated, false otherwise
      */
     public static boolean sysctl(int[] name, Structure struct) {
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference(struct.size())) {
-            if (0 != OpenBsdLibc.INSTANCE.sysctl(name, name.length, struct.getPointer(), size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                return false;
-            }
-        }
-        struct.read();
-        return true;
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> OpenBsdLibc.INSTANCE.sysctl(name, name.length, oldp, oldlenp, null, size_t.ZERO),
+                Arrays.toString(name), struct, LOG, Level.ERROR);
     }
 
     /**
      * Executes a sysctl call with a Pointer result
      *
-     * @param name name of the sysctl
+     * @param name MIB array identifying the sysctl
      * @return An allocated memory buffer containing the result on success, null otherwise. Its value on failure is
      *         undefined.
      */
     public static Memory sysctl(int[] name) {
-        try (CloseableSizeTByReference size = new CloseableSizeTByReference()) {
-            if (0 != OpenBsdLibc.INSTANCE.sysctl(name, name.length, null, size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                return null;
-            }
-            Memory m = new Memory(size.longValue());
-            if (0 != OpenBsdLibc.INSTANCE.sysctl(name, name.length, m, size, null, size_t.ZERO)) {
-                LOG.error(SYSCTL_FAIL, name, Native.getLastError());
-                m.close();
-                return null;
-            }
-            return m;
-        }
+        return SysctlUtilJNA.sysctl(
+                (oldp, oldlenp) -> OpenBsdLibc.INSTANCE.sysctl(name, name.length, oldp, oldlenp, null, size_t.ZERO),
+                Arrays.toString(name), LOG, Level.ERROR);
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/unix/openbsd/OpenBsdSysctlUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/openbsd/OpenBsdSysctlUtil.java
@@ -15,16 +15,12 @@ import com.sun.jna.platform.unix.LibCAPI.size_t;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseableSizeTByReference;
 import oshi.jna.platform.unix.OpenBsdLibc;
-import oshi.util.ExecutingCommand;
-import oshi.util.ParseUtil;
 
 /**
  * Provides access to sysctl calls on OpenBSD
  */
 @ThreadSafe
 public final class OpenBsdSysctlUtil {
-
-    private static final String SYSCTL_N = "sysctl -n ";
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenBsdSysctlUtil.class);
 
@@ -134,46 +130,5 @@ public final class OpenBsdSysctlUtil {
             }
             return m;
         }
-    }
-
-    /*
-     * Backup versions with command parsing
-     */
-
-    /**
-     * Executes a sysctl call with an int result
-     *
-     * @param name name of the sysctl
-     * @param def  default int value
-     * @return The int result of the call if successful; the default otherwise
-     */
-    public static int sysctl(String name, int def) {
-        return ParseUtil.parseIntOrDefault(ExecutingCommand.getFirstAnswer(SYSCTL_N + name), def);
-    }
-
-    /**
-     * Executes a sysctl call with a long result
-     *
-     * @param name name of the sysctl
-     * @param def  default long value
-     * @return The long result of the call if successful; the default otherwise
-     */
-    public static long sysctl(String name, long def) {
-        return ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer(SYSCTL_N + name), def);
-    }
-
-    /**
-     * Executes a sysctl call with a String result
-     *
-     * @param name name of the sysctl
-     * @param def  default String value
-     * @return The String result of the call if successful; the default otherwise
-     */
-    public static String sysctl(String name, String def) {
-        String v = ExecutingCommand.getFirstAnswer(SYSCTL_N + name);
-        if (null == v || v.isEmpty()) {
-            return def;
-        }
-        return v;
     }
 }

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/CentralProcessorTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/CentralProcessorTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -70,6 +71,21 @@ class CentralProcessorTest {
                 assertThat("Logical processor frequency should be within 3x its max frequency", freq,
                         is(lessThanOrEqualTo(max * 3)));
             }
+        }
+    }
+
+    @Test
+    void testVendorFreqSanity() {
+        // The vendor-advertised frequency and the max frequency describe the same CPU, so when both are known they
+        // must be the same order of magnitude. This guards against native-read bugs that silently corrupt the value:
+        // e.g. reading the 4-byte FreeBSD hw.clockrate sysctl through an 8-byte buffer produced a vendor frequency of
+        // ~6.2 EHz against a ~2.6 GHz max (oshi/oshi#3517).
+        long vendorFreq = p.getProcessorIdentifier().getVendorFreq();
+        long maxFreq = p.getMaxFreq();
+        if (vendorFreq > 0 && maxFreq > 0) {
+            double ratio = (double) Math.max(vendorFreq, maxFreq) / Math.min(vendorFreq, maxFreq);
+            assertThat("Vendor frequency (" + vendorFreq + ") and max frequency (" + maxFreq
+                    + ") should be within an order of magnitude", ratio, is(lessThan(10.0)));
         }
     }
 


### PR DESCRIPTION
## Summary

Consolidates the duplicated `sysctl` utility code into three shared helpers and fixes a latent bug the consolidation surfaced.

Before this change the `sysctl` logic was copied across eight classes: the command-line `sysctl -n` implementation existed in three places, and the JNA and FFM native bodies were near-identical per key-type (`sysctlbyname(String)` for macOS/FreeBSD, `sysctl(int[])` for NetBSD/OpenBSD), differing only in which native `INSTANCE`/function was called.

## Changes

1. **Command-line (`oshi-common`)** — Move the NetBSD-specific command-line `NetBsdSysctlUtil` to a generic `oshi.util.common.platform.unix.bsd.BsdSysctlUtil` (usable by any BSD-family OS, including macOS) and repoint all command-line call sites: the 7 NetBSD common classes, and the "backup" `String` overloads of the JNA `OpenBsdSysctlUtil` and FFM `OpenBsdSysctlUtilFFM` (which duplicated it). Three copies → one.

2. **JNA (`oshi-core`)** — Extract the shared buffer-sizing/error/decoding logic into `oshi.jna.util.SysctlUtilJNA`; each per-platform class supplies its native call as a lambda. Preserves per-method log levels and the macOS `logWarning` variants.

3. **FFM (`oshi-core-ffm`)** — Mirror the extraction into `oshi.ffm.util.SysctlFFM`, using the existing `callInArena*` helpers.

4. **Bug fix (closes #3517)** — The shared `long` helper now honors the byte count the kernel reports via `oldlenp`: when the OID is a 4-byte int (e.g. FreeBSD `hw.clockrate`) it reads a `ParseUtil.unsignedIntToLong` widened `int` rather than `getLong` over a buffer whose high 4 bytes were never written. Previously `new Memory()` (unzeroed, unlike an FFM arena) left those bytes as `malloc` garbage, intermittently reporting an absurd CPU vendor frequency (e.g. 6.2 EHz). Applied to both JNA and FFM for symmetry. A `CentralProcessorTest` assertion that vendor and max frequency stay within an order of magnitude reproduces the bug and guards against regressions on every platform.

Also fixes a minor latent issue: the NetBSD/OpenBSD JNA classes logged the raw `int[]` MIB (`[I@...`) on failure; they now log `Arrays.toString`, matching FFM.

## Testing

- New `BsdSysctlUtilTest` covers the shared command-line class (success + failure paths of all overloads), gated to platforms that ship a `sysctl` command.
- New `CentralProcessorTest.testVendorFreqSanity()` reproduces #3517.
- All existing tests pass, including the JNA/FFM `NativeComparisonTest` (`-Paggregate-coverage`).
- Verified green on CI across Linux, macOS, Windows, FreeBSD, OpenBSD, NetBSD (with and without JNA), DragonFly BSD, OpenIndiana, and the native-free path.

Closes #3517.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware and operating-system information detection across BSD platforms.
  * Fixed reading certain integer-width system values, including CPU frequency data.
  * Preserved fallback behavior when system information is unavailable.

* **Improvements**
  * Standardized system information retrieval and error handling across native integrations.
  * Improved consistency of memory, disk, processor, filesystem, and hardware identifier reporting.

* **Tests**
  * Added coverage for BSD system queries, fallback values, and CPU frequency sanity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->