### PR TITLE
Harden the macOS SMC fan speed and CPU voltage paths

### DIFF
--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -218,8 +218,30 @@ class NativeComparisonTest {
         Sensors jna = jnaHal.getSensors();
         Sensors ffm = ffmHal.getSensors();
         assertWithinRatio(ffm.getCpuTemperature(), jna.getCpuTemperature(), 0.25, "cpuTemperature");
-        assertThat(ffm.getFanSpeeds()).hasSameSizeAs(jna.getFanSpeeds());
+        int[] jnaFans = jna.getFanSpeeds();
+        int[] ffmFans = ffm.getFanSpeeds();
+        assertThat(ffmFans).hasSameSizeAs(jnaFans);
+        for (int i = 0; i < jnaFans.length; i++) {
+            assertThat(ffmFans[i]).as("fanSpeed[%d] non-negative", i).isGreaterThanOrEqualTo(0);
+            // Only compare the ratio when both reads are nonzero: rpm legitimately differs between the sequential JNA
+            // and FFM reads, and assertWithinRatio's one-value-zero branch would fail hard if a fan spun up between
+            // them (asserting the nonzero rpm is <= the ratio).
+            if (jnaFans[i] != 0 && ffmFans[i] != 0) {
+                assertWithinRatio(ffmFans[i], jnaFans[i], 0.25, "fanSpeed[" + i + "]");
+            }
+        }
         assertWithinRatio(ffm.getCpuVoltage(), jna.getCpuVoltage(), 0.25, "cpuVoltage");
+    }
+
+    /**
+     * Fan speed keys are discovered from the SMC at runtime by each backend independently, so comparing the discovered
+     * lists is the sharpest available check that the two binary searches agree — sharper than the fluctuating rpm
+     * readings themselves.
+     */
+    @Test
+    @EnabledOnOs(OS.MAC)
+    void fanSpeedKeys() {
+        assertThat(SmcUtilFFM.getFanSpeedKeys()).isEqualTo(SmcUtil.getFanSpeedKeys());
     }
 
     // ---- Hardware: Power Sources ----

