### PR TITLE
Route no-argument catch-log-return blocks through ExceptionUtil

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/net/NetStatFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/net/NetStatFFM.java
@@ -7,8 +7,9 @@ package oshi.driver.mac.net;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+import static oshi.util.LogLevel.ERROR;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.foreign.ValueLayout.OfLong;
@@ -88,7 +89,7 @@ public final class NetStatFFM {
      */
     public static Map<Integer, IFdata> queryIFdata(int index) {
         Map<Integer, IFdata> data = new HashMap<>();
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             int[] mib = { CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0 };
             MemorySegment mibSeg = arena.allocate(ValueLayout.JAVA_INT, mib.length);
             for (int i = 0; i < mib.length; i++) {
@@ -145,9 +146,7 @@ public final class NetStatFFM {
                 }
                 offset += msgLen;
             }
-        } catch (Throwable t) {
-            LOG.error("Error querying network interface data", t);
-        }
-        return data;
+            return data;
+        }, LOG, ERROR, "Error querying network interface data", data);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessWtsDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessWtsDataFFM.java
@@ -7,6 +7,7 @@ package oshi.driver.windows.registry;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.readWideStringFromPointer;
 import static oshi.ffm.platform.windows.Wtsapi32FFM.PROCESS_INFO_EX_HANDLE_COUNT;
 import static oshi.ffm.platform.windows.Wtsapi32FFM.PROCESS_INFO_EX_KERNEL_TIME;
@@ -20,8 +21,8 @@ import static oshi.ffm.platform.windows.Wtsapi32FFM.WTS_ANY_SESSION;
 import static oshi.ffm.platform.windows.Wtsapi32FFM.WTS_CURRENT_SERVER_HANDLE;
 import static oshi.ffm.platform.windows.Wtsapi32FFM.WTS_PROCESS_INFO_LEVEL_1;
 import static oshi.ffm.platform.windows.Wtsapi32FFM.WTS_TYPE_PROCESS_INFO_LEVEL_1;
+import static oshi.util.LogLevel.ERROR;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.Collection;
 import java.util.HashMap;
@@ -71,7 +72,7 @@ public final class ProcessWtsDataFFM {
     private static Map<Integer, WtsInfo> queryProcessWtsMapFromWTS(Collection<Integer> pids) {
         Set<Integer> pidSet = pids != null ? new HashSet<>(pids) : null;
         Map<Integer, WtsInfo> wtsMap = new HashMap<>();
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment pLevel = arena.allocate(JAVA_INT);
             pLevel.set(JAVA_INT, 0, WTS_PROCESS_INFO_LEVEL_1);
             MemorySegment ppProcessInfo = arena.allocate(ADDRESS);
@@ -108,10 +109,8 @@ public final class ProcessWtsDataFFM {
                             Kernel32FFM.GetLastError().orElse(-1));
                 }
             }
-        } catch (Throwable t) {
-            LOG.error("Failed to enumerate Processes via WTS", t);
-        }
-        return wtsMap;
+            return wtsMap;
+        }, LOG, ERROR, "Failed to enumerate Processes via WTS", wtsMap);
     }
 
     static Map<Integer, WtsInfo> queryProcessWtsMapFromWMI(Collection<Integer> pids) {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/NativeHandle.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/NativeHandle.java
@@ -4,6 +4,8 @@
  */
 package oshi.ffm;
 
+import static oshi.util.ExceptionUtil.runOrLog;
+
 import java.lang.foreign.MemorySegment;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -89,11 +91,7 @@ public final class NativeHandle implements AutoCloseable {
     @Override
     public void close() {
         if (!isNull() && closed.compareAndSet(false, true)) {
-            try {
-                closer.close(handle);
-            } catch (Throwable t) {
-                LOG.debug("Failed to close native handle: {}", t.getMessage());
-            }
+            runOrLog(() -> closer.close(handle), LOG, "Failed to close native handle: {}");
         }
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/DxgiFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/DxgiFFM.java
@@ -8,6 +8,8 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+import static oshi.util.LogLevel.DEBUG;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
@@ -79,7 +81,7 @@ public final class DxgiFFM extends ForeignFunctions {
         if (!AVAILABLE) {
             return Collections.emptyList();
         }
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             // Write IID to memory
             MemorySegment riid = arena.allocate(16);
             riid.copyFrom(MemorySegment.ofArray(IID_IDXGI_FACTORY));
@@ -130,10 +132,7 @@ public final class DxgiFFM extends ForeignFunctions {
                 vtableRelease(factory, arena);
             }
             return Collections.unmodifiableList(result);
-        } catch (Throwable t) {
-            LOG.debug("DXGI enumeration failed: {}", t.getMessage());
-            return Collections.emptyList();
-        }
+        }, LOG, DEBUG, "DXGI enumeration failed", Collections.emptyList());
     }
 
     // IDXGIFactory::EnumAdapters is vtable slot 7

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Kernel32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Kernel32FFM.java
@@ -17,6 +17,7 @@ import static oshi.util.ExceptionUtil.getOptional;
 import static oshi.util.ExceptionUtil.getOptionalInt;
 import static oshi.util.ExceptionUtil.getOptionalLong;
 import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.LogLevel.DEBUG;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -69,14 +70,11 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
 
     public static boolean DeviceIoControl(MemorySegment hDevice, int dwIoControlCode, MemorySegment lpInBuffer,
             int nInBufferSize, MemorySegment lpOutBuffer, int nOutBufferSize) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaBooleanOrDefault(arena -> {
             MemorySegment lpBytesReturned = arena.allocate(JAVA_INT);
             return isSuccess((int) DeviceIoControl.invokeExact(hDevice, dwIoControlCode, lpInBuffer, nInBufferSize,
                     lpOutBuffer, nOutBufferSize, lpBytesReturned, MemorySegment.NULL));
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.DeviceIoControl failed: {}", t.getMessage());
-            return false;
-        }
+        }, LOG, DEBUG, "Kernel32FFM.DeviceIoControl failed", false);
     }
 
     private static final MethodHandle FindFirstVolume = downcall(K32, "FindFirstVolumeW", ADDRESS, ADDRESS, JAVA_INT);
