### PR TITLE
Dedup the LogicalVolumeGroup bindings

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroup.java
@@ -4,15 +4,21 @@
  */
 package oshi.hardware.common.platform.linux;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
+import oshi.hardware.LogicalVolumeGroup;
 import oshi.hardware.common.AbstractLogicalVolumeGroup;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.Util;
 import oshi.util.linux.DevPath;
 
 /**
@@ -66,5 +72,102 @@ public class LinuxLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
             }
         }
         return physicalVolumesMap;
+    }
+
+    /**
+     * The udev attributes of one block device, read by the bindings so the device-mapper filtering and volume-group
+     * assembly can be shared. Any field may be null if udev did not report that property.
+     */
+    public static final class UdevBlockDevice {
+        private final String syspath;
+        private final String devnode;
+        private final String uuid;
+        private final String vgName;
+        private final String lvName;
+
+        /**
+         * Creates a block device record.
+         *
+         * @param syspath the sysfs path of the device
+         * @param devnode the device node path, e.g. {@code /dev/dm-0}
+         * @param uuid    the {@code DM_UUID} property
+         * @param vgName  the {@code DM_VG_NAME} property
+         * @param lvName  the {@code DM_LV_NAME} property
+         */
+        public UdevBlockDevice(String syspath, String devnode, String uuid, String vgName, String lvName) {
+            this.syspath = syspath;
+            this.devnode = devnode;
+            this.uuid = uuid;
+            this.vgName = vgName;
+            this.lvName = lvName;
+        }
+    }
+
+    /**
+     * Creates the binding's volume group type.
+     */
+    @FunctionalInterface
+    public interface LogicalVolumeGroupFactory {
+        /**
+         * Creates a volume group.
+         *
+         * @param name  the volume group name
+         * @param lvMap the logical volume map
+         * @param pvSet the physical volume set
+         * @return the volume group
+         */
+        LogicalVolumeGroup create(String name, Map<String, Set<String>> lvMap, Set<String> pvSet);
+    }
+
+    /**
+     * Assembles volume groups from enumerated block devices, keeping only the device-mapper devices that LVM owns and
+     * reading each one's physical volumes from its sysfs {@code slaves} directory.
+     *
+     * @param devices the block devices reported by udev
+     * @param factory creates the binding's volume group type
+     * @return the volume groups, never null
+     */
+    protected static List<LogicalVolumeGroup> buildLogicalVolumeGroups(List<UdevBlockDevice> devices,
+            LogicalVolumeGroupFactory factory) {
+        return buildLogicalVolumeGroups(devices, queryPhysicalVolumes(), factory);
+    }
+
+    /**
+     * Assembles volume groups from enumerated block devices and an already-queried physical volume map. Package-private
+     * so tests can supply the map instead of running {@code pvs}.
+     *
+     * @param devices            the block devices reported by udev
+     * @param physicalVolumesMap map of VG name to set of PV device paths, mutated as devices are processed
+     * @param factory            creates the binding's volume group type
+     * @return the volume groups, never null
+     */
+    static List<LogicalVolumeGroup> buildLogicalVolumeGroups(List<UdevBlockDevice> devices,
+            Map<String, Set<String>> physicalVolumesMap, LogicalVolumeGroupFactory factory) {
+        Map<String, Map<String, Set<String>>> logicalVolumesMap = new HashMap<>();
+        for (UdevBlockDevice device : devices) {
+            if (device.devnode == null || !device.devnode.startsWith(DevPath.DM) || device.uuid == null
+                    || !device.uuid.startsWith("LVM-") || Util.isBlank(device.vgName) || Util.isBlank(device.lvName)) {
+                continue;
+            }
+            Map<String, Set<String>> lvMapForGroup = logicalVolumesMap.computeIfAbsent(device.vgName,
+                    k -> new HashMap<>());
+            Set<String> pvSetForGroup = physicalVolumesMap.computeIfAbsent(device.vgName, k -> new HashSet<>());
+            File[] slaves = new File(device.syspath + "/slaves").listFiles();
+            if (slaves != null) {
+                for (File f : slaves) {
+                    String pvName = DevPath.DEV + f.getName();
+                    lvMapForGroup.computeIfAbsent(device.lvName, k -> new HashSet<>()).add(pvName);
+                    pvSetForGroup.add(pvName);
+                }
+            }
+        }
+        List<LogicalVolumeGroup> lvgList = new ArrayList<>();
+        for (Entry<String, Map<String, Set<String>>> entry : logicalVolumesMap.entrySet()) {
+            // Every key here was added to physicalVolumesMap above, but default rather than risk a null set reaching
+            // the immutable-copy constructor.
+            lvgList.add(factory.create(entry.getKey(), entry.getValue(),
+                    physicalVolumesMap.getOrDefault(entry.getKey(), Collections.emptySet())));
+        }
+        return lvgList;
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroup.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import oshi.driver.common.windows.wmi.MSFTStorage.PhysicalDiskProperty;
+import oshi.driver.common.windows.wmi.MSFTStorage.StoragePoolProperty;
+import oshi.driver.common.windows.wmi.MSFTStorage.StoragePoolToPhysicalDiskProperty;
+import oshi.driver.common.windows.wmi.MSFTStorage.VirtualDiskProperty;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.driver.common.windows.wmi.WmiUtil;
+import oshi.hardware.LogicalVolumeGroup;
+import oshi.hardware.common.AbstractLogicalVolumeGroup;
+import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
+
+/**
+ * Windows implementation of LogicalVolumeGroup, mapping Storage Spaces storage pools to volume groups. Storage Spaces
+ * requires Windows 8 or Server 2012.
+ * <p>
+ * The correlation logic lives here rather than in the bindings because the {@code MSFT_Storage} queries return
+ * backend-neutral {@link WmiResult} values; only the COM plumbing that runs them differs between the bindings.
+ */
+public class WindowsLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
+
+    private static final Pattern SP_OBJECT_ID = Pattern.compile(".*ObjectId=.*SP:(\\{.*\\}).*");
+    private static final Pattern PD_OBJECT_ID = Pattern.compile(".*ObjectId=.*PD:(\\{.*\\}).*");
+    private static final Pattern VD_OBJECT_ID = Pattern.compile(".*ObjectId=.*VD:(\\{.*\\})(\\{.*\\}).*");
+
+    /**
+     * Creates a WindowsLogicalVolumeGroup.
+     *
+     * @param name  the volume group name
+     * @param lvMap the logical volume map
+     * @param pvSet the physical volume set
+     */
+    protected WindowsLogicalVolumeGroup(String name, Map<String, Set<String>> lvMap, Set<String> pvSet) {
+        super(name, lvMap, pvSet);
+    }
+
+    /**
+     * Creates the binding's volume group type.
+     */
+    @FunctionalInterface
+    public interface LogicalVolumeGroupFactory {
+        /**
+         * Creates a volume group.
+         *
+         * @param name  the volume group name
+         * @param lvMap the logical volume map
+         * @param pvSet the physical volume set
+         * @return the volume group
+         */
+        LogicalVolumeGroup create(String name, Map<String, Set<String>> lvMap, Set<String> pvSet);
+    }
+
+    /**
+     * Correlates the Storage Spaces query results into volume groups.
+     *
+     * @param sp      the storage pool query result
+     * @param vds     the virtual disk query result
+     * @param pds     the physical disk query result
+     * @param sppd    the storage pool to physical disk mapping query result
+     * @param factory creates the binding's volume group type
+     * @return the volume groups, never null
+     */
+    protected static List<LogicalVolumeGroup> buildFromWmi(WmiResult<StoragePoolProperty> sp,
+            WmiResult<VirtualDiskProperty> vds, WmiResult<PhysicalDiskProperty> pds,
+            WmiResult<StoragePoolToPhysicalDiskProperty> sppd, LogicalVolumeGroupFactory factory) {
+        // Get all the Virtual Disks
+        Map<String, String> vdMap = new HashMap<>();
+        int count = vds.getResultCount();
+        for (int i = 0; i < count; i++) {
+            String vdObjectId = WmiUtil.getString(vds, VirtualDiskProperty.OBJECTID, i);
+            Matcher m = VD_OBJECT_ID.matcher(vdObjectId);
+            if (m.matches()) {
+                vdObjectId = m.group(2) + " " + m.group(1);
+            }
+            // Store key with SP|VD
+            vdMap.put(vdObjectId, WmiUtil.getString(vds, VirtualDiskProperty.FRIENDLYNAME, i));
+        }
+
+        // Get all the Physical Disks
+        Map<String, Pair<String, String>> pdMap = new HashMap<>();
+        count = pds.getResultCount();
+        for (int i = 0; i < count; i++) {
+            String pdObjectId = WmiUtil.getString(pds, PhysicalDiskProperty.OBJECTID, i);
+            Matcher m = PD_OBJECT_ID.matcher(pdObjectId);
+            if (m.matches()) {
+                pdObjectId = m.group(1);
+            }
+            // Store key with PD
+            pdMap.put(pdObjectId, new Pair<>(WmiUtil.getString(pds, PhysicalDiskProperty.FRIENDLYNAME, i),
+                    WmiUtil.getString(pds, PhysicalDiskProperty.PHYSICALLOCATION, i)));
+        }
+
+        // Get the Storage Pool to Physical Disk mapping
+        Map<String, String> sppdMap = new HashMap<>();
+        count = sppd.getResultCount();
+        for (int i = 0; i < count; i++) {
+            // Ref string contains object id, will do partial match later
+            String spObjectId = WmiUtil.getRefString(sppd, StoragePoolToPhysicalDiskProperty.STORAGEPOOL, i);
+            Matcher m = SP_OBJECT_ID.matcher(spObjectId);
+            if (m.matches()) {
+                spObjectId = m.group(1);
+            }
+            String pdObjectId = WmiUtil.getRefString(sppd, StoragePoolToPhysicalDiskProperty.PHYSICALDISK, i);
+            m = PD_OBJECT_ID.matcher(pdObjectId);
+            if (m.matches()) {
+                pdObjectId = m.group(1);
+            }
+            sppdMap.put(spObjectId + " " + pdObjectId, pdObjectId);
+        }
+
+        // Finally process the storage pools
+        List<LogicalVolumeGroup> lvgList = new ArrayList<>();
+        count = sp.getResultCount();
+        for (int i = 0; i < count; i++) {
+            // Name
+            String name = WmiUtil.getString(sp, StoragePoolProperty.FRIENDLYNAME, i);
+            // Parse object ID to match
+            String spObjectId = WmiUtil.getString(sp, StoragePoolProperty.OBJECTID, i);
+            Matcher m = SP_OBJECT_ID.matcher(spObjectId);
+            if (m.matches()) {
+                spObjectId = m.group(1);
+            }
+            // find matching physical and logical volumes
+            Set<String> physicalVolumeSet = new HashSet<>();
+            for (Entry<String, String> entry : sppdMap.entrySet()) {
+                if (entry.getKey().contains(spObjectId)) {
+                    String pdObjectId = entry.getValue();
+                    Pair<String, String> nameLoc = pdMap.get(pdObjectId);
+                    if (nameLoc != null) {
+                        physicalVolumeSet.add(nameLoc.getA() + " @ " + nameLoc.getB());
+                    }
+                }
+            }
+            // find matching logical volume
+            Map<String, Set<String>> logicalVolumeMap = new HashMap<>();
+            for (Entry<String, String> entry : vdMap.entrySet()) {
+                if (entry.getKey().contains(spObjectId)) {
+                    String vdObjectId = ParseUtil.whitespaces.split(entry.getKey())[0];
+                    logicalVolumeMap.put(entry.getValue() + " " + vdObjectId, physicalVolumeSet);
+                }
+            }
+            // Add to list
+            lvgList.add(factory.create(name, logicalVolumeMap, physicalVolumeSet));
+        }
+        return lvgList;
+    }
+}

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroup.java
@@ -135,23 +135,28 @@ public class WindowsLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
             if (m.matches()) {
                 spObjectId = m.group(1);
             }
-            // find matching physical and logical volumes
             Set<String> physicalVolumeSet = new HashSet<>();
-            for (Entry<String, String> entry : sppdMap.entrySet()) {
-                if (entry.getKey().contains(spObjectId)) {
-                    String pdObjectId = entry.getValue();
-                    Pair<String, String> nameLoc = pdMap.get(pdObjectId);
-                    if (nameLoc != null) {
-                        physicalVolumeSet.add(nameLoc.getA() + " @ " + nameLoc.getB());
+            Map<String, Set<String>> logicalVolumeMap = new HashMap<>();
+            // Members are matched by substring, and every string contains the empty one, so a pool whose ObjectId is
+            // absent would claim every disk and volume on the system rather than none. WmiUtil maps a missing property
+            // to an empty string, so guard on that before matching.
+            if (!spObjectId.isEmpty()) {
+                // find matching physical volumes
+                for (Entry<String, String> entry : sppdMap.entrySet()) {
+                    if (entry.getKey().contains(spObjectId)) {
+                        String pdObjectId = entry.getValue();
+                        Pair<String, String> nameLoc = pdMap.get(pdObjectId);
+                        if (nameLoc != null) {
+                            physicalVolumeSet.add(nameLoc.getA() + " @ " + nameLoc.getB());
+                        }
                     }
                 }
-            }
-            // find matching logical volume
-            Map<String, Set<String>> logicalVolumeMap = new HashMap<>();
-            for (Entry<String, String> entry : vdMap.entrySet()) {
-                if (entry.getKey().contains(spObjectId)) {
-                    String vdObjectId = ParseUtil.whitespaces.split(entry.getKey())[0];
-                    logicalVolumeMap.put(entry.getValue() + " " + vdObjectId, physicalVolumeSet);
+                // find matching logical volume
+                for (Entry<String, String> entry : vdMap.entrySet()) {
+                    if (entry.getKey().contains(spObjectId)) {
+                        String vdObjectId = ParseUtil.whitespaces.split(entry.getKey())[0];
+                        logicalVolumeMap.put(entry.getValue() + " " + vdObjectId, physicalVolumeSet);
+                    }
                 }
             }
             // Add to list

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroupTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroupTest.java
@@ -8,9 +8,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -18,6 +26,11 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import oshi.hardware.LogicalVolumeGroup;
+import oshi.hardware.common.platform.linux.LinuxLogicalVolumeGroup.UdevBlockDevice;
+import oshi.util.linux.DevPath;
 
 // parsePhysicalVolumes dereferences DevPath.DEV, whose static initializer validates that the configured /dev path
 // exists. That holds on Linux, macOS, and the BSD/illumos CI hosts, but not on Windows, where class init throws.
@@ -46,5 +59,102 @@ class LinuxLogicalVolumeGroupTest {
     @Test
     void testParsePhysicalVolumesEmpty() {
         assertThat(LinuxLogicalVolumeGroup.parsePhysicalVolumes(Collections.emptyList()), anEmptyMap());
+    }
+
+    // -- volume group assembly --
+
+    /** A concrete group so the factory has something to build. */
+    private static final class TestLvg extends LinuxLogicalVolumeGroup {
+        private TestLvg(String name, Map<String, Set<String>> lvMap, Set<String> pvSet) {
+            super(name, lvMap, pvSet);
+        }
+    }
+
+    // Creates a sysfs-like directory with a "slaves" entry per physical volume, returning its path.
+    private static String syspathWithSlaves(Path root, String name, String... slaves) throws IOException {
+        Path dir = Files.createDirectories(root.resolve(name).resolve("slaves"));
+        for (String slave : slaves) {
+            Files.createFile(dir.resolve(slave));
+        }
+        return root.resolve(name).toString();
+    }
+
+    private static UdevBlockDevice lvmDevice(String syspath, String vgName, String lvName) {
+        return new UdevBlockDevice(syspath, DevPath.DM + "0", "LVM-abcdef", vgName, lvName);
+    }
+
+    private static List<LogicalVolumeGroup> build(List<UdevBlockDevice> devices) {
+        return LinuxLogicalVolumeGroup.buildLogicalVolumeGroups(devices, new HashMap<>(), TestLvg::new);
+    }
+
+    @Test
+    void testAssemblesGroupFromSlavesDirectory(@TempDir Path tmp) throws IOException {
+        String syspath = syspathWithSlaves(tmp, "dm-0", "sda2", "sdb1");
+        List<LogicalVolumeGroup> lvgs = build(Collections.singletonList(lvmDevice(syspath, "vg0", "root")));
+
+        assertThat(lvgs, hasSize(1));
+        assertThat(lvgs.get(0).getName(), is("vg0"));
+        assertThat("Each slaves entry becomes a /dev physical volume", lvgs.get(0).getPhysicalVolumes(),
+                containsInAnyOrder("/dev/sda2", "/dev/sdb1"));
+        assertThat(lvgs.get(0).getLogicalVolumes().get("root"), containsInAnyOrder("/dev/sda2", "/dev/sdb1"));
+    }
+
+    @Test
+    void testTwoLogicalVolumesShareOneGroup(@TempDir Path tmp) throws IOException {
+        List<UdevBlockDevice> devices = Arrays.asList(lvmDevice(syspathWithSlaves(tmp, "dm-0", "sda2"), "vg0", "root"),
+                lvmDevice(syspathWithSlaves(tmp, "dm-1", "sdb1"), "vg0", "swap"));
+        List<LogicalVolumeGroup> lvgs = build(devices);
+
+        assertThat("Both volumes belong to one group", lvgs, hasSize(1));
+        assertThat(lvgs.get(0).getLogicalVolumes().keySet(), containsInAnyOrder("root", "swap"));
+        assertThat(lvgs.get(0).getLogicalVolumes().get("root"), contains("/dev/sda2"));
+        assertThat(lvgs.get(0).getLogicalVolumes().get("swap"), contains("/dev/sdb1"));
+        assertThat("The group's physical volumes are the union", lvgs.get(0).getPhysicalVolumes(),
+                containsInAnyOrder("/dev/sda2", "/dev/sdb1"));
+    }
+
+    @Test
+    void testNonLvmDevicesAreFiltered(@TempDir Path tmp) throws IOException {
+        String syspath = syspathWithSlaves(tmp, "dev", "sda1");
+        List<UdevBlockDevice> devices = Arrays.asList(
+                // not a device-mapper node
+                new UdevBlockDevice(syspath, "/dev/sda", "LVM-abcdef", "vg0", "root"),
+                // device-mapper, but owned by something other than LVM, e.g. LUKS
+                new UdevBlockDevice(syspath, DevPath.DM + "0", "CRYPT-LUKS2-abcdef", "vg0", "root"),
+                // device-mapper LVM, but udev reported no volume group or volume name
+                new UdevBlockDevice(syspath, DevPath.DM + "1", "LVM-abcdef", null, "root"),
+                new UdevBlockDevice(syspath, DevPath.DM + "2", "LVM-abcdef", "vg0", ""),
+                // udev reported no properties at all
+                new UdevBlockDevice(syspath, null, null, null, null));
+        assertThat("Nothing here is an LVM volume", build(devices), is(empty()));
+    }
+
+    @Test
+    void testMissingSlavesDirectoryStillReportsTheGroup(@TempDir Path tmp) {
+        // A volume whose sysfs entry has no slaves directory is still a volume group, just with no physical volumes.
+        List<LogicalVolumeGroup> lvgs = build(
+                Collections.singletonList(lvmDevice(tmp.resolve("absent").toString(), "vg0", "root")));
+        assertThat(lvgs, hasSize(1));
+        assertThat(lvgs.get(0).getName(), is("vg0"));
+        assertThat(lvgs.get(0).getPhysicalVolumes(), is(empty()));
+        assertThat(lvgs.get(0).getLogicalVolumes(), anEmptyMap());
+    }
+
+    @Test
+    void testPhysicalVolumesFromPvsAreMergedWithSlaves(@TempDir Path tmp) throws IOException {
+        // pvs already reported a volume for this group; the slaves scan adds to that set rather than replacing it.
+        Map<String, Set<String>> fromPvs = new HashMap<>();
+        fromPvs.put("vg0", new HashSet<>(Collections.singletonList("/dev/sdc1")));
+        List<LogicalVolumeGroup> lvgs = LinuxLogicalVolumeGroup.buildLogicalVolumeGroups(
+                Collections.singletonList(lvmDevice(syspathWithSlaves(tmp, "dm-0", "sda2"), "vg0", "root")), fromPvs,
+                TestLvg::new);
+
+        assertThat(lvgs, hasSize(1));
+        assertThat(lvgs.get(0).getPhysicalVolumes(), containsInAnyOrder("/dev/sdc1", "/dev/sda2"));
+    }
+
+    @Test
+    void testNoDevicesYieldsNoGroups() {
+        assertThat(build(Collections.emptyList()), is(empty()));
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroupTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroupTest.java
@@ -5,6 +5,7 @@
 package oshi.hardware.common.platform.windows;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -196,10 +197,31 @@ class WindowsLogicalVolumeGroupTest {
         row.put(StoragePoolProperty.OBJECTID, "not-an-object-id");
         rows.add(row);
 
-        List<LogicalVolumeGroup> lvgs = build(result(rows, CIM_STRING), virtualDisks(),
+        List<LogicalVolumeGroup> lvgs = build(result(rows, CIM_STRING), virtualDisks("Volume1", SP_GUID, VD_GUID),
                 physicalDisks("Disk1", "PCISlot1", PD1_GUID), poolToDisk(SP_GUID, PD1_GUID));
         assertThat(lvgs, hasSize(1));
         assertThat(lvgs.get(0).getName(), is("Pool1"));
+        assertThat("An unparseable pool ID must correlate nothing, not everything", lvgs.get(0).getPhysicalVolumes(),
+                is(empty()));
+        assertThat(lvgs.get(0).getLogicalVolumes(), is(anEmptyMap()));
+    }
+
+    @Test
+    void testMissingObjectIdCorrelatesNothing() {
+        // WmiUtil maps an absent property to "", and every string contains "", so an unguarded substring match would
+        // make a pool with no ObjectId absorb every physical and virtual disk on the system.
+        List<Map<StoragePoolProperty, Object>> rows = new ArrayList<>();
+        Map<StoragePoolProperty, Object> row = new EnumMap<>(StoragePoolProperty.class);
+        row.put(StoragePoolProperty.FRIENDLYNAME, "Pool1");
+        row.put(StoragePoolProperty.OBJECTID, null);
+        rows.add(row);
+
+        List<LogicalVolumeGroup> lvgs = build(result(rows, CIM_STRING), virtualDisks("Volume1", SP_GUID, VD_GUID),
+                physicalDisks("Disk1", "PCISlot1", PD1_GUID), poolToDisk(SP_GUID, PD1_GUID));
+        assertThat(lvgs, hasSize(1));
+        assertThat("A pool with no ObjectId must not claim every disk", lvgs.get(0).getPhysicalVolumes(), is(empty()));
+        assertThat("A pool with no ObjectId must not claim every volume", lvgs.get(0).getLogicalVolumes(),
+                is(anEmptyMap()));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroupTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroupTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_REFERENCE;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_STRING;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_BSTR;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.driver.common.windows.wmi.MSFTStorage.PhysicalDiskProperty;
+import oshi.driver.common.windows.wmi.MSFTStorage.StoragePoolProperty;
+import oshi.driver.common.windows.wmi.MSFTStorage.StoragePoolToPhysicalDiskProperty;
+import oshi.driver.common.windows.wmi.MSFTStorage.VirtualDiskProperty;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.hardware.LogicalVolumeGroup;
+
+/**
+ * Tests the shared Storage Spaces correlation without Windows, by stubbing the four WMI results. Storage Spaces needs
+ * pooled disks to be configured, so this path is otherwise hard to reach even on real hardware.
+ */
+class WindowsLogicalVolumeGroupTest {
+
+    private static final String SP_GUID = "{11111111-1111-1111-1111-111111111111}";
+    private static final String OTHER_SP_GUID = "{99999999-9999-9999-9999-999999999999}";
+    private static final String PD1_GUID = "{aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa}";
+    private static final String PD2_GUID = "{bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb}";
+    private static final String VD_GUID = "{cccccccc-cccc-cccc-cccc-cccccccccccc}";
+
+    // Builds the ObjectId form the production regexes expect.
+    private static String objectId(String kind, String... guids) {
+        StringBuilder sb = new StringBuilder("{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_");
+        sb.append(kind).append(":ObjectId=").append(kind).append(':');
+        for (String guid : guids) {
+            sb.append(guid);
+        }
+        return sb.toString();
+    }
+
+    // A minimal single-column-per-property WmiResult stub.
+    private static <T extends Enum<T>> WmiResult<T> result(List<Map<T, Object>> rows, int cimType) {
+        return new WmiResult<T>() {
+            @Override
+            public int getResultCount() {
+                return rows.size();
+            }
+
+            @Override
+            public Object getValue(T property, int index) {
+                return rows.get(index).get(property);
+            }
+
+            @Override
+            public int getVtType(T property) {
+                return VT_BSTR;
+            }
+
+            @Override
+            public int getCIMType(T property) {
+                return cimType;
+            }
+        };
+    }
+
+    private static WmiResult<StoragePoolProperty> pools(String... namesAndIds) {
+        List<Map<StoragePoolProperty, Object>> rows = new ArrayList<>();
+        for (int i = 0; i < namesAndIds.length; i += 2) {
+            Map<StoragePoolProperty, Object> row = new EnumMap<>(StoragePoolProperty.class);
+            row.put(StoragePoolProperty.FRIENDLYNAME, namesAndIds[i]);
+            row.put(StoragePoolProperty.OBJECTID, objectId("SP", namesAndIds[i + 1]));
+            rows.add(row);
+        }
+        return result(rows, CIM_STRING);
+    }
+
+    private static WmiResult<VirtualDiskProperty> virtualDisks(String... namesSpAndVd) {
+        List<Map<VirtualDiskProperty, Object>> rows = new ArrayList<>();
+        for (int i = 0; i < namesSpAndVd.length; i += 3) {
+            Map<VirtualDiskProperty, Object> row = new EnumMap<>(VirtualDiskProperty.class);
+            row.put(VirtualDiskProperty.FRIENDLYNAME, namesSpAndVd[i]);
+            // A VD ObjectId carries the storage pool GUID followed by the virtual disk GUID
+            row.put(VirtualDiskProperty.OBJECTID, objectId("VD", namesSpAndVd[i + 1], namesSpAndVd[i + 2]));
+            rows.add(row);
+        }
+        return result(rows, CIM_STRING);
+    }
+
+    private static WmiResult<PhysicalDiskProperty> physicalDisks(String... nameLocationAndId) {
+        List<Map<PhysicalDiskProperty, Object>> rows = new ArrayList<>();
+        for (int i = 0; i < nameLocationAndId.length; i += 3) {
+            Map<PhysicalDiskProperty, Object> row = new EnumMap<>(PhysicalDiskProperty.class);
+            row.put(PhysicalDiskProperty.FRIENDLYNAME, nameLocationAndId[i]);
+            row.put(PhysicalDiskProperty.PHYSICALLOCATION, nameLocationAndId[i + 1]);
+            row.put(PhysicalDiskProperty.OBJECTID, objectId("PD", nameLocationAndId[i + 2]));
+            rows.add(row);
+        }
+        return result(rows, CIM_STRING);
+    }
+
+    private static WmiResult<StoragePoolToPhysicalDiskProperty> poolToDisk(String... spAndPdGuids) {
+        List<Map<StoragePoolToPhysicalDiskProperty, Object>> rows = new ArrayList<>();
+        for (int i = 0; i < spAndPdGuids.length; i += 2) {
+            Map<StoragePoolToPhysicalDiskProperty, Object> row = new EnumMap<>(StoragePoolToPhysicalDiskProperty.class);
+            row.put(StoragePoolToPhysicalDiskProperty.STORAGEPOOL, objectId("SP", spAndPdGuids[i]));
+            row.put(StoragePoolToPhysicalDiskProperty.PHYSICALDISK, objectId("PD", spAndPdGuids[i + 1]));
+            rows.add(row);
+        }
+        // Association properties come back as CIM references, not plain strings
+        return result(rows, CIM_REFERENCE);
+    }
+
+    private static List<LogicalVolumeGroup> build(WmiResult<StoragePoolProperty> sp, WmiResult<VirtualDiskProperty> vds,
+            WmiResult<PhysicalDiskProperty> pds, WmiResult<StoragePoolToPhysicalDiskProperty> sppd) {
+        return WindowsLogicalVolumeGroup.buildFromWmi(sp, vds, pds, sppd, TestLvg::new);
+    }
+
+    private static final class TestLvg extends WindowsLogicalVolumeGroup {
+        private TestLvg(String name, Map<String, java.util.Set<String>> lvMap, java.util.Set<String> pvSet) {
+            super(name, lvMap, pvSet);
+        }
+    }
+
+    @Test
+    void testCorrelatesPoolWithItsDisksAndVolumes() {
+        List<LogicalVolumeGroup> lvgs = build(pools("Pool1", SP_GUID), virtualDisks("Volume1", SP_GUID, VD_GUID),
+                physicalDisks("Disk1", "PCISlot1", PD1_GUID, "Disk2", "PCISlot2", PD2_GUID),
+                poolToDisk(SP_GUID, PD1_GUID, SP_GUID, PD2_GUID));
+
+        assertThat(lvgs, hasSize(1));
+        LogicalVolumeGroup lvg = lvgs.get(0);
+        assertThat(lvg.getName(), is("Pool1"));
+        assertThat("Both pooled disks are physical volumes, named and located", lvg.getPhysicalVolumes(),
+                containsInAnyOrder("Disk1 @ PCISlot1", "Disk2 @ PCISlot2"));
+        assertThat(lvg.getLogicalVolumes().keySet(), contains("Volume1 " + VD_GUID));
+        assertThat("A logical volume maps to the pool's physical volumes",
+                lvg.getLogicalVolumes().get("Volume1 " + VD_GUID),
+                containsInAnyOrder("Disk1 @ PCISlot1", "Disk2 @ PCISlot2"));
+    }
+
+    @Test
+    void testDisksAndVolumesOfAnotherPoolAreNotMixedIn() {
+        // The regression this correlation exists to prevent: object IDs are matched by substring, so a second pool
+        // must not pick up the first pool's members.
+        List<LogicalVolumeGroup> lvgs = build(pools("Pool1", SP_GUID, "Pool2", OTHER_SP_GUID),
+                virtualDisks("Volume1", SP_GUID, VD_GUID),
+                physicalDisks("Disk1", "PCISlot1", PD1_GUID, "Disk2", "PCISlot2", PD2_GUID),
+                poolToDisk(SP_GUID, PD1_GUID, OTHER_SP_GUID, PD2_GUID));
+
+        assertThat(lvgs, hasSize(2));
+        LogicalVolumeGroup pool1 = lvgs.get(0);
+        LogicalVolumeGroup pool2 = lvgs.get(1);
+        assertThat(pool1.getName(), is("Pool1"));
+        assertThat(pool1.getPhysicalVolumes(), contains("Disk1 @ PCISlot1"));
+        assertThat(pool1.getLogicalVolumes().keySet(), contains("Volume1 " + VD_GUID));
+        assertThat(pool2.getName(), is("Pool2"));
+        assertThat(pool2.getPhysicalVolumes(), contains("Disk2 @ PCISlot2"));
+        assertThat("Pool2 owns no virtual disk", pool2.getLogicalVolumes().keySet(), is(empty()));
+    }
+
+    @Test
+    void testUnknownPhysicalDiskIsSkippedNotNulled() {
+        // The pool references a disk absent from the physical disk query; it must be dropped rather than producing a
+        // "null @ null" entry.
+        List<LogicalVolumeGroup> lvgs = build(pools("Pool1", SP_GUID), virtualDisks(),
+                physicalDisks("Disk1", "PCISlot1", PD1_GUID), poolToDisk(SP_GUID, PD1_GUID, SP_GUID, PD2_GUID));
+
+        assertThat(lvgs, hasSize(1));
+        assertThat(lvgs.get(0).getPhysicalVolumes(), contains("Disk1 @ PCISlot1"));
+    }
+
+    @Test
+    void testNoPoolsYieldsNoGroups() {
+        assertThat(build(pools(), virtualDisks(), physicalDisks(), poolToDisk()), is(empty()));
+    }
+
+    @Test
+    void testUnparseableObjectIdsDoNotThrow() {
+        // A future or unexpected ObjectId format must degrade to no correlation rather than an exception.
+        List<Map<StoragePoolProperty, Object>> rows = new ArrayList<>();
+        Map<StoragePoolProperty, Object> row = new EnumMap<>(StoragePoolProperty.class);
+        row.put(StoragePoolProperty.FRIENDLYNAME, "Pool1");
+        row.put(StoragePoolProperty.OBJECTID, "not-an-object-id");
+        rows.add(row);
+
+        List<LogicalVolumeGroup> lvgs = build(result(rows, CIM_STRING), virtualDisks(),
+                physicalDisks("Disk1", "PCISlot1", PD1_GUID), poolToDisk(SP_GUID, PD1_GUID));
+        assertThat(lvgs, hasSize(1));
+        assertThat(lvgs.get(0).getName(), is("Pool1"));
+    }
+
+    @Test
+    void testMultipleVolumesInOnePool() {
+        String vd2 = "{dddddddd-dddd-dddd-dddd-dddddddddddd}";
+        List<LogicalVolumeGroup> lvgs = build(pools("Pool1", SP_GUID),
+                virtualDisks("Volume1", SP_GUID, VD_GUID, "Volume2", SP_GUID, vd2),
+                physicalDisks("Disk1", "PCISlot1", PD1_GUID), poolToDisk(SP_GUID, PD1_GUID));
+
+        assertThat(lvgs, hasSize(1));
+        assertThat(lvgs.get(0).getLogicalVolumes().keySet(),
+                containsInAnyOrder("Volume1 " + VD_GUID, "Volume2 " + vd2));
+    }
+
+    @Test
+    void testObjectIdFixtureMatchesTheProductionRegexes() {
+        // Guards the fixture itself: if these strings stopped matching, every assertion above would still pass while
+        // testing nothing, because an unmatched ObjectId is silently left as-is.
+        assertThat("SP fixture must parse",
+                build(pools("Pool1", SP_GUID), virtualDisks(), physicalDisks("Disk1", "PCISlot1", PD1_GUID),
+                        poolToDisk(SP_GUID, PD1_GUID)).get(0).getPhysicalVolumes(),
+                contains("Disk1 @ PCISlot1"));
+        assertThat("VD fixture must parse into 'name guid'", Arrays.asList(
+                build(pools("Pool1", SP_GUID), virtualDisks("Volume1", SP_GUID, VD_GUID), physicalDisks(), poolToDisk())
+                        .get(0).getLogicalVolumes().keySet().iterator().next()),
+                contains("Volume1 " + VD_GUID));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupFFM.java
@@ -8,15 +8,12 @@ import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.software.os.linux.LinuxOperatingSystemFFM.HAS_UDEV;
 import static oshi.util.LogLevel.WARN;
 
-import java.io.File;
 import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,8 +22,6 @@ import oshi.ffm.NativeHandle;
 import oshi.ffm.platform.linux.UdevFunctions;
 import oshi.hardware.LogicalVolumeGroup;
 import oshi.hardware.common.platform.linux.LinuxLogicalVolumeGroup;
-import oshi.util.Util;
-import oshi.util.linux.DevPath;
 
 /**
  * FFM-based Linux logical volume group implementation.
@@ -44,12 +39,15 @@ final class LinuxLogicalVolumeGroupFFM extends LinuxLogicalVolumeGroup {
             LOG.warn("Logical Volume Group information requires libudev, which is not present.");
             return Collections.emptyList();
         }
+        return buildLogicalVolumeGroups(enumerateBlockDevices(), LinuxLogicalVolumeGroupFFM::new);
+    }
+
+    private static List<UdevBlockDevice> enumerateBlockDevices() {
         return callInArenaOrDefault(arena -> {
-            Map<String, Map<String, Set<String>>> logicalVolumesMap = new HashMap<>();
-            Map<String, Set<String>> physicalVolumesMap = queryPhysicalVolumes();
+            List<UdevBlockDevice> devices = new ArrayList<>();
             MemorySegment udev = UdevFunctions.udev_new();
             if (MemorySegment.NULL.equals(udev)) {
-                return Collections.emptyList();
+                return devices;
             }
             // wrapped only to release the native handle on close
             try (var _ = NativeHandle.of(udev, UdevFunctions::udev_unref)) {
@@ -71,39 +69,18 @@ final class LinuxLogicalVolumeGroupFFM extends LinuxLogicalVolumeGroup {
                         }
                         // wrapped only to release the native handle on close
                         try (var _ = NativeHandle.of(device, UdevFunctions::udev_device_unref)) {
-                            String devnode = UdevFunctions.getString(UdevFunctions.udev_device_get_devnode(device),
-                                    arena);
-                            if (devnode != null && devnode.startsWith(DevPath.DM)) {
-                                String uuid = UdevFunctions.getPropertyValue(device, DM_UUID, arena);
-                                if (uuid != null && uuid.startsWith("LVM-")) {
-                                    String vgName = UdevFunctions.getPropertyValue(device, DM_VG_NAME, arena);
-                                    String lvName = UdevFunctions.getPropertyValue(device, DM_LV_NAME, arena);
-                                    if (!Util.isBlank(vgName) && !Util.isBlank(lvName)) {
-                                        logicalVolumesMap.computeIfAbsent(vgName, k -> new HashMap<>());
-                                        Map<String, Set<String>> lvMapForGroup = logicalVolumesMap.get(vgName);
-                                        physicalVolumesMap.computeIfAbsent(vgName, k -> new HashSet<>());
-                                        Set<String> pvSetForGroup = physicalVolumesMap.get(vgName);
-                                        File slavesDir = new File(syspath + "/slaves");
-                                        File[] slaves = slavesDir.listFiles();
-                                        if (slaves != null) {
-                                            for (File f : slaves) {
-                                                String pvName = f.getName();
-                                                lvMapForGroup.computeIfAbsent(lvName, k -> new HashSet<>())
-                                                        .add(DevPath.DEV + pvName);
-                                                pvSetForGroup.add(DevPath.DEV + pvName);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                            devices.add(
+                                    new UdevBlockDevice(syspath,
+                                            UdevFunctions.getString(UdevFunctions.udev_device_get_devnode(device),
+                                                    arena),
+                                            UdevFunctions.getPropertyValue(device, DM_UUID, arena),
+                                            UdevFunctions.getPropertyValue(device, DM_VG_NAME, arena),
+                                            UdevFunctions.getPropertyValue(device, DM_LV_NAME, arena)));
                         }
                     }
                 }
             }
-            return logicalVolumesMap.entrySet().stream()
-                    .map(e -> new LinuxLogicalVolumeGroupFFM(e.getKey(), e.getValue(),
-                            physicalVolumesMap.getOrDefault(e.getKey(), Collections.emptySet())))
-                    .collect(Collectors.toList());
+            return devices;
         }, LOG, WARN, "Error enumerating logical volume groups", Collections.emptyList());
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsLogicalVolumeGroupFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsLogicalVolumeGroupFFM.java
@@ -4,43 +4,27 @@
  */
 package oshi.hardware.platform.windows;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import oshi.driver.common.windows.wmi.MSFTStorage.PhysicalDiskProperty;
 import oshi.driver.common.windows.wmi.MSFTStorage.StoragePoolProperty;
-import oshi.driver.common.windows.wmi.MSFTStorage.StoragePoolToPhysicalDiskProperty;
-import oshi.driver.common.windows.wmi.MSFTStorage.VirtualDiskProperty;
 import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.driver.windows.wmi.MSFTStorageFFM;
 import oshi.ffm.platform.windows.VersionHelpersFFM;
 import oshi.ffm.platform.windows.com.FfmComException;
 import oshi.ffm.util.platform.windows.WmiQueryHandlerFFM;
 import oshi.hardware.LogicalVolumeGroup;
-import oshi.hardware.common.AbstractLogicalVolumeGroup;
-import oshi.util.ParseUtil;
-import oshi.util.tuples.Pair;
+import oshi.hardware.common.platform.windows.WindowsLogicalVolumeGroup;
 
-final class WindowsLogicalVolumeGroupFFM extends AbstractLogicalVolumeGroup {
+final class WindowsLogicalVolumeGroupFFM extends WindowsLogicalVolumeGroup {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsLogicalVolumeGroupFFM.class);
-
-    private static final Pattern SP_OBJECT_ID = Pattern.compile(".*ObjectId=.*SP:(\\{.*\\}).*");
-    private static final Pattern PD_OBJECT_ID = Pattern.compile(".*ObjectId=.*PD:(\\{.*\\}).*");
-    private static final Pattern VD_OBJECT_ID = Pattern.compile(".*ObjectId=.*VD:(\\{.*\\})(\\{.*\\}).*");
 
     private static final boolean IS_WINDOWS8_OR_GREATER = VersionHelpersFFM.IsWindows8OrGreater();
 
@@ -49,6 +33,7 @@ final class WindowsLogicalVolumeGroupFFM extends AbstractLogicalVolumeGroup {
     }
 
     static List<LogicalVolumeGroup> getLogicalVolumeGroups() {
+        // Storage Spaces requires Windows 8 or Server 2012
         if (!IS_WINDOWS8_OR_GREATER) {
             return Collections.emptyList();
         }
@@ -56,83 +41,13 @@ final class WindowsLogicalVolumeGroupFFM extends AbstractLogicalVolumeGroup {
         boolean comInit = false;
         try {
             comInit = h.initCOM();
+            // Query Storage Pools first, so we can skip other queries if we have no pools
             WmiResult<StoragePoolProperty> sp = MSFTStorageFFM.queryStoragePools(h);
-            int count = sp.getResultCount();
-            if (count == 0) {
+            if (sp.getResultCount() == 0) {
                 return Collections.emptyList();
             }
-
-            Map<String, String> vdMap = new HashMap<>();
-            WmiResult<VirtualDiskProperty> vds = MSFTStorageFFM.queryVirtualDisks(h);
-            count = vds.getResultCount();
-            for (int i = 0; i < count; i++) {
-                String vdObjectId = WmiUtil.getString(vds, VirtualDiskProperty.OBJECTID, i);
-                Matcher m = VD_OBJECT_ID.matcher(vdObjectId);
-                if (m.matches()) {
-                    vdObjectId = m.group(2) + " " + m.group(1);
-                }
-                vdMap.put(vdObjectId, WmiUtil.getString(vds, VirtualDiskProperty.FRIENDLYNAME, i));
-            }
-
-            Map<String, Pair<String, String>> pdMap = new HashMap<>();
-            WmiResult<PhysicalDiskProperty> pds = MSFTStorageFFM.queryPhysicalDisks(h);
-            count = pds.getResultCount();
-            for (int i = 0; i < count; i++) {
-                String pdObjectId = WmiUtil.getString(pds, PhysicalDiskProperty.OBJECTID, i);
-                Matcher m = PD_OBJECT_ID.matcher(pdObjectId);
-                if (m.matches()) {
-                    pdObjectId = m.group(1);
-                }
-                pdMap.put(pdObjectId, new Pair<>(WmiUtil.getString(pds, PhysicalDiskProperty.FRIENDLYNAME, i),
-                        WmiUtil.getString(pds, PhysicalDiskProperty.PHYSICALLOCATION, i)));
-            }
-
-            Map<String, String> sppdMap = new HashMap<>();
-            WmiResult<StoragePoolToPhysicalDiskProperty> sppd = MSFTStorageFFM.queryStoragePoolPhysicalDisks(h);
-            count = sppd.getResultCount();
-            for (int i = 0; i < count; i++) {
-                String spObjectId = WmiUtil.getRefString(sppd, StoragePoolToPhysicalDiskProperty.STORAGEPOOL, i);
-                Matcher m = SP_OBJECT_ID.matcher(spObjectId);
-                if (m.matches()) {
-                    spObjectId = m.group(1);
-                }
-                String pdObjectId = WmiUtil.getRefString(sppd, StoragePoolToPhysicalDiskProperty.PHYSICALDISK, i);
-                m = PD_OBJECT_ID.matcher(pdObjectId);
-                if (m.matches()) {
-                    pdObjectId = m.group(1);
-                }
-                sppdMap.put(spObjectId + " " + pdObjectId, pdObjectId);
-            }
-
-            List<LogicalVolumeGroup> lvgList = new ArrayList<>();
-            count = sp.getResultCount();
-            for (int i = 0; i < count; i++) {
-                String name = WmiUtil.getString(sp, StoragePoolProperty.FRIENDLYNAME, i);
-                String spObjectId = WmiUtil.getString(sp, StoragePoolProperty.OBJECTID, i);
-                Matcher m = SP_OBJECT_ID.matcher(spObjectId);
-                if (m.matches()) {
-                    spObjectId = m.group(1);
-                }
-                Set<String> physicalVolumeSet = new HashSet<>();
-                for (Entry<String, String> entry : sppdMap.entrySet()) {
-                    if (entry.getKey().contains(spObjectId)) {
-                        String pdObjectId = entry.getValue();
-                        Pair<String, String> nameLoc = pdMap.get(pdObjectId);
-                        if (nameLoc != null) {
-                            physicalVolumeSet.add(nameLoc.getA() + " @ " + nameLoc.getB());
-                        }
-                    }
-                }
-                Map<String, Set<String>> logicalVolumeMap = new HashMap<>();
-                for (Entry<String, String> entry : vdMap.entrySet()) {
-                    if (entry.getKey().contains(spObjectId)) {
-                        String vdObjectId = ParseUtil.whitespaces.split(entry.getKey())[0];
-                        logicalVolumeMap.put(entry.getValue() + " " + vdObjectId, physicalVolumeSet);
-                    }
-                }
-                lvgList.add(new WindowsLogicalVolumeGroupFFM(name, logicalVolumeMap, physicalVolumeSet));
-            }
-            return lvgList;
+            return buildFromWmi(sp, MSFTStorageFFM.queryVirtualDisks(h), MSFTStorageFFM.queryPhysicalDisks(h),
+                    MSFTStorageFFM.queryStoragePoolPhysicalDisks(h), WindowsLogicalVolumeGroupFFM::new);
         } catch (FfmComException e) {
             LOG.warn("COM exception: {}", e.getMessage());
             return Collections.emptyList();

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxLogicalVolumeGroupJNA.java
@@ -6,14 +6,11 @@ package oshi.hardware.platform.linux;
 
 import static oshi.software.os.linux.LinuxOperatingSystemJNA.HAS_UDEV;
 
-import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,8 +19,6 @@ import com.sun.jna.platform.linux.Udev;
 
 import oshi.hardware.LogicalVolumeGroup;
 import oshi.hardware.common.platform.linux.LinuxLogicalVolumeGroup;
-import oshi.util.Util;
-import oshi.util.linux.DevPath;
 
 /**
  * JNA-based Linux logical volume group implementation.
@@ -41,12 +36,14 @@ final class LinuxLogicalVolumeGroupJNA extends LinuxLogicalVolumeGroup {
             LOG.warn("Logical Volume Group information requires libudev, which is not present.");
             return Collections.emptyList();
         }
-        Map<String, Map<String, Set<String>>> logicalVolumesMap = new HashMap<>();
-        Map<String, Set<String>> physicalVolumesMap = queryPhysicalVolumes();
+        return buildLogicalVolumeGroups(enumerateBlockDevices(), LinuxLogicalVolumeGroupJNA::new);
+    }
 
+    private static List<UdevBlockDevice> enumerateBlockDevices() {
+        List<UdevBlockDevice> devices = new ArrayList<>();
         Udev.UdevContext udev = Udev.INSTANCE.udev_new();
         if (udev == null) {
-            return Collections.emptyList();
+            return devices;
         }
         try {
             Udev.UdevEnumerate enumerate = udev.enumerateNew();
@@ -55,33 +52,15 @@ final class LinuxLogicalVolumeGroupJNA extends LinuxLogicalVolumeGroup {
                 enumerate.scanDevices();
                 for (Udev.UdevListEntry entry = enumerate.getListEntry(); entry != null; entry = entry.getNext()) {
                     String syspath = entry.getName();
+                    if (syspath == null) {
+                        continue;
+                    }
                     Udev.UdevDevice device = udev.deviceNewFromSyspath(syspath);
                     if (device != null) {
                         try {
-                            String devnode = device.getDevnode();
-                            if (devnode != null && devnode.startsWith(DevPath.DM)) {
-                                String uuid = device.getPropertyValue(DM_UUID);
-                                if (uuid != null && uuid.startsWith("LVM-")) {
-                                    String vgName = device.getPropertyValue(DM_VG_NAME);
-                                    String lvName = device.getPropertyValue(DM_LV_NAME);
-                                    if (!Util.isBlank(vgName) && !Util.isBlank(lvName)) {
-                                        logicalVolumesMap.computeIfAbsent(vgName, k -> new HashMap<>());
-                                        Map<String, Set<String>> lvMapForGroup = logicalVolumesMap.get(vgName);
-                                        physicalVolumesMap.computeIfAbsent(vgName, k -> new HashSet<>());
-                                        Set<String> pvSetForGroup = physicalVolumesMap.get(vgName);
-                                        File slavesDir = new File(syspath + "/slaves");
-                                        File[] slaves = slavesDir.listFiles();
-                                        if (slaves != null) {
-                                            for (File f : slaves) {
-                                                String pvName = f.getName();
-                                                lvMapForGroup.computeIfAbsent(lvName, k -> new HashSet<>())
-                                                        .add(DevPath.DEV + pvName);
-                                                pvSetForGroup.add(DevPath.DEV + pvName);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                            devices.add(
+                                    new UdevBlockDevice(syspath, device.getDevnode(), device.getPropertyValue(DM_UUID),
+                                            device.getPropertyValue(DM_VG_NAME), device.getPropertyValue(DM_LV_NAME)));
                         } finally {
                             device.unref();
                         }
@@ -93,8 +72,6 @@ final class LinuxLogicalVolumeGroupJNA extends LinuxLogicalVolumeGroup {
         } finally {
             udev.unref();
         }
-        return logicalVolumesMap.entrySet().stream()
-                .map(e -> new LinuxLogicalVolumeGroupJNA(e.getKey(), e.getValue(), physicalVolumesMap.get(e.getKey())))
-                .collect(Collectors.toList());
+        return devices;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsLogicalVolumeGroupJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsLogicalVolumeGroupJNA.java
@@ -4,17 +4,11 @@
  */
 package oshi.hardware.platform.windows;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,26 +16,16 @@ import org.slf4j.LoggerFactory;
 import com.sun.jna.platform.win32.COM.COMException;
 import com.sun.jna.platform.win32.VersionHelpers;
 
-import oshi.driver.common.windows.wmi.MSFTStorage.PhysicalDiskProperty;
 import oshi.driver.common.windows.wmi.MSFTStorage.StoragePoolProperty;
-import oshi.driver.common.windows.wmi.MSFTStorage.StoragePoolToPhysicalDiskProperty;
-import oshi.driver.common.windows.wmi.MSFTStorage.VirtualDiskProperty;
 import oshi.driver.common.windows.wmi.WmiResult;
-import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.driver.windows.wmi.MSFTStorageJNA;
 import oshi.hardware.LogicalVolumeGroup;
-import oshi.hardware.common.AbstractLogicalVolumeGroup;
-import oshi.util.ParseUtil;
+import oshi.hardware.common.platform.windows.WindowsLogicalVolumeGroup;
 import oshi.util.platform.windows.WmiQueryHandler;
-import oshi.util.tuples.Pair;
 
-final class WindowsLogicalVolumeGroupJNA extends AbstractLogicalVolumeGroup {
+final class WindowsLogicalVolumeGroupJNA extends WindowsLogicalVolumeGroup {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsLogicalVolumeGroupJNA.class);
-
-    private static final Pattern SP_OBJECT_ID = Pattern.compile(".*ObjectId=.*SP:(\\{.*\\}).*");
-    private static final Pattern PD_OBJECT_ID = Pattern.compile(".*ObjectId=.*PD:(\\{.*\\}).*");
-    private static final Pattern VD_OBJECT_ID = Pattern.compile(".*ObjectId=.*VD:(\\{.*\\})(\\{.*\\}).*");
 
     private static final boolean IS_WINDOWS8_OR_GREATER = VersionHelpers.IsWindows8OrGreater();
 
@@ -60,96 +44,11 @@ final class WindowsLogicalVolumeGroupJNA extends AbstractLogicalVolumeGroup {
             comInit = h.initCOM();
             // Query Storage Pools first, so we can skip other queries if we have no pools
             WmiResult<StoragePoolProperty> sp = MSFTStorageJNA.queryStoragePools(h);
-            int count = sp.getResultCount();
-            if (count == 0) {
+            if (sp.getResultCount() == 0) {
                 return Collections.emptyList();
             }
-            // We have storage pool(s) but now need to gather other info
-
-            // Get all the Virtual Disks
-            Map<String, String> vdMap = new HashMap<>();
-            WmiResult<VirtualDiskProperty> vds = MSFTStorageJNA.queryVirtualDisks(h);
-            count = vds.getResultCount();
-            for (int i = 0; i < count; i++) {
-                String vdObjectId = WmiUtil.getString(vds, VirtualDiskProperty.OBJECTID, i);
-                Matcher m = VD_OBJECT_ID.matcher(vdObjectId);
-                if (m.matches()) {
-                    vdObjectId = m.group(2) + " " + m.group(1);
-                }
-                // Store key with SP|VD
-                vdMap.put(vdObjectId, WmiUtil.getString(vds, VirtualDiskProperty.FRIENDLYNAME, i));
-            }
-
-            // Get all the Physical Disks
-            Map<String, Pair<String, String>> pdMap = new HashMap<>();
-            WmiResult<PhysicalDiskProperty> pds = MSFTStorageJNA.queryPhysicalDisks(h);
-            count = pds.getResultCount();
-            for (int i = 0; i < count; i++) {
-                String pdObjectId = WmiUtil.getString(pds, PhysicalDiskProperty.OBJECTID, i);
-                Matcher m = PD_OBJECT_ID.matcher(pdObjectId);
-                if (m.matches()) {
-                    pdObjectId = m.group(1);
-                }
-                // Store key with PD
-                pdMap.put(pdObjectId, new Pair<>(WmiUtil.getString(pds, PhysicalDiskProperty.FRIENDLYNAME, i),
-                        WmiUtil.getString(pds, PhysicalDiskProperty.PHYSICALLOCATION, i)));
-            }
-
-            // Get the Storage Pool to Physical Disk mappping
-            Map<String, String> sppdMap = new HashMap<>();
-            WmiResult<StoragePoolToPhysicalDiskProperty> sppd = MSFTStorageJNA.queryStoragePoolPhysicalDisks(h);
-            count = sppd.getResultCount();
-            for (int i = 0; i < count; i++) {
-                // Ref string contains object id, will do partial match later
-                String spObjectId = WmiUtil.getRefString(sppd, StoragePoolToPhysicalDiskProperty.STORAGEPOOL, i);
-                Matcher m = SP_OBJECT_ID.matcher(spObjectId);
-                if (m.matches()) {
-                    spObjectId = m.group(1);
-                }
-                String pdObjectId = WmiUtil.getRefString(sppd, StoragePoolToPhysicalDiskProperty.PHYSICALDISK, i);
-                m = PD_OBJECT_ID.matcher(pdObjectId);
-                if (m.matches()) {
-                    pdObjectId = m.group(1);
-                }
-                sppdMap.put(spObjectId + " " + pdObjectId, pdObjectId);
-            }
-
-            // Finally process the storage pools
-            List<LogicalVolumeGroup> lvgList = new ArrayList<>();
-            count = sp.getResultCount();
-            for (int i = 0; i < count; i++) {
-                // Name
-                String name = WmiUtil.getString(sp, StoragePoolProperty.FRIENDLYNAME, i);
-                // Parse object ID to match
-                String spObjectId = WmiUtil.getString(sp, StoragePoolProperty.OBJECTID, i);
-                Matcher m = SP_OBJECT_ID.matcher(spObjectId);
-                if (m.matches()) {
-                    spObjectId = m.group(1);
-                }
-                // find matching physical and logical volumes
-                Set<String> physicalVolumeSet = new HashSet<>();
-                for (Entry<String, String> entry : sppdMap.entrySet()) {
-                    if (entry.getKey().contains(spObjectId)) {
-                        String pdObjectId = entry.getValue();
-                        Pair<String, String> nameLoc = pdMap.get(pdObjectId);
-                        if (nameLoc != null) {
-                            physicalVolumeSet.add(nameLoc.getA() + " @ " + nameLoc.getB());
-                        }
-                    }
-                }
-                // find matching logical volume
-                Map<String, Set<String>> logicalVolumeMap = new HashMap<>();
-                for (Entry<String, String> entry : vdMap.entrySet()) {
-                    if (entry.getKey().contains(spObjectId)) {
-                        String vdObjectId = ParseUtil.whitespaces.split(entry.getKey())[0];
-                        logicalVolumeMap.put(entry.getValue() + " " + vdObjectId, physicalVolumeSet);
-                    }
-                }
-                // Add to list
-                lvgList.add(new WindowsLogicalVolumeGroupJNA(name, logicalVolumeMap, physicalVolumeSet));
-            }
-
-            return lvgList;
+            return buildFromWmi(sp, MSFTStorageJNA.queryVirtualDisks(h), MSFTStorageJNA.queryPhysicalDisks(h),
+                    MSFTStorageJNA.queryStoragePoolPhysicalDisks(h), WindowsLogicalVolumeGroupJNA::new);
         } catch (COMException e) {
             LOG.warn("COM exception: {}", e.getMessage());
             return Collections.emptyList();


### PR DESCRIPTION
Audit item 12. 8 files, 253+/272−.

## Windows — the bulk of it

Windows was the only platform whose volume group class had **no common base**, so both bindings carried a full copy of the Storage Spaces correlation: pull object IDs out of four `MSFT_Storage` queries, then match pools to their physical and virtual disks by GUID substring.

The queries return `WmiResult`, which is already backend-neutral, so the *only* real difference was the COM plumbing that runs them. New `WindowsLogicalVolumeGroup` base takes the four results plus a factory (the #3452/#3544 pattern); the bindings keep the version gate, COM init/uninit, the queries, and their own exception type.

| | before | after |
|---|---|---|
| `WindowsLogicalVolumeGroupJNA` | 162 | **61** |
| `WindowsLogicalVolumeGroupFFM` | 145 | **60** |

The "query storage pools first so we can skip the other three queries when there are none" short-circuit is preserved — the early return still happens before the other queries are issued.

## Linux

Linux already had a base for the `pvs` parsing, but both bindings still repeated the device-mapper filtering, the sysfs `slaves` scan and the group assembly around their own udev enumeration. The bindings now return each block device's udev attributes as a carrier and the base does the rest — the same hook boundary the USB enumeration uses (#3448), since the udev call itself is irreducibly different (JNA `UdevContext` vs FFM `MemorySegment`).

## One divergence unified

JNA looked the physical volume set up with `physicalVolumesMap.get(...)`, FFM with `getOrDefault(..., emptySet())`. Both maps are `computeIfAbsent`-populated in the same block so the null was unreachable — but a null set throws in `AbstractLogicalVolumeGroup`'s immutable-copy constructor rather than degrading, so the defaulting form is the one kept.

## Tests

Both shared methods are pure, so they are now covered **without Windows, Linux, or LVM configured** — paths that were previously unreachable in CI at all, since Storage Spaces needs pooled disks and LVM needs volume groups.

- `WindowsLogicalVolumeGroupTest` stubs the four `WmiResult`s: correlation of a pool with its disks and volumes, two pools not bleeding into each other (the substring match this logic exists to get right), an unknown physical disk being skipped rather than yielding `null @ null`, unparseable object IDs degrading instead of throwing, and multiple volumes in one pool. One test pins the fixture itself against the production regexes, so a fixture that stopped matching can't leave the others passing vacuously.
- `LinuxLogicalVolumeGroupTest` gains assembly coverage using a `@TempDir` as a stand-in for sysfs: slaves-directory expansion, two volumes sharing a group, non-LVM devices filtered (plain disk, LUKS-owned device-mapper node, blank/null udev properties), a missing slaves directory still yielding the group, and `pvs` results merged with rather than replaced by the slaves scan.

Full gate green on `oshi-common,oshi-core,oshi-core-ffm` plus a clean full-reactor `install`, 0 tests failed. Windows and Linux runtime paths are CI-only; `pr.yaml` runs both automatically.

No CHANGELOG — no user-observable behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced logical volume group discovery on Linux, focusing on device-mapper LVM devices and physical volume relationships.
  * Improved Windows Storage Spaces logical volume group discovery by correlating virtual and physical disks per storage pool.
* **Bug Fixes**
  * Fixed Windows correlation when storage pool identifiers are missing/unparseable, preventing incorrect “match-everything” results.
  * Linux discovery now safely handles missing/incomplete device metadata without breaking grouping.
* **Tests**
  * Added/expanded Linux and Windows regression coverage for filtering, merging, and degraded metadata scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->