### PR TITLE
Dedup NvmlUtil JNA/FFM twins behind a shared query skeleton

### DIFF
--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -58,6 +58,7 @@ module com.github.oshi.common {
     exports oshi.software.os;
     exports oshi.spi;
     exports oshi.util;
+    exports oshi.util.common.gpu;
     exports oshi.util.common.platform.mac;
     exports oshi.util.common.platform.unix.bsd;
     exports oshi.util.common.platform.unix.dragonflybsd;

--- a/oshi-common/src/main/java/oshi/util/common/gpu/NvmlDeviceCache.java
+++ b/oshi-common/src/main/java/oshi/util/common/gpu/NvmlDeviceCache.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.common.gpu;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+
+/**
+ * Caches the PCI bus IDs of the NVML devices present on this machine.
+ * <p>
+ * Enumeration is retried on every call until it succeeds and is then never repeated: the set of installed devices does
+ * not change for the lifetime of the JVM, but a transient NVML failure must not be cached as "no devices". That is why
+ * the enumerator distinguishes a failure ({@code null}) from a machine with no NVIDIA hardware (an empty set).
+ */
+@ThreadSafe
+public final class NvmlDeviceCache {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NvmlDeviceCache.class);
+
+    private final AtomicReference<Set<String>> busIds = new AtomicReference<>(Collections.emptySet());
+    private final String backend;
+    private volatile boolean enumerated;
+
+    /**
+     * Creates an empty cache, to be populated on the first successful enumeration.
+     *
+     * @param backend names the binding in log messages, e.g. {@code JNA} or {@code FFM}
+     */
+    public NvmlDeviceCache(String backend) {
+        this.backend = backend;
+    }
+
+    /**
+     * Returns the cached bus IDs, enumerating them first if that has not yet succeeded. Must be called while NVML is
+     * initialized.
+     *
+     * @param enumerator supplies the bus IDs, returning {@code null} if NVML could not be queried
+     * @return the enumerated bus IDs, empty if enumeration has never succeeded
+     */
+    public Set<String> get(Supplier<Set<String>> enumerator) {
+        if (!enumerated) {
+            Set<String> ids = enumerator.get();
+            if (ids != null) {
+                busIds.set(ids);
+                enumerated = true;
+                LOG.debug("NVML ({}) enumerated {} device(s)", backend, ids.size());
+            }
+        }
+        return busIds.get();
+    }
+}

--- a/oshi-common/src/main/java/oshi/util/common/gpu/NvmlQuery.java
+++ b/oshi-common/src/main/java/oshi/util/common/gpu/NvmlQuery.java
@@ -103,7 +103,13 @@ public final class NvmlQuery {
     }
 
     /**
-     * Returns the enumerated bus ID matching the given fragment.
+     * Returns the enumerated bus ID matching the given fragment, preferring the most qualified form.
+     * <p>
+     * Both of a device's bus ID forms are enumerated, so a bare fragment such as {@code 01:00.0} matches the modern and
+     * legacy entries alike. The modern form carries the full eight-digit domain and is therefore the longer of the two,
+     * so returning the longest match yields it consistently, and matches what the name lookup returns. Returning the
+     * first match instead would let set iteration order decide, which can differ between runs and between the two
+     * bindings.
      *
      * @param busIds   the enumerated PCI bus IDs, already lowercased
      * @param fragment the fragment to match
@@ -111,11 +117,12 @@ public final class NvmlQuery {
      */
     public static String matchBusId(Set<String> busIds, String fragment) {
         String needle = fragment.toLowerCase(Locale.ROOT);
+        String best = null;
         for (String id : busIds) {
-            if (matches(id, needle)) {
-                return id;
+            if (matches(id, needle) && (best == null || id.length() > best.length())) {
+                best = id;
             }
         }
-        return null;
+        return best;
     }
 }

--- a/oshi-common/src/main/java/oshi/util/common/gpu/NvmlQuery.java
+++ b/oshi-common/src/main/java/oshi/util/common/gpu/NvmlQuery.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.common.gpu;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.Function;
+
+import oshi.annotation.concurrent.ThreadSafe;
+
+/**
+ * Backend-independent logic shared by the JNA and FFM bindings to the NVIDIA Management Library (NVML).
+ * <p>
+ * Every NVML metric has the same shape: reject a blank device identifier, pair {@code nvmlInit_v2} with
+ * {@code nvmlShutdown} around the query, acquire a fresh device handle inside that scope, and fall back to a sentinel
+ * whenever any step fails. Only the native read differs between the backends, so the skeleton lives here and each
+ * backend supplies a one-line reader.
+ * <p>
+ * Device handles are valid only within a single init/shutdown scope, which is why the backends exchange stable PCI bus
+ * ID strings with their callers and re-acquire a handle for each query.
+ */
+@ThreadSafe
+public final class NvmlQuery {
+
+    private NvmlQuery() {
+    }
+
+    /**
+     * A backend's NVML lifecycle and device-handle acquisition, implemented once per binding.
+     *
+     * @param <H> the backend's device handle type: a JNA {@code Pointer}, or an FFM handle bundled with the arena its
+     *            out-parameters are allocated from
+     */
+    public interface NvmlScope<H> {
+
+        /**
+         * Calls {@code nvmlInit_v2}, incrementing NVML's internal reference count.
+         *
+         * @return true if NVML was initialized, in which case {@link #uninit()} must be called exactly once
+         */
+        boolean init();
+
+        /**
+         * Calls {@code nvmlShutdown}, decrementing the reference count {@link #init()} incremented.
+         */
+        void uninit();
+
+        /**
+         * Acquires a device handle matching the given identifier and applies {@code body} to it. Must be called while
+         * NVML is initialized. Any scope the handle depends on, such as an FFM arena, is opened and closed around
+         * {@code body} by the implementation, so no native resource escapes the backend.
+         *
+         * @param <R>      the reader's result type
+         * @param deviceId the stable device identifier to match
+         * @param body     the reader to apply to the acquired handle
+         * @param sentinel the value to return if no matching device could be acquired
+         * @return the reader's result, or {@code sentinel} if no device matched
+         */
+        <R> R withDevice(String deviceId, Function<H, R> body, R sentinel);
+    }
+
+    /**
+     * Runs an NVML query against a device, returning the sentinel if the identifier is blank, NVML cannot be
+     * initialized, no matching device can be acquired, or the read itself fails.
+     *
+     * @param <H>      the backend's device handle type
+     * @param <R>      the query's result type
+     * @param deviceId the stable device identifier
+     * @param scope    the backend's NVML lifecycle
+     * @param reader   reads the metric from a device handle, itself returning {@code sentinel} if the read fails
+     * @param sentinel the value denoting an unavailable metric
+     * @return the metric, or {@code sentinel}
+     */
+    public static <H, R> R query(String deviceId, NvmlScope<H> scope, Function<H, R> reader, R sentinel) {
+        if (deviceId == null || deviceId.isEmpty()) {
+            return sentinel;
+        }
+        if (!scope.init()) {
+            return sentinel;
+        }
+        try {
+            return scope.withDevice(deviceId, reader, sentinel);
+        } finally {
+            scope.uninit();
+        }
+    }
+
+    /**
+     * Tests whether an NVML identifier matches a sought fragment, in either direction, so that a domain-qualified form
+     * matches a bare one: {@code 00000000:01:00.0}, {@code 0000:01:00.0} and {@code 01:00.0} all match each other.
+     * <p>
+     * An empty candidate never matches. Bidirectional containment would otherwise make it match everything, because
+     * every string contains the empty string, letting a device whose PCI info read back blank answer to any query.
+     *
+     * @param candidate the identifier read from a device, lowercased
+     * @param needle    the sought fragment, lowercased
+     * @return true if the two identify the same device
+     */
+    public static boolean matches(String candidate, String needle) {
+        return !candidate.isEmpty() && (candidate.contains(needle) || needle.contains(candidate));
+    }
+
+    /**
+     * Returns the enumerated bus ID matching the given fragment.
+     *
+     * @param busIds   the enumerated PCI bus IDs, already lowercased
+     * @param fragment the fragment to match
+     * @return the matching bus ID, or {@code null} if none matched
+     */
+    public static String matchBusId(Set<String> busIds, String fragment) {
+        String needle = fragment.toLowerCase(Locale.ROOT);
+        for (String id : busIds) {
+            if (matches(id, needle)) {
+                return id;
+            }
+        }
+        return null;
+    }
+}

