### PR TITLE
Replace the CPUID feature flag switch with an enum lookup

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -279,6 +279,43 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
     }
 
     /**
+     * The x86 CPUID feature flags carried in the EDX word of the processor ID, with the bit each one sets. Bits 42 and
+     * 52 are reserved by the specification, which is why the numbering skips them. A constant with more than one name
+     * is a feature that platforms report under different spellings, and those names share a bit.
+     */
+    private enum CpuidFeature {
+        FPU(32, "fpu"), VME(33, "vme"), DE(34, "de"), PSE(35, "pse"), TSC(36, "tsc"), MSR(37, "msr"), PAE(38, "pae"),
+        MCE(39, "mce"), CX8(40, "cx8"), APIC(41, "apic"), SEP(43, "sep"), MTRR(44, "mtrr"), PGE(45, "pge"),
+        MCA(46, "mca"), CMOV(47, "cmov"), PAT(48, "pat"), PSE36(49, "pse-36", "pse36"), PSN(50, "psn"),
+        CLFSH(51, "clfsh", "clflush"), DS(53, "ds"), ACPI(54, "acpi"), MMX(55, "mmx"), FXSR(56, "fxsr"), SSE(57, "sse"),
+        SSE2(58, "sse2"), SS(59, "ss"), HTT(60, "htt", "ht"), TM(61, "tm"), IA64(62, "ia64"), PBE(63, "pbe");
+
+        private final int bit;
+        private final String[] names;
+
+        CpuidFeature(int bit, String... names) {
+            this.bit = bit;
+            this.names = names;
+        }
+    }
+
+    /**
+     * Feature flag name to the bit it sets. Keyed by string because the names come from platform text such as
+     * {@code /proc/cpuinfo}, so an {@code EnumMap} would be the wrong direction.
+     */
+    private static final Map<String, Integer> CPUID_FEATURE_BITS = mapCpuidFeatureBits();
+
+    private static Map<String, Integer> mapCpuidFeatureBits() {
+        Map<String, Integer> bits = new HashMap<>();
+        for (CpuidFeature feature : CpuidFeature.values()) {
+            for (String name : feature.names) {
+                bits.put(name, feature.bit);
+            }
+        }
+        return Collections.unmodifiableMap(bits);
+    }
+
+    /**
      * Creates a Processor ID by encoding the stepping, model, family, and feature flags.
      *
      * @param stepping The CPU stepping
@@ -320,102 +357,9 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
             processorIdBytes |= hwcap << 32;
         } else {
             for (String flag : flags) {
-                switch (flag) { // NOSONAR squid:S1479
-                    case "fpu":
-                        processorIdBytes |= 1L << 32;
-                        break;
-                    case "vme":
-                        processorIdBytes |= 1L << 33;
-                        break;
-                    case "de":
-                        processorIdBytes |= 1L << 34;
-                        break;
-                    case "pse":
-                        processorIdBytes |= 1L << 35;
-                        break;
-                    case "tsc":
-                        processorIdBytes |= 1L << 36;
-                        break;
-                    case "msr":
-                        processorIdBytes |= 1L << 37;
-                        break;
-                    case "pae":
-                        processorIdBytes |= 1L << 38;
-                        break;
-                    case "mce":
-                        processorIdBytes |= 1L << 39;
-                        break;
-                    case "cx8":
-                        processorIdBytes |= 1L << 40;
-                        break;
-                    case "apic":
-                        processorIdBytes |= 1L << 41;
-                        break;
-                    case "sep":
-                        processorIdBytes |= 1L << 43;
-                        break;
-                    case "mtrr":
-                        processorIdBytes |= 1L << 44;
-                        break;
-                    case "pge":
-                        processorIdBytes |= 1L << 45;
-                        break;
-                    case "mca":
-                        processorIdBytes |= 1L << 46;
-                        break;
-                    case "cmov":
-                        processorIdBytes |= 1L << 47;
-                        break;
-                    case "pat":
-                        processorIdBytes |= 1L << 48;
-                        break;
-                    case "pse-36":
-                    case "pse36":
-                        processorIdBytes |= 1L << 49;
-                        break;
-                    case "psn":
-                        processorIdBytes |= 1L << 50;
-                        break;
-                    case "clfsh":
-                    case "clflush":
-                        processorIdBytes |= 1L << 51;
-                        break;
-                    case "ds":
-                        processorIdBytes |= 1L << 53;
-                        break;
-                    case "acpi":
-                        processorIdBytes |= 1L << 54;
-                        break;
-                    case "mmx":
-                        processorIdBytes |= 1L << 55;
-                        break;
-                    case "fxsr":
-                        processorIdBytes |= 1L << 56;
-                        break;
-                    case "sse":
-                        processorIdBytes |= 1L << 57;
-                        break;
-                    case "sse2":
-                        processorIdBytes |= 1L << 58;
-                        break;
-                    case "ss":
-                        processorIdBytes |= 1L << 59;
-                        break;
-                    case "htt":
-                    case "ht":
-                        processorIdBytes |= 1L << 60;
-                        break;
-                    case "tm":
-                        processorIdBytes |= 1L << 61;
-                        break;
-                    case "ia64":
-                        processorIdBytes |= 1L << 62;
-                        break;
-                    case "pbe":
-                        processorIdBytes |= 1L << 63;
-                        break;
-                    default:
-                        break;
+                Integer bit = CPUID_FEATURE_BITS.get(flag);
+                if (bit != null) {
+                    processorIdBytes |= 1L << bit;
                 }
             }
         }

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractCentralProcessorTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -319,6 +320,38 @@ class AbstractCentralProcessorTest {
                 "htt", "tm", "ia64", "pbe" };
         String id = AbstractCentralProcessor.createProcessorID("0", "0", "0", allFlags);
         assertThat(id, is("FFEFFBFF00000000"));
+    }
+
+    /**
+     * Three features are reported under two spellings depending on the platform, and each pair must set the same bit.
+     * The all-flags test above only uses one spelling of each, so without this the aliases are unverified.
+     */
+    @Test
+    void testCreateProcessorIDFlagAliasesSetTheSameBit() {
+        String[][] aliases = { { "pse-36", "pse36" }, { "clfsh", "clflush" }, { "htt", "ht" } };
+        for (String[] pair : aliases) {
+            String first = AbstractCentralProcessor.createProcessorID("0", "0", "0", new String[] { pair[0] });
+            String second = AbstractCentralProcessor.createProcessorID("0", "0", "0", new String[] { pair[1] });
+            assertThat(pair[0] + " and " + pair[1] + " must set the same bit", second, is(first));
+            assertThat("An alias must actually set a bit", first, is(not("0000000000000000")));
+        }
+    }
+
+    /**
+     * Bits 42 and 52 are reserved, so no flag name may claim them. Guards the enum's bit numbering, which skips them.
+     */
+    @Test
+    void testReservedFeatureBitsAreNeverSet() {
+        String[] allFlags = { "fpu", "vme", "de", "pse", "tsc", "msr", "pae", "mce", "cx8", "apic", "sep", "mtrr",
+                "pge", "mca", "cmov", "pat", "pse-36", "pse36", "psn", "clfsh", "clflush", "ds", "acpi", "mmx", "fxsr",
+                "sse", "sse2", "ss", "htt", "ht", "tm", "ia64", "pbe" };
+        String hex = AbstractCentralProcessor.createProcessorID("0", "0", "0", allFlags);
+        // Adding every alias must not change the value, since an alias shares its primary's bit. Asserting the exact
+        // mask also stops the reserved-bit checks below passing vacuously against an all-zero result.
+        assertThat("Aliases share bits, so the mask is unchanged", hex, is("FFEFFBFF00000000"));
+        long id = ParseUtil.hexStringToLong(hex, 0L);
+        assertThat("bit 42 is reserved", id & (1L << 42), is(0L));
+        assertThat("bit 52 is reserved", id & (1L << 52), is(0L));
     }
 
     @Test