@@ -112,7 +110,7 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
     private static final MethodHandle GetComputerName = downcall(K32, "GetComputerNameW", JAVA_INT, ADDRESS, ADDRESS);
 
     public static Optional<String> GetComputerName() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             int maxLen = 32;
 
             MemorySegment buffer = arena.allocate(JAVA_CHAR, maxLen);
@@ -123,21 +121,18 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
             if (!success) {
                 int errorCode = (int) GetLastError.invokeExact();
                 LOG.error("Failed to get computer name. Error code: {}", errorCode);
-                return Optional.empty();
+                return Optional.<String>empty();
             }
 
             return Optional.of(readWideString(buffer));
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.GetComputerName failed: {}", t.getMessage());
-            return Optional.empty();
-        }
+        }, LOG, DEBUG, "Kernel32FFM.GetComputerName failed", Optional.empty());
     }
 
     private static final MethodHandle GetComputerNameEx = downcall(K32, "GetComputerNameExW", JAVA_INT, JAVA_INT,
             ADDRESS, ADDRESS);
 
     public static Optional<String> GetComputerNameEx() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             int maxLen = 256;
 
             MemorySegment buffer = arena.allocate(JAVA_CHAR, maxLen);
@@ -151,14 +146,11 @@ public final class Kernel32FFM extends WindowsForeignFunctions {
             if (!success) {
                 int errorCode = (int) GetLastError.invokeExact();
                 LOG.error("Failed to get DNS domain name. Error code: {}", errorCode);
-                return Optional.empty();
+                return Optional.<String>empty();
             }
 
             return Optional.of(readWideString(buffer));
-        } catch (Throwable t) {
-            LOG.debug("Kernel32FFM.GetComputerNameEx failed: {}", t.getMessage());
-            return Optional.empty();
-        }
+        }, LOG, DEBUG, "Kernel32FFM.GetComputerNameEx failed", Optional.empty());
     }
 
     private static final MethodHandle GetCurrentProcess = downcall(K32, "GetCurrentProcess", ADDRESS);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Shell32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Shell32FFM.java
@@ -7,8 +7,9 @@ package oshi.ffm.platform.windows;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+import static oshi.util.LogLevel.DEBUG;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
@@ -43,7 +44,7 @@ public final class Shell32FFM extends WindowsForeignFunctions {
             return Collections.emptyList();
         }
 
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment cmdLineSegment = toWideString(arena, commandLine);
             MemorySegment numArgsSegment = arena.allocate(JAVA_INT);
 
@@ -84,9 +85,6 @@ public final class Shell32FFM extends WindowsForeignFunctions {
                 // Free the memory allocated by CommandLineToArgvW
                 Kernel32FFM.LocalFree(argvPtr);
             }
