### PR TITLE
Consolidate SLF4J level dispatch into a new LogUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug Fixes and Improvements
 
 * [#3526](https://github.com/oshi/oshi/pull/3526): Fix a potential `NullPointerException` in the macOS FFM process backend when an `IOPlatformDevice` entry has no readable name, and guard the native `passwd`/`group` struct dereferences against a null return - [@dbwiddis](https://github.com/dbwiddis).
+* [#3527](https://github.com/oshi/oshi/pull/3527): Consolidate the SLF4J log level dispatch duplicated in `ExceptionUtil` and `PerfDataUtil` into a new `oshi.util.LogUtil`, whose `isEnabled` method offers the slf4j 1.x-compatible equivalent of `Logger#isEnabledForLevel` - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24)
 

--- a/config/forbidden-apis.txt
+++ b/config/forbidden-apis.txt
@@ -20,6 +20,6 @@ java.lang.Long#decode(java.lang.String)
 
 java.lang.Double#parseDouble(java.lang.String)
 
-@defaultMessage Use oshi.util.LogLevel; org.slf4j.event.Level requires slf4j-api 1.7.15+ and breaks hosts providing an older slf4j (see #3524)
+@defaultMessage Use oshi.util.LogLevel; the org.slf4j.event package arrived in slf4j-api 1.7.15 and breaks hosts providing an older slf4j (see #3524)
 
-org.slf4j.event.Level
+org.slf4j.event.**

--- a/oshi-common/src/main/java/oshi/util/ExceptionUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ExceptionUtil.java
@@ -23,9 +23,9 @@ public final class ExceptionUtil {
     }
 
     /**
-     * Logs a throwable at the given level using only SLF4J 1.x-compatible {@link Logger} methods (no {@code atLevel}
-     * fluent API). Relies on SLF4J's implicit-cause handling: when the last of the extra arguments is a
-     * {@link Throwable}, it is attached as the log event's cause rather than substituted into the format string.
+     * Logs a throwable at the given level, substituting its message into the format string and attaching the throwable
+     * itself as the log event's cause via SLF4J's implicit-cause handling. Level dispatch is delegated to
+     * {@link LogUtil#logAtLevel(Logger, LogLevel, String, Object...)}.
      * <p>
      * Public so other modules (e.g., {@code oshi-core-ffm}) can share this dispatch instead of duplicating it.
      *
@@ -35,24 +35,7 @@ public final class ExceptionUtil {
      * @param t     the throwable to log
      */
     public static void logAtLevel(Logger log, LogLevel level, String msg, Throwable t) {
-        switch (level) {
-            case ERROR:
-                log.error(msg, t.getMessage(), t);
-                break;
-            case WARN:
-                log.warn(msg, t.getMessage(), t);
-                break;
-            case INFO:
-                log.info(msg, t.getMessage(), t);
-                break;
-            case TRACE:
-                log.trace(msg, t.getMessage(), t);
-                break;
-            case DEBUG:
-            default:
-                log.debug(msg, t.getMessage(), t);
-                break;
-        }
+        LogUtil.logAtLevel(log, level, msg, t.getMessage(), t);
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/LogUtil.java
+++ b/oshi-common/src/main/java/oshi/util/LogUtil.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util;
+
+import org.slf4j.Logger;
+
+import oshi.annotation.concurrent.ThreadSafe;
+
+/**
+ * Utility methods for logging at a {@link LogLevel} chosen at runtime.
+ */
+@ThreadSafe
+public final class LogUtil {
+
+    private LogUtil() {
+    }
+
+    /**
+     * Tests whether a level is enabled for a logger, using only SLF4J 1.x-compatible {@link Logger} methods. This is
+     * the equivalent of slf4j 2.x's {@code Logger.isEnabledForLevel}, whose parameter type OSHI cannot reference (see
+     * {@link LogLevel}).
+     * <p>
+     * {@link #logAtLevel(Logger, LogLevel, String, Object...)} does not need this guard: SLF4J checks the level itself
+     * before substituting {@code {}} placeholders. Use this only to skip work the caller must perform <em>before</em>
+     * the logging call, such as formatting an argument.
+     *
+     * @param log   the logger to query
+     * @param level the level to test
+     * @return true if the level is enabled for the logger
+     */
+    public static boolean isEnabled(Logger log, LogLevel level) {
+        switch (level) {
+            case ERROR:
+                return log.isErrorEnabled();
+            case WARN:
+                return log.isWarnEnabled();
+            case INFO:
+                return log.isInfoEnabled();
+            case TRACE:
+                return log.isTraceEnabled();
+            case DEBUG:
+            default:
+                return log.isDebugEnabled();
+        }
+    }
+
+    /**
+     * Logs a message at the given level using only SLF4J 1.x-compatible {@link Logger} methods (no {@code atLevel}
+     * fluent API).
+     * <p>
+     * The message is formatted by SLF4J only if the level is enabled, so callers do not need to guard this call with
+     * {@code isDebugEnabled()} and friends. Use {@code {}} placeholders rather than concatenation so that argument
+     * substitution remains deferred. Guard with {@link #isEnabled(Logger, LogLevel)} only when computing an argument is
+     * itself expensive.
+     * <p>
+     * SLF4J's implicit-cause handling applies: when the last argument is a {@link Throwable} with no matching
+     * placeholder, it is attached as the log event's cause rather than substituted into the format string.
+     *
+     * @param log   the logger to use
+     * @param level the level at which to log
+     * @param msg   the log message, with {@code {}} placeholders for the arguments
+     * @param args  the arguments to substitute into the message
+     */
+    public static void logAtLevel(Logger log, LogLevel level, String msg, Object... args) {
+        switch (level) {
+            case ERROR:
+                log.error(msg, args);
+                break;
+            case WARN:
+                log.warn(msg, args);
+                break;
+            case INFO:
+                log.info(msg, args);
+                break;
+            case TRACE:
+                log.trace(msg, args);
+                break;
+            case DEBUG:
+            default:
+                log.debug(msg, args);
+                break;
+        }
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
@@ -5,6 +5,7 @@
 package oshi.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -391,5 +392,15 @@ class ExceptionUtilTest {
             }, "no exception", LOG, level, "failed: {}");
             assertThat(result, is("no exception"));
         }
+    }
+
+    @Test
+    void testLogAtLevelPassesThrowableMessageAndThrowable() {
+        LogUtilTest.RecordingLogger recorder = LogUtilTest.RecordingLogger.create();
+        Throwable t = new IllegalStateException("boom");
+        ExceptionUtil.logAtLevel(recorder.logger(), LogLevel.WARN, "Failed: {}", t);
+        assertThat("Dispatched to the method matching the level", recorder.onlyCall(), is("warn"));
+        // The message fills the placeholder; the trailing throwable is left for SLF4J to pull out as the cause
+        assertThat("Throwable message then throwable", recorder.arguments(), arrayContaining("boom", t));
     }
 }

--- a/oshi-common/src/test/java/oshi/util/LogUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/LogUtilTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for {@link LogUtil}.
+ */
+class LogUtilTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LogUtilTest.class);
+
+    /**
+     * A {@link Logger} proxy which records the name and arguments of each logging method invoked on it. Used in place
+     * of SLF4J's own test doubles, which expose {@code org.slf4j.event.Level} and are therefore off limits here.
+     */
+    static final class RecordingLogger implements InvocationHandler {
+        private final List<String> calls = new ArrayList<>();
+        private Object[] lastArgs;
+        private boolean enabled = true;
+
+        static RecordingLogger create() {
+            return new RecordingLogger();
+        }
+
+        /**
+         * Makes every {@code isXEnabled()} check answer false, as a logger with the level turned off would.
+         *
+         * @return this recorder
+         */
+        RecordingLogger disabled() {
+            this.enabled = false;
+            return this;
+        }
+
+        Logger logger() {
+            return (Logger) Proxy.newProxyInstance(Logger.class.getClassLoader(), new Class<?>[] { Logger.class },
+                    this);
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            calls.add(method.getName());
+            if (boolean.class.equals(method.getReturnType())) {
+                return enabled;
+            }
+            lastArgs = args;
+            return null;
+        }
+
+        String onlyCall() {
+            assertThat("Expected exactly one logging call", calls.size(), is(1));
+            return calls.get(0);
+        }
+
+        String message() {
+            return (String) lastArgs[0];
+        }
+
+        Object[] arguments() {
+            return (Object[]) lastArgs[1];
+        }
+    }
+
+    /**
+     * Maps a level to the {@link Logger} enabled-check expected to answer for it, e.g. WARN to isWarnEnabled.
+     *
+     * @param level the level
+     * @return the expected method name
+     */
+    private static String enabledCheckFor(LogLevel level) {
+        String name = level.name();
+        return "is" + name.charAt(0) + name.substring(1).toLowerCase(Locale.ROOT) + "Enabled";
+    }
+
+    @Test
+    void testIsEnabledQueriesMatchingCheck() {
+        for (LogLevel level : LogLevel.values()) {
+            RecordingLogger recorder = RecordingLogger.create();
+            assertThat("Reports the logger's answer", LogUtil.isEnabled(recorder.logger(), level), is(true));
+            assertThat("Queried the check matching the level", recorder.onlyCall(), is(enabledCheckFor(level)));
+        }
+    }
+
+    @Test
+    void testIsEnabledReportsDisabledLevel() {
+        for (LogLevel level : LogLevel.values()) {
+            RecordingLogger recorder = RecordingLogger.create().disabled();
+            assertThat("Reports the logger's answer", LogUtil.isEnabled(recorder.logger(), level), is(false));
+            assertThat("Queried the check matching the level", recorder.onlyCall(), is(enabledCheckFor(level)));
+        }
+    }
+
+    @Test
+    void testLogAtEveryLevelWithRealLogger() {
+        for (LogLevel level : LogLevel.values()) {
+            assertDoesNotThrow(() -> LogUtil.logAtLevel(LOG, level, "Testing {} at {}", "message", level));
+        }
+    }
+
+    @Test
+    void testLogAtLevelDispatchesToMatchingMethod() {
+        for (LogLevel level : LogLevel.values()) {
+            RecordingLogger recorder = RecordingLogger.create();
+            LogUtil.logAtLevel(recorder.logger(), level, "Value is {}", 42);
+            assertThat("Dispatched to the method matching the level", recorder.onlyCall(),
+                    is(level.name().toLowerCase(Locale.ROOT)));
+            assertThat("Message left unformatted for the logging backend", recorder.message(), is("Value is {}"));
+            assertThat("Argument passed through for deferred substitution", recorder.arguments(),
+                    arrayContaining((Object) 42));
+        }
+    }
+
+    @Test
+    void testLogAtLevelWithNoArguments() {
+        RecordingLogger recorder = RecordingLogger.create();
+        LogUtil.logAtLevel(recorder.logger(), LogLevel.INFO, "No placeholders here");
+        assertThat("Dispatched to info", recorder.onlyCall(), is("info"));
+        assertThat("Message passed through", recorder.message(), is("No placeholders here"));
+        assertThat("No arguments passed", recorder.arguments(), is(emptyArray()));
+    }
+
+    @Test
+    void testLogAtLevelPassesMultipleArgumentsInOrder() {
+        RecordingLogger recorder = RecordingLogger.create();
+        LogUtil.logAtLevel(recorder.logger(), LogLevel.ERROR, "{} then {}", "first", "second");
+        assertThat("Dispatched to error", recorder.onlyCall(), is("error"));
+        assertThat("Arguments passed through in order", recorder.arguments(),
+                arrayContaining((Object) "first", "second"));
+    }
+}

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQueryHandler.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQueryHandler.java
@@ -5,7 +5,6 @@
 package oshi.util.platform.windows;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -137,7 +136,7 @@ public final class PerfCounterQueryHandler implements AutoCloseable {
         if (value < 0) {
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Error querying counter {}: {}", counter.getCounterPath(),
-                        String.format(Locale.ROOT, FormatUtil.formatError((int) value)));
+                        FormatUtil.formatError((int) value));
             }
             return 0L;
         }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfDataUtil.java
