### PR TITLE
Hoist the Windows graphics card WMI fallback into a common base

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGraphicsCard.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.gpu.DxgiAdapterInfo;
+import oshi.driver.common.windows.gpu.DxgiUtil;
+import oshi.driver.common.windows.wmi.Win32VideoController.VideoControllerProperty;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.driver.common.windows.wmi.WmiUtil;
+import oshi.hardware.GraphicsCard;
+import oshi.hardware.common.AbstractGraphicsCard;
+import oshi.util.Constants;
+import oshi.util.ParseUtil;
+import oshi.util.Util;
+import oshi.util.tuples.Pair;
+import oshi.util.tuples.Triplet;
+
+/**
+ * Common logic for a Windows {@link GraphicsCard}, including the WMI fallback enumeration used when the display device
+ * registry keys yield nothing.
+ * <p>
+ * Both bindings enumerate cards identically once their driver has returned the WMI rows; only which driver is called
+ * differs, so {@link #buildFromWmi} takes the query result and a factory rather than performing the query itself.
+ */
+@ThreadSafe
+public abstract class WindowsGraphicsCard extends AbstractGraphicsCard {
+
+    /** PDH instance prefix for this adapter's LUID, e.g. {@code luid_0x00000000_0x0001234_phys_0}. */
+    private final String luidPrefix;
+
+    /** LHM hardware identifier for this GPU, e.g. {@code /gpu-nvidia/0}. Empty if LHM is not available. */
+    private final String lhmParent;
+
+    /** PCI bus number from DXGI, used to correlate with ADL. -1 if unknown. */
+    private final int pciBusNumber;
+
+    /** PCI bus ID string for NVML correlation, e.g. {@code 0000:01:00.0}. Empty if unknown. */
+    private final String pciBusId;
+
+    /**
+     * Creates a Windows graphics card.
+     *
+     * @param name         the card name
+     * @param deviceId     the device ID
+     * @param vendor       the vendor
+     * @param versionInfo  the version info
+     * @param vram         the VRAM in bytes
+     * @param luidPrefix   PDH LUID instance prefix for this adapter, or an empty string if unknown
+     * @param lhmParent    LHM hardware identifier for this GPU, or an empty string if unavailable
+     * @param pciBusNumber PCI bus number for ADL correlation, or -1 if unknown
+     * @param pciBusId     PCI bus ID string for NVML correlation, or an empty string if unknown
+     */
+    protected WindowsGraphicsCard(String name, String deviceId, String vendor, String versionInfo, long vram,
+            String luidPrefix, String lhmParent, int pciBusNumber, String pciBusId) {
+        super(name, deviceId, vendor, versionInfo, vram);
+        this.luidPrefix = luidPrefix;
+        this.lhmParent = lhmParent;
+        this.pciBusNumber = pciBusNumber;
+        this.pciBusId = pciBusId;
+    }
+
+    /**
+     * Returns this adapter's PDH instance prefix, used to filter GPU Engine and GPU Adapter Memory counters.
+     *
+     * @return the PDH LUID instance prefix, or an empty string if unknown
+     */
+    protected String getLuidPrefix() {
+        return luidPrefix;
+    }
+
+    /**
+     * Returns this GPU's LibreHardwareMonitor hardware identifier, used to select its LHM sensors.
+     *
+     * @return the LHM hardware identifier, or an empty string if unavailable
+     */
+    protected String getLhmParent() {
+        return lhmParent;
+    }
+
+    /**
+     * Returns this adapter's PCI bus number, used to correlate with ADL.
+     *
+     * @return the PCI bus number, or -1 if unknown
+     */
+    protected int getPciBusNumber() {
+        return pciBusNumber;
+    }
+
+    /**
+     * Returns this adapter's PCI bus ID, used to correlate with NVML.
+     *
+     * @return the PCI bus ID string, or an empty string if unknown
+     */
+    protected String getPciBusId() {
+        return pciBusId;
+    }
+
+    /**
+     * Creates a backend's concrete card type.
+     */
+    @FunctionalInterface
+    public interface CardFactory {
+        /**
+         * @param name         the card name
+         * @param deviceId     the device ID
+         * @param vendor       the vendor
+         * @param versionInfo  the version info
+         * @param vram         the VRAM in bytes
+         * @param luidPrefix   PDH LUID instance prefix, or an empty string if unknown
+         * @param lhmParent    LHM hardware identifier, or an empty string if unavailable
+         * @param pciBusNumber PCI bus number, or -1 if unknown
+         * @param pciBusId     PCI bus ID string, or an empty string if unknown
+         * @return the card
+         */
+        GraphicsCard create(String name, String deviceId, String vendor, String versionInfo, long vram,
+                String luidPrefix, String lhmParent, int pciBusNumber, String pciBusId);
+    }
+
+    /**
+     * Builds the card list from {@code Win32_VideoController} rows, used as a fallback when the display device registry
+     * keys yield nothing.
+     * <p>
+     * The returned list is ordered to match DXGI enumeration order, which places the primary desktop adapter first,
+     * with any unmatched cards appended.
+     *
+     * @param dxgiAdapters      all DXGI adapters, retained unmutated as the stable reference for ordering lookups
+     * @param lhmParentMap      normalized GPU name to LHM parent identifier
+     * @param cards             the {@code Win32_VideoController} query result
+     * @param luidPrefixBuilder derives the PDH LUID prefix for a matched adapter, falling back to a PDH instance lookup
+     * @param factory           creates the backend's card type
+     * @return the cards, never null
+     */
+    protected static List<GraphicsCard> buildFromWmi(List<DxgiAdapterInfo> dxgiAdapters,
+            Map<String, String> lhmParentMap, WmiResult<VideoControllerProperty> cards,
+            Function<DxgiAdapterInfo, String> luidPrefixBuilder, CardFactory factory) {
+        boolean dxgiAvailable = !dxgiAdapters.isEmpty();
+        // dxgiAdapters is not mutated; remainingDxgi is the working copy consumed during matching, and dxgiAdapters is
+        // retained as the stable reference for indexOf ordering lookups.
+        List<DxgiAdapterInfo> remainingDxgi = new ArrayList<>(dxgiAdapters);
+        TreeMap<Integer, GraphicsCard> dxgiOrdered = new TreeMap<>();
+        List<GraphicsCard> cardList = new ArrayList<>();
+
+        for (int index = 0; index < cards.getResultCount(); index++) {
+            // ConfigManagerErrorCode 0 = working properly; non-zero = disabled/error (ghost device).
+            // When DXGI is unavailable, keep all entries for maximum compatibility.
+            if (dxgiAvailable && WmiUtil.getUint32(cards, VideoControllerProperty.CONFIGMANAGERERRORCODE, index) != 0) {
+                continue;
+            }
+            String name = WmiUtil.getString(cards, VideoControllerProperty.NAME, index);
+            Triplet<String, String, String> idPair = ParseUtil.parseDeviceIdToVendorProductSerial(
+                    WmiUtil.getString(cards, VideoControllerProperty.PNPDEVICEID, index));
+            String deviceId = idPair == null ? Constants.UNKNOWN : idPair.getB();
+            String vendor = WmiUtil.getString(cards, VideoControllerProperty.ADAPTERCOMPATIBILITY, index);
+            if (idPair != null) {
+                if (Util.isBlank(vendor)) {
+                    deviceId = idPair.getA();
+                } else {
+                    vendor = vendor + " (" + idPair.getA() + ")";
+                }
+            }
+            String versionInfo = WmiUtil.getString(cards, VideoControllerProperty.DRIVERVERSION, index);
+            versionInfo = Util.isBlank(versionInfo) ? Constants.UNKNOWN : "DriverVersion=" + versionInfo;
+
+            // Prefer DXGI DedicatedVideoMemory when a match can be found via the PCI IDs extracted from PNPDEVICEID.
+            // Fall back to WMI AdapterRAM (32-bit capped) only when no DXGI match is available.
+            Pair<Integer, Integer> pciIds = ParseUtil.parseDeviceIdToVendorProductIds(
+                    WmiUtil.getString(cards, VideoControllerProperty.PNPDEVICEID, index));
+            int pciVendorId = pciIds == null ? 0 : pciIds.getA();
+            int pciDeviceId = pciIds == null ? 0 : pciIds.getB();
+            DxgiAdapterInfo dxgiMatch = DxgiUtil.findMatch(remainingDxgi, pciVendorId, pciDeviceId, name);
+
+            long vram;
+            int dxgiIndex = -1;
+            String luidPrefix = "";
+            if (dxgiMatch == null) {
+                vram = WmiUtil.getUint32asLong(cards, VideoControllerProperty.ADAPTERRAM, index);
+            } else {
+                vram = dxgiMatch.getDedicatedVideoMemory();
+                dxgiIndex = dxgiAdapters.indexOf(dxgiMatch);
+                luidPrefix = luidPrefixBuilder.apply(dxgiMatch);
+            }
+            String lhmParent = lhmParentMap.getOrDefault(DxgiUtil.normalizeName(Util.isBlank(name) ? "" : name), "");
+
+            // pciBusNumber and pciBusId are not available via WMI; ADL and NVML correlation are skipped for cards
+            // enumerated through this path.
+            GraphicsCard card = factory.create(Util.isBlank(name) ? Constants.UNKNOWN : name, deviceId,
+                    Util.isBlank(vendor) ? Constants.UNKNOWN : vendor, versionInfo, vram, luidPrefix, lhmParent, -1,
+                    "");
+
+            // Remove dxgiMatch only after the card is successfully constructed, matching the registry path's defensive
+            // pattern so that a failure during construction leaves the match available for subsequent entries.
+            if (dxgiMatch != null) {
+                remainingDxgi.remove(dxgiMatch);
+            }
+            if (dxgiIndex >= 0) {
+                dxgiOrdered.put(dxgiIndex, card);
+            } else {
+                cardList.add(card);
+            }
+        }
+        List<GraphicsCard> result = new ArrayList<>(dxgiOrdered.values());
+        result.addAll(cardList);
+        return result;
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGraphicsCardTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_STRING;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT32;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_BSTR;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_I4;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.driver.common.windows.gpu.DxgiAdapterInfo;
+import oshi.driver.common.windows.wmi.Win32VideoController.VideoControllerProperty;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.hardware.GraphicsCard;
+import oshi.util.Constants;
+
+/**
+ * Tests the shared Windows graphics card enumeration without Windows, by stubbing the WMI result. This path is the
+ * fallback used only when the display device registry keys yield nothing, so it is otherwise hard to reach on real
+ * hardware.
+ */
+class WindowsGraphicsCardTest {
+
+    /** A concrete card so the factory has something to build. */
+    private static final class TestCard extends WindowsGraphicsCard {
+        private TestCard(String name, String deviceId, String vendor, String versionInfo, long vram, String luidPrefix,
+                String lhmParent, int pciBusNumber, String pciBusId) {
+            super(name, deviceId, vendor, versionInfo, vram, luidPrefix, lhmParent, pciBusNumber, pciBusId);
+        }
+
+        @Override
+        public oshi.hardware.GpuStats createStatsSession() {
+            return null;
+        }
+    }
+
+    /** One Win32_VideoController row. */
+    private static final class Row {
+        private final Map<VideoControllerProperty, Object> values = new EnumMap<>(VideoControllerProperty.class);
+
+        private Row set(VideoControllerProperty property, Object value) {
+            values.put(property, value);
+            return this;
+        }
+    }
+
+    private static Row row(String name, String pnpDeviceId, String vendor, String driverVersion, int errorCode,
+            int adapterRam) {
+        return new Row().set(VideoControllerProperty.NAME, name).set(VideoControllerProperty.PNPDEVICEID, pnpDeviceId)
+                .set(VideoControllerProperty.ADAPTERCOMPATIBILITY, vendor)
+                .set(VideoControllerProperty.DRIVERVERSION, driverVersion)
+                .set(VideoControllerProperty.CONFIGMANAGERERRORCODE, errorCode)
+                .set(VideoControllerProperty.ADAPTERRAM, adapterRam);
+    }
+
+    private static WmiResult<VideoControllerProperty> result(Row... rows) {
+        List<Row> list = Arrays.asList(rows);
+        return new WmiResult<VideoControllerProperty>() {
+            @Override
+            public int getResultCount() {
+                return list.size();
+            }
+
+            @Override
+            public Object getValue(VideoControllerProperty property, int index) {
+                return list.get(index).values.get(property);
+            }
+
+            @Override
+            public int getVtType(VideoControllerProperty property) {
+                return isNumeric(property) ? VT_I4 : VT_BSTR;
+            }
+
+            @Override
+            public int getCIMType(VideoControllerProperty property) {
+                return isNumeric(property) ? CIM_UINT32 : CIM_STRING;
+            }
+
+            private boolean isNumeric(VideoControllerProperty property) {
+                return property == VideoControllerProperty.CONFIGMANAGERERRORCODE
+                        || property == VideoControllerProperty.ADAPTERRAM;
+            }
+        };
+    }
+
+    private static List<GraphicsCard> build(List<DxgiAdapterInfo> adapters, WmiResult<VideoControllerProperty> cards) {
+        return WindowsGraphicsCard.buildFromWmi(adapters, Collections.emptyMap(), cards, adapter -> "luid_test",
+                TestCard::new);
+    }
+
+    private static List<String> names(List<GraphicsCard> cards) {
+        return cards.stream().map(GraphicsCard::getName).collect(Collectors.toList());
+    }
+
+    @Test
+    void testWithoutDxgiEveryRowIsKeptInOrder() {
+        // With no DXGI adapters there is nothing to match against, so all rows are kept for maximum compatibility,
+        // including ones reporting a non-zero ConfigManagerErrorCode.
+        List<GraphicsCard> cards = build(Collections.emptyList(),
+                result(row("Card A", "PCI\\VEN_10DE&DEV_1C03", "NVIDIA", "1.2.3", 0, 4096),
+                        row("Card B", "PCI\\VEN_8086&DEV_56A0", "Intel", "4.5.6", 22, 2048)));
+        assertThat("both rows are kept", names(cards), contains("Card A", "Card B"));
+        assertThat("VRAM falls back to AdapterRAM", cards.get(0).getVRam(), is(4096L));
+    }
+
+    @Test
+    void testGhostDevicesAreSkippedWhenDxgiIsAvailable() {
+        // A non-zero ConfigManagerErrorCode marks a disabled or errored device once DXGI can confirm what is present.
+        List<DxgiAdapterInfo> adapters = Collections
+                .singletonList(new DxgiAdapterInfo("NVIDIA GeForce", 0x10DE, 0x1C03, 8_000_000_000L, 1, 0));
+        List<GraphicsCard> cards = build(adapters,
+                result(row("Ghost", "PCI\\VEN_8086&DEV_56A0", "Intel", "4.5.6", 22, 2048),
+                        row("NVIDIA GeForce", "PCI\\VEN_10DE&DEV_1C03", "NVIDIA", "1.2.3", 0, 2048)));
+        assertThat("the ghost row is dropped", names(cards), contains("NVIDIA GeForce"));
+        assertThat("DXGI VRAM beats the 32-bit AdapterRAM", cards.get(0).getVRam(), is(8_000_000_000L));
+        assertThat("the LUID prefix comes from the supplied builder", ((TestCard) cards.get(0)).getLuidPrefix(),
+                is("luid_test"));
+    }
+
+    @Test
+    void testMatchedCardsAreOrderedByDxgiIndex() {
+        // DXGI enumerates the primary desktop adapter first, so the result follows DXGI order, not WMI row order.
+        List<DxgiAdapterInfo> adapters = Arrays.asList(new DxgiAdapterInfo("Primary", 0x10DE, 0x1C03, 100L, 1, 0),
+                new DxgiAdapterInfo("Secondary", 0x8086, 0x56A0, 200L, 2, 0));
+        List<GraphicsCard> cards = build(adapters,
+                result(row("Secondary", "PCI\\VEN_8086&DEV_56A0", "Intel", "4.5.6", 0, 1),
+                        row("Primary", "PCI\\VEN_10DE&DEV_1C03", "NVIDIA", "1.2.3", 0, 1)));
+        assertThat("DXGI order wins over row order", names(cards), contains("Primary", "Secondary"));
+    }
+
+    @Test
+    void testAnAdapterIsConsumedByTheFirstMatchingRow() {
+        // Two rows for the same PCI IDs must not both claim the single DXGI adapter, or the second would inherit the
+        // first one's VRAM.
+        List<DxgiAdapterInfo> adapters = Collections
+                .singletonList(new DxgiAdapterInfo("Shared", 0x10DE, 0x1C03, 9999L, 1, 0));
+        List<GraphicsCard> cards = build(adapters,
+                result(row("Shared", "PCI\\VEN_10DE&DEV_1C03", "NVIDIA", "1.2.3", 0, 111),
+                        row("Shared", "PCI\\VEN_10DE&DEV_1C03", "NVIDIA", "1.2.3", 0, 222)));
+        assertThat("both rows are returned", cards.size(), is(2));
+        List<Long> vram = cards.stream().map(GraphicsCard::getVRam).collect(Collectors.toList());
+        assertThat("only one row got the DXGI VRAM", vram, contains(9999L, 222L));
+    }
+
+    @Test
+    void testVendorAndDeviceIdDerivation() {
+        List<GraphicsCard> cards = build(Collections.emptyList(),
+                result(row("Card", "PCI\\VEN_10DE&DEV_1C03&SUBSYS_0&REV_A1\\4&SERIAL&0", "NVIDIA", "1.2.3", 0, 1)));
+        GraphicsCard card = cards.get(0);
+        assertThat("the vendor keeps its PCI id in parentheses", card.getVendor(), is("NVIDIA (0x10de)"));
+        assertThat("the version is prefixed", card.getVersionInfo(), is("DriverVersion=1.2.3"));
+    }
+
+    @Test
+    void testBlankFieldsFallBackToUnknown() {
+        List<GraphicsCard> cards = build(Collections.emptyList(), result(row("", "", "", "", 0, 1)));
+        GraphicsCard card = cards.get(0);
+        assertThat("a blank name is unknown", card.getName(), is(Constants.UNKNOWN));
+        assertThat("a blank vendor is unknown", card.getVendor(), is(Constants.UNKNOWN));
+        assertThat("a blank version is unknown", card.getVersionInfo(), is(Constants.UNKNOWN));
+    }
+
+    @Test
+    void testNoRowsYieldsAnEmptyList() {
+        assertThat("no rows means no cards", build(Collections.emptyList(), result()), is(empty()));
+    }
+
+    @Test
+    void testPciCorrelationFieldsAreUnsetOnThisPath() {
+        // The bus number and bus ID come from the registry LocationInformation value, which WMI does not expose, so
+        // ADL and NVML correlation are deliberately skipped for cards found this way.
+        List<GraphicsCard> cards = build(Collections.emptyList(),
+                result(row("Card", "PCI\\VEN_10DE&DEV_1C03", "NVIDIA", "1.2.3", 0, 1)));
+        assertThat("bus number is unknown", ((TestCard) cards.get(0)).getPciBusNumber(), is(-1));
+        assertThat("bus id is empty", ((TestCard) cards.get(0)).getPciBusId(), is(""));
+    }
+
+    @Test
+    void testLhmParentIsMatchedOnNormalizedName() {
+        Map<String, String> lhm = new HashMap<>();
+        lhm.put("nvidia geforce rtx 3080", "/gpu-nvidia/0");
+        List<GraphicsCard> cards = new ArrayList<>(WindowsGraphicsCard.buildFromWmi(Collections.emptyList(), lhm,
+                result(row("NVIDIA GeForce RTX 3080", "PCI\\VEN_10DE&DEV_1C03", "NVIDIA", "1.2.3", 0, 1)),
+                adapter -> "", TestCard::new));
+        assertThat("the LHM identifier is attached", ((TestCard) cards.get(0)).getLhmParent(), is("/gpu-nvidia/0"));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardFFM.java
@@ -8,6 +8,7 @@ import static oshi.util.ExceptionUtil.runOrLog;
 
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,31 +22,32 @@ import oshi.driver.common.windows.gpu.DxgiAdapterInfo;
 import oshi.driver.common.windows.gpu.DxgiUtil;
 import oshi.driver.common.windows.perfmon.GpuInformation.GpuAdapterMemoryProperty;
 import oshi.driver.common.windows.wmi.LhmSensor.LhmHardwareProperty;
-import oshi.driver.common.windows.wmi.Win32VideoController.VideoControllerProperty;
 import oshi.driver.common.windows.wmi.WmiResult;
 import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.driver.windows.perfmon.GpuInformationFFM;
 import oshi.driver.windows.wmi.LhmSensorFFM;
 import oshi.driver.windows.wmi.Win32VideoControllerFFM;
 import oshi.ffm.platform.windows.DxgiFFM;
+import oshi.ffm.platform.windows.VersionHelpersFFM;
 import oshi.ffm.platform.windows.WinRegFFM;
 import oshi.ffm.util.platform.windows.Advapi32UtilFFM;
 import oshi.hardware.GpuStats;
 import oshi.hardware.GraphicsCard;
-import oshi.hardware.common.AbstractGraphicsCard;
+import oshi.hardware.common.platform.windows.WindowsGraphicsCard;
 import oshi.util.Constants;
 import oshi.util.ParseUtil;
 import oshi.util.Util;
 import oshi.util.tuples.Pair;
-import oshi.util.tuples.Triplet;
 
 /**
  * Graphics Card obtained from the Windows registry using FFM, with VRAM sourced from DXGI.
  */
 @ThreadSafe
-final class WindowsGraphicsCardFFM extends AbstractGraphicsCard {
+final class WindowsGraphicsCardFFM extends WindowsGraphicsCard {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsGraphicsCardFFM.class);
+
+    private static final boolean IS_VISTA_OR_GREATER = VersionHelpersFFM.IsWindowsVistaOrGreater();
 
     private static final MemorySegment HKLM = MemorySegment.ofAddress(WinRegFFM.HKEY_LOCAL_MACHINE);
 
@@ -58,23 +60,14 @@ final class WindowsGraphicsCardFFM extends AbstractGraphicsCard {
     private static final String LOCATION_INFORMATION = "LocationInformation";
     private static final String DISPLAY_DEVICES_REGISTRY_PATH = "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\";
 
-    private final String luidPrefix;
-    private final String lhmParent;
-    private final int pciBusNumber;
-    private final String pciBusId;
-
     WindowsGraphicsCardFFM(String name, String deviceId, String vendor, String versionInfo, long vram,
             String luidPrefix, String lhmParent, int pciBusNumber, String pciBusId) {
-        super(name, deviceId, vendor, versionInfo, vram);
-        this.luidPrefix = luidPrefix;
-        this.lhmParent = lhmParent;
-        this.pciBusNumber = pciBusNumber;
-        this.pciBusId = pciBusId;
+        super(name, deviceId, vendor, versionInfo, vram, luidPrefix, lhmParent, pciBusNumber, pciBusId);
     }
 
     @Override
     public GpuStats createStatsSession() {
-        return new WindowsGpuStatsFFM(luidPrefix, lhmParent, pciBusNumber, pciBusId, getName());
+        return new WindowsGpuStatsFFM(getLuidPrefix(), getLhmParent(), getPciBusNumber(), getPciBusId(), getName());
     }
 
     public static List<GraphicsCard> getGraphicsCards() {
@@ -161,75 +154,19 @@ final class WindowsGraphicsCardFFM extends AbstractGraphicsCard {
         result.addAll(cardList);
 
         if (result.isEmpty()) {
-            return getGraphicsCardsFromWmi(dxgiAdapters, remainingDxgi, lhmParentMap);
+            return getGraphicsCardsFromWmi(dxgiAdapters, lhmParentMap);
         }
         return result;
     }
 
+    // fall back if something went wrong
     private static List<GraphicsCard> getGraphicsCardsFromWmi(List<DxgiAdapterInfo> dxgiAdapters,
-            List<DxgiAdapterInfo> remainingDxgi, Map<String, String> lhmParentMap) {
-        boolean dxgiAvailable = !dxgiAdapters.isEmpty();
-        List<DxgiAdapterInfo> working = new ArrayList<>(remainingDxgi);
-        TreeMap<Integer, GraphicsCard> dxgiOrdered = new TreeMap<>();
-        List<GraphicsCard> cardList = new ArrayList<>();
-
-        WmiResult<VideoControllerProperty> cards = Win32VideoControllerFFM.queryVideoController();
-        for (int index = 0; index < cards.getResultCount(); index++) {
-            if (dxgiAvailable && WmiUtil.getUint32(cards, VideoControllerProperty.CONFIGMANAGERERRORCODE, index) != 0) {
-                continue;
-            }
-            String name = WmiUtil.getString(cards, VideoControllerProperty.NAME, index);
-            Triplet<String, String, String> idPair = ParseUtil.parseDeviceIdToVendorProductSerial(
-                    WmiUtil.getString(cards, VideoControllerProperty.PNPDEVICEID, index));
-            String deviceId = idPair == null ? Constants.UNKNOWN : idPair.getB();
-            String vendor = WmiUtil.getString(cards, VideoControllerProperty.ADAPTERCOMPATIBILITY, index);
-            if (idPair != null) {
-                if (Util.isBlank(vendor)) {
-                    deviceId = idPair.getA();
-                } else {
-                    vendor = vendor + " (" + idPair.getA() + ")";
-                }
-            }
-            String versionInfo = WmiUtil.getString(cards, VideoControllerProperty.DRIVERVERSION, index);
-            if (!Util.isBlank(versionInfo)) {
-                versionInfo = "DriverVersion=" + versionInfo;
-            } else {
-                versionInfo = Constants.UNKNOWN;
-            }
-
-            Pair<Integer, Integer> pciIds = ParseUtil.parseDeviceIdToVendorProductIds(
-                    WmiUtil.getString(cards, VideoControllerProperty.PNPDEVICEID, index));
-            int pciVendorId = pciIds == null ? 0 : pciIds.getA();
-            int pciDeviceId = pciIds == null ? 0 : pciIds.getB();
-            DxgiAdapterInfo dxgiMatch = DxgiUtil.findMatch(working, pciVendorId, pciDeviceId, name);
-            long vram;
-            int dxgiIndex = -1;
-            String luidPrefix = "";
-            int pciBusNumber = -1;
-            String pciBusId = "";
-            if (dxgiMatch != null) {
-                vram = dxgiMatch.getDedicatedVideoMemory();
-                dxgiIndex = dxgiAdapters.indexOf(dxgiMatch);
-                luidPrefix = DxgiUtil.buildLuidPrefix(dxgiMatch);
-            } else {
-                vram = WmiUtil.getUint32asLong(cards, VideoControllerProperty.ADAPTERRAM, index);
-            }
-            String lhmParent = lhmParentMap.getOrDefault(DxgiUtil.normalizeName(Util.isBlank(name) ? "" : name), "");
-            GraphicsCard card = new WindowsGraphicsCardFFM(Util.isBlank(name) ? Constants.UNKNOWN : name, deviceId,
-                    Util.isBlank(vendor) ? Constants.UNKNOWN : vendor, versionInfo, vram, luidPrefix, lhmParent,
-                    pciBusNumber, pciBusId);
-            if (dxgiMatch != null) {
-                working.remove(dxgiMatch);
-            }
-            if (dxgiIndex >= 0) {
-                dxgiOrdered.put(dxgiIndex, card);
-            } else {
-                cardList.add(card);
-            }
+            Map<String, String> lhmParentMap) {
+        if (!IS_VISTA_OR_GREATER) {
+            return Collections.emptyList();
         }
-        List<GraphicsCard> result = new ArrayList<>(dxgiOrdered.values());
-        result.addAll(cardList);
-        return result;
+        return buildFromWmi(dxgiAdapters, lhmParentMap, Win32VideoControllerFFM.queryVideoController(),
+                WindowsGraphicsCardFFM::buildLuidPrefix, WindowsGraphicsCardFFM::new);
     }
 
     private static Map<String, String> buildLhmParentMap() {

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardJNA.java
@@ -5,6 +5,7 @@
 package oshi.hardware.platform.windows;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,6 @@ import oshi.driver.common.windows.gpu.DxgiAdapterInfo;
 import oshi.driver.common.windows.gpu.DxgiUtil;
 import oshi.driver.common.windows.perfmon.GpuInformation.GpuAdapterMemoryProperty;
 import oshi.driver.common.windows.wmi.LhmSensor.LhmHardwareProperty;
-import oshi.driver.common.windows.wmi.Win32VideoController.VideoControllerProperty;
 import oshi.driver.common.windows.wmi.WmiResult;
 import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.driver.windows.perfmon.GpuInformationJNA;
@@ -32,14 +32,13 @@ import oshi.driver.windows.wmi.LhmSensorJNA;
 import oshi.driver.windows.wmi.Win32VideoControllerJNA;
 import oshi.hardware.GpuStats;
 import oshi.hardware.GraphicsCard;
-import oshi.hardware.common.AbstractGraphicsCard;
+import oshi.hardware.common.platform.windows.WindowsGraphicsCard;
 import oshi.util.Constants;
 import oshi.util.ParseUtil;
 import oshi.util.Util;
 import oshi.util.gpu.DxgiUtilJNA;
 import oshi.util.platform.windows.RegistryUtil;
 import oshi.util.tuples.Pair;
-import oshi.util.tuples.Triplet;
 
 /**
  * Graphics Card obtained from the Windows registry, with VRAM sourced from DXGI.
@@ -68,7 +67,7 @@ import oshi.util.tuples.Triplet;
  * counters (Windows 10 1709+) and optionally from LibreHardwareMonitor WMI sensors when LHM is running.
  */
 @ThreadSafe
-final class WindowsGraphicsCardJNA extends AbstractGraphicsCard {
+final class WindowsGraphicsCardJNA extends WindowsGraphicsCard {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsGraphicsCardJNA.class);
 
@@ -82,19 +81,6 @@ final class WindowsGraphicsCardJNA extends AbstractGraphicsCard {
     public static final String MATCHING_DEVICE_ID = "MatchingDeviceId";
     public static final String LOCATION_INFORMATION = "LocationInformation";
     public static final String DISPLAY_DEVICES_REGISTRY_PATH = "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\";
-
-    // PDH instance prefix for this adapter's LUID, e.g. "luid_0x00000000_0x0001234_phys_0"
-    // Used to filter GPU Engine and GPU Adapter Memory counter instances.
-    private final String luidPrefix;
-
-    // LHM hardware identifier for this GPU, e.g. "/gpu-nvidia/0". Empty if LHM is not available.
-    private final String lhmParent;
-
-    // PCI bus number from DXGI, used to correlate with ADL. -1 if unknown.
-    private final int pciBusNumber;
-
-    // PCI bus ID string for NVML correlation, e.g. "0000:01:00.0". Empty if unknown.
-    private final String pciBusId;
 
     /**
      * Constructor for WindowsGraphicsCard
@@ -111,16 +97,12 @@ final class WindowsGraphicsCardJNA extends AbstractGraphicsCard {
      */
     WindowsGraphicsCardJNA(String name, String deviceId, String vendor, String versionInfo, long vram,
             String luidPrefix, String lhmParent, int pciBusNumber, String pciBusId) {
-        super(name, deviceId, vendor, versionInfo, vram);
-        this.luidPrefix = luidPrefix;
-        this.lhmParent = lhmParent;
-        this.pciBusNumber = pciBusNumber;
-        this.pciBusId = pciBusId;
+        super(name, deviceId, vendor, versionInfo, vram, luidPrefix, lhmParent, pciBusNumber, pciBusId);
     }
 
     @Override
     public GpuStats createStatsSession() {
-        return new WindowsGpuStatsJNA(luidPrefix, lhmParent, pciBusNumber, pciBusId, getName());
+        return new WindowsGpuStatsJNA(getLuidPrefix(), getLhmParent(), getPciBusNumber(), getPciBusId(), getName());
     }
 
     /**
@@ -264,84 +246,11 @@ final class WindowsGraphicsCardJNA extends AbstractGraphicsCard {
     // fall back if something went wrong
     private static List<GraphicsCard> getGraphicsCardsFromWmi(List<DxgiAdapterInfo> dxgiAdapters,
             Map<String, String> lhmParentMap) {
-        List<GraphicsCard> cardList = new ArrayList<>();
-        if (IS_VISTA_OR_GREATER) {
-            boolean dxgiAvailable = !dxgiAdapters.isEmpty();
-            // dxgiAdapters is not mutated; remainingDxgi is the working copy consumed during matching.
-            // dxgiAdapters is retained as the stable reference for indexOf ordering lookups.
-            List<DxgiAdapterInfo> remainingDxgi = new ArrayList<>(dxgiAdapters);
-            TreeMap<Integer, GraphicsCard> dxgiOrdered = new TreeMap<>();
-
-            WmiResult<VideoControllerProperty> cards = Win32VideoControllerJNA.queryVideoController();
-            for (int index = 0; index < cards.getResultCount(); index++) {
-                // ConfigManagerErrorCode 0 = working properly; non-zero = disabled/error (ghost device).
-                // When DXGI is unavailable, keep all entries for maximum compatibility.
-                if (dxgiAvailable
-                        && WmiUtil.getUint32(cards, VideoControllerProperty.CONFIGMANAGERERRORCODE, index) != 0) {
-                    continue;
-                }
-                String name = WmiUtil.getString(cards, VideoControllerProperty.NAME, index);
-                Triplet<String, String, String> idPair = ParseUtil.parseDeviceIdToVendorProductSerial(
-                        WmiUtil.getString(cards, VideoControllerProperty.PNPDEVICEID, index));
-                String deviceId = idPair == null ? Constants.UNKNOWN : idPair.getB();
-                String vendor = WmiUtil.getString(cards, VideoControllerProperty.ADAPTERCOMPATIBILITY, index);
-                if (idPair != null) {
-                    if (Util.isBlank(vendor)) {
-                        deviceId = idPair.getA();
-                    } else {
-                        vendor = vendor + " (" + idPair.getA() + ")";
-                    }
-                }
-                String versionInfo = WmiUtil.getString(cards, VideoControllerProperty.DRIVERVERSION, index);
-                if (!Util.isBlank(versionInfo)) {
-                    versionInfo = "DriverVersion=" + versionInfo;
-                } else {
-                    versionInfo = Constants.UNKNOWN;
-                }
-                // Prefer DXGI DedicatedVideoMemory when a match can be found via the PCI IDs
-                // extracted from PNPDEVICEID. Fall back to WMI AdapterRAM (32-bit capped) only
-                // when no DXGI match is available.
-                Pair<Integer, Integer> pciIds = ParseUtil.parseDeviceIdToVendorProductIds(
-                        WmiUtil.getString(cards, VideoControllerProperty.PNPDEVICEID, index));
-                int pciVendorId = pciIds == null ? 0 : pciIds.getA();
-                int pciDeviceId = pciIds == null ? 0 : pciIds.getB();
-                DxgiAdapterInfo dxgiMatch = DxgiUtilJNA.findMatch(remainingDxgi, pciVendorId, pciDeviceId, name);
-                long vram;
-                int dxgiIndex = -1;
-                String luidPrefix = "";
-                int pciBusNumber = -1;
-                String pciBusId = "";
-                if (dxgiMatch != null) {
-                    vram = dxgiMatch.getDedicatedVideoMemory();
-                    dxgiIndex = dxgiAdapters.indexOf(dxgiMatch);
-                    luidPrefix = buildLuidPrefix(dxgiMatch);
-                    // pciBusNumber and pciBusId are not available via WMI; leave as -1 / empty.
-                    // ADL and NVML correlation will be skipped for cards enumerated via this path.
-                } else {
-                    vram = WmiUtil.getUint32asLong(cards, VideoControllerProperty.ADAPTERRAM, index);
-                }
-                String lhmParent = lhmParentMap.getOrDefault(DxgiUtilJNA.normalizeName(Util.isBlank(name) ? "" : name),
-                        "");
-                GraphicsCard card = new WindowsGraphicsCardJNA(Util.isBlank(name) ? Constants.UNKNOWN : name, deviceId,
-                        Util.isBlank(vendor) ? Constants.UNKNOWN : vendor, versionInfo, vram, luidPrefix, lhmParent,
-                        pciBusNumber, pciBusId);
-                // Remove dxgiMatch from remainingDxgi only after the card is successfully
-                // constructed, matching the registry path's defensive pattern so that a
-                // failure during construction leaves the match available for subsequent entries.
-                if (dxgiMatch != null) {
-                    remainingDxgi.remove(dxgiMatch);
-                }
-                if (dxgiIndex >= 0) {
-                    dxgiOrdered.put(dxgiIndex, card);
-                } else {
-                    cardList.add(card);
-                }
-            }
-            List<GraphicsCard> result = new ArrayList<>(dxgiOrdered.values());
-            result.addAll(cardList);
-            return result;
+        if (!IS_VISTA_OR_GREATER) {
+            return Collections.emptyList();
         }
-        return cardList;
+        return buildFromWmi(dxgiAdapters, lhmParentMap, Win32VideoControllerJNA.queryVideoController(),
+                WindowsGraphicsCardJNA::buildLuidPrefix, WindowsGraphicsCardJNA::new);
     }
 
     /**


### PR DESCRIPTION
Item 9c of the cross-OS consistency audit, completing the GPU family after #3542 (NvmlUtil) and #3543 (macOS GpuStats).

## What was duplicated

The two Windows `GraphicsCard` twins duplicated the four correlation fields, their constructor, and the whole `Win32_VideoController` enumeration used as a fallback when the display device registry keys yield nothing. Only which driver returns the rows actually differed.

## What changed

New **`WindowsGraphicsCard`** in oshi-common holds `luidPrefix`, `lhmParent`, `pciBusNumber` and `pciBusId` with protected getters, plus a static `buildFromWmi`. It takes the `WmiResult` and a `CardFactory` rather than running the query itself, so each twin supplies only its driver call and its own card type — the factory pattern from #3452.

`WindowsGraphicsCardJNA` 474 → 383, `WindowsGraphicsCardFFM` 287 → 224.

## Behavior changes, all adopting what JNA already did

1. **Fixed: the FFM WMI path lost the PDH LUID fallback.** It called `DxgiUtil.buildLuidPrefix` directly, while FFM's *own registry path* and both of JNA's paths use the local `buildLuidPrefix`, which falls back to a PDH instance lookup when DXGI reports an empty LUID. A card enumerated through the WMI path with an empty DXGI LUID therefore got no PDH prefix on FFM, leaving its GPU Engine and Adapter Memory counters unfilterable and its metrics unavailable. FFM was inconsistent with itself here, not only with JNA.
2. **FFM gains JNA's pre-Vista gate** on this path. `VersionHelpersFFM` already exists and is used by `WindowsBluetoothDeviceFFM` and `WindowsOSProcessFFM`, so its absence here looks like an omission. Pre-Vista with a modern JDK is not a real combination, so this is a consistency change rather than a functional one.
3. **The working DXGI list always starts fresh** from `dxgiAdapters`, as JNA did; FFM previously passed in its registry path's partially consumed list. Only observable if that loop matched adapters and still returned nothing.

No CHANGELOG: the LUID fix only restores metrics on a fallback path that requires the registry enumeration to have produced nothing, and the other two are unobservable in practice.

## Testing

New `WindowsGraphicsCardTest` (9 cases). `WmiResult` is an interface, so the enumeration is testable without Windows — worth having, because this path only runs when the registry enumeration returns nothing and is otherwise near-unreachable on real hardware. It covers ghost-device skipping, DXGI ordering beating WMI row order, an adapter being consumed by only the first matching row, the DXGI-VRAM-over-AdapterRAM preference, vendor and device ID derivation, blank fields falling back to `UNKNOWN`, and the PCI correlation fields being deliberately unset on this path.

Local gate green: spotless, checkstyle, install, forbiddenapis, javadoc, clean full-reactor build, 1407 tests. `NativeComparisonTest` 40/40 on macOS. Windows runtime validation is CI-only, which pr.yaml runs automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows graphics-card detection and identification.
  * Preserves primary-adapter ordering and provides more accurate dedicated video memory when available.
  * Adds better handling for adapter relationships and hardware identifiers.

* **Bug Fixes**
  * Filters inactive or invalid graphics-card entries when reliable system data is available.
  * Adds fallback handling for systems without modern graphics adapter information.
  * Improves handling of missing or blank adapter details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->