-        } catch (Throwable t) {
-            LOG.debug("Shell32FFM.CommandLineToArgv failed: {}", t.getMessage());
-            return Collections.emptyList();
-        }
+        }, LOG, DEBUG, "Shell32FFM.CommandLineToArgv failed", Collections.emptyList());
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
@@ -7,6 +7,12 @@ package oshi.ffm.util.gpu;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaDoubleOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
+import static oshi.util.ExceptionUtil.getBooleanOrDefault;
+import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.ExceptionUtil.runOrLog;
+import static oshi.util.LogLevel.DEBUG;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
@@ -180,25 +186,21 @@ public final class AdlUtilFFM {
         if (!AVAILABLE) {
             return null;
         }
-        try {
+        return getOrDefault(() -> {
             MemorySegment ctxRef = arena.allocate(ADDRESS);
             int ret = (int) ADL2_MAIN_CONTROL_CREATE.invokeExact(MALLOC_STUB, 1, ctxRef);
             if (ret == ADL_OK) {
                 return ctxRef.get(ADDRESS, 0);
             }
             LOG.debug("ADL2_Main_Control_Create failed with code {}", ret);
-        } catch (Throwable t) {
-            LOG.debug("ADL init failed: {}", t.getMessage());
-        }
-        return null;
+            return null;
+        }, null, LOG, "ADL init failed: {}");
     }
 
     private static void adlUninit(MemorySegment context) {
-        try {
+        runOrLog(() -> {
             ADL2_MAIN_CONTROL_DESTROY.invokeExact(context);
-        } catch (Throwable t) {
-            LOG.debug("ADL uninit failed: {}", t.getMessage());
-        }
+        }, LOG, "ADL uninit failed: {}");
     }
 
     private static void ensureAdaptersEnumerated(MemorySegment context, Arena arena) {
@@ -220,7 +222,7 @@ public final class AdlUtilFFM {
     }
 
     private static Map<Integer, Integer> enumerateAdapters(MemorySegment ctx, Arena arena) {
-        try {
+        return getOrDefault(() -> {
             MemorySegment numRef = arena.allocate(JAVA_INT);
             if ((int) ADL2_ADAPTER_NUMBER_OF_ADAPTERS_GET.invokeExact(ctx, numRef) != ADL_OK) {
                 return null;
@@ -255,10 +257,7 @@ public final class AdlUtilFFM {
                 }
             }
             return Collections.unmodifiableMap(map);
-        } catch (Throwable t) {
-            LOG.debug("ADL adapter enumeration failed: {}", t.getMessage());
-            return null;
-        }
+        }, null, LOG, "ADL adapter enumeration failed: {}");
     }
 
     private static boolean supportsOverdriveN(MemorySegment context, int adapterIndex, Arena arena) {
@@ -271,17 +270,15 @@ public final class AdlUtilFFM {
 
     private static boolean supportsOverdriveVersion(MemorySegment context, int adapterIndex, Arena arena,
             int minVersion) {
-        try {
+        return getBooleanOrDefault(() -> {
             MemorySegment supported = arena.allocate(JAVA_INT);
             MemorySegment enabled = arena.allocate(JAVA_INT);
             MemorySegment version = arena.allocate(JAVA_INT);
             if ((int) ADL2_OVERDRIVE_CAPS.invokeExact(context, adapterIndex, supported, enabled, version) == ADL_OK) {
                 return supported.get(JAVA_INT, 0) != 0 && version.get(JAVA_INT, 0) >= minVersion;
             }
-        } catch (Throwable t) {
-            LOG.debug("ADL Overdrive_Caps failed: {}", t.getMessage());
-        }
-        return false;
+            return false;
+        }, false, LOG, "ADL Overdrive_Caps failed: {}");
     }
 
     // -------------------------------------------------------------------------
@@ -331,7 +328,7 @@ public final class AdlUtilFFM {
         if (adapterIndex < 0) {
             return -1d;
         }
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaDoubleOrDefault(arena -> {
             MemorySegment ctx = adlInit(arena);
             if (ctx == null) {
                 return -1d;
@@ -348,10 +345,8 @@ public final class AdlUtilFFM {
             } finally {
                 adlUninit(ctx);
             }
-        } catch (Throwable t) {
-            LOG.debug("ADL getTemperature failed: {}", t.getMessage());
-        }
-        return -1d;
+            return -1d;
+        }, LOG, DEBUG, "ADL getTemperature failed", -1d);
     }
 
     /**
@@ -364,7 +359,7 @@ public final class AdlUtilFFM {
         if (adapterIndex < 0) {
             return -1L;
         }
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment ctx = adlInit(arena);
             if (ctx == null) {
                 return -1L;
@@ -380,10 +375,8 @@ public final class AdlUtilFFM {
             } finally {
                 adlUninit(ctx);
             }
-        } catch (Throwable t) {
-            LOG.debug("ADL getCoreClockMhz failed: {}", t.getMessage());
-        }
-        return -1L;
+            return -1L;
+        }, LOG, DEBUG, "ADL getCoreClockMhz failed", -1L);
     }
 
     /**
@@ -396,7 +389,7 @@ public final class AdlUtilFFM {
         if (adapterIndex < 0) {
             return -1L;
         }
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment ctx = adlInit(arena);
             if (ctx == null) {
                 return -1L;
@@ -412,10 +405,8 @@ public final class AdlUtilFFM {
             } finally {
                 adlUninit(ctx);
             }
-        } catch (Throwable t) {
-            LOG.debug("ADL getMemoryClockMhz failed: {}", t.getMessage());
-        }
-        return -1L;
+            return -1L;
+        }, LOG, DEBUG, "ADL getMemoryClockMhz failed", -1L);
     }
 
     /**
@@ -428,7 +419,7 @@ public final class AdlUtilFFM {
         if (adapterIndex < 0) {
             return -1d;
         }
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaDoubleOrDefault(arena -> {
             MemorySegment ctx = adlInit(arena);
             if (ctx == null) {
                 return -1d;
@@ -446,10 +437,8 @@ public final class AdlUtilFFM {
             } finally {
                 adlUninit(ctx);
             }
-        } catch (Throwable t) {
-            LOG.debug("ADL getPowerDraw failed: {}", t.getMessage());
-        }
-        return -1d;
+            return -1d;
+        }, LOG, DEBUG, "ADL getPowerDraw failed", -1d);
     }
 
     /**
@@ -462,7 +451,7 @@ public final class AdlUtilFFM {
         if (adapterIndex < 0) {
             return -1d;
         }
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaDoubleOrDefault(arena -> {
             MemorySegment ctx = adlInit(arena);
             if (ctx == null) {
                 return -1d;
@@ -481,9 +470,7 @@ public final class AdlUtilFFM {
             } finally {
                 adlUninit(ctx);
             }
-        } catch (Throwable t) {
-            LOG.debug("ADL getFanSpeedPercent failed: {}", t.getMessage());
-        }
-        return -1d;
+            return -1d;
+        }, LOG, DEBUG, "ADL getFanSpeedPercent failed", -1d);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -7,6 +7,7 @@ package oshi.ffm.util.platform.mac;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.platform.mac.IOKitFunctions.IOConnectCallStructMethod;
 import static oshi.ffm.platform.mac.IOKitFunctions.IOServiceClose;
 import static oshi.ffm.platform.mac.IOKitFunctions.IOServiceOpen;
@@ -24,6 +25,7 @@ import static oshi.ffm.platform.mac.MacSystem.SMC_VAL_DATA_SIZE;
 import static oshi.ffm.platform.mac.MacSystem.SMC_VAL_DATA_TYPE;
 import static oshi.ffm.platform.mac.MacSystemFunctions.mach_task_self;
 import static oshi.util.ExceptionUtil.getIntOrDefault;
+import static oshi.util.LogLevel.ERROR;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -99,24 +101,23 @@ public final class SmcUtilFFM {
             LOG.error("Unable to locate AppleSMC service");
             return 0;
         }
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment connPtr = arena.allocate(JAVA_INT);
-            int task = mach_task_self();
-            int result = IOServiceOpen(smcService.segment(), task, 0, connPtr);
-            if (result == 0) {
-                int conn = connPtr.get(JAVA_INT, 0);
-                if (conn == 0) {
-                    LOG.error("IOServiceOpen returned null connect handle");
-                    return 0;
+        try {
+            return callInArenaIntOrDefault(arena -> {
+                MemorySegment connPtr = arena.allocate(JAVA_INT);
+                int task = mach_task_self();
+                int result = IOServiceOpen(smcService.segment(), task, 0, connPtr);
+                if (result == 0) {
+                    int conn = connPtr.get(JAVA_INT, 0);
+                    if (conn == 0) {
+                        LOG.error("IOServiceOpen returned null connect handle");
+                        return 0;
+                    }
+                    return conn;
                 }
-                return conn;
-            }
-            String hex = String.format(Locale.ROOT, "0x%08x", result);
-            LOG.error("Unable to open connection to AppleSMC service. Error: {}", hex);
-            return 0;
-        } catch (Throwable e) {
-            LOG.error("Exception opening SMC connection", e);
-            return 0;
+                String hex = String.format(Locale.ROOT, "0x%08x", result);
+                LOG.error("Unable to open connection to AppleSMC service. Error: {}", hex);
+                return 0;
+            }, LOG, ERROR, "Exception opening SMC connection", 0);
         } finally {
             smcService.release();
         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
@@ -25,6 +25,9 @@ import static oshi.ffm.platform.unix.solaris.LibKstatFunctions.namedValueChar;
 import static oshi.ffm.platform.unix.solaris.LibKstatFunctions.namedValueInt32;
 import static oshi.ffm.platform.unix.solaris.LibKstatFunctions.namedValueInt64;
 import static oshi.ffm.platform.unix.solaris.LibKstatFunctions.namedValueString;
+import static oshi.util.ExceptionUtil.getBooleanOrDefault;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
+import static oshi.util.LogLevel.WARN;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -82,7 +85,7 @@ public final class KstatUtilFFM {
          */
         @GuardedBy("CHAIN")
         public boolean read(MemorySegment ksp) {
-            try {
+            return getBooleanOrDefault(() -> {
                 int retry = 0;
                 while (LibKstatFunctions.kstat_read(ctl, ksp, MemorySegment.NULL) == -1) {
                     if (++retry >= 5) {
@@ -98,10 +101,7 @@ public final class KstatUtilFFM {
                     }
                 }
                 return true;
-            } catch (Throwable t) {
-                LOG.warn("kstat_read failed", t);
-                return false;
-            }
+            }, false, LOG, WARN, "kstat_read failed");
         }
 
         /**
@@ -161,12 +161,8 @@ public final class KstatUtilFFM {
          */
         @GuardedBy("CHAIN")
         public int update() {
-            try {
-                return LibKstatFunctions.kstat_chain_update(ctl);
-            } catch (Throwable t) {
-                LOG.warn("kstat_chain_update failed", t);
-                return -1;
-            }
+            return getIntOrDefault(() -> LibKstatFunctions.kstat_chain_update(ctl), -1, LOG, WARN,
+                    "kstat_chain_update failed");
         }
 
         @Override

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
@@ -10,6 +10,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.windows.Advapi32FFM.GetTokenInformation;
 import static oshi.ffm.platform.windows.Advapi32FFM.OpenProcessToken;
@@ -31,6 +32,8 @@ import static oshi.ffm.platform.windows.WinNTFFM.REG_SZ;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.checkSuccess;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.toWideString;
+import static oshi.util.LogLevel.DEBUG;
+import static oshi.util.LogLevel.ERROR;
 import static oshi.util.LogLevel.TRACE;
 import static oshi.util.Memoizer.memoize;
 
@@ -71,7 +74,7 @@ public final class Advapi32UtilFFM {
      * @return true if the process is elevated, false otherwise
      */
     public static boolean isCurrentProcessElevated() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaBooleanOrDefault(arena -> {
 
             Optional<MemorySegment> hProcessOpt = Kernel32FFM.GetCurrentProcess();
             if (hProcessOpt.isEmpty()) {
@@ -105,10 +108,7 @@ public final class Advapi32UtilFFM {
             } finally {
                 Kernel32FFM.CloseHandle(hToken);
             }
-        } catch (Throwable t) {
-            LOG.debug("Advapi32FFM.isCurrentProcessElevated failed", t);
-            return false;
-        }
+        }, LOG, DEBUG, "Advapi32FFM.isCurrentProcessElevated failed", false);
     }
 
     /**
@@ -439,11 +439,12 @@ public final class Advapi32UtilFFM {
      */
     public static long querySystemBootTime() {
         String eventLog = SYSTEM_LOG.get();
-        try (Arena arena = Arena.ofConfined()) {
+        // A zero result means "no boot event found"; every such path shares the uptime fallback below.
+        long bootTime = callInArenaLongOrDefault(arena -> {
             Optional<MemorySegment> hEventLogOpt = Advapi32FFM.OpenEventLog(arena, eventLog);
             if (hEventLogOpt.isEmpty()) {
                 LOG.warn("Unable to open system Event Log. Falling back to uptime.");
-                return System.currentTimeMillis() / 1000L - Kernel32UtilFFM.querySystemUptime();
+                return 0L;
             }
 
             MemorySegment hEventLog = hEventLogOpt.get();
@@ -495,8 +496,10 @@ public final class Advapi32UtilFFM {
                 // Close on every path, including a Throwable from a malformed record (matches the fallback contract).
                 Advapi32FFM.CloseEventLog(hEventLog);
             }
-        } catch (Throwable t) {
-            LOG.error("Exception while querying system boottime, fallback to boot time from uptime", t);
+            return 0L;
+        }, LOG, ERROR, "Exception while querying system boottime, fallback to boot time from uptime", 0L);
+        if (bootTime > 0) {
+            return bootTime;
         }
         // Fallback: approximate boot time from uptime
         return System.currentTimeMillis() / 1000L - Kernel32UtilFFM.querySystemUptime();
@@ -513,7 +516,7 @@ public final class Advapi32UtilFFM {
             return null;
         }
 
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment sourceName = toWideString(arena, systemLog);
 
             Optional<MemorySegment> hEventLog = Advapi32FFM.OpenEventLog(NULL, sourceName);
@@ -526,9 +529,6 @@ public final class Advapi32UtilFFM {
             // Opened only to validate the configured log name; close it so the handle is not leaked.
             Advapi32FFM.CloseEventLog(hEventLog.get());
             return systemLog;
-        } catch (Throwable t) {
-            LOG.error("Exception while opening system event log", t);
-            return null;
-        }
+        }, LOG, ERROR, "Exception while opening system event log", null);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacCentralProcessorFFM.java
@@ -12,7 +12,6 @@ import static oshi.util.ExceptionUtil.runOrLog;
 import static oshi.util.LogLevel.DEBUG;
 import static oshi.util.LogLevel.ERROR;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -82,7 +81,7 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
 
     @Override
     protected int[] queryProcessorCpuTicks() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment callState = arena.allocate(CAPTURED_STATE_LAYOUT);
             MemorySegment procCountSeg = arena.allocate(ValueLayout.JAVA_INT);
             MemorySegment procInfoPtrSeg = arena.allocate(ValueLayout.ADDRESS);
@@ -108,10 +107,7 @@ final class MacCentralProcessorFFM extends MacCentralProcessor {
                                 rawProcInfoPtr.address(), (long) procInfoCount * MacSystem.INT_SIZE),
                         LOG, "Failed to vm_deallocate processor info buffer");
             }
-        } catch (Throwable e) {
-            LOG.error("Failed to update CPU Load", e);
-        }
-        return new int[0];
+        }, LOG, ERROR, "Failed to update CPU Load", new int[0]);
     }
 
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -4,6 +4,9 @@
  */
 package oshi.hardware.platform.mac;
 
