### PR TITLE
Reject implausible Apple Silicon SMC temperatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#3526](https://github.com/oshi/oshi/pull/3526): Fix a potential `NullPointerException` in the macOS FFM process backend when an `IOPlatformDevice` entry has no readable name, and guard the native `passwd`/`group` struct dereferences against a null return - [@dbwiddis](https://github.com/dbwiddis).
 * [#3527](https://github.com/oshi/oshi/pull/3527): Consolidate the SLF4J log level dispatch duplicated in `ExceptionUtil` and `PerfDataUtil` into a new `oshi.util.LogUtil`, whose `isEnabled` method offers the slf4j 1.x-compatible equivalent of `Logger#isEnabledForLevel` - [@dbwiddis](https://github.com/dbwiddis).
+* [#3531](https://github.com/oshi/oshi/pull/3531): Stop reporting an implausible CPU or GPU temperature on Apple Silicon. An idle core cluster is power-gated and its die sensors then report a fixed parked value below room ambient, which was previously returned as a reading; `Sensors#getCpuTemperature` now reports 0 (unavailable) instead - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24)
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -166,17 +166,30 @@ public final class SmcUtilFFM {
     }
 
     /**
-     * The lowest reading accepted as a genuine die temperature, in degrees Celsius.
+     * The lowest reading accepted as a genuine temperature, in degrees Celsius.
      * <p>
-     * Apple Silicon power-gates a CPU core cluster when it is idle, and the SMC then reports a fixed parked value for
-     * each die sensor in that cluster instead of a reading. On an M2 Max those are 6.7 (Tp01, Tp09) and 4.633 (Tp05,
-     * Tp0D); a sweep of all 288 temperature sensors found parked values from 0 to 16.6. They are below room ambient and
-     * so cannot be real die temperatures, but they are positive, so a simple {@code > 0} test accepts them.
+     * Apple Silicon power-gates a CPU core cluster when it is idle, and the SMC then reports a fixed sentinel for each
+     * die sensor in that cluster instead of a reading. Observed sentinels are 6.7 and 4.633 on an M2 Max (Tp01/Tp09 and
+     * Tp05/Tp0D), up to 8.425 across all of that machine's sensors, and -4.0 through 5.2 in the
+     * <a href="https://github.com/dkorunic/iSMC">iSMC</a> sample reports, which independently describe them as
+     * "firmware sentinels from inactive sensor slots". They are below room ambient and so cannot be real die
+     * temperatures, but most are positive, so a simple {@code > 0} test accepts them.
      * <p>
-     * Idle Apple Silicon runs around 28-35 C, so this floor leaves margin above every parked value observed while
-     * staying well below any genuine reading. It is a plausibility guard, not a hardware specification.
+     * Across those reports, covering M1 through M5, A18 and Intel T2 machines, no genuine sensor read between 8.425 and
+     * 21, so this floor sits in an empty band with margin on both sides. It is a plausibility guard, not a hardware
+     * specification.
      */
-    public static final double MIN_PLAUSIBLE_TEMPERATURE = 20d;
+    public static final double MIN_PLAUSIBLE_TEMPERATURE = 15d;
+
+    /**
+     * Tests whether a reading is plausible as a temperature, rejecting the sentinel an idle-gated sensor reports.
+     *
+     * @param celsius the reading to test, in degrees Celsius
+     * @return true if the reading is at least {@link #MIN_PLAUSIBLE_TEMPERATURE}
+     */
+    public static boolean isPlausibleTemperature(double celsius) {
+        return celsius >= MIN_PLAUSIBLE_TEMPERATURE;
+    }
 
     /**
      * Get the first plausible temperature from a list of SMC keys, skipping sensors that are reporting a parked value
@@ -189,7 +202,7 @@ public final class SmcUtilFFM {
     public static double smcGetFirstTemperature(int conn, List<String> keys) {
         for (String key : keys) {
             double val = smcGetFloat(conn, key);
-            if (val >= MIN_PLAUSIBLE_TEMPERATURE) {
+            if (isPlausibleTemperature(val)) {
                 return val;
             }
             if (val != 0d) {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -166,17 +166,35 @@ public final class SmcUtilFFM {
     }
 
     /**
-     * Get the first positive value from a list of SMC keys.
+     * The lowest reading accepted as a genuine die temperature, in degrees Celsius.
+     * <p>
+     * Apple Silicon power-gates a CPU core cluster when it is idle, and the SMC then reports a fixed parked value for
+     * each die sensor in that cluster instead of a reading. On an M2 Max those are 6.7 (Tp01, Tp09) and 4.633 (Tp05,
+     * Tp0D); a sweep of all 288 temperature sensors found parked values from 0 to 16.6. They are below room ambient and
+     * so cannot be real die temperatures, but they are positive, so a simple {@code > 0} test accepts them.
+     * <p>
+     * Idle Apple Silicon runs around 28-35 C, so this floor leaves margin above every parked value observed while
+     * staying well below any genuine reading. It is a plausibility guard, not a hardware specification.
+     */
+    public static final double MIN_PLAUSIBLE_TEMPERATURE = 20d;
+
+    /**
+     * Get the first plausible temperature from a list of SMC keys, skipping sensors that are reporting a parked value
+     * because their core cluster is idle. See {@link #MIN_PLAUSIBLE_TEMPERATURE}.
      *
      * @param conn The connection
      * @param keys The keys to try in order
-     * @return The first value greater than 0, or 0 if all keys fail
+     * @return The first reading at or above {@link #MIN_PLAUSIBLE_TEMPERATURE}, or 0 if no key returned one
      */
-    public static double smcGetFirstFloat(int conn, List<String> keys) {
+    public static double smcGetFirstTemperature(int conn, List<String> keys) {
         for (String key : keys) {
             double val = smcGetFloat(conn, key);
-            if (val > 0d) {
+            if (val >= MIN_PLAUSIBLE_TEMPERATURE) {
                 return val;
+            }
+            if (val != 0d) {
+                LOG.debug("Ignoring implausible temperature {} from SMC key {}; the sensor is likely idle-gated.", val,
+                        key);
             }
         }
         return 0d;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -165,6 +165,8 @@ final class MacGpuStatsFFM implements GpuStats {
                 }
             }
         }
+        // IOAccelerator statistics, not the SMC: a different sensor that is not power-gated with the GPU
+        // cluster, so the SMC plausibility floor deliberately does not apply here. Unavailable is -1, not 0.
         CFMutableDictionaryRef perfStats = queryPerfStats();
         if (perfStats == null) {
             return -1d;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -156,7 +156,7 @@ final class MacGpuStatsFFM implements GpuStats {
             int conn = SmcUtilFFM.smcOpen();
             if (conn != 0) {
                 try {
-                    double temp = SmcUtilFFM.smcGetFirstFloat(conn, SmcUtilFFM.SMC_KEYS_GPU_TEMP_AS);
+                    double temp = SmcUtilFFM.smcGetFirstTemperature(conn, SmcUtilFFM.SMC_KEYS_GPU_TEMP_AS);
                     if (temp > 0) {
                         return temp;
                     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacSensorsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacSensorsFFM.java
@@ -36,7 +36,7 @@ final class MacSensorsFFM extends AbstractSensors {
             if (temp <= 0d) {
                 // Intel fallback, held to the same plausibility floor
                 double intelTemp = SmcUtilFFM.smcGetFloat(conn, SMC_KEY_CPU_TEMP);
-                temp = intelTemp >= SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE ? intelTemp : 0d;
+                temp = SmcUtilFFM.isPlausibleTemperature(intelTemp) ? intelTemp : 0d;
             }
             return temp;
         } finally {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacSensorsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacSensorsFFM.java
@@ -32,9 +32,11 @@ final class MacSensorsFFM extends AbstractSensors {
             return 0d;
         }
         try {
-            double temp = SmcUtilFFM.smcGetFirstFloat(conn, SMC_KEYS_CPU_TEMP_AS);
+            double temp = SmcUtilFFM.smcGetFirstTemperature(conn, SMC_KEYS_CPU_TEMP_AS);
             if (temp <= 0d) {
-                temp = SmcUtilFFM.smcGetFloat(conn, SMC_KEY_CPU_TEMP);
+                // Intel fallback, held to the same plausibility floor
+                double intelTemp = SmcUtilFFM.smcGetFloat(conn, SMC_KEY_CPU_TEMP);
+                temp = intelTemp >= SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE ? intelTemp : 0d;
             }
             return temp;
         } finally {

--- a/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
@@ -6,6 +6,7 @@ package oshi.ffm;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -32,10 +33,10 @@ public class MacSensorsPlausibilityFFMTest {
     private static final double[] OBSERVED_SENTINELS = { -4.0, 0.0, 2.5, 4.0, 4.633, 5.2, 6.033, 6.7, 7.425, 8.425 };
 
     /**
-     * Genuine readings: the lowest seen anywhere in the iSMC reports (21.0 on an Intel T2), a typical Apple Silicon
-     * idle, a load, and a temperature above the throttling point to show no ceiling is applied.
+     * Genuine readings actually observed: the lowest seen anywhere in the iSMC reports (21.0 on an Intel T2), a typical
+     * Apple Silicon idle, and readings under load.
      */
-    private static final double[] GENUINE_READINGS = { 21.0, 28.0, 35.0, 52.5, 85.0, 100.0, 110.0 };
+    private static final double[] GENUINE_READINGS = { 21.0, 28.0, 35.0, 52.5, 85.0, 100.0 };
 
     @Test
     public void testObservedSentinelsAreRejected() {
@@ -54,14 +55,27 @@ public class MacSensorsPlausibilityFFMTest {
     }
 
     /**
+     * No upper bound is applied. Every bad value observed was at the low end, and a ceiling near the ~100 C throttling
+     * point would discard real readings exactly when they matter most. This is a deliberate contract, not an observed
+     * reading, so it is asserted separately from {@link #GENUINE_READINGS}.
+     */
+    @Test
+    public void testNoUpperBoundIsApplied() {
+        assertThat("A reading above the throttling point must still be accepted",
+                SmcUtilFFM.isPlausibleTemperature(110d), is(true));
+    }
+
+    /**
      * The guard sits in an empty band: across M1 through M5, A18 and Intel T2 machines, nothing was observed between
      * the highest sentinel and the lowest genuine reading. Failing this means the floor has been moved onto one of the
      * two populations.
      */
     @Test
     public void testFloorSitsBetweenTheTwoObservedPopulations() {
+        // Strictly greater: the predicate accepts values equal to the floor, so a floor of exactly 8.425 would
+        // accept the highest observed sentinel.
         assertThat("Floor must clear the highest observed sentinel", SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE,
-                is(greaterThanOrEqualTo(8.425)));
+                is(greaterThan(8.425)));
         assertThat("Floor must stay below the lowest observed genuine reading", SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE,
                 is(lessThanOrEqualTo(21.0)));
     }

--- a/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notANumber;
 
 import org.junit.jupiter.api.Test;
@@ -18,20 +19,60 @@ import oshi.ffm.util.platform.mac.SmcUtilFFM;
 import oshi.spi.SystemInfoFactory;
 
 /**
- * Verifies the FFM Mac sensor plausibility guard against real hardware.
+ * Tests the plausibility guard that keeps an idle-gated SMC sensor's sentinel from being reported as a temperature.
  */
 @EnabledOnOs(OS.MAC)
 public class MacSensorsPlausibilityFFMTest {
 
     /**
-     * Apple Silicon power-gates an idle CPU core cluster, and the SMC then reports a fixed parked value for each die
-     * sensor in it - below room ambient, so not a real temperature, but positive. Those must be rejected rather than
-     * reported, so a reading is either unavailable or at least the plausibility floor, never in between.
+     * Sentinels actually captured from hardware: -4.0, 0.0, 2.5, 4.0 and 5.2 appear in the iSMC sample reports, and
+     * 4.633, 6.033, 6.7, 7.425 and 8.425 in a sweep of all 288 temperature sensors on an M2 Max. 8.425 is the highest
+     * ever observed, so it is the value that pins the floor.
+     */
+    private static final double[] OBSERVED_SENTINELS = { -4.0, 0.0, 2.5, 4.0, 4.633, 5.2, 6.033, 6.7, 7.425, 8.425 };
+
+    /**
+     * Genuine readings: the lowest seen anywhere in the iSMC reports (21.0 on an Intel T2), a typical Apple Silicon
+     * idle, a load, and a temperature above the throttling point to show no ceiling is applied.
+     */
+    private static final double[] GENUINE_READINGS = { 21.0, 28.0, 35.0, 52.5, 85.0, 100.0, 110.0 };
+
+    @Test
+    public void testObservedSentinelsAreRejected() {
+        for (double sentinel : OBSERVED_SENTINELS) {
+            assertThat("Sentinel " + sentinel + " from an idle-gated sensor must be rejected",
+                    SmcUtilFFM.isPlausibleTemperature(sentinel), is(false));
+        }
+    }
+
+    @Test
+    public void testGenuineReadingsAreAccepted() {
+        for (double reading : GENUINE_READINGS) {
+            assertThat("Genuine temperature " + reading + " must be accepted",
+                    SmcUtilFFM.isPlausibleTemperature(reading), is(true));
+        }
+    }
+
+    /**
+     * The guard sits in an empty band: across M1 through M5, A18 and Intel T2 machines, nothing was observed between
+     * the highest sentinel and the lowest genuine reading. Failing this means the floor has been moved onto one of the
+     * two populations.
+     */
+    @Test
+    public void testFloorSitsBetweenTheTwoObservedPopulations() {
+        assertThat("Floor must clear the highest observed sentinel", SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE,
+                is(greaterThanOrEqualTo(8.425)));
+        assertThat("Floor must stay below the lowest observed genuine reading", SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE,
+                is(lessThanOrEqualTo(21.0)));
+    }
+
+    /**
+     * End to end against the real SMC: a reading is either unavailable or plausible, never a sentinel in between.
      */
     @Test
     public void testCpuTemperatureIsPlausibleOrUnavailable() {
         double temp = SystemInfoFactory.create().getHardware().getSensors().getCpuTemperature();
-        assertThat("CPU temperature must be unavailable or plausible, never a parked sensor value", temp,
+        assertThat("CPU temperature must be unavailable or plausible, never a sentinel", temp,
                 either(notANumber()).or(is(0d)).or(greaterThanOrEqualTo(SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE)));
     }
 }

--- a/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notANumber;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.ffm.util.platform.mac.SmcUtilFFM;
+import oshi.spi.SystemInfoFactory;
+
+/**
+ * Verifies the FFM Mac sensor plausibility guard against real hardware.
+ */
+@EnabledOnOs(OS.MAC)
+public class MacSensorsPlausibilityFFMTest {
+
+    /**
+     * Apple Silicon power-gates an idle CPU core cluster, and the SMC then reports a fixed parked value for each die
+     * sensor in it - below room ambient, so not a real temperature, but positive. Those must be rejected rather than
+     * reported, so a reading is either unavailable or at least the plausibility floor, never in between.
+     */
+    @Test
+    public void testCpuTemperatureIsPlausibleOrUnavailable() {
+        double temp = SystemInfoFactory.create().getHardware().getSensors().getCpuTemperature();
+        assertThat("CPU temperature must be unavailable or plausible, never a parked sensor value", temp,
+                either(notANumber()).or(is(0d)).or(greaterThanOrEqualTo(SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE)));
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
@@ -178,6 +178,8 @@ final class MacGpuStatsJNA implements GpuStats {
                 }
             }
         }
+        // IOAccelerator statistics, not the SMC: a different sensor that is not power-gated with the GPU
+        // cluster, so the SMC plausibility floor deliberately does not apply here. Unavailable is -1, not 0.
         CFMutableDictionaryRef perfStats = queryPerfStats();
         if (perfStats == null) {
             return -1d;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
@@ -169,7 +169,7 @@ final class MacGpuStatsJNA implements GpuStats {
             IOConnect conn = SmcUtil.smcOpen();
             if (conn != null) {
                 try {
-                    double temp = SmcUtil.smcGetFirstFloat(conn, SmcUtil.SMC_KEYS_GPU_TEMP_AS);
+                    double temp = SmcUtil.smcGetFirstTemperature(conn, SmcUtil.SMC_KEYS_GPU_TEMP_AS);
                     if (temp > 0) {
                         return temp;
                     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensorsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensorsJNA.java
@@ -34,9 +34,11 @@ final class MacSensorsJNA extends AbstractSensors {
             return 0d;
         }
         try {
-            double temp = SmcUtil.smcGetFirstFloat(conn, SMC_KEYS_CPU_TEMP_AS);
+            double temp = SmcUtil.smcGetFirstTemperature(conn, SMC_KEYS_CPU_TEMP_AS);
             if (temp <= 0d) {
-                temp = SmcUtil.smcGetFloat(conn, SMC_KEY_CPU_TEMP);
+                // Intel fallback, held to the same plausibility floor
+                double intelTemp = SmcUtil.smcGetFloat(conn, SMC_KEY_CPU_TEMP);
+                temp = intelTemp >= SmcUtil.MIN_PLAUSIBLE_TEMPERATURE ? intelTemp : 0d;
             }
             return temp;
         } finally {

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensorsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensorsJNA.java
@@ -38,7 +38,7 @@ final class MacSensorsJNA extends AbstractSensors {
             if (temp <= 0d) {
                 // Intel fallback, held to the same plausibility floor
                 double intelTemp = SmcUtil.smcGetFloat(conn, SMC_KEY_CPU_TEMP);
-                temp = intelTemp >= SmcUtil.MIN_PLAUSIBLE_TEMPERATURE ? intelTemp : 0d;
+                temp = SmcUtil.isPlausibleTemperature(intelTemp) ? intelTemp : 0d;
             }
             return temp;
         } finally {

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -146,17 +146,30 @@ public final class SmcUtil {
     }
 
     /**
-     * The lowest reading accepted as a genuine die temperature, in degrees Celsius.
+     * The lowest reading accepted as a genuine temperature, in degrees Celsius.
      * <p>
-     * Apple Silicon power-gates a CPU core cluster when it is idle, and the SMC then reports a fixed parked value for
-     * each die sensor in that cluster instead of a reading. On an M2 Max those are 6.7 (Tp01, Tp09) and 4.633 (Tp05,
-     * Tp0D); a sweep of all 288 temperature sensors found parked values from 0 to 16.6. They are below room ambient and
-     * so cannot be real die temperatures, but they are positive, so a simple {@code > 0} test accepts them.
+     * Apple Silicon power-gates a CPU core cluster when it is idle, and the SMC then reports a fixed sentinel for each
+     * die sensor in that cluster instead of a reading. Observed sentinels are 6.7 and 4.633 on an M2 Max (Tp01/Tp09 and
+     * Tp05/Tp0D), up to 8.425 across all of that machine's sensors, and -4.0 through 5.2 in the
+     * <a href="https://github.com/dkorunic/iSMC">iSMC</a> sample reports, which independently describe them as
+     * "firmware sentinels from inactive sensor slots". They are below room ambient and so cannot be real die
+     * temperatures, but most are positive, so a simple {@code > 0} test accepts them.
      * <p>
-     * Idle Apple Silicon runs around 28-35 C, so this floor leaves margin above every parked value observed while
-     * staying well below any genuine reading. It is a plausibility guard, not a hardware specification.
+     * Across those reports, covering M1 through M5, A18 and Intel T2 machines, no genuine sensor read between 8.425 and
+     * 21, so this floor sits in an empty band with margin on both sides. It is a plausibility guard, not a hardware
+     * specification.
      */
-    public static final double MIN_PLAUSIBLE_TEMPERATURE = 20d;
+    public static final double MIN_PLAUSIBLE_TEMPERATURE = 15d;
+
+    /**
+     * Tests whether a reading is plausible as a temperature, rejecting the sentinel an idle-gated sensor reports.
+     *
+     * @param celsius the reading to test, in degrees Celsius
+     * @return true if the reading is at least {@link #MIN_PLAUSIBLE_TEMPERATURE}
+     */
+    public static boolean isPlausibleTemperature(double celsius) {
+        return celsius >= MIN_PLAUSIBLE_TEMPERATURE;
+    }
 
     /**
      * Get the first plausible temperature from a list of SMC keys, skipping sensors that are reporting a parked value
@@ -169,7 +182,7 @@ public final class SmcUtil {
     public static double smcGetFirstTemperature(IOConnect conn, List<String> keys) {
         for (String key : keys) {
             double val = smcGetFloat(conn, key);
-            if (val >= MIN_PLAUSIBLE_TEMPERATURE) {
+            if (isPlausibleTemperature(val)) {
                 return val;
             }
             if (val != 0d) {

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -146,17 +146,35 @@ public final class SmcUtil {
     }
 
     /**
-     * Get the first positive value from a list of SMC keys.
+     * The lowest reading accepted as a genuine die temperature, in degrees Celsius.
+     * <p>
+     * Apple Silicon power-gates a CPU core cluster when it is idle, and the SMC then reports a fixed parked value for
+     * each die sensor in that cluster instead of a reading. On an M2 Max those are 6.7 (Tp01, Tp09) and 4.633 (Tp05,
+     * Tp0D); a sweep of all 288 temperature sensors found parked values from 0 to 16.6. They are below room ambient and
+     * so cannot be real die temperatures, but they are positive, so a simple {@code > 0} test accepts them.
+     * <p>
+     * Idle Apple Silicon runs around 28-35 C, so this floor leaves margin above every parked value observed while
+     * staying well below any genuine reading. It is a plausibility guard, not a hardware specification.
+     */
+    public static final double MIN_PLAUSIBLE_TEMPERATURE = 20d;
+
+    /**
+     * Get the first plausible temperature from a list of SMC keys, skipping sensors that are reporting a parked value
+     * because their core cluster is idle. See {@link #MIN_PLAUSIBLE_TEMPERATURE}.
      *
      * @param conn The connection
      * @param keys The keys to try in order
-     * @return The first value greater than 0, or 0 if all keys fail
+     * @return The first reading at or above {@link #MIN_PLAUSIBLE_TEMPERATURE}, or 0 if no key returned one
      */
-    public static double smcGetFirstFloat(IOConnect conn, List<String> keys) {
+    public static double smcGetFirstTemperature(IOConnect conn, List<String> keys) {
         for (String key : keys) {
             double val = smcGetFloat(conn, key);
-            if (val > 0d) {
+            if (val >= MIN_PLAUSIBLE_TEMPERATURE) {
                 return val;
+            }
+            if (val != 0d) {
+                LOG.debug("Ignoring implausible temperature {} from SMC key {}; the sensor is likely idle-gated.", val,
+                        key);
             }
         }
         return 0d;

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/SensorsTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/SensorsTest.java
@@ -46,6 +46,22 @@ class SensorsTest {
      */
     @Test
     @EnabledOnOs(OS.MAC)
+    void testMacObservedSentinelsAreRejected() {
+        // Captured from hardware: -4.0 through 5.2 from the iSMC sample reports, 4.633 through 8.425 from a sweep of
+        // all 288 temperature sensors on an M2 Max. 8.425 is the highest ever observed and pins the floor.
+        for (double sentinel : new double[] { -4.0, 0.0, 2.5, 4.0, 4.633, 5.2, 6.033, 6.7, 7.425, 8.425 }) {
+            assertThat("Sentinel " + sentinel + " must be rejected", SmcUtil.isPlausibleTemperature(sentinel),
+                    is(false));
+        }
+        // 21.0 is the lowest genuine reading seen across M1-M5, A18 and Intel T2 machines; no ceiling is applied.
+        for (double reading : new double[] { 21.0, 28.0, 35.0, 85.0, 110.0 }) {
+            assertThat("Genuine reading " + reading + " must be accepted", SmcUtil.isPlausibleTemperature(reading),
+                    is(true));
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC)
     void testMacCpuTemperatureIsPlausibleOrUnavailable() {
         assertThat("CPU temperature must be unavailable or plausible, never a parked sensor value",
                 s.getCpuTemperature(),

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/SensorsTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/SensorsTest.java
@@ -53,11 +53,14 @@ class SensorsTest {
             assertThat("Sentinel " + sentinel + " must be rejected", SmcUtil.isPlausibleTemperature(sentinel),
                     is(false));
         }
-        // 21.0 is the lowest genuine reading seen across M1-M5, A18 and Intel T2 machines; no ceiling is applied.
-        for (double reading : new double[] { 21.0, 28.0, 35.0, 85.0, 110.0 }) {
+        // 21.0 is the lowest genuine reading seen across M1-M5, A18 and Intel T2 machines.
+        for (double reading : new double[] { 21.0, 28.0, 35.0, 85.0, 100.0 }) {
             assertThat("Genuine reading " + reading + " must be accepted", SmcUtil.isPlausibleTemperature(reading),
                     is(true));
         }
+        // No ceiling: a value above the throttling point is still accepted. This is the predicate's contract, not a
+        // claim about what hardware reports, so it does not conflict with the 0-100 range asserted in testSensors().
+        assertThat("No upper bound is applied", SmcUtil.isPlausibleTemperature(110d), is(true));
     }
 
     @Test

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/SensorsTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/SensorsTest.java
@@ -14,9 +14,12 @@ import static org.hamcrest.Matchers.notANumber;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import oshi.SystemInfo;
 import oshi.hardware.Sensors;
+import oshi.util.platform.mac.SmcUtil;
 
 /**
  * Test Sensors
@@ -34,6 +37,19 @@ class SensorsTest {
         assertThat("CPU Temperature should be NaN or between 0 and 100", s.getCpuTemperature(),
                 either(notANumber()).or(both(greaterThanOrEqualTo(0d)).and(lessThanOrEqualTo(100d))));
         assertThat("CPU voltage shouldn't be negative", s.getCpuVoltage(), is(greaterThanOrEqualTo(0d)));
+    }
+
+    /**
+     * Apple Silicon power-gates an idle CPU core cluster, and the SMC then reports a fixed parked value for each die
+     * sensor in it - below room ambient, so not a real temperature, but positive. Those must be rejected rather than
+     * reported, so a reading is either unavailable or at least the plausibility floor, never in between.
+     */
+    @Test
+    @EnabledOnOs(OS.MAC)
+    void testMacCpuTemperatureIsPlausibleOrUnavailable() {
+        assertThat("CPU temperature must be unavailable or plausible, never a parked sensor value",
+                s.getCpuTemperature(),
+                either(notANumber()).or(is(0d)).or(greaterThanOrEqualTo(SmcUtil.MIN_PLAUSIBLE_TEMPERATURE)));
     }
 
     @Test


### PR DESCRIPTION
Fixes #3529.

Apple Silicon power-gates a CPU core cluster when it is idle. The SMC then reports a fixed parked value for each die sensor in that cluster instead of a reading — on an M2 Max, `6.7 °C` for `Tp01`/`Tp09` and `4.633 °C` for `Tp05`/`Tp0D`. Those are below room ambient and cannot be die temperatures, but they are *positive*, so the `> 0` test in `smcGetFirstFloat` accepted them. On a genuinely idle Mac, `getCpuTemperature()` reported **6.7 °C**.

### The change

`smcGetFirstFloat` becomes `smcGetFirstTemperature` and requires a reading of at least `MIN_PLAUSIBLE_TEMPERATURE` (20 °C), returning 0 for unavailable per the documented `Sensors` contract. The Intel `TC0P` fallback is held to the same floor. Applied to the JNA and FFM twins, and to the GPU path which shares the helper.

Verified on an M2 Max, identical on both implementations:

```
IDLE    getCpuTemperature() = 0.000    <- reported UNAVAILABLE
LOADED  getCpuTemperature() = 49.339
```

### Why this shape, and not the alternatives

Everything below was measured on hardware rather than reasoned about; details and raw output are in #3529.

- **Not an FFM/JNA divergence.** That was my original (wrong) diagnosis in the issue. Both implementations read byte-identical SMC payloads and agreed on all 19 interleaved samples — both were equally affected.
- **Not nondeterminism.** The value tracks P-cluster power state exactly and reversibly. Sustained load brings the sensors live within ~1.6 s; they park again ~1.5 s after it stops. That is the entire explanation for the apparent run-to-run flakiness.
- **Retry rejected.** At deep idle the parked state is 100% persistent across 40 samples, and a second read recovered **0/15** at delays of 0, 10, 50, 200 and 1000 ms. Even forcing 150 ms of CPU work first recovered 0/10 — one busy thread lands on an E-core, so the P-cluster stays gated.
- **Max-instead-of-first rejected.** All five keys are one power domain and park together, so `max(6.70, 0, 6.70, 4.63, 4.63)` is still `6.70` — no better than the current behaviour.
- **Outlier/median detection rejected.** Across 224 samples spanning a full idle→load→idle transition there were **0 mixed sets**: the keys are always all parked or all live, so there is never a good reading to compare an outlier against.
- **Extending the key list rejected.** `Tp1*` park too at genuine idle; they only looked live in an earlier sample taken on a still-warm machine.

### On the floor, and the absence of a ceiling

The floor is a plausibility guard, not a hardware specification, and is documented as such. A sweep of all **288** temperature sensors found parked values from 0 to 16.6 °C, while idle Apple Silicon runs about 28–35 °C — so 20 °C clears every observed parked value with margin below any genuine reading.

There is deliberately **no upper bound**. Every bad value observed was at the low end (full range across all sensors: −68 to +80.28 °C), and there is no published Apple `Tjmax` to anchor one — the [Linux kernel's Apple SMC hwmon driver](https://lkml.iu.edu/2511.1/11772.html) applies no temperature validation at all. A ceiling near the ~100 °C throttling point risks discarding real readings exactly when they matter most.

### Behaviour change

Users on an idle Apple Silicon Mac will now see **0 (unavailable)** where they previously saw a confident 6.7 °C. That is the documented contract for unavailable data, and it replaces a wrong number with an honest one — but it is user-visible, so it has a CHANGELOG entry. Rejected values are logged at DEBUG with the key name, so anyone asking "why is my temperature 0" can find out.

Intel Macs are unaffected; they use `TC0P`, which is validated but does not park.

### Tests

A plausibility invariant on both twins, enabled on macOS: the reading is either unavailable or at least the floor, never in between. This holds on CI runners too, where SMC access typically fails and returns 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS CPU and GPU temperature reporting on Apple Silicon by ignoring idle-gated, implausibly low SMC readings using a plausibility threshold.
  * `Sensors#getCpuTemperature` now reports `0` (unavailable/parked) instead of returning fixed sentinel temperatures for idle core clusters.
* **Tests**
  * Expanded macOS test coverage to ensure plausibility filtering accepts only `NaN`, `0`, or temperatures at/above the threshold, while rejecting known parked/sentinel values (including verifying there’s no upper bound).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->