### PR TITLE
Fix NPE in macOS FFM process backend and harden native struct dereferences

### DIFF
--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -3,7 +3,7 @@ name: Coverity Scan
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 9 */4 * *" # every 4 days at 09:00 UTC
+    - cron: "0 0 * * 6" # weekly, Saturday 00:00 UTC (Coverity Scan throttles frequent runs; trigger manually after major changes)
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 7.4.3 (in progress)
 
-* Your contribution here!
+##### Bug Fixes and Improvements
+
+* [#3526](https://github.com/oshi/oshi/pull/3526): Fix a potential `NullPointerException` in the macOS FFM process backend when an `IOPlatformDevice` entry has no readable name, and guard the native `passwd`/`group` struct dereferences against a null return - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24)
 

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
@@ -106,13 +106,16 @@ public class MacOSProcessFFM extends MacOSProcess {
             IORegistryEntry cpu = iter.next();
             while (cpu != null) {
                 try (IORegistryEntry current = cpu) {
-                    String s = current.getName().toLowerCase(Locale.ROOT);
-                    if (s.startsWith("cpu") && s.length() > 3) {
-                        // Frequency is typically only on lowest-numbered P-core
-                        byte[] data = current.getByteArrayProperty("timebase-frequency");
-                        if (data != null) {
-                            ticksPerSec = ParseUtil.byteArrayToLong(data, 4, false);
-                            break;
+                    String name = current.getName();
+                    if (name != null) {
+                        String s = name.toLowerCase(Locale.ROOT);
+                        if (s.startsWith("cpu") && s.length() > 3) {
+                            // Frequency is typically only on lowest-numbered P-core
+                            byte[] data = current.getByteArrayProperty("timebase-frequency");
+                            if (data != null) {
+                                ticksPerSec = ParseUtil.byteArrayToLong(data, 4, false);
+                                break;
+                            }
                         }
                     }
                 }
@@ -275,8 +278,8 @@ public class MacOSProcessFFM extends MacOSProcess {
             int uid = pbsd.get(JAVA_INT, PROC_BSD_INFO.byteOffset(PBI_UID));
             this.userID = Integer.toString(uid);
             MemorySegment pwuid = getpwuid(uid);
-            if (pwuid != null) {
-                MemorySegment passwdStruct = ForeignFunctions.getStructFromNativePointer(pwuid, PASSWD, arena);
+            MemorySegment passwdStruct = ForeignFunctions.getStructFromNativePointer(pwuid, PASSWD, arena);
+            if (passwdStruct != null) {
                 MemorySegment nameAddress = passwdStruct.get(ADDRESS, PASSWD.byteOffset(groupElement("pw_name")));
                 this.user = ForeignFunctions.getStringFromNativePointer(nameAddress, arena);
             } else {
@@ -286,8 +289,8 @@ public class MacOSProcessFFM extends MacOSProcess {
             int gid = pbsd.get(JAVA_INT, PROC_BSD_INFO.byteOffset(PBI_GID));
             this.groupID = Integer.toString(gid);
             MemorySegment grgid = getgrgid(gid);
-            if (grgid != null) {
-                MemorySegment groupStruct = ForeignFunctions.getStructFromNativePointer(grgid, GROUP, arena);
+            MemorySegment groupStruct = ForeignFunctions.getStructFromNativePointer(grgid, GROUP, arena);
+            if (groupStruct != null) {
                 MemorySegment nameAddress = groupStruct.get(ADDRESS, GROUP.byteOffset(groupElement("gr_name")));
                 this.group = ForeignFunctions.getStringFromNativePointer(nameAddress, arena);
             } else {


### PR DESCRIPTION
## Summary

Addresses the real findings from the first Coverity Scan of `oshi-core-ffm` (now captured after the scan was configured to reach the FFM module).

**One real bug + one hardening**, both in `MacOSProcessFFM`:

- **Fix `NullPointerException` (Coverity CID 1673024).** The static initializer dereferenced `IORegistryEntry.getName()` without a guard. `getName()` is nullable (null segment, native `IORegistryEntryGetName` failure, or `getOrDefault` fallback), so a CPU `IOPlatformDevice` entry with no readable name would throw an `ExceptionInInitializerError` and render the entire `MacOSProcessFFM` class unusable. Now guarded, mirroring the existing pattern in `MacFirmwareFFM`.

- **Harden `getpwuid`/`getgrgid` struct dereferences (Coverity CID 1673015).** These are safe today — `getpwuid`/`getgrgid` convert the native `NULL` to Java `null`, and the `!= null` guard admits only real pointers — but the guard was on the raw pointer rather than on the `getStructFromNativePointer` result actually dereferenced. Moving the guard onto the struct keeps the code correct even if `getpwuid`/`getgrgid` ever stop converting `NULL` to `null`, and clears the finding at the source.

The remaining Coverity findings in the module were triaged as false positives / intentional (unnamed-variable `try (var _ = …)` handling, `@SuppressWarnings("resource")` on borrowed `CFAllocatorGetDefault` singletons, benign NULL-wrapped `getOrDefault` defaults, `poll()` after `isEmpty()`, and a WMI date FP already accepted on the JNA twin).

## Also

Reduce the Coverity Scan schedule from every 4 days to **weekly (Saturday 00:00 UTC)**. Coverity Scan throttles frequent runs on lower-priority projects; weekly is ample, and the workflow can still be dispatched manually after major changes.

## Testing

Both sites are native IOKit/libc boundaries with no parse seam, so a fixture test isn't practical; `NativeComparisonTest` covers JNA/FFM parity. Pre-commit gate (spotless, checkstyle, install, forbiddenapis, javadoc) passes on `oshi-core-ffm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS process information handling to prevent crashes when CPU registry entries or user/group details are unavailable.
  * Added safer fallbacks that display numeric user and group identifiers when name lookups cannot be completed.

* **Chores**
  * Updated automated security scanning to run weekly instead of every four days.

* **Documentation**
  * Updated the upcoming release changelog with these fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->