### PR TITLE
Hoist the macOS GpuStats session into a common base

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOReportSampler.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOReportSampler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.GpuTicks;
+
+/**
+ * A subscription to the macOS IOReport GPU channels, implemented once per binding.
+ * <p>
+ * The two implementations wrap genuinely different native APIs, so only this shape is shared. It exists so
+ * {@link MacGpuStats} can hold the sampling logic once rather than duplicating it per backend.
+ * <p>
+ * IOReport GPU channels exist only on Apple Silicon, so a sampler is created only there; see
+ * {@link MacGpuStats#MacGpuStats}.
+ */
+@ThreadSafe
+public interface IOReportSampler extends AutoCloseable {
+
+    /**
+     * Samples the GPU busy and idle tick counters.
+     *
+     * @return the ticks since the previous sample
+     */
+    GpuTicks sampleGpuTicks();
+
+    /**
+     * Samples GPU utilization.
+     *
+     * @return utilization as a percentage, or a negative value if it could not be derived
+     */
+    double sampleGpuUtilization();
+
+    /**
+     * Samples GPU power draw.
+     *
+     * @return power in watts, or a negative value if it could not be derived
+     */
+    double samplePowerWatts();
+
+    /**
+     * Releases the subscription. Overridden to drop {@code AutoCloseable}'s checked exception.
+     */
+    @Override
+    void close();
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGpuStats.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.hardware.GpuStats;
+import oshi.hardware.GpuTicks;
+
+/**
+ * Common logic for a macOS {@link GpuStats} session.
+ *
+ * <p>
+ * On Apple Silicon, GPU ticks, utilization, and power are sourced from an {@link IOReportSampler} subscription.
+ * Utilization falls back to IOAccelerator PerformanceStatistics when the subscription fails or returns a negative
+ * value. Temperature is read from the SMC first, then falls back to IOAccelerator {@code Temperature(C)}.
+ *
+ * <p>
+ * On Intel Mac, utilization and VRAM used are sourced from IOAccelerator PerformanceStatistics.
+ *
+ * <p>
+ * Clock speeds, fan speed, and shared memory are not available on any macOS path and always return -1.
+ *
+ * <p>
+ * Only the two native reads differ between the bindings, so subclasses implement {@link #queryPerfStats} and
+ * {@link #queryGpuTemperatureFromSmc} and inherit everything else.
+ */
+@ThreadSafe
+public abstract class MacGpuStats implements GpuStats {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MacGpuStats.class);
+
+    // IOAccelerator PerformanceStatistics keys. Private because subclasses never name a key themselves: this class
+    // decides which to ask for and passes them to queryPerfStats.
+    private static final String GPU_CORE_UTIL_KEY = "GPU Core Utilization";
+    private static final String DEVICE_UTIL_KEY = "Device Utilization %";
+    private static final String VRAM_USED_KEY = "vramUsedBytes";
+    private static final String VRAM_USED_KEY_AS = "In use system memory";
+    private static final String TEMPERATURE_KEY = "Temperature(C)";
+
+    private static final double GPU_UTIL_DIVISOR = 0xFFFFFFFFL;
+
+    /**
+     * Cards whose IOAccelerator statistics have no Temperature(C) key, so the lookup is not repeated. Static because a
+     * GpuStats session is short-lived, and keyed by card because one card lacking the sensor says nothing about another
+     * on the same machine.
+     */
+    private static final Set<String> PERF_STATS_TEMP_ABSENT = ConcurrentHashMap.newKeySet();
+
+    private static final Pattern TRADEMARK_PATTERN = Pattern.compile("[®™]|\\([Rr]\\)|\\([Tt][Mm]\\)");
+
+    private final boolean isAppleSilicon;
+    private final String normCardName;
+    private final Pattern cardNamePattern;
+
+    /** Non-null only on Apple Silicon, where the IOReport GPU channels exist. */
+    private final IOReportSampler sampler;
+
+    private boolean closed;
+
+    /**
+     * Creates a session for one card.
+     *
+     * @param isAppleSilicon whether this machine is Apple Silicon
+     * @param cardName       the card's reported name, matched against IOAccelerator model names
+     * @param samplerFactory creates the IOReport subscription, returning {@code null} if it could not be established.
+     *                       It is consulted only on Apple Silicon: the IOReport GPU channels do not exist on Intel, so
+     *                       subscribing there would attempt a subscription that can never yield a sample.
+     */
+    protected MacGpuStats(boolean isAppleSilicon, String cardName, Supplier<IOReportSampler> samplerFactory) {
+        this.isAppleSilicon = isAppleSilicon;
+        this.normCardName = normalize(cardName);
+        this.cardNamePattern = Pattern.compile("\\b" + Pattern.quote(normCardName) + "\\b");
+        this.sampler = isAppleSilicon ? samplerFactory.get() : null;
+        if (isAppleSilicon && sampler == null) {
+            LOG.warn("IOReport subscription failed for '{}'; GPU ticks and power will be unavailable."
+                    + " Utilization will fall back to IOAccelerator PerformanceStatistics.", cardName);
+        }
+    }
+
+    /**
+     * Reads IOAccelerator PerformanceStatistics values for this card, in a single registry walk.
+     * <p>
+     * Returning {@code null} rather than an empty map when the card's statistics cannot be read at all is load-bearing:
+     * {@link #getTemperature()} latches a card as having no temperature sensor only when the dictionary was present and
+     * the key was absent, never when the dictionary itself was missing, which can be transient.
+     *
+     * @param keys the keys to read
+     * @return the requested keys that were present, or {@code null} if this card's statistics could not be read
+     */
+    protected abstract Map<String, Long> queryPerfStats(String... keys);
+
+    /**
+     * Reads the GPU temperature from the SMC. Called only on Apple Silicon.
+     *
+     * @return the temperature in degrees Celsius, or a value at or below zero if unavailable
+     */
+    protected abstract double queryGpuTemperatureFromSmc();
+
+    /**
+     * Tests whether an IOAccelerator model name refers to this card, ignoring case and trademark symbols.
+     *
+     * @param model the model name read from the registry
+     * @return true if it names this card
+     */
+    protected final boolean matchesName(String model) {
+        if (model == null || model.isEmpty()) {
+            return false;
+        }
+        String normModel = normalize(model);
+        return normModel.equals(normCardName) || cardNamePattern.matcher(normModel).find();
+    }
+
+    private static String normalize(String name) {
+        return TRADEMARK_PATTERN.matcher(name.toLowerCase(Locale.ROOT)).replaceAll("").trim();
+    }
+
+    @Override
+    public synchronized void close() {
+        closed = true;
+        if (sampler != null) {
+            sampler.close();
+        }
+    }
+
+    @Override
+    public synchronized boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public synchronized GpuTicks getGpuTicks() {
+        checkOpen();
+        if (sampler != null) {
+            return sampler.sampleGpuTicks();
+        }
+        return new GpuTicks(0L, 0L);
+    }
+
+    @Override
+    public synchronized double getGpuUtilization() {
+        checkOpen();
+        if (sampler != null) {
+            double util = sampler.sampleGpuUtilization();
+            if (util >= 0) {
+                return util;
+            }
+        }
+        Map<String, Long> stats = queryPerfStats(GPU_CORE_UTIL_KEY, DEVICE_UTIL_KEY);
+        if (stats == null) {
+            return -1d;
+        }
+        Long coreUtil = stats.get(GPU_CORE_UTIL_KEY);
+        if (coreUtil != null) {
+            return coreUtil / GPU_UTIL_DIVISOR * 100.0;
+        }
+        Long deviceUtil = stats.get(DEVICE_UTIL_KEY);
+        return deviceUtil == null ? -1d : deviceUtil;
+    }
+
+    @Override
+    public synchronized long getVramUsed() {
+        checkOpen();
+        // Apple Silicon reports GPU memory as a share of unified system memory, so its key differs from the discrete
+        // VRAM key an Intel Mac reports. Each is tried as the other's fallback.
+        String primaryKey = isAppleSilicon ? VRAM_USED_KEY_AS : VRAM_USED_KEY;
+        String fallbackKey = isAppleSilicon ? VRAM_USED_KEY : VRAM_USED_KEY_AS;
+        Map<String, Long> stats = queryPerfStats(primaryKey, fallbackKey);
+        if (stats == null) {
+            return -1L;
+        }
+        Long used = stats.get(primaryKey);
+        if (used == null) {
+            used = stats.get(fallbackKey);
+        }
+        return used == null ? -1L : used;
+    }
+
+    @Override
+    public synchronized long getSharedMemoryUsed() {
+        checkOpen();
+        return -1L;
+    }
+
+    @Override
+    public synchronized double getTemperature() {
+        checkOpen();
+        if (isAppleSilicon) {
+            double temp = queryGpuTemperatureFromSmc();
+            if (temp > 0) {
+                return temp;
+            }
+        }
+        // IOAccelerator statistics, not the SMC: a different sensor that is not power-gated with the GPU cluster, so
+        // the SMC plausibility floor deliberately does not apply here. Unavailable is -1, not 0. This key does not
+        // exist on Apple Silicon, so it is tried once per card and then latched off rather than repeating an IOKit
+        // registry walk on every call. Latch only on structural absence, not on a low reading.
+        if (PERF_STATS_TEMP_ABSENT.contains(normCardName)) {
+            return -1d;
+        }
+        Map<String, Long> stats = queryPerfStats(TEMPERATURE_KEY);
+        if (stats == null) {
+            // Not latched: a missing accelerator entry can be transient (driver reset, eGPU unplugged), unlike a
+            // dictionary that is present but has no temperature key.
+            return -1d;
+        }
+        Long temp = stats.get(TEMPERATURE_KEY);
+        if (temp == null) {
+            LOG.debug("No Temperature(C) in IOAccelerator statistics for {}; not retrying.", normCardName);
+            PERF_STATS_TEMP_ABSENT.add(normCardName);
+            return -1d;
+        }
+        return temp > 0 ? temp : -1d;
+    }
+
+    @Override
+    public synchronized double getPowerDraw() {
+        checkOpen();
+        if (sampler != null) {
+            return sampler.samplePowerWatts();
+        }
+        return -1d;
+    }
+
+    @Override
+    public synchronized long getCoreClockMhz() {
+        checkOpen();
+        return -1L;
+    }
+
+    @Override
+    public synchronized long getMemoryClockMhz() {
+        checkOpen();
+        return -1L;
+    }
+
+    @Override
+    public synchronized double getFanSpeedPercent() {
+        checkOpen();
+        return -1d;
+    }
+
+    private void checkOpen() {
+        if (closed) {
+            throw new IllegalStateException(
+                    "GpuStats session has been closed. Obtain a new session via GraphicsCard.createStatsSession().");
+        }
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGpuStatsTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.GpuTicks;
+
+/**
+ * Tests the shared macOS GpuStats logic without a Mac, by stubbing the two native hooks. This is why the logic lives
+ * here rather than in the bindings, whose CoreFoundation and SMC calls cannot run in a unit test.
+ */
+public class MacGpuStatsTest {
+
+    private static final String CORE_UTIL = "GPU Core Utilization";
+    private static final String DEVICE_UTIL = "Device Utilization %";
+    private static final String VRAM_INTEL = "vramUsedBytes";
+    private static final String VRAM_APPLE = "In use system memory";
+    private static final String TEMPERATURE = "Temperature(C)";
+
+    /** Records whether a sampler was requested, and hands out a fixed one. */
+    private static final class RecordingFactory implements Supplier<IOReportSampler> {
+        private final IOReportSampler sampler;
+        private int calls;
+
+        RecordingFactory(IOReportSampler sampler) {
+            this.sampler = sampler;
+        }
+
+        @Override
+        public IOReportSampler get() {
+            calls++;
+            return sampler;
+        }
+    }
+
+    /** A sampler returning fixed values and recording that it was closed. */
+    private static final class FakeSampler implements IOReportSampler {
+        private final double utilization;
+        private final double watts;
+        private boolean closed;
+
+        FakeSampler(double utilization, double watts) {
+            this.utilization = utilization;
+            this.watts = watts;
+        }
+
+        @Override
+        public GpuTicks sampleGpuTicks() {
+            return new GpuTicks(7L, 3L);
+        }
+
+        @Override
+        public double sampleGpuUtilization() {
+            return utilization;
+        }
+
+        @Override
+        public double samplePowerWatts() {
+            return watts;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    /** Serves canned PerformanceStatistics, with null meaning the dictionary itself could not be read. */
+    private static final class StubGpuStats extends MacGpuStats {
+        private final Map<String, Long> stats;
+        private final double smcTemp;
+        private int perfStatQueries;
+
+        StubGpuStats(boolean isAppleSilicon, String cardName, Supplier<IOReportSampler> samplerFactory,
+                Map<String, Long> stats, double smcTemp) {
+            super(isAppleSilicon, cardName, samplerFactory);
+            this.stats = stats;
+            this.smcTemp = smcTemp;
+        }
+
+        @Override
+        protected Map<String, Long> queryPerfStats(String... keys) {
+            perfStatQueries++;
+            if (stats == null) {
+                return null;
+            }
+            Map<String, Long> requested = new HashMap<>();
+            for (String key : keys) {
+                if (stats.containsKey(key)) {
+                    requested.put(key, stats.get(key));
+                }
+            }
+            return requested;
+        }
+
+        @Override
+        protected double queryGpuTemperatureFromSmc() {
+            return smcTemp;
+        }
+    }
+
+    private static Map<String, Long> stats(Object... keyValues) {
+        Map<String, Long> map = new HashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            map.put((String) keyValues[i], (Long) keyValues[i + 1]);
+        }
+        return map;
+    }
+
+    @Test
+    void testIntelDoesNotSubscribeToIoReport() {
+        // The IOReport GPU channels exist only on Apple Silicon, so no subscription is attempted on Intel.
+        RecordingFactory factory = new RecordingFactory(new FakeSampler(50d, 12d));
+        StubGpuStats intel = new StubGpuStats(false, "intel card", factory, stats(), -1d);
+        assertThat("no sampler is created on Intel", factory.calls, is(0));
+        // GpuTicks has no equals(), so compare the components.
+        assertThat("active ticks fall back to zero without a sampler", intel.getGpuTicks().getActiveTicks(), is(0L));
+        assertThat("idle ticks fall back to zero without a sampler", intel.getGpuTicks().getIdleTicks(), is(0L));
+        assertThat("power is unavailable without a sampler", intel.getPowerDraw(), is(-1d));
+    }
+
+    @Test
+    void testAppleSiliconSubscribesAndSamples() {
+        RecordingFactory factory = new RecordingFactory(new FakeSampler(42d, 12.5d));
+        StubGpuStats apple = new StubGpuStats(true, "apple card", factory, stats(), -1d);
+        assertThat("a sampler is created on Apple Silicon", factory.calls, is(1));
+        assertThat("active ticks come from the sampler", apple.getGpuTicks().getActiveTicks(), is(7L));
+        assertThat("idle ticks come from the sampler", apple.getGpuTicks().getIdleTicks(), is(3L));
+        assertThat("utilization comes from the sampler", apple.getGpuUtilization(), is(42d));
+        assertThat("power comes from the sampler", apple.getPowerDraw(), is(12.5d));
+    }
+
+    @Test
+    void testUtilizationFallsBackWhenTheSamplerReturnsNegative() {
+        RecordingFactory factory = new RecordingFactory(new FakeSampler(-1d, 5d));
+        StubGpuStats apple = new StubGpuStats(true, "fallback card", factory, stats(CORE_UTIL, 0xFFFFFFFFL / 2), -1d);
+        assertThat("core utilization is scaled against the residency divisor", apple.getGpuUtilization(),
+                is(closeTo(50d, 0.001d)));
+    }
+
+    @Test
+    void testUtilizationPrefersCoreThenDeviceThenSentinel() {
+        StubGpuStats withBoth = new StubGpuStats(false, "both card", nullFactory(),
+                stats(CORE_UTIL, 0xFFFFFFFFL, DEVICE_UTIL, 17L), -1d);
+        assertThat("core utilization wins", withBoth.getGpuUtilization(), is(closeTo(100d, 0.001d)));
+
+        StubGpuStats deviceOnly = new StubGpuStats(false, "device card", nullFactory(), stats(DEVICE_UTIL, 17L), -1d);
+        assertThat("device utilization is used unscaled", deviceOnly.getGpuUtilization(), is(17d));
+
+        StubGpuStats neither = new StubGpuStats(false, "neither card", nullFactory(), stats(), -1d);
+        assertThat("no key yields the sentinel", neither.getGpuUtilization(), is(-1d));
+
+        StubGpuStats unreadable = new StubGpuStats(false, "unreadable card", nullFactory(), null, -1d);
+        assertThat("an unreadable dictionary yields the sentinel", unreadable.getGpuUtilization(), is(-1d));
+    }
+
+    @Test
+    void testVramKeySelectionDiffersByArchitecture() {
+        // Apple Silicon reports GPU memory as a share of unified memory under a different key than discrete VRAM.
+        Map<String, Long> both = stats(VRAM_INTEL, 100L, VRAM_APPLE, 200L);
+        assertThat("Apple Silicon prefers the unified memory key",
+                new StubGpuStats(true, "vram a", nullFactory(), both, -1d).getVramUsed(), is(200L));
+        assertThat("Intel prefers the discrete VRAM key",
+                new StubGpuStats(false, "vram b", nullFactory(), both, -1d).getVramUsed(), is(100L));
+
+        // Each key is the other's fallback.
+        assertThat("Apple Silicon falls back to the discrete key",
+                new StubGpuStats(true, "vram c", nullFactory(), stats(VRAM_INTEL, 100L), -1d).getVramUsed(), is(100L));
+        assertThat("Intel falls back to the unified key",
+                new StubGpuStats(false, "vram d", nullFactory(), stats(VRAM_APPLE, 200L), -1d).getVramUsed(), is(200L));
+        assertThat("neither key yields the sentinel",
+                new StubGpuStats(false, "vram e", nullFactory(), stats(), -1d).getVramUsed(), is(-1L));
+    }
+
+    @Test
+    void testTemperaturePrefersSmcOnAppleSilicon() {
+        StubGpuStats apple = new StubGpuStats(true, "smc card", nullFactory(), stats(TEMPERATURE, 55L), 61.5d);
+        assertThat("a plausible SMC reading wins", apple.getTemperature(), is(61.5d));
+        assertThat("the accelerator was not consulted", apple.perfStatQueries, is(0));
+
+        StubGpuStats noSmc = new StubGpuStats(true, "no smc card", nullFactory(), stats(TEMPERATURE, 55L), 0d);
+        assertThat("an unavailable SMC reading falls through", noSmc.getTemperature(), is(55d));
+    }
+
+    @Test
+    void testTemperatureLatchesOnlyOnAMissingKey() {
+        // A dictionary present but lacking the key means this card has no such sensor: latch it off.
+        StubGpuStats missingKey = new StubGpuStats(false, "latch card", nullFactory(), stats(), -1d);
+        assertThat("missing key yields the sentinel", missingKey.getTemperature(), is(-1d));
+        assertThat("the first call queried", missingKey.perfStatQueries, is(1));
+        assertThat("still the sentinel", missingKey.getTemperature(), is(-1d));
+        assertThat("the lookup is not repeated once latched", missingKey.perfStatQueries, is(1));
+    }
+
+    @Test
+    void testTemperatureDoesNotLatchOnAnUnreadableDictionary() {
+        // A missing accelerator entry can be transient (driver reset, eGPU unplugged), so it must stay retryable.
+        StubGpuStats unreadable = new StubGpuStats(false, "transient card", nullFactory(), null, -1d);
+        assertThat("unreadable yields the sentinel", unreadable.getTemperature(), is(-1d));
+        assertThat("unreadable still yields the sentinel", unreadable.getTemperature(), is(-1d));
+        assertThat("the lookup is retried", unreadable.perfStatQueries, is(2));
+    }
+
+    @Test
+    void testUnsupportedMetricsReturnSentinels() {
+        StubGpuStats gpu = new StubGpuStats(true, "sentinel card", nullFactory(), stats(), -1d);
+        assertThat("clock is unavailable on macOS", gpu.getCoreClockMhz(), is(-1L));
+        assertThat("memory clock is unavailable on macOS", gpu.getMemoryClockMhz(), is(-1L));
+        assertThat("fan speed is unavailable on macOS", gpu.getFanSpeedPercent(), is(-1d));
+        assertThat("shared memory is unavailable on macOS", gpu.getSharedMemoryUsed(), is(-1L));
+    }
+
+    @Test
+    void testCloseReleasesTheSamplerAndBlocksFurtherReads() {
+        FakeSampler sampler = new FakeSampler(10d, 1d);
+        StubGpuStats gpu = new StubGpuStats(true, "close card", new RecordingFactory(sampler), stats(), -1d);
+        assertThat("open to begin with", gpu.isClosed(), is(false));
+        gpu.close();
+        assertThat("closed after close", gpu.isClosed(), is(true));
+        assertThat("the sampler was released", sampler.closed, is(true));
+        try {
+            gpu.getGpuUtilization();
+            throw new AssertionError("reading a closed session should throw");
+        } catch (IllegalStateException expected) {
+            // Every metric guards on the closed flag.
+        }
+    }
+
+    @Test
+    void testMatchesNameIgnoresCaseAndTrademarks() {
+        StubGpuStats gpu = new StubGpuStats(false, "Radeon Pro 5500M", nullFactory(), stats(), -1d);
+        assertThat("exact match", gpu.matchesName("radeon pro 5500m"), is(true));
+        assertThat("case is ignored", gpu.matchesName("RADEON PRO 5500M"), is(true));
+        assertThat("trademark symbols are stripped", gpu.matchesName("Radeon™ Pro 5500M"), is(true));
+        assertThat("a containing name matches on a word boundary", gpu.matchesName("AMD Radeon Pro 5500M GPU"),
+                is(true));
+        assertThat("a different card does not match", gpu.matchesName("Radeon Pro 5300M"), is(false));
+        assertThat("null does not match", gpu.matchesName(null), is(false));
+        assertThat("empty does not match", gpu.matchesName(""), is(false));
+    }
+
+    private static Supplier<IOReportSampler> nullFactory() {
+        return () -> null;
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGpuStatsTest.java
@@ -7,6 +7,7 @@ package oshi.hardware.common.platform.mac;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -229,12 +230,8 @@ public class MacGpuStatsTest {
         gpu.close();
         assertThat("closed after close", gpu.isClosed(), is(true));
         assertThat("the sampler was released", sampler.closed, is(true));
-        try {
-            gpu.getGpuUtilization();
-            throw new AssertionError("reading a closed session should throw");
-        } catch (IllegalStateException expected) {
-            // Every metric guards on the closed flag.
-        }
+        // Every metric guards on the closed flag.
+        assertThrows(IllegalStateException.class, gpu::getGpuUtilization, "reading a closed session should throw");
     }
 
     @Test

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
@@ -25,6 +25,7 @@ import oshi.ffm.platform.mac.CoreFoundation.CFStringRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFTypeRef;
 import oshi.ffm.platform.mac.IOReportFunctions;
 import oshi.hardware.GpuTicks;
+import oshi.hardware.common.platform.mac.IOReportSampler;
 
 /**
  * FFM equivalent of {@code IOReportClient}: manages a single IOReport subscription for GPU Stats and Energy Model
@@ -36,7 +37,7 @@ import oshi.hardware.GpuTicks;
  * <p>
  * Call {@link #close()} when done to release all CoreFoundation references.
  */
-public final class IOReportClientFFM {
+public final class IOReportClientFFM implements IOReportSampler {
 
     private static final Logger LOG = LoggerFactory.getLogger(IOReportClientFFM.class);
 
@@ -110,6 +111,7 @@ public final class IOReportClientFFM {
      *
      * @return GpuTicks snapshot; never null
      */
+    @Override
     public synchronized GpuTicks sampleGpuTicks() {
         if (closed) {
             return new GpuTicks(0L, 0L);
@@ -138,6 +140,7 @@ public final class IOReportClientFFM {
      *
      * @return GPU utilization percentage, or -1.0
      */
+    @Override
     public synchronized double sampleGpuUtilization() {
         if (closed) {
             return -1d;
@@ -186,6 +189,7 @@ public final class IOReportClientFFM {
      *
      * @return GPU power in watts, or -1.0
      */
+    @Override
     public synchronized double samplePowerWatts() {
         if (closed) {
             return -1d;
@@ -238,6 +242,7 @@ public final class IOReportClientFFM {
     /**
      * Releases all CoreFoundation references held by this client. Idempotent.
      */
+    @Override
     public synchronized void close() {
         if (closed) {
             return;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -5,13 +5,8 @@
 package oshi.hardware.platform.mac;
 
 import java.lang.foreign.MemorySegment;
-import java.util.Locale;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.HashMap;
+import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.mac.IOReportClientFFM;
@@ -24,227 +19,62 @@ import oshi.ffm.platform.mac.IOKit.IOIterator;
 import oshi.ffm.platform.mac.IOKit.IORegistryEntry;
 import oshi.ffm.util.platform.mac.IOKitUtilFFM;
 import oshi.ffm.util.platform.mac.SmcUtilFFM;
-import oshi.hardware.GpuStats;
-import oshi.hardware.GpuTicks;
+import oshi.hardware.common.platform.mac.MacGpuStats;
 
 /**
- * macOS {@link GpuStats} session using FFM.
- *
- * <p>
- * On Apple Silicon, GPU ticks, utilization, and power via IOReport are not yet available in the FFM path; utilization
- * falls back to IOAccelerator PerformanceStatistics. Temperature is read from SMC first, then falls back to
- * IOAccelerator {@code Temperature(C)}.
- *
- * <p>
- * On Intel Mac, utilization and VRAM used are sourced from IOAccelerator PerformanceStatistics.
- *
- * <p>
- * Clock speeds, fan speed, and shared memory are not available on any macOS path and always return -1.
+ * macOS {@link oshi.hardware.GpuStats} session using FFM. All sampling logic lives in {@link MacGpuStats}; this class
+ * supplies only the two native reads.
  */
 @ThreadSafe
-final class MacGpuStatsFFM implements GpuStats {
+final class MacGpuStatsFFM extends MacGpuStats {
 
     private static final String PERF_STATS_KEY = "PerformanceStatistics";
-    private static final String GPU_CORE_UTIL_KEY = "GPU Core Utilization";
-    private static final String DEVICE_UTIL_KEY = "Device Utilization %";
-    private static final String VRAM_USED_KEY = "vramUsedBytes";
-    private static final String VRAM_USED_KEY_AS = "In use system memory";
-    private static final Logger LOG = LoggerFactory.getLogger(MacGpuStatsFFM.class);
-
-    private static final double GPU_UTIL_DIVISOR = 0xFFFFFFFFL;
-
-    /**
-     * Cards whose IOAccelerator statistics have no Temperature(C) key, so the lookup is not repeated. Static because a
-     * GpuStats session is short-lived, and keyed by card because one card lacking the sensor says nothing about another
-     * on the same machine.
-     */
-    private static final Set<String> PERF_STATS_TEMP_ABSENT = ConcurrentHashMap.newKeySet();
-    private static final Pattern TRADEMARK_PATTERN = Pattern.compile("[®™]|\\([Rr]\\)|\\([Tt][Mm]\\)");
-
-    private final boolean isAppleSilicon;
-    private final IOReportClientFFM ioReportClient;
-    private final String normCardName;
-    private final Pattern cardNamePattern;
-
-    private boolean closed;
 
     MacGpuStatsFFM(boolean isAppleSilicon, String cardName) {
-        this.isAppleSilicon = isAppleSilicon;
-        this.ioReportClient = IOReportClientFFM.create();
-        this.normCardName = TRADEMARK_PATTERN.matcher(cardName.toLowerCase(Locale.ROOT)).replaceAll("").trim();
-        this.cardNamePattern = Pattern.compile("\\b" + Pattern.quote(normCardName) + "\\b");
+        super(isAppleSilicon, cardName, IOReportClientFFM::create);
     }
 
     @Override
-    public synchronized void close() {
-        closed = true;
-        if (ioReportClient != null) {
-            ioReportClient.close();
-        }
-    }
-
-    @Override
-    public synchronized boolean isClosed() {
-        return closed;
-    }
-
-    @Override
-    public synchronized GpuTicks getGpuTicks() {
-        checkOpen();
-        if (ioReportClient != null) {
-            return ioReportClient.sampleGpuTicks();
-        }
-        return new GpuTicks(0L, 0L);
-    }
-
-    @Override
-    public synchronized double getGpuUtilization() {
-        checkOpen();
-        if (ioReportClient != null) {
-            double util = ioReportClient.sampleGpuUtilization();
-            if (util >= 0) {
-                return util;
-            }
-        }
-        CFMutableDictionaryRef perfStats = queryPerfStats();
+    protected Map<String, Long> queryPerfStats(String... keys) {
+        CFMutableDictionaryRef perfStats = openPerfStats();
         if (perfStats == null) {
-            return -1d;
+            return null; // NOSONAR squid:S1168 - null and empty are different answers; see the superclass javadoc
         }
         try (perfStats) {
-            CFStringRef coreUtilKey = CFStringRef.createCFString(GPU_CORE_UTIL_KEY);
-            try (coreUtilKey) {
-                MemorySegment result = perfStats.getValue(coreUtilKey);
-                if (!result.equals(MemorySegment.NULL)) {
-                    return CFNumberRef.longValue(result) / GPU_UTIL_DIVISOR * 100.0;
-                }
-            }
-            CFStringRef devUtilKey = CFStringRef.createCFString(DEVICE_UTIL_KEY);
-            try (devUtilKey) {
-                MemorySegment result = perfStats.getValue(devUtilKey);
-                if (!result.equals(MemorySegment.NULL)) {
-                    return CFNumberRef.longValue(result);
-                }
-            }
-        }
-        return -1d;
-    }
-
-    @Override
-    public synchronized long getVramUsed() {
-        checkOpen();
-        CFMutableDictionaryRef perfStats = queryPerfStats();
-        if (perfStats == null) {
-            return -1L;
-        }
-        try (perfStats) {
-            String primaryKey = isAppleSilicon ? VRAM_USED_KEY_AS : VRAM_USED_KEY;
-            String fallbackKey = isAppleSilicon ? VRAM_USED_KEY : VRAM_USED_KEY_AS;
-            CFStringRef key = CFStringRef.createCFString(primaryKey);
-            try (key) {
-                MemorySegment result = perfStats.getValue(key);
-                if (!result.equals(MemorySegment.NULL)) {
-                    return CFNumberRef.longValue(result);
-                }
-            }
-            CFStringRef fallback = CFStringRef.createCFString(fallbackKey);
-            try (fallback) {
-                MemorySegment result = perfStats.getValue(fallback);
-                if (!result.equals(MemorySegment.NULL)) {
-                    return CFNumberRef.longValue(result);
-                }
-            }
-        }
-        return -1L;
-    }
-
-    @Override
-    public synchronized long getSharedMemoryUsed() {
-        checkOpen();
-        return -1L;
-    }
-
-    @Override
-    public synchronized double getTemperature() {
-        checkOpen();
-        if (isAppleSilicon) {
-            int conn = SmcUtilFFM.smcOpen();
-            if (conn != 0) {
-                try {
-                    double temp = SmcUtilFFM.smcGetMaxTemperature(conn, SmcUtilFFM.getGpuTemperatureKeys());
-                    if (temp > 0) {
-                        return temp;
+            Map<String, Long> values = new HashMap<>();
+            for (String key : keys) {
+                CFStringRef cfKey = CFStringRef.createCFString(key);
+                try (cfKey) {
+                    MemorySegment result = perfStats.getValue(cfKey);
+                    if (!result.equals(MemorySegment.NULL)) {
+                        values.put(key, CFNumberRef.longValue(result));
                     }
-                } finally {
-                    SmcUtilFFM.smcClose(conn);
                 }
             }
+            return values;
         }
-        // IOAccelerator statistics, not the SMC: a different sensor that is not power-gated with the GPU
-        // cluster, so the SMC plausibility floor deliberately does not apply here. Unavailable is -1, not 0.
-        // This key does not exist on Apple Silicon, so it is tried once per card and then latched off rather than
-        // repeating an IOKit registry walk on every call. Latch only on structural absence, not on a low reading.
-        if (PERF_STATS_TEMP_ABSENT.contains(normCardName)) {
+    }
+
+    @Override
+    protected double queryGpuTemperatureFromSmc() {
+        int conn = SmcUtilFFM.smcOpen();
+        if (conn == 0) {
             return -1d;
         }
-        CFMutableDictionaryRef perfStats = queryPerfStats();
-        if (perfStats == null) {
-            // Not latched: a missing accelerator entry can be transient (driver reset, eGPU unplugged), unlike a
-            // dictionary that is present but has no temperature key.
-            return -1d;
-        }
-        try (perfStats) {
-            CFStringRef tempKey = CFStringRef.createCFString("Temperature(C)");
-            try (tempKey) {
-                MemorySegment result = perfStats.getValue(tempKey);
-                if (result.equals(MemorySegment.NULL)) {
-                    LOG.debug("No Temperature(C) in IOAccelerator statistics for {}; not retrying.", normCardName);
-                    PERF_STATS_TEMP_ABSENT.add(normCardName);
-                    return -1d;
-                }
-                long val = CFNumberRef.longValue(result);
-                if (val > 0) {
-                    return val;
-                }
-            }
-        }
-        return -1d;
-    }
-
-    @Override
-    public synchronized double getPowerDraw() {
-        checkOpen();
-        if (ioReportClient != null) {
-            return ioReportClient.samplePowerWatts();
-        }
-        return -1d;
-    }
-
-    @Override
-    public synchronized long getCoreClockMhz() {
-        checkOpen();
-        return -1L;
-    }
-
-    @Override
-    public synchronized long getMemoryClockMhz() {
-        checkOpen();
-        return -1L;
-    }
-
-    @Override
-    public synchronized double getFanSpeedPercent() {
-        checkOpen();
-        return -1d;
-    }
-
-    private void checkOpen() {
-        if (closed) {
-            throw new IllegalStateException(
-                    "GpuStats session has been closed. Obtain a new session via GraphicsCard.createStatsSession().");
+        try {
+            return SmcUtilFFM.smcGetMaxTemperature(conn, SmcUtilFFM.getGpuTemperatureKeys());
+        } finally {
+            SmcUtilFFM.smcClose(conn);
         }
     }
 
-    private CFMutableDictionaryRef queryPerfStats() {
+    /**
+     * Walks the IOAccelerator registry for this card's PerformanceStatistics dictionary.
+     *
+     * @return the retained dictionary, which the caller must close, or {@code null} if this card has no accelerator
+     *         entry
+     */
+    private CFMutableDictionaryRef openPerfStats() {
         IOIterator iter = IOKitUtilFFM.getMatchingServices("IOAccelerator");
         if (iter == null) {
             return null;
@@ -261,18 +91,16 @@ final class MacGpuStatsFFM implements GpuStats {
                         CFDictionaryRef props = new CFDictionaryRef(propsSeg);
                         try (props) {
                             MemorySegment modelSeg = props.getValue(modelKey);
-                            if (!modelSeg.equals(MemorySegment.NULL)) {
-                                String model = CFStringRef.stringValue(modelSeg);
-                                if (matchesName(model)) {
-                                    MemorySegment statsSeg = props.getValue(perfStatsKey);
-                                    if (!statsSeg.equals(MemorySegment.NULL)) {
-                                        try {
-                                            CoreFoundationFunctions.CFRetain(statsSeg);
-                                        } catch (Throwable _) {
-                                            // CFRetain declares throws Throwable; swallow to keep flow clean
-                                        }
-                                        result = new CFMutableDictionaryRef(statsSeg);
+                            if (!modelSeg.equals(MemorySegment.NULL)
+                                    && matchesName(CFStringRef.stringValue(modelSeg))) {
+                                MemorySegment statsSeg = props.getValue(perfStatsKey);
+                                if (!statsSeg.equals(MemorySegment.NULL)) {
+                                    try {
+                                        CoreFoundationFunctions.CFRetain(statsSeg);
+                                    } catch (Throwable _) {
+                                        // CFRetain declares throws Throwable; swallow to keep flow clean
                                     }
+                                    result = new CFMutableDictionaryRef(statsSeg);
                                 }
                             }
                         }
@@ -285,16 +113,5 @@ final class MacGpuStatsFFM implements GpuStats {
             }
         }
         return null;
-    }
-
-    private boolean matchesName(String model) {
-        if (model == null || model.isEmpty()) {
-            return false;
-        }
-        String normModel = TRADEMARK_PATTERN.matcher(model.toLowerCase(Locale.ROOT)).replaceAll("").trim();
-        if (normModel.equals(normCardName)) {
-            return true;
-        }
-        return cardNamePattern.matcher(normModel).find();
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -8,6 +8,9 @@ import java.lang.foreign.MemorySegment;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.mac.IOReportClientFFM;
 import oshi.ffm.platform.mac.CoreFoundation.CFDictionaryRef;
@@ -27,6 +30,8 @@ import oshi.hardware.common.platform.mac.MacGpuStats;
  */
 @ThreadSafe
 final class MacGpuStatsFFM extends MacGpuStats {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MacGpuStatsFFM.class);
 
     private static final String PERF_STATS_KEY = "PerformanceStatistics";
 
@@ -95,12 +100,17 @@ final class MacGpuStatsFFM extends MacGpuStats {
                                     && matchesName(CFStringRef.stringValue(modelSeg))) {
                                 MemorySegment statsSeg = props.getValue(perfStatsKey);
                                 if (!statsSeg.equals(MemorySegment.NULL)) {
+                                    // getValue follows the CoreFoundation Get rule, so this dictionary belongs to
+                                    // props; retain it to outlive props.close(). The wrapper is built only once the
+                                    // retain succeeds, because the caller releases whatever it receives and releasing
+                                    // a reference that was never taken would over-release the dictionary.
                                     try {
                                         CoreFoundationFunctions.CFRetain(statsSeg);
+                                        result = new CFMutableDictionaryRef(statsSeg);
                                     } catch (Throwable _) {
-                                        // CFRetain declares throws Throwable; swallow to keep flow clean
+                                        LOG.debug("CFRetain failed for {} statistics; skipping this entry.",
+                                                PERF_STATS_KEY);
                                     }
-                                    result = new CFMutableDictionaryRef(statsSeg);
                                 }
                             }
                         }

--- a/oshi-core/src/main/java/oshi/driver/mac/IOReportClient.java
+++ b/oshi-core/src/main/java/oshi/driver/mac/IOReportClient.java
@@ -10,12 +10,13 @@ import java.util.Map;
 
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
-import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.platform.mac.CoreFoundation.CFArrayRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFDictionaryRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFStringRef;
+import com.sun.jna.ptr.PointerByReference;
 
 import oshi.hardware.GpuTicks;
+import oshi.hardware.common.platform.mac.IOReportSampler;
 import oshi.jna.platform.mac.IOReport;
 import oshi.jna.platform.mac.IOReport.IOReportSubscriptionRef;
 
@@ -31,7 +32,7 @@ import oshi.jna.platform.mac.IOReport.IOReportSubscriptionRef;
  * Call {@link #close()} when done to release all CoreFoundation references. After {@code close()}, all sampling methods
  * return sentinel values.
  */
-public final class IOReportClient {
+public final class IOReportClient implements IOReportSampler {
 
     private static final String GROUP_GPU_STATS = "GPU Stats";
     private static final String GROUP_ENERGY = "Energy Model";
@@ -118,6 +119,7 @@ public final class IOReportClient {
      *
      * @return GpuTicks snapshot; never null
      */
+    @Override
     public synchronized GpuTicks sampleGpuTicks() {
         if (closed) {
             return new GpuTicks(0L, 0L);
@@ -154,6 +156,7 @@ public final class IOReportClient {
      *
      * @return GPU utilization percentage, or -1.0
      */
+    @Override
     public synchronized double sampleGpuUtilization() {
         if (closed) {
             return -1d;
@@ -202,6 +205,7 @@ public final class IOReportClient {
      *
      * @return GPU power in watts, or -1.0
      */
+    @Override
     public synchronized double samplePowerWatts() {
         if (closed) {
             return -1d;
@@ -255,6 +259,7 @@ public final class IOReportClient {
     /**
      * Releases all CoreFoundation references held by this client. Idempotent.
      */
+    @Override
     public synchronized void close() {
         if (closed) {
             return;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
@@ -4,13 +4,8 @@
  */
 package oshi.hardware.platform.mac;
 
-import java.util.Locale;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.mac.CoreFoundation;
@@ -24,236 +19,66 @@ import com.sun.jna.platform.mac.IOKitUtil;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.mac.IOReportClient;
-import oshi.hardware.GpuStats;
-import oshi.hardware.GpuTicks;
+import oshi.hardware.common.platform.mac.MacGpuStats;
 import oshi.util.platform.mac.SmcUtil;
 
 /**
- * macOS {@link GpuStats} session.
- *
- * <p>
- * On Apple Silicon, GPU ticks, utilization, and power are sourced from an {@link IOReportClient} subscription.
- * Utilization falls back to IOAccelerator PerformanceStatistics when the IOReport subscription fails or returns -1.
- * Temperature is read from SMC first, then falls back to IOAccelerator {@code Temperature(C)}.
- *
- * <p>
- * On Intel Mac, utilization and VRAM used are sourced from IOAccelerator PerformanceStatistics.
- *
- * <p>
- * Clock speeds, fan speed, and shared memory are not available on any macOS path and always return -1.
+ * macOS {@link oshi.hardware.GpuStats} session. All sampling logic lives in {@link MacGpuStats}; this class supplies
+ * only the two native reads.
  */
 @ThreadSafe
-final class MacGpuStatsJNA implements GpuStats {
+final class MacGpuStatsJNA extends MacGpuStats {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MacGpuStatsJNA.class);
     private static final CoreFoundation CF = CoreFoundation.INSTANCE;
 
     private static final String PERF_STATS_KEY = "PerformanceStatistics";
-    private static final String GPU_CORE_UTIL_KEY = "GPU Core Utilization";
-    private static final String DEVICE_UTIL_KEY = "Device Utilization %";
-    private static final String VRAM_USED_KEY = "vramUsedBytes";
-    private static final String VRAM_USED_KEY_AS = "In use system memory";
-    private static final double GPU_UTIL_DIVISOR = 0xFFFFFFFFL;
-
-    /**
-     * Cards whose IOAccelerator statistics have no Temperature(C) key, so the lookup is not repeated. Static because a
-     * GpuStats session is short-lived, and keyed by card because one card lacking the sensor says nothing about another
-     * on the same machine.
-     */
-    private static final Set<String> PERF_STATS_TEMP_ABSENT = ConcurrentHashMap.newKeySet();
-    private static final Pattern TRADEMARK_PATTERN = Pattern.compile("[®™]|\\([Rr]\\)|\\([Tt][Mm]\\)");
-
-    private final boolean isAppleSilicon;
-    private final String normCardName;
-    private final Pattern cardNamePattern;
-
-    // Non-null only on Apple Silicon
-    private final IOReportClient ioReportClient;
-
-    private boolean closed;
 
     MacGpuStatsJNA(boolean isAppleSilicon, String cardName) {
-        this.isAppleSilicon = isAppleSilicon;
-        this.normCardName = TRADEMARK_PATTERN.matcher(cardName.toLowerCase(Locale.ROOT)).replaceAll("").trim();
-        this.cardNamePattern = Pattern.compile("\\b" + Pattern.quote(normCardName) + "\\b");
-        this.ioReportClient = isAppleSilicon ? IOReportClient.create() : null;
-        if (isAppleSilicon && ioReportClient == null) {
-            LOG.warn("IOReport subscription failed for '{}'; GPU ticks and power will be unavailable."
-                    + " Utilization will fall back to IOAccelerator PerformanceStatistics.", cardName);
-        }
+        super(isAppleSilicon, cardName, IOReportClient::create);
     }
 
     @Override
-    public synchronized void close() {
-        closed = true;
-        if (ioReportClient != null) {
-            ioReportClient.close();
-        }
-    }
-
-    @Override
-    public synchronized boolean isClosed() {
-        return closed;
-    }
-
-    @Override
-    public synchronized GpuTicks getGpuTicks() {
-        checkOpen();
-        if (isAppleSilicon && ioReportClient != null) {
-            return ioReportClient.sampleGpuTicks();
-        }
-        return new GpuTicks(0L, 0L);
-    }
-
-    @Override
-    public synchronized double getGpuUtilization() {
-        checkOpen();
-        if (isAppleSilicon && ioReportClient != null) {
-            double util = ioReportClient.sampleGpuUtilization();
-            if (util >= 0) {
-                return util;
-            }
-        }
-        CFMutableDictionaryRef perfStats = queryPerfStats();
+    protected Map<String, Long> queryPerfStats(String... keys) {
+        CFMutableDictionaryRef perfStats = openPerfStats();
         if (perfStats == null) {
-            return -1d;
+            return null; // NOSONAR squid:S1168 - null and empty are different answers; see the superclass javadoc
         }
         try {
-            CFStringRef coreUtilKey = CFStringRef.createCFString(GPU_CORE_UTIL_KEY);
-            Pointer result = perfStats.getValue(coreUtilKey);
-            coreUtilKey.release();
-            if (result != null) {
-                return new CFNumberRef(result).longValue() / GPU_UTIL_DIVISOR * 100.0;
-            }
-            CFStringRef devUtilKey = CFStringRef.createCFString(DEVICE_UTIL_KEY);
-            result = perfStats.getValue(devUtilKey);
-            devUtilKey.release();
-            if (result != null) {
-                return new CFNumberRef(result).longValue();
-            }
-        } finally {
-            perfStats.release();
-        }
-        return -1d;
-    }
-
-    @Override
-    public synchronized long getVramUsed() {
-        checkOpen();
-        CFMutableDictionaryRef perfStats = queryPerfStats();
-        if (perfStats == null) {
-            return -1L;
-        }
-        try {
-            String primaryKey = isAppleSilicon ? VRAM_USED_KEY_AS : VRAM_USED_KEY;
-            String fallbackKey = isAppleSilicon ? VRAM_USED_KEY : VRAM_USED_KEY_AS;
-            CFStringRef key = CFStringRef.createCFString(primaryKey);
-            Pointer result = perfStats.getValue(key);
-            key.release();
-            if (result != null) {
-                return new CFNumberRef(result).longValue();
-            }
-            CFStringRef fallback = CFStringRef.createCFString(fallbackKey);
-            result = perfStats.getValue(fallback);
-            fallback.release();
-            if (result != null) {
-                return new CFNumberRef(result).longValue();
-            }
-        } finally {
-            perfStats.release();
-        }
-        return -1L;
-    }
-
-    @Override
-    public synchronized long getSharedMemoryUsed() {
-        checkOpen();
-        return -1L;
-    }
-
-    @Override
-    public synchronized double getTemperature() {
-        checkOpen();
-        if (isAppleSilicon) {
-            IOConnect conn = SmcUtil.smcOpen();
-            if (conn != null) {
-                try {
-                    double temp = SmcUtil.smcGetMaxTemperature(conn, SmcUtil.getGpuTemperatureKeys());
-                    if (temp > 0) {
-                        return temp;
-                    }
-                } finally {
-                    SmcUtil.smcClose(conn);
+            Map<String, Long> values = new HashMap<>();
+            for (String key : keys) {
+                CFStringRef cfKey = CFStringRef.createCFString(key);
+                Pointer result = perfStats.getValue(cfKey);
+                cfKey.release();
+                if (result != null) {
+                    values.put(key, new CFNumberRef(result).longValue());
                 }
             }
-        }
-        // IOAccelerator statistics, not the SMC: a different sensor that is not power-gated with the GPU
-        // cluster, so the SMC plausibility floor deliberately does not apply here. Unavailable is -1, not 0.
-        // This key does not exist on Apple Silicon, so it is tried once per card and then latched off rather than
-        // repeating an IOKit registry walk on every call. Latch only on structural absence, not on a low reading.
-        if (PERF_STATS_TEMP_ABSENT.contains(normCardName)) {
-            return -1d;
-        }
-        CFMutableDictionaryRef perfStats = queryPerfStats();
-        if (perfStats == null) {
-            // Not latched: a missing accelerator entry can be transient (driver reset, eGPU unplugged), unlike a
-            // dictionary that is present but has no temperature key.
-            return -1d;
-        }
-        try {
-            CFStringRef tempKey = CFStringRef.createCFString("Temperature(C)");
-            Pointer result = perfStats.getValue(tempKey);
-            tempKey.release();
-            if (result == null) {
-                LOG.debug("No Temperature(C) in IOAccelerator statistics for {}; not retrying.", normCardName);
-                PERF_STATS_TEMP_ABSENT.add(normCardName);
-                return -1d;
-            }
-            long val = new CFNumberRef(result).longValue();
-            if (val > 0) {
-                return val;
-            }
+            return values;
         } finally {
             perfStats.release();
         }
-        return -1d;
     }
 
     @Override
-    public synchronized double getPowerDraw() {
-        checkOpen();
-        if (isAppleSilicon && ioReportClient != null) {
-            return ioReportClient.samplePowerWatts();
+    protected double queryGpuTemperatureFromSmc() {
+        IOConnect conn = SmcUtil.smcOpen();
+        if (conn == null) {
+            return -1d;
         }
-        return -1d;
-    }
-
-    @Override
-    public synchronized long getCoreClockMhz() {
-        checkOpen();
-        return -1L;
-    }
-
-    @Override
-    public synchronized long getMemoryClockMhz() {
-        checkOpen();
-        return -1L;
-    }
-
-    @Override
-    public synchronized double getFanSpeedPercent() {
-        checkOpen();
-        return -1d;
-    }
-
-    private void checkOpen() {
-        if (closed) {
-            throw new IllegalStateException(
-                    "GpuStats session has been closed. Obtain a new session via GraphicsCard.createStatsSession().");
+        try {
+            return SmcUtil.smcGetMaxTemperature(conn, SmcUtil.getGpuTemperatureKeys());
+        } finally {
+            SmcUtil.smcClose(conn);
         }
     }
 
-    private CFMutableDictionaryRef queryPerfStats() {
+    /**
+     * Walks the IOAccelerator registry for this card's PerformanceStatistics dictionary.
+     *
+     * @return the retained dictionary, which the caller must release, or {@code null} if this card has no accelerator
+     *         entry
+     */
+    private CFMutableDictionaryRef openPerfStats() {
         IOIterator iter = IOKitUtil.getMatchingServices("IOAccelerator");
         if (iter == null) {
             return null;
@@ -296,16 +121,5 @@ final class MacGpuStatsJNA implements GpuStats {
             modelKey.release();
         }
         return null;
-    }
-
-    private boolean matchesName(String model) {
-        if (model == null || model.isEmpty()) {
-            return false;
-        }
-        String normModel = TRADEMARK_PATTERN.matcher(model.toLowerCase(Locale.ROOT)).replaceAll("").trim();
-        if (normModel.equals(normCardName)) {
-            return true;
-        }
-        return cardNamePattern.matcher(normModel).find();
     }
 }


### PR DESCRIPTION
Item 9b of the cross-OS consistency audit, following #3542. The two macOS `GpuStats` twins duplicated an entire session — lifecycle and closed-state guarding, card-name normalization and matching, VRAM key selection, the temperature cascade with its absence latch, and every sentinel-returning metric. Only two native reads actually differed.

## What changed

New in `oshi.hardware.common.platform.mac`:

- **`MacGpuStats`** holds the session. Subclasses implement `queryPerfStats` and `queryGpuTemperatureFromSmc` and inherit everything else.
- **`IOReportSampler`** is the five-method shape `IOReportClient` and `IOReportClientFFM` already had; both now declare `implements`. Their internals wrap genuinely different native APIs and are untouched.

The CoreFoundation dictionary types differ between the bindings, so the hook boundary is "read these keys in one registry walk" rather than passing a dictionary up. `queryPerfStats` returns `null` when the card's statistics cannot be read at all, and an empty map when the dictionary was present but held none of the requested keys. That distinction is load-bearing: `getTemperature` latches a card as having no sensor only on the second case, never on the first, which can be transient after a driver reset or an eGPU unplug.

`MacGpuStatsJNA` 311 → 125, `MacGpuStatsFFM` 300 → 117.

## Behavior changes

1. **FFM now gates the IOReport subscription behind `isAppleSilicon`, as JNA already did.** The IOReport GPU channels do not exist on Intel, so FFM was attempting a subscription there that could never yield a sample and that JNA never made. FFM also gains JNA's warning when an Apple Silicon subscription fails.
2. The temperature-absence latch is now one set shared by both bindings rather than one per twin. Only one backend is active per JVM, so this is inert in practice.

No CHANGELOG: no user-observable change on Apple Silicon, and on Intel the affected path only ever returned sentinels.

## Testing

New `MacGpuStatsTest` (11 cases) stubs both hooks and the sampler: the Intel no-subscription rule, sampler-versus-accelerator precedence, core utilization scaling against the residency divisor, the VRAM key swap in both directions, both latch behaviors, close and `checkOpen`, and name normalization.

**Validated live on an M2 Max** — both backends drive the new base against real hardware, exercising the IOReport utilization and power deltas, GPU ticks, SMC temperature, and the IOAccelerator VRAM lookup:

```
JNA impl=MacGpuStatsJNA   util=  6.89% power=44.200W temp=51.53C vram=747847680 ticks=400302043926/19054707578748
FFM impl=MacGpuStatsFFM   util=  2.78% power=26.399W temp=51.12C vram=551239680 ticks=400303259111/19054740156297
```

(Values differ because these are instantaneous samples taken under a second apart on a live system.)

Local gate green: spotless, checkstyle, install, forbiddenapis, javadoc, clean full-reactor build, 1398 tests, and `NativeComparisonTest` 40/40.

## Noted, not fixed here

`GpuTicks` has `toString` but no `equals`/`hashCode`, so comparing two instances falls back to identity. `NativeComparisonTest` only avoids this via `usingRecursiveComparison()`. Happy to do that as a standalone change if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added macOS GPU monitoring via a unified sampler, including activity ticks, utilization, and power draw.
  - Expanded GPU statistics support with Apple Silicon vs Intel handling for VRAM and temperature.
- **Bug Fixes**
  - Improved GPU identification across name variations and trademark/symbol differences.
  - Enhanced sensor fallback logic when certain statistics are missing or unreadable, including reduced repeated temperature lookups.
- **Tests**
  - Added macOS GPU stats test coverage using stubs to validate fallback, sentinel, and close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->