--- a/oshi-common/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-common/src/main/java/oshi/util/GlobalConfig.java
@@ -164,6 +164,22 @@ public final class GlobalConfig {
     public static final String OSHI_OS_MAC_SENSORS_GPUTEMPERATURE_KEYS = "oshi.os.mac.sensors.gputemperature.keys";
 
     /**
+     * Comma-separated list of macOS SMC keys to read for fan speeds, one per fan. Empty by default, meaning the keys
+     * are discovered from the SMC at runtime and cross-checked against the fan count {@code FNum} reports. Set this
+     * only to override that discovery.
+     */
+    public static final String OSHI_OS_MAC_SENSORS_FANSPEED_KEYS = "oshi.os.mac.sensors.fanspeed.keys";
+
+    /**
+     * Comma-separated list of macOS SMC keys to read for CPU voltage, tried in order until one returns a plausible
+     * value. Empty by default, meaning the Apple Silicon key is tried and then the Intel one. Unlike GPU temperature
+     * these keys are not discovered at runtime, because the {@code V} prefix covers supply rails as well as the CPU and
+     * nothing in the naming distinguishes them, so this property is the way to name the key on hardware where neither
+     * default works.
+     */
+    public static final String OSHI_OS_MAC_SENSORS_CPUVOLTAGE_KEYS = "oshi.os.mac.sensors.cpuvoltage.keys";
+
+    /**
      * The name of the Windows System event log containing bootup event IDs 12 and 6005, used for a one-time calculation
      * of system boot time that is consistent across process runs regardless of sleep/hibernate cycles. If set to the
      * empty string, boot time is calculated by subtracting uptime from the current time (faster but less accurate).

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.DoublePredicate;
 import java.util.function.IntFunction;
@@ -44,8 +45,30 @@ public final class SmcKeyIndex {
      */
     private static final Pattern GPU_TEMPERATURE_KEY = Pattern.compile("^Tg\\d[\\dA-Za-z]$");
 
+    /**
+     * Fan current-speed keys, e.g. {@code F0Ac} or {@code F1Ac}.
+     * <p>
+     * Unlike {@link #GPU_TEMPERATURE_KEY} the fourth character is fixed, not variable: the published fan keys are
+     * {@code F%dAc} current, {@code F%dMn} minimum, {@code F%dMx} maximum, {@code F%dSf} safe and {@code F%dTg} target,
+     * so only the {@code Ac} suffix names the current speed. The mask matters because the other fan keys sort inside
+     * the same {@code F} prefix block: an M3 Pro's block is
+     * {@code F0Ac F0CR F0Dc F0Fb F0Fc F0Md F0Mn F0Mx F0Sf F0St F0Tg}, the same again for {@code F1}, then
+     * {@code FBAC FBAD FNum FOFC FOff FRmp Fpds Frqd Ftst}.
+     */
+    private static final Pattern FAN_SPEED_KEY = Pattern.compile("^F\\dAc$");
+
     /** SMC keys are four characters. */
     private static final int KEY_LENGTH = 4;
+
+    /**
+     * Upper bound on a fan count read from {@code FNum}.
+     * <p>
+     * The binding constraint is the key format, not the hardware: {@code String.format("F%dAc", 10)} produces the
+     * five-character {@code "F10Ac"}, and reading a key truncates it to four characters, so an eleventh fan would
+     * silently read {@code "F10A"} instead. Ten is therefore the highest index this naming scheme can express. It also
+     * sits above the hardware bound, since no Mac has more than eight fans.
+     */
+    public static final int MAX_FANS = 10;
 
     /**
      * Upper bound on a plausible {@code #KEY} count, guarding against a garbage read. Observed counts are in the low
@@ -191,6 +214,70 @@ public final class SmcKeyIndex {
      */
     public static boolean isGpuTemperatureKey(String key) {
         return key != null && GPU_TEMPERATURE_KEY.matcher(key).matches();
+    }
+
+    /**
+     * Tests whether a key names a fan's current speed.
+     *
+     * @param key the four-character SMC key
+     * @return true if the key matches the fan current-speed naming convention
+     */
+    public static boolean isFanSpeedKey(String key) {
+        return key != null && FAN_SPEED_KEY.matcher(key).matches();
+    }
+
+    /**
+     * Builds the fan current-speed keys for a fan count, as the naming convention implies them.
+     *
+     * @param fanCount the number of fans, from the SMC's {@code FNum} key
+     * @return the keys {@code F0Ac} through {@code F(n-1)Ac}, clamped to {@link #MAX_FANS}, never null
+     */
+    public static List<String> fanSpeedKeys(long fanCount) {
+        // Clamp before narrowing: FNum is a single byte, but a mis-sized read returns whatever the buffer held.
+        int fans = (int) Math.max(0, Math.min(MAX_FANS, fanCount));
+        if (fans < fanCount) {
+            LOG.warn("Ignoring an implausible SMC fan count of {}; using {}.", fanCount, fans);
+        }
+        List<String> keys = new ArrayList<>(fans);
+        for (int i = 0; i < fans; i++) {
+            keys.add(String.format(Locale.ROOT, "F%dAc", i));
+        }
+        return Collections.unmodifiableList(keys);
+    }
+
+    /**
+     * Reconciles the fan keys found in the key index against the count reported by {@code FNum}.
+     * <p>
+     * Discovery is preferred where it produced anything, because the index lists the keys that actually exist. Where it
+     * did not, a positive {@code FNum} still implies the conventionally named keys, which is what earlier versions of
+     * OSHI read directly, so this never reports fewer fans than they did.
+     * <p>
+     * Returns {@code null} when the two sources together cannot distinguish "this machine has no fans" from "the keys
+     * could not be read", so that the caller does not cache the answer. That happens when discovery failed and
+     * {@code FNum} read as zero.
+     *
+     * @param discovered the keys found by {@link #findKeys}, or {@code null} if the index could not be read
+     * @param fanCount   the count from {@code FNum}, or 0 if that read failed
+     * @return the keys to read, or {@code null} if the answer is not yet known
+     */
+    public static List<String> reconcileFanKeys(List<String> discovered, long fanCount) {
+        if (discovered != null && !discovered.isEmpty()) {
+            if (fanCount > 0 && discovered.size() != fanCount) {
+                LOG.debug("Found {} fan speed keys {} but FNum reports {} fans; using the discovered keys.",
+                        discovered.size(), discovered, fanCount);
+            }
+            return discovered;
+        }
+        if (fanCount > 0) {
+            List<String> keys = fanSpeedKeys(fanCount);
+            LOG.debug("Fan speed key discovery found none; using the {} keys FNum implies: {}", keys.size(), keys);
+            return keys;
+        }
+        if (discovered == null) {
+            LOG.debug("Neither the SMC key index nor FNum could be read; deferring the fan count.");
+            return null; // NOSONAR squid:S1168 - null and empty are different answers; see the javadoc
+        }
+        return Collections.emptyList();
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcSensorValues.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcSensorValues.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.common.platform.mac;
+
+import oshi.annotation.concurrent.ThreadSafe;
+
+/**
+ * Connection-independent interpretation of the values macOS SMC sensor keys report.
+ * <p>
+ * These methods take a reading rather than an SMC connection, so the JNA and FFM backends share them and so they can be
+ * tested without Mac hardware. Locating the keys themselves is {@link SmcKeyIndex}.
+ */
+@ThreadSafe
+public final class SmcSensorValues {
+
+    /** The SMC data type reporting a value as fixed point with two fractional bits. */
+    private static final String DATATYPE_FPE2 = "fpe2";
+
+    /**
+     * The lowest reading accepted as a genuine CPU voltage, in volts.
+     * <p>
+     * No CPU core rail runs this low. The lowest confirmed reading is 0.748 V, from {@code VP0C} on an M3 Pro, and the
+     * nearest neighbour on that machine is 0.864 V.
+     * <p>
+     * What this rejects is a value scaled by the wrong factor: an {@code fpe2} reading treated as volts rather than
+     * millivolts yields about 0.0012 V where 1.2 V was meant. That is two orders of magnitude below the floor, and the
+     * floor is two orders of magnitude below a real reading, so it sits in an empty band with margin either way.
+     * <p>
+     * Unlike temperature there is no known voltage sentinel: an idle-gated sensor parks its temperature below ambient,
+     * but nothing comparable has been observed for the voltage keys. This is a scaling and garbage guard rather than a
+     * sentinel filter.
+     */
+    public static final double MIN_PLAUSIBLE_VOLTAGE = 0.2;
+
+    private SmcSensorValues() {
+    }
+
+    /**
+     * Converts a fan speed reading to rpm.
+     * <p>
+     * A reading of zero is preserved rather than discarded. A fan that is stopped genuinely reads zero: on an idle M3
+     * Pro both {@code F0Ac} and {@code F1Ac} read 0.0 while {@code F0Mn} and {@code F0Mx} report 1350 and 5349, so the
+     * fans are present and readable but not spinning. Dropping those readings would turn two stopped fans into no fans,
+     * and {@link oshi.hardware.Sensors#getFanSpeeds()} distinguishes the two: an empty array means no fans were
+     * detected, while a zero entry means a fan whose speed is zero or could not be measured.
+     *
+     * @param reading the raw reading
+     * @return the speed in rpm, never negative
+     */
+    public static int toRpm(double reading) {
+        if (Double.isNaN(reading) || reading <= 0d) {
+            return 0;
+        }
+        // Round rather than truncate: rpm is reported as a float but is integral in nature, and truncating biases low.
+        return (int) Math.min(Integer.MAX_VALUE, Math.round(reading));
+    }
+
+    /**
+     * Tests whether a reading is plausible as a CPU voltage.
+     *
+     * @param volts the reading to test, in volts
+     * @return true if the reading is at least {@link #MIN_PLAUSIBLE_VOLTAGE}
+     */
+    public static boolean isPlausibleVoltage(double volts) {
+        return volts >= MIN_PLAUSIBLE_VOLTAGE;
+    }
+
+    /**
+     * Converts a voltage reading to volts, according to the units its SMC data type implies.
+     * <p>
+     * An {@code fpe2} value is fourteen integer bits and two fractional bits, so it resolves to a quarter of a unit
+     * over a range of 0 to 16383.75. Read as volts that would express a 1.2 V core rail only as 1.00 or 1.25, which is
+     * too coarse to be the intent; read as millivolts it resolves to 0.25 mV over 0 to 16.4 V, which is what a voltage
+     * sensor wants. Millivolts is the only self-consistent reading, so an {@code fpe2} value is scaled.
+     * <p>
+     * Every other type is already in volts, including the {@code flt} that Apple Silicon reports. Scaling from the type
+     * rather than from the key name means a key whose encoding differs from the one expected still reads correctly.
+     *
+     * @param raw      the decoded reading
+     * @param dataType the key's SMC data type, which may be empty if that read failed
+     * @return the reading in volts
+     */
+    public static double scaleVoltage(double raw, String dataType) {
+        return DATATYPE_FPE2.equals(dataType) ? raw / 1000d : raw;
+    }
+}

--- a/oshi-common/src/main/resources/oshi.properties
+++ b/oshi-common/src/main/resources/oshi.properties
@@ -309,6 +309,20 @@ oshi.os.linux.sensors.cputemperature.types=cpu-thermal,x86_pkg_temp
 # sensors do not follow the usual Tg<digit><alphanumeric> naming.
 oshi.os.mac.sensors.gputemperature.keys=
 
+# Comma-separated list of macOS SMC keys to read for fan speeds, one key per fan.
+# Leave empty (the default) to discover the keys from the SMC at runtime, cross-checked against the fan
+# count FNum reports. Set this only to override that discovery.
+oshi.os.mac.sensors.fanspeed.keys=
+
+# Comma-separated list of macOS SMC keys to read for CPU voltage, tried in order until one returns a
+# plausible reading. Each is scaled to volts according to its own SMC data type.
+# Leave empty (the default) to try the Apple Silicon key VP0C and then the Intel key VC0C. These keys
+# are deliberately NOT discovered at runtime the way GPU temperature keys are: the V prefix covers
+# supply rails as well as the CPU (an M3 Pro reports 0.75 V from VP0C and 20 V from VD0R) and no naming
+# convention separates them, so a scan could report a rail voltage as the CPU's. Set this property to
+# name the key on hardware where neither default works.
+oshi.os.mac.sensors.cpuvoltage.keys=
+
 # ==============================================================================
 # Privilege Escalation Configuration (Linux/Unix)
 # ==============================================================================

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
@@ -194,6 +194,88 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
         assertThat(SmcKeyIndex.isGpuTemperatureKey(null), is(false));
     }
 
+    // -- fan keys --
+
+    @Test
+    public void testFindsFanSpeedKeysExcludingOtherFanKeys() {
+        // The SORTED fixture has a single fan key; discovery on it must return exactly that one.
+        assertThat(SmcKeyIndex.findKeys(SORTED.length, lookup(SORTED), "F", SmcKeyIndex::isFanSpeedKey),
+                contains("F0Ac"));
+        // A realistic F block: the mask must reject FNum, F0Mn, F0Mx, FBAC and Ftst, which all sort inside it.
+        String[] keys = { "F0Ac", "F0Mn", "F0Mx", "F1Ac", "FBAC", "FNum", "FOff", "Ftst" };
+        assertThat(SmcKeyIndex.findKeys(keys.length, lookup(keys), "F", SmcKeyIndex::isFanSpeedKey),
+                contains("F0Ac", "F1Ac"));
+    }
+
+    @Test
+    public void testFanSpeedMaskAcceptsRealFanKeys() {
+        for (int i = 0; i <= 9; i++) {
+            String key = "F" + i + "Ac";
+            assertThat(key + " must match", SmcKeyIndex.isFanSpeedKey(key), is(true));
+        }
+    }
+
+    @Test
+    public void testFanSpeedMaskRejectsNonFanKeys() {
+        // FNum/F0Mn/F0Mx/F0Tg/FBAC/Ftst are other keys in the F block; the rest are malformed or wrong case.
+        for (String key : new String[] { "FNum", "F0Mn", "F0Mx", "F0Tg", "FBAC", "Ftst", "f0ac", "F0AC", "F10Ac", "FAc",
+                "" }) {
+            assertThat("'" + key + "' must not match", SmcKeyIndex.isFanSpeedKey(key), is(false));
+        }
+        assertThat(SmcKeyIndex.isFanSpeedKey(null), is(false));
+    }
+
+    @Test
+    public void testFanSpeedKeysSynthesizedFromCount() {
+        assertThat(SmcKeyIndex.fanSpeedKeys(0), is(empty()));
+        assertThat(SmcKeyIndex.fanSpeedKeys(2), contains("F0Ac", "F1Ac"));
+        assertThat("A negative count clamps to empty", SmcKeyIndex.fanSpeedKeys(-1), is(empty()));
+    }
+
+    @Test
+    public void testFanSpeedKeysAreAlwaysFourCharacters() {
+        // Pins the latent defect: F%dAc with a two-digit index formats a five-character key that reads a different key.
+        // Clamping to MAX_FANS keeps every synthesized key exactly four characters.
+        for (long count : new long[] { 99L, Long.MAX_VALUE }) {
+            List<String> keys = SmcKeyIndex.fanSpeedKeys(count);
+            assertThat(keys.size(), is(SmcKeyIndex.MAX_FANS));
+            for (String key : keys) {
+                assertThat("'" + key + "' must be four characters", key.length(), is(4));
+            }
+        }
+    }
+
+    @Test
+    public void testReconcileFanKeysPrefersDiscovered() {
+        List<String> discovered = Arrays.asList("F0Ac", "F1Ac");
+        // Non-empty discovery is authoritative regardless of FNum, including when the two disagree.
+        assertThat(SmcKeyIndex.reconcileFanKeys(discovered, 2), contains("F0Ac", "F1Ac"));
+        assertThat(SmcKeyIndex.reconcileFanKeys(discovered, 5), contains("F0Ac", "F1Ac"));
+        assertThat(SmcKeyIndex.reconcileFanKeys(discovered, 0), contains("F0Ac", "F1Ac"));
+    }
+
+    @Test
+    public void testReconcileFanKeysSynthesizesFromFnumWhenDiscoveryEmpty() {
+        // No-regression: an index that yielded no fan keys still reports the fans FNum implies, as older OSHI did.
+        assertThat(SmcKeyIndex.reconcileFanKeys(null, 2), contains("F0Ac", "F1Ac"));
+        assertThat(SmcKeyIndex.reconcileFanKeys(Arrays.<String>asList(), 2), contains("F0Ac", "F1Ac"));
+    }
+
+    @Test
+    public void testReconcileFanKeysCannotTellReturnsNull() {
+        // Discovery failed and FNum read zero: "no fans" is indistinguishable from "could not read", so defer.
+        assertThat("Null must not be cached as a confirmed absence", SmcKeyIndex.reconcileFanKeys(null, 0),
+                is(nullValue()));
+    }
+
+    @Test
+    public void testReconcileFanKeysConfirmedNoFansReturnsEmpty() {
+        // Discovery completed with no fan keys and FNum agrees: a genuine fanless machine, a cacheable empty answer.
+        List<String> result = SmcKeyIndex.reconcileFanKeys(Arrays.<String>asList(), 0);
+        assertThat(result, is(notNullValue()));
+        assertThat(result, is(empty()));
+    }
+
     // -- configured keys --
 
     @Test

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcSensorValuesTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcSensorValuesTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.common.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests connection-independent SMC sensor value interpretation without Mac hardware.
+ * <p>
+ * The class and its methods are {@code public} because the module system only opens public types to the JUnit platform;
+ * a package-private test class in a named module fails to run.
+ */
+public class SmcSensorValuesTest { // NOSONAR squid:S5786 - public is required by JPMS, not redundant
+
+    // -- toRpm --
+
+    @Test
+    public void testToRpmPreservesZero() {
+        // A stopped fan genuinely reads 0.0 (both fans on an idle M3 Pro do). Dropping it would turn stopped fans into
+        // no fans; iSMC's < 0.005 filter is deliberately not applied here.
+        assertThat(SmcSensorValues.toRpm(0d), is(0));
+    }
+
+    @Test
+    public void testToRpmClampsNegativeAndNaN() {
+        assertThat(SmcSensorValues.toRpm(-5d), is(0));
+        assertThat(SmcSensorValues.toRpm(Double.NaN), is(0));
+    }
+
+    @Test
+    public void testToRpmRoundsRatherThanTruncates() {
+        assertThat(SmcSensorValues.toRpm(1349.6d), is(1350));
+        assertThat(SmcSensorValues.toRpm(1350.4d), is(1350));
+    }
+
+    @Test
+    public void testToRpmDoesNotOverflow() {
+        assertThat(SmcSensorValues.toRpm(1e30d), is(greaterThanOrEqualTo(0)));
+        assertThat(SmcSensorValues.toRpm(1e30d), is(Integer.MAX_VALUE));
+    }
+
+    // -- voltage plausibility --
+
+    @Test
+    public void testIsPlausibleVoltageRejectsLowAndMisscaled() {
+        assertThat(SmcSensorValues.isPlausibleVoltage(0d), is(false));
+        assertThat(SmcSensorValues.isPlausibleVoltage(-1d), is(false));
+        assertThat("A /1000 mis-scaling of a 1.2 V rail must be rejected", SmcSensorValues.isPlausibleVoltage(0.0012d),
+                is(false));
+    }
+
+    @Test
+    public void testIsPlausibleVoltageAcceptsRealReadings() {
+        for (double volts : new double[] { 0.7477d, 0.8638d, 1.2d, 1.35d }) {
+            assertThat(volts + " V must be plausible", SmcSensorValues.isPlausibleVoltage(volts), is(true));
+        }
+    }
+
+    @Test
+    public void testNoUpperBoundIsApplied() {
+        // No ceiling: since voltage keys are never discovered, no rail key is read, so a ceiling would guard nothing.
+        assertThat(SmcSensorValues.isPlausibleVoltage(20.2d), is(true));
+    }
+
+    @Test
+    public void testFloorSitsBetweenTheTwoPopulations() {
+        // The floor separates the mis-scaling target (~0.0012 V) from the lowest confirmed reading (0.7477 V).
+        assertThat(SmcSensorValues.MIN_PLAUSIBLE_VOLTAGE, is(greaterThanOrEqualTo(0.0012d)));
+        assertThat(SmcSensorValues.MIN_PLAUSIBLE_VOLTAGE, is(lessThanOrEqualTo(0.5d)));
+    }
+
+    // -- voltage scaling --
+
+    @Test
+    public void testScaleVoltageFpe2IsMillivolts() {
+        // fpe2 resolves to 0.25 units; only as millivolts is that a usable voltage resolution.
+        assertThat(SmcSensorValues.scaleVoltage(1200d, "fpe2"), is(closeTo(1.2d, 1e-9)));
+    }
+
+    @Test
+    public void testScaleVoltageOtherTypesAreVolts() {
+        assertThat(SmcSensorValues.scaleVoltage(0.7477d, "flt"), is(closeTo(0.7477d, 1e-9)));
+        assertThat(SmcSensorValues.scaleVoltage(1.2d, "sp78"), is(closeTo(1.2d, 1e-9)));
+        assertThat("An unknown or unread type is treated as volts and left to the floor",
+                SmcSensorValues.scaleVoltage(0d, ""), is(closeTo(0d, 1e-9)));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -51,6 +51,7 @@ import oshi.ffm.platform.mac.IOKit.IOService;
 import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.mac.SmcKeyIndex;
+import oshi.util.common.platform.mac.SmcSensorValues;
 
 /**
  * Provides access to SMC calls on macOS using FFM
@@ -111,8 +112,20 @@ public final class SmcUtilFFM {
     /** The prefix shared by Apple Silicon GPU cluster temperature keys. */
     private static final String GPU_KEY_PREFIX = "Tg";
 
+    /** The prefix shared by fan keys. */
+    private static final String FAN_KEY_PREFIX = "F";
+
     /** Guards {@link #gpuTemperatureKeys}. */
     private static final Object GPU_KEY_LOCK = new Object();
+
+    /** Guards {@link #fanSpeedKeys}. */
+    private static final Object FAN_KEY_LOCK = new Object();
+
+    /**
+     * Discovered fan speed keys, or null if discovery has not yet produced a cacheable answer. Deliberately not a
+     * {@link oshi.util.Memoizer}, for the same reason as {@link #gpuTemperatureKeys}.
+     */
+    private static volatile List<String> fanSpeedKeys; // NOSONAR squid:S3077 - published value is immutable
 
     /**
      * Discovered GPU temperature keys, or null if discovery has not yet completed successfully. Deliberately not a
@@ -125,6 +138,12 @@ public final class SmcUtilFFM {
     private static volatile List<String> gpuTemperatureKeys; // NOSONAR squid:S3077 - published value is immutable
     /** SMC key for Apple Silicon CPU voltage. */
     public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
+
+    /**
+     * CPU voltage keys, tried in order until one returns a plausible value: the Apple Silicon key first, then the Intel
+     * one. Each reading is scaled according to its own data type, so the order does not imply the units.
+     */
+    public static final List<String> SMC_KEYS_CPU_VOLTAGE = List.of(SMC_KEY_CPU_VOLTAGE_AS, SMC_KEY_CPU_VOLTAGE);
 
     /** SMC command to read bytes. */
     public static final byte SMC_CMD_READ_BYTES = 5;
@@ -369,6 +388,125 @@ public final class SmcUtilFFM {
             gpuTemperatureKeys = discovered;
             return discovered;
         }
+    }
+
+    /**
+     * Get the fan speed keys for this machine, discovering them from the SMC on first use and caching the result.
+     * <p>
+     * Discovery binary searches the sorted key index for the {@code F} block and keeps the keys matching the fan
+     * current-speed naming convention, then reconciles the result against {@code FNum}: the index is authoritative, but
+     * a positive {@code FNum} still implies the conventionally named keys where discovery finds none, so this never
+     * reports fewer fans than reading {@code FNum} directly did. See
+     * {@link SmcKeyIndex#reconcileFanKeys(java.util.List, long)}.
+     * <p>
+     * Can be overridden with the {@link GlobalConfig#OSHI_OS_MAC_SENSORS_FANSPEED_KEYS} configuration property, which
+     * bypasses discovery entirely.
+     *
+     * @return The keys to read for fan speeds, never null
+     */
+    public static List<String> getFanSpeedKeys() {
+        List<String> keys = fanSpeedKeys;
+        if (keys != null) {
+            return keys;
+        }
+        synchronized (FAN_KEY_LOCK) {
+            if (fanSpeedKeys != null) {
+                return fanSpeedKeys;
+            }
+            // Read the config lazily rather than at class initialization, so GlobalConfig.set() still takes effect.
+            List<String> configured = SmcKeyIndex
+                    .parseConfiguredKeys(GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SENSORS_FANSPEED_KEYS, ""));
+            if (!configured.isEmpty()) {
+                LOG.debug("Using configured fan speed keys {}", configured);
+                fanSpeedKeys = configured;
+                return configured;
+            }
+            List<String> discovered = discoverFanSpeedKeys();
+            if (discovered == null) {
+                LOG.debug("Fan speed key discovery did not complete; reporting no fans this time.");
+                return List.of();
+            }
+            LOG.debug("Using {} fan speed keys: {}", discovered.size(), discovered);
+            fanSpeedKeys = discovered;
+            return discovered;
+        }
+    }
+
+    /**
+     * @return the keys to read, or null if neither the key index nor {@code FNum} could be read
+     */
+    private static List<String> discoverFanSpeedKeys() {
+        int conn = smcOpen();
+        if (conn == 0) {
+            return null; // NOSONAR squid:S1168 - null means "could not read", which the caller must not cache
+        }
+        try {
+            int keyCount = (int) smcGetLong(conn, SMC_KEY_COUNT);
+            // Scanning the index rather than probing F0Ac through F9Ac directly, because smcGetDataType cannot tell an
+            // absent key from a failed read: both return an empty string. findKeys tracks read failures and so can
+            // distinguish "this machine has no fans" from "ask again later", which a direct probe cannot.
+            List<String> discovered = SmcKeyIndex.findKeys(keyCount, i -> smcReadKeyAtIndex(conn, i), FAN_KEY_PREFIX,
+                    SmcKeyIndex::isFanSpeedKey);
+            // Read FNum on the same connection, so a machine whose index is unreadable still reports its fans.
+            return SmcKeyIndex.reconcileFanKeys(discovered, smcGetLong(conn, SMC_KEY_FAN_NUM));
+        } finally {
+            smcClose(conn);
+        }
+    }
+
+    /**
+     * Get the keys to read for CPU voltage, in the order they should be tried.
+     * <p>
+     * Unlike the GPU temperature keys these are not discovered from the key index, because the {@code V} prefix is not
+     * specific to the CPU: an M3 Pro reports a 0.75 V core voltage from {@code VP0C} alongside a 20 V supply rail from
+     * {@code VD0R}, with no naming convention separating them. A prefix scan could therefore report a rail voltage as
+     * the CPU's, which is worse than reporting nothing. Use {@link GlobalConfig#OSHI_OS_MAC_SENSORS_CPUVOLTAGE_KEYS} to
+     * name the key on hardware where neither default works.
+     *
+     * @return The keys to read for CPU voltage, never null
+     */
+    public static List<String> getCpuVoltageKeys() {
+        List<String> configured = SmcKeyIndex
+                .parseConfiguredKeys(GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SENSORS_CPUVOLTAGE_KEYS, ""));
+        return configured.isEmpty() ? SMC_KEYS_CPU_VOLTAGE : configured;
+    }
+
+    /**
+     * The lowest reading accepted as a genuine CPU voltage, in volts. See
+     * {@link SmcSensorValues#MIN_PLAUSIBLE_VOLTAGE}.
+     */
+    public static final double MIN_PLAUSIBLE_VOLTAGE = SmcSensorValues.MIN_PLAUSIBLE_VOLTAGE;
+
+    /**
+     * Tests whether a reading is plausible as a CPU voltage.
+     *
+     * @param volts the reading to test, in volts
+     * @return true if the reading is at least {@link #MIN_PLAUSIBLE_VOLTAGE}
+     */
+    public static boolean isPlausibleVoltage(double volts) {
+        return SmcSensorValues.isPlausibleVoltage(volts);
+    }
+
+    /**
+     * Get the first plausible CPU voltage from a list of SMC keys, scaling each reading according to its data type.
+     *
+     * @param conn The connection
+     * @param keys The keys to try in order
+     * @return The first reading at or above {@link #MIN_PLAUSIBLE_VOLTAGE}, or 0 if no key returned one
+     */
+    public static double smcGetFirstVoltage(int conn, List<String> keys) {
+        for (String key : keys) {
+            double raw = smcGetFloat(conn, key);
+            if (raw == 0d) {
+                continue;
+            }
+            double volts = SmcSensorValues.scaleVoltage(raw, smcGetDataType(conn, key));
+            if (isPlausibleVoltage(volts)) {
+                return volts;
+            }
+            LOG.debug("Ignoring implausible voltage {} from SMC key {}.", volts, key);
+        }
+        return 0d;
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacSensorsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacSensorsFFM.java
@@ -7,24 +7,19 @@ package oshi.hardware.platform.mac;
 import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEYS_CPU_TEMP_AGGREGATE_AS;
 import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEYS_CPU_TEMP_AS;
 import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEY_CPU_TEMP;
-import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEY_CPU_VOLTAGE;
-import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEY_CPU_VOLTAGE_AS;
-import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEY_FAN_NUM;
-import static oshi.ffm.util.platform.mac.SmcUtilFFM.SMC_KEY_FAN_SPEED;
 
-import java.util.Locale;
+import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.util.platform.mac.SmcUtilFFM;
 import oshi.hardware.common.AbstractSensors;
+import oshi.util.common.platform.mac.SmcSensorValues;
 
 /**
  * Sensors from SMC
  */
 @ThreadSafe
 final class MacSensorsFFM extends AbstractSensors {
-
-    private volatile int numFans = 0;
 
     @Override
     public double queryCpuTemperature() {
@@ -52,19 +47,18 @@ final class MacSensorsFFM extends AbstractSensors {
 
     @Override
     public int[] queryFanSpeeds() {
+        // Resolve the keys before opening a connection: discovery opens its own, and nesting two would leak a handle.
+        List<String> keys = SmcUtilFFM.getFanSpeedKeys();
         int conn = SmcUtilFFM.smcOpen();
+        // On open failure return an array sized to the known key count rather than empty, so the length stays stable
+        // across polls. An empty array means "no fans detected"; a zero entry means "a fan reading zero or unmeasured".
         if (conn == 0) {
-            return new int[this.numFans];
+            return new int[keys.size()];
         }
         try {
-            int fans = this.numFans;
-            if (fans == 0) {
-                fans = (int) SmcUtilFFM.smcGetLong(conn, SMC_KEY_FAN_NUM);
-                this.numFans = fans;
-            }
-            int[] fanSpeeds = new int[fans];
-            for (int i = 0; i < fans; i++) {
-                fanSpeeds[i] = (int) SmcUtilFFM.smcGetFloat(conn, String.format(Locale.ROOT, SMC_KEY_FAN_SPEED, i));
+            int[] fanSpeeds = new int[keys.size()];
+            for (int i = 0; i < keys.size(); i++) {
+                fanSpeeds[i] = SmcSensorValues.toRpm(SmcUtilFFM.smcGetFloat(conn, keys.get(i)));
             }
             return fanSpeeds;
         } finally {
@@ -79,11 +73,7 @@ final class MacSensorsFFM extends AbstractSensors {
             return 0d;
         }
         try {
-            double volts = SmcUtilFFM.smcGetFloat(conn, SMC_KEY_CPU_VOLTAGE_AS);
-            if (volts > 0d) {
-                return volts;
-            }
-            return SmcUtilFFM.smcGetFloat(conn, SMC_KEY_CPU_VOLTAGE) / 1000d;
+            return SmcUtilFFM.smcGetFirstVoltage(conn, SmcUtilFFM.getCpuVoltageKeys());
         } finally {
             SmcUtilFFM.smcClose(conn);
         }

--- a/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
@@ -235,8 +235,10 @@ public class MacSensorsPlausibilityFFMTest { // NOSONAR squid:S5786 - public is 
             assertThat("One speed per discovered key", speeds.length, is(keys.size()));
             for (int i = 0; i < speeds.length; i++) {
                 assertThat("Fan speed must not be negative", speeds[i], is(greaterThanOrEqualTo(0)));
-                // F%dMx is the fan's hardware maximum; only assert against it where it reads a real value.
-                double max = SmcUtilFFM.smcGetFloat(conn, String.format(java.util.Locale.ROOT, "F%dMx", i));
+                // F%dMx is the fan's hardware maximum. Derive it from the discovered key rather than the loop index:
+                // discovery returns keys in index order, so a machine numbering its fans non-contiguously would
+                // otherwise be compared against a different fan's maximum. Only assert where the key reads a value.
+                double max = SmcUtilFFM.smcGetFloat(conn, keys.get(i).substring(0, 2) + "Mx");
                 if (max > 0) {
                     assertThat("Fan speed must not exceed the hardware maximum", (double) speeds[i],
                             is(lessThanOrEqualTo(max * 1.5)));

--- a/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
@@ -187,4 +187,107 @@ public class MacSensorsPlausibilityFFMTest { // NOSONAR squid:S5786 - public is 
     public void testFallbackKeysIncludeTheHistoricalFour() {
         assertThat(SmcUtilFFM.SMC_KEYS_GPU_TEMP_AS, hasItems("Tg05", "Tg0D", "Tg0f", "Tg0j"));
     }
+
+    // -- fans --
+
+    @Test
+    public void testFanSpeedKeysAreDiscoveredAndWellFormed() {
+        List<String> keys = SmcUtilFFM.getFanSpeedKeys();
+        assertThat("Discovery must never return null", keys, is(notNullValue()));
+        for (String key : keys) {
+            assertThat(key + " must match the fan speed key convention", SmcKeyIndex.isFanSpeedKey(key), is(true));
+        }
+    }
+
+    @Test
+    public void testFanSpeedKeyDiscoveryIsCached() {
+        List<String> keys = SmcUtilFFM.getFanSpeedKeys();
+        List<String> second = SmcUtilFFM.getFanSpeedKeys();
+        assertThat("Repeated calls must agree", second, is(equalTo(keys)));
+        // A completed discovery is cached; the "cannot tell" outcome deliberately is not, and returns an empty list
+        // without caching, so asserting identity on an empty result could pass vacuously.
+        if (!keys.isEmpty()) {
+            assertThat("A completed discovery must be cached, not repeated", second, is(sameInstance(keys)));
+        }
+    }
+
+    @Test
+    public void testFanCountAgreesWithFanNum() {
+        int conn = SmcUtilFFM.smcOpen();
+        assumeTrue(conn != 0, "SMC unavailable");
+        try {
+            long fanNum = SmcUtilFFM.smcGetLong(conn, SmcUtilFFM.SMC_KEY_FAN_NUM);
+            assumeTrue(fanNum > 0, "FNum unavailable");
+            assertThat("Discovered fan count must agree with FNum", (long) SmcUtilFFM.getFanSpeedKeys().size(),
+                    is(equalTo(fanNum)));
+        } finally {
+            SmcUtilFFM.smcClose(conn);
+        }
+    }
+
+    @Test
+    public void testFanSpeedsAreWithinTheHardwareLimits() {
+        int conn = SmcUtilFFM.smcOpen();
+        assumeTrue(conn != 0, "SMC unavailable");
+        try {
+            int[] speeds = SystemInfoFactory.create().getHardware().getSensors().getFanSpeeds();
+            List<String> keys = SmcUtilFFM.getFanSpeedKeys();
+            assertThat("One speed per discovered key", speeds.length, is(keys.size()));
+            for (int i = 0; i < speeds.length; i++) {
+                assertThat("Fan speed must not be negative", speeds[i], is(greaterThanOrEqualTo(0)));
+                // F%dMx is the fan's hardware maximum; only assert against it where it reads a real value.
+                double max = SmcUtilFFM.smcGetFloat(conn, String.format(java.util.Locale.ROOT, "F%dMx", i));
+                if (max > 0) {
+                    assertThat("Fan speed must not exceed the hardware maximum", (double) speeds[i],
+                            is(lessThanOrEqualTo(max * 1.5)));
+                }
+            }
+        } finally {
+            SmcUtilFFM.smcClose(conn);
+        }
+    }
+
+    @Test
+    public void testStoppedFanIsReportedAsZeroNotDropped() {
+        // An empty array means "no fans detected"; a zero entry means "a fan reading zero". A stopped fan must produce
+        // the latter, so the array length tracks the key count regardless of whether any fan is spinning.
+        int[] speeds = SystemInfoFactory.create().getHardware().getSensors().getFanSpeeds();
+        assertThat("One speed per discovered key, even when all are stopped", speeds.length,
+                is(SmcUtilFFM.getFanSpeedKeys().size()));
+    }
+
+    // -- voltage --
+
+    @Test
+    public void testCpuVoltageIsPlausibleOrUnavailable() {
+        double volts = SystemInfoFactory.create().getHardware().getSensors().getCpuVoltage();
+        assertThat("CPU voltage must be unavailable or plausible, never a mis-scaled fraction", volts,
+                either(is(0d)).or(greaterThanOrEqualTo(SmcUtilFFM.MIN_PLAUSIBLE_VOLTAGE)));
+    }
+
+    @Test
+    public void testAppleSiliconVoltageKeyReadsPlausibly() {
+        int conn = SmcUtilFFM.smcOpen();
+        assumeTrue(conn != 0, "SMC unavailable");
+        try {
+            // Skips on Intel, where VP0C is absent (its data type reads empty).
+            assumeTrue(!SmcUtilFFM.smcGetDataType(conn, SmcUtilFFM.SMC_KEY_CPU_VOLTAGE_AS).isEmpty(),
+                    "VP0C unavailable (Intel)");
+            double volts = SmcUtilFFM.smcGetFirstVoltage(conn, SmcUtilFFM.getCpuVoltageKeys());
+            assertThat("Apple Silicon core voltage must read plausibly", volts,
+                    is(greaterThanOrEqualTo(SmcUtilFFM.MIN_PLAUSIBLE_VOLTAGE)));
+        } finally {
+            SmcUtilFFM.smcClose(conn);
+        }
+    }
+
+    @Test
+    public void testVoltageKeysAreNotDiscovered() {
+        // Guards against someone "completing the pattern" and adding a V-prefix scan that could return a supply rail
+        // (e.g. VD0R at 20 V) as the CPU voltage. The default keys are the two named keys, no discovery.
+        assertThat("Voltage keys must remain the named defaults", SmcUtilFFM.getCpuVoltageKeys(),
+                is(equalTo(SmcUtilFFM.SMC_KEYS_CPU_VOLTAGE)));
+        assertThat(SmcUtilFFM.SMC_KEYS_CPU_VOLTAGE,
+                contains(SmcUtilFFM.SMC_KEY_CPU_VOLTAGE_AS, SmcUtilFFM.SMC_KEY_CPU_VOLTAGE));
+    }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensorsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacSensorsJNA.java
@@ -7,17 +7,14 @@ package oshi.hardware.platform.mac;
 import static oshi.util.platform.mac.SmcUtil.SMC_KEYS_CPU_TEMP_AGGREGATE_AS;
 import static oshi.util.platform.mac.SmcUtil.SMC_KEYS_CPU_TEMP_AS;
 import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_TEMP;
-import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_VOLTAGE;
-import static oshi.util.platform.mac.SmcUtil.SMC_KEY_CPU_VOLTAGE_AS;
-import static oshi.util.platform.mac.SmcUtil.SMC_KEY_FAN_NUM;
-import static oshi.util.platform.mac.SmcUtil.SMC_KEY_FAN_SPEED;
 
-import java.util.Locale;
+import java.util.List;
 
 import com.sun.jna.platform.mac.IOKit.IOConnect;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.AbstractSensors;
+import oshi.util.common.platform.mac.SmcSensorValues;
 import oshi.util.platform.mac.SmcUtil;
 
 /**
@@ -25,8 +22,6 @@ import oshi.util.platform.mac.SmcUtil;
  */
 @ThreadSafe
 final class MacSensorsJNA extends AbstractSensors {
-
-    private volatile int numFans = 0;
 
     @Override
     public double queryCpuTemperature() {
@@ -54,19 +49,18 @@ final class MacSensorsJNA extends AbstractSensors {
 
     @Override
     public int[] queryFanSpeeds() {
+        // Resolve the keys before opening a connection: discovery opens its own, and nesting two would leak a handle.
+        List<String> keys = SmcUtil.getFanSpeedKeys();
         IOConnect conn = SmcUtil.smcOpen();
+        // On open failure return an array sized to the known key count rather than empty, so the length stays stable
+        // across polls. An empty array means "no fans detected"; a zero entry means "a fan reading zero or unmeasured".
         if (conn == null) {
-            return new int[this.numFans];
+            return new int[keys.size()];
         }
         try {
-            int fans = this.numFans;
-            if (fans == 0) {
-                fans = (int) SmcUtil.smcGetLong(conn, SMC_KEY_FAN_NUM);
-                this.numFans = fans;
-            }
-            int[] fanSpeeds = new int[fans];
-            for (int i = 0; i < fans; i++) {
-                fanSpeeds[i] = (int) SmcUtil.smcGetFloat(conn, String.format(Locale.ROOT, SMC_KEY_FAN_SPEED, i));
+            int[] fanSpeeds = new int[keys.size()];
+            for (int i = 0; i < keys.size(); i++) {
+                fanSpeeds[i] = SmcSensorValues.toRpm(SmcUtil.smcGetFloat(conn, keys.get(i)));
             }
             return fanSpeeds;
         } finally {
@@ -81,13 +75,7 @@ final class MacSensorsJNA extends AbstractSensors {
             return 0d;
         }
         try {
-            // Apple Silicon: VP0C is flt already in volts, no scaling needed
-            double volts = SmcUtil.smcGetFloat(conn, SMC_KEY_CPU_VOLTAGE_AS);
-            if (volts > 0d) {
-                return volts;
-            }
-            // Intel: VC0C is FPE2 in millivolts, divide by 1000 to get volts
-            return SmcUtil.smcGetFloat(conn, SMC_KEY_CPU_VOLTAGE) / 1000d;
+            return SmcUtil.smcGetFirstVoltage(conn, SmcUtil.getCpuVoltageKeys());
         } finally {
             SmcUtil.smcClose(conn);
         }

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -32,6 +32,7 @@ import oshi.jna.platform.mac.SystemB;
 import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.mac.SmcKeyIndex;
+import oshi.util.common.platform.mac.SmcSensorValues;
 
 /**
  * Provides access to SMC calls on macOS
@@ -96,8 +97,20 @@ public final class SmcUtil {
     /** The prefix shared by Apple Silicon GPU cluster temperature keys. */
     private static final String GPU_KEY_PREFIX = "Tg";
 
+    /** The prefix shared by fan keys. */
+    private static final String FAN_KEY_PREFIX = "F";
+
     /** Guards {@link #gpuTemperatureKeys}. */
     private static final Object GPU_KEY_LOCK = new Object();
+
+    /** Guards {@link #fanSpeedKeys}. */
+    private static final Object FAN_KEY_LOCK = new Object();
+
+    /**
+     * Discovered fan speed keys, or null if discovery has not yet produced a cacheable answer. Deliberately not a
+     * {@link oshi.util.Memoizer}, for the same reason as {@link #gpuTemperatureKeys}.
+     */
+    private static volatile List<String> fanSpeedKeys; // NOSONAR squid:S3077 - published value is immutable
 
     /**
      * Discovered GPU temperature keys, or null if discovery has not yet completed successfully. Deliberately not a
@@ -110,6 +123,13 @@ public final class SmcUtil {
     private static volatile List<String> gpuTemperatureKeys; // NOSONAR squid:S3077 - published value is immutable
     /** SMC key for CPU voltage (Apple Silicon). */
     public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
+
+    /**
+     * CPU voltage keys, tried in order until one returns a plausible value: the Apple Silicon key first, then the Intel
+     * one. Each reading is scaled according to its own data type, so the order does not imply the units.
+     */
+    public static final List<String> SMC_KEYS_CPU_VOLTAGE = Collections
+            .unmodifiableList(Arrays.asList(SMC_KEY_CPU_VOLTAGE_AS, SMC_KEY_CPU_VOLTAGE));
 
     /** SMC command to read bytes. */
     public static final byte SMC_CMD_READ_BYTES = 5;
@@ -341,6 +361,124 @@ public final class SmcUtil {
             gpuTemperatureKeys = discovered;
             return discovered;
         }
+    }
+
+    /**
+     * Get the keys to read for fan speeds, discovering them from the SMC key index on first use and caching the result.
+     * <p>
+     * The key index is authoritative about which keys exist, so it is preferred over the count {@code FNum} reports. A
+     * positive {@code FNum} still implies the conventionally named keys where discovery finds none, so this never
+     * reports fewer fans than reading {@code FNum} directly did. See
+     * {@link SmcKeyIndex#reconcileFanKeys(java.util.List, long)}.
+     * <p>
+     * Can be overridden with the {@link GlobalConfig#OSHI_OS_MAC_SENSORS_FANSPEED_KEYS} configuration property, which
+     * bypasses discovery entirely.
+     *
+     * @return The keys to read for fan speeds, never null
+     */
+    public static List<String> getFanSpeedKeys() {
+        List<String> keys = fanSpeedKeys;
+        if (keys != null) {
+            return keys;
+        }
+        synchronized (FAN_KEY_LOCK) {
+            if (fanSpeedKeys != null) {
+                return fanSpeedKeys;
+            }
+            // Read the config lazily rather than at class initialization, so GlobalConfig.set() still takes effect.
+            List<String> configured = SmcKeyIndex
+                    .parseConfiguredKeys(GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SENSORS_FANSPEED_KEYS, ""));
+            if (!configured.isEmpty()) {
+                LOG.debug("Using configured fan speed keys {}", configured);
+                fanSpeedKeys = configured;
+                return configured;
+            }
+            List<String> discovered = discoverFanSpeedKeys();
+            if (discovered == null) {
+                LOG.debug("Fan speed key discovery did not complete; reporting no fans this time.");
+                return Collections.emptyList();
+            }
+            LOG.debug("Using {} fan speed keys: {}", discovered.size(), discovered);
+            fanSpeedKeys = discovered;
+            return discovered;
+        }
+    }
+
+    /**
+     * @return the keys to read, or null if neither the key index nor {@code FNum} could be read
+     */
+    private static List<String> discoverFanSpeedKeys() {
+        IOConnect conn = smcOpen();
+        if (conn == null) {
+            return null; // NOSONAR squid:S1168 - null means "could not read", which the caller must not cache
+        }
+        try {
+            int keyCount = (int) smcGetLong(conn, SMC_KEY_COUNT);
+            // Scanning the index rather than probing F0Ac through F9Ac directly, because smcGetDataType cannot tell an
+            // absent key from a failed read: both return an empty string. findKeys tracks read failures and so can
+            // distinguish "this machine has no fans" from "ask again later", which a direct probe cannot.
+            List<String> discovered = SmcKeyIndex.findKeys(keyCount, i -> smcReadKeyAtIndex(conn, i), FAN_KEY_PREFIX,
+                    SmcKeyIndex::isFanSpeedKey);
+            // Read FNum on the same connection, so a machine whose index is unreadable still reports its fans.
+            return SmcKeyIndex.reconcileFanKeys(discovered, smcGetLong(conn, SMC_KEY_FAN_NUM));
+        } finally {
+            smcClose(conn);
+        }
+    }
+
+    /**
+     * Get the keys to read for CPU voltage, in the order they should be tried.
+     * <p>
+     * Unlike the GPU temperature keys these are not discovered from the key index, because the {@code V} prefix is not
+     * specific to the CPU: an M3 Pro reports a 0.75 V core voltage from {@code VP0C} alongside a 20 V supply rail from
+     * {@code VD0R}, with no naming convention separating them. A prefix scan could therefore report a rail voltage as
+     * the CPU's, which is worse than reporting nothing. Use {@link GlobalConfig#OSHI_OS_MAC_SENSORS_CPUVOLTAGE_KEYS} to
+     * name the key on hardware where neither default works.
+     *
+     * @return The keys to read for CPU voltage, never null
+     */
+    public static List<String> getCpuVoltageKeys() {
+        List<String> configured = SmcKeyIndex
+                .parseConfiguredKeys(GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SENSORS_CPUVOLTAGE_KEYS, ""));
+        return configured.isEmpty() ? SMC_KEYS_CPU_VOLTAGE : configured;
+    }
+
+    /**
+     * The lowest reading accepted as a genuine CPU voltage, in volts. See
+     * {@link SmcSensorValues#MIN_PLAUSIBLE_VOLTAGE}.
+     */
+    public static final double MIN_PLAUSIBLE_VOLTAGE = SmcSensorValues.MIN_PLAUSIBLE_VOLTAGE;
+
+    /**
+     * Tests whether a reading is plausible as a CPU voltage.
+     *
+     * @param volts the reading to test, in volts
+     * @return true if the reading is at least {@link #MIN_PLAUSIBLE_VOLTAGE}
+     */
+    public static boolean isPlausibleVoltage(double volts) {
+        return SmcSensorValues.isPlausibleVoltage(volts);
+    }
+
+    /**
+     * Get the first plausible CPU voltage from a list of SMC keys, scaling each reading according to its data type.
+     *
+     * @param conn The connection
+     * @param keys The keys to try in order
+     * @return The first reading at or above {@link #MIN_PLAUSIBLE_VOLTAGE}, or 0 if no key returned one
+     */
+    public static double smcGetFirstVoltage(IOConnect conn, List<String> keys) {
+        for (String key : keys) {
+            double raw = smcGetFloat(conn, key);
+            if (raw == 0d) {
+                continue;
+            }
+            double volts = SmcSensorValues.scaleVoltage(raw, smcGetDataType(conn, key));
+            if (isPlausibleVoltage(volts)) {
+                return volts;
+            }
+            LOG.debug("Ignoring implausible voltage {} from SMC key {}.", volts, key);
+        }
+        return 0d;
     }
 
     /**

--- a/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
@@ -189,4 +189,106 @@ public class MacSensorsPlausibilityTest { // NOSONAR squid:S5786 - public is req
     public void testFallbackKeysIncludeTheHistoricalFour() {
         assertThat(SmcUtil.SMC_KEYS_GPU_TEMP_AS, hasItems("Tg05", "Tg0D", "Tg0f", "Tg0j"));
     }
+
+    // -- fans --
+
+    @Test
+    public void testFanSpeedKeysAreDiscoveredAndWellFormed() {
+        List<String> keys = SmcUtil.getFanSpeedKeys();
+        assertThat("Discovery must never return null", keys, is(notNullValue()));
+        for (String key : keys) {
+            assertThat(key + " must match the fan speed key convention", SmcKeyIndex.isFanSpeedKey(key), is(true));
+        }
+    }
+
+    @Test
+    public void testFanSpeedKeyDiscoveryIsCached() {
+        List<String> keys = SmcUtil.getFanSpeedKeys();
+        List<String> second = SmcUtil.getFanSpeedKeys();
+        assertThat("Repeated calls must agree", second, is(equalTo(keys)));
+        // A completed discovery is cached; the "cannot tell" outcome deliberately is not, and returns an empty list
+        // without caching, so asserting identity on an empty result could pass vacuously.
+        if (!keys.isEmpty()) {
+            assertThat("A completed discovery must be cached, not repeated", second, is(sameInstance(keys)));
+        }
+    }
+
+    @Test
+    public void testFanCountAgreesWithFanNum() {
+        IOKit.IOConnect conn = SmcUtil.smcOpen();
+        assumeTrue(conn != null, "SMC unavailable");
+        try {
+            long fanNum = SmcUtil.smcGetLong(conn, SmcUtil.SMC_KEY_FAN_NUM);
+            assumeTrue(fanNum > 0, "FNum unavailable");
+            assertThat("Discovered fan count must agree with FNum", (long) SmcUtil.getFanSpeedKeys().size(),
+                    is(equalTo(fanNum)));
+        } finally {
+            SmcUtil.smcClose(conn);
+        }
+    }
+
+    @Test
+    public void testFanSpeedsAreWithinTheHardwareLimits() {
+        IOKit.IOConnect conn = SmcUtil.smcOpen();
+        assumeTrue(conn != null, "SMC unavailable");
+        try {
+            int[] speeds = new SystemInfo().getHardware().getSensors().getFanSpeeds();
+            List<String> keys = SmcUtil.getFanSpeedKeys();
+            assertThat("One speed per discovered key", speeds.length, is(keys.size()));
+            for (int i = 0; i < speeds.length; i++) {
+                assertThat("Fan speed must not be negative", speeds[i], is(greaterThanOrEqualTo(0)));
+                // F%dMx is the fan's hardware maximum; only assert against it where it reads a real value.
+                double max = SmcUtil.smcGetFloat(conn, String.format(java.util.Locale.ROOT, "F%dMx", i));
+                if (max > 0) {
+                    assertThat("Fan speed must not exceed the hardware maximum", (double) speeds[i],
+                            is(lessThanOrEqualTo(max * 1.5)));
+                }
+            }
+        } finally {
+            SmcUtil.smcClose(conn);
+        }
+    }
+
+    @Test
+    public void testStoppedFanIsReportedAsZeroNotDropped() {
+        // An empty array means "no fans detected"; a zero entry means "a fan reading zero". A stopped fan must produce
+        // the latter, so the array length tracks the key count regardless of whether any fan is spinning.
+        int[] speeds = new SystemInfo().getHardware().getSensors().getFanSpeeds();
+        assertThat("One speed per discovered key, even when all are stopped", speeds.length,
+                is(SmcUtil.getFanSpeedKeys().size()));
+    }
+
+    // -- voltage --
+
+    @Test
+    public void testCpuVoltageIsPlausibleOrUnavailable() {
+        double volts = new SystemInfo().getHardware().getSensors().getCpuVoltage();
+        assertThat("CPU voltage must be unavailable or plausible, never a mis-scaled fraction", volts,
+                either(is(0d)).or(greaterThanOrEqualTo(SmcUtil.MIN_PLAUSIBLE_VOLTAGE)));
+    }
+
+    @Test
+    public void testAppleSiliconVoltageKeyReadsPlausibly() {
+        IOKit.IOConnect conn = SmcUtil.smcOpen();
+        assumeTrue(conn != null, "SMC unavailable");
+        try {
+            // Skips on Intel, where VP0C is absent (its data type reads empty).
+            assumeTrue(!SmcUtil.smcGetDataType(conn, SmcUtil.SMC_KEY_CPU_VOLTAGE_AS).isEmpty(),
+                    "VP0C unavailable (Intel)");
+            double volts = SmcUtil.smcGetFirstVoltage(conn, SmcUtil.getCpuVoltageKeys());
+            assertThat("Apple Silicon core voltage must read plausibly", volts,
+                    is(greaterThanOrEqualTo(SmcUtil.MIN_PLAUSIBLE_VOLTAGE)));
+        } finally {
+            SmcUtil.smcClose(conn);
+        }
+    }
+
+    @Test
+    public void testVoltageKeysAreNotDiscovered() {
+        // Guards against someone "completing the pattern" and adding a V-prefix scan that could return a supply rail
+        // (e.g. VD0R at 20 V) as the CPU voltage. The default keys are the two named keys, no discovery.
+        assertThat("Voltage keys must remain the named defaults", SmcUtil.getCpuVoltageKeys(),
+                is(equalTo(SmcUtil.SMC_KEYS_CPU_VOLTAGE)));
+        assertThat(SmcUtil.SMC_KEYS_CPU_VOLTAGE, contains(SmcUtil.SMC_KEY_CPU_VOLTAGE_AS, SmcUtil.SMC_KEY_CPU_VOLTAGE));
+    }
 }

--- a/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
@@ -237,8 +237,10 @@ public class MacSensorsPlausibilityTest { // NOSONAR squid:S5786 - public is req
             assertThat("One speed per discovered key", speeds.length, is(keys.size()));
             for (int i = 0; i < speeds.length; i++) {
                 assertThat("Fan speed must not be negative", speeds[i], is(greaterThanOrEqualTo(0)));
-                // F%dMx is the fan's hardware maximum; only assert against it where it reads a real value.
-                double max = SmcUtil.smcGetFloat(conn, String.format(java.util.Locale.ROOT, "F%dMx", i));
+                // F%dMx is the fan's hardware maximum. Derive it from the discovered key rather than the loop index:
+                // discovery returns keys in index order, so a machine numbering its fans non-contiguously would
+                // otherwise be compared against a different fan's maximum. Only assert where the key reads a value.
+                double max = SmcUtil.smcGetFloat(conn, keys.get(i).substring(0, 2) + "Mx");
                 if (max > 0) {
                     assertThat("Fan speed must not exceed the hardware maximum", (double) speeds[i],
                             is(lessThanOrEqualTo(max * 1.5)));


### PR DESCRIPTION
## What this changes

PRs #3531, #3535 and #3536 fixed macOS **temperature** reporting and left behind reusable machinery: a generic key-index scanner (`SmcKeyIndex`), a plausibility-guard idiom, and a config-override pattern. The fan and voltage paths in `MacSensors*` were never revisited and still read single hardcoded keys with no discovery, no plausibility guard, and no test coverage. This applies that machinery to both.

### Fans — discover the keys instead of synthesizing them from `FNum`

Fan speeds came from `FNum` alone: read the count, then format `F%dAc` for each index. **That is a latent bug for a count of eleven or more.** `String.format("F%dAc", 10)` produces the five-character `"F10Ac"`, and `smcReadKey` passes the key through `ParseUtil.strToLong(key, 4)`, which reads only the first four bytes. Verified empirically:

```
F10Ac  len=5  strToLong(,4)=0x46313041
F10A   len=4  strToLong(,4)=0x46313041
F10Ac and F10A collide: true
```

So a corrupt or spoofed `FNum` makes OSHI read a *different key* and report its value as a fan speed — no exception, no log. Keys are now discovered from the sorted key index (as the GPU keys are) and reconciled against `FNum`:

| discovered | `FNum` | result |
|---|---|---|
| non-empty | any | discovered (index is authoritative) |
| `null`/empty | > 0 | synthesize, clamped to `MAX_FANS` — no regression vs. today |
| `null` | 0 | **`null`** — can't distinguish "no fans" from "couldn't read", so don't cache |
| empty | 0 | empty (cacheable; a genuinely fanless machine) |

Scanned rather than probing `F0Ac`…`F9Ac` directly because `smcGetDataType` returns `""` for both "absent" and "read failed"; `findKeys`' `readFailed` tracker already distinguishes those.

### Voltage — scale by data type, and hold to a floor

Voltage read `VP0C`, then `VC0C / 1000` if that returned zero, with the divisor tied to the *key* rather than to its *encoding*. It is now scaled from the SMC data type and held to a plausibility floor.

`fpe2` is 14 integer + 2 fractional bits, so it resolves to a quarter of a unit. Read as volts, a 1.2 V core rail could only be expressed as 1.00 or 1.25; read as millivolts it resolves to 0.25 mV over 0–16.4 V. Millivolts is the only self-consistent reading, so the existing divisor is kept — now derived from the type, so a key whose encoding differs from the one expected still reads correctly. The floor makes the choice fail safe either way: a wrongly divided reading lands near 0.0012 V and is rejected as unavailable rather than returned as a believable wrong number.

**Voltage keys are deliberately *not* discovered** — an asymmetry with fans and GPU that I'd rather document than have re-litigated. `Tg` is a semantic prefix, where every match is a GPU cluster sensor; `V` is not. This M3 Pro's 37 `V*` keys mix a 0.75 V core voltage (`VP0C`) with a 20.2 V supply rail (`VD0R`) and a 0.86 V `VPsC`, under no naming rule that separates them, so a prefix scan could report a rail voltage as the CPU's — worse than reporting nothing. The two named keys stay, and `oshi.os.mac.sensors.cpuvoltage.keys` is the escape hatch, handing the guess to the user rather than making it in OSHI. `testVoltageKeysAreNotDiscovered` asserts the defaults so the pattern isn't "completed" later.

### A stopped fan reads zero, and must stay zero

iSMC drops readings below 0.005. Applied here that would drop **both** fans on an idle M3 Pro, where `F0Ac`/`F1Ac` read 0.0 while `F0Mn`/`F0Mx` report 1350/5349 — the fans are present and readable, just not spinning. `Sensors#getFanSpeeds` documents an empty array as "no fans detected" and a zero entry as "a fan reading zero or unmeasurable", so dropping them would turn two stopped fans into no fans. Commented so nobody adds it later.

## Structure

New logic goes in **oshi-common**, so both backends share it and it is testable off a Mac:
- `SmcKeyIndex` gains `isFanSpeedKey` (`^F\dAc$` — the fourth char is fixed here, unlike the GPU mask), `MAX_FANS`, `fanSpeedKeys`, `reconcileFanKeys`
- New `SmcSensorValues` holds `toRpm`, the voltage floor, and `scaleVoltage`

Both `SmcUtil` twins gain `getFanSpeedKeys`/`discoverFanSpeedKeys`/`getCpuVoltageKeys`/`smcGetFirstVoltage`, following the existing `getGpuTemperatureKeys` shape exactly (including the "deliberately not a `Memoizer`" caching, so a transient SMC failure can't disable the sensor for the JVM lifetime).

Also removes the per-instance `numFans` field — the key list in `SmcUtil` is now the single process-wide cache, matching `gpuTemperatureKeys`, and `queryFanSpeeds` resolves it *before* opening a connection because discovery opens its own. Re: #3442, which moved memoized suppliers to instance fields: this list is small, bounded and hardware-invariant, the same character as `gpuTemperatureKeys`.

## Verification

**No CHANGELOG entry: on testable hardware nothing changes.** The `FNum` truncation is only reachable through a corrupt or spoofed fan count, and the voltage scaling is unchanged for every data type observed. This is hardening plus missing test coverage, not a user-facing fix.

Verified on an M3 Pro (Mac15,7, macOS 26.5.2, JDK 26):

| Probe | Result |
|---|---|
| `FNum` (`ui8`, via `smcGetLong`) | 2 |
| `F0Ac` / `F1Ac` (`flt`) | 0.0 / 0.0 — genuinely stopped at idle |
| `F0Mn` / `F0Mx` | 1350 / 5349 — fans are real and readable |
| `getFanSpeeds()` | `[0, 0]` — **unchanged before and after** |
| `VP0C` (`flt`) | plausible core voltage on both backends |
| `VC0C` | absent (type `""`), as expected on Apple Silicon |

Suites: oshi-common 1219, oshi-core 104 (+8), oshi-core-ffm 89 (+8), all 0 failed. `-Pnative-comparison` 41 including the new `fanSpeedKeys()`. Spotless + Checkstyle clean.

**Untested for want of hardware:** the Intel `fpe2` branch and every non-M3-Pro fan topology. I'd like to file a follow-up asking an Intel Mac owner for `VC0C`'s data type and raw value to confirm the millivolts reasoning empirically.

The iSMC corpus does *not* support a cross-machine key-variation argument here the way it did for temperature: its `internal/reports/*.txt` (23 machines) holds 6052 keys, **every one starting with `T`**. Its voltage list is Intel-era and lacks `VP0C` entirely, and its README states Apple Silicon voltage is read over a HID sensor hub rather than SMC — an approach deliberately rejected in #3535. What it *does* confirm: `F%dAc` is the right current-speed key, and a fan-count clamp is warranted.

## Tests

Eight fan cases in `SmcKeyIndexTest` including both `null`-versus-empty rows of `reconcileFanKeys` and a case pinning every synthesized key at four characters (the defect above); a new `SmcSensorValuesTest`; eight matching cases in each `MacSensorsPlausibility` twin (identical method names, as the existing ten are); and a `fanSpeedKeys()` comparison in `NativeComparisonTest`.

That last one compares the two backends' *discovered key lists*, which is sharper than comparing rpm. The fan readings themselves are only compared when both are nonzero — a fan spinning up between the sequential JNA and FFM reads would otherwise fail `assertWithinRatio`'s one-value-zero branch, which asserts the nonzero value is `<= ratio`.

## Deliberately out of scope

- **`smcReadKey`/`smcGetKeyInfo`/`smcCall` visibility asymmetry** (public in `SmcUtil`, private in `SmcUtilFFM`). Narrowing JNA breaks `oshi-demo`'s `SmcDump`; widening FFM would put `MemorySegment`/`Arena` into an exported public API for a cosmetic win. Flagging it so the asymmetry reads as deliberate.
- **Migrating `MIN_PLAUSIBLE_TEMPERATURE` into oshi-common** alongside the new voltage floor. It's still duplicated across both `SmcUtil` twins; defining it once is the better shape, but that's a separate change.
- **Changing Intel `fpe2` behavior**, pending the data above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced macOS fan-speed monitoring via SMC key auto-discovery, with new configurable sensor-key overrides.
  * Improved macOS CPU voltage detection with clearer default key selection and better interpretation of voltage data.
* **Bug Fixes**
  * More robust normalization of fan speeds (preserve zero; clamp invalid values).
  * Added plausibility filtering for voltage readings to reduce false/garbled results.
  * Improved consistency of sensor behavior across macOS backends.
* **Tests**
  * Expanded macOS SMC plausibility and key-discovery regression coverage for fans and CPU voltage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->