--- a/oshi-common/src/main/java/oshi/util/common/gpu/NvmlQuery.java
+++ b/oshi-common/src/main/java/oshi/util/common/gpu/NvmlQuery.java
@@ -111,11 +111,18 @@ public final class NvmlQuery {
      * first match instead would let set iteration order decide, which can differ between runs and between the two
      * bindings.
      *
+     * A blank fragment matches nothing, rather than matching every enumerated ID as bidirectional containment would
+     * otherwise have it do. This is checked here rather than left to {@link #matches}, whose guard covers a blank
+     * candidate read from a device and not a blank fragment supplied by a caller.
+     *
      * @param busIds   the enumerated PCI bus IDs, already lowercased
      * @param fragment the fragment to match
-     * @return the matching bus ID, or {@code null} if none matched
+     * @return the matching bus ID, or {@code null} if none matched or the fragment was blank
      */
     public static String matchBusId(Set<String> busIds, String fragment) {
+        if (fragment == null || fragment.isEmpty()) {
+            return null;
+        }
         String needle = fragment.toLowerCase(Locale.ROOT);
         String best = null;
         for (String id : busIds) {

--- a/oshi-common/src/main/java/oshi/util/common/gpu/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/gpu/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Provides utilities shared across the GPU JNA and FFM implementations
+ */
+package oshi.util.common.gpu;

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -39,6 +39,8 @@
 --add-opens
   com.github.oshi.common/oshi.util.tuples=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.util.common.gpu=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.util.driver.unix=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.software.common.os.windows=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/util/common/gpu/NvmlQueryTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/gpu/NvmlQueryTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.common.gpu;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.common.gpu.NvmlQuery.NvmlScope;
+
+/**
+ * Tests the NVML logic shared by the JNA and FFM bindings, without an NVIDIA GPU or either native library. This is why
+ * the logic lives here rather than in the bindings, whose native library loading makes them unusable in a unit test.
+ */
+public class NvmlQueryTest {
+
+    /** A scope that records its lifecycle calls and hands out a fixed handle. */
+    private static final class FakeScope implements NvmlScope<String> {
+        private final String handle;
+        private final boolean initSucceeds;
+        private int inits;
+        private int uninits;
+
+        FakeScope(String handle, boolean initSucceeds) {
+            this.handle = handle;
+            this.initSucceeds = initSucceeds;
+        }
+
+        @Override
+        public boolean init() {
+            inits++;
+            return initSucceeds;
+        }
+
+        @Override
+        public void uninit() {
+            uninits++;
+        }
+
+        @Override
+        public <R> R withDevice(String deviceId, Function<String, R> body, R sentinel) {
+            return handle == null ? sentinel : body.apply(handle);
+        }
+    }
+
+    @Test
+    void testQueryReadsThroughAndBalancesInit() {
+        FakeScope scope = new FakeScope("device", true);
+        double value = NvmlQuery.query("0000:01:00.0", scope, handle -> 42d, -1d);
+        assertThat("reader result is returned", value, is(42d));
+        assertThat("init called once", scope.inits, is(1));
+        assertThat("uninit paired with init", scope.uninits, is(1));
+    }
+
+    @Test
+    void testQueryRejectsBlankDeviceIdWithoutInitializing() {
+        for (String blank : new String[] { null, "" }) {
+            FakeScope scope = new FakeScope("device", true);
+            assertThat("blank id yields the sentinel", NvmlQuery.query(blank, scope, handle -> 42d, -1d), is(-1d));
+            assertThat("NVML is never initialized for a blank id", scope.inits, is(0));
+            assertThat("nothing to shut down", scope.uninits, is(0));
+        }
+    }
+
+    @Test
+    void testQueryReturnsSentinelWhenInitFails() {
+        FakeScope scope = new FakeScope("device", false);
+        assertThat("failed init yields the sentinel", NvmlQuery.query("id", scope, handle -> 42d, -1d), is(-1d));
+        // A failed nvmlInit_v2 did not increment NVML's reference count, so it must not be decremented.
+        assertThat("uninit is not called after a failed init", scope.uninits, is(0));
+    }
+
+    @Test
+    void testQueryReturnsSentinelWhenDeviceNotFound() {
+        FakeScope scope = new FakeScope(null, true);
+        assertThat("missing device yields the sentinel", NvmlQuery.query("id", scope, handle -> 42d, -1d), is(-1d));
+        assertThat("init is still balanced", scope.uninits, is(1));
+    }
+
+    @Test
+    void testQueryUninitsWhenTheReaderThrows() {
+        FakeScope scope = new FakeScope("device", true);
+        try {
+            NvmlQuery.query("id", scope, handle -> {
+                throw new IllegalStateException("native read blew up");
+            }, -1d);
+        } catch (IllegalStateException expected) {
+            // The reference count must still be released on the exceptional path.
+        }
+        assertThat("uninit runs even when the reader throws", scope.uninits, is(1));
+    }
+
+    @Test
+    void testMatchesIsBidirectional() {
+        assertThat("qualified matches bare", NvmlQuery.matches("00000000:01:00.0", "01:00.0"), is(true));
+        assertThat("bare matches qualified", NvmlQuery.matches("01:00.0", "00000000:01:00.0"), is(true));
+        assertThat("legacy matches modern", NvmlQuery.matches("0000:01:00.0", "00000000:01:00.0"), is(true));
+        assertThat("identical matches", NvmlQuery.matches("0000:01:00.0", "0000:01:00.0"), is(true));
+        assertThat("different devices do not match", NvmlQuery.matches("0000:01:00.0", "0000:02:00.0"), is(false));
+    }
+
+    @Test
+    void testEmptyCandidateNeverMatches() {
+        // Bidirectional containment would otherwise make a blank PCI read answer to every query, since every string
+        // contains the empty string.
+        assertThat("blank candidate does not match", NvmlQuery.matches("", "0000:01:00.0"), is(false));
+    }
+
+    @Test
+    void testMatchBusIdReturnsTheEnumeratedForm() {
+        Set<String> busIds = new LinkedHashSet<>(Arrays.asList("00000000:01:00.0", "00000000:02:00.0"));
+        assertThat("returns the canonical enumerated id", NvmlQuery.matchBusId(busIds, "02:00.0"),
+                is("00000000:02:00.0"));
+        assertThat("is case-insensitive", NvmlQuery.matchBusId(busIds, "01:00.0"), is("00000000:01:00.0"));
+        assertThat("no match yields null", NvmlQuery.matchBusId(busIds, "09:00.0"), is(nullValue()));
+        assertThat("empty set yields null", NvmlQuery.matchBusId(Collections.emptySet(), "01:00.0"), is(nullValue()));
+    }
+
+    @Test
+    void testDeviceCacheRetriesUntilEnumerationSucceeds() {
+        NvmlDeviceCache cache = new NvmlDeviceCache("test");
+        int[] calls = new int[1];
+        Set<String> ids = new HashSet<>(Collections.singletonList("00000000:01:00.0"));
+
+        calls[0] = 0;
+        assertThat("a failed enumeration is not cached", cache.get(() -> {
+            calls[0]++;
+            return null;
+        }), is(Collections.<String>emptySet()));
+
+        assertThat("the failure is retried", cache.get(() -> {
+            calls[0]++;
+            return ids;
+        }), is(ids));
+        assertThat("both attempts ran", calls[0], is(2));
+
+        assertThat("success is cached", cache.get(() -> {
+            calls[0]++;
+            return Collections.<String>emptySet();
+        }), is(ids));
+        assertThat("the enumerator is not called again", calls[0], is(2));
+    }
+
+    @Test
+    void testDeviceCacheCachesAGenuinelyEmptyResult() {
+        // An empty set means "no NVIDIA hardware", which is a real answer and must not be retried forever.
+        NvmlDeviceCache cache = new NvmlDeviceCache("test");
+        int[] calls = new int[1];
+        for (int i = 0; i < 2; i++) {
+            cache.get(() -> {
+                calls[0]++;
+                return Collections.<String>emptySet();
+            });
+        }
+        assertThat("an empty result is cached", calls[0], is(1));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/common/gpu/NvmlQueryTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/gpu/NvmlQueryTest.java
@@ -128,6 +128,15 @@ public class NvmlQueryTest {
     }
 
     @Test
+    void testMatchBusIdRejectsABlankFragment() {
+        // Every string contains the empty string, so without an explicit guard a blank fragment would match every
+        // enumerated id and resolve to the longest of them.
+        Set<String> busIds = new LinkedHashSet<>(Arrays.asList("0000:01:00.0", "00000000:01:00.0"));
+        assertThat("an empty fragment matches nothing", NvmlQuery.matchBusId(busIds, ""), is(nullValue()));
+        assertThat("a null fragment matches nothing", NvmlQuery.matchBusId(busIds, null), is(nullValue()));
+    }
+
+    @Test
     void testMatchBusIdPrefersTheQualifiedForm() {
         // Both of a device's forms are enumerated and a bare fragment matches both, so the answer must not depend on
         // which one iteration happens to reach first.

--- a/oshi-common/src/test/java/oshi/util/common/gpu/NvmlQueryTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/gpu/NvmlQueryTest.java
@@ -119,12 +119,24 @@ public class NvmlQueryTest {
 
     @Test
     void testMatchBusIdReturnsTheEnumeratedForm() {
-        Set<String> busIds = new LinkedHashSet<>(Arrays.asList("00000000:01:00.0", "00000000:02:00.0"));
+        Set<String> busIds = new LinkedHashSet<>(Arrays.asList("00000000:0a:00.0", "00000000:02:00.0"));
         assertThat("returns the canonical enumerated id", NvmlQuery.matchBusId(busIds, "02:00.0"),
                 is("00000000:02:00.0"));
-        assertThat("is case-insensitive", NvmlQuery.matchBusId(busIds, "01:00.0"), is("00000000:01:00.0"));
+        assertThat("is case-insensitive", NvmlQuery.matchBusId(busIds, "0A:00.0"), is("00000000:0a:00.0"));
         assertThat("no match yields null", NvmlQuery.matchBusId(busIds, "09:00.0"), is(nullValue()));
         assertThat("empty set yields null", NvmlQuery.matchBusId(Collections.emptySet(), "01:00.0"), is(nullValue()));
+    }
+
+    @Test
+    void testMatchBusIdPrefersTheQualifiedForm() {
+        // Both of a device's forms are enumerated and a bare fragment matches both, so the answer must not depend on
+        // which one iteration happens to reach first.
+        Set<String> legacyFirst = new LinkedHashSet<>(Arrays.asList("0000:01:00.0", "00000000:01:00.0"));
+        Set<String> modernFirst = new LinkedHashSet<>(Arrays.asList("00000000:01:00.0", "0000:01:00.0"));
+        assertThat("the domain-qualified form wins", NvmlQuery.matchBusId(legacyFirst, "01:00.0"),
+                is("00000000:01:00.0"));
+        assertThat("regardless of iteration order", NvmlQuery.matchBusId(modernFirst, "01:00.0"),
+                is("00000000:01:00.0"));
     }
 
     @Test

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/NvmlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/NvmlUtilFFM.java
@@ -15,27 +15,73 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.common.NvmlFunctions;
+import oshi.util.common.gpu.NvmlDeviceCache;
+import oshi.util.common.gpu.NvmlQuery;
+import oshi.util.common.gpu.NvmlQuery.NvmlScope;
+import oshi.util.tuples.Pair;
 
 /**
  * FFM-based optional runtime binding to the NVIDIA Management Library (NVML). All methods return sentinel values
  * ({@code -1} or {@code -1L}) when NVML is unavailable or a specific query fails.
+ * <p>
+ * The query skeleton shared with the JNA binding lives in {@link NvmlQuery}; only the native reads below differ.
  */
 @ThreadSafe
 public final class NvmlUtilFFM {
 
     private static final Logger LOG = LoggerFactory.getLogger(NvmlUtilFFM.class);
 
-    private static volatile boolean devicesEnumerated = false;
-    private static final AtomicReference<Set<String>> DEVICE_BUS_IDS = new AtomicReference<>(Collections.emptySet());
+    private static final long BUS_ID_LEGACY_OFFSET = NvmlFunctions.PCI_INFO_LAYOUT
+            .byteOffset(MemoryLayout.PathElement.groupElement("busIdLegacy"));
+    private static final long BUS_ID_OFFSET = NvmlFunctions.PCI_INFO_LAYOUT
+            .byteOffset(MemoryLayout.PathElement.groupElement("busId"));
+
+    private static final NvmlDeviceCache DEVICE_CACHE = new NvmlDeviceCache("FFM");
+
+    private static final NvmlScope<Device> SCOPE = new NvmlScope<Device>() {
+        @Override
+        public boolean init() {
+            return nvmlInit();
+        }
+
+        @Override
+        public void uninit() {
+            nvmlUninit();
+        }
+
+        @Override
+        public <R> R withDevice(String deviceId, Function<Device, R> body, R sentinel) {
+            // The arena is opened and closed here so no MemorySegment outlives the query or escapes this package.
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment handle = acquireHandleByBusId(deviceId, arena);
+                return handle == null ? sentinel : body.apply(new Device(handle, arena));
+            }
+        }
+    };
 
     private NvmlUtilFFM() {
+    }
+
+    /**
+     * An acquired device handle together with the arena its out-parameters are allocated from. Both are valid only for
+     * the duration of one {@link NvmlScope#withDevice} call.
+     */
+    private static final class Device {
+        private final MemorySegment handle;
+        private final Arena arena;
+
+        Device(MemorySegment handle, Arena arena) {
+            this.handle = handle;
+            this.arena = arena;
+        }
     }
 
     private static boolean nvmlInit() {
@@ -54,132 +100,201 @@ public final class NvmlUtilFFM {
         NvmlFunctions.shutdown();
     }
 
-    private static void ensureDevicesEnumerated() {
-        if (devicesEnumerated) {
-            return;
+    // -------------------------------------------------------------------------
+    // Device enumeration
+    // -------------------------------------------------------------------------
+
+    /**
+     * Applies {@code visitor} to each NVML device handle in index order, stopping early if it returns true. Devices
+     * whose handle cannot be acquired are skipped. Must be called while NVML is initialized.
+     *
+     * @param arena   allocates the out-parameters for the walk
+     * @param visitor applied to each handle, returning true to stop the walk
+     * @return false if the device count could not be read, letting callers distinguish an NVML failure from a machine
+     *         with no devices
+     */
+    private static boolean forEachDevice(Arena arena, Predicate<MemorySegment> visitor) {
+        MemorySegment countSeg = arena.allocate(JAVA_INT);
+        if (NvmlFunctions.deviceGetCount(countSeg) != NvmlFunctions.NVML_SUCCESS) {
+            return false;
         }
-        Set<String> ids = enumerateDeviceBusIds();
-        if (ids != null) {
-            DEVICE_BUS_IDS.set(ids);
-            devicesEnumerated = true;
-            LOG.debug("NVML (FFM) enumerated {} device(s)", DEVICE_BUS_IDS.get().size());
+        int count = countSeg.get(JAVA_INT, 0);
+        for (int i = 0; i < count; i++) {
+            MemorySegment handleSeg = arena.allocate(ADDRESS);
+            if (NvmlFunctions.deviceGetHandleByIndex(i, handleSeg) != NvmlFunctions.NVML_SUCCESS) {
+                continue;
+            }
+            if (visitor.test(handleSeg.get(ADDRESS, 0))) {
+                return true;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Reads a device's two PCI bus ID forms, lowercased.
+     *
+     * @param handle the device handle
+     * @param arena  allocates the PCI info struct
+     * @return the modern and legacy bus IDs, or {@code null} if the PCI info could not be read
+     */
+    private static Pair<String, String> readBusIds(MemorySegment handle, Arena arena) {
+        MemorySegment pciSeg = arena.allocate(NvmlFunctions.PCI_INFO_LAYOUT);
+        if (NvmlFunctions.deviceGetPciInfo(handle, pciSeg) != NvmlFunctions.NVML_SUCCESS) {
+            return null;
+        }
+        return new Pair<>(NvmlFunctions.readString(pciSeg, BUS_ID_OFFSET, 32).toLowerCase(Locale.ROOT),
+                NvmlFunctions.readString(pciSeg, BUS_ID_LEGACY_OFFSET, 16).toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Reads a device's name, lowercased.
+     *
+     * @param handle the device handle
+     * @param arena  allocates the name buffer
+     * @return the name, or {@code null} if it could not be read
+     */
+    private static String readName(MemorySegment handle, Arena arena) {
+        MemorySegment nameSeg = arena.allocate(NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE);
+        if (NvmlFunctions.deviceGetName(handle, nameSeg,
+                NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE) != NvmlFunctions.NVML_SUCCESS) {
+            return null;
+        }
+        return nameSeg.getString(0).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Returns a set of PCI bus ID strings for all NVML devices, or {@code null} on NVML error (so the caller can
+     * distinguish a real failure from a legitimate empty result).
+     *
+     * @return set of PCI bus ID strings, or {@code null} on NVML error
+     */
+    private static Set<String> enumerateDeviceBusIds() {
+        try (Arena arena = Arena.ofConfined()) {
+            Set<String> ids = new HashSet<>();
+            boolean enumerated = forEachDevice(arena, handle -> {
+                Pair<String, String> busIds = readBusIds(handle, arena);
+                if (busIds != null) {
+                    addIfNotEmpty(ids, busIds.getA());
+                    addIfNotEmpty(ids, busIds.getB());
+                }
+                return false;
+            });
+            return enumerated ? Collections.unmodifiableSet(ids) : null;
         }
     }
 
-    private static Set<String> enumerateDeviceBusIds() {
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment countSeg = arena.allocate(JAVA_INT);
-            if (NvmlFunctions.deviceGetCount(countSeg) != NvmlFunctions.NVML_SUCCESS) {
-                return null;
-            }
-            int count = countSeg.get(JAVA_INT, 0);
-            Set<String> ids = new HashSet<>();
-            long busIdLegacyOffset = NvmlFunctions.PCI_INFO_LAYOUT
-                    .byteOffset(MemoryLayout.PathElement.groupElement("busIdLegacy"));
-            long busIdOffset = NvmlFunctions.PCI_INFO_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("busId"));
-            for (int i = 0; i < count; i++) {
-                MemorySegment handleSeg = arena.allocate(ADDRESS);
-                if (NvmlFunctions.deviceGetHandleByIndex(i, handleSeg) != NvmlFunctions.NVML_SUCCESS) {
-                    continue;
-                }
-                MemorySegment handle = handleSeg.get(ADDRESS, 0);
-                MemorySegment pciSeg = arena.allocate(NvmlFunctions.PCI_INFO_LAYOUT);
-                if (NvmlFunctions.deviceGetPciInfo(handle, pciSeg) == NvmlFunctions.NVML_SUCCESS) {
-                    String legacyId = NvmlFunctions.readString(pciSeg, busIdLegacyOffset, 16).toLowerCase(Locale.ROOT);
-                    if (!legacyId.isEmpty()) {
-                        ids.add(legacyId);
-                    }
-                    String busId = NvmlFunctions.readString(pciSeg, busIdOffset, 32).toLowerCase(Locale.ROOT);
-                    if (!busId.isEmpty()) {
-                        ids.add(busId);
-                    }
-                }
-            }
-            return Collections.unmodifiableSet(ids);
+    private static void addIfNotEmpty(Set<String> ids, String id) {
+        if (!id.isEmpty()) {
+            ids.add(id);
         }
     }
 
     private static MemorySegment acquireHandleByBusId(String pciBusId, Arena arena) {
-        MemorySegment countSeg = arena.allocate(JAVA_INT);
-        if (NvmlFunctions.deviceGetCount(countSeg) != NvmlFunctions.NVML_SUCCESS) {
-            return null;
-        }
         String needle = pciBusId.toLowerCase(Locale.ROOT);
-        int count = countSeg.get(JAVA_INT, 0);
-        long busIdLegacyOffset = NvmlFunctions.PCI_INFO_LAYOUT
-                .byteOffset(MemoryLayout.PathElement.groupElement("busIdLegacy"));
-        long busIdOffset = NvmlFunctions.PCI_INFO_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("busId"));
-        for (int i = 0; i < count; i++) {
-            MemorySegment handleSeg = arena.allocate(ADDRESS);
-            if (NvmlFunctions.deviceGetHandleByIndex(i, handleSeg) != NvmlFunctions.NVML_SUCCESS) {
-                continue;
+        MemorySegment[] found = new MemorySegment[1];
+        forEachDevice(arena, handle -> {
+            Pair<String, String> busIds = readBusIds(handle, arena);
+            if (busIds != null
+                    && (NvmlQuery.matches(busIds.getA(), needle) || NvmlQuery.matches(busIds.getB(), needle))) {
+                found[0] = handle;
+                return true;
             }
-            MemorySegment handle = handleSeg.get(ADDRESS, 0);
-            MemorySegment pciSeg = arena.allocate(NvmlFunctions.PCI_INFO_LAYOUT);
-            if (NvmlFunctions.deviceGetPciInfo(handle, pciSeg) == NvmlFunctions.NVML_SUCCESS) {
-                String legacyId = NvmlFunctions.readString(pciSeg, busIdLegacyOffset, 16).toLowerCase(Locale.ROOT);
-                String busId = NvmlFunctions.readString(pciSeg, busIdOffset, 32).toLowerCase(Locale.ROOT);
-                if (busId.contains(needle) || needle.contains(busId) || legacyId.contains(needle)
-                        || needle.contains(legacyId)) {
-                    return handle;
-                }
-            }
-        }
-        return null;
+            return false;
+        });
+        return found[0];
     }
 
     private static MemorySegment acquireHandleByName(String gpuName, Arena arena) {
-        MemorySegment countSeg = arena.allocate(JAVA_INT);
-        if (NvmlFunctions.deviceGetCount(countSeg) != NvmlFunctions.NVML_SUCCESS) {
-            return null;
-        }
         String needle = gpuName.toLowerCase(Locale.ROOT);
-        int count = countSeg.get(JAVA_INT, 0);
-        for (int i = 0; i < count; i++) {
-            MemorySegment handleSeg = arena.allocate(ADDRESS);
-            if (NvmlFunctions.deviceGetHandleByIndex(i, handleSeg) != NvmlFunctions.NVML_SUCCESS) {
-                continue;
+        MemorySegment[] found = new MemorySegment[1];
+        forEachDevice(arena, handle -> {
+            String name = readName(handle, arena);
+            if (name != null && NvmlQuery.matches(name, needle)) {
+                found[0] = handle;
+                return true;
             }
-            MemorySegment handle = handleSeg.get(ADDRESS, 0);
-            MemorySegment nameSeg = arena.allocate(NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE);
-            if (NvmlFunctions.deviceGetName(handle, nameSeg,
-                    NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE) == NvmlFunctions.NVML_SUCCESS) {
-                String name = nameSeg.getString(0).toLowerCase(Locale.ROOT);
-                if (name.contains(needle) || needle.contains(name)) {
-                    return handle;
-                }
-            }
-        }
-        return null;
+            return false;
+        });
+        return found[0];
     }
 
+    /**
+     * Counts the devices whose name matches, so an ambiguous match can be rejected rather than resolved arbitrarily.
+     *
+     * @param gpuName GPU name to match
+     * @param arena   allocates the out-parameters for the walk
+     * @return the number of matching devices, or {@code -1} if the devices could not be enumerated
+     */
     private static int countMatchesByName(String gpuName, Arena arena) {
-        MemorySegment countSeg = arena.allocate(JAVA_INT);
-        if (NvmlFunctions.deviceGetCount(countSeg) != NvmlFunctions.NVML_SUCCESS) {
-            return -1;
-        }
         String needle = gpuName.toLowerCase(Locale.ROOT);
-        int total = countSeg.get(JAVA_INT, 0);
-        int matches = 0;
-        for (int i = 0; i < total; i++) {
-            MemorySegment handleSeg = arena.allocate(ADDRESS);
-            if (NvmlFunctions.deviceGetHandleByIndex(i, handleSeg) != NvmlFunctions.NVML_SUCCESS) {
-                continue;
+        int[] matches = new int[1];
+        boolean enumerated = forEachDevice(arena, handle -> {
+            String name = readName(handle, arena);
+            if (name != null && NvmlQuery.matches(name, needle)) {
+                matches[0]++;
             }
-            MemorySegment nameSeg = arena.allocate(NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE);
-            if (NvmlFunctions.deviceGetName(handleSeg.get(ADDRESS, 0), nameSeg,
-                    NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE) == NvmlFunctions.NVML_SUCCESS) {
-                String name = nameSeg.getString(0).toLowerCase(Locale.ROOT);
-                if (name.contains(needle) || needle.contains(name)) {
-                    matches++;
-                }
-            }
-        }
-        return matches;
+            return false;
+        });
+        return enumerated ? matches[0] : -1;
     }
 
     // -------------------------------------------------------------------------
-    // Public API — mirrors NvmlUtil (JNA) exactly
+    // Metric readers — the only part that differs from the JNA binding
+    // -------------------------------------------------------------------------
+
+    private static double readUtilization(Device device) {
+        MemorySegment utilSeg = device.arena.allocate(NvmlFunctions.UTILIZATION_LAYOUT);
+        if (NvmlFunctions.deviceGetUtilizationRates(device.handle, utilSeg) == NvmlFunctions.NVML_SUCCESS) {
+            return utilSeg.get(JAVA_INT, 0);
+        }
+        return -1d;
+    }
+
+    private static long readVramUsed(Device device) {
+        MemorySegment memSeg = device.arena.allocate(NvmlFunctions.MEMORY_LAYOUT);
+        if (NvmlFunctions.deviceGetMemoryInfo(device.handle, memSeg) == NvmlFunctions.NVML_SUCCESS) {
+            return memSeg.get(JAVA_LONG,
+                    NvmlFunctions.MEMORY_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("used")));
+        }
+        return -1L;
+    }
+
+    private static double readTemperature(Device device) {
+        MemorySegment tempSeg = device.arena.allocate(JAVA_INT);
+        if (NvmlFunctions.deviceGetTemperature(device.handle, NvmlFunctions.NVML_TEMPERATURE_GPU,
+                tempSeg) == NvmlFunctions.NVML_SUCCESS) {
+            return tempSeg.get(JAVA_INT, 0);
+        }
+        return -1d;
+    }
+
+    private static double readPowerDraw(Device device) {
+        MemorySegment powerSeg = device.arena.allocate(JAVA_INT);
+        if (NvmlFunctions.deviceGetPowerUsage(device.handle, powerSeg) == NvmlFunctions.NVML_SUCCESS) {
+            return powerSeg.get(JAVA_INT, 0) / 1000.0;
+        }
+        return -1d;
+    }
+
+    private static long readClock(Device device, int clockType) {
+        MemorySegment clockSeg = device.arena.allocate(JAVA_INT);
+        if (NvmlFunctions.deviceGetClockInfo(device.handle, clockType, clockSeg) == NvmlFunctions.NVML_SUCCESS) {
+            return clockSeg.get(JAVA_INT, 0);
+        }
+        return -1L;
+    }
+
+    private static double readFanSpeed(Device device) {
+        MemorySegment speedSeg = device.arena.allocate(JAVA_INT);
+        if (NvmlFunctions.deviceGetFanSpeed(device.handle, speedSeg) == NvmlFunctions.NVML_SUCCESS) {
+            return speedSeg.get(JAVA_INT, 0);
+        }
+        return -1d;
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API — mirrors NvmlUtilJNA exactly
     // -------------------------------------------------------------------------
 
     /**
@@ -201,19 +316,11 @@ public final class NvmlUtilFFM {
         if (!NvmlFunctions.isAvailable() || pciBusId == null || pciBusId.isEmpty()) {
             return null;
         }
-        boolean init = nvmlInit();
-        if (!init) {
+        if (!nvmlInit()) {
             return null;
         }
         try {
-            ensureDevicesEnumerated();
-            String needle = pciBusId.toLowerCase(Locale.ROOT);
-            for (String id : DEVICE_BUS_IDS.get()) {
-                if (id.contains(needle) || needle.contains(id)) {
-                    return id;
-                }
-            }
-            return null;
+            return NvmlQuery.matchBusId(DEVICE_CACHE.get(NvmlUtilFFM::enumerateDeviceBusIds), pciBusId);
         } finally {
             nvmlUninit();
         }
@@ -229,12 +336,10 @@ public final class NvmlUtilFFM {
         if (!NvmlFunctions.isAvailable() || gpuName == null || gpuName.isEmpty()) {
             return null;
         }
-        boolean init = nvmlInit();
-        if (!init) {
+        if (!nvmlInit()) {
             return null;
         }
         try (Arena arena = Arena.ofConfined()) {
-            ensureDevicesEnumerated();
             int matchCount = countMatchesByName(gpuName, arena);
             if (matchCount <= 0) {
                 return null;
@@ -248,19 +353,19 @@ public final class NvmlUtilFFM {
             if (handle == null) {
                 return null;
             }
-            long busIdLegacyOffset = NvmlFunctions.PCI_INFO_LAYOUT
-                    .byteOffset(MemoryLayout.PathElement.groupElement("busIdLegacy"));
-            MemorySegment pciSeg = arena.allocate(NvmlFunctions.PCI_INFO_LAYOUT);
-            if (NvmlFunctions.deviceGetPciInfo(handle, pciSeg) == NvmlFunctions.NVML_SUCCESS) {
-                String busId = NvmlFunctions.readString(pciSeg, busIdLegacyOffset, 16).toLowerCase(Locale.ROOT);
-                if (!busId.isEmpty()) {
-                    return busId;
-                }
+            Pair<String, String> busIds = readBusIds(handle, arena);
+            if (busIds == null) {
+                return null;
             }
-            return null;
+            // Prefer the modern form, matching the order enumerateDeviceBusIds records them in.
+            return busIds.getA().isEmpty() ? emptyToNull(busIds.getB()) : busIds.getA();
         } finally {
             nvmlUninit();
         }
+    }
+
+    private static String emptyToNull(String value) {
+        return value.isEmpty() ? null : value;
     }
 
     /**
@@ -270,26 +375,7 @@ public final class NvmlUtilFFM {
      * @return utilization percentage or -1
      */
     public static double getGpuUtilization(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1d;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1d;
-        }
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment device = acquireHandleByBusId(deviceId, arena);
-            if (device == null) {
-                return -1d;
-            }
-            MemorySegment utilSeg = arena.allocate(NvmlFunctions.UTILIZATION_LAYOUT);
-            if (NvmlFunctions.deviceGetUtilizationRates(device, utilSeg) == NvmlFunctions.NVML_SUCCESS) {
-                return utilSeg.get(JAVA_INT, 0);
-            }
-            return -1d;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readUtilization, -1d);
     }
 
     /**
@@ -299,27 +385,7 @@ public final class NvmlUtilFFM {
      * @return bytes used or -1
      */
     public static long getVramUsed(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1L;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1L;
-        }
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment device = acquireHandleByBusId(deviceId, arena);
-            if (device == null) {
-                return -1L;
-            }
-            MemorySegment memSeg = arena.allocate(NvmlFunctions.MEMORY_LAYOUT);
-            if (NvmlFunctions.deviceGetMemoryInfo(device, memSeg) == NvmlFunctions.NVML_SUCCESS) {
-                return memSeg.get(JAVA_LONG,
-                        NvmlFunctions.MEMORY_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("used")));
-            }
-            return -1L;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readVramUsed, -1L);
     }
 
     /**
@@ -329,27 +395,7 @@ public final class NvmlUtilFFM {
      * @return temperature in °C or -1
      */
     public static double getTemperature(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1d;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1d;
-        }
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment device = acquireHandleByBusId(deviceId, arena);
-            if (device == null) {
-                return -1d;
-            }
-            MemorySegment tempSeg = arena.allocate(JAVA_INT);
-            if (NvmlFunctions.deviceGetTemperature(device, NvmlFunctions.NVML_TEMPERATURE_GPU,
-                    tempSeg) == NvmlFunctions.NVML_SUCCESS) {
-                return tempSeg.get(JAVA_INT, 0);
-            }
-            return -1d;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readTemperature, -1d);
     }
 
     /**
@@ -359,26 +405,7 @@ public final class NvmlUtilFFM {
      * @return power in watts or -1
      */
     public static double getPowerDraw(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1d;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1d;
-        }
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment device = acquireHandleByBusId(deviceId, arena);
-            if (device == null) {
-                return -1d;
-            }
-            MemorySegment powerSeg = arena.allocate(JAVA_INT);
-            if (NvmlFunctions.deviceGetPowerUsage(device, powerSeg) == NvmlFunctions.NVML_SUCCESS) {
-                return powerSeg.get(JAVA_INT, 0) / 1000.0;
-            }
-            return -1d;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readPowerDraw, -1d);
     }
 
     /**
@@ -388,27 +415,7 @@ public final class NvmlUtilFFM {
      * @return core clock in MHz or -1
      */
     public static long getCoreClockMhz(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1L;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1L;
-        }
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment device = acquireHandleByBusId(deviceId, arena);
-            if (device == null) {
-                return -1L;
-            }
-            MemorySegment clockSeg = arena.allocate(JAVA_INT);
-            if (NvmlFunctions.deviceGetClockInfo(device, NvmlFunctions.NVML_CLOCK_GRAPHICS,
-                    clockSeg) == NvmlFunctions.NVML_SUCCESS) {
-                return clockSeg.get(JAVA_INT, 0);
-            }
-            return -1L;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, device -> readClock(device, NvmlFunctions.NVML_CLOCK_GRAPHICS), -1L);
     }
 
     /**
@@ -418,27 +425,7 @@ public final class NvmlUtilFFM {
      * @return memory clock in MHz or -1
      */
     public static long getMemoryClockMhz(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1L;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1L;
-        }
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment device = acquireHandleByBusId(deviceId, arena);
-            if (device == null) {
-                return -1L;
-            }
-            MemorySegment clockSeg = arena.allocate(JAVA_INT);
-            if (NvmlFunctions.deviceGetClockInfo(device, NvmlFunctions.NVML_CLOCK_MEM,
-                    clockSeg) == NvmlFunctions.NVML_SUCCESS) {
-                return clockSeg.get(JAVA_INT, 0);
-            }
-            return -1L;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, device -> readClock(device, NvmlFunctions.NVML_CLOCK_MEM), -1L);
     }
 
     /**
@@ -448,25 +435,6 @@ public final class NvmlUtilFFM {
      * @return fan speed percentage or -1
      */
     public static double getFanSpeedPercent(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1d;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1d;
-        }
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment device = acquireHandleByBusId(deviceId, arena);
-            if (device == null) {
-                return -1d;
-            }
-            MemorySegment speedSeg = arena.allocate(JAVA_INT);
-            if (NvmlFunctions.deviceGetFanSpeed(device, speedSeg) == NvmlFunctions.NVML_SUCCESS) {
-                return speedSeg.get(JAVA_INT, 0);
-            }
-            return -1d;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readFanSpeed, -1d);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/NvmlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/NvmlUtilFFM.java
@@ -44,6 +44,12 @@ public final class NvmlUtilFFM {
     private static final long BUS_ID_OFFSET = NvmlFunctions.PCI_INFO_LAYOUT
             .byteOffset(MemoryLayout.PathElement.groupElement("busId"));
 
+    // Derived from the layout rather than repeated as literals, so the reads cannot drift from the struct definition.
+    private static final int BUS_ID_LEGACY_LENGTH = (int) NvmlFunctions.PCI_INFO_LAYOUT
+            .select(MemoryLayout.PathElement.groupElement("busIdLegacy")).byteSize();
+    private static final int BUS_ID_LENGTH = (int) NvmlFunctions.PCI_INFO_LAYOUT
+            .select(MemoryLayout.PathElement.groupElement("busId")).byteSize();
+
     private static final NvmlDeviceCache DEVICE_CACHE = new NvmlDeviceCache("FFM");
 
     private static final NvmlScope<Device> SCOPE = new NvmlScope<Device>() {
@@ -143,8 +149,8 @@ public final class NvmlUtilFFM {
         if (NvmlFunctions.deviceGetPciInfo(handle, pciSeg) != NvmlFunctions.NVML_SUCCESS) {
             return null;
         }
-        return new Pair<>(NvmlFunctions.readString(pciSeg, BUS_ID_OFFSET, 32).toLowerCase(Locale.ROOT),
-                NvmlFunctions.readString(pciSeg, BUS_ID_LEGACY_OFFSET, 16).toLowerCase(Locale.ROOT));
+        return new Pair<>(NvmlFunctions.readString(pciSeg, BUS_ID_OFFSET, BUS_ID_LENGTH).toLowerCase(Locale.ROOT),
+                NvmlFunctions.readString(pciSeg, BUS_ID_LEGACY_OFFSET, BUS_ID_LEGACY_LENGTH).toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/util/gpu/NvmlUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/NvmlUtilJNA.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -223,17 +222,17 @@ public final class NvmlUtilJNA {
      */
     private static Pointer acquireHandleByBusId(String pciBusId) {
         String needle = pciBusId.toLowerCase(Locale.ROOT);
-        AtomicReference<Pointer> found = new AtomicReference<>();
+        Pointer[] found = new Pointer[1];
         forEachDevice(handle -> {
             Pair<String, String> busIds = readBusIds(handle);
             if (busIds != null
                     && (NvmlQuery.matches(busIds.getA(), needle) || NvmlQuery.matches(busIds.getB(), needle))) {
-                found.set(handle);
+                found[0] = handle;
                 return true;
             }
             return false;
         });
-        return found.get();
+        return found[0];
     }
 
     /**
@@ -245,16 +244,16 @@ public final class NvmlUtilJNA {
      */
     private static Pointer acquireHandleByName(String gpuName) {
         String needle = gpuName.toLowerCase(Locale.ROOT);
-        AtomicReference<Pointer> found = new AtomicReference<>();
+        Pointer[] found = new Pointer[1];
         forEachDevice(handle -> {
             String name = readName(handle);
             if (name != null && NvmlQuery.matches(name, needle)) {
-                found.set(handle);
+                found[0] = handle;
                 return true;
             }
             return false;
         });
-        return found.get();
+        return found[0];
     }
 
     /**

--- a/oshi-core/src/main/java/oshi/util/gpu/NvmlUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/NvmlUtilJNA.java
@@ -9,6 +9,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +27,10 @@ import oshi.jna.common.Nvml.NvmlLibrary;
 import oshi.jna.common.Nvml.NvmlMemory;
 import oshi.jna.common.Nvml.NvmlPciInfo;
 import oshi.jna.common.Nvml.NvmlUtilization;
+import oshi.util.common.gpu.NvmlDeviceCache;
+import oshi.util.common.gpu.NvmlQuery;
+import oshi.util.common.gpu.NvmlQuery.NvmlScope;
+import oshi.util.tuples.Pair;
 
 /**
  * Optional runtime binding to the NVIDIA Management Library (NVML). All methods return sentinel values ({@code -1} or
@@ -37,7 +43,7 @@ import oshi.jna.common.Nvml.NvmlUtilization;
  *
  * <p>
  * Device handles are enumerated once on first successful init and cached by PCI bus ID string for correlation with OSHI
- * GraphicsCard instances.
+ * GraphicsCard instances. The query skeleton shared with the FFM binding lives in {@link NvmlQuery}.
  */
 @ThreadSafe
 public final class NvmlUtilJNA {
@@ -67,11 +73,27 @@ public final class NvmlUtilJNA {
         }
     }
 
-    // Lazy device enumeration state — written once on first successful enumeration, read-only thereafter.
-    // Stores PCI bus ID strings (stable identifiers) rather than Pointer handles, which are only valid
-    // within a single nvmlInit/nvmlShutdown scope.
-    private static volatile boolean devicesEnumerated = false;
-    private static final AtomicReference<Set<String>> DEVICE_BUS_IDS = new AtomicReference<>(Collections.emptySet());
+    // Stores PCI bus ID strings (stable identifiers) rather than Pointer handles, which are only valid within a
+    // single nvmlInit/nvmlShutdown scope.
+    private static final NvmlDeviceCache DEVICE_CACHE = new NvmlDeviceCache("JNA");
+
+    private static final NvmlScope<Pointer> SCOPE = new NvmlScope<Pointer>() {
+        @Override
+        public boolean init() {
+            return nvmlInit();
+        }
+
+        @Override
+        public void uninit() {
+            nvmlUninit();
+        }
+
+        @Override
+        public <R> R withDevice(String deviceId, Function<Pointer, R> body, R sentinel) {
+            Pointer device = acquireHandleByBusId(deviceId);
+            return device == null ? sentinel : body.apply(device);
+        }
+    };
 
     private NvmlUtilJNA() {
     }
@@ -107,20 +129,64 @@ public final class NvmlUtilJNA {
         Holder.LIB.nvmlShutdown();
     }
 
+    // -------------------------------------------------------------------------
+    // Device enumeration
+    // -------------------------------------------------------------------------
+
     /**
-     * Enumerates device PCI bus IDs on first call after a successful init. Only sets {@code devicesEnumerated} on
-     * success so transient NVML failures allow a retry on the next call. Must be called while NVML is initialized.
+     * Applies {@code visitor} to each NVML device handle in index order, stopping early if it returns true. Devices
+     * whose handle cannot be acquired are skipped. Must be called while NVML is initialized.
+     *
+     * @param visitor applied to each handle, returning true to stop the walk
+     * @return false if the device count could not be read, letting callers distinguish an NVML failure from a machine
+     *         with no devices
      */
-    private static void ensureDevicesEnumerated() {
-        if (devicesEnumerated) {
-            return;
+    private static boolean forEachDevice(Predicate<Pointer> visitor) {
+        IntByReference countRef = new IntByReference();
+        if (Holder.LIB.nvmlDeviceGetCount_v2(countRef) != Nvml.NVML_SUCCESS) {
+            return false;
         }
-        Set<String> ids = enumerateDeviceBusIds();
-        if (ids != null) {
-            DEVICE_BUS_IDS.set(ids);
-            devicesEnumerated = true;
-            LOG.debug("NVML enumerated {} device(s)", DEVICE_BUS_IDS.get().size());
+        int count = countRef.getValue();
+        for (int i = 0; i < count; i++) {
+            PointerByReference handleRef = new PointerByReference();
+            if (Holder.LIB.nvmlDeviceGetHandleByIndex_v2(i, handleRef) != Nvml.NVML_SUCCESS) {
+                continue;
+            }
+            if (visitor.test(handleRef.getValue())) {
+                return true;
+            }
         }
+        return true;
+    }
+
+    /**
+     * Reads a device's two PCI bus ID forms, lowercased.
+     *
+     * @param handle the device handle
+     * @return the modern and legacy bus IDs, or {@code null} if the PCI info could not be read
+     */
+    private static Pair<String, String> readBusIds(Pointer handle) {
+        NvmlPciInfo pci = new NvmlPciInfo();
+        if (Holder.LIB.nvmlDeviceGetPciInfo_v3(handle, pci) != Nvml.NVML_SUCCESS) {
+            return null;
+        }
+        pci.read();
+        return new Pair<>(Native.toString(pci.busId).toLowerCase(Locale.ROOT),
+                Native.toString(pci.busIdLegacy).toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Reads a device's name, lowercased.
+     *
+     * @param handle the device handle
+     * @return the name, or {@code null} if it could not be read
+     */
+    private static String readName(Pointer handle) {
+        byte[] nameBuf = new byte[Nvml.NVML_DEVICE_NAME_BUFFER_SIZE];
+        if (Holder.LIB.nvmlDeviceGetName(handle, nameBuf, nameBuf.length) != Nvml.NVML_SUCCESS) {
+            return null;
+        }
+        return Native.toString(nameBuf).toLowerCase(Locale.ROOT);
     }
 
     /**
@@ -130,32 +196,22 @@ public final class NvmlUtilJNA {
      * @return set of PCI bus ID strings, or {@code null} on NVML error
      */
     private static Set<String> enumerateDeviceBusIds() {
-        IntByReference countRef = new IntByReference();
-        if (Holder.LIB.nvmlDeviceGetCount_v2(countRef) != Nvml.NVML_SUCCESS) {
-            return null;
-        }
-        int count = countRef.getValue();
         Set<String> ids = new HashSet<>();
-        for (int i = 0; i < count; i++) {
-            PointerByReference handleRef = new PointerByReference();
-            if (Holder.LIB.nvmlDeviceGetHandleByIndex_v2(i, handleRef) != Nvml.NVML_SUCCESS) {
-                continue;
+        boolean enumerated = forEachDevice(handle -> {
+            Pair<String, String> busIds = readBusIds(handle);
+            if (busIds != null) {
+                addIfNotEmpty(ids, busIds.getA());
+                addIfNotEmpty(ids, busIds.getB());
             }
-            Pointer handle = handleRef.getValue();
-            NvmlPciInfo pci = new NvmlPciInfo();
-            if (Holder.LIB.nvmlDeviceGetPciInfo_v3(handle, pci) == Nvml.NVML_SUCCESS) {
-                pci.read();
-                String busId = Native.toString(pci.busId).toLowerCase(Locale.ROOT);
-                if (!busId.isEmpty()) {
-                    ids.add(busId);
-                }
-                String legacyId = Native.toString(pci.busIdLegacy).toLowerCase(Locale.ROOT);
-                if (!legacyId.isEmpty()) {
-                    ids.add(legacyId);
-                }
-            }
+            return false;
+        });
+        return enumerated ? Collections.unmodifiableSet(ids) : null;
+    }
+
+    private static void addIfNotEmpty(Set<String> ids, String id) {
+        if (!id.isEmpty()) {
+            ids.add(id);
         }
-        return Collections.unmodifiableSet(ids);
     }
 
     /**
@@ -166,30 +222,18 @@ public final class NvmlUtilJNA {
      * @return device handle Pointer, or {@code null} if not found
      */
     private static Pointer acquireHandleByBusId(String pciBusId) {
-        IntByReference countRef = new IntByReference();
-        if (Holder.LIB.nvmlDeviceGetCount_v2(countRef) != Nvml.NVML_SUCCESS) {
-            return null;
-        }
         String needle = pciBusId.toLowerCase(Locale.ROOT);
-        int count = countRef.getValue();
-        for (int i = 0; i < count; i++) {
-            PointerByReference handleRef = new PointerByReference();
-            if (Holder.LIB.nvmlDeviceGetHandleByIndex_v2(i, handleRef) != Nvml.NVML_SUCCESS) {
-                continue;
+        AtomicReference<Pointer> found = new AtomicReference<>();
+        forEachDevice(handle -> {
+            Pair<String, String> busIds = readBusIds(handle);
+            if (busIds != null
+                    && (NvmlQuery.matches(busIds.getA(), needle) || NvmlQuery.matches(busIds.getB(), needle))) {
+                found.set(handle);
+                return true;
             }
-            Pointer handle = handleRef.getValue();
-            NvmlPciInfo pci = new NvmlPciInfo();
-            if (Holder.LIB.nvmlDeviceGetPciInfo_v3(handle, pci) == Nvml.NVML_SUCCESS) {
-                pci.read();
-                String busId = Native.toString(pci.busId).toLowerCase(Locale.ROOT);
-                String legacyId = Native.toString(pci.busIdLegacy).toLowerCase(Locale.ROOT);
-                if (busId.contains(needle) || needle.contains(busId) || legacyId.contains(needle)
-                        || needle.contains(legacyId)) {
-                    return handle;
-                }
-            }
-        }
-        return null;
+            return false;
+        });
+        return found.get();
     }
 
     /**
@@ -200,51 +244,90 @@ public final class NvmlUtilJNA {
      * @return device handle Pointer, or {@code null} if not found
      */
     private static Pointer acquireHandleByName(String gpuName) {
-        IntByReference countRef = new IntByReference();
-        if (Holder.LIB.nvmlDeviceGetCount_v2(countRef) != Nvml.NVML_SUCCESS) {
-            return null;
-        }
         String needle = gpuName.toLowerCase(Locale.ROOT);
-        int count = countRef.getValue();
-        for (int i = 0; i < count; i++) {
-            PointerByReference handleRef = new PointerByReference();
-            if (Holder.LIB.nvmlDeviceGetHandleByIndex_v2(i, handleRef) != Nvml.NVML_SUCCESS) {
-                continue;
+        AtomicReference<Pointer> found = new AtomicReference<>();
+        forEachDevice(handle -> {
+            String name = readName(handle);
+            if (name != null && NvmlQuery.matches(name, needle)) {
+                found.set(handle);
+                return true;
             }
-            Pointer handle = handleRef.getValue();
-            byte[] nameBuf = new byte[Nvml.NVML_DEVICE_NAME_BUFFER_SIZE];
-            if (Holder.LIB.nvmlDeviceGetName(handle, nameBuf, nameBuf.length) == Nvml.NVML_SUCCESS) {
-                String name = Native.toString(nameBuf).toLowerCase(Locale.ROOT);
-                if (name.contains(needle) || needle.contains(name)) {
-                    return handle;
-                }
-            }
-        }
-        return null;
+            return false;
+        });
+        return found.get();
     }
 
+    /**
+     * Counts the devices whose name matches, so an ambiguous match can be rejected rather than resolved arbitrarily.
+     *
+     * @param gpuName GPU name to match
+     * @return the number of matching devices, or {@code -1} if the devices could not be enumerated
+     */
     private static int countMatchesByName(String gpuName) {
-        IntByReference countRef = new IntByReference();
-        if (Holder.LIB.nvmlDeviceGetCount_v2(countRef) != Nvml.NVML_SUCCESS) {
-            return -1;
-        }
         String needle = gpuName.toLowerCase(Locale.ROOT);
-        int total = countRef.getValue();
-        int matches = 0;
-        for (int i = 0; i < total; i++) {
-            PointerByReference handleRef = new PointerByReference();
-            if (Holder.LIB.nvmlDeviceGetHandleByIndex_v2(i, handleRef) != Nvml.NVML_SUCCESS) {
-                continue;
+        int[] matches = new int[1];
+        boolean enumerated = forEachDevice(handle -> {
+            String name = readName(handle);
+            if (name != null && NvmlQuery.matches(name, needle)) {
+                matches[0]++;
             }
-            byte[] nameBuf = new byte[Nvml.NVML_DEVICE_NAME_BUFFER_SIZE];
-            if (Holder.LIB.nvmlDeviceGetName(handleRef.getValue(), nameBuf, nameBuf.length) == Nvml.NVML_SUCCESS) {
-                String name = Native.toString(nameBuf).toLowerCase(Locale.ROOT);
-                if (name.contains(needle) || needle.contains(name)) {
-                    matches++;
-                }
-            }
+            return false;
+        });
+        return enumerated ? matches[0] : -1;
+    }
+
+    // -------------------------------------------------------------------------
+    // Metric readers — the only part that differs from the FFM binding
+    // -------------------------------------------------------------------------
+
+    private static double readUtilization(Pointer device) {
+        NvmlUtilization util = new NvmlUtilization();
+        if (Holder.LIB.nvmlDeviceGetUtilizationRates(device, util) == Nvml.NVML_SUCCESS) {
+            util.read();
+            return util.gpu;
         }
-        return matches;
+        return -1d;
+    }
+
+    private static long readVramUsed(Pointer device) {
+        NvmlMemory mem = new NvmlMemory();
+        if (Holder.LIB.nvmlDeviceGetMemoryInfo(device, mem) == Nvml.NVML_SUCCESS) {
+            mem.read();
+            return mem.used;
+        }
+        return -1L;
+    }
+
+    private static double readTemperature(Pointer device) {
+        IntByReference temp = new IntByReference();
+        if (Holder.LIB.nvmlDeviceGetTemperature(device, Nvml.NVML_TEMPERATURE_GPU, temp) == Nvml.NVML_SUCCESS) {
+            return temp.getValue();
+        }
+        return -1d;
+    }
+
+    private static double readPowerDraw(Pointer device) {
+        IntByReference power = new IntByReference();
+        if (Holder.LIB.nvmlDeviceGetPowerUsage(device, power) == Nvml.NVML_SUCCESS) {
+            return power.getValue() / 1000.0;
+        }
+        return -1d;
+    }
+
+    private static long readClock(Pointer device, int clockType) {
+        IntByReference clock = new IntByReference();
+        if (Holder.LIB.nvmlDeviceGetClockInfo(device, clockType, clock) == Nvml.NVML_SUCCESS) {
+            return clock.getValue();
+        }
+        return -1L;
+    }
+
+    private static double readFanSpeed(Pointer device) {
+        IntByReference speed = new IntByReference();
+        if (Holder.LIB.nvmlDeviceGetFanSpeed(device, speed) == Nvml.NVML_SUCCESS) {
+            return speed.getValue();
+        }
+        return -1d;
     }
 
     // -------------------------------------------------------------------------
@@ -278,21 +361,12 @@ public final class NvmlUtilJNA {
         if (!Holder.LIBRARY_LOADED || pciBusId == null || pciBusId.isEmpty()) {
             return null;
         }
-        boolean init = nvmlInit();
-        if (!init) {
+        if (!nvmlInit()) {
             return null;
         }
         try {
-            ensureDevicesEnumerated();
-            // Verify a handle can be acquired (device exists), then return the canonical bus ID
-            // from the enumerated set that matches — not the handle itself.
-            String needle = pciBusId.toLowerCase(Locale.ROOT);
-            for (String id : DEVICE_BUS_IDS.get()) {
-                if (id.contains(needle) || needle.contains(id)) {
-                    return id;
-                }
-            }
-            return null;
+            // Return the canonical bus ID from the enumerated set that matches, not a handle.
+            return NvmlQuery.matchBusId(DEVICE_CACHE.get(NvmlUtilJNA::enumerateDeviceBusIds), pciBusId);
         } finally {
             nvmlUninit();
         }
@@ -312,19 +386,14 @@ public final class NvmlUtilJNA {
         if (!Holder.LIBRARY_LOADED || gpuName == null || gpuName.isEmpty()) {
             return null;
         }
-        boolean init = nvmlInit();
-        if (!init) {
+        if (!nvmlInit()) {
             return null;
         }
         try {
-            ensureDevicesEnumerated();
             // Check for ambiguous name matches before committing to the first hit.
             int matchCount = countMatchesByName(gpuName);
-            if (matchCount < 0) {
-                // nvmlDeviceGetCount_v2 failed; cannot enumerate devices
-                return null;
-            }
-            if (matchCount == 0) {
+            if (matchCount <= 0) {
+                // Zero matches, or nvmlDeviceGetCount_v2 failed so the devices could not be enumerated.
                 return null;
             }
             if (matchCount > 1) {
@@ -337,18 +406,19 @@ public final class NvmlUtilJNA {
             if (handle == null) {
                 return null;
             }
-            NvmlPciInfo pci = new NvmlPciInfo();
-            if (Holder.LIB.nvmlDeviceGetPciInfo_v3(handle, pci) == Nvml.NVML_SUCCESS) {
-                pci.read();
-                String busId = Native.toString(pci.busId).toLowerCase(Locale.ROOT);
-                if (!busId.isEmpty()) {
-                    return busId;
-                }
+            Pair<String, String> busIds = readBusIds(handle);
+            if (busIds == null) {
+                return null;
             }
-            return null;
+            // Prefer the modern form, matching the order enumerateDeviceBusIds records them in.
+            return busIds.getA().isEmpty() ? emptyToNull(busIds.getB()) : busIds.getA();
         } finally {
             nvmlUninit();
         }
+    }
+
+    private static String emptyToNull(String value) {
+        return value.isEmpty() ? null : value;
     }
 
     /**
@@ -358,27 +428,7 @@ public final class NvmlUtilJNA {
      * @return utilization percentage or -1
      */
     public static double getGpuUtilization(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1d;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1d;
-        }
-        try {
-            Pointer device = acquireHandleByBusId(deviceId);
-            if (device == null) {
-                return -1d;
-            }
-            NvmlUtilization util = new NvmlUtilization();
-            if (Holder.LIB.nvmlDeviceGetUtilizationRates(device, util) == Nvml.NVML_SUCCESS) {
-                util.read();
-                return util.gpu;
-            }
-            return -1d;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readUtilization, -1d);
     }
 
     /**
@@ -388,27 +438,7 @@ public final class NvmlUtilJNA {
      * @return bytes used or -1
      */
     public static long getVramUsed(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1L;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1L;
-        }
-        try {
-            Pointer device = acquireHandleByBusId(deviceId);
-            if (device == null) {
-                return -1L;
-            }
-            NvmlMemory mem = new NvmlMemory();
-            if (Holder.LIB.nvmlDeviceGetMemoryInfo(device, mem) == Nvml.NVML_SUCCESS) {
-                mem.read();
-                return mem.used;
-            }
-            return -1L;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readVramUsed, -1L);
     }
 
     /**
@@ -418,26 +448,7 @@ public final class NvmlUtilJNA {
      * @return temperature in °C or -1
      */
     public static double getTemperature(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1d;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1d;
-        }
-        try {
-            Pointer device = acquireHandleByBusId(deviceId);
-            if (device == null) {
-                return -1d;
-            }
-            IntByReference temp = new IntByReference();
-            if (Holder.LIB.nvmlDeviceGetTemperature(device, Nvml.NVML_TEMPERATURE_GPU, temp) == Nvml.NVML_SUCCESS) {
-                return temp.getValue();
-            }
-            return -1d;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readTemperature, -1d);
     }
 
     /**
@@ -447,26 +458,7 @@ public final class NvmlUtilJNA {
      * @return power in watts or -1
      */
     public static double getPowerDraw(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1d;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1d;
-        }
-        try {
-            Pointer device = acquireHandleByBusId(deviceId);
-            if (device == null) {
-                return -1d;
-            }
-            IntByReference power = new IntByReference();
-            if (Holder.LIB.nvmlDeviceGetPowerUsage(device, power) == Nvml.NVML_SUCCESS) {
-                return power.getValue() / 1000.0;
-            }
-            return -1d;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readPowerDraw, -1d);
     }
 
     /**
@@ -476,26 +468,7 @@ public final class NvmlUtilJNA {
      * @return core clock in MHz or -1
      */
     public static long getCoreClockMhz(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1L;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1L;
-        }
-        try {
-            Pointer device = acquireHandleByBusId(deviceId);
-            if (device == null) {
-                return -1L;
-            }
-            IntByReference clock = new IntByReference();
-            if (Holder.LIB.nvmlDeviceGetClockInfo(device, Nvml.NVML_CLOCK_GRAPHICS, clock) == Nvml.NVML_SUCCESS) {
-                return clock.getValue();
-            }
-            return -1L;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, device -> readClock(device, Nvml.NVML_CLOCK_GRAPHICS), -1L);
     }
 
     /**
@@ -505,26 +478,7 @@ public final class NvmlUtilJNA {
      * @return memory clock in MHz or -1
      */
     public static long getMemoryClockMhz(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1L;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1L;
-        }
-        try {
-            Pointer device = acquireHandleByBusId(deviceId);
-            if (device == null) {
-                return -1L;
-            }
-            IntByReference clock = new IntByReference();
-            if (Holder.LIB.nvmlDeviceGetClockInfo(device, Nvml.NVML_CLOCK_MEM, clock) == Nvml.NVML_SUCCESS) {
-                return clock.getValue();
-            }
-            return -1L;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, device -> readClock(device, Nvml.NVML_CLOCK_MEM), -1L);
     }
 
     /**
@@ -534,25 +488,6 @@ public final class NvmlUtilJNA {
      * @return fan speed percentage or -1
      */
     public static double getFanSpeedPercent(String deviceId) {
-        if (deviceId == null || deviceId.isEmpty()) {
-            return -1d;
-        }
-        boolean init = nvmlInit();
-        if (!init) {
-            return -1d;
-        }
-        try {
-            Pointer device = acquireHandleByBusId(deviceId);
-            if (device == null) {
-                return -1d;
-            }
-            IntByReference speed = new IntByReference();
-            if (Holder.LIB.nvmlDeviceGetFanSpeed(device, speed) == Nvml.NVML_SUCCESS) {
-                return speed.getValue();
-            }
-            return -1d;
-        } finally {
-            nvmlUninit();
-        }
+        return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readFanSpeed, -1d);
     }
 }


### PR DESCRIPTION
Item 9a of the cross-OS consistency audit: the GPU family. NvmlUtil was the largest remaining duplication cluster in the project (100 + 82 Sonar duplicated lines).

## What was duplicated

Every NVML metric had the same shape in both bindings — reject a blank device id, pair `nvmlInit_v2` with `nvmlShutdown`, acquire a fresh handle inside that scope, fall back to a sentinel when any step fails. Only the native read differed. On top of that, each twin repeated its own device-enumeration walk three or four times.

## What changed

New in `oshi.util.common.gpu`:

- **`NvmlQuery`** holds the query skeleton behind an `NvmlScope<H>` interface each twin implements once, plus the shared identifier matching. The FFM scope opens and closes its `Arena` inside `withDevice`, so no `MemorySegment` escapes the exported package.
- **`NvmlDeviceCache`** holds the enumerate-once-on-success bus ID cache, previously three statics duplicated per twin. Enumeration is retried until it succeeds so a transient NVML failure is not cached as "no devices" — which is why the enumerator distinguishes `null` from empty.

The twins keep only their native readers, and their internal device walks collapse behind `forEachDevice` / `readBusIds` / `readName`. `NvmlUtilJNA` 558 → 493, `NvmlUtilFFM` 472 → 440.

The public static API of both twins is unchanged, so no caller was touched.

## Behavior changes, all deliberate

1. **`findDeviceByName` returned a different string per backend for the same device.** JNA read `pci.busId` (32-byte, 8-hex-digit domain, `00000000:01:00.0`) while FFM read `busIdLegacy` (16-byte, 4-digit, `0000:01:00.0`). Both bindings declare both fields identically, so this was a real divergence — masked downstream only because `acquireHandleByBusId` matches by substring in either direction. Both now prefer the modern form and fall back to legacy, matching the order `enumerateDeviceBusIds` records them in.
2. **`NvmlQuery.matches` rejects an empty candidate.** Bidirectional containment previously let a device whose PCI bus ID or name read back blank match *every* query, since every string contains the empty string. Pre-existing in both twins.
3. The JNA enumeration debug log gains a backend tag, matching the format FFM already used.
4. `findDeviceByName` no longer calls `ensureDevicesEnumerated()` — it was a no-op on that path; the enumerated set is only read by `findDevice`, which warms it itself.

No CHANGELOG entry: `deviceId` is internal plumbing between the `GpuStats` base and `NvmlUtil`, never surfaced in the public `GraphicsCard`/`GpuStats` API.

## Testing

New portable `NvmlQueryTest` (10 cases) covers the lifecycle pairing including the exception path, every sentinel path, identifier matching, and the cache's retry-vs-cache semantics — all without an NVML library present. This is the first test coverage this code has had.

Local gate green: spotless, checkstyle, install, forbiddenapis, javadoc, clean full-reactor build, 1385 tests across all modules, and `NativeComparisonTest` 40/40 on an M2 Max.

⚠️ **Coverage caveat:** neither this machine nor the CI runners have an NVIDIA GPU, so the NVML native paths execute only their unavailable branch. That is unchanged from before this PR — the code has never been exercised on real hardware — but it means the refactor's runtime correctness rests on structural equivalence and the new unit tests rather than on execution. Aligning the two backends at least reduces it to one implementation to fix if a bug does surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of NVIDIA GPU lookups and metric reads by ensuring proper initialization/cleanup across success and failure paths.
  - More accurate PCI bus ID matching between legacy and modern formats, including deterministic preference for the canonical form.
  - Reduced repeated NVML discovery retries by caching successful results while still retrying after actual failures.
- **Improvements**
  - Standardized GPU discovery and metrics retrieval behavior across supported runtime modes for utilization, VRAM, temperature, power, clocks, and fan speed.
- **New Features**
  - Exposed shared GPU utility package for modular integrations.
- **Tests**
  - Added unit tests covering shared query logic, matching behavior, cache semantics, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->