### PR TITLE
Fix Solaris Kstat2 CPU vendor frequency reported in MHz instead of Hz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#3505](https://github.com/oshi/oshi/pull/3505): Fix the AIX FFM backend reading `perfstat_partition_config_t.processorMHz` at the wrong struct offset (344 instead of 340), which reported the processor's vendor frequency as unknown - [@dbwiddis](https://github.com/dbwiddis).
 * [#3507](https://github.com/oshi/oshi/pull/3507): Extend the native-free provider (`oshi-common` alone, no JNA or FFM) to NetBSD, so NetBSD users without the JNA native library can depend on `oshi-common` without `--enable-native-access`, as Linux already can - [@dbwiddis](https://github.com/dbwiddis).
 * [#3518](https://github.com/oshi/oshi/pull/3518): Consolidate the duplicated `sysctl` utility code into shared command-line (`BsdSysctlUtil`), JNA (`SysctlUtilJNA`), and FFM (`SysctlFFM`) helpers, and fix a latent bug where reading an int-width sysctl (e.g. FreeBSD `hw.clockrate`) through the `long` API returned uninitialized bytes, intermittently reporting an absurd CPU vendor frequency such as 6.2 EHz - [@dbwiddis](https://github.com/dbwiddis).
+* [#3519](https://github.com/oshi/oshi/pull/3519): Fix the Solaris JNA Kstat2 processor identifier reporting the CPU vendor frequency in MHz instead of Hz (missing the `clock_MHz` to Hz conversion applied on the other code paths) - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18)
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessorJNA.java
@@ -79,7 +79,9 @@ final class SolarisCentralProcessorJNA extends SolarisCentralProcessor {
         String cpuFamily = results[2] == null ? "" : results[2].toString();
         String cpuModel = results[3] == null ? "" : results[3].toString();
         String cpuStepping = results[4] == null ? "" : results[4].toString();
-        long cpuFreq = results[5] == null ? 0L : (long) results[5];
+        // clock_MHz is in MHz; the ProcessorIdentifier vendor frequency contract is Hz (matches the non-Kstat2 path
+        // above and the FFM implementation).
+        long cpuFreq = results[5] == null ? 0L : (long) results[5] * 1_000_000L;
 
         String processorID = getProcessorID(cpuStepping, cpuModel, cpuFamily);
         return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,


### PR DESCRIPTION
## Summary

Fixes the Solaris JNA Kstat2 processor identifier reporting the CPU vendor frequency in **MHz instead of Hz**.

`SolarisCentralProcessorJNA.queryProcessorId2()` (the Kstat2 path) read the `clock_MHz` kstat value and passed it straight to `ProcessorIdentifier` as the vendor frequency, omitting the `* 1_000_000L` conversion to Hz that **both** sibling code paths apply:

- the non-Kstat2 path in the same class (`queryProcessorId()`), and
- the FFM implementation (`SolarisCentralProcessorFFM.queryProcessorId()`).

On a SPARC system this reported a ~5067 Hz vendor frequency against a ~5.07 GHz max frequency.

```java
// before
long cpuFreq = results[5] == null ? 0L : (long) results[5];
// after
long cpuFreq = results[5] == null ? 0L : (long) results[5] * 1_000_000L;
```

## How it was found

Caught by the `CentralProcessorTest.testVendorFreqSanity()` assertion added in #3518 (vendor and max frequency must be within an order of magnitude) — the FreeBSD sysctl fix's regression test surfaced this pre-existing Solaris bug.

## Testing

This is a cfarm-only path: `HAS_KSTAT2` is false on the OpenIndiana x86 CI runner, so the Kstat2 branch is only exercised on real Solaris. Verified by inspection against the two sibling paths that already perform the MHz→Hz conversion. Builds clean (checkstyle, forbiddenapis, javadoc).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Solaris CPU identification so processor frequencies are reported in hertz rather than megahertz.
  * Improved the accuracy of CPU information displayed to users on Solaris systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->