+import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.LogLevel.ERROR;
+
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -244,111 +247,111 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
         List<HWDiskStore> diskList = new ArrayList<>();
 
         try {
-            @SuppressWarnings("resource") // CFAllocatorGetDefault returns a borrowed singleton
-            CFAllocatorRef alloc = new CFAllocatorRef(CoreFoundationFunctions.CFAllocatorGetDefault());
-            try (DASessionRef session = DASessionRef.create(alloc)) {
-                if (session.isNull()) {
-                    LOG.error("Unable to open session to DiskArbitration framework.");
-                    return Collections.emptyList();
-                }
-                List<String> bsdNames = new ArrayList<>();
-                IOIterator iter = IOKitUtilFFM.getMatchingServices("IOMedia");
-                if (iter != null) {
-                    try (iter) {
-                        IORegistryEntry media = iter.next();
-                        while (media != null) {
-                            try (IORegistryEntry current = media) {
-                                Boolean whole = current.getBooleanProperty("Whole");
-                                if (Boolean.TRUE.equals(whole)) {
-                                    try (DADiskRef disk = DADiskRef.createFromIOMedia(alloc, session, current)) {
-                                        if (!disk.isNull()) {
-                                            String bsdName = disk.getBSDName();
-                                            if (bsdName != null) {
-                                                bsdNames.add(bsdName);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            media = iter.next();
-                        }
+            return getOrDefault(() -> {
+                @SuppressWarnings("resource") // CFAllocatorGetDefault returns a borrowed singleton
+                CFAllocatorRef alloc = new CFAllocatorRef(CoreFoundationFunctions.CFAllocatorGetDefault());
+                try (DASessionRef session = DASessionRef.create(alloc)) {
+                    if (session.isNull()) {
+                        LOG.error("Unable to open session to DiskArbitration framework.");
+                        return Collections.emptyList();
                     }
-                }
-
-                for (String bsdName : bsdNames) {
-                    String model = "";
-                    String serial = "";
-                    long size = 0L;
-
-                    String path = "/dev/" + bsdName;
-                    try (DADiskRef disk = DADiskRef.createFromBSDName(alloc, session, path)) {
-                        if (disk.isNull()) {
-                            continue;
-                        }
-                        try (CFDictionaryRef diskInfo = disk.copyDescription()) {
-                            if (!diskInfo.isNull()) {
-                                MemorySegment result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_DEVICE_MODEL));
-                                model = CFUtilFFM.cfPointerToString(result);
-                                result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_MEDIA_SIZE));
-                                if (!result.equals(MemorySegment.NULL)) {
-                                    size = CFNumberRef.longValue(result);
-                                }
-
-                                if (!"Disk Image".equals(model)) {
-                                    try (CFStringRef modelNameRef = CFStringRef.createCFString(model)) {
-                                        @SuppressWarnings("resource") // consumed by matchingDict
-                                        CFMutableDictionaryRef propertyDict = new CFMutableDictionaryRef(
-                                                CoreFoundationFunctions.CFDictionaryCreateMutable(alloc.segment(), 0,
-                                                        MemorySegment.NULL, MemorySegment.NULL));
-                                        propertyDict.setValue(cfKeyMap.get(CFKey.MODEL), modelNameRef);
-                                        @SuppressWarnings("resource") // consumed by getMatchingServices
-                                        CFMutableDictionaryRef matchingDict = new CFMutableDictionaryRef(
-                                                CoreFoundationFunctions.CFDictionaryCreateMutable(alloc.segment(), 0,
-                                                        MemorySegment.NULL, MemorySegment.NULL));
-                                        matchingDict.setValue(cfKeyMap.get(CFKey.IO_PROPERTY_MATCH), propertyDict);
-
-                                        IOIterator serviceIterator = IOKitUtilFFM
-                                                .getMatchingServices(matchingDict.segment());
-                                        propertyDict.release();
-
-                                        if (serviceIterator != null) {
-                                            try (serviceIterator) {
-                                                IORegistryEntry sdService = serviceIterator.next();
-                                                while (sdService != null) {
-                                                    try (IORegistryEntry current = sdService) {
-                                                        serial = current.getStringProperty("Serial Number");
-                                                    }
-                                                    if (serial != null) {
-                                                        break;
-                                                    }
-                                                    sdService = serviceIterator.next();
+                    List<String> bsdNames = new ArrayList<>();
+                    IOIterator iter = IOKitUtilFFM.getMatchingServices("IOMedia");
+                    if (iter != null) {
+                        try (iter) {
+                            IORegistryEntry media = iter.next();
+                            while (media != null) {
+                                try (IORegistryEntry current = media) {
+                                    Boolean whole = current.getBooleanProperty("Whole");
+                                    if (Boolean.TRUE.equals(whole)) {
+                                        try (DADiskRef disk = DADiskRef.createFromIOMedia(alloc, session, current)) {
+                                            if (!disk.isNull()) {
+                                                String bsdName = disk.getBSDName();
+                                                if (bsdName != null) {
+                                                    bsdNames.add(bsdName);
                                                 }
                                             }
                                         }
                                     }
-                                    if (serial == null) {
-                                        serial = "";
-                                    }
                                 }
+                                media = iter.next();
                             }
                         }
                     }
 
-                    if (size <= 0) {
-                        continue;
+                    for (String bsdName : bsdNames) {
+                        String model = "";
+                        String serial = "";
+                        long size = 0L;
+
+                        String path = "/dev/" + bsdName;
+                        try (DADiskRef disk = DADiskRef.createFromBSDName(alloc, session, path)) {
+                            if (disk.isNull()) {
+                                continue;
+                            }
+                            try (CFDictionaryRef diskInfo = disk.copyDescription()) {
+                                if (!diskInfo.isNull()) {
+                                    MemorySegment result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_DEVICE_MODEL));
+                                    model = CFUtilFFM.cfPointerToString(result);
+                                    result = diskInfo.getValue(cfKeyMap.get(CFKey.DA_MEDIA_SIZE));
+                                    if (!result.equals(MemorySegment.NULL)) {
+                                        size = CFNumberRef.longValue(result);
+                                    }
+
+                                    if (!"Disk Image".equals(model)) {
+                                        try (CFStringRef modelNameRef = CFStringRef.createCFString(model)) {
+                                            @SuppressWarnings("resource") // consumed by matchingDict
+                                            CFMutableDictionaryRef propertyDict = new CFMutableDictionaryRef(
+                                                    CoreFoundationFunctions.CFDictionaryCreateMutable(alloc.segment(),
+                                                            0, MemorySegment.NULL, MemorySegment.NULL));
+                                            propertyDict.setValue(cfKeyMap.get(CFKey.MODEL), modelNameRef);
+                                            @SuppressWarnings("resource") // consumed by getMatchingServices
+                                            CFMutableDictionaryRef matchingDict = new CFMutableDictionaryRef(
+                                                    CoreFoundationFunctions.CFDictionaryCreateMutable(alloc.segment(),
+                                                            0, MemorySegment.NULL, MemorySegment.NULL));
+                                            matchingDict.setValue(cfKeyMap.get(CFKey.IO_PROPERTY_MATCH), propertyDict);
+
+                                            IOIterator serviceIterator = IOKitUtilFFM
+                                                    .getMatchingServices(matchingDict.segment());
+                                            propertyDict.release();
+
+                                            if (serviceIterator != null) {
+                                                try (serviceIterator) {
+                                                    IORegistryEntry sdService = serviceIterator.next();
+                                                    while (sdService != null) {
+                                                        try (IORegistryEntry current = sdService) {
+                                                            serial = current.getStringProperty("Serial Number");
+                                                        }
+                                                        if (serial != null) {
+                                                            break;
+                                                        }
+                                                        sdService = serviceIterator.next();
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        if (serial == null) {
+                                            serial = "";
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if (size <= 0) {
+                            continue;
+                        }
+                        diskList.add(new MacHWDiskStoreFFM(bsdName, model.trim(), serial.trim(), size,
+                                detectDiskType(bsdName), session, mountPointMap, cfKeyMap));
                     }
-                    diskList.add(new MacHWDiskStoreFFM(bsdName, model.trim(), serial.trim(), size,
-                            detectDiskType(bsdName), session, mountPointMap, cfKeyMap));
                 }
-            }
-        } catch (Throwable e) {
-            LOG.error("Error enumerating disks", e);
+                return diskList;
+            }, diskList, LOG, ERROR, "Error enumerating disks");
         } finally {
             for (CFStringRef value : cfKeyMap.values()) {
                 value.release();
             }
         }
-        return diskList;
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/CupsPrinterFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/CupsPrinterFFM.java
@@ -5,8 +5,9 @@
 package oshi.hardware.platform.unix;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+import static oshi.util.LogLevel.WARN;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +51,7 @@ public final class CupsPrinterFFM extends CupsPrinter {
 
     private static List<Printer> getPrintersFromLibCups() {
         List<Printer> printers = new ArrayList<>();
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment ptrSlot = arena.allocate(ADDRESS);
             int numDests = CupsFunctions.cupsGetDests(ptrSlot);
             if (numDests <= 0) {
@@ -96,10 +97,8 @@ public final class CupsPrinterFFM extends CupsPrinter {
             } finally {
                 CupsFunctions.cupsFreeDests(numDests, destsPtr);
             }
-        } catch (Throwable e) {
-            LOG.warn("Failed to query printers from libcups: {}", e.getMessage(), e);
-        }
-        return printers;
+            return printers;
+        }, LOG, WARN, "Failed to query printers from libcups", printers);
     }
 
     private static PrinterStatus parseStateFromCups(String state, String stateReasons) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsBluetoothDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsBluetoothDeviceFFM.java
@@ -8,11 +8,13 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.windows.BluetoothApisFFM.BLUETOOTH_DEVICE_INFO_LAYOUT;
 import static oshi.ffm.platform.windows.BluetoothApisFFM.BLUETOOTH_DEVICE_SEARCH_PARAMS_LAYOUT;
 import static oshi.ffm.platform.windows.BluetoothApisFFM.BLUETOOTH_FIND_RADIO_PARAMS_LAYOUT;
 import static oshi.ffm.platform.windows.BluetoothApisFFM.BLUETOOTH_MAX_NAME_SIZE;
 import static oshi.ffm.platform.windows.BluetoothApisFFM.BLUETOOTH_RADIO_INFO_LAYOUT;
+import static oshi.util.LogLevel.WARN;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
@@ -59,14 +61,14 @@ public final class WindowsBluetoothDeviceFFM extends AbstractBluetoothDevice {
             return Collections.emptyList();
         }
         List<BluetoothDevice> devices = new ArrayList<>();
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment radioParams = arena.allocate(BLUETOOTH_FIND_RADIO_PARAMS_LAYOUT);
             radioParams.set(JAVA_INT, 0, (int) BLUETOOTH_FIND_RADIO_PARAMS_LAYOUT.byteSize());
             MemorySegment phRadio = arena.allocate(ADDRESS);
 
             MemorySegment hFindRadio = BluetoothApisFFM.BluetoothFindFirstRadio(radioParams, phRadio);
             if (hFindRadio.equals(MemorySegment.NULL)) {
-                return Collections.emptyList();
+                return Collections.<BluetoothDevice>emptyList();
             }
 
             // wrapped only to release the native handle on close
@@ -82,10 +84,9 @@ public final class WindowsBluetoothDeviceFFM extends AbstractBluetoothDevice {
                 } while (WindowsForeignFunctions
                         .isSuccess(BluetoothApisFFM.BluetoothFindNextRadio(hFindRadio, phRadio)));
             }
-        } catch (Throwable t) {
-            LOG.warn("Error enumerating Bluetooth devices: {}", t.getMessage());
-        }
-        return Collections.unmodifiableList(devices);
+            return Collections.unmodifiableList(devices);
+            // The default is an unmodifiable *view*, so a partial enumeration is still returned on failure.
+        }, LOG, WARN, "Error enumerating Bluetooth devices", Collections.unmodifiableList(devices));
     }
 
     private static String getRadioName(Arena arena, MemorySegment hRadio) throws Throwable {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
@@ -6,6 +6,7 @@ package oshi.hardware.platform.windows;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.util.ExceptionUtil.getOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -88,7 +89,7 @@ final class WindowsDisplayFFM extends AbstractDisplay {
     }
 
     private static byte[] queryEdidFromKey(MemorySegment key, MemorySegment edidName, Arena arena) {
-        try {
+        return getOrDefault(() -> {
             MemorySegment pType = arena.allocate(JAVA_INT);
             MemorySegment lpcbData = arena.allocate(JAVA_INT);
             MemorySegment dummyBuf = arena.allocate(1);
@@ -105,9 +106,7 @@ final class WindowsDisplayFFM extends AbstractDisplay {
             if (rc == ERROR_SUCCESS) {
                 return edidBuf.asSlice(0, size).toArray(JAVA_BYTE);
             }
-        } catch (Throwable t) {
-            LOG.debug("Failed to read EDID from registry: {}", t.getMessage());
-        }
-        return null;
+            return null;
+        }, null, LOG, "Failed to read EDID from registry: {}");
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
@@ -5,7 +5,11 @@
 package oshi.software.os.linux;
 
 import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.util.ExceptionUtil.getBooleanOrDefault;
+import static oshi.util.ExceptionUtil.getIntOrDefault;
+import static oshi.util.ExceptionUtil.getOptionalInt;
 import static oshi.util.LogLevel.ERROR;
+import static oshi.util.LogLevel.WARN;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,6 +17,7 @@ import java.lang.foreign.MemorySegment;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,11 +103,8 @@ public class LinuxOperatingSystemFFM extends LinuxOperatingSystem {
     static {
         boolean hasSyscallGettid = LinuxLibcFunctions.hasGettid();
         if (!hasSyscallGettid) {
-            try {
-                hasSyscallGettid = LinuxLibcFunctions.syscallGettid() > 0;
-            } catch (Throwable _) {
-                LOG.debug("Did not find working syscall gettid via FFM. Using procfs");
-            }
+            hasSyscallGettid = getBooleanOrDefault(() -> LinuxLibcFunctions.syscallGettid() > 0, false, LOG,
+                    "Did not find working syscall gettid via FFM, using procfs: {}");
         }
         HAS_SYSCALL_GETTID = hasSyscallGettid;
     }
@@ -138,22 +140,16 @@ public class LinuxOperatingSystemFFM extends LinuxOperatingSystem {
 
     @Override
     public int getProcessId() {
-        try {
-            return LinuxLibcFunctions.getpid();
-        } catch (Throwable e) {
-            LOG.warn("FFM getpid failed: {}", e.toString());
-            return 0;
-        }
+        return getIntOrDefault(LinuxLibcFunctions::getpid, 0, LOG, WARN, "FFM getpid failed: {}");
     }
 
     @Override
     public int getThreadId() {
         if (HAS_SYSCALL_GETTID) {
-            try {
-                return LinuxLibcFunctions.hasGettid() ? LinuxLibcFunctions.gettid()
-                        : (int) LinuxLibcFunctions.syscallGettid();
-            } catch (Throwable e) {
-                LOG.warn("FFM gettid failed: {}", e.toString());
+            OptionalInt tid = getOptionalInt(() -> LinuxLibcFunctions.hasGettid() ? LinuxLibcFunctions.gettid()
+                    : (int) LinuxLibcFunctions.syscallGettid(), LOG, WARN, "FFM gettid failed: {}");
+            if (tid.isPresent()) {
+                return tid.getAsInt();
             }
         }
         try {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
@@ -6,6 +6,7 @@ package oshi.software.os.mac;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.mac.CoreFoundationFunctions.CFAllocatorGetDefault;
 import static oshi.ffm.platform.mac.DiskArbitrationFunctions.DASessionCreate;
 import static oshi.ffm.platform.mac.MacSystem.F_FFREE;
@@ -17,9 +18,9 @@ import static oshi.ffm.platform.mac.MacSystem.F_MNTONNAME;
 import static oshi.ffm.platform.mac.MacSystem.MNT_NOWAIT;
 import static oshi.ffm.platform.mac.MacSystem.STATFS;
 import static oshi.ffm.platform.mac.MacSystemFunctions.getfsstat64;
+import static oshi.util.LogLevel.WARN;
 
 import java.io.File;
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +65,7 @@ public class MacFileSystemFFM extends MacFileSystem {
     // Called by MacOSFileStore
     static List<OSFileStore> getFileStoreMatching(String nameToMatch, boolean localOnly) {
         List<OSFileStore> fsList = new ArrayList<>();
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             // Use getfsstat to find fileSystems
             // Query with null to get total # required
             int numfs = getfsstat64(MemorySegment.NULL, 0, 0);
@@ -182,11 +183,8 @@ public class MacFileSystemFFM extends MacFileSystem {
                     }
                 }
             }
-        } catch (Throwable e) {
-            LOG.warn("Failed to query file systems: {}", e.getMessage(), e);
             return fsList;
-        }
-        return fsList;
+        }, LOG, WARN, "Failed to query file systems", fsList);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
@@ -6,14 +6,15 @@ package oshi.software.os.unix.freebsd;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.ForeignFunctions.getByteArrayFromNativePointer;
 import static oshi.ffm.ForeignFunctions.getErrno;
 import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.RLIMIT_LAYOUT;
 import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.RLIMIT_NOFILE;
 import static oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions.SIZE_T;
+import static oshi.util.LogLevel.WARN;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.Collections;
 import java.util.List;
@@ -97,7 +98,7 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
             long written = size.get(SIZE_T, 0);
             byte[] bytes = getByteArrayFromNativePointer(buf, written, arena);
             return Collections.unmodifiableMap(ParseUtil.parseByteArrayToStringMap(bytes));
-        }, LOG, oshi.util.LogLevel.WARN, "queryEnvironmentVariables failed", Collections.<String, String>emptyMap());
+        }, LOG, WARN, "queryEnvironmentVariables failed", Collections.<String, String>emptyMap());
     }
 
     @Override
@@ -107,16 +108,13 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
 
     @Override
     protected long queryRlimitNofile(boolean soft) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment rlim = arena.allocate(RLIMIT_LAYOUT);
             if (FreeBsdLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) != 0) {
                 return -1L;
             }
             return soft ? FreeBsdLibcFunctions.rlimitCur(rlim) : FreeBsdLibcFunctions.rlimitMax(rlim);
-        } catch (Throwable t) {
-            LOG.warn("getrlimit(RLIMIT_NOFILE) failed", t);
-            return -1L;
-        }
+        }, LOG, WARN, "getrlimit(RLIMIT_NOFILE) failed", -1L);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcessFFM.java
@@ -4,7 +4,9 @@
  */
 package oshi.software.os.unix.solaris;
 
-import java.lang.foreign.Arena;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
+import static oshi.util.LogLevel.WARN;
+
 import java.lang.foreign.MemorySegment;
 import java.util.List;
 import java.util.Map;
@@ -64,15 +66,12 @@ public final class SolarisOSProcessFFM extends SolarisOSProcess {
     }
 
     private static long rlimitNofile(boolean soft) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment rlim = arena.allocate(SolarisLibcFunctions.RLIMIT_LAYOUT);
             if (SolarisLibcFunctions.getrlimit(SolarisLibcFunctions.RLIMIT_NOFILE, rlim) != 0) {
                 return -1L;
             }
             return soft ? SolarisLibcFunctions.rlimitCur(rlim) : SolarisLibcFunctions.rlimitMax(rlim);
-        } catch (Throwable t) {
-            LOG.warn("getrlimit failed", t);
-            return -1L;
-        }
+        }, LOG, WARN, "getrlimit failed", -1L);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -7,7 +7,9 @@ package oshi.software.os.windows;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.windows.Kernel32FFM.GetLastError;
 import static oshi.ffm.platform.windows.WinNTFFM.PERFORMANCE_INFORMATION;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.readWideString;
@@ -87,7 +89,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     }
 
     private static boolean enableDebugPrivilege() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaBooleanOrDefault(arena -> {
             MemorySegment hTokenPtr = arena.allocate(ADDRESS);
 
             Optional<MemorySegment> hProcess = Kernel32FFM.GetCurrentProcess();
@@ -117,10 +119,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
 
                 return true;
             }
-        } catch (Throwable t) {
-            LOG.error("enableDebugPrivilege exception: {}", t.getMessage());
-            return false;
-        }
+        }, LOG, ERROR, "enableDebugPrivilege exception", false);
     }
 
     @Override
@@ -146,7 +145,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     private static final long PROCESS_ID_OFFSET = 44;
 
     private static List<OSService> queryServicesFFM() {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment hSCManager = Advapi32FFM.OpenSCManager(MemorySegment.NULL, MemorySegment.NULL,
                     SC_MANAGER_ENUMERATE_SERVICE);
             if (hSCManager == null || hSCManager.address() == 0) {
@@ -203,10 +202,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
                 }
                 return svcArray;
             }
-        } catch (Throwable t) {
-            LOG.error("Error enumerating services: {}", t.getMessage());
-            return Collections.emptyList();
-        }
+        }, LOG, ERROR, "Error enumerating services", Collections.emptyList());
     }
 
     @Override