@@ -7,8 +7,6 @@ package oshi.util.platform.windows;
 import static oshi.util.LogLevel.ERROR;
 import static oshi.util.LogLevel.WARN;
 
-import java.util.Locale;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +24,7 @@ import oshi.jna.ByRef.CloseableLONGLONGByReference;
 import oshi.jna.Struct.CloseablePdhRawCounter;
 import oshi.util.FormatUtil;
 import oshi.util.LogLevel;
+import oshi.util.LogUtil;
 import oshi.util.ParseUtil;
 import oshi.util.Util;
 
@@ -158,38 +157,10 @@ public final class PerfDataUtil {
         return WinError.ERROR_SUCCESS == PDH.PdhRemoveCounter(p.getValue());
     }
 
-    private static String formatErrorMessage(String message, int ret) {
-        return message + " Error code: " + String.format(Locale.ROOT, FormatUtil.formatError(ret));
-    }
-
     static <T> T handleError(int ret, LogLevel level, String message, T defaultValue) {
-        switch (level) {
-            case ERROR:
-                if (LOG.isErrorEnabled()) {
-                    LOG.error(formatErrorMessage(message, ret));
-                }
-                break;
-            case WARN:
-                if (LOG.isWarnEnabled()) {
-                    LOG.warn(formatErrorMessage(message, ret));
-                }
-                break;
-            case INFO:
-                if (LOG.isInfoEnabled()) {
-                    LOG.info(formatErrorMessage(message, ret));
-                }
-                break;
-            case TRACE:
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace(formatErrorMessage(message, ret));
-                }
-                break;
-            case DEBUG:
-            default:
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(formatErrorMessage(message, ret));
-                }
-                break;
+        // Guarded because formatting the error code happens before the logging call
+        if (LogUtil.isEnabled(LOG, level)) {
+            LogUtil.logAtLevel(LOG, level, "{} Error code: {}", message, FormatUtil.formatError(ret));
         }
         return defaultValue;
     }