### PR DESCRIPTION
Found while re-scoping the dedup audit: `AbstractCentralProcessor` was the single largest duplication hit in the project at 134 lines, and it duplicated against **itself**.

## What it was

`createProcessorID` mapped x86 feature flag names to their bit in the processor ID with a 33-arm switch:

```java
case "sse":
    processorIdBytes |= 1L << 57;
    break;
```

That is a lookup table written as control flow. Sonar counted 134 lines as self-duplicated because the arms differ only in their literals, and the method already carried a `// NOSONAR squid:S1479` for having too many cases.

## What it is now

A private enum pairing each name with the bit it sets, read once into a name-to-bit map:

```java
private enum CpuidFeature {
    FPU(32, "fpu"), VME(33, "vme"), ... APIC(41, "apic"), SEP(43, "sep"), ...
    CLFSH(51, "clfsh", "clflush"), DS(53, "ds"), ... HTT(60, "htt", "ht"), ... PBE(63, "pbe");
```

`AbstractCentralProcessor` drops **499 → 443 lines**, the duplication goes to zero, and the suppression is retired.

**Bits 42 and 52 are reserved by the specification.** The switch omitted them silently; the enum's numbering visibly steps over them (`APIC(41)` → `SEP(43)`, `CLFSH(51)` → `DS(53)`), and a test now asserts nothing claims either. I verified that independently of the code: the two zero bits in the existing test's expected `FFEFFBFF00000000` fall at exactly long bits 42 and 52.

**Keyed by string rather than an `EnumMap`, deliberately.** The names arrive as platform text such as `/proc/cpuinfo`, so the enum is the *value* side of the lookup, not the key side — an `EnumMap` would be the wrong direction. That is noted in the javadoc so it does not get "improved" later.

## Tests

`testCreateProcessorIDAllFlags` already pinned the exact encoded value, so every bit was covered before this change — that is the regression oracle here, not something written to fit the new code. It did have two gaps, now closed:

- It used only one spelling of each aliased feature, leaving `pse36`, `clflush` and `ht` unverified. Aliases are now asserted to share their primary's bit.
- Reserved bits were unasserted. The new test also pins the exact mask, so the reserved-bit checks cannot pass vacuously against an all-zero result.

I checked the suite actually bites rather than assuming it:

| deliberate break | result |
|---|---|
| `SEP(43)` → `SEP(42)`, onto a reserved bit | 2 tests fail |
| drop the `"ht"` alias | 1 test fails |

The method is `protected static` and pure, reached from Solaris, Linux and both Windows bindings; behaviour is unchanged for all of them.

Full gate green on `oshi-common,oshi-core,oshi-core-ffm` plus a clean full-reactor `install`, 0 tests failed. 33 insertions, 96 deletions.

No CHANGELOG — no user-observable behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processor identification handling for supported CPU feature-name aliases.
  * Reserved processor feature bits are now kept unset, ensuring more accurate processor information.

* **Tests**
  * Added coverage for feature aliases and reserved-bit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->