### PR DESCRIPTION
#3444 consolidated the try/catch-log-return-default pattern onto `ExceptionUtil`, but it only reached part of the codebase. Sweeping every `catch (Throwable)` in main source turns up 47 blocks still hand-rolling it with a message that needs no arguments beyond the exception — so the existing helpers cover them with no API change.

This converts 36. No user-facing change, so no CHANGELOG entry.

### What moved where

| | |
|---|---|
| 21 sites | `ExceptionUtil.getOrDefault` / `get{Int,Long,Boolean,Double}OrDefault` / `getOptionalInt` / `runOrLog` |
| 15 sites | `ForeignFunctions.callInArena{,Int,Long,Double,Boolean}OrDefault`, where the body already opened a confined arena |

Most are a straight unwrap. A few restructure slightly:

- `Advapi32UtilFFM.querySystemBootTime` — the three "no boot event found" paths (empty log, no matching record, throwable) all now return `0L` and share the single uptime fallback, instead of duplicating the fallback expression.
- `LinuxOperatingSystemFFM.getThreadId` — uses `getOptionalInt` rather than a sentinel, so a successful `gettid` of any value is still distinguishable from a failure that should fall through to procfs.
- `WindowsBluetoothDeviceFFM` / `NetStatFFM` / `CupsPrinterFFM` / `MacFileSystemFFM` / `ProcessWtsDataFFM` — the accumulator is passed as the default, so a partial result on failure is preserved exactly as before.
- `SmcUtilFFM.smcOpen` and `MacHWDiskStoreFFM.getDisks` keep an outer `try`/`finally` for their native cleanup, since `callInArena*` has no `finally` hook.

### The 11 that stay

All for one reason: the try body assigns locals declared outside it, which a lambda cannot do.

- **7 static-initializer library-binding blocks** — `AdlUtilFFM`, `NvmlFunctions`, `SystemdFunctions`, `UdevFunctions`, `LinuxLibcFunctions`, `Kstat2Functions`, `DxgiFFM`. Each binds 5–11 method handles into enclosing locals.
- `MacDisplayFFM.synthesize` and `WindowsCentralProcessorFFM.queryProcessorId` assign locals read after the try.
- `IWbemLocatorFFM.connectServer` and `IWbemServicesFFM.execQuery` free a BSTR in a `finally` that is assigned inside the try; converting needs an array holder, which reads worse than what is there.

### One behavior change

Sites that logged `("...: {}", t.getMessage())` now also attach the throwable as the SLF4J cause, so those lines gain a stack trace. That is inherent to the `ExceptionUtil` contract and already true of every call site converted in #3444 — this makes the remainder consistent rather than introducing something new. All affected sites are `debug`/`trace`/`warn`.

Also fixes a pre-existing fully-qualified `oshi.util.LogLevel.WARN` in `FreeBsdOSProcessFFM`.

### Verification

Clean full-reactor `install`: 1122 + 84 + 67 + 30 tests, 0 failures. Spotless, checkstyle, forbidden-apis and javadoc all clean.

Because several conversions restructure control flow rather than just swapping a wrapper, I also ran the FFM provider live on macOS (M2 Max) over the affected paths — disk stores, file stores, network interfaces, displays, CPU tick array, processor identifier and power sources all return real data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of system, hardware, process, network, and service information retrieval when native platform calls fail.
  * Standardized fallback behavior, preserving safe defaults such as empty results, optional values, or sentinel values.
  * Improved consistency of diagnostic logging across macOS, Windows, Linux, Solaris, FreeBSD, and related platform integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->