### PR TITLE
Support parameterized log messages in ExceptionUtil and callInArena helpers

### DIFF
--- a/oshi-common/src/main/java/oshi/util/ExceptionUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ExceptionUtil.java
@@ -4,6 +4,7 @@
  */
 package oshi.util;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -27,15 +28,24 @@ public final class ExceptionUtil {
      * itself as the log event's cause via SLF4J's implicit-cause handling. Level dispatch is delegated to
      * {@link LogUtil#logAtLevel(Logger, LogLevel, String, Object...)}.
      * <p>
+     * The caller's arguments fill the leading {@code {}} placeholders in order, and the throwable's message fills one
+     * final placeholder, so {@code msg} should carry one {@code {}} per argument plus a trailing one. For example,
+     * {@code logAtLevel(log, DEBUG, "Failed to read {}: {}", t, path)} logs the path and then the exception message.
+     * <p>
      * Public so other modules (e.g., {@code oshi-core-ffm}) can share this dispatch instead of duplicating it.
      *
      * @param log   the logger to use
      * @param level the level at which to log
-     * @param msg   the log message (use {} for the exception message placeholder)
+     * @param msg   the log message (use {} for each argument, then one for the exception message)
      * @param t     the throwable to log
+     * @param args  the arguments filling the leading {} placeholders, if any
      */
-    public static void logAtLevel(Logger log, LogLevel level, String msg, Throwable t) {
-        LogUtil.logAtLevel(log, level, msg, t.getMessage(), t);
+    public static void logAtLevel(Logger log, LogLevel level, String msg, Throwable t, Object... args) {
+        // Append the exception message and the throwable itself; SLF4J takes the trailing throwable as the cause.
+        Object[] all = Arrays.copyOf(args, args.length + 2);
+        all[args.length] = t.getMessage();
+        all[args.length + 1] = t;
+        LogUtil.logAtLevel(log, level, msg, all);
     }
 
     /**
@@ -148,10 +158,12 @@ public final class ExceptionUtil {
      * @param defaultValue the value to return on failure
      * @param log          the logger to use
      * @param msg          the log message (use {} for the exception message placeholder)
+     * @param args         the arguments filling the leading {} placeholders, if any
      * @return the supplier's result or the default value
      */
-    public static <T> T getOrDefault(ThrowingSupplier<T> supplier, T defaultValue, Logger log, String msg) {
-        return getOrDefault(supplier, defaultValue, log, LogLevel.DEBUG, msg);
+    public static <T> T getOrDefault(ThrowingSupplier<T> supplier, T defaultValue, Logger log, String msg,
+            Object... args) {
+        return getOrDefault(supplier, defaultValue, log, LogLevel.DEBUG, msg, args);
     }
 
     /**
@@ -164,14 +176,15 @@ public final class ExceptionUtil {
      * @param log          the logger to use
      * @param level        the level at which to log the exception
      * @param msg          the log message (use {} for the exception message placeholder)
+     * @param args         the arguments filling the leading {} placeholders, if any
      * @return the supplier's result or the default value
      */
     public static <T> T getOrDefault(ThrowingSupplier<T> supplier, T defaultValue, Logger log, LogLevel level,
-            String msg) {
+            String msg, Object... args) {
         try {
             return supplier.get();
         } catch (Throwable t) {
-            logAtLevel(log, level, msg, t);
+            logAtLevel(log, level, msg, t, args);
             return defaultValue;
         }
     }
@@ -199,10 +212,12 @@ public final class ExceptionUtil {
      * @param defaultValue the value to return on failure
      * @param log          the logger to use
      * @param msg          the log message
+     * @param args         the arguments filling the leading {} placeholders, if any
      * @return the supplier's result or the default value
      */
-    public static int getIntOrDefault(ThrowingIntSupplier supplier, int defaultValue, Logger log, String msg) {
-        return getIntOrDefault(supplier, defaultValue, log, LogLevel.DEBUG, msg);
+    public static int getIntOrDefault(ThrowingIntSupplier supplier, int defaultValue, Logger log, String msg,
+            Object... args) {
+        return getIntOrDefault(supplier, defaultValue, log, LogLevel.DEBUG, msg, args);
     }
 
     /**
@@ -214,14 +229,15 @@ public final class ExceptionUtil {
      * @param log          the logger to use
      * @param level        the level at which to log the exception
      * @param msg          the log message
+     * @param args         the arguments filling the leading {} placeholders, if any
      * @return the supplier's result or the default value
      */
     public static int getIntOrDefault(ThrowingIntSupplier supplier, int defaultValue, Logger log, LogLevel level,
-            String msg) {
+            String msg, Object... args) {
         try {
             return supplier.getAsInt();
         } catch (Throwable t) {
-            logAtLevel(log, level, msg, t);
+            logAtLevel(log, level, msg, t, args);
             return defaultValue;
         }
     }
@@ -249,10 +265,12 @@ public final class ExceptionUtil {
      * @param defaultValue the value to return on failure
      * @param log          the logger to use
      * @param msg          the log message
+     * @param args         the arguments filling the leading {} placeholders, if any
      * @return the supplier's result or the default value
      */
-    public static long getLongOrDefault(ThrowingLongSupplier supplier, long defaultValue, Logger log, String msg) {
-        return getLongOrDefault(supplier, defaultValue, log, LogLevel.DEBUG, msg);
+    public static long getLongOrDefault(ThrowingLongSupplier supplier, long defaultValue, Logger log, String msg,
+            Object... args) {
+        return getLongOrDefault(supplier, defaultValue, log, LogLevel.DEBUG, msg, args);
     }
 
     /**
@@ -264,14 +282,15 @@ public final class ExceptionUtil {
      * @param log          the logger to use
      * @param level        the level at which to log the exception
      * @param msg          the log message
+     * @param args         the arguments filling the leading {} placeholders, if any
      * @return the supplier's result or the default value
      */
     public static long getLongOrDefault(ThrowingLongSupplier supplier, long defaultValue, Logger log, LogLevel level,
-            String msg) {
+            String msg, Object... args) {
         try {
             return supplier.getAsLong();
         } catch (Throwable t) {
-            logAtLevel(log, level, msg, t);
+            logAtLevel(log, level, msg, t, args);
             return defaultValue;
         }
     }
@@ -299,11 +318,12 @@ public final class ExceptionUtil {
      * @param defaultValue the value to return on failure
      * @param log          the logger to use
      * @param msg          the log message
+     * @param args         the arguments filling the leading {} placeholders, if any
      * @return the supplier's result or the default value
      */
     public static boolean getBooleanOrDefault(ThrowingBooleanSupplier supplier, boolean defaultValue, Logger log,
-            String msg) {
-        return getBooleanOrDefault(supplier, defaultValue, log, LogLevel.DEBUG, msg);
+            String msg, Object... args) {
+        return getBooleanOrDefault(supplier, defaultValue, log, LogLevel.DEBUG, msg, args);
     }
 
     /**
@@ -315,14 +335,15 @@ public final class ExceptionUtil {
      * @param log          the logger to use
      * @param level        the level at which to log the exception
      * @param msg          the log message
+     * @param args         the arguments filling the leading {} placeholders, if any
      * @return the supplier's result or the default value
      */
     public static boolean getBooleanOrDefault(ThrowingBooleanSupplier supplier, boolean defaultValue, Logger log,
-            LogLevel level, String msg) {
+            LogLevel level, String msg, Object... args) {
         try {
             return supplier.getAsBoolean();
         } catch (Throwable t) {
-            logAtLevel(log, level, msg, t);
+            logAtLevel(log, level, msg, t, args);
             return defaultValue;
         }
     }
@@ -350,11 +371,12 @@ public final class ExceptionUtil {
      * @param defaultValue the value to return on failure
      * @param log          the logger to use
      * @param msg          the log message
+     * @param args         the arguments filling the leading {} placeholders, if any
      * @return the supplier's result or the default value
      */
     public static double getDoubleOrDefault(ThrowingDoubleSupplier supplier, double defaultValue, Logger log,
-            String msg) {
-        return getDoubleOrDefault(supplier, defaultValue, log, LogLevel.DEBUG, msg);
+            String msg, Object... args) {
+        return getDoubleOrDefault(supplier, defaultValue, log, LogLevel.DEBUG, msg, args);
     }
 
     /**
@@ -366,14 +388,15 @@ public final class ExceptionUtil {
      * @param log          the logger to use
      * @param level        the level at which to log the exception
      * @param msg          the log message
+     * @param args         the arguments filling the leading {} placeholders, if any
      * @return the supplier's result or the default value
      */
     public static double getDoubleOrDefault(ThrowingDoubleSupplier supplier, double defaultValue, Logger log,
-            LogLevel level, String msg) {
+            LogLevel level, String msg, Object... args) {
         try {
             return supplier.getAsDouble();
         } catch (Throwable t) {
-            logAtLevel(log, level, msg, t);
+            logAtLevel(log, level, msg, t, args);
             return defaultValue;
         }
     }
@@ -385,10 +408,11 @@ public final class ExceptionUtil {
      * @param supplier the operation to attempt
      * @param log      the logger to use
      * @param msg      the log message
+     * @param args     the arguments filling the leading {} placeholders, if any
      * @return an Optional containing the result, or empty on failure
      */
-    public static <T> Optional<T> getOptional(ThrowingSupplier<T> supplier, Logger log, String msg) {
-        return getOptional(supplier, log, LogLevel.DEBUG, msg);
+    public static <T> Optional<T> getOptional(ThrowingSupplier<T> supplier, Logger log, String msg, Object... args) {
+        return getOptional(supplier, log, LogLevel.DEBUG, msg, args);
     }
 
     /**
@@ -400,13 +424,15 @@ public final class ExceptionUtil {
      * @param log      the logger to use
      * @param level    the level at which to log the exception
      * @param msg      the log message
+     * @param args     the arguments filling the leading {} placeholders, if any
      * @return an Optional containing the result, or empty on failure
      */
-    public static <T> Optional<T> getOptional(ThrowingSupplier<T> supplier, Logger log, LogLevel level, String msg) {
+    public static <T> Optional<T> getOptional(ThrowingSupplier<T> supplier, Logger log, LogLevel level, String msg,
+            Object... args) {
         try {
             return Optional.ofNullable(supplier.get());
         } catch (Throwable t) {
-            logAtLevel(log, level, msg, t);
+            logAtLevel(log, level, msg, t, args);
             return Optional.empty();
         }
     }
@@ -418,10 +444,11 @@ public final class ExceptionUtil {
      * @param supplier the operation to attempt
      * @param log      the logger to use
      * @param msg      the log message
+     * @param args     the arguments filling the leading {} placeholders, if any
      * @return an OptionalInt containing the result, or empty on failure
      */
-    public static OptionalInt getOptionalInt(ThrowingIntSupplier supplier, Logger log, String msg) {
-        return getOptionalInt(supplier, log, LogLevel.DEBUG, msg);
+    public static OptionalInt getOptionalInt(ThrowingIntSupplier supplier, Logger log, String msg, Object... args) {
+        return getOptionalInt(supplier, log, LogLevel.DEBUG, msg, args);
     }
 
     /**
@@ -432,13 +459,15 @@ public final class ExceptionUtil {
      * @param log      the logger to use
      * @param level    the level at which to log the exception
      * @param msg      the log message
+     * @param args     the arguments filling the leading {} placeholders, if any
      * @return an OptionalInt containing the result, or empty on failure
      */
-    public static OptionalInt getOptionalInt(ThrowingIntSupplier supplier, Logger log, LogLevel level, String msg) {
+    public static OptionalInt getOptionalInt(ThrowingIntSupplier supplier, Logger log, LogLevel level, String msg,
+            Object... args) {
         try {
             return OptionalInt.of(supplier.getAsInt());
         } catch (Throwable t) {
-            logAtLevel(log, level, msg, t);
+            logAtLevel(log, level, msg, t, args);
             return OptionalInt.empty();
         }
     }
@@ -450,10 +479,11 @@ public final class ExceptionUtil {
      * @param supplier the operation to attempt
      * @param log      the logger to use
      * @param msg      the log message
+     * @param args     the arguments filling the leading {} placeholders, if any
      * @return an OptionalLong containing the result, or empty on failure
      */
-    public static OptionalLong getOptionalLong(ThrowingLongSupplier supplier, Logger log, String msg) {
-        return getOptionalLong(supplier, log, LogLevel.DEBUG, msg);
+    public static OptionalLong getOptionalLong(ThrowingLongSupplier supplier, Logger log, String msg, Object... args) {
+        return getOptionalLong(supplier, log, LogLevel.DEBUG, msg, args);
     }
 
     /**
@@ -464,13 +494,15 @@ public final class ExceptionUtil {
      * @param log      the logger to use
      * @param level    the level at which to log the exception
      * @param msg      the log message
+     * @param args     the arguments filling the leading {} placeholders, if any
      * @return an OptionalLong containing the result, or empty on failure
      */
-    public static OptionalLong getOptionalLong(ThrowingLongSupplier supplier, Logger log, LogLevel level, String msg) {
+    public static OptionalLong getOptionalLong(ThrowingLongSupplier supplier, Logger log, LogLevel level, String msg,
+            Object... args) {
         try {
             return OptionalLong.of(supplier.getAsLong());
         } catch (Throwable t) {
-            logAtLevel(log, level, msg, t);
+            logAtLevel(log, level, msg, t, args);
             return OptionalLong.empty();
         }
     }
@@ -494,9 +526,10 @@ public final class ExceptionUtil {
      * @param runnable the operation to attempt
      * @param log      the logger to use
      * @param msg      the log message
+     * @param args     the arguments filling the leading {} placeholders, if any
      */
-    public static void runOrLog(ThrowingRunnable runnable, Logger log, String msg) {
-        runOrLog(runnable, log, LogLevel.DEBUG, msg);
+    public static void runOrLog(ThrowingRunnable runnable, Logger log, String msg, Object... args) {
+        runOrLog(runnable, log, LogLevel.DEBUG, msg, args);
     }
 
     /**
@@ -506,12 +539,13 @@ public final class ExceptionUtil {
      * @param log      the logger to use
      * @param level    the level at which to log the exception
      * @param msg      the log message
+     * @param args     the arguments filling the leading {} placeholders, if any
      */
-    public static void runOrLog(ThrowingRunnable runnable, Logger log, LogLevel level, String msg) {
+    public static void runOrLog(ThrowingRunnable runnable, Logger log, LogLevel level, String msg, Object... args) {
         try {
             runnable.run();
         } catch (Throwable t) {
-            logAtLevel(log, level, msg, t);
+            logAtLevel(log, level, msg, t, args);
         }
     }
 }

--- a/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ExceptionUtilTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -402,5 +403,61 @@ class ExceptionUtilTest {
         assertThat("Dispatched to the method matching the level", recorder.onlyCall(), is("warn"));
         // The message fills the placeholder; the trailing throwable is left for SLF4J to pull out as the cause
         assertThat("Throwable message then throwable", recorder.arguments(), arrayContaining("boom", t));
+    }
+
+    @Test
+    void testLogAtLevelPutsCallerArgumentsBeforeTheThrowableMessage() {
+        LogUtilTest.RecordingLogger recorder = LogUtilTest.RecordingLogger.create();
+        Throwable t = new IllegalStateException("boom");
+        ExceptionUtil.logAtLevel(recorder.logger(), LogLevel.DEBUG, "Failed to read {} of {}: {}", t, "key", 42);
+        assertThat("Dispatched to the method matching the level", recorder.onlyCall(), is("debug"));
+        // Caller arguments fill the leading placeholders in order, then the exception message, then the cause
+        assertThat("Caller args, exception message, throwable", recorder.arguments(),
+                arrayContaining("key", 42, "boom", t));
+    }
+
+    @Test
+    void testGetOrDefaultForwardsArgumentsOnFailure() {
+        LogUtilTest.RecordingLogger recorder = LogUtilTest.RecordingLogger.create();
+        String result = ExceptionUtil.getOrDefault(() -> {
+            throw new IllegalStateException("boom");
+        }, "fallback", recorder.logger(), "Lookup of {} failed: {}", "someKey");
+        assertThat("Returns the default", result, is("fallback"));
+        assertThat("Defaults to debug", recorder.onlyCall(), is("debug"));
+        assertThat("Argument precedes the exception message", recorder.arguments(),
+                arrayContaining(is("someKey"), is("boom"), instanceOf(IllegalStateException.class)));
+    }
+
+    @Test
+    void testGetLongOrDefaultForwardsArgumentsAtExplicitLevel() {
+        LogUtilTest.RecordingLogger recorder = LogUtilTest.RecordingLogger.create();
+        long result = ExceptionUtil.getLongOrDefault(() -> {
+            throw new IllegalStateException("boom");
+        }, -1L, recorder.logger(), LogLevel.WARN, "Read of {}/{} failed: {}", "path", "value");
+        assertThat("Returns the default", result, is(-1L));
+        assertThat("Honors the explicit level", recorder.onlyCall(), is("warn"));
+        assertThat("Both arguments precede the exception message", recorder.arguments(),
+                arrayContaining(is("path"), is("value"), is("boom"), instanceOf(IllegalStateException.class)));
+    }
+
+    @Test
+    void testNoArgumentCallsAreUnchanged() {
+        LogUtilTest.RecordingLogger recorder = LogUtilTest.RecordingLogger.create();
+        String result = ExceptionUtil.getOrDefault(() -> {
+            throw new IllegalStateException("boom");
+        }, "fallback", recorder.logger(), "Failed: {}");
+        assertThat("Returns the default", result, is("fallback"));
+        // Adding the varargs parameter must not change what an existing zero-argument call logs
+        assertThat("Exception message then throwable", recorder.arguments(),
+                arrayContaining(is("boom"), instanceOf(IllegalStateException.class)));
+    }
+
+    @Test
+    void testSuccessfulCallLogsNothing() {
+        LogUtilTest.RecordingLogger recorder = LogUtilTest.RecordingLogger.create();
+        String result = ExceptionUtil.getOrDefault(() -> "ok", "fallback", recorder.logger(), "Failed for {}: {}",
+                "key");
+        assertThat("Returns the supplied value", result, is("ok"));
+        assertThat("Nothing logged on the success path", recorder.calls(), is(empty()));
     }
 }

--- a/oshi-common/src/test/java/oshi/util/LogUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/LogUtilTest.java
@@ -66,6 +66,10 @@ class LogUtilTest {
             return null;
         }
 
+        List<String> calls() {
+            return calls;
+        }
+
         String onlyCall() {
             assertThat("Expected exactly one logging call", calls.size(), is(1));
             return calls.get(0);

--- a/oshi-core-ffm/src/main/java/oshi/driver/unix/aix/PsInfoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/unix/aix/PsInfoFFM.java
@@ -7,9 +7,10 @@ package oshi.driver.unix.aix;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+import static oshi.util.LogLevel.DEBUG;
 
 import java.io.IOException;
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -59,7 +60,7 @@ public final class PsInfoFFM {
             return new Pair<>(args, env);
         }
 
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment procasPath = arena.allocateFrom("/proc/" + pid + "/as");
             int fd = AixLibcFunctions.open(procasPath, 0);
             if (fd < 0) {
@@ -137,10 +138,8 @@ public final class PsInfoFFM {
             } finally {
                 AixLibcFunctions.close(fd);
             }
-        } catch (Throwable t) {
-            LOG.debug("FFM queryArgsEnv failed for pid {}: {}", pid, t.getMessage());
-        }
-        return new Pair<>(args, env);
+            return new Pair<>(args, env);
+        }, new Pair<>(args, env), LOG, DEBUG, "FFM queryArgsEnv failed for pid {}", pid);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/DeviceTreeFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/DeviceTreeFFM.java
@@ -5,6 +5,7 @@
 package oshi.driver.windows;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.util.ExceptionUtil.runOrLog;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -103,7 +104,7 @@ public final class DeviceTreeFFM {
                                     Cfgmgr32FFM.getDevNodeProperty(node, Cfgmgr32FFM.CM_DRP_MFG, buf, sizeSeg));
 
                             // Traverse children
-                            try {
+                            runOrLog(() -> {
                                 if (Cfgmgr32FFM.CM_Get_Child(childSeg, node, 0) == Cfgmgr32FFM.CR_SUCCESS) {
                                     int child = childSeg.get(JAVA_INT, 0);
                                     parentMap.put(child, node);
@@ -115,9 +116,7 @@ public final class DeviceTreeFFM {
                                         child = sibling;
                                     }
                                 }
-                            } catch (Throwable t) {
-                                LOG.debug("CM_Get_Child/Sibling threw for node {}", node, t);
-                            }
+                            }, LOG, "CM_Get_Child/Sibling threw for node {}: {}", node);
                         }
                     }
                 } finally {

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/HkeyUserDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/HkeyUserDataFFM.java
@@ -8,6 +8,8 @@ import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.windows.Advapi32FFM.ConvertStringSidToSid;
 import static oshi.ffm.platform.windows.Advapi32FFM.LookupAccountSid;
@@ -20,9 +22,9 @@ import static oshi.ffm.platform.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.toWideString;
 import static oshi.util.ExceptionUtil.getOrDefault;
 import static oshi.util.ExceptionUtil.runOrLog;
+import static oshi.util.LogLevel.DEBUG;
 import static oshi.util.LogLevel.TRACE;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
@@ -137,7 +139,7 @@ public final class HkeyUserDataFFM {
     }
 
     private static boolean registryKeyExists(MemorySegment rootKey, String keyPath) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaBooleanOrDefault(arena -> {
             MemorySegment phkResult = arena.allocate(ADDRESS);
             int rc = RegOpenKeyEx(rootKey, toWideString(arena, keyPath), 0, KEY_READ, phkResult);
             if (rc != ERROR_SUCCESS) {
@@ -145,14 +147,11 @@ public final class HkeyUserDataFFM {
             }
             RegCloseKey(phkResult.get(ADDRESS, 0));
             return true;
-        } catch (Throwable t) {
-            LOG.debug("Error checking registry key {}: {}", keyPath, t.getMessage());
-            return false;
-        }
+        }, false, LOG, DEBUG, "Error checking registry key {}", keyPath);
     }
 
     private static long queryKeyWriteTime(MemorySegment rootKey, String keyPath) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment phkResult = arena.allocate(ADDRESS);
             int rc = RegOpenKeyEx(rootKey, toWideString(arena, keyPath), 0, KEY_READ, phkResult);
             if (rc != ERROR_SUCCESS) {
@@ -170,10 +169,7 @@ public final class HkeyUserDataFFM {
             } finally {
                 RegCloseKey(hKey);
             }
-        } catch (Throwable t) {
-            LOG.debug("Error querying write time for {}: {}", keyPath, t.getMessage());
-            return 0;
-        }
+        }, 0L, LOG, DEBUG, "Error querying write time for {}", keyPath);
     }
 
     private static String[] getSubKeys(MemorySegment rootKey, String keyPath) {

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/InstalledAppsDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/InstalledAppsDataFFM.java
@@ -15,6 +15,8 @@ import static oshi.ffm.platform.windows.WinRegFFM.HKEY_LOCAL_MACHINE;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.checkSuccess;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.toWideString;
 import static oshi.ffm.util.platform.windows.Advapi32UtilFFM.registryGetValue;
+import static oshi.util.ExceptionUtil.runOrLog;
+import static oshi.util.LogLevel.TRACE;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -61,15 +63,16 @@ public final class InstalledAppsDataFFM {
 
             for (String registryPath : uninstallPaths) {
                 for (int accessFlag : ACCESS_FLAGS) {
-                    try {
+                    runOrLog(() -> {
                         String[] keys = Advapi32UtilFFM.registryGetKeys(rootKey, registryPath, accessFlag);
                         for (String key : keys) {
                             String fullPath = registryPath + "\\" + key;
-                            try {
+                            runOrLog(() -> {
                                 String name = RegistryValueUtil.registryValueToString(
                                         getRegistryValueOrNull(rootKey, fullPath, "DisplayName", accessFlag));
                                 if (name == null) {
-                                    continue;
+                                    // Exits this key's lambda; the enclosing loop moves to the next key.
+                                    return;
                                 }
                                 String version = RegistryValueUtil.registryValueToString(
                                         getRegistryValueOrNull(rootKey, fullPath, "DisplayVersion", accessFlag));
@@ -90,13 +93,9 @@ public final class InstalledAppsDataFFM {
                                         additionalInfo);
                                 appInfoSet.add(app);
 
-                            } catch (Throwable e) {
-                                LOG.trace("Skipping key {}: {}", fullPath, e.getMessage());
-                            }
+                            }, LOG, TRACE, "Skipping key {}: {}", fullPath);
                         }
-                    } catch (Throwable e) {
-                        LOG.trace("Skipping path {}: {}", registryPath, e.getMessage());
-                    }
+                    }, LOG, TRACE, "Skipping path {}: {}", registryPath);
                 }
             }
         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -159,6 +159,37 @@ public abstract class ForeignFunctions {
         }
     }
 
+    // ---- parameterized-message variants ----
+    // The overloads above take the default value last, which leaves no room for a trailing varargs. These take it
+    // second instead, matching ExceptionUtil's (operation, defaultValue, log, level, msg, args...) order so both
+    // utilities read the same way. Second rather than merely swapped with the message on purpose: with the default
+    // fourth, a no-argument call whose T is String would match both overloads, and Java's fixed-arity-first
+    // resolution would silently pick the older one with message and default transposed.
+
+    /**
+     * Executes an operation in a confined arena, returning a default value if the operation throws, and logging a
+     * message whose {@code {}} placeholders are filled by {@code args}.
+     *
+     * @param <T>          the return type
+     * @param callable     the operation to execute
+     * @param defaultValue the value to return if the operation throws
+     * @param logger       the logger for the calling class
+     * @param level        the level at which to log thrown failures
+     * @param message      the message to log, with one {} per argument (the exception message is appended)
+     * @param args         the arguments filling the message placeholders
+     * @return the operation result, or {@code defaultValue} if the operation throws
+     */
+    public static <T> T callInArenaOrDefault(ArenaCallable<T> callable, T defaultValue, Logger logger, LogLevel level,
+            String message, Object... args) {
+        Objects.requireNonNull(callable, "callable");
+        try (Arena arena = Arena.ofConfined()) {
+            return callable.call(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t, args);
+            return defaultValue;
+        }
+    }
+
     /**
      * Executes an {@code int}-returning operation in a confined arena, returning a default value if the operation
      * throws.
@@ -180,6 +211,29 @@ public abstract class ForeignFunctions {
             return callable.call(arena);
         } catch (Throwable t) {
             logThrowable(logger, level, message, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes an {@code int}-returning operation in a confined arena, returning a default value if the operation
+     * throws, and logging a message whose {@code {}} placeholders are filled by {@code args}.
+     *
+     * @param callable     the operation to execute
+     * @param defaultValue the value to return if the operation throws
+     * @param logger       the logger for the calling class
+     * @param level        the level at which to log thrown failures
+     * @param message      the message to log, with one {} per argument (the exception message is appended)
+     * @param args         the arguments filling the message placeholders
+     * @return the operation result, or {@code defaultValue} if the operation throws
+     */
+    public static int callInArenaIntOrDefault(ArenaIntCallable callable, int defaultValue, Logger logger,
+            LogLevel level, String message, Object... args) {
+        Objects.requireNonNull(callable, "callable");
+        try (Arena arena = Arena.ofConfined()) {
+            return callable.call(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t, args);
             return defaultValue;
         }
     }
@@ -210,6 +264,29 @@ public abstract class ForeignFunctions {
     }
 
     /**
+     * Executes a {@code long}-returning operation in a confined arena, returning a default value if the operation
+     * throws, and logging a message whose {@code {}} placeholders are filled by {@code args}.
+     *
+     * @param callable     the operation to execute
+     * @param defaultValue the value to return if the operation throws
+     * @param logger       the logger for the calling class
+     * @param level        the level at which to log thrown failures
+     * @param message      the message to log, with one {} per argument (the exception message is appended)
+     * @param args         the arguments filling the message placeholders
+     * @return the operation result, or {@code defaultValue} if the operation throws
+     */
+    public static long callInArenaLongOrDefault(ArenaLongCallable callable, long defaultValue, Logger logger,
+            LogLevel level, String message, Object... args) {
+        Objects.requireNonNull(callable, "callable");
+        try (Arena arena = Arena.ofConfined()) {
+            return callable.call(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t, args);
+            return defaultValue;
+        }
+    }
+
+    /**
      * Executes a {@code double}-returning operation in a confined arena, returning a default value if the operation
      * throws.
      * <p>
@@ -235,6 +312,29 @@ public abstract class ForeignFunctions {
     }
 
     /**
+     * Executes a {@code double}-returning operation in a confined arena, returning a default value if the operation
+     * throws, and logging a message whose {@code {}} placeholders are filled by {@code args}.
+     *
+     * @param callable     the operation to execute
+     * @param defaultValue the value to return if the operation throws
+     * @param logger       the logger for the calling class
+     * @param level        the level at which to log thrown failures
+     * @param message      the message to log, with one {} per argument (the exception message is appended)
+     * @param args         the arguments filling the message placeholders
+     * @return the operation result, or {@code defaultValue} if the operation throws
+     */
+    public static double callInArenaDoubleOrDefault(ArenaDoubleCallable callable, double defaultValue, Logger logger,
+            LogLevel level, String message, Object... args) {
+        Objects.requireNonNull(callable, "callable");
+        try (Arena arena = Arena.ofConfined()) {
+            return callable.call(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t, args);
+            return defaultValue;
+        }
+    }
+
+    /**
      * Executes a {@code boolean}-returning operation in a confined arena, returning a default value if the operation
      * throws.
      * <p>
@@ -255,6 +355,29 @@ public abstract class ForeignFunctions {
             return callable.call(arena);
         } catch (Throwable t) {
             logThrowable(logger, level, message, t);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Executes a {@code boolean}-returning operation in a confined arena, returning a default value if the operation
+     * throws, and logging a message whose {@code {}} placeholders are filled by {@code args}.
+     *
+     * @param callable     the operation to execute
+     * @param defaultValue the value to return if the operation throws
+     * @param logger       the logger for the calling class
+     * @param level        the level at which to log thrown failures
+     * @param message      the message to log, with one {} per argument (the exception message is appended)
+     * @param args         the arguments filling the message placeholders
+     * @return the operation result, or {@code defaultValue} if the operation throws
+     */
+    public static boolean callInArenaBooleanOrDefault(ArenaBooleanCallable callable, boolean defaultValue,
+            Logger logger, LogLevel level, String message, Object... args) {
+        Objects.requireNonNull(callable, "callable");
+        try (Arena arena = Arena.ofConfined()) {
+            return callable.call(arena);
+        } catch (Throwable t) {
+            logThrowable(logger, level, message, t, args);
             return defaultValue;
         }
     }
@@ -469,9 +592,10 @@ public abstract class ForeignFunctions {
         return (int) ERRNO_HANDLE.get(callState, 0);
     }
 
-    private static void logThrowable(Logger logger, LogLevel level, String message, Throwable t) {
+    private static void logThrowable(Logger logger, LogLevel level, String message, Throwable t, Object... args) {
         Objects.requireNonNull(logger, "logger");
         Objects.requireNonNull(level, "level");
-        ExceptionUtil.logAtLevel(logger, level, message + ": {}", t);
+        // Callers pass a bare message; the trailing placeholder for the exception message is appended here.
+        ExceptionUtil.logAtLevel(logger, level, message + ": {}", t, args);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Cfgmgr32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Cfgmgr32FFM.java
@@ -6,6 +6,7 @@ package oshi.ffm.platform.windows;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static oshi.util.ExceptionUtil.getOrDefault;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -108,16 +109,14 @@ public final class Cfgmgr32FFM extends WindowsForeignFunctions {
      * @return the device ID string, or empty string on failure
      */
     public static String getDeviceId(int dnDevInst, Arena arena) {
-        try {
+        return getOrDefault(() -> {
             MemorySegment buf = arena.allocate(520); // MAX_DEVICE_ID_LEN = 200 chars * 2 = 400 bytes; 520 provides
                                                      // margin
             if (CM_Get_Device_ID(dnDevInst, buf, 260, 0) == CR_SUCCESS) {
                 return readWideString(buf);
             }
-        } catch (Throwable _) {
-            LOG.debug("CM_Get_Device_ID failed for node {}", dnDevInst);
-        }
-        return "";
+            return "";
+        }, "", LOG, "CM_Get_Device_ID failed for node {}: {}", dnDevInst);
     }
 
     /**
@@ -130,16 +129,14 @@ public final class Cfgmgr32FFM extends WindowsForeignFunctions {
      * @return the property value string, or empty string on failure
      */
     public static String getDevNodeProperty(int dnDevInst, int ulProperty, MemorySegment buf, MemorySegment sizeSeg) {
-        try {
+        return getOrDefault(() -> {
             buf.fill((byte) 0);
             sizeSeg.set(JAVA_INT, 0, (int) buf.byteSize());
             if (CM_Get_DevNode_Registry_Property(dnDevInst, ulProperty, MemorySegment.NULL, buf, sizeSeg,
                     0) == CR_SUCCESS) {
                 return readWideString(buf);
             }
-        } catch (Throwable _) {
-            LOG.debug("CM_Get_DevNode_Registry_Property failed for node {} property {}", dnDevInst, ulProperty);
-        }
-        return "";
+            return "";
+        }, "", LOG, "CM_Get_DevNode_Registry_Property failed for node {} property {}: {}", dnDevInst, ulProperty);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -7,7 +7,9 @@ package oshi.ffm.util.platform.mac;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static oshi.ffm.ForeignFunctions.callInArenaDoubleOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
 import static oshi.ffm.platform.mac.IOKitFunctions.IOConnectCallStructMethod;
 import static oshi.ffm.platform.mac.IOKitFunctions.IOServiceClose;
 import static oshi.ffm.platform.mac.IOKitFunctions.IOServiceOpen;
@@ -26,6 +28,7 @@ import static oshi.ffm.platform.mac.MacSystem.SMC_VAL_DATA_TYPE;
 import static oshi.ffm.platform.mac.MacSystemFunctions.mach_task_self;
 import static oshi.util.ExceptionUtil.getIntOrDefault;
 import static oshi.util.LogLevel.ERROR;
+import static oshi.util.LogLevel.WARN;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -141,7 +144,7 @@ public final class SmcUtilFFM {
      * @return Double representing the value
      */
     public static double smcGetFloat(int conn, String key) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaDoubleOrDefault(arena -> {
             MemorySegment val = arena.allocate(SMC_VAL);
             int result = smcReadKey(conn, key, val, arena);
             if (result == 0) {
@@ -158,10 +161,8 @@ public final class SmcUtilFFM {
                     }
                 }
             }
-        } catch (Throwable e) {
-            LOG.warn("Failed to read SMC float key {}: {}", key, e.getMessage());
-        }
-        return 0d;
+            return 0d;
+        }, 0d, LOG, WARN, "Failed to read SMC float key {}", key);
     }
 
     /**
@@ -189,7 +190,7 @@ public final class SmcUtilFFM {
      * @return Long representing the value
      */
     public static long smcGetLong(int conn, String key) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment val = arena.allocate(SMC_VAL);
             int result = smcReadKey(conn, key, val, arena);
             if (result == 0) {
@@ -197,10 +198,8 @@ public final class SmcUtilFFM {
                 byte[] bytes = readByteArray(val, SMC_VAL.byteOffset(SMC_VAL_BYTES), dataSize);
                 return ParseUtil.byteArrayToLong(bytes, dataSize);
             }
-        } catch (Throwable e) {
-            LOG.warn("Failed to read SMC long key {}: {}", key, e.getMessage());
-        }
-        return 0L;
+            return 0L;
+        }, 0L, LOG, WARN, "Failed to read SMC long key {}", key);
     }
 
     private static int smcReadKey(int conn, String key, MemorySegment val, Arena arena) throws Throwable {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.ffm.util.platform.unix.solaris;
 
+import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.unix.solaris.LibKstatFunctions.KSTAT_DATA_CHAR;
 import static oshi.ffm.platform.unix.solaris.LibKstatFunctions.KSTAT_DATA_INT32;
 import static oshi.ffm.platform.unix.solaris.LibKstatFunctions.KSTAT_DATA_INT64;
@@ -29,7 +31,6 @@ import static oshi.util.ExceptionUtil.getBooleanOrDefault;
 import static oshi.util.ExceptionUtil.getIntOrDefault;
 import static oshi.util.LogLevel.WARN;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
@@ -116,7 +117,7 @@ public final class KstatUtilFFM {
          */
         @GuardedBy("CHAIN")
         public MemorySegment lookup(String module, int instance, String name) {
-            try (Arena arena = Arena.ofConfined()) {
+            return callInArenaOrDefault(arena -> {
                 MemorySegment modSeg = module == null ? MemorySegment.NULL : arena.allocateFrom(module);
                 MemorySegment nameSeg = name == null ? MemorySegment.NULL : arena.allocateFrom(name);
                 MemorySegment hit = LibKstatFunctions.kstat_lookup(ctl, modSeg, instance, nameSeg);
@@ -124,10 +125,7 @@ public final class KstatUtilFFM {
                     return MemorySegment.NULL;
                 }
                 return hit.reinterpret(KSTAT_LAYOUT.byteSize());
-            } catch (Throwable t) {
-                LOG.warn("kstat_lookup failed for {}:{}:{}", module, instance, name, t);
-                return MemorySegment.NULL;
-            }
+            }, MemorySegment.NULL, LOG, WARN, "kstat_lookup failed for {}:{}:{}", module, instance, name);
         }
 
         /**
@@ -209,7 +207,7 @@ public final class KstatUtilFFM {
         if (type != KSTAT_TYPE_NAMED && type != KSTAT_TYPE_TIMER) {
             throw new IllegalArgumentException("Not a kstat_named or kstat_timer kstat.");
         }
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment data = LibKstatFunctions.kstat_data_lookup(ksp, nameSeg);
             if (data.address() == 0L) {
@@ -235,10 +233,7 @@ public final class KstatUtilFFM {
                     LOG.error("Unimplemented kstat data type {}", dt);
                     return "";
             }
-        } catch (Throwable t) {
-            LOG.warn("kstat_data_lookup failed for key {}", name, t);
-            return "";
-        }
+        }, "", LOG, WARN, "kstat_data_lookup failed for key {}", name);
     }
 
     /**
@@ -253,7 +248,7 @@ public final class KstatUtilFFM {
         if (type != KSTAT_TYPE_NAMED && type != KSTAT_TYPE_TIMER) {
             throw new IllegalArgumentException("Not a kstat_named or kstat_timer kstat.");
         }
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaLongOrDefault(arena -> {
             MemorySegment nameSeg = arena.allocateFrom(name);
             MemorySegment data = LibKstatFunctions.kstat_data_lookup(ksp, nameSeg);
             if (data.address() == 0L) {
@@ -276,10 +271,7 @@ public final class KstatUtilFFM {
                     LOG.error("Unimplemented or non-numeric kstat data type {}", dt);
                     return 0L;
             }
-        } catch (Throwable t) {
-            LOG.warn("kstat_data_lookup failed for key {}", name, t);
-            return 0L;
-        }
+        }, 0L, LOG, WARN, "kstat_data_lookup failed for key {}", name);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
@@ -35,6 +35,7 @@ import static oshi.ffm.platform.windows.WindowsForeignFunctions.toWideString;
 import static oshi.util.LogLevel.DEBUG;
 import static oshi.util.LogLevel.ERROR;
 import static oshi.util.LogLevel.TRACE;
+import static oshi.util.LogLevel.WARN;
 import static oshi.util.Memoizer.memoize;
 
 import java.lang.foreign.Arena;
@@ -367,7 +368,7 @@ public final class Advapi32UtilFFM {
      * @return An array of strings from the multi-sz value, or an empty array on failure
      */
     public static String[] registryGetStringArray(MemorySegment rootKey, String keyPath, String valueName) {
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment phkResult = arena.allocate(ADDRESS);
             int rc = RegOpenKeyEx(rootKey, toWideString(arena, keyPath), 0, KEY_READ, phkResult);
             if (rc != ERROR_SUCCESS) {
@@ -426,10 +427,7 @@ public final class Advapi32UtilFFM {
                     LOG.debug("Failed to close registry key {}\\\\{}: error {}", keyPath, valueName, closeRc);
                 }
             }
-        } catch (Throwable t) {
-            LOG.warn("Failed to read registry string array {}\\\\{}: {}", keyPath, valueName, t.getMessage());
-            return new String[0];
-        }
+        }, new String[0], LOG, WARN, "Failed to read registry string array {}\\\\{}", keyPath, valueName);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfDataUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfDataUtilFFM.java
@@ -26,6 +26,8 @@ import static oshi.ffm.platform.windows.WinErrorFFM.ERROR_SUCCESS;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.checkSuccess;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.toWideString;
+import static oshi.util.ExceptionUtil.runOrLog;
+import static oshi.util.LogLevel.DEBUG;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -79,14 +81,13 @@ public final class PerfDataUtilFFM {
         T[] props = propertyEnum.getEnumConstants();
         EnumMap<T, Long> valueMap = new EnumMap<>(propertyEnum);
 
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment queryPtr = arena.allocate(ADDRESS);
             checkSuccess(PdhOpenQuery(MemorySegment.NULL, MemorySegment.NULL, queryPtr));
-            MemorySegment query = null;
+            // Read once into an effectively-final local so the per-counter lambdas below can capture it.
+            MemorySegment query = queryPtr.get(ADDRESS, 0);
 
             try {
-                query = queryPtr.get(ADDRESS, 0);
-
                 // Add all counters to the single query, skipping any that fail
                 EnumMap<T, MemorySegment> counterHandles = new EnumMap<>(propertyEnum);
                 EnumMap<T, Boolean> baseFlags = new EnumMap<>(propertyEnum);
@@ -97,12 +98,10 @@ public final class PerfDataUtilFFM {
                         counterName = PerfCounter.stripBaseSuffix(counterName);
                     }
                     String path = counterPath(perfObject, prop.getInstance(), counterName);
-                    try {
+                    runOrLog(() -> {
                         counterHandles.put(prop, addEnglishCounter(arena, query, path));
                         baseFlags.put(prop, isBase);
-                    } catch (Throwable t) {
-                        LOG.debug("Failed to add counter {}: {}", path, t.getMessage());
-                    }
+                    }, LOG, "Failed to add counter {}: {}", path);
                 }
                 if (counterHandles.isEmpty()) {
                     return valueMap;
@@ -113,25 +112,17 @@ public final class PerfDataUtilFFM {
 
                 // Read all values, skipping any that fail
                 for (var entry : counterHandles.entrySet()) {
-                    try {
-                        valueMap.put(entry.getKey(),
-                                readRawCounterValue(arena, entry.getValue(), baseFlags.get(entry.getKey())));
-                    } catch (Throwable t) {
-                        LOG.debug("Failed to read counter for {}: {}", entry.getKey(), t.getMessage());
-                    }
+                    runOrLog(
+                            () -> valueMap.put(entry.getKey(),
+                                    readRawCounterValue(arena, entry.getValue(), baseFlags.get(entry.getKey()))),
+                            LOG, "Failed to read counter for {}: {}", entry.getKey());
                 }
 
             } finally {
-                if (query != null) {
-                    PdhCloseQuery(query);
-                }
+                PdhCloseQuery(query);
             }
-
-        } catch (Throwable t) {
-            LOG.debug("PDH queryCounters failed for {}: {}", perfObject, t.getMessage(), t);
-            return new EnumMap<>(propertyEnum);
-        }
-        return valueMap;
+            return valueMap;
+        }, new EnumMap<>(propertyEnum), LOG, DEBUG, "PDH queryCounters failed for {}", perfObject);
     }
 
     private static String counterPath(String object, String instance, String counter) {
@@ -306,7 +297,7 @@ public final class PerfDataUtilFFM {
             return new Pair<>(Collections.emptyList(), valuesMap);
         }
 
-        try (Arena arena = Arena.ofConfined()) {
+        return callInArenaOrDefault(arena -> {
             MemorySegment queryPtr = arena.allocate(ADDRESS);
             checkSuccess(PdhOpenQuery(MemorySegment.NULL, MemorySegment.NULL, queryPtr));
             MemorySegment query = null;
@@ -359,11 +350,9 @@ public final class PerfDataUtilFFM {
                     PdhCloseQuery(query);
                 }
             }
-        } catch (Throwable t) {
-            LOG.debug("PDH queryWildcardCounters failed for {}: {}", perfObject, t.getMessage(), t);
-            return new Pair<>(Collections.emptyList(), new EnumMap<>(propertyEnum));
-        }
-        return new Pair<>(instances, valuesMap);
+            return new Pair<>(instances, valuesMap);
+        }, new Pair<>(Collections.emptyList(), new EnumMap<>(propertyEnum)), LOG, DEBUG,
+                "PDH queryWildcardCounters failed for {}", perfObject);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -5,6 +5,7 @@
 package oshi.hardware.platform.mac;
 
 import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.ExceptionUtil.runOrLog;
 import static oshi.util.LogLevel.ERROR;
 
 import java.lang.foreign.MemorySegment;
@@ -154,7 +155,7 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                             MemorySegment bsdUnitSeg = driveProps.getValue(cfKeyMap.get(CFKey.BSD_UNIT));
                             MemorySegment cfFalseSeg = driveProps.getValue(cfKeyMap.get(CFKey.LEAF));
 
-                            try {
+                            runOrLog(() -> {
                                 @SuppressWarnings("resource") // CFAllocatorGetDefault returns a borrowed singleton
                                 CFAllocatorRef alloc = new CFAllocatorRef(
                                         CoreFoundationFunctions.CFAllocatorGetDefault());
@@ -224,9 +225,7 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                                         }
                                     }
                                 }
-                            } catch (Throwable e) {
-                                LOG.debug("Error building partition list for {}", bsdName, e);
-                            }
+                            }, LOG, "Error building partition list for {}: {}", bsdName);
                         }
                     }
                     setPartitionList(Collections.unmodifiableList(

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacNetworkIfFFM.java
@@ -7,6 +7,7 @@ package oshi.hardware.platform.mac;
 import static oshi.ffm.platform.mac.SystemConfigurationFunctions.SCNetworkInterfaceCopyAll;
 import static oshi.ffm.platform.mac.SystemConfigurationFunctions.SCNetworkInterfaceGetBSDName;
 import static oshi.ffm.platform.mac.SystemConfigurationFunctions.SCNetworkInterfaceGetLocalizedDisplayName;
+import static oshi.util.ExceptionUtil.getOrDefault;
 
 import java.lang.foreign.MemorySegment;
 import java.net.NetworkInterface;
@@ -39,7 +40,7 @@ public final class MacNetworkIfFFM extends MacNetworkIF {
 
     private static String queryIfDisplayName(NetworkInterface netint) {
         String name = netint.getName();
-        try {
+        return getOrDefault(() -> {
             MemorySegment ifArray = SCNetworkInterfaceCopyAll();
             if (ifArray.equals(MemorySegment.NULL)) {
                 return name;
@@ -58,10 +59,8 @@ public final class MacNetworkIfFFM extends MacNetworkIF {
                     }
                 }
             }
-        } catch (Throwable _) {
-            LOG.debug("Failed to query SC network interface display name for {}", name);
-        }
-        return name;
+            return name;
+        }, name, LOG, "Failed to query SC network interface display name for {}: {}", name);
     }
 
     public static List<NetworkIF> getNetworks(boolean includeLocalInterfaces) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
@@ -4,6 +4,9 @@
  */
 package oshi.hardware.platform.windows;
 
+import static oshi.util.ExceptionUtil.getLongOrDefault;
+import static oshi.util.ExceptionUtil.getOrDefault;
+
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -275,7 +278,7 @@ class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
     }
 
     private static String registryGetString(Arena arena, String path, String valueName) {
-        try {
+        return getOrDefault(() -> {
             MemorySegment hKey = arena.allocate(ValueLayout.ADDRESS);
             MemorySegment subKey = WindowsForeignFunctions.toWideString(arena, path);
             if (Advapi32FFM.RegOpenKeyEx(HKLM, subKey, 0, WinNTFFM.KEY_READ, hKey) == 0) {
@@ -290,14 +293,12 @@ class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
                     }
                 }
             }
-        } catch (Throwable t) {
-            LOG.debug("Failed to read registry string {}/{}: {}", path, valueName, t.getMessage());
-        }
-        return "";
+            return "";
+        }, "", LOG, "Failed to read registry string {}/{}: {}", path, valueName);
     }
 
     private static long registryGetDword(Arena arena, String path, String valueName) {
-        try {
+        return getLongOrDefault(() -> {
             MemorySegment hKey = arena.allocate(ValueLayout.ADDRESS);
             MemorySegment subKey = WindowsForeignFunctions.toWideString(arena, path);
             if (Advapi32FFM.RegOpenKeyEx(HKLM, subKey, 0, WinNTFFM.KEY_READ, hKey) == 0) {
@@ -312,9 +313,7 @@ class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
                     }
                 }
             }
-        } catch (Throwable t) {
-            LOG.debug("Failed to read registry DWORD {}/{}: {}", path, valueName, t.getMessage());
-        }
-        return 0L;
+            return 0L;
+        }, 0L, LOG, "Failed to read registry DWORD {}/{}: {}", path, valueName);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
@@ -8,6 +8,7 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static oshi.ffm.ForeignFunctions.CAPTURED_STATE_LAYOUT;
 import static oshi.ffm.ForeignFunctions.NATIVE_LONG_SIZE;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.CTL_KERN;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_ARGMAX;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_PROC_ARGS;
@@ -15,8 +16,8 @@ import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_PROC_ARGV
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.KERN_PROC_ENV;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.RLIMIT_NOFILE;
 import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.SIZE_T;
+import static oshi.util.LogLevel.WARN;
 
-import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,7 +63,7 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
     protected List<String> queryArguments() {
         if (ARGMAX > 0) {
             int[] mib = { CTL_KERN, KERN_PROC_ARGS, getProcessID(), KERN_PROC_ARGV };
-            try (Arena arena = Arena.ofConfined()) {
+            return callInArenaOrDefault(arena -> {
                 MemorySegment mibSeg = arena.allocate(JAVA_INT, mib.length);
                 for (int i = 0; i < mib.length; i++) {
                     mibSeg.setAtIndex(JAVA_INT, i, mib[i]);
@@ -85,9 +86,8 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
                     }
                     return Collections.unmodifiableList(args);
                 }
-            } catch (Throwable e) {
-                LOG.warn("Failed to get process arguments for pid {}", getProcessID(), e);
-            }
+                return Collections.<String>emptyList();
+            }, Collections.emptyList(), LOG, WARN, "Failed to get process arguments for pid {}", getProcessID());
         }
         return Collections.emptyList();
     }
@@ -96,7 +96,7 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
     protected Map<String, String> queryEnvironmentVariables() {
         if (ARGMAX > 0) {
             int[] mib = { CTL_KERN, KERN_PROC_ARGS, getProcessID(), KERN_PROC_ENV };
-            try (Arena arena = Arena.ofConfined()) {
+            return callInArenaOrDefault(arena -> {
                 MemorySegment mibSeg = arena.allocate(JAVA_INT, mib.length);
                 for (int i = 0; i < mib.length; i++) {
                     mibSeg.setAtIndex(JAVA_INT, i, mib[i]);
@@ -123,9 +123,8 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
                     }
                     return Collections.unmodifiableMap(env);
                 }
-            } catch (Throwable e) {
-                LOG.warn("Failed to get environment variables for pid {}", getProcessID(), e);
-            }
+                return Collections.<String, String>emptyMap();
+            }, Collections.emptyMap(), LOG, WARN, "Failed to get environment variables for pid {}", getProcessID());
         }
         return Collections.emptyMap();
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -27,6 +27,8 @@ import static oshi.ffm.platform.windows.WinNTFFM.PROCESS_VM_READ;
 import static oshi.ffm.platform.windows.WinNTFFM.TOKEN_QUERY;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.readWideStringFromPointer;
+import static oshi.util.ExceptionUtil.getOrDefault;
+import static oshi.util.LogLevel.WARN;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -188,53 +190,42 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
 
     @Override
     protected Pair<String, String> queryUserInfo() {
-        Pair<String, String> pair = null;
-        Optional<MemorySegment> pHandleOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION, false, getProcessID());
-        if (pHandleOpt.isPresent()) {
-            try (NativeHandle pHandle = NativeHandle.of(pHandleOpt.get(), Kernel32FFM::CloseHandle);
-                    Arena arena = Arena.ofConfined()) {
-                MemorySegment hTokenPtr = arena.allocate(ADDRESS);
-                if (Advapi32FFM.OpenProcessToken(pHandle.get(), TOKEN_QUERY, hTokenPtr)) {
-                    try (NativeHandle hToken = NativeHandle.of(hTokenPtr.get(ADDRESS, 0), Kernel32FFM::CloseHandle)) {
-                        pair = getTokenAccountInfo(hToken.get(), TokenUser, arena);
-                    }
-                } else {
-                    int error = Kernel32FFM.GetLastError().orElse(0);
-                    if (error != WinErrorFFM.ERROR_ACCESS_DENIED) {
-                        LOG.error("Failed to get process token for process {}: {}", getProcessID(), error);
-                    }
-                }
-            } catch (Throwable e) {
-                LOG.warn("Failed to query user info for process {} ({}): {}", getProcessID(), getName(),
-                        e.getMessage());
-            }
-        }
-        return pair != null ? pair : defaultPair();
+        return queryTokenAccountInfo(TokenUser, "user");
     }
 
     @Override
     protected Pair<String, String> queryGroupInfo() {
-        Pair<String, String> pair = null;
+        return queryTokenAccountInfo(TokenPrimaryGroup, "group");
+    }
+
+    /**
+     * Opens this process's access token and reads the requested account information class from it.
+     *
+     * @param tokenInformationClass {@code TokenUser} or {@code TokenPrimaryGroup}
+     * @param what                  the noun used in the failure log message
+     * @return the name/SID pair, or {@link #defaultPair()} if the token could not be read
+     */
+    private Pair<String, String> queryTokenAccountInfo(int tokenInformationClass, String what) {
         Optional<MemorySegment> pHandleOpt = Kernel32FFM.OpenProcess(PROCESS_QUERY_INFORMATION, false, getProcessID());
-        if (pHandleOpt.isPresent()) {
+        if (!pHandleOpt.isPresent()) {
+            return defaultPair();
+        }
+        Pair<String, String> pair = getOrDefault(() -> {
             try (NativeHandle pHandle = NativeHandle.of(pHandleOpt.get(), Kernel32FFM::CloseHandle);
                     Arena arena = Arena.ofConfined()) {
                 MemorySegment hTokenPtr = arena.allocate(ADDRESS);
                 if (Advapi32FFM.OpenProcessToken(pHandle.get(), TOKEN_QUERY, hTokenPtr)) {
                     try (NativeHandle hToken = NativeHandle.of(hTokenPtr.get(ADDRESS, 0), Kernel32FFM::CloseHandle)) {
-                        pair = getTokenAccountInfo(hToken.get(), TokenPrimaryGroup, arena);
-                    }
-                } else {
-                    int error = Kernel32FFM.GetLastError().orElse(0);
-                    if (error != WinErrorFFM.ERROR_ACCESS_DENIED) {
-                        LOG.error("Failed to get process token for process {}: {}", getProcessID(), error);
+                        return getTokenAccountInfo(hToken.get(), tokenInformationClass, arena);
                     }
                 }
-            } catch (Throwable e) {
-                LOG.warn("Failed to query group info for process {} ({}): {}", getProcessID(), getName(),
-                        e.getMessage());
+                int error = Kernel32FFM.GetLastError().orElse(0);
+                if (error != WinErrorFFM.ERROR_ACCESS_DENIED) {
+                    LOG.error("Failed to get process token for process {}: {}", getProcessID(), error);
+                }
+                return null;
             }
-        }
+        }, null, LOG, WARN, "Failed to query {} info for process {} ({}): {}", what, getProcessID(), getName());
         return pair != null ? pair : defaultPair();
     }
 

--- a/oshi-core-ffm/src/test/java/oshi/ffm/ForeignFunctionsTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/ForeignFunctionsTest.java
@@ -117,4 +117,57 @@ class ForeignFunctionsTest {
         assertThat(result, is(false));
     }
 
+    // -- parameterized-message overloads (default value second) --
+
+    /**
+     * The parameterized overloads take the default value second rather than merely swapping it with the message. With
+     * the default fourth, this call - whose {@code T} is String, so message and default have the same type - would
+     * match both overloads, and Java's fixed-arity-before-varargs resolution would silently bind it to the older one
+     * with the two transposed. This test fails to compile, or returns the message, if that ordering ever regresses.
+     */
+    @Test
+    void testExistingOverloadStillWinsWhenTypeParameterIsString() {
+        String result = ForeignFunctions.callInArenaOrDefault(arena -> {
+            throw new Throwable("failure");
+        }, LOG, DEBUG, "this is the message", "this is the default");
+
+        assertThat(result, is("this is the default"));
+    }
+
+    @Test
+    void testCallInArenaOrDefaultWithArgumentsReturnsDefaultOnThrowable() {
+        String result = ForeignFunctions.callInArenaOrDefault(arena -> {
+            throw new Throwable("failure");
+        }, "the default", LOG, DEBUG, "failed for {}", "someKey");
+
+        assertThat(result, is("the default"));
+    }
+
+    @Test
+    void testCallInArenaOrDefaultWithArgumentsReturnsValue() {
+        String result = ForeignFunctions.callInArenaOrDefault(arena -> "computed", "the default", LOG, DEBUG,
+                "failed for {}", "someKey");
+
+        assertThat(result, is("computed"));
+    }
+
+    @Test
+    void testCallInArenaPrimitiveVariantsWithArguments() {
+        assertThat(ForeignFunctions.callInArenaIntOrDefault(arena -> {
+            throw new Throwable("failure");
+        }, -1, LOG, DEBUG, "int failed for {}", "k"), is(-1));
+
+        assertThat(ForeignFunctions.callInArenaLongOrDefault(arena -> {
+            throw new Throwable("failure");
+        }, -1L, LOG, DEBUG, "long failed for {}", "k"), is(-1L));
+
+        assertThat(ForeignFunctions.callInArenaDoubleOrDefault(arena -> {
+            throw new Throwable("failure");
+        }, -1d, LOG, DEBUG, "double failed for {}", "k"), is(-1d));
+
+        assertThat(ForeignFunctions.callInArenaBooleanOrDefault(arena -> {
+            throw new Throwable("failure");
+        }, true, LOG, DEBUG, "boolean failed for {}", "k"), is(true));
+    }
+
 }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSFileStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSFileStoreJNA.java
@@ -4,6 +4,8 @@
  */
 package oshi.software.os.mac;
 
+import static oshi.util.ExceptionUtil.getBooleanOrDefault;
+
 import java.io.File;
 
 import org.slf4j.Logger;
@@ -34,7 +36,7 @@ public class MacOSFileStoreJNA extends MacOSFileStore {
     @Override
     public boolean updateAttributes() {
         // Fast path: call statfs64 directly on the known mount point
-        try {
+        if (getBooleanOrDefault(() -> {
             Statfs stat = new Statfs();
             if (SystemB.INSTANCE.statfs64(getMount(), stat) == 0) {
                 File f = new File(getMount());
@@ -42,8 +44,9 @@ public class MacOSFileStoreJNA extends MacOSFileStore {
                         stat.f_files);
                 return true;
             }
-        } catch (Throwable e) {
-            LOG.debug("statfs64 fast path failed for {}: {}", getMount(), e.getMessage());
+            return false;
+        }, false, LOG, "statfs64 fast path failed for {}: {}", getMount())) {
+            return true;
         }
         // Fall back to full enumeration
         for (OSFileStore fileStore : MacFileSystemJNA.getFileStoreMatching(getName(), isLocal())) {


### PR DESCRIPTION
Completes the sweep started in #3528. That PR converted the catch blocks whose message needed no argument but the exception; the 29 that remained all log extra context — a path, a pid, a registry key — which the helpers had no way to express. This adds that support and converts 27 of them.

No user-facing change, so no CHANGELOG entry.

### `ExceptionUtil` — modified in place, no new methods

`msg` was already the last parameter, so appending `Object... args` to the 18 logging overloads leaves every existing call site compiling unchanged. Caller arguments fill the leading placeholders in order, then the exception message fills a final one:

```java
getOrDefault(() -> ..., "", LOG, "Failed to read {} of {}: {}", path, valueName);
//                                              ^^    ^^   ^^ exception message
```

Safe to change in place because `ExceptionUtil` is not `@oshi.annotation.PublicApi`, and japicmp is configured to gate only `@PublicApi` types.

### `ForeignFunctions` — five new overloads, default value **second**

`callInArena*` takes the default value last, leaving no room for a trailing varargs, so it needs new overloads rather than an in-place change. They take the default second, matching `ExceptionUtil`'s existing `(operation, defaultValue, log, level, msg, args...)` order so both utilities read the same way.

Second rather than merely swapped with the message on purpose. With the default fourth, this call — whose `T` is `String`, so message and default have the same type — matches **both** overloads:

```java
callInArenaOrDefault(c, LOG, DEBUG, "the message", "the default")
```

Java resolves fixed-arity before varargs, so it would silently bind to the older overload with the two transposed. That is reachable in practice (`KstatUtilFFM.dataLookupString` returns `String`). Putting the default second makes argument three a `Logger` in one form and a `LogLevel` in the other, so the two cannot collide at any arity. `ForeignFunctionsTest` pins this down.

### The two that stayed

- **`WindowsGraphicsCardFFM.getGraphicsCards`** — the body both `continue`s the enclosing loop and increments an enclosing local. A lambda can do neither.
- **`PerfDataUtilFFM.queryWildcardCounters`** — the nested add-counter catch aborts the whole method; a helper cannot express "abort the enclosing lambda" from inside it. The outer catch in the same method *was* converted, so this one now sits inside that lambda, where its `return` still exits the method as before.

### Notable conversions

- **`WindowsOSProcessFFM.queryUserInfo` / `queryGroupInfo`** assigned an enclosing local read after the try. They were near-identical twins differing only in the token class and one noun, so both now delegate to a single `queryTokenAccountInfo` whose lambda returns the pair directly.
- **`InstalledAppsDataFFM`** had a `continue` skipping the current registry key. Inside a `runOrLog` lambda the equivalent is `return` — the enclosing loop still advances.
- **`PerfDataUtilFFM.queryCounters`** needed its query handle read into an effectively-final local so the per-counter lambdas could capture it. Previously it was assigned inside the try with a null guard in `finally`; the handle is read immediately after a checked `PdhOpenQuery`, so hoisting it changes nothing (in both forms a throw before the assignment leaves the handle unclosed).

### Verification

Clean full-reactor `install`: 1127 + 84 + 71 + 30 tests, 0 failures. Spotless, checkstyle, forbidden-apis and javadoc all clean. New tests cover argument ordering, the zero-argument path being unchanged, the success path logging nothing, and the overload-resolution hazard above.

Also ran the FFM provider live on macOS (M2 Max) over the affected paths. Specifically checked that `en0` still resolves to `Wi-Fi` through `SCNetworkInterface` rather than falling back to the raw interface name — a broken conversion of `MacNetworkIfFFM.queryIfDisplayName`, the site that prompted this whole sweep, would otherwise have looked healthy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logging helpers now support formatted messages with `{}` placeholders and additional arguments.
  * Native system-call utilities support formatted failure messages while returning configured fallback values.

* **Bug Fixes**
  * Improved diagnostic context for failures across hardware, operating-system, registry, and performance-data queries.
  * Standardized failure handling preserves application stability by returning safe defaults instead of propagating unexpected errors.

* **Tests**
  * Added coverage for formatted logging arguments, exception details, fallback behavior, and successful native-call results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->