### PR TITLE
Guard null listFiles in MacOperatingSystem.getServices (Coverity CID 1673010)

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
@@ -203,15 +203,20 @@ public abstract class MacOperatingSystem extends AbstractOperatingSystem {
         }
         // Get Directories for stopped services
         ArrayList<File> files = new ArrayList<>();
+        File[] listFiles;
         File dir = new File(SYSTEM_LIBRARY_LAUNCH_AGENTS);
         if (dir.exists() && dir.isDirectory()) {
-            files.addAll(Arrays.asList(dir.listFiles((f, name) -> name.toLowerCase(Locale.ROOT).endsWith(".plist"))));
+            if ((listFiles = dir.listFiles((f, name) -> name.toLowerCase(Locale.ROOT).endsWith(".plist"))) != null) {
+                files.addAll(Arrays.asList(listFiles));
+            }
         } else {
             LOG.error("Directory: /System/Library/LaunchAgents does not exist");
         }
         dir = new File(SYSTEM_LIBRARY_LAUNCH_DAEMONS);
         if (dir.exists() && dir.isDirectory()) {
-            files.addAll(Arrays.asList(dir.listFiles((f, name) -> name.toLowerCase(Locale.ROOT).endsWith(".plist"))));
+            if ((listFiles = dir.listFiles((f, name) -> name.toLowerCase(Locale.ROOT).endsWith(".plist"))) != null) {
+                files.addAll(Arrays.asList(listFiles));
+            }
         } else {
             LOG.error("Directory: /System/Library/LaunchDaemons does not exist");
         }


### PR DESCRIPTION
`File.listFiles(FilenameFilter)` may return `null` on an I/O error even after `exists() && isDirectory()` pass (transient FS error, permission race, TOCTOU). `Arrays.asList` on that `null` then throws an NPE.

This folds the null check into the guard, matching the pattern already used in the sibling `getServices()` methods in `AixOperatingSystem`, `SolarisOperatingSystem`, and `BsdOperatingSystem`. Mac was the lone outlier dereferencing `listFiles()` unchecked.

Resolves Coverity CID 1673010 (Dereference null return value, CWE-476). Defensive-only null path; no user-facing behavior change, so no CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service detection reliability when system service directories are unavailable or cannot be read.
  * Prevented errors while collecting macOS launch service definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->