--- a/oshi-core/src/test/java/oshi/util/platform/windows/PerfDataUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/windows/PerfDataUtilTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.condition.OS;
 
 import com.sun.jna.platform.win32.PdhMsg;
 
-import oshi.util.LogLevel;
-
 @EnabledOnOs(OS.WINDOWS)
 class PerfDataUtilTest {
 
@@ -36,12 +34,5 @@ class PerfDataUtilTest {
     void testHandleErrorStringDefault() {
         assertThat(PerfDataUtil.handleError(PdhMsg.PDH_INVALID_HANDLE, WARN, "Failed to get counter.", "default"),
                 is("default"));
-    }
-
-    @Test
-    void testHandleErrorAtEveryLevel() {
-        for (LogLevel level : LogLevel.values()) {
-            assertThat(PerfDataUtil.handleError(PdhMsg.PDH_INVALID_HANDLE, level, "Failed.", "default"), is("default"));
-        }
     }
 }


### PR DESCRIPTION
`PerfDataUtil.handleError` and `ExceptionUtil.logAtLevel` each carried their own five-way `LogLevel` switch. This hoists the dispatch into a new `oshi.util.LogUtil` and has both delegate to it.

### `LogUtil`

Two methods, the level-parameterized halves of classic SLF4J logging:

- `logAtLevel(Logger, LogLevel, String, Object...)` — the shared dispatch, now varargs.
- `isEnabled(Logger, LogLevel)` — restores the capability of `Logger#isEnabledForLevel` that #3432 had to drop for slf4j 1.x compatibility.

`ExceptionUtil.logAtLevel` keeps its exact signature and becomes a one-line delegate, so `oshi-core-ffm` and any downstream caller are unaffected.

### `PerfDataUtil.handleError`

31 lines to 7. `isEnabled` lets it keep skipping `FormatUtil.formatError` when the level is off, without an inline switch to do the checking.

It was also double-formatting: `FormatUtil.formatError` returns the output of `String.format`, and the result was passed through `String.format` again with no arguments. Harmless, since the hex output contains no `%`, but pointless. `PerfCounterQueryHandler` had the same copy-paste and is fixed too — its `isWarnEnabled` guards are left alone, since both sites log at a level known at the call site and can check it directly.

### forbidden-apis

Widened from `org.slf4j.event.Level` to `org.slf4j.event.**`. Checking the jars, slf4j-api 1.7.5 has no `org/slf4j/event` package at all, while 1.7.25 has six entries — the package arrives as a unit, so every type in it breaks the same hosts that motivated #3524 and #3525.

### Coverage

The level switch now lives in `oshi-common`, where a cross-platform test covers all ten branches. Previously the only fully covered copy was in `PerfDataUtil`, reachable only on Windows CI. Local JaCoCo, before vs after:

```
oshi-common  ExceptionUtil  LINE 77/77  BRAN 5/5   ->  LINE 68/68  (no branches)
             LogUtil                    (new)      ->  LINE 17/17  BRAN 10/10

oshi-core    PerfDataUtil             54 line, 41 br  ->  43 line, 26 br
             PerfCounterQueryHandler  56 line, 26 br  ->  53 line, 22 br
```

The `oshi-core` classes are Windows-only and read 0-covered on a Mac either way; the point is the shrinking denominator.

`LogUtilTest` uses a `java.lang.reflect.Proxy` recorder rather than SLF4J's own `SubstituteLogger`, because `SubstituteLoggingEvent.getLevel()` returns the banned `org.slf4j.event.Level`. The proxy asserts the contract directly: which `Logger` method each level dispatches to, and that arguments arrive unformatted for deferred substitution.

No user-observable behavior change — the emitted message text is byte-identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging compatibility across supported SLF4J versions.
  * Ensured log messages preserve formatting arguments and exception details.
  * Improved handling of enabled and disabled log levels.
  * Maintained clear warnings for invalid performance counter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->