### PR TITLE
Read Apple Silicon CPU temp from SMC die-aggregate keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#3526](https://github.com/oshi/oshi/pull/3526): Fix a potential `NullPointerException` in the macOS FFM process backend when an `IOPlatformDevice` entry has no readable name, and guard the native `passwd`/`group` struct dereferences against a null return - [@dbwiddis](https://github.com/dbwiddis).
 * [#3527](https://github.com/oshi/oshi/pull/3527): Consolidate the SLF4J log level dispatch duplicated in `ExceptionUtil` and `PerfDataUtil` into a new `oshi.util.LogUtil`, whose `isEnabled` method offers the slf4j 1.x-compatible equivalent of `Logger#isEnabledForLevel` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3531](https://github.com/oshi/oshi/pull/3531): Stop reporting an implausible CPU or GPU temperature on Apple Silicon. An idle core cluster is power-gated and its die sensors then report a fixed parked value below room ambient, which was previously returned as a reading; `Sensors#getCpuTemperature` now reports 0 (unavailable) instead - [@dbwiddis](https://github.com/dbwiddis).
+* [#3535](https://github.com/oshi/oshi/pull/3535): Fix `Sensors#getCpuTemperature` returning 0 on Apple Silicon chips whose per-core SMC keys differ from the hardcoded set (e.g. the M3 Pro, where all five are absent). Prefer the chip-independent, firmware-computed CPU-die aggregate keys `TCMb` (die average) and `TCMz` (die max) before the per-core keys, reporting the die average - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24)
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -76,6 +76,14 @@ public final class SmcUtilFFM {
     /** SMC key for CPU voltage. */
     public static final String SMC_KEY_CPU_VOLTAGE = "VC0C";
 
+    /**
+     * Apple Silicon CPU-die aggregate temperature keys, tried in order until one returns a plausible value. These are
+     * computed by the SMC firmware and are chip-independent, unlike the per-core {@link #SMC_KEYS_CPU_TEMP_AS} keys
+     * which vary between chips (and are entirely absent on some, e.g. the M3 Pro). {@code TCMb} is the CPU-die average
+     * and {@code TCMz} is the CPU-die maximum; the average is preferred because it stays close to the single-sensor
+     * value OSHI historically reported.
+     */
+    public static final List<String> SMC_KEYS_CPU_TEMP_AGGREGATE_AS = List.of("TCMb", "TCMz");
     /** SMC keys for Apple Silicon CPU temperature sensors. */
     public static final List<String> SMC_KEYS_CPU_TEMP_AS = List.of("Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D");
     /** SMC keys for Apple Silicon GPU temperature sensors. */

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacSensorsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacSensorsFFM.java
@@ -4,6 +4,7 @@
  */
 package oshi.hardware.platform.mac;
 
+import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEYS_CPU_TEMP_AGGREGATE_AS;
 import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEYS_CPU_TEMP_AS;
 import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEY_CPU_TEMP;
 import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEY_CPU_VOLTAGE;
@@ -32,7 +33,12 @@ final class MacSensorsFFM extends AbstractSensors {
             return 0d;
         }
         try {
-            double temp = SmcUtilFFM.smcGetFirstTemperature(conn, SMC_KEYS_CPU_TEMP_AS);
+            // Prefer the chip-independent CPU-die aggregate keys (TCMb average, TCMz max), which the firmware
+            // computes even on chips whose per-core keys are named differently or absent (e.g. the M3 Pro).
+            double temp = SmcUtilFFM.smcGetFirstTemperature(conn, SMC_KEYS_CPU_TEMP_AGGREGATE_AS);
+            if (temp <= 0d) {
+                temp = SmcUtilFFM.smcGetFirstTemperature(conn, SMC_KEYS_CPU_TEMP_AS);
+            }
             if (temp <= 0d) {
                 // Intel fallback, held to the same plausibility floor
                 double intelTemp = SmcUtilFFM.smcGetFloat(conn, SMC_KEY_CPU_TEMP);

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensorsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensorsJNA.java
@@ -4,6 +4,7 @@
  */
 package oshi.hardware.platform.mac;
 
+import static oshi.util.platform.mac.SmcUtil.SMC_KEYS_CPU_TEMP_AGGREGATE_AS;
 import static oshi.util.platform.mac.SmcUtil.SMC_KEYS_CPU_TEMP_AS;
 import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_TEMP;
 import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_VOLTAGE;
@@ -34,7 +35,12 @@ final class MacSensorsJNA extends AbstractSensors {
             return 0d;
         }
         try {
-            double temp = SmcUtil.smcGetFirstTemperature(conn, SMC_KEYS_CPU_TEMP_AS);
+            // Prefer the chip-independent CPU-die aggregate keys (TCMb average, TCMz max), which the firmware
+            // computes even on chips whose per-core keys are named differently or absent (e.g. the M3 Pro).
+            double temp = SmcUtil.smcGetFirstTemperature(conn, SMC_KEYS_CPU_TEMP_AGGREGATE_AS);
+            if (temp <= 0d) {
+                temp = SmcUtil.smcGetFirstTemperature(conn, SMC_KEYS_CPU_TEMP_AS);
+            }
             if (temp <= 0d) {
                 // Intel fallback, held to the same plausibility floor
                 double intelTemp = SmcUtil.smcGetFloat(conn, SMC_KEY_CPU_TEMP);

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -62,6 +62,15 @@ public final class SmcUtil {
     /** SMC key for CPU voltage (Intel). */
     public static final String SMC_KEY_CPU_VOLTAGE = "VC0C";
 
+    /**
+     * Apple Silicon CPU-die aggregate temperature keys, tried in order until one returns a plausible value. These are
+     * computed by the SMC firmware and are chip-independent, unlike the per-core {@link #SMC_KEYS_CPU_TEMP_AS} keys
+     * which vary between chips (and are entirely absent on some, e.g. the M3 Pro). {@code TCMb} is the CPU-die average
+     * and {@code TCMz} is the CPU-die maximum; the average is preferred because it stays close to the single-sensor
+     * value OSHI historically reported.
+     */
+    public static final List<String> SMC_KEYS_CPU_TEMP_AGGREGATE_AS = Collections
+            .unmodifiableList(Arrays.asList("TCMb", "TCMz"));
     /** Apple Silicon CPU temperature keys, tried in order until one returns a positive value. */
     public static final List<String> SMC_KEYS_CPU_TEMP_AS = Collections
             .unmodifiableList(Arrays.asList("Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D"));

--- a/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.ffm;
+package oshi.util.platform.mac;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -17,14 +17,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import oshi.ffm.util.platform.mac.SmcUtilFFM;
-import oshi.spi.SystemInfoFactory;
+import oshi.SystemInfo;
 
 /**
- * Tests the plausibility guard that keeps an idle-gated SMC sensor's sentinel from being reported as a temperature.
+ * Tests the plausibility guard that keeps an idle-gated SMC sensor's sentinel from being reported as a temperature. JNA
+ * twin of {@code oshi.ffm.MacSensorsPlausibilityFFMTest}.
  */
 @EnabledOnOs(OS.MAC)
-public class MacSensorsPlausibilityFFMTest {
+public class MacSensorsPlausibilityTest {
 
     /**
      * Sentinels actually captured from hardware: -4.0, 0.0, 2.5, 4.0 and 5.2 appear in the iSMC sample reports, and
@@ -43,15 +43,15 @@ public class MacSensorsPlausibilityFFMTest {
     public void testObservedSentinelsAreRejected() {
         for (double sentinel : OBSERVED_SENTINELS) {
             assertThat("Sentinel " + sentinel + " from an idle-gated sensor must be rejected",
-                    SmcUtilFFM.isPlausibleTemperature(sentinel), is(false));
+                    SmcUtil.isPlausibleTemperature(sentinel), is(false));
         }
     }
 
     @Test
     public void testGenuineReadingsAreAccepted() {
         for (double reading : GENUINE_READINGS) {
-            assertThat("Genuine temperature " + reading + " must be accepted",
-                    SmcUtilFFM.isPlausibleTemperature(reading), is(true));
+            assertThat("Genuine temperature " + reading + " must be accepted", SmcUtil.isPlausibleTemperature(reading),
+                    is(true));
         }
     }
 
@@ -62,8 +62,8 @@ public class MacSensorsPlausibilityFFMTest {
      */
     @Test
     public void testNoUpperBoundIsApplied() {
-        assertThat("A reading above the throttling point must still be accepted",
-                SmcUtilFFM.isPlausibleTemperature(110d), is(true));
+        assertThat("A reading above the throttling point must still be accepted", SmcUtil.isPlausibleTemperature(110d),
+                is(true));
     }
 
     /**
@@ -75,9 +75,9 @@ public class MacSensorsPlausibilityFFMTest {
     public void testFloorSitsBetweenTheTwoObservedPopulations() {
         // Strictly greater: the predicate accepts values equal to the floor, so a floor of exactly 8.425 would
         // accept the highest observed sentinel.
-        assertThat("Floor must clear the highest observed sentinel", SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE,
+        assertThat("Floor must clear the highest observed sentinel", SmcUtil.MIN_PLAUSIBLE_TEMPERATURE,
                 is(greaterThan(8.425)));
-        assertThat("Floor must stay below the lowest observed genuine reading", SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE,
+        assertThat("Floor must stay below the lowest observed genuine reading", SmcUtil.MIN_PLAUSIBLE_TEMPERATURE,
                 is(lessThanOrEqualTo(21.0)));
     }
 
@@ -86,9 +86,9 @@ public class MacSensorsPlausibilityFFMTest {
      */
     @Test
     public void testCpuTemperatureIsPlausibleOrUnavailable() {
-        double temp = SystemInfoFactory.create().getHardware().getSensors().getCpuTemperature();
+        double temp = new SystemInfo().getHardware().getSensors().getCpuTemperature();
         assertThat("CPU temperature must be unavailable or plausible, never a sentinel", temp,
-                either(notANumber()).or(is(0d)).or(greaterThanOrEqualTo(SmcUtilFFM.MIN_PLAUSIBLE_TEMPERATURE)));
+                either(notANumber()).or(is(0d)).or(greaterThanOrEqualTo(SmcUtil.MIN_PLAUSIBLE_TEMPERATURE)));
     }
 
     /**
@@ -98,10 +98,10 @@ public class MacSensorsPlausibilityFFMTest {
      */
     @Test
     public void testCpuTempAggregateKeysArePreferredAverageFirst() {
-        assertThat("TCMb (average) must be tried before TCMz (max)", SmcUtilFFM.SMC_KEYS_CPU_TEMP_AGGREGATE_AS,
+        assertThat("TCMb (average) must be tried before TCMz (max)", SmcUtil.SMC_KEYS_CPU_TEMP_AGGREGATE_AS,
                 is(contains("TCMb", "TCMz")));
         assertThat("Aggregate keys must be distinct from the per-core keys",
-                SmcUtilFFM.SMC_KEYS_CPU_TEMP_AGGREGATE_AS.stream().noneMatch(SmcUtilFFM.SMC_KEYS_CPU_TEMP_AS::contains),
+                SmcUtil.SMC_KEYS_CPU_TEMP_AGGREGATE_AS.stream().noneMatch(SmcUtil.SMC_KEYS_CPU_TEMP_AS::contains),
                 is(true));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3534. OSHI read the macOS CPU temperature from five hardcoded per-core SMC FourCC keys (`Tp09, Tp0T, Tp01, Tp05, Tp0D`). These are chip-specific, and **all five are absent on the M3 Pro** (which exposes a different set: `Tp06/Tp0E…`, `Te0…`, `Tp3P/Tp3X/Tp3T`), so `Sensors#getCpuTemperature()` returned 0.

This reads the **chip-independent, firmware-computed CPU-die aggregate keys** that the SMC already exposes:

- **`TCMb`** — CPU die **average**, preferred as primary
- **`TCMz`** — CPU die **max**, secondary

Both are `flt` type and decode through the existing `smcGetFirstTemperature` path, which already applies the 15 °C plausibility floor from #3531 — **no new native binding and no private API**. This supersedes the IOHID-fallback idea explored in the issue: across every chip in the iSMC hardware dataset (M1→M5, A18, Intel T2) a usable SMC CPU key is always present — even the M3 Pro, which lacks the per-core keys, still exposes `TCMb`/`TCMz` — so IOHID would only have defended a case that does not occur, at the cost of undocumented private-API bindings reading a different (die-diode) sensor ~20-30 °C lower.

`TCMb` is preferred so the reported value stays close to the historical single-core reading rather than jumping ~20 °C to the die max.

New query order in `queryCpuTemperature` (both backends):
1. SMC CPU-die aggregate keys — `TCMb` then `TCMz` (plausibility-guarded)
2. SMC per-core keys (existing `SMC_KEYS_CPU_TEMP_AS`) — unchanged
3. Intel `TC0P` — unchanged, plausibility-guarded

**Scope: CPU temperature only.** GPU is deferred to a follow-up — it has no analogous `TGM*` die aggregate, and `MacGpuStats.getTemperature()` already has a key-independent IOAccelerator fallback.

## Changes

Changed in lockstep across the JNA (`oshi-core`) and FFM (`oshi-core-ffm`) backends so `NativeComparisonTest.sensors()` stays green:

- `SmcUtil` / `SmcUtilFFM` — add `SMC_KEYS_CPU_TEMP_AGGREGATE_AS = [TCMb, TCMz]`
- `MacSensorsJNA` / `MacSensorsFFM` — try the aggregate keys before the per-core keys
- New JNA `MacSensorsPlausibilityTest` (twin of the existing FFM test) + an aggregate-keys-average-first contract test in both

## Verification

- `mvn -pl oshi-core -am clean test` — 1127 passed
- `mvn -pl oshi-core-ffm -am clean test` — 1127 passed
- `mvn test -pl oshi-benchmark -Pnative-comparison` — `NativeComparisonTest.sensors()` passes (FFM within 25% of JNA)
- **Real M3 Pro hardware** (Mac15,7, macOS 26.5.2, JDK 26): `getCpuTemperature()` went from 0 → the `TCMb` value on both backends (paired same-JVM read: JNA `TCMb`=72.117 → `getCpuTemperature()`=72.117; FFM `TCMb`=73.521 → `getCpuTemperature()`=73.521), confirming it tracks the die average and not `TCMz` or 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed CPU temperature reporting on Apple Silicon so `Sensors#getCpuTemperature` no longer incorrectly returns `0` for chips with differing SMC CPU-die keys.
  - Improved temperature detection by prioritizing chip-independent aggregate CPU-die readings, with fallback to existing per-core readings.
  - Ensured implausible temperature sentinel values are not reported as valid readings.
- **Tests**
  - Added/expanded tests to verify aggregate-key preference and plausibility handling for macOS CPU temperature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->