### PR TITLE
Discover Apple Silicon GPU temperature SMC keys at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#3527](https://github.com/oshi/oshi/pull/3527): Consolidate the SLF4J log level dispatch duplicated in `ExceptionUtil` and `PerfDataUtil` into a new `oshi.util.LogUtil`, whose `isEnabled` method offers the slf4j 1.x-compatible equivalent of `Logger#isEnabledForLevel` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3531](https://github.com/oshi/oshi/pull/3531): Stop reporting an implausible CPU or GPU temperature on Apple Silicon. An idle core cluster is power-gated and its die sensors then report a fixed parked value below room ambient, which was previously returned as a reading; `Sensors#getCpuTemperature` now reports 0 (unavailable) instead - [@dbwiddis](https://github.com/dbwiddis).
 * [#3535](https://github.com/oshi/oshi/pull/3535): Fix `Sensors#getCpuTemperature` returning 0 on Apple Silicon chips whose per-core SMC keys differ from the hardcoded set (e.g. the M3 Pro, where all five are absent). Prefer the chip-independent, firmware-computed CPU-die aggregate keys `TCMb` (die average) and `TCMz` (die max) before the per-core keys, reporting the die average - [@dbwiddis](https://github.com/dbwiddis).
+* [#3536](https://github.com/oshi/oshi/pull/3536): Discover Apple Silicon GPU temperature SMC keys at runtime instead of reading a fixed list of four chip-specific keys, and report the hottest GPU cluster rather than the first one found. Adds `oshi.os.mac.sensors.gputemperature.keys` to override the discovered keys - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24)
 

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import oshi.ffm.util.platform.mac.SmcUtilFFM;
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.ComputerSystem;
 import oshi.hardware.Display;
@@ -48,6 +49,7 @@ import oshi.software.os.OperatingSystem;
 import oshi.util.GlobalConfig;
 import oshi.util.PlatformEnum;
 import oshi.util.Util;
+import oshi.util.platform.mac.SmcUtil;
 
 /**
  * Compares JNA and FFM implementations of the OSHI API to detect regressions, missing implementations, or incorrect
@@ -337,6 +339,16 @@ class NativeComparisonTest {
     }
 
     // ---- Hardware: Graphics Cards ----
+
+    /**
+     * GPU temperature keys are discovered from the SMC at runtime by each backend independently, so comparing the
+     * discovered lists is the sharpest available check that the two binary searches agree.
+     */
+    @Test
+    @EnabledOnOs(OS.MAC)
+    void gpuTemperatureKeys() {
+        assertThat(SmcUtilFFM.getGpuTemperatureKeys()).isEqualTo(SmcUtil.getGpuTemperatureKeys());
+    }
 
     @Test
     void graphicsCards() {

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -58,6 +58,7 @@ module com.github.oshi.common {
     exports oshi.software.os;
     exports oshi.spi;
     exports oshi.util;
+    exports oshi.util.common.platform.mac;
     exports oshi.util.common.platform.unix.bsd;
     exports oshi.util.common.platform.unix.dragonflybsd;
     exports oshi.util.common.platform.unix.freebsd;

--- a/oshi-common/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-common/src/main/java/oshi/util/GlobalConfig.java
@@ -157,6 +157,13 @@ public final class GlobalConfig {
     public static final String OSHI_OS_MAC_SYSCTL_LOGWARNING = "oshi.os.mac.sysctl.logwarning";
 
     /**
+     * Comma-separated list of macOS SMC keys to read for Apple Silicon GPU temperature; the highest plausible reading
+     * among them is reported. Empty by default, meaning the keys are discovered from the SMC at runtime so that chips
+     * with differently named sensors are handled without a code change. Set this only to override that discovery.
+     */
+    public static final String OSHI_OS_MAC_SENSORS_GPUTEMPERATURE_KEYS = "oshi.os.mac.sensors.gputemperature.keys";
+
+    /**
      * The name of the Windows System event log containing bootup event IDs 12 and 6005, used for a one-time calculation
      * of system boot time that is consistent across process runs regardless of sleep/hibernate cycles. If set to the
      * empty string, boot time is calculated by subtracting uptime from the current time (faster but less accurate).

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.common.platform.mac;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.DoublePredicate;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.function.ToDoubleFunction;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+
+/**
+ * Connection-independent logic for locating macOS SMC sensor keys by index.
+ * <p>
+ * The SMC exposes its keys as a list addressed by index, and returns them in ascending order of the key's four
+ * characters. That ordering lets a caller binary-search for a prefix rather than reading every key: on an M2 Max the
+ * full index is 2409 keys, of which 297 begin with {@code T} and 16 with {@code Tg}.
+ * <p>
+ * These methods take the index size and a lookup function rather than an SMC connection, so the JNA and FFM backends
+ * can share this logic despite their different connection handle types, and so it can be tested without Mac hardware.
+ */
+@ThreadSafe
+public final class SmcKeyIndex {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SmcKeyIndex.class);
+
+    /**
+     * Apple Silicon GPU cluster temperature keys, e.g. {@code Tg0f} or {@code Tg1A}.
+     * <p>
+     * The third character is always a digit, but the fourth varies: across the sensor keys published for M1 through M5
+     * and A18 it is uppercase in 42% of cases, lowercase in 43%, and a digit in 15%. A mask requiring an uppercase
+     * fourth character would miss {@code Tg0f}, which is the only GPU key present on some M2 machines.
+     */
+    private static final Pattern GPU_TEMPERATURE_KEY = Pattern.compile("^Tg[0-9][0-9A-Za-z]$");
+
+    /** SMC keys are four characters. */
+    private static final int KEY_LENGTH = 4;
+
+    /**
+     * Upper bound on a plausible {@code #KEY} count, guarding against a garbage read. Observed counts are in the low
+     * thousands.
+     */
+    private static final int MAX_KEY_COUNT = 65536;
+
+    /** Upper bound on the forward scan, so an unsorted index cannot cause a runaway read. */
+    private static final int MAX_SCAN = 256;
+
+    private SmcKeyIndex() {
+    }
+
+    /**
+     * Locates the keys sharing a prefix, by binary searching the sorted key index and then scanning forward.
+     * <p>
+     * Returns {@code null}, rather than an empty list, if the index could not be read reliably. Callers must not cache
+     * a {@code null} result: an empty list means "this machine has no such keys", while {@code null} means "ask again
+     * later".
+     *
+     * @param keyCount   the number of keys in the index, from the SMC's {@code #KEY} key
+     * @param keyAtIndex looks up the key name at an index, returning {@code null} if that read fails
+     * @param prefix     the key prefix to locate, e.g. {@code "Tg"}
+     * @param mask       an additional test each candidate key must pass
+     * @return the matching keys in index order, or {@code null} if the index could not be read
+     */
+    public static List<String> findKeys(int keyCount, IntFunction<String> keyAtIndex, String prefix,
+            Predicate<String> mask) {
+        if (keyCount <= 0 || keyCount > MAX_KEY_COUNT) {
+            LOG.debug("Implausible SMC key count {}; skipping key discovery.", keyCount);
+            return null;
+        }
+        int start = lowerBound(keyCount, keyAtIndex, prefix);
+        if (start < 0) {
+            return null;
+        }
+        Set<String> found = new LinkedHashSet<>();
+        int limit = Math.min(keyCount, start + MAX_SCAN);
+        boolean readAny = false;
+        for (int i = start; i < limit; i++) {
+            String key = keyAtIndex.apply(i);
+            if (key == null) {
+                key = keyAtIndex.apply(i); // one retry, in case the failure was transient
+            }
+            if (key == null) {
+                // Skip rather than stop: an unreadable key in the middle of the block would otherwise discard every
+                // key after it. The scan is bounded, and the prefix test below still ends it at the block boundary.
+                LOG.debug("Could not read SMC key at index {}; continuing the scan.", i);
+                continue;
+            }
+            readAny = true;
+            if (!key.startsWith(prefix)) {
+                break;
+            }
+            if (mask.test(key)) {
+                found.add(key);
+            }
+        }
+        if (!readAny && start < limit) {
+            // The scan had indices to read and none of them worked, so we cannot distinguish "no such keys" from "SMC
+            // unavailable"; returning null keeps the caller from caching an empty set and disabling the sensor for the
+            // JVM lifetime. An empty scan range is different: the search itself read successfully and simply landed
+            // past the end, which is a genuine "this machine has none".
+            LOG.debug("No SMC keys were readable from index {}; skipping key discovery.", start);
+            return null;
+        }
+        return Collections.unmodifiableList(new ArrayList<>(found));
+    }
+
+    /**
+     * Binary searches for the first index whose key sorts at or after the prefix.
+     *
+     * @param keyCount   the number of keys in the index
+     * @param keyAtIndex looks up the key name at an index
+     * @param prefix     the prefix to locate
+     * @return that index, or {@code -1} if the index could not be read
+     */
+    private static int lowerBound(int keyCount, IntFunction<String> keyAtIndex, String prefix) {
+        int lo = 0;
+        int hi = keyCount;
+        while (lo < hi) {
+            int mid = (lo + hi) >>> 1;
+            String key = probe(keyAtIndex, mid, keyCount);
+            if (key == null) {
+                return -1;
+            }
+            // A four-character key is never equal to the shorter prefix, so this also skips the prefix itself.
+            if (key.compareTo(prefix) > 0) {
+                hi = mid;
+            } else {
+                lo = mid + 1;
+            }
+        }
+        return lo;
+    }
+
+    /**
+     * Reads the key at an index, retrying at neighbouring indices if that read fails, so a single unreadable key does
+     * not abort discovery. Walking outward keeps the binary search's ordering assumption intact, since neighbours sort
+     * adjacently.
+     *
+     * @param keyAtIndex looks up the key name at an index
+     * @param index      the index to read
+     * @param keyCount   the number of keys in the index, bounding the outward walk
+     * @return a key name, or {@code null} if nothing nearby could be read
+     */
+    private static String probe(IntFunction<String> keyAtIndex, int index, int keyCount) {
+        String key = keyAtIndex.apply(index);
+        if (key != null) {
+            return key;
+        }
+        for (int delta = 1; delta <= 4; delta++) {
+            if (index - delta >= 0) {
+                key = keyAtIndex.apply(index - delta);
+                if (key != null) {
+                    return key;
+                }
+            }
+            if (index + delta < keyCount) {
+                key = keyAtIndex.apply(index + delta);
+                if (key != null) {
+                    return key;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Tests whether a key names an Apple Silicon GPU cluster temperature sensor.
+     *
+     * @param key the four-character SMC key
+     * @return true if the key matches the GPU temperature naming convention
+     */
+    public static boolean isGpuTemperatureKey(String key) {
+        return key != null && GPU_TEMPERATURE_KEY.matcher(key).matches();
+    }
+
+    /**
+     * Parses a user-supplied comma-separated list of SMC keys, ignoring blanks and warning about malformed entries.
+     *
+     * @param csv the configured value, which may be null or empty
+     * @return the keys, never null
+     */
+    public static List<String> parseConfiguredKeys(String csv) {
+        if (csv == null || csv.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> keys = new ArrayList<>();
+        for (String token : csv.split(",")) {
+            String key = token.trim();
+            if (key.isEmpty()) {
+                continue;
+            }
+            if (key.length() != KEY_LENGTH) {
+                LOG.warn("Ignoring configured SMC key '{}': keys are exactly {} characters.", key, KEY_LENGTH);
+                continue;
+            }
+            keys.add(key);
+        }
+        return Collections.unmodifiableList(keys);
+    }
+
+    /**
+     * Returns the highest plausible temperature among the given keys.
+     * <p>
+     * Plausibility is applied here, at read time, rather than when the keys were discovered. Whether a key exists is a
+     * property of the hardware and does not change; whether it currently reports a usable value is not, because an idle
+     * sensor may report a sentinel below ambient. Filtering at discovery time would let a single unlucky first read
+     * cache an empty set and disable the sensor for the lifetime of the JVM.
+     *
+     * @param keys        the keys to read
+     * @param reader      reads a key, returning the temperature in degrees Celsius
+     * @param isPlausible tests whether a reading is usable
+     * @return the highest plausible reading, or 0 if none were plausible
+     */
+    public static double maxPlausible(List<String> keys, ToDoubleFunction<String> reader, DoublePredicate isPlausible) {
+        double max = 0d;
+        for (String key : keys) {
+            double value = reader.applyAsDouble(key);
+            if (isPlausible.test(value) && value > max) {
+                max = value;
+            }
+        }
+        if (max == 0d && !keys.isEmpty()) {
+            LOG.debug("No plausible temperature among SMC keys {}; sensors are likely idle-gated.", keys);
+        }
+        return max;
+    }
+}

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides utilities shared across the macOS JNA and FFM implementations
+ */
+package oshi.util.common.platform.mac;

--- a/oshi-common/src/main/resources/oshi.properties
+++ b/oshi-common/src/main/resources/oshi.properties
@@ -302,6 +302,13 @@ oshi.os.linux.sensors.hwmon.names=coretemp,k10temp,zenpower,k8temp,via-cputemp
 # The order of entries in the list does represent the priority, the first match will be used.
 oshi.os.linux.sensors.cputemperature.types=cpu-thermal,x86_pkg_temp
 
+# Comma-separated list of macOS SMC keys to read for Apple Silicon GPU temperature. The highest
+# plausible reading among them is reported.
+# Leave empty (the default) to discover the keys from the SMC at runtime, which adapts to chips whose
+# key names differ. Set this only to override that discovery, for example on hardware whose GPU
+# sensors do not follow the usual Tg<digit><alphanumeric> naming.
+oshi.os.mac.sensors.gputemperature.keys=
+
 # ==============================================================================
 # Privilege Escalation Configuration (Linux/Unix)
 # ==============================================================================

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.common.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.IntFunction;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests SMC key index logic without Mac hardware. This is why the logic lives here rather than in {@code SmcUtil},
+ * whose static {@code IOKit.INSTANCE} field makes any of its members unloadable off a Mac.
+ */
+public class SmcKeyIndexTest {
+
+    /** A realistic slice of a sorted SMC key index, with a Tg block in the middle. */
+    private static final String[] SORTED = { "#KEY", "ALI0", "F0Ac", "TB0T", "TC0P", "TCMb", "TCMz", "Tf00", "Tf11",
+            "Tg0W", "Tg0X", "Tg0e", "Tg0f", "Tg1g", "Tg1h", "Th00", "Tp01", "Tp09", "VP0C", "zSPc" };
+
+    private static IntFunction<String> lookup(String[] keys) {
+        return i -> i >= 0 && i < keys.length ? keys[i] : null;
+    }
+
+    private static List<String> findTg(String[] keys) {
+        return SmcKeyIndex.findKeys(keys.length, lookup(keys), "Tg", SmcKeyIndex::isGpuTemperatureKey);
+    }
+
+    // -- binary search --
+
+    @Test
+    public void testFindsBlockInTheMiddle() {
+        assertThat(findTg(SORTED), contains("Tg0W", "Tg0X", "Tg0e", "Tg0f", "Tg1g", "Tg1h"));
+    }
+
+    @Test
+    public void testFindsBlockAtStart() {
+        String[] keys = { "Tg0W", "Tg0X", "Th00", "Tp01" };
+        assertThat(findTg(keys), contains("Tg0W", "Tg0X"));
+    }
+
+    @Test
+    public void testFindsBlockAtEnd() {
+        String[] keys = { "TB0T", "TCMb", "Tg0W", "Tg0X" };
+        assertThat(findTg(keys), contains("Tg0W", "Tg0X"));
+    }
+
+    @Test
+    public void testAbsentBlockYieldsEmptyNotNull() {
+        // Empty means "this machine has no such keys" and is a cacheable answer; null means "could not read".
+        String[] keys = { "TB0T", "TCMb", "Th00", "Tp01" };
+        List<String> found = findTg(keys);
+        assertThat("Absent block is a completed run", found, is(notNullValue()));
+        assertThat(found, is(empty()));
+    }
+
+    @Test
+    public void testEmptyAndSingleElementIndex() {
+        assertThat("Zero count is not a readable index", findTg(new String[0]), is(nullValue()));
+        assertThat(findTg(new String[] { "Tg0f" }), contains("Tg0f"));
+        assertThat(findTg(new String[] { "TB0T" }), is(empty()));
+    }
+
+    @Test
+    public void testImplausibleKeyCountIsRejected() {
+        assertThat(SmcKeyIndex.findKeys(0, lookup(SORTED), "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
+        assertThat(SmcKeyIndex.findKeys(-1, lookup(SORTED), "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
+        assertThat("Guards against a garbage #KEY read",
+                SmcKeyIndex.findKeys(Integer.MAX_VALUE, lookup(SORTED), "Tg", SmcKeyIndex::isGpuTemperatureKey),
+                is(nullValue()));
+    }
+
+    @Test
+    public void testKeyCountLargerThanIndexDegradesSafely() {
+        // A count that overruns the readable range must degrade to "could not read", not throw and not report empty.
+        assertThat(SmcKeyIndex.findKeys(SORTED.length + 50, lookup(SORTED), "Tg", SmcKeyIndex::isGpuTemperatureKey),
+                is(nullValue()));
+    }
+
+    // -- read failures --
+
+    @Test
+    public void testAllReadsFailingYieldsNull() {
+        assertThat("Nothing readable must not be cached as empty",
+                SmcKeyIndex.findKeys(20, i -> null, "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
+    }
+
+    @Test
+    public void testTransientFailureIsRecovered() {
+        // Fails the first read of one index, then succeeds: the retry must recover the full block.
+        Set<Integer> failedOnce = new HashSet<>();
+        IntFunction<String> flaky = i -> i == 12 && failedOnce.add(i) ? null : SORTED[i];
+        assertThat(SmcKeyIndex.findKeys(SORTED.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey),
+                contains("Tg0W", "Tg0X", "Tg0e", "Tg0f", "Tg1g", "Tg1h"));
+    }
+
+    @Test
+    public void testPermanentFailureMidScanSkipsOnlyThatKey() {
+        // Index 12 is Tg0f. Skipping rather than stopping preserves Tg1g/Tg1h, which a break would have discarded.
+        IntFunction<String> flaky = i -> i == 12 ? null : SORTED[i];
+        assertThat(SmcKeyIndex.findKeys(SORTED.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey),
+                contains("Tg0W", "Tg0X", "Tg0e", "Tg1g", "Tg1h"));
+    }
+
+    @Test
+    public void testFailedProbeDuringSearchIsRetriedAtNeighbour() {
+        // A permanently unreadable index during the binary search descends via a neighbour instead of aborting.
+        IntFunction<String> flaky = i -> i == SORTED.length / 2 ? null : SORTED[i];
+        assertThat(SmcKeyIndex.findKeys(SORTED.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey),
+                is(notNullValue()));
+    }
+
+    // -- robustness --
+
+    @Test
+    public void testUnsortedIndexTerminatesAndIsBounded() {
+        String[] shuffled = SORTED.clone();
+        Arrays.sort(shuffled, (a, b) -> b.compareTo(a)); // reverse order breaks the search's assumption
+        List<String> found = SmcKeyIndex.findKeys(shuffled.length, lookup(shuffled), "Tg",
+                SmcKeyIndex::isGpuTemperatureKey);
+        assertThat("Must terminate rather than hang or overrun", found == null || found.size() <= shuffled.length,
+                is(true));
+    }
+
+    @Test
+    public void testDuplicateKeysAreDeduped() {
+        String[] keys = { "TB0T", "Tg0f", "Tg0f", "Tg1h", "Th00" };
+        assertThat(findTg(keys), contains("Tg0f", "Tg1h"));
+    }
+
+    // -- mask --
+
+    @Test
+    public void testMaskAcceptsRealGpuKeys() {
+        // Every shape seen across M1-M5 and A18: uppercase, lowercase and digit fourth characters.
+        for (String key : new String[] { "Tg05", "Tg0D", "Tg0f", "Tg0j", "Tg0W", "Tg1A", "Tg1k", "Tg99", "Tg0P" }) {
+            assertThat(key + " must match", SmcKeyIndex.isGpuTemperatureKey(key), is(true));
+        }
+    }
+
+    @Test
+    public void testMaskRejectsNonGpuKeys() {
+        // Tp/TG are CPU and Intel-era GPU keys; the rest are malformed.
+        for (String key : new String[] { "Tp09", "TG05", "TCMb", "Tg0", "Tg005", "TgA5", "Tg0_", "tg05", "",
+                " Tg0f" }) {
+            assertThat("'" + key + "' must not match", SmcKeyIndex.isGpuTemperatureKey(key), is(false));
+        }
+        assertThat(SmcKeyIndex.isGpuTemperatureKey(null), is(false));
+    }
+
+    // -- configured keys --
+
+    @Test
+    public void testParseConfiguredKeys() {
+        assertThat(SmcKeyIndex.parseConfiguredKeys(null), is(empty()));
+        assertThat(SmcKeyIndex.parseConfiguredKeys(""), is(empty()));
+        assertThat(SmcKeyIndex.parseConfiguredKeys("   "), is(empty()));
+        assertThat(SmcKeyIndex.parseConfiguredKeys(",,,"), is(empty()));
+        assertThat(SmcKeyIndex.parseConfiguredKeys("Tg05,Tg0D"), contains("Tg05", "Tg0D"));
+        assertThat(SmcKeyIndex.parseConfiguredKeys(" Tg05 , ,Tg0D "), contains("Tg05", "Tg0D"));
+        assertThat("Wrong-length tokens are dropped, not passed to the SMC",
+                SmcKeyIndex.parseConfiguredKeys("TOOLONG,Tg05,ab"), contains("Tg05"));
+    }
+
+    // -- aggregation --
+
+    /** Sentinels and genuine readings captured from hardware; see MacSensorsPlausibilityTest. */
+    private static final double FLOOR = 15d;
+
+    private static double read(String key) {
+        switch (key) {
+            case "Tg0W":
+                return 6.7d; // idle-gated sentinel
+            case "Tg0X":
+                return 40.7d;
+            case "Tg0f":
+                return 63.4d;
+            case "Tg1h":
+                return -4.0d; // negative sentinel, seen on M4 Max
+            default:
+                return 0d;
+        }
+    }
+
+    @Test
+    public void testMaxPlausibleIgnoresSentinels() {
+        List<String> keys = Arrays.asList("Tg0W", "Tg0X", "Tg0f", "Tg1h");
+        assertThat("Returns the hottest genuine reading, not the global max",
+                SmcKeyIndex.maxPlausible(keys, SmcKeyIndexTest::read, v -> v >= FLOOR), is(63.4d));
+    }
+
+    @Test
+    public void testMaxPlausibleWithNothingUsable() {
+        assertThat("All-sentinel reads must report unavailable",
+                SmcKeyIndex.maxPlausible(Arrays.asList("Tg0W", "Tg1h"), SmcKeyIndexTest::read, v -> v >= FLOOR),
+                is(0d));
+        assertThat(SmcKeyIndex.maxPlausible(Arrays.<String>asList(), SmcKeyIndexTest::read, v -> v >= FLOOR), is(0d));
+    }
+
+    @Test
+    public void testMaxPlausibleNeverReturnsBelowTheFloor() {
+        double result = SmcKeyIndex.maxPlausible(Arrays.asList("Tg0W", "Tg0X"), SmcKeyIndexTest::read, v -> v >= FLOOR);
+        assertThat("A result is either 0 or at least the floor, never in between", result == 0d || result >= FLOOR,
+                is(true));
+        assertThat(6.7d, is(lessThanOrEqualTo(result)));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -98,11 +98,12 @@ public final class SmcUtilFFM {
      * GPU sensor keys are chip-specific, so no fixed list is complete: on an M2 Max only {@code Tg0f} and {@code Tg0j}
      * of the four originally shipped exist, and six of that machine's sensors appear in no published key table at all.
      * {@link #getGpuTemperatureKeys()} therefore discovers them from the SMC instead; this list is breadth-first
-     * insurance for the case where that fails, drawn from the keys most commonly present across published M1 through M5
-     * and A18 sensor dumps.
+     * insurance for the case where that fails. It leads with the four keys OSHI read before discovery existed, so the
+     * fallback can never report less than the previous implementation, followed by the keys most commonly present
+     * across published M1 through M5 and A18 sensor dumps.
      */
-    public static final List<String> SMC_KEYS_GPU_TEMP_AS = List.of("Tg0C", "Tg04", "Tg05", "Tg0K", "Tg0L", "Tg0D",
-            "Tg0j", "Tg0d", "Tg0e", "Tg1k", "Tg0X", "Tg0S", "Tg0y", "Tg0z");
+    public static final List<String> SMC_KEYS_GPU_TEMP_AS = List.of("Tg05", "Tg0D", "Tg0f", "Tg0j", "Tg0C", "Tg04",
+            "Tg0K", "Tg0L", "Tg0d", "Tg0e", "Tg1k", "Tg0X", "Tg0S", "Tg0y", "Tg0z");
 
     /** SMC key whose value is the number of keys in the key index. */
     public static final String SMC_KEY_COUNT = "#KEY";

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -10,10 +10,12 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static oshi.ffm.ForeignFunctions.callInArenaDoubleOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaLongOrDefault;
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.ffm.platform.mac.IOKitFunctions.IOConnectCallStructMethod;
 import static oshi.ffm.platform.mac.IOKitFunctions.IOServiceClose;
 import static oshi.ffm.platform.mac.IOKitFunctions.IOServiceOpen;
 import static oshi.ffm.platform.mac.MacSystem.SMC_BYTES;
+import static oshi.ffm.platform.mac.MacSystem.SMC_DATA32;
 import static oshi.ffm.platform.mac.MacSystem.SMC_DATA8;
 import static oshi.ffm.platform.mac.MacSystem.SMC_DATA_ATTRIBUTES;
 import static oshi.ffm.platform.mac.MacSystem.SMC_DATA_SIZE;
@@ -27,6 +29,7 @@ import static oshi.ffm.platform.mac.MacSystem.SMC_VAL_DATA_SIZE;
 import static oshi.ffm.platform.mac.MacSystem.SMC_VAL_DATA_TYPE;
 import static oshi.ffm.platform.mac.MacSystemFunctions.mach_task_self;
 import static oshi.util.ExceptionUtil.getIntOrDefault;
+import static oshi.util.LogLevel.DEBUG;
 import static oshi.util.LogLevel.ERROR;
 import static oshi.util.LogLevel.WARN;
 
@@ -45,7 +48,9 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.mac.IOKit.IOService;
+import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
+import oshi.util.common.platform.mac.SmcKeyIndex;
 
 /**
  * Provides access to SMC calls on macOS using FFM
@@ -86,13 +91,41 @@ public final class SmcUtilFFM {
     public static final List<String> SMC_KEYS_CPU_TEMP_AGGREGATE_AS = List.of("TCMb", "TCMz");
     /** SMC keys for Apple Silicon CPU temperature sensors. */
     public static final List<String> SMC_KEYS_CPU_TEMP_AS = List.of("Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D");
-    /** SMC keys for Apple Silicon GPU temperature sensors. */
-    public static final List<String> SMC_KEYS_GPU_TEMP_AS = List.of("Tg05", "Tg0D", "Tg0f", "Tg0j");
+    /**
+     * Fallback Apple Silicon GPU temperature keys, used only when runtime discovery cannot complete. The hottest
+     * plausible reading among them is reported.
+     * <p>
+     * GPU sensor keys are chip-specific, so no fixed list is complete: on an M2 Max only {@code Tg0f} and {@code Tg0j}
+     * of the four originally shipped exist, and six of that machine's sensors appear in no published key table at all.
+     * {@link #getGpuTemperatureKeys()} therefore discovers them from the SMC instead; this list is breadth-first
+     * insurance for the case where that fails, drawn from the keys most commonly present across published M1 through M5
+     * and A18 sensor dumps.
+     */
+    public static final List<String> SMC_KEYS_GPU_TEMP_AS = List.of("Tg0C", "Tg04", "Tg05", "Tg0K", "Tg0L", "Tg0D",
+            "Tg0j", "Tg0d", "Tg0e", "Tg1k", "Tg0X", "Tg0S", "Tg0y", "Tg0z");
+
+    /** SMC key whose value is the number of keys in the key index. */
+    public static final String SMC_KEY_COUNT = "#KEY";
+
+    /** The prefix shared by Apple Silicon GPU cluster temperature keys. */
+    private static final String GPU_KEY_PREFIX = "Tg";
+
+    /** Guards {@link #gpuTemperatureKeys}. */
+    private static final Object GPU_KEY_LOCK = new Object();
+
+    /**
+     * Discovered GPU temperature keys, or null if discovery has not yet completed successfully. Deliberately not a
+     * {@link oshi.util.Memoizer}: that would cache a failed discovery permanently, and a transient failure to open the
+     * SMC would then disable GPU temperature for the lifetime of the JVM.
+     */
+    private static volatile List<String> gpuTemperatureKeys;
     /** SMC key for Apple Silicon CPU voltage. */
     public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
 
     /** SMC command to read bytes. */
     public static final byte SMC_CMD_READ_BYTES = 5;
+    /** SMC command to read the key at an index in the key index. */
+    public static final byte SMC_CMD_READ_INDEX = 8;
     /** SMC command to read key info. */
     public static final byte SMC_CMD_READ_KEYINFO = 9;
     /** Kernel index for SMC. */
@@ -219,6 +252,138 @@ public final class SmcUtilFFM {
             }
         }
         return 0d;
+    }
+
+    /**
+     * Get the highest plausible temperature among a list of SMC keys.
+     * <p>
+     * Plausibility is applied per read rather than when the keys were discovered, because whether a key exists is a
+     * property of the hardware while whether it currently reports a usable value is not.
+     * <p>
+     * Clusters expose their sensors in pairs at different locations on the die, offset by a few degrees and tracking
+     * each other as load changes; verified on an M2 Max where a pair moved 44.8/51.4 to 56.1/62.6 under load and fell
+     * together afterwards. They are not an instantaneous/peak-hold pair, so taking the maximum consistently reports the
+     * hotter location rather than a latched peak.
+     *
+     * @param conn The connection
+     * @param keys The keys to read
+     * @return The highest reading at or above {@link #MIN_PLAUSIBLE_TEMPERATURE}, or 0 if none were plausible
+     */
+    public static double smcGetMaxTemperature(int conn, List<String> keys) {
+        return SmcKeyIndex.maxPlausible(keys, key -> smcGetFloat(conn, key), SmcUtilFFM::isPlausibleTemperature);
+    }
+
+    /**
+     * Get the name of the key at an index in the SMC key index.
+     *
+     * @param conn  The connection
+     * @param index The index, from 0 to the value of {@link #SMC_KEY_COUNT}
+     * @return The four-character key name, or null if it could not be read
+     */
+    public static String smcReadKeyAtIndex(int conn, int index) {
+        return callInArenaOrDefault(arena -> {
+            MemorySegment input = arena.allocate(SMC_KEY_DATA);
+            MemorySegment output = arena.allocate(SMC_KEY_DATA);
+            input.set(JAVA_BYTE, SMC_KEY_DATA.byteOffset(SMC_DATA8), SMC_CMD_READ_INDEX);
+            input.set(JAVA_INT, SMC_KEY_DATA.byteOffset(SMC_DATA32), index);
+            if (smcCall(conn, KERNEL_INDEX_SMC, input, output) != 0) {
+                return null;
+            }
+            int key = output.get(JAVA_INT, SMC_KEY_DATA.byteOffset(SMC_KEY));
+            byte[] keyBytes = ParseUtil.longToByteArray(key, 4, 4);
+            StringBuilder sb = new StringBuilder(4);
+            for (byte b : keyBytes) {
+                sb.append((char) (b & 0xFF));
+            }
+            return sb.toString();
+        }, null, LOG, DEBUG, "Failed to read SMC key at index {}", index);
+    }
+
+    /**
+     * Get the SMC data type of a key, e.g. {@code flt} or {@code sp78}.
+     *
+     * @param conn The connection
+     * @param key  The key to query
+     * @return The data type, or an empty string if it could not be read
+     */
+    public static String smcGetDataType(int conn, String key) {
+        return callInArenaOrDefault(arena -> {
+            MemorySegment val = arena.allocate(SMC_VAL);
+            if (smcReadKey(conn, key, val, arena) != 0) {
+                return "";
+            }
+            byte[] type = readByteArray(val, SMC_VAL.byteOffset(SMC_VAL_DATA_TYPE), 5);
+            StringBuilder sb = new StringBuilder(4);
+            for (byte b : type) {
+                if (b == 0) {
+                    break;
+                }
+                sb.append((char) b);
+            }
+            return sb.toString().trim();
+        }, "", LOG, DEBUG, "Failed to read SMC data type for key {}", key);
+    }
+
+    /**
+     * Get the Apple Silicon GPU temperature keys for this machine, discovering them from the SMC on first use and
+     * caching the result.
+     * <p>
+     * Discovery binary searches the sorted key index for the {@code Tg} block and keeps the keys matching the GPU
+     * naming convention. It does not filter by plausibility: an idle sensor reports a sentinel below ambient, so
+     * filtering here would let one unlucky first call cache an empty set and disable GPU temperature permanently.
+     * Plausibility is applied per read by {@link #smcGetMaxTemperature}.
+     * <p>
+     * Can be overridden with the {@link GlobalConfig#OSHI_OS_MAC_SENSORS_GPUTEMPERATURE_KEYS} configuration property,
+     * which bypasses discovery entirely. Falls back to {@link #SMC_KEYS_GPU_TEMP_AS} if discovery cannot complete,
+     * without caching, so a later call retries.
+     *
+     * @return The keys to read for GPU temperature, never null
+     */
+    public static List<String> getGpuTemperatureKeys() {
+        List<String> keys = gpuTemperatureKeys;
+        if (keys != null) {
+            return keys;
+        }
+        synchronized (GPU_KEY_LOCK) {
+            if (gpuTemperatureKeys != null) {
+                return gpuTemperatureKeys;
+            }
+            // Read the config lazily rather than at class initialization, so GlobalConfig.set() still takes effect.
+            List<String> configured = SmcKeyIndex
+                    .parseConfiguredKeys(GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SENSORS_GPUTEMPERATURE_KEYS, ""));
+            if (!configured.isEmpty()) {
+                LOG.debug("Using configured GPU temperature keys {}", configured);
+                gpuTemperatureKeys = configured;
+                return configured;
+            }
+            List<String> discovered = discoverGpuTemperatureKeys();
+            if (discovered == null) {
+                LOG.debug("GPU temperature key discovery did not complete; using the fallback list this time.");
+                return SMC_KEYS_GPU_TEMP_AS;
+            }
+            LOG.debug("Discovered {} GPU temperature keys: {}", discovered.size(), discovered);
+            gpuTemperatureKeys = discovered;
+            return discovered;
+        }
+    }
+
+    /**
+     * @return the discovered keys, or null if the SMC key index could not be read
+     */
+    private static List<String> discoverGpuTemperatureKeys() {
+        int conn = smcOpen();
+        if (conn == 0) {
+            return null;
+        }
+        try {
+            int keyCount = (int) smcGetLong(conn, SMC_KEY_COUNT);
+            // No data-type filter: smcGetFloat already decodes every temperature encoding the SMC uses (flt, sp78,
+            // fpe2) and returns 0 for anything else, which the plausibility floor then rejects.
+            return SmcKeyIndex.findKeys(keyCount, i -> smcReadKeyAtIndex(conn, i), GPU_KEY_PREFIX,
+                    SmcKeyIndex::isGpuTemperatureKey);
+        } finally {
+            smcClose(conn);
+        }
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -6,7 +6,12 @@ package oshi.hardware.platform.mac;
 
 import java.lang.foreign.MemorySegment;
 import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.mac.IOReportClientFFM;
@@ -44,7 +49,16 @@ final class MacGpuStatsFFM implements GpuStats {
     private static final String DEVICE_UTIL_KEY = "Device Utilization %";
     private static final String VRAM_USED_KEY = "vramUsedBytes";
     private static final String VRAM_USED_KEY_AS = "In use system memory";
+    private static final Logger LOG = LoggerFactory.getLogger(MacGpuStatsFFM.class);
+
     private static final double GPU_UTIL_DIVISOR = 0xFFFFFFFFL;
+
+    /**
+     * Cards whose IOAccelerator statistics have no Temperature(C) key, so the lookup is not repeated. Static because a
+     * GpuStats session is short-lived, and keyed by card because one card lacking the sensor says nothing about another
+     * on the same machine.
+     */
+    private static final Set<String> PERF_STATS_TEMP_ABSENT = ConcurrentHashMap.newKeySet();
     private static final Pattern TRADEMARK_PATTERN = Pattern.compile("[®™]|\\([Rr]\\)|\\([Tt][Mm]\\)");
 
     private final boolean isAppleSilicon;
@@ -156,7 +170,7 @@ final class MacGpuStatsFFM implements GpuStats {
             int conn = SmcUtilFFM.smcOpen();
             if (conn != 0) {
                 try {
-                    double temp = SmcUtilFFM.smcGetFirstTemperature(conn, SmcUtilFFM.SMC_KEYS_GPU_TEMP_AS);
+                    double temp = SmcUtilFFM.smcGetMaxTemperature(conn, SmcUtilFFM.getGpuTemperatureKeys());
                     if (temp > 0) {
                         return temp;
                     }
@@ -167,19 +181,28 @@ final class MacGpuStatsFFM implements GpuStats {
         }
         // IOAccelerator statistics, not the SMC: a different sensor that is not power-gated with the GPU
         // cluster, so the SMC plausibility floor deliberately does not apply here. Unavailable is -1, not 0.
+        // This key does not exist on Apple Silicon, so it is tried once per card and then latched off rather than
+        // repeating an IOKit registry walk on every call. Latch only on structural absence, not on a low reading.
+        if (PERF_STATS_TEMP_ABSENT.contains(normCardName)) {
+            return -1d;
+        }
         CFMutableDictionaryRef perfStats = queryPerfStats();
         if (perfStats == null) {
+            PERF_STATS_TEMP_ABSENT.add(normCardName);
             return -1d;
         }
         try (perfStats) {
             CFStringRef tempKey = CFStringRef.createCFString("Temperature(C)");
             try (tempKey) {
                 MemorySegment result = perfStats.getValue(tempKey);
-                if (!result.equals(MemorySegment.NULL)) {
-                    long val = CFNumberRef.longValue(result);
-                    if (val > 0) {
-                        return val;
-                    }
+                if (result.equals(MemorySegment.NULL)) {
+                    LOG.debug("No Temperature(C) in IOAccelerator statistics for {}; not retrying.", normCardName);
+                    PERF_STATS_TEMP_ABSENT.add(normCardName);
+                    return -1d;
+                }
+                long val = CFNumberRef.longValue(result);
+                if (val > 0) {
+                    return val;
                 }
             }
         }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -188,7 +188,8 @@ final class MacGpuStatsFFM implements GpuStats {
         }
         CFMutableDictionaryRef perfStats = queryPerfStats();
         if (perfStats == null) {
-            PERF_STATS_TEMP_ABSENT.add(normCardName);
+            // Not latched: a missing accelerator entry can be transient (driver reset, eGPU unplugged), unlike a
+            // dictionary that is present but has no temperature key.
             return -1d;
         }
         try (perfStats) {

--- a/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notANumber;
@@ -165,5 +166,15 @@ public class MacSensorsPlausibilityFFMTest {
         } finally {
             SmcUtilFFM.smcClose(conn);
         }
+    }
+
+    /**
+     * The fallback list must remain a superset of the four keys OSHI read before discovery existed, so a machine that
+     * falls back can never report less than the previous implementation did. Widening the list by frequency across
+     * published sensor dumps once dropped {@code Tg0f}, which is the only one of the four present on some M2 hardware.
+     */
+    @Test
+    public void testFallbackKeysIncludeTheHistoricalFour() {
+        assertThat(SmcUtilFFM.SMC_KEYS_GPU_TEMP_AS, hasItems("Tg05", "Tg0D", "Tg0f", "Tg0j"));
     }
 }

--- a/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
@@ -7,6 +7,7 @@ package oshi.ffm;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -124,8 +125,14 @@ public class MacSensorsPlausibilityFFMTest {
         for (String key : keys) {
             assertThat(key + " must match the GPU key convention", SmcKeyIndex.isGpuTemperatureKey(key), is(true));
         }
-        assertThat("Result must be cached, not rediscovered", SmcUtilFFM.getGpuTemperatureKeys(),
-                is(sameInstance(keys)));
+        List<String> second = SmcUtilFFM.getGpuTemperatureKeys();
+        assertThat("Repeated calls must agree", second, is(equalTo(keys)));
+        // A completed discovery is cached; a failed one deliberately is not, and returns the shared fallback constant
+        // instead. Asserting identity unconditionally would pass vacuously in that case, since both calls would return
+        // the same constant without anything having been cached.
+        if (!keys.equals(SmcUtilFFM.SMC_KEYS_GPU_TEMP_AS)) {
+            assertThat("A completed discovery must be cached, not repeated", second, is(sameInstance(keys)));
+        }
     }
 
     /**

--- a/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
@@ -9,9 +9,15 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notANumber;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -19,6 +25,7 @@ import org.junit.jupiter.api.condition.OS;
 
 import oshi.ffm.util.platform.mac.SmcUtilFFM;
 import oshi.spi.SystemInfoFactory;
+import oshi.util.common.platform.mac.SmcKeyIndex;
 
 /**
  * Tests the plausibility guard that keeps an idle-gated SMC sensor's sentinel from being reported as a temperature.
@@ -103,5 +110,60 @@ public class MacSensorsPlausibilityFFMTest {
         assertThat("Aggregate keys must be distinct from the per-core keys",
                 SmcUtilFFM.SMC_KEYS_CPU_TEMP_AGGREGATE_AS.stream().noneMatch(SmcUtilFFM.SMC_KEYS_CPU_TEMP_AS::contains),
                 is(true));
+    }
+
+    /**
+     * GPU keys are discovered from the SMC rather than hardcoded, because they are chip-specific: on this hardware only
+     * two of the four keys OSHI originally shipped exist, and six sensors appear in no published key table.
+     */
+    @Test
+    public void testGpuTemperatureKeysAreDiscovered() {
+        List<String> keys = SmcUtilFFM.getGpuTemperatureKeys();
+        assertThat("Discovery must never return null", keys, is(notNullValue()));
+        for (String key : keys) {
+            assertThat(key + " must match the GPU key convention", SmcKeyIndex.isGpuTemperatureKey(key), is(true));
+        }
+        assertThat("Result must be cached, not rediscovered", SmcUtilFFM.getGpuTemperatureKeys(),
+                is(sameInstance(keys)));
+    }
+
+    /**
+     * Regression guard against a discovery bug silently narrowing the sensor set: any of the legacy hardcoded keys that
+     * this machine can actually read must also have been discovered. Passes on any Apple Silicon Mac.
+     */
+    @Test
+    public void testDiscoveryIsASupersetOfReadableLegacyKeys() {
+        int conn = SmcUtilFFM.smcOpen();
+        assumeTrue(conn != 0, "SMC unavailable");
+        try {
+            List<String> discovered = SmcUtilFFM.getGpuTemperatureKeys();
+            for (String legacy : SmcUtilFFM.SMC_KEYS_GPU_TEMP_AS) {
+                if (SmcUtilFFM.isPlausibleTemperature(SmcUtilFFM.smcGetFloat(conn, legacy))) {
+                    assertThat(legacy + " reads a real value but was not discovered", discovered, hasItem(legacy));
+                }
+            }
+        } finally {
+            SmcUtilFFM.smcClose(conn);
+        }
+    }
+
+    /**
+     * The reported value is the hottest cluster, so it can never be below the first-match value the previous
+     * implementation would have returned from the same key set.
+     */
+    @Test
+    public void testMaxIsNotLessThanFirstMatch() {
+        int conn = SmcUtilFFM.smcOpen();
+        assumeTrue(conn != 0, "SMC unavailable");
+        try {
+            List<String> keys = SmcUtilFFM.getGpuTemperatureKeys();
+            double max = SmcUtilFFM.smcGetMaxTemperature(conn, keys);
+            double first = SmcUtilFFM.smcGetFirstTemperature(conn, keys);
+            assertThat("max must be at least the first plausible reading", max, is(greaterThanOrEqualTo(first)));
+            assertThat("A GPU temperature is unavailable or plausible, never a sentinel in between",
+                    max == 0d || SmcUtilFFM.isPlausibleTemperature(max), is(true));
+        } finally {
+            SmcUtilFFM.smcClose(conn);
+        }
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
@@ -196,7 +196,8 @@ final class MacGpuStatsJNA implements GpuStats {
         }
         CFMutableDictionaryRef perfStats = queryPerfStats();
         if (perfStats == null) {
-            PERF_STATS_TEMP_ABSENT.add(normCardName);
+            // Not latched: a missing accelerator entry can be transient (driver reset, eGPU unplugged), unlike a
+            // dictionary that is present but has no temperature key.
             return -1d;
         }
         try {

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
@@ -5,6 +5,8 @@
 package oshi.hardware.platform.mac;
 
 import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -52,6 +54,13 @@ final class MacGpuStatsJNA implements GpuStats {
     private static final String VRAM_USED_KEY = "vramUsedBytes";
     private static final String VRAM_USED_KEY_AS = "In use system memory";
     private static final double GPU_UTIL_DIVISOR = 0xFFFFFFFFL;
+
+    /**
+     * Cards whose IOAccelerator statistics have no Temperature(C) key, so the lookup is not repeated. Static because a
+     * GpuStats session is short-lived, and keyed by card because one card lacking the sensor says nothing about another
+     * on the same machine.
+     */
+    private static final Set<String> PERF_STATS_TEMP_ABSENT = ConcurrentHashMap.newKeySet();
     private static final Pattern TRADEMARK_PATTERN = Pattern.compile("[®™]|\\([Rr]\\)|\\([Tt][Mm]\\)");
 
     private final boolean isAppleSilicon;
@@ -169,7 +178,7 @@ final class MacGpuStatsJNA implements GpuStats {
             IOConnect conn = SmcUtil.smcOpen();
             if (conn != null) {
                 try {
-                    double temp = SmcUtil.smcGetFirstTemperature(conn, SmcUtil.SMC_KEYS_GPU_TEMP_AS);
+                    double temp = SmcUtil.smcGetMaxTemperature(conn, SmcUtil.getGpuTemperatureKeys());
                     if (temp > 0) {
                         return temp;
                     }
@@ -180,19 +189,28 @@ final class MacGpuStatsJNA implements GpuStats {
         }
         // IOAccelerator statistics, not the SMC: a different sensor that is not power-gated with the GPU
         // cluster, so the SMC plausibility floor deliberately does not apply here. Unavailable is -1, not 0.
+        // This key does not exist on Apple Silicon, so it is tried once per card and then latched off rather than
+        // repeating an IOKit registry walk on every call. Latch only on structural absence, not on a low reading.
+        if (PERF_STATS_TEMP_ABSENT.contains(normCardName)) {
+            return -1d;
+        }
         CFMutableDictionaryRef perfStats = queryPerfStats();
         if (perfStats == null) {
+            PERF_STATS_TEMP_ABSENT.add(normCardName);
             return -1d;
         }
         try {
             CFStringRef tempKey = CFStringRef.createCFString("Temperature(C)");
             Pointer result = perfStats.getValue(tempKey);
             tempKey.release();
-            if (result != null) {
-                long val = new CFNumberRef(result).longValue();
-                if (val > 0) {
-                    return val;
-                }
+            if (result == null) {
+                LOG.debug("No Temperature(C) in IOAccelerator statistics for {}; not retrying.", normCardName);
+                PERF_STATS_TEMP_ABSENT.add(normCardName);
+                return -1d;
+            }
+            long val = new CFNumberRef(result).longValue();
+            if (val > 0) {
+                return val;
             }
         } finally {
             perfStats.release();

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -83,11 +83,12 @@ public final class SmcUtil {
      * GPU sensor keys are chip-specific, so no fixed list is complete: on an M2 Max only {@code Tg0f} and {@code Tg0j}
      * of the four originally shipped exist, and six of that machine's sensors appear in no published key table at all.
      * {@link #getGpuTemperatureKeys()} therefore discovers them from the SMC instead; this list is breadth-first
-     * insurance for the case where that fails, drawn from the keys most commonly present across published M1 through M5
-     * and A18 sensor dumps.
+     * insurance for the case where that fails. It leads with the four keys OSHI read before discovery existed, so the
+     * fallback can never report less than the previous implementation, followed by the keys most commonly present
+     * across published M1 through M5 and A18 sensor dumps.
      */
-    public static final List<String> SMC_KEYS_GPU_TEMP_AS = Collections.unmodifiableList(Arrays.asList("Tg0C", "Tg04",
-            "Tg05", "Tg0K", "Tg0L", "Tg0D", "Tg0j", "Tg0d", "Tg0e", "Tg1k", "Tg0X", "Tg0S", "Tg0y", "Tg0z"));
+    public static final List<String> SMC_KEYS_GPU_TEMP_AS = Collections.unmodifiableList(Arrays.asList("Tg05", "Tg0D",
+            "Tg0f", "Tg0j", "Tg0C", "Tg04", "Tg0K", "Tg0L", "Tg0d", "Tg0e", "Tg1k", "Tg0X", "Tg0S", "Tg0y", "Tg0z"));
 
     /** SMC key whose value is the number of keys in the key index. */
     public static final String SMC_KEY_COUNT = "#KEY";

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -29,7 +29,9 @@ import oshi.jna.platform.mac.IOKit.SMCKeyData;
 import oshi.jna.platform.mac.IOKit.SMCKeyDataKeyInfo;
 import oshi.jna.platform.mac.IOKit.SMCVal;
 import oshi.jna.platform.mac.SystemB;
+import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
+import oshi.util.common.platform.mac.SmcKeyIndex;
 
 /**
  * Provides access to SMC calls on macOS
@@ -74,14 +76,41 @@ public final class SmcUtil {
     /** Apple Silicon CPU temperature keys, tried in order until one returns a positive value. */
     public static final List<String> SMC_KEYS_CPU_TEMP_AS = Collections
             .unmodifiableList(Arrays.asList("Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D"));
-    /** Apple Silicon GPU temperature keys, tried in order until one returns a positive value. */
-    public static final List<String> SMC_KEYS_GPU_TEMP_AS = Collections
-            .unmodifiableList(Arrays.asList("Tg05", "Tg0D", "Tg0f", "Tg0j"));
+    /**
+     * Fallback Apple Silicon GPU temperature keys, used only when runtime discovery cannot complete. The hottest
+     * plausible reading among them is reported.
+     * <p>
+     * GPU sensor keys are chip-specific, so no fixed list is complete: on an M2 Max only {@code Tg0f} and {@code Tg0j}
+     * of the four originally shipped exist, and six of that machine's sensors appear in no published key table at all.
+     * {@link #getGpuTemperatureKeys()} therefore discovers them from the SMC instead; this list is breadth-first
+     * insurance for the case where that fails, drawn from the keys most commonly present across published M1 through M5
+     * and A18 sensor dumps.
+     */
+    public static final List<String> SMC_KEYS_GPU_TEMP_AS = Collections.unmodifiableList(Arrays.asList("Tg0C", "Tg04",
+            "Tg05", "Tg0K", "Tg0L", "Tg0D", "Tg0j", "Tg0d", "Tg0e", "Tg1k", "Tg0X", "Tg0S", "Tg0y", "Tg0z"));
+
+    /** SMC key whose value is the number of keys in the key index. */
+    public static final String SMC_KEY_COUNT = "#KEY";
+
+    /** The prefix shared by Apple Silicon GPU cluster temperature keys. */
+    private static final String GPU_KEY_PREFIX = "Tg";
+
+    /** Guards {@link #gpuTemperatureKeys}. */
+    private static final Object GPU_KEY_LOCK = new Object();
+
+    /**
+     * Discovered GPU temperature keys, or null if discovery has not yet completed successfully. Deliberately not a
+     * {@link oshi.util.Memoizer}: that would cache a failed discovery permanently, and a transient failure to open the
+     * SMC would then disable GPU temperature for the lifetime of the JVM.
+     */
+    private static volatile List<String> gpuTemperatureKeys;
     /** SMC key for CPU voltage (Apple Silicon). */
     public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
 
     /** SMC command to read bytes. */
     public static final byte SMC_CMD_READ_BYTES = 5;
+    /** SMC command to read the key at an index in the key index. */
+    public static final byte SMC_CMD_READ_INDEX = 8;
     /** SMC command to read key info. */
     public static final byte SMC_CMD_READ_KEYINFO = 9;
     /** Kernel index for SMC calls. */
@@ -200,6 +229,134 @@ public final class SmcUtil {
             }
         }
         return 0d;
+    }
+
+    /**
+     * Get the highest plausible temperature among a list of SMC keys.
+     * <p>
+     * Plausibility is applied per read rather than when the keys were discovered, because whether a key exists is a
+     * property of the hardware while whether it currently reports a usable value is not.
+     * <p>
+     * Clusters expose their sensors in pairs at different locations on the die, offset by a few degrees and tracking
+     * each other as load changes; verified on an M2 Max where a pair moved 44.8/51.4 to 56.1/62.6 under load and fell
+     * together afterwards. They are not an instantaneous/peak-hold pair, so taking the maximum consistently reports the
+     * hotter location rather than a latched peak.
+     *
+     * @param conn The connection
+     * @param keys The keys to read
+     * @return The highest reading at or above {@link #MIN_PLAUSIBLE_TEMPERATURE}, or 0 if none were plausible
+     */
+    public static double smcGetMaxTemperature(IOConnect conn, List<String> keys) {
+        return SmcKeyIndex.maxPlausible(keys, key -> smcGetFloat(conn, key), SmcUtil::isPlausibleTemperature);
+    }
+
+    /**
+     * Get the name of the key at an index in the SMC key index.
+     *
+     * @param conn  The connection
+     * @param index The index, from 0 to the value of {@link #SMC_KEY_COUNT}
+     * @return The four-character key name, or null if it could not be read
+     */
+    public static String smcReadKeyAtIndex(IOConnect conn, int index) {
+        try (SMCKeyData input = new SMCKeyData(); SMCKeyData output = new SMCKeyData()) {
+            input.data8 = SMC_CMD_READ_INDEX;
+            input.data32 = index;
+            if (smcCall(conn, KERNEL_INDEX_SMC, input, output) != 0) {
+                return null;
+            }
+            byte[] keyBytes = ParseUtil.longToByteArray(output.key, 4, 4);
+            StringBuilder sb = new StringBuilder(4);
+            for (byte b : keyBytes) {
+                sb.append((char) (b & 0xFF));
+            }
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Get the SMC data type of a key, e.g. {@code flt} or {@code sp78}.
+     *
+     * @param conn The connection
+     * @param key  The key to query
+     * @return The data type, or an empty string if it could not be read
+     */
+    public static String smcGetDataType(IOConnect conn, String key) {
+        try (SMCVal val = new SMCVal()) {
+            if (smcReadKey(conn, key, val) != 0 || val.dataType == null) {
+                return "";
+            }
+            StringBuilder sb = new StringBuilder(4);
+            for (byte b : val.dataType) {
+                if (b == 0) {
+                    break;
+                }
+                sb.append((char) b);
+            }
+            return sb.toString().trim();
+        }
+    }
+
+    /**
+     * Get the Apple Silicon GPU temperature keys for this machine, discovering them from the SMC on first use and
+     * caching the result.
+     * <p>
+     * Discovery binary searches the sorted key index for the {@code Tg} block and keeps the keys matching the GPU
+     * naming convention. It does not filter by plausibility: an idle sensor reports a sentinel below ambient, so
+     * filtering here would let one unlucky first call cache an empty set and disable GPU temperature permanently.
+     * Plausibility is applied per read by {@link #smcGetMaxTemperature}.
+     * <p>
+     * Can be overridden with the {@link GlobalConfig#OSHI_OS_MAC_SENSORS_GPUTEMPERATURE_KEYS} configuration property,
+     * which bypasses discovery entirely. Falls back to {@link #SMC_KEYS_GPU_TEMP_AS} if discovery cannot complete,
+     * without caching, so a later call retries.
+     *
+     * @return The keys to read for GPU temperature, never null
+     */
+    public static List<String> getGpuTemperatureKeys() {
+        List<String> keys = gpuTemperatureKeys;
+        if (keys != null) {
+            return keys;
+        }
+        synchronized (GPU_KEY_LOCK) {
+            if (gpuTemperatureKeys != null) {
+                return gpuTemperatureKeys;
+            }
+            // Read the config lazily rather than at class initialization, so GlobalConfig.set() still takes effect.
+            List<String> configured = SmcKeyIndex
+                    .parseConfiguredKeys(GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SENSORS_GPUTEMPERATURE_KEYS, ""));
+            if (!configured.isEmpty()) {
+                LOG.debug("Using configured GPU temperature keys {}", configured);
+                gpuTemperatureKeys = configured;
+                return configured;
+            }
+            List<String> discovered = discoverGpuTemperatureKeys();
+            if (discovered == null) {
+                LOG.debug("GPU temperature key discovery did not complete; using the fallback list this time.");
+                return SMC_KEYS_GPU_TEMP_AS;
+            }
+            LOG.debug("Discovered {} GPU temperature keys: {}", discovered.size(), discovered);
+            gpuTemperatureKeys = discovered;
+            return discovered;
+        }
+    }
+
+    /**
+     * @return the discovered keys, or null if the SMC key index could not be read
+     */
+    private static List<String> discoverGpuTemperatureKeys() {
+        IOConnect conn = smcOpen();
+        if (conn == null) {
+            return null;
+        }
+        try {
+            int keyCount = (int) smcGetLong(conn, SMC_KEY_COUNT);
+            // No data-type filter: smcGetFloat already decodes every temperature encoding the SMC uses (flt, sp78,
+            // fpe2) and returns 0 for anything else, which the plausibility floor then rejects. Filtering on "flt"
+            // here would cost a second read per key and would wrongly exclude a sensor reported as sp78.
+            return SmcKeyIndex.findKeys(keyCount, i -> smcReadKeyAtIndex(conn, i), GPU_KEY_PREFIX,
+                    SmcKeyIndex::isGpuTemperatureKey);
+        } finally {
+            smcClose(conn);
+        }
     }
 
     /**

--- a/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notANumber;
@@ -166,5 +167,15 @@ public class MacSensorsPlausibilityTest {
         } finally {
             SmcUtil.smcClose(conn);
         }
+    }
+
+    /**
+     * The fallback list must remain a superset of the four keys OSHI read before discovery existed, so a machine that
+     * falls back can never report less than the previous implementation did. Widening the list by frequency across
+     * published sensor dumps once dropped {@code Tg0f}, which is the only one of the four present on some M2 hardware.
+     */
+    @Test
+    public void testFallbackKeysIncludeTheHistoricalFour() {
+        assertThat(SmcUtil.SMC_KEYS_GPU_TEMP_AS, hasItems("Tg05", "Tg0D", "Tg0f", "Tg0j"));
     }
 }

--- a/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
@@ -9,15 +9,24 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notANumber;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import com.sun.jna.platform.mac.IOKit;
+
 import oshi.SystemInfo;
+import oshi.util.common.platform.mac.SmcKeyIndex;
 
 /**
  * Tests the plausibility guard that keeps an idle-gated SMC sensor's sentinel from being reported as a temperature. JNA
@@ -103,5 +112,59 @@ public class MacSensorsPlausibilityTest {
         assertThat("Aggregate keys must be distinct from the per-core keys",
                 SmcUtil.SMC_KEYS_CPU_TEMP_AGGREGATE_AS.stream().noneMatch(SmcUtil.SMC_KEYS_CPU_TEMP_AS::contains),
                 is(true));
+    }
+
+    /**
+     * GPU keys are discovered from the SMC rather than hardcoded, because they are chip-specific: on this hardware only
+     * two of the four keys OSHI originally shipped exist, and six sensors appear in no published key table.
+     */
+    @Test
+    public void testGpuTemperatureKeysAreDiscovered() {
+        List<String> keys = SmcUtil.getGpuTemperatureKeys();
+        assertThat("Discovery must never return null", keys, is(notNullValue()));
+        for (String key : keys) {
+            assertThat(key + " must match the GPU key convention", SmcKeyIndex.isGpuTemperatureKey(key), is(true));
+        }
+        assertThat("Result must be cached, not rediscovered", SmcUtil.getGpuTemperatureKeys(), is(sameInstance(keys)));
+    }
+
+    /**
+     * Regression guard against a discovery bug silently narrowing the sensor set: any of the legacy hardcoded keys that
+     * this machine can actually read must also have been discovered. Passes on any Apple Silicon Mac.
+     */
+    @Test
+    public void testDiscoveryIsASupersetOfReadableLegacyKeys() {
+        IOKit.IOConnect conn = SmcUtil.smcOpen();
+        assumeTrue(conn != null, "SMC unavailable");
+        try {
+            List<String> discovered = SmcUtil.getGpuTemperatureKeys();
+            for (String legacy : SmcUtil.SMC_KEYS_GPU_TEMP_AS) {
+                if (SmcUtil.isPlausibleTemperature(SmcUtil.smcGetFloat(conn, legacy))) {
+                    assertThat(legacy + " reads a real value but was not discovered", discovered, hasItem(legacy));
+                }
+            }
+        } finally {
+            SmcUtil.smcClose(conn);
+        }
+    }
+
+    /**
+     * The reported value is the hottest cluster, so it can never be below the first-match value the previous
+     * implementation would have returned from the same key set.
+     */
+    @Test
+    public void testMaxIsNotLessThanFirstMatch() {
+        IOKit.IOConnect conn = SmcUtil.smcOpen();
+        assumeTrue(conn != null, "SMC unavailable");
+        try {
+            List<String> keys = SmcUtil.getGpuTemperatureKeys();
+            double max = SmcUtil.smcGetMaxTemperature(conn, keys);
+            double first = SmcUtil.smcGetFirstTemperature(conn, keys);
+            assertThat("max must be at least the first plausible reading", max, is(greaterThanOrEqualTo(first)));
+            assertThat("A GPU temperature is unavailable or plausible, never a sentinel in between",
+                    max == 0d || SmcUtil.isPlausibleTemperature(max), is(true));
+        } finally {
+            SmcUtil.smcClose(conn);
+        }
     }
 }

--- a/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
@@ -7,6 +7,7 @@ package oshi.util.platform.mac;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -126,7 +127,14 @@ public class MacSensorsPlausibilityTest {
         for (String key : keys) {
             assertThat(key + " must match the GPU key convention", SmcKeyIndex.isGpuTemperatureKey(key), is(true));
         }
-        assertThat("Result must be cached, not rediscovered", SmcUtil.getGpuTemperatureKeys(), is(sameInstance(keys)));
+        List<String> second = SmcUtil.getGpuTemperatureKeys();
+        assertThat("Repeated calls must agree", second, is(equalTo(keys)));
+        // A completed discovery is cached; a failed one deliberately is not, and returns the shared fallback constant
+        // instead. Asserting identity unconditionally would pass vacuously in that case, since both calls would return
+        // the same constant without anything having been cached.
+        if (!keys.equals(SmcUtil.SMC_KEYS_GPU_TEMP_AS)) {
+            assertThat("A completed discovery must be cached, not repeated", second, is(sameInstance(keys)));
+        }
     }
 
     /**

--- a/oshi-demo/src/main/java/oshi/demo/SmcDump.java
+++ b/oshi-demo/src/main/java/oshi/demo/SmcDump.java
@@ -6,15 +6,10 @@ package oshi.demo;
 
 import java.util.Locale;
 
-import com.sun.jna.NativeLong;
 import com.sun.jna.platform.mac.IOKit.IOConnect;
 
 import oshi.annotation.SuppressForbidden;
-import oshi.jna.ByRef.CloseableNativeLongByReference;
-import oshi.jna.platform.mac.IOKit;
-import oshi.jna.platform.mac.IOKit.SMCKeyData;
 import oshi.jna.platform.mac.IOKit.SMCVal;
-import oshi.util.ParseUtil;
 import oshi.util.platform.mac.SmcUtil;
 
 /**
@@ -22,9 +17,6 @@ import oshi.util.platform.mac.SmcUtil;
  * voltage, and other sensors.
  */
 public final class SmcDump {
-
-    private static final byte SMC_CMD_READ_INDEX = 8;
-    private static final IOKit IO = IOKit.INSTANCE;
 
     private SmcDump() {
     }
@@ -48,13 +40,13 @@ public final class SmcDump {
             System.out.println("----------------------------------------------");
 
             for (int i = 0; i < keyCount; i++) {
-                String keyName = readKeyAtIndex(conn, i);
+                String keyName = SmcUtil.smcReadKeyAtIndex(conn, i);
                 if (keyName == null) {
                     continue;
                 }
                 try (SMCVal val = new SMCVal()) {
                     int result = SmcUtil.smcReadKey(conn, keyName, val);
-                    String typeName = result == 0 ? asciiType(val.dataType) : "?";
+                    String typeName = result == 0 ? SmcUtil.smcGetDataType(conn, keyName) : "?";
                     int size = result == 0 ? val.dataSize : 0;
                     double floatVal = SmcUtil.smcGetFloat(conn, keyName);
                     char first = keyName.charAt(0);
@@ -66,41 +58,5 @@ public final class SmcDump {
         } finally {
             SmcUtil.smcClose(conn);
         }
-    }
-
-    private static String readKeyAtIndex(IOConnect conn, int index) {
-        try (SMCKeyData input = new SMCKeyData();
-                SMCKeyData output = new SMCKeyData();
-                CloseableNativeLongByReference size = new CloseableNativeLongByReference(
-                        new NativeLong(output.size()))) {
-            input.data8 = SMC_CMD_READ_INDEX;
-            input.data32 = index;
-            int result = IO.IOConnectCallStructMethod(conn, SmcUtil.KERNEL_INDEX_SMC, input,
-                    new NativeLong(input.size()), output, size);
-            if (result != 0) {
-                return null;
-            }
-            // Key is stored as a big-endian 4-byte int in output.key; convert to ASCII string
-            byte[] keyBytes = ParseUtil.longToByteArray(output.key, 4, 4);
-            StringBuilder sb = new StringBuilder(4);
-            for (byte b : keyBytes) {
-                sb.append((char) (b & 0xFF));
-            }
-            return sb.toString();
-        }
-    }
-
-    private static String asciiType(byte[] dataType) {
-        if (dataType == null) {
-            return "";
-        }
-        StringBuilder sb = new StringBuilder();
-        for (byte b : dataType) {
-            if (b == 0) {
-                break;
-            }
-            sb.append((char) b);
-        }
-        return sb.toString();
     }
 }


### PR DESCRIPTION
Follow-up to #3535, which fixed the CPU side. GPU temperature reads a fixed list of four SMC keys, `SMC_KEYS_GPU_TEMP_AS = [Tg05, Tg0D, Tg0f, Tg0j]`, and returns the **first** plausible one.

**Nothing is broken today** — those four cover every Apple Silicon machine in the [iSMC hardware dataset](https://github.com/dkorunic/iSMC/tree/master/internal/reports). But the list survives by luck, not design: on an M2 Max only `Tg0f` and `Tg0j` exist, and six of that machine's sixteen GPU sensors appear in no published key table at all. It also reports one arbitrary cluster out of the 8–84 a modern chip exposes.

There is no GPU analogue of #3535's `TCMb`/`TCMz` firmware die aggregate, so that solution does not transfer.

### What this does

Binary-searches the SMC's sorted key index for the `Tg` block, keeps the keys matching the GPU naming convention, and reports the hottest plausible reading. ~14 ms once, cached for the JVM lifetime.

Measured across the dataset, decoding raw `flt` bytes for the older report format:

| report | today (first of 4) | this PR (max) | keys found |
|---|---|---|---|
| a18 | 66.4 | **68.1** | 8 |
| m1-pro | 62.9 | **63.6** | 4 |
| m3-max | 41.0 | **43.0** | 32 |
| m4-pro | 56.0 | **57.2** | 22 |
| m5-pro | 38.0 | **41.0** | 42 |
| m1-max / m3-pro | 45.7 / 38.2 | unchanged | 8 / 18 |

### The mask is derived from data

Character 3 is always a digit, but character 4 is uppercase in only 42% of published keys, lowercase in 43%, a digit in 15%:

| mask | this M2 Max | iSMC's 100 known GPU keys |
|---|---|---|
| `^Tg[0-9a-z][A-Z]$` | 6/16 | 42/100 |
| **`^Tg[0-9][0-9A-Za-z]$`** | **16/16** | **100/100** |

The narrower mask misses `Tg0f` — the only one of the original four present on this hardware. Zero false positives: every `Tg*` key in the dataset is a GPU sensor.

### Design notes

- **The index logic lives in `oshi-common`**, not `SmcUtil`, whose static `IOKit.INSTANCE` field makes any of its members unloadable off a Mac. Passing an `IntFunction` keeps the two connection handle types out of the shared code, so the binary search, mask, config parsing and aggregation are unit-tested on **any OS** — that is where the edge cases are (18 tests: block at index 0/last/middle/absent, read failures transient and permanent, unsorted input, duplicates, `#KEY` garbage).
- **Caches which keys *exist*, not which currently read plausibly.** Existence is a hardware property; plausibility is not, since an idle sensor reports a sentinel below ambient. Filtering at discovery time would let one unlucky first call cache an empty set and disable GPU temperature for the JVM lifetime.
- **Not `Memoizer`**, which caches whatever the supplier returned including a failure — a transient `smcOpen` failure would be permanent. A failed discovery falls back without caching so a later call retries.
- **No data-type filter.** `smcGetFloat` already decodes every temperature encoding the SMC uses and returns 0 otherwise, which the plausibility floor rejects. The check cost a second read per key and would have wrongly excluded a sensor reported as `sp78`.
- **Max, not average.** Each cluster exposes a pair of sensors at different die locations. Averaging would combine two different measurements, and separating them needs the per-chip table this avoids. Verified the pair is *not* instantaneous/peak-hold — both members rose 44.8/51.4 → 56.1/62.6 under load and fell together afterwards, so the max tracks the hotter location rather than a latched peak.

`SMC_KEYS_GPU_TEMP_AS` is kept as the fallback when the index cannot be read, widened from 4 to the 14 keys most common across published M1–M5 and A18 dumps. `oshi.os.mac.sensors.gputemperature.keys` overrides discovery entirely, parsed lazily so `GlobalConfig.set()` still takes effect.

The Intel IOAccelerator `Temperature(C)` fallback is absent on Apple Silicon, so it is now tried once per card then latched off rather than repeating an IOKit registry walk every call.

### Why not IOReport or IOHID

Both were investigated on hardware and eliminated, detail in #3534:

- **IOReport `GPU Stats → Temperature`** is a driver stub. All 64 channels read 0 as root, under GPU load, and in the raw `RawElements` blob, byte-identical across samples.
- **IOHID** measures the wrong thing: under Metal load the SMC GPU sensors rose +21 °C while the best HID sensor moved +5 °C. It is a damped board/PMU sensor, and the gap widens with load, so it is not a correctable offset.

### Verification

- Full reactor: 1146 + 95 + 80 + 30 tests, 0 failures. Spotless, checkstyle, forbidden-apis, javadoc clean.
- `./mvnw test -pl oshi-benchmark -Pnative-comparison` — `sensors()` and the new `gpuTemperatureKeys()` both pass. The latter asserts the two backends discover **identical** key lists; since each runs its own binary search, list equality is the sharpest available parity check.
- M2 Max, idle → Metal load → idle: `getTemperature()` = 47.8 → 66.5 → 55.1 °C. Discovery finds all 16 keys in both backends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS now discovers Apple Silicon GPU temperature sensor keys dynamically for broader hardware support.
  * GPU temperature selection now prefers the hottest available GPU cluster.
  * Added an optional configuration (`oshi.os.mac.sensors.gputemperature.keys`) to override which SMC temperature keys are used.

* **Bug Fixes**
  * Improved reliability when GPU temperature data is unavailable by reducing repeated lookups and tightening fallback behavior when sensors/perf stats are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->