### PR TITLE
Clear the open SonarQube findings

### DIFF
--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
@@ -78,24 +78,33 @@ public final class SmcKeyIndex {
             LOG.debug("Implausible SMC key count {}; skipping key discovery.", keyCount);
             return null; // NOSONAR squid:S1168 - null and empty are different answers; see the javadoc
         }
-        int start = lowerBound(keyCount, keyAtIndex, prefix);
+        // Any failed read, in the binary search or in the forward scan, could have hidden a matching key: the search
+        // substitutes a neighbour for an unreadable probe, which can move the landing point past the block entirely,
+        // and the scan skips an unreadable index outright. Track failures through one wrapper so no path is missed.
+        boolean[] readFailed = new boolean[1];
+        IntFunction<String> tracked = i -> {
+            String key = keyAtIndex.apply(i);
+            if (key == null) {
+                readFailed[0] = true;
+            }
+            return key;
+        };
+        int start = lowerBound(keyCount, tracked, prefix);
         if (start < 0) {
             return null; // NOSONAR squid:S1168 - null and empty are different answers; see the javadoc
         }
         Set<String> found = new LinkedHashSet<>();
         int limit = Math.min(keyCount, start + MAX_SCAN);
-        boolean readAny = false;
         for (int i = start; i < limit; i++) {
-            String key = keyAtIndex.apply(i);
+            String key = tracked.apply(i);
             if (key == null) {
-                key = keyAtIndex.apply(i); // one retry, in case the failure was transient
+                key = tracked.apply(i); // one retry, in case the failure was transient
             }
             if (key == null) {
                 // Skip rather than stop: an unreadable key in the middle of the block would otherwise discard every
                 // key after it. The scan is bounded, and the prefix test below still ends it at the block boundary.
                 LOG.debug("Could not read SMC key at index {}; continuing the scan.", i);
             } else {
-                readAny = true;
                 if (!key.startsWith(prefix)) {
                     break;
                 }
@@ -104,12 +113,12 @@ public final class SmcKeyIndex {
                 }
             }
         }
-        if (!readAny && start < limit) {
-            // The scan had indices to read and none of them worked, so we cannot distinguish "no such keys" from "SMC
-            // unavailable"; returning null keeps the caller from caching an empty set and disabling the sensor for the
-            // JVM lifetime. An empty scan range is different: the search itself read successfully and simply landed
-            // past the end, which is a genuine "this machine has none".
-            LOG.debug("No SMC keys were readable from index {}; skipping key discovery.", start);
+        if (found.isEmpty() && readFailed[0]) {
+            // Nothing matched, but a read failed, so "no such keys" cannot be distinguished from "the one key this
+            // machine has was unreadable". Returning null keeps the caller from caching an empty set and disabling the
+            // sensor for the JVM lifetime. An empty result from a run with no failed read is different: that is a
+            // genuine "this machine has none", and is a cacheable answer.
+            LOG.debug("No SMC keys matched '{}' and at least one read failed; skipping key discovery.", prefix);
             return null; // NOSONAR squid:S1168 - null and empty are different answers; see the javadoc
         }
         return Collections.unmodifiableList(new ArrayList<>(found));

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
@@ -42,7 +42,7 @@ public final class SmcKeyIndex {
      * and A18 it is uppercase in 42% of cases, lowercase in 43%, and a digit in 15%. A mask requiring an uppercase
      * fourth character would miss {@code Tg0f}, which is the only GPU key present on some M2 machines.
      */
-    private static final Pattern GPU_TEMPERATURE_KEY = Pattern.compile("^Tg[0-9][0-9A-Za-z]$");
+    private static final Pattern GPU_TEMPERATURE_KEY = Pattern.compile("^Tg\\d[\\dA-Za-z]$");
 
     /** SMC keys are four characters. */
     private static final int KEY_LENGTH = 4;
@@ -76,11 +76,11 @@ public final class SmcKeyIndex {
             Predicate<String> mask) {
         if (keyCount <= 0 || keyCount > MAX_KEY_COUNT) {
             LOG.debug("Implausible SMC key count {}; skipping key discovery.", keyCount);
-            return null;
+            return null; // NOSONAR squid:S1168 - null and empty are different answers; see the javadoc
         }
         int start = lowerBound(keyCount, keyAtIndex, prefix);
         if (start < 0) {
-            return null;
+            return null; // NOSONAR squid:S1168 - null and empty are different answers; see the javadoc
         }
         Set<String> found = new LinkedHashSet<>();
         int limit = Math.min(keyCount, start + MAX_SCAN);
@@ -94,14 +94,14 @@ public final class SmcKeyIndex {
                 // Skip rather than stop: an unreadable key in the middle of the block would otherwise discard every
                 // key after it. The scan is bounded, and the prefix test below still ends it at the block boundary.
                 LOG.debug("Could not read SMC key at index {}; continuing the scan.", i);
-                continue;
-            }
-            readAny = true;
-            if (!key.startsWith(prefix)) {
-                break;
-            }
-            if (mask.test(key)) {
-                found.add(key);
+            } else {
+                readAny = true;
+                if (!key.startsWith(prefix)) {
+                    break;
+                }
+                if (mask.test(key)) {
+                    found.add(key);
+                }
             }
         }
         if (!readAny && start < limit) {
@@ -110,7 +110,7 @@ public final class SmcKeyIndex {
             // JVM lifetime. An empty scan range is different: the search itself read successfully and simply landed
             // past the end, which is a genuine "this machine has none".
             LOG.debug("No SMC keys were readable from index {}; skipping key discovery.", start);
-            return null;
+            return null; // NOSONAR squid:S1168 - null and empty are different answers; see the javadoc
         }
         return Collections.unmodifiableList(new ArrayList<>(found));
     }
@@ -197,14 +197,11 @@ public final class SmcKeyIndex {
         List<String> keys = new ArrayList<>();
         for (String token : csv.split(",")) {
             String key = token.trim();
-            if (key.isEmpty()) {
-                continue;
-            }
-            if (key.length() != KEY_LENGTH) {
+            if (key.length() == KEY_LENGTH) {
+                keys.add(key);
+            } else if (!key.isEmpty()) {
                 LOG.warn("Ignoring configured SMC key '{}': keys are exactly {} characters.", key, KEY_LENGTH);
-                continue;
             }
-            keys.add(key);
         }
         return Collections.unmodifiableList(keys);
     }

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
@@ -130,9 +130,12 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     @Test
     public void testFailedSearchProbeThatSkipsTheBlockIsNotReportedAsAbsent() {
         // Same shape, but the failure is consumed by the binary search rather than the scan: substituting a neighbour
-        // for the unreadable probe moves the landing point past Tg0f, so the scan never attempts it at all.
+        // for the unreadable probe moves the landing point past Tg0f, so the scan never attempts it at all. Failing
+        // only the first read is what makes null the proof of that -- had the scan reached index 2, its retry would
+        // have recovered Tg0f and returned a non-empty list. A permanently failing index cannot tell the two apart.
         String[] keys = { "TB0T", "TCMb", "Tg0f", "Th00" };
-        IntFunction<String> flaky = i -> i == 2 ? null : keys[i];
+        Set<Integer> failedOnce = new HashSet<>();
+        IntFunction<String> flaky = i -> i == 2 && failedOnce.add(i) ? null : keys[i];
         assertThat("A search that skipped the block on a failed read must not report a confirmed absence",
                 SmcKeyIndex.findKeys(keys.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
     }

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
@@ -23,8 +23,11 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests SMC key index logic without Mac hardware. This is why the logic lives here rather than in {@code SmcUtil},
  * whose static {@code IOKit.INSTANCE} field makes any of its members unloadable off a Mac.
+ * <p>
+ * The class and its methods are {@code public} because the module system only opens public types to the JUnit platform;
+ * a package-private test class in a named module fails to run.
  */
-public class SmcKeyIndexTest {
+public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JPMS, not redundant
 
     /** A realistic slice of a sorted SMC key index, with a Tg block in the middle. */
     private static final String[] SORTED = { "#KEY", "ALI0", "F0Ac", "TB0T", "TC0P", "TCMb", "TCMz", "Tf00", "Tf11",

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
@@ -118,6 +118,34 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
+    public void testFailedSoleMatchIsNotReportedAsAbsent() {
+        // The only Tg key is unreadable and the next key ends the block. Reporting empty would be cached as "this
+        // machine has no GPU sensors" and would disable the sensor for the JVM lifetime.
+        String[] keys = { "TB0T", "Tg0f", "Th00", "Tp01" };
+        IntFunction<String> flaky = i -> i == 1 ? null : keys[i];
+        assertThat("An unreadable sole match must not be cached as a confirmed absence",
+                SmcKeyIndex.findKeys(keys.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
+    }
+
+    @Test
+    public void testFailedSearchProbeThatSkipsTheBlockIsNotReportedAsAbsent() {
+        // Same shape, but the failure is consumed by the binary search rather than the scan: substituting a neighbour
+        // for the unreadable probe moves the landing point past Tg0f, so the scan never attempts it at all.
+        String[] keys = { "TB0T", "TCMb", "Tg0f", "Th00" };
+        IntFunction<String> flaky = i -> i == 2 ? null : keys[i];
+        assertThat("A search that skipped the block on a failed read must not report a confirmed absence",
+                SmcKeyIndex.findKeys(keys.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
+    }
+
+    @Test
+    public void testConfirmedAbsenceStillReportsEmpty() {
+        // The counterpart guard: with every read succeeding, "no Tg keys" is a real answer and must stay cacheable,
+        // so the fix above cannot degrade into "never return empty".
+        String[] keys = { "TB0T", "TCMb", "Th00", "Tp01" };
+        assertThat(findTg(keys), is(empty()));
+    }
+
+    @Test
     public void testFailedProbeDuringSearchIsRetriedAtNeighbour() {
         // A permanently unreadable index during the binary search descends via a neighbour instead of aborting.
         IntFunction<String> flaky = i -> i == SORTED.length / 2 ? null : SORTED[i];

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/DxgiFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/DxgiFFM.java
@@ -8,7 +8,6 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.util.LogLevel.DEBUG;
 
 import java.lang.foreign.Arena;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Shell32FFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Shell32FFM.java
@@ -7,7 +7,6 @@ package oshi.ffm.platform.windows;
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.util.LogLevel.DEBUG;
 
 import java.lang.foreign.MemorySegment;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/SysctlFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/SysctlFFM.java
@@ -34,6 +34,12 @@ public final class SysctlFFM {
     /** All supported platforms define {@code size_t} as an unsigned 64-bit value. */
     public static final ValueLayout.OfLong SIZE_T = JAVA_LONG;
 
+    /**
+     * Logged when a sysctl call fails. Parameterized rather than concatenated so the name is only formatted on the
+     * failure path, and shared so the message is identical across every result type.
+     */
+    private static final String FAILURE_MESSAGE = "Failed to get sysctl value for {}";
+
     private SysctlFFM() {
     }
 
@@ -50,9 +56,11 @@ public final class SysctlFFM {
          * @param oldp    buffer to receive the result, or {@link MemorySegment#NULL} to query the required size
          * @param oldlenp in/out size of {@code oldp}
          * @return {@code true} on success; {@code false} on failure
-         * @throws Throwable on FFM invocation error
+         * @throws Throwable on FFM invocation error. Implementations call {@link java.lang.invoke.MethodHandle}
+         *                   {@code invokeExact}, which declares {@code Throwable}, so nothing narrower can be declared
+         *                   here.
          */
-        boolean invoke(Arena arena, MemorySegment oldp, MemorySegment oldlenp) throws Throwable;
+        boolean invoke(Arena arena, MemorySegment oldp, MemorySegment oldlenp) throws Throwable; // NOSONAR squid:S112
     }
 
     /**
@@ -72,7 +80,7 @@ public final class SysctlFFM {
                 return def;
             }
             return valueSeg.get(JAVA_INT, 0);
-        }, log, LogLevel.WARN, "Failed to get sysctl value for " + name, def);
+        }, def, log, LogLevel.WARN, FAILURE_MESSAGE, name);
     }
 
     /**
@@ -97,7 +105,7 @@ public final class SysctlFFM {
             return sizeSeg.get(SIZE_T, 0) == JAVA_INT.byteSize()
                     ? ParseUtil.unsignedIntToLong(valueSeg.get(JAVA_INT, 0))
                     : valueSeg.get(JAVA_LONG, 0);
-        }, log, LogLevel.WARN, "Failed to get sysctl value for " + name, def);
+        }, def, log, LogLevel.WARN, FAILURE_MESSAGE, name);
     }
 
     /**
@@ -121,7 +129,7 @@ public final class SysctlFFM {
                 return def;
             }
             return valueSeg.getString(0);
-        }, log, LogLevel.WARN, "Failed to get sysctl value for " + name, def);
+        }, def, log, LogLevel.WARN, FAILURE_MESSAGE, name);
     }
 
     /**
@@ -137,7 +145,7 @@ public final class SysctlFFM {
         return callInArenaBooleanOrDefault(arena -> {
             MemorySegment sizeSeg = arena.allocateFrom(SIZE_T, struct.byteSize());
             return op.invoke(arena, struct, sizeSeg);
-        }, log, LogLevel.WARN, "Failed to get sysctl value for " + name, false);
+        }, false, log, LogLevel.WARN, FAILURE_MESSAGE, name);
     }
 
     /**
@@ -162,6 +170,6 @@ public final class SysctlFFM {
             MemorySegment returnSeg = Arena.ofAuto().allocate(size);
             returnSeg.copyFrom(valueSeg);
             return returnSeg;
-        }, log, LogLevel.WARN, "Failed to get sysctl value for " + name, null);
+        }, null, log, LogLevel.WARN, FAILURE_MESSAGE, name);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
@@ -198,7 +198,10 @@ public final class AdlUtilFFM {
     }
 
     private static void adlUninit(MemorySegment context) {
-        runOrLog(() -> {
+        // Block lambda (not an expression lambda) so invokeExact() on this void handle is in a statement context and
+        // its return type is inferred as void; an expression lambda infers Object -> WrongMethodTypeException (#3422).
+        // NOSONAR on the next line so S1602 does not collapse the block back to the buggy expression form.
+        runOrLog(() -> { // NOSONAR java:S1602 - block form required; expression lambda miscompiles void invokeExact
             ADL2_MAIN_CONTROL_DESTROY.invokeExact(context);
         }, LOG, "ADL uninit failed: {}");
     }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -118,8 +118,11 @@ public final class SmcUtilFFM {
      * Discovered GPU temperature keys, or null if discovery has not yet completed successfully. Deliberately not a
      * {@link oshi.util.Memoizer}: that would cache a failed discovery permanently, and a transient failure to open the
      * SMC would then disable GPU temperature for the lifetime of the JVM.
+     * <p>
+     * Only ever assigned an unmodifiable copy of a completed discovery, so the reference is safely published by the
+     * volatile write and the list it points at is immutable; no further synchronization is needed on the read path.
      */
-    private static volatile List<String> gpuTemperatureKeys;
+    private static volatile List<String> gpuTemperatureKeys; // NOSONAR squid:S3077 - published value is immutable
     /** SMC key for Apple Silicon CPU voltage. */
     public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
 
@@ -374,7 +377,7 @@ public final class SmcUtilFFM {
     private static List<String> discoverGpuTemperatureKeys() {
         int conn = smcOpen();
         if (conn == 0) {
-            return null;
+            return null; // NOSONAR squid:S1168 - null means "could not read", which the caller must not cache
         }
         try {
             int keyCount = (int) smcGetLong(conn, SMC_KEY_COUNT);

--- a/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
@@ -31,9 +31,12 @@ import oshi.util.common.platform.mac.SmcKeyIndex;
 
 /**
  * Tests the plausibility guard that keeps an idle-gated SMC sensor's sentinel from being reported as a temperature.
+ * <p>
+ * The class and its methods are {@code public} because the module system only opens public types to the JUnit platform;
+ * a package-private test class in a named module fails to run.
  */
 @EnabledOnOs(OS.MAC)
-public class MacSensorsPlausibilityFFMTest {
+public class MacSensorsPlausibilityFFMTest { // NOSONAR squid:S5786 - public is required by JPMS, not redundant
 
     /**
      * Sentinels actually captured from hardware: -4.0, 0.0, 2.5, 4.0 and 5.2 appear in the iSMC sample reports, and

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -103,8 +103,11 @@ public final class SmcUtil {
      * Discovered GPU temperature keys, or null if discovery has not yet completed successfully. Deliberately not a
      * {@link oshi.util.Memoizer}: that would cache a failed discovery permanently, and a transient failure to open the
      * SMC would then disable GPU temperature for the lifetime of the JVM.
+     * <p>
+     * Only ever assigned an unmodifiable copy of a completed discovery, so the reference is safely published by the
+     * volatile write and the list it points at is immutable; no further synchronization is needed on the read path.
      */
-    private static volatile List<String> gpuTemperatureKeys;
+    private static volatile List<String> gpuTemperatureKeys; // NOSONAR squid:S3077 - published value is immutable
     /** SMC key for CPU voltage (Apple Silicon). */
     public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
 
@@ -346,7 +349,7 @@ public final class SmcUtil {
     private static List<String> discoverGpuTemperatureKeys() {
         IOConnect conn = smcOpen();
         if (conn == null) {
-            return null;
+            return null; // NOSONAR squid:S1168 - null means "could not read", which the caller must not cache
         }
         try {
             int keyCount = (int) smcGetLong(conn, SMC_KEY_COUNT);

--- a/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
@@ -33,9 +33,12 @@ import oshi.util.common.platform.mac.SmcKeyIndex;
 /**
  * Tests the plausibility guard that keeps an idle-gated SMC sensor's sentinel from being reported as a temperature. JNA
  * twin of {@code oshi.ffm.MacSensorsPlausibilityFFMTest}.
+ * <p>
+ * The class and its methods are {@code public} because the module system only opens public types to the JUnit platform;
+ * a package-private test class in a named module fails to run.
  */
 @EnabledOnOs(OS.MAC)
-public class MacSensorsPlausibilityTest {
+public class MacSensorsPlausibilityTest { // NOSONAR squid:S5786 - public is required by JPMS, not redundant
 
     /**
      * Sentinels actually captured from hardware: -4.0, 0.0, 2.5, 4.0 and 5.2 appear in the iSMC sample reports, and


### PR DESCRIPTION
Clears the SonarCloud backlog: 8 findings fixed in code, 10 suppressed with an inline reason, and the 4 remaining `S3776` complexity findings accepted in SonarCloud rather than refactored.

## Fixed

| Rule | Where | Change |
|---|---|---|
| `S1128` ×2 | `DxgiFFM`, `Shell32FFM` | Genuinely redundant. Both classes extend `ForeignFunctions` / `WindowsForeignFunctions` and inherit `callInArenaOrDefault`; spotless can't detect this because the bare name is textually referenced. |
| `S135` ×2 | `SmcKeyIndex` scan loop, `parseConfiguredKeys` | Restructured as if/else. Behaviour identical. |
| `S6353` | `SmcKeyIndex` GPU key mask | `^Tg[0-9][0-9A-Za-z]$` → `^Tg\d[\dA-Za-z]$`. Identical without `UNICODE_CHARACTER_CLASS`. |
| `S1192` | `SysctlFFM` ×5 | The failure message was concatenated **eagerly at every call site**, formatting the sysctl name on every call whether or not it failed. Now uses the parameterized `callInArena*OrDefault` overloads (#3530) with one shared constant, so the name is only formatted on the failure path. |
| `S1602` | `AdlUtilFFM.adlUninit` | Added the block-lambda guard comment matching `BStrFFM`. Collapsing the block would reintroduce #3422; `VoidInvokeExactSourceTest` already guards the code, this stops the rule nagging toward the bug. |

## Suppressed

Each carries `// NOSONAR squid:Sxxxx` plus the reason, and a javadoc note where one wasn't already present.

- **`S1168` ×5** (`SmcKeyIndex` ×3, both `SmcUtil` twins) — `null` and empty are different answers. Empty is a cacheable *"this machine has no GPU temperature keys"*; returning it after a failed read would cache the failure and disable GPU temperature for the lifetime of the JVM.
- **`S3077` ×2** (`gpuTemperatureKeys`) — false positive. Only ever assigned an unmodifiable copy of a completed discovery, so the volatile write safely publishes an immutable value. `Memoizer` carries the same suppression.
- **`S5786` ×3** (test classes) — the module system only opens public types to the JUnit platform, so `public` is required, not redundant. `SystemInfoTest` carries the same suppression.

## Accepted in SonarCloud, not refactored

The four `S3776` cognitive-complexity findings, per the project's standing policy. Three are an artifact of the `ExceptionUtil` / `callInArena` conversions in #3528 and #3530 — moving a method body into a `callInArenaOrDefault` lambda adds a nesting level Sonar scores, with no change to the logic. `Shell32FFM.CommandLineToArgv` went from roughly at-threshold to 18 that way.

## Verification

Pre-commit gate clean on `oshi-common,oshi-core,oshi-core-ffm` (spotless, checkstyle, install, forbiddenapis, javadoc), plus a clean full-reactor `install` from root. All tests pass. `NativeComparisonTest` under `-Pnative-comparison` passes on an M2 Max including `sensors()`, so JNA/FFM parity is intact.

No CHANGELOG entry: no user-observable behaviour changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS GPU temperature key discovery so unreadable probes no longer get treated as confirmed absence; empty results are still reported correctly when all reads succeed.
* **Documentation**
  * Clarified GPU temperature key cache semantics, including safe publication and that “null” indicates discovery failure.
  * Refined messaging around sysctl retrieval failure logging.
* **Tests**
  * Expanded macOS sensor discovery tests to cover failure-handling and cache behavior under module discovery.
* **Refactor**
  * Centralized repeated sysctl failure text and adjusted minor native/language cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->