### PR TITLE
Share the SMC key resolution between the two backends

### DIFF
--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyCache.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyCache.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.common.platform.mac;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.GlobalConfig;
+
+/**
+ * Holds the SMC keys a sensor reads, resolved once and then cached.
+ * <p>
+ * Every sensor whose keys are discovered rather than fixed needs the same three-step resolution: a configuration
+ * property naming the keys outright, then discovery from the SMC key index, then a fallback for when discovery cannot
+ * complete. This holds that once so each backend supplies only the discovery itself.
+ * <p>
+ * Deliberately not an {@link oshi.util.Memoizer}: that caches whatever the supplier returned, including a failure, so a
+ * transient inability to open the SMC would disable the sensor for the lifetime of the JVM. A completed discovery is
+ * cached, including one that legitimately found nothing; an incomplete one is not, so a later call retries.
+ */
+@ThreadSafe
+public final class SmcKeyCache {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SmcKeyCache.class);
+
+    private final String configProperty;
+    private final String description;
+    private final List<String> fallback;
+
+    private final Object lock = new Object();
+
+    /** Only ever assigned an unmodifiable list, so the volatile write safely publishes an immutable value. */
+    private volatile List<String> keys; // NOSONAR squid:S3077 - published value is immutable
+
+    /**
+     * Creates a key cache.
+     *
+     * @param configProperty the {@link GlobalConfig} property that names the keys outright, bypassing discovery
+     * @param description    what these keys read, for log messages, e.g. {@code "GPU temperature"}
+     * @param fallback       the keys to report when discovery cannot complete. Not cached, so a later call retries.
+     */
+    public SmcKeyCache(String configProperty, String description, List<String> fallback) {
+        this.configProperty = configProperty;
+        this.description = description;
+        this.fallback = fallback;
+    }
+
+    /**
+     * Returns the keys to read, resolving them on first use.
+     *
+     * @param discovery discovers the keys from the SMC, returning null if discovery could not complete. Called at most
+     *                  once per completed resolution.
+     * @return the keys, never null
+     */
+    public List<String> get(Supplier<List<String>> discovery) {
+        List<String> resolved = keys;
+        if (resolved != null) {
+            return resolved;
+        }
+        synchronized (lock) {
+            if (keys != null) {
+                return keys;
+            }
+            // Read the config lazily rather than at class initialization, so GlobalConfig.set() still takes effect.
+            List<String> configured = SmcKeyIndex.parseConfiguredKeys(GlobalConfig.get(configProperty, ""));
+            if (!configured.isEmpty()) {
+                LOG.debug("Using configured {} keys {}", description, configured);
+                keys = configured;
+                return configured;
+            }
+            List<String> discovered = discovery.get();
+            if (discovered == null) {
+                LOG.debug("{} key discovery did not complete; using {} this time.", description,
+                        fallback.isEmpty() ? "no keys" : "the fallback list");
+                return fallback;
+            }
+            LOG.debug("Using {} {} keys: {}", discovered.size(), description, discovered);
+            keys = discovered;
+            return discovered;
+        }
+    }
+
+    /**
+     * The keys reported when discovery cannot complete.
+     *
+     * @return the fallback keys
+     */
+    public List<String> fallback() {
+        return fallback;
+    }
+}

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
@@ -303,6 +303,34 @@ public final class SmcKeyIndex {
     }
 
     /**
+     * Returns the first plausible reading among the given keys, in the order given.
+     * <p>
+     * Plausibility is applied here, at read time, for the same reason as in {@link #maxPlausible}: whether a key exists
+     * is a property of the hardware and does not change, but whether it currently reports a usable value is not.
+     *
+     * @param keys        the keys to read, in preference order
+     * @param reader      reads a key and returns the value in its final units, 0 if unavailable
+     * @param isPlausible tests whether a reading is usable
+     * @param description what is being read, for log messages, e.g. {@code "temperature"}
+     * @return the first plausible reading, or 0 if none were plausible
+     */
+    public static double firstPlausible(List<String> keys, ToDoubleFunction<String> reader, DoublePredicate isPlausible,
+            String description) {
+        for (String key : keys) {
+            double value = reader.applyAsDouble(key);
+            if (isPlausible.test(value)) {
+                return value;
+            }
+            // A zero means the key was absent or undecodable, which is expected while scanning a candidate list; a
+            // non-zero implausible value means a sensor answered with something unusable, which is worth a note.
+            if (value != 0d) {
+                LOG.debug("Ignoring implausible {} {} from SMC key {}.", description, value, key);
+            }
+        }
+        return 0d;
+    }
+
+    /**
      * Returns the highest plausible temperature among the given keys.
      * <p>
      * Plausibility is applied here, at read time, rather than when the keys were discovered. Whether a key exists is a

--- a/oshi-common/src/test/java/module-info.test
+++ b/oshi-common/src/test/java/module-info.test
@@ -61,6 +61,8 @@
 --add-opens
   com.github.oshi.common/oshi.software.common.os.unix.dragonflybsd=org.junit.platform.commons
 --add-opens
+  com.github.oshi.common/oshi.util.common.platform.mac=org.junit.platform.commons
+--add-opens
   com.github.oshi.common/oshi.util.common.platform.unix.bsd=org.junit.platform.commons
 --add-opens
   com.github.oshi.common/oshi.util.common.platform.unix.dragonflybsd=org.junit.platform.commons

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyCacheTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyCacheTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.common.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.util.GlobalConfig;
+
+/**
+ * Tests the resolve-once-and-cache behavior the SMC sensors share, without a Mac.
+ * <p>
+ * Each test uses a property name of its own rather than a real OSHI property, because the suite runs in parallel and a
+ * shared property would race.
+ */
+class SmcKeyCacheTest {
+
+    private static final List<String> FALLBACK = Collections.unmodifiableList(Arrays.asList("Tg05", "Tg0D"));
+
+    /** A discovery function that records how many times it ran. */
+    private static final class CountingDiscovery implements Supplier<List<String>> {
+        private final AtomicInteger calls = new AtomicInteger();
+        private final List<String> result;
+
+        private CountingDiscovery(List<String> result) {
+            this.result = result;
+        }
+
+        @Override
+        public List<String> get() {
+            calls.incrementAndGet();
+            return result;
+        }
+    }
+
+    private static SmcKeyCache cache(String property) {
+        return new SmcKeyCache(property, "test", FALLBACK);
+    }
+
+    @Test
+    void testCompletedDiscoveryIsCached() {
+        CountingDiscovery discovery = new CountingDiscovery(Arrays.asList("Tg0f", "Tg0j"));
+        SmcKeyCache keys = cache("oshi.test.smckeycache.completed");
+        assertThat(keys.get(discovery), contains("Tg0f", "Tg0j"));
+        assertThat(keys.get(discovery), contains("Tg0f", "Tg0j"));
+        assertThat("Discovery must run only once", discovery.calls.get(), is(1));
+    }
+
+    @Test
+    void testIncompleteDiscoveryFallsBackWithoutCaching() {
+        // Null means "could not read". Caching it would disable the sensor for the lifetime of the JVM, so the next
+        // call must try again.
+        CountingDiscovery discovery = new CountingDiscovery(null);
+        SmcKeyCache keys = cache("oshi.test.smckeycache.incomplete");
+        assertThat(keys.get(discovery), is(sameInstance(FALLBACK)));
+        assertThat(keys.get(discovery), is(sameInstance(FALLBACK)));
+        assertThat("A failed discovery must be retried, not cached", discovery.calls.get(), is(2));
+    }
+
+    @Test
+    void testEmptyDiscoveryIsCached() {
+        // Empty is a real answer from a completed run: this machine has no such sensor. That is cacheable, unlike null.
+        CountingDiscovery discovery = new CountingDiscovery(Collections.emptyList());
+        SmcKeyCache keys = cache("oshi.test.smckeycache.empty");
+        assertThat(keys.get(discovery), is(empty()));
+        assertThat(keys.get(discovery), is(empty()));
+        assertThat("An empty completed discovery must be cached", discovery.calls.get(), is(1));
+    }
+
+    @Test
+    void testConfiguredKeysBypassDiscovery() {
+        String property = "oshi.test.smckeycache.configured";
+        GlobalConfig.set(property, "Tg1k,Tg1l");
+        try {
+            CountingDiscovery discovery = new CountingDiscovery(Arrays.asList("Tg0f"));
+            SmcKeyCache keys = cache(property);
+            assertThat(keys.get(discovery), contains("Tg1k", "Tg1l"));
+            assertThat(keys.get(discovery), contains("Tg1k", "Tg1l"));
+            assertThat("Configured keys must bypass discovery entirely", discovery.calls.get(), is(0));
+        } finally {
+            GlobalConfig.remove(property);
+        }
+    }
+
+    @Test
+    void testUnusableConfiguredKeysFallThroughToDiscovery() {
+        // Every token is the wrong length, so parseConfiguredKeys drops them all and the result is empty. That must be
+        // treated as "nothing configured" rather than as an empty key list.
+        String property = "oshi.test.smckeycache.malformed";
+        GlobalConfig.set(property, "TOOLONG,ab");
+        try {
+            CountingDiscovery discovery = new CountingDiscovery(Arrays.asList("Tg0f"));
+            assertThat(cache(property).get(discovery), contains("Tg0f"));
+            assertThat(discovery.calls.get(), is(1));
+        } finally {
+            GlobalConfig.remove(property);
+        }
+    }
+
+    @Test
+    void testFallbackIsReportedByIdentity() {
+        // Callers distinguish "fell back" from "discovered" by identity, so the fallback must be handed back as-is
+        // rather than copied.
+        SmcKeyCache keys = cache("oshi.test.smckeycache.identity");
+        assertThat(keys.fallback(), is(sameInstance(FALLBACK)));
+        assertThat(keys.get(new CountingDiscovery(null)), is(sameInstance(keys.fallback())));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
@@ -23,11 +23,8 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests SMC key index logic without Mac hardware. This is why the logic lives here rather than in {@code SmcUtil},
  * whose static {@code IOKit.INSTANCE} field makes any of its members unloadable off a Mac.
- * <p>
- * The class and its methods are {@code public} because the module system only opens public types to the JUnit platform;
- * a package-private test class in a named module fails to run.
  */
-public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JPMS, not redundant
+class SmcKeyIndexTest {
 
     /** A realistic slice of a sorted SMC key index, with a Tg block in the middle. */
     private static final String[] SORTED = { "#KEY", "ALI0", "F0Ac", "TB0T", "TC0P", "TCMb", "TCMz", "Tf00", "Tf11",
@@ -44,24 +41,24 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     // -- binary search --
 
     @Test
-    public void testFindsBlockInTheMiddle() {
+    void testFindsBlockInTheMiddle() {
         assertThat(findTg(SORTED), contains("Tg0W", "Tg0X", "Tg0e", "Tg0f", "Tg1g", "Tg1h"));
     }
 
     @Test
-    public void testFindsBlockAtStart() {
+    void testFindsBlockAtStart() {
         String[] keys = { "Tg0W", "Tg0X", "Th00", "Tp01" };
         assertThat(findTg(keys), contains("Tg0W", "Tg0X"));
     }
 
     @Test
-    public void testFindsBlockAtEnd() {
+    void testFindsBlockAtEnd() {
         String[] keys = { "TB0T", "TCMb", "Tg0W", "Tg0X" };
         assertThat(findTg(keys), contains("Tg0W", "Tg0X"));
     }
 
     @Test
-    public void testAbsentBlockYieldsEmptyNotNull() {
+    void testAbsentBlockYieldsEmptyNotNull() {
         // Empty means "this machine has no such keys" and is a cacheable answer; null means "could not read".
         String[] keys = { "TB0T", "TCMb", "Th00", "Tp01" };
         List<String> found = findTg(keys);
@@ -70,14 +67,14 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testEmptyAndSingleElementIndex() {
+    void testEmptyAndSingleElementIndex() {
         assertThat("Zero count is not a readable index", findTg(new String[0]), is(nullValue()));
         assertThat(findTg(new String[] { "Tg0f" }), contains("Tg0f"));
         assertThat(findTg(new String[] { "TB0T" }), is(empty()));
     }
 
     @Test
-    public void testImplausibleKeyCountIsRejected() {
+    void testImplausibleKeyCountIsRejected() {
         assertThat(SmcKeyIndex.findKeys(0, lookup(SORTED), "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
         assertThat(SmcKeyIndex.findKeys(-1, lookup(SORTED), "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
         assertThat("Guards against a garbage #KEY read",
@@ -86,7 +83,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testKeyCountLargerThanIndexDegradesSafely() {
+    void testKeyCountLargerThanIndexDegradesSafely() {
         // A count that overruns the readable range must degrade to "could not read", not throw and not report empty.
         assertThat(SmcKeyIndex.findKeys(SORTED.length + 50, lookup(SORTED), "Tg", SmcKeyIndex::isGpuTemperatureKey),
                 is(nullValue()));
@@ -95,13 +92,13 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     // -- read failures --
 
     @Test
-    public void testAllReadsFailingYieldsNull() {
+    void testAllReadsFailingYieldsNull() {
         assertThat("Nothing readable must not be cached as empty",
                 SmcKeyIndex.findKeys(20, i -> null, "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
     }
 
     @Test
-    public void testTransientFailureIsRecovered() {
+    void testTransientFailureIsRecovered() {
         // Fails the first read of one index, then succeeds: the retry must recover the full block.
         Set<Integer> failedOnce = new HashSet<>();
         IntFunction<String> flaky = i -> i == 12 && failedOnce.add(i) ? null : SORTED[i];
@@ -110,7 +107,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testPermanentFailureMidScanSkipsOnlyThatKey() {
+    void testPermanentFailureMidScanSkipsOnlyThatKey() {
         // Index 12 is Tg0f. Skipping rather than stopping preserves Tg1g/Tg1h, which a break would have discarded.
         IntFunction<String> flaky = i -> i == 12 ? null : SORTED[i];
         assertThat(SmcKeyIndex.findKeys(SORTED.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey),
@@ -118,7 +115,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testFailedSoleMatchIsNotReportedAsAbsent() {
+    void testFailedSoleMatchIsNotReportedAsAbsent() {
         // The only Tg key is unreadable and the next key ends the block. Reporting empty would be cached as "this
         // machine has no GPU sensors" and would disable the sensor for the JVM lifetime.
         String[] keys = { "TB0T", "Tg0f", "Th00", "Tp01" };
@@ -128,7 +125,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testFailedSearchProbeThatSkipsTheBlockIsNotReportedAsAbsent() {
+    void testFailedSearchProbeThatSkipsTheBlockIsNotReportedAsAbsent() {
         // Same shape, but the failure is consumed by the binary search rather than the scan: substituting a neighbour
         // for the unreadable probe moves the landing point past Tg0f, so the scan never attempts it at all. Failing
         // only the first read is what makes null the proof of that -- had the scan reached index 2, its retry would
@@ -141,7 +138,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testConfirmedAbsenceStillReportsEmpty() {
+    void testConfirmedAbsenceStillReportsEmpty() {
         // The counterpart guard: with every read succeeding, "no Tg keys" is a real answer and must stay cacheable,
         // so the fix above cannot degrade into "never return empty".
         String[] keys = { "TB0T", "TCMb", "Th00", "Tp01" };
@@ -149,7 +146,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testFailedProbeDuringSearchIsRetriedAtNeighbour() {
+    void testFailedProbeDuringSearchIsRetriedAtNeighbour() {
         // A permanently unreadable index during the binary search descends via a neighbour instead of aborting.
         IntFunction<String> flaky = i -> i == SORTED.length / 2 ? null : SORTED[i];
         assertThat(SmcKeyIndex.findKeys(SORTED.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey),
@@ -159,7 +156,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     // -- robustness --
 
     @Test
-    public void testUnsortedIndexTerminatesAndIsBounded() {
+    void testUnsortedIndexTerminatesAndIsBounded() {
         String[] shuffled = SORTED.clone();
         Arrays.sort(shuffled, (a, b) -> b.compareTo(a)); // reverse order breaks the search's assumption
         List<String> found = SmcKeyIndex.findKeys(shuffled.length, lookup(shuffled), "Tg",
@@ -169,7 +166,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testDuplicateKeysAreDeduped() {
+    void testDuplicateKeysAreDeduped() {
         String[] keys = { "TB0T", "Tg0f", "Tg0f", "Tg1h", "Th00" };
         assertThat(findTg(keys), contains("Tg0f", "Tg1h"));
     }
@@ -177,7 +174,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     // -- mask --
 
     @Test
-    public void testMaskAcceptsRealGpuKeys() {
+    void testMaskAcceptsRealGpuKeys() {
         // Every shape seen across M1-M5 and A18: uppercase, lowercase and digit fourth characters.
         for (String key : new String[] { "Tg05", "Tg0D", "Tg0f", "Tg0j", "Tg0W", "Tg1A", "Tg1k", "Tg99", "Tg0P" }) {
             assertThat(key + " must match", SmcKeyIndex.isGpuTemperatureKey(key), is(true));
@@ -185,7 +182,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testMaskRejectsNonGpuKeys() {
+    void testMaskRejectsNonGpuKeys() {
         // Tp/TG are CPU and Intel-era GPU keys; the rest are malformed.
         for (String key : new String[] { "Tp09", "TG05", "TCMb", "Tg0", "Tg005", "TgA5", "Tg0_", "tg05", "",
                 " Tg0f" }) {
@@ -197,7 +194,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     // -- fan keys --
 
     @Test
-    public void testFindsFanSpeedKeysExcludingOtherFanKeys() {
+    void testFindsFanSpeedKeysExcludingOtherFanKeys() {
         // The SORTED fixture has a single fan key; discovery on it must return exactly that one.
         assertThat(SmcKeyIndex.findKeys(SORTED.length, lookup(SORTED), "F", SmcKeyIndex::isFanSpeedKey),
                 contains("F0Ac"));
@@ -208,7 +205,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testFanSpeedMaskAcceptsRealFanKeys() {
+    void testFanSpeedMaskAcceptsRealFanKeys() {
         for (int i = 0; i <= 9; i++) {
             String key = "F" + i + "Ac";
             assertThat(key + " must match", SmcKeyIndex.isFanSpeedKey(key), is(true));
@@ -216,7 +213,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testFanSpeedMaskRejectsNonFanKeys() {
+    void testFanSpeedMaskRejectsNonFanKeys() {
         // FNum/F0Mn/F0Mx/F0Tg/FBAC/Ftst are other keys in the F block; the rest are malformed or wrong case.
         for (String key : new String[] { "FNum", "F0Mn", "F0Mx", "F0Tg", "FBAC", "Ftst", "f0ac", "F0AC", "F10Ac", "FAc",
                 "" }) {
@@ -226,14 +223,14 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testFanSpeedKeysSynthesizedFromCount() {
+    void testFanSpeedKeysSynthesizedFromCount() {
         assertThat(SmcKeyIndex.fanSpeedKeys(0), is(empty()));
         assertThat(SmcKeyIndex.fanSpeedKeys(2), contains("F0Ac", "F1Ac"));
         assertThat("A negative count clamps to empty", SmcKeyIndex.fanSpeedKeys(-1), is(empty()));
     }
 
     @Test
-    public void testFanSpeedKeysAreAlwaysFourCharacters() {
+    void testFanSpeedKeysAreAlwaysFourCharacters() {
         // Pins the latent defect: F%dAc with a two-digit index formats a five-character key that reads a different key.
         // Clamping to MAX_FANS keeps every synthesized key exactly four characters.
         for (long count : new long[] { 99L, Long.MAX_VALUE }) {
@@ -246,7 +243,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testReconcileFanKeysPrefersDiscovered() {
+    void testReconcileFanKeysPrefersDiscovered() {
         List<String> discovered = Arrays.asList("F0Ac", "F1Ac");
         // Non-empty discovery is authoritative regardless of FNum, including when the two disagree.
         assertThat(SmcKeyIndex.reconcileFanKeys(discovered, 2), contains("F0Ac", "F1Ac"));
@@ -255,21 +252,21 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testReconcileFanKeysSynthesizesFromFnumWhenDiscoveryEmpty() {
+    void testReconcileFanKeysSynthesizesFromFnumWhenDiscoveryEmpty() {
         // No-regression: an index that yielded no fan keys still reports the fans FNum implies, as older OSHI did.
         assertThat(SmcKeyIndex.reconcileFanKeys(null, 2), contains("F0Ac", "F1Ac"));
         assertThat(SmcKeyIndex.reconcileFanKeys(Arrays.<String>asList(), 2), contains("F0Ac", "F1Ac"));
     }
 
     @Test
-    public void testReconcileFanKeysCannotTellReturnsNull() {
+    void testReconcileFanKeysCannotTellReturnsNull() {
         // Discovery failed and FNum read zero: "no fans" is indistinguishable from "could not read", so defer.
         assertThat("Null must not be cached as a confirmed absence", SmcKeyIndex.reconcileFanKeys(null, 0),
                 is(nullValue()));
     }
 
     @Test
-    public void testReconcileFanKeysConfirmedNoFansReturnsEmpty() {
+    void testReconcileFanKeysConfirmedNoFansReturnsEmpty() {
         // Discovery completed with no fan keys and FNum agrees: a genuine fanless machine, a cacheable empty answer.
         List<String> result = SmcKeyIndex.reconcileFanKeys(Arrays.<String>asList(), 0);
         assertThat(result, is(notNullValue()));
@@ -279,7 +276,7 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     // -- configured keys --
 
     @Test
-    public void testParseConfiguredKeys() {
+    void testParseConfiguredKeys() {
         assertThat(SmcKeyIndex.parseConfiguredKeys(null), is(empty()));
         assertThat(SmcKeyIndex.parseConfiguredKeys(""), is(empty()));
         assertThat(SmcKeyIndex.parseConfiguredKeys("   "), is(empty()));
@@ -311,14 +308,14 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testMaxPlausibleIgnoresSentinels() {
+    void testMaxPlausibleIgnoresSentinels() {
         List<String> keys = Arrays.asList("Tg0W", "Tg0X", "Tg0f", "Tg1h");
         assertThat("Returns the hottest genuine reading, not the global max",
                 SmcKeyIndex.maxPlausible(keys, SmcKeyIndexTest::read, v -> v >= FLOOR), is(63.4d));
     }
 
     @Test
-    public void testMaxPlausibleWithNothingUsable() {
+    void testMaxPlausibleWithNothingUsable() {
         assertThat("All-sentinel reads must report unavailable",
                 SmcKeyIndex.maxPlausible(Arrays.asList("Tg0W", "Tg1h"), SmcKeyIndexTest::read, v -> v >= FLOOR),
                 is(0d));
@@ -326,10 +323,43 @@ public class SmcKeyIndexTest { // NOSONAR squid:S5786 - public is required by JP
     }
 
     @Test
-    public void testMaxPlausibleNeverReturnsBelowTheFloor() {
+    void testMaxPlausibleNeverReturnsBelowTheFloor() {
         double result = SmcKeyIndex.maxPlausible(Arrays.asList("Tg0W", "Tg0X"), SmcKeyIndexTest::read, v -> v >= FLOOR);
         assertThat("A result is either 0 or at least the floor, never in between", result == 0d || result >= FLOOR,
                 is(true));
         assertThat(6.7d, is(lessThanOrEqualTo(result)));
+    }
+
+    // -- first plausible --
+
+    @Test
+    void testFirstPlausibleReturnsTheFirstNotTheBest() {
+        // Order is preference order, so an earlier plausible reading wins even though a later one is higher. This is
+        // what distinguishes it from maxPlausible.
+        List<String> keys = Arrays.asList("Tg0W", "Tg0X", "Tg0f");
+        assertThat(SmcKeyIndex.firstPlausible(keys, SmcKeyIndexTest::read, v -> v >= FLOOR, "temperature"), is(40.7d));
+    }
+
+    @Test
+    void testFirstPlausibleSkipsImplausibleAndSentinelReads() {
+        assertThat("A leading sentinel must not stop the scan",
+                SmcKeyIndex.firstPlausible(Arrays.asList("Tg1h", "Tg0W", "Tg0f"), SmcKeyIndexTest::read,
+                        v -> v >= FLOOR, "temperature"),
+                is(63.4d));
+    }
+
+    @Test
+    void testFirstPlausibleWithNothingUsable() {
+        assertThat(SmcKeyIndex.firstPlausible(Arrays.asList("Tg0W", "Tg1h"), SmcKeyIndexTest::read, v -> v >= FLOOR,
+                "temperature"), is(0d));
+        assertThat(SmcKeyIndex.firstPlausible(Arrays.<String>asList(), SmcKeyIndexTest::read, v -> v >= FLOOR,
+                "temperature"), is(0d));
+    }
+
+    @Test
+    void testFirstPlausibleAndMaxPlausibleAgreeOnASingleKey() {
+        List<String> one = Arrays.asList("Tg0f");
+        assertThat(SmcKeyIndex.firstPlausible(one, SmcKeyIndexTest::read, v -> v >= FLOOR, "temperature"),
+                is(SmcKeyIndex.maxPlausible(one, SmcKeyIndexTest::read, v -> v >= FLOOR)));
     }
 }

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcSensorValuesTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcSensorValuesTest.java
@@ -14,35 +14,32 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests connection-independent SMC sensor value interpretation without Mac hardware.
- * <p>
- * The class and its methods are {@code public} because the module system only opens public types to the JUnit platform;
- * a package-private test class in a named module fails to run.
  */
-public class SmcSensorValuesTest { // NOSONAR squid:S5786 - public is required by JPMS, not redundant
+class SmcSensorValuesTest {
 
     // -- toRpm --
 
     @Test
-    public void testToRpmPreservesZero() {
+    void testToRpmPreservesZero() {
         // A stopped fan genuinely reads 0.0 (both fans on an idle M3 Pro do). Dropping it would turn stopped fans into
         // no fans; iSMC's < 0.005 filter is deliberately not applied here.
         assertThat(SmcSensorValues.toRpm(0d), is(0));
     }
 
     @Test
-    public void testToRpmClampsNegativeAndNaN() {
+    void testToRpmClampsNegativeAndNaN() {
         assertThat(SmcSensorValues.toRpm(-5d), is(0));
         assertThat(SmcSensorValues.toRpm(Double.NaN), is(0));
     }
 
     @Test
-    public void testToRpmRoundsRatherThanTruncates() {
+    void testToRpmRoundsRatherThanTruncates() {
         assertThat(SmcSensorValues.toRpm(1349.6d), is(1350));
         assertThat(SmcSensorValues.toRpm(1350.4d), is(1350));
     }
 
     @Test
-    public void testToRpmDoesNotOverflow() {
+    void testToRpmDoesNotOverflow() {
         assertThat(SmcSensorValues.toRpm(1e30d), is(greaterThanOrEqualTo(0)));
         assertThat(SmcSensorValues.toRpm(1e30d), is(Integer.MAX_VALUE));
     }
@@ -50,7 +47,7 @@ public class SmcSensorValuesTest { // NOSONAR squid:S5786 - public is required b
     // -- voltage plausibility --
 
     @Test
-    public void testIsPlausibleVoltageRejectsLowAndMisscaled() {
+    void testIsPlausibleVoltageRejectsLowAndMisscaled() {
         assertThat(SmcSensorValues.isPlausibleVoltage(0d), is(false));
         assertThat(SmcSensorValues.isPlausibleVoltage(-1d), is(false));
         assertThat("A /1000 mis-scaling of a 1.2 V rail must be rejected", SmcSensorValues.isPlausibleVoltage(0.0012d),
@@ -58,20 +55,20 @@ public class SmcSensorValuesTest { // NOSONAR squid:S5786 - public is required b
     }
 
     @Test
-    public void testIsPlausibleVoltageAcceptsRealReadings() {
+    void testIsPlausibleVoltageAcceptsRealReadings() {
         for (double volts : new double[] { 0.7477d, 0.8638d, 1.2d, 1.35d }) {
             assertThat(volts + " V must be plausible", SmcSensorValues.isPlausibleVoltage(volts), is(true));
         }
     }
 
     @Test
-    public void testNoUpperBoundIsApplied() {
+    void testNoUpperBoundIsApplied() {
         // No ceiling: since voltage keys are never discovered, no rail key is read, so a ceiling would guard nothing.
         assertThat(SmcSensorValues.isPlausibleVoltage(20.2d), is(true));
     }
 
     @Test
-    public void testFloorSitsBetweenTheTwoPopulations() {
+    void testFloorSitsBetweenTheTwoPopulations() {
         // The floor separates the mis-scaling target (~0.0012 V) from the lowest confirmed reading (0.7477 V).
         assertThat(SmcSensorValues.MIN_PLAUSIBLE_VOLTAGE, is(greaterThanOrEqualTo(0.0012d)));
         assertThat(SmcSensorValues.MIN_PLAUSIBLE_VOLTAGE, is(lessThanOrEqualTo(0.5d)));
@@ -80,13 +77,13 @@ public class SmcSensorValuesTest { // NOSONAR squid:S5786 - public is required b
     // -- voltage scaling --
 
     @Test
-    public void testScaleVoltageFpe2IsMillivolts() {
+    void testScaleVoltageFpe2IsMillivolts() {
         // fpe2 resolves to 0.25 units; only as millivolts is that a usable voltage resolution.
         assertThat(SmcSensorValues.scaleVoltage(1200d, "fpe2"), is(closeTo(1.2d, 1e-9)));
     }
 
     @Test
-    public void testScaleVoltageOtherTypesAreVolts() {
+    void testScaleVoltageOtherTypesAreVolts() {
         assertThat(SmcSensorValues.scaleVoltage(0.7477d, "flt"), is(closeTo(0.7477d, 1e-9)));
         assertThat(SmcSensorValues.scaleVoltage(1.2d, "sp78"), is(closeTo(1.2d, 1e-9)));
         assertThat("An unknown or unread type is treated as volts and left to the floor",

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -38,6 +38,7 @@ import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -50,6 +51,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.mac.IOKit.IOService;
 import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
+import oshi.util.common.platform.mac.SmcKeyCache;
 import oshi.util.common.platform.mac.SmcKeyIndex;
 import oshi.util.common.platform.mac.SmcSensorValues;
 
@@ -115,27 +117,13 @@ public final class SmcUtilFFM {
     /** The prefix shared by fan keys. */
     private static final String FAN_KEY_PREFIX = "F";
 
-    /** Guards {@link #gpuTemperatureKeys}. */
-    private static final Object GPU_KEY_LOCK = new Object();
+    /** GPU temperature keys, discovered on first use. */
+    private static final SmcKeyCache GPU_KEYS = new SmcKeyCache(GlobalConfig.OSHI_OS_MAC_SENSORS_GPUTEMPERATURE_KEYS,
+            "GPU temperature", SMC_KEYS_GPU_TEMP_AS);
 
-    /** Guards {@link #fanSpeedKeys}. */
-    private static final Object FAN_KEY_LOCK = new Object();
-
-    /**
-     * Discovered fan speed keys, or null if discovery has not yet produced a cacheable answer. Deliberately not a
-     * {@link oshi.util.Memoizer}, for the same reason as {@link #gpuTemperatureKeys}.
-     */
-    private static volatile List<String> fanSpeedKeys; // NOSONAR squid:S3077 - published value is immutable
-
-    /**
-     * Discovered GPU temperature keys, or null if discovery has not yet completed successfully. Deliberately not a
-     * {@link oshi.util.Memoizer}: that would cache a failed discovery permanently, and a transient failure to open the
-     * SMC would then disable GPU temperature for the lifetime of the JVM.
-     * <p>
-     * Only ever assigned an unmodifiable copy of a completed discovery, so the reference is safely published by the
-     * volatile write and the list it points at is immutable; no further synchronization is needed on the read path.
-     */
-    private static volatile List<String> gpuTemperatureKeys; // NOSONAR squid:S3077 - published value is immutable
+    /** Fan speed keys, discovered on first use. Reports no fans when discovery cannot complete. */
+    private static final SmcKeyCache FAN_KEYS = new SmcKeyCache(GlobalConfig.OSHI_OS_MAC_SENSORS_FANSPEED_KEYS,
+            "fan speed", Collections.emptyList());
     /** SMC key for Apple Silicon CPU voltage. */
     public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
 
@@ -264,17 +252,8 @@ public final class SmcUtilFFM {
      * @return The first reading at or above {@link #MIN_PLAUSIBLE_TEMPERATURE}, or 0 if no key returned one
      */
     public static double smcGetFirstTemperature(int conn, List<String> keys) {
-        for (String key : keys) {
-            double val = smcGetFloat(conn, key);
-            if (isPlausibleTemperature(val)) {
-                return val;
-            }
-            if (val != 0d) {
-                LOG.debug("Ignoring implausible temperature {} from SMC key {}; the sensor is likely idle-gated.", val,
-                        key);
-            }
-        }
-        return 0d;
+        return SmcKeyIndex.firstPlausible(keys, key -> smcGetFloat(conn, key), SmcUtilFFM::isPlausibleTemperature,
+                "temperature");
     }
 
     /**
@@ -363,31 +342,7 @@ public final class SmcUtilFFM {
      * @return The keys to read for GPU temperature, never null
      */
     public static List<String> getGpuTemperatureKeys() {
-        List<String> keys = gpuTemperatureKeys;
-        if (keys != null) {
-            return keys;
-        }
-        synchronized (GPU_KEY_LOCK) {
-            if (gpuTemperatureKeys != null) {
-                return gpuTemperatureKeys;
-            }
-            // Read the config lazily rather than at class initialization, so GlobalConfig.set() still takes effect.
-            List<String> configured = SmcKeyIndex
-                    .parseConfiguredKeys(GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SENSORS_GPUTEMPERATURE_KEYS, ""));
-            if (!configured.isEmpty()) {
-                LOG.debug("Using configured GPU temperature keys {}", configured);
-                gpuTemperatureKeys = configured;
-                return configured;
-            }
-            List<String> discovered = discoverGpuTemperatureKeys();
-            if (discovered == null) {
-                LOG.debug("GPU temperature key discovery did not complete; using the fallback list this time.");
-                return SMC_KEYS_GPU_TEMP_AS;
-            }
-            LOG.debug("Discovered {} GPU temperature keys: {}", discovered.size(), discovered);
-            gpuTemperatureKeys = discovered;
-            return discovered;
-        }
+        return GPU_KEYS.get(SmcUtilFFM::discoverGpuTemperatureKeys);
     }
 
     /**
@@ -405,31 +360,7 @@ public final class SmcUtilFFM {
      * @return The keys to read for fan speeds, never null
      */
     public static List<String> getFanSpeedKeys() {
-        List<String> keys = fanSpeedKeys;
-        if (keys != null) {
-            return keys;
-        }
-        synchronized (FAN_KEY_LOCK) {
-            if (fanSpeedKeys != null) {
-                return fanSpeedKeys;
-            }
-            // Read the config lazily rather than at class initialization, so GlobalConfig.set() still takes effect.
-            List<String> configured = SmcKeyIndex
-                    .parseConfiguredKeys(GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SENSORS_FANSPEED_KEYS, ""));
-            if (!configured.isEmpty()) {
-                LOG.debug("Using configured fan speed keys {}", configured);
-                fanSpeedKeys = configured;
-                return configured;
-            }
-            List<String> discovered = discoverFanSpeedKeys();
-            if (discovered == null) {
-                LOG.debug("Fan speed key discovery did not complete; reporting no fans this time.");
-                return List.of();
-            }
-            LOG.debug("Using {} fan speed keys: {}", discovered.size(), discovered);
-            fanSpeedKeys = discovered;
-            return discovered;
-        }
+        return FAN_KEYS.get(SmcUtilFFM::discoverFanSpeedKeys);
     }
 
     /**
@@ -495,18 +426,10 @@ public final class SmcUtilFFM {
      * @return The first reading at or above {@link #MIN_PLAUSIBLE_VOLTAGE}, or 0 if no key returned one
      */
     public static double smcGetFirstVoltage(int conn, List<String> keys) {
-        for (String key : keys) {
+        return SmcKeyIndex.firstPlausible(keys, key -> {
             double raw = smcGetFloat(conn, key);
-            if (raw == 0d) {
-                continue;
-            }
-            double volts = SmcSensorValues.scaleVoltage(raw, smcGetDataType(conn, key));
-            if (isPlausibleVoltage(volts)) {
-                return volts;
-            }
-            LOG.debug("Ignoring implausible voltage {} from SMC key {}.", volts, key);
-        }
-        return 0d;
+            return raw == 0d ? 0d : SmcSensorValues.scaleVoltage(raw, smcGetDataType(conn, key));
+        }, SmcUtilFFM::isPlausibleVoltage, "voltage");
     }
 
     /**

--- a/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/MacSensorsPlausibilityFFMTest.java
@@ -269,9 +269,11 @@ class MacSensorsPlausibilityFFMTest {
         int conn = SmcUtilFFM.smcOpen();
         assumeTrue(conn != 0, "SMC unavailable");
         try {
-            // Skips on Intel, where VP0C is absent (its data type reads empty).
+            // VP0C is chip-specific, not simply Apple Silicon versus Intel: it reads 0.75 V on an M3 Pro but is
+            // absent on an M2 Max, whose 53 V keys contain no identified core voltage at all. So skip when the key
+            // is absent, without inferring which chip that implies.
             assumeTrue(!SmcUtilFFM.smcGetDataType(conn, SmcUtilFFM.SMC_KEY_CPU_VOLTAGE_AS).isEmpty(),
-                    "VP0C unavailable (Intel)");
+                    "VP0C absent on this chip");
             double volts = SmcUtilFFM.smcGetFirstVoltage(conn, SmcUtilFFM.getCpuVoltageKeys());
             assertThat("Apple Silicon core voltage must read plausibly", volts,
                     is(greaterThanOrEqualTo(SmcUtilFFM.MIN_PLAUSIBLE_VOLTAGE)));

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -31,6 +31,7 @@ import oshi.jna.platform.mac.IOKit.SMCVal;
 import oshi.jna.platform.mac.SystemB;
 import oshi.util.GlobalConfig;
 import oshi.util.ParseUtil;
+import oshi.util.common.platform.mac.SmcKeyCache;
 import oshi.util.common.platform.mac.SmcKeyIndex;
 import oshi.util.common.platform.mac.SmcSensorValues;
 
@@ -100,27 +101,13 @@ public final class SmcUtil {
     /** The prefix shared by fan keys. */
     private static final String FAN_KEY_PREFIX = "F";
 
-    /** Guards {@link #gpuTemperatureKeys}. */
-    private static final Object GPU_KEY_LOCK = new Object();
+    /** GPU temperature keys, discovered on first use. */
+    private static final SmcKeyCache GPU_KEYS = new SmcKeyCache(GlobalConfig.OSHI_OS_MAC_SENSORS_GPUTEMPERATURE_KEYS,
+            "GPU temperature", SMC_KEYS_GPU_TEMP_AS);
 
-    /** Guards {@link #fanSpeedKeys}. */
-    private static final Object FAN_KEY_LOCK = new Object();
-
-    /**
-     * Discovered fan speed keys, or null if discovery has not yet produced a cacheable answer. Deliberately not a
-     * {@link oshi.util.Memoizer}, for the same reason as {@link #gpuTemperatureKeys}.
-     */
-    private static volatile List<String> fanSpeedKeys; // NOSONAR squid:S3077 - published value is immutable
-
-    /**
-     * Discovered GPU temperature keys, or null if discovery has not yet completed successfully. Deliberately not a
-     * {@link oshi.util.Memoizer}: that would cache a failed discovery permanently, and a transient failure to open the
-     * SMC would then disable GPU temperature for the lifetime of the JVM.
-     * <p>
-     * Only ever assigned an unmodifiable copy of a completed discovery, so the reference is safely published by the
-     * volatile write and the list it points at is immutable; no further synchronization is needed on the read path.
-     */
-    private static volatile List<String> gpuTemperatureKeys; // NOSONAR squid:S3077 - published value is immutable
+    /** Fan speed keys, discovered on first use. Reports no fans when discovery cannot complete. */
+    private static final SmcKeyCache FAN_KEYS = new SmcKeyCache(GlobalConfig.OSHI_OS_MAC_SENSORS_FANSPEED_KEYS,
+            "fan speed", Collections.emptyList());
     /** SMC key for CPU voltage (Apple Silicon). */
     public static final String SMC_KEY_CPU_VOLTAGE_AS = "VP0C";
 
@@ -242,17 +229,8 @@ public final class SmcUtil {
      * @return The first reading at or above {@link #MIN_PLAUSIBLE_TEMPERATURE}, or 0 if no key returned one
      */
     public static double smcGetFirstTemperature(IOConnect conn, List<String> keys) {
-        for (String key : keys) {
-            double val = smcGetFloat(conn, key);
-            if (isPlausibleTemperature(val)) {
-                return val;
-            }
-            if (val != 0d) {
-                LOG.debug("Ignoring implausible temperature {} from SMC key {}; the sensor is likely idle-gated.", val,
-                        key);
-            }
-        }
-        return 0d;
+        return SmcKeyIndex.firstPlausible(keys, key -> smcGetFloat(conn, key), SmcUtil::isPlausibleTemperature,
+                "temperature");
     }
 
     /**
@@ -336,31 +314,7 @@ public final class SmcUtil {
      * @return The keys to read for GPU temperature, never null
      */
     public static List<String> getGpuTemperatureKeys() {
-        List<String> keys = gpuTemperatureKeys;
-        if (keys != null) {
-            return keys;
-        }
-        synchronized (GPU_KEY_LOCK) {
-            if (gpuTemperatureKeys != null) {
-                return gpuTemperatureKeys;
-            }
-            // Read the config lazily rather than at class initialization, so GlobalConfig.set() still takes effect.
-            List<String> configured = SmcKeyIndex
-                    .parseConfiguredKeys(GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SENSORS_GPUTEMPERATURE_KEYS, ""));
-            if (!configured.isEmpty()) {
-                LOG.debug("Using configured GPU temperature keys {}", configured);
-                gpuTemperatureKeys = configured;
-                return configured;
-            }
-            List<String> discovered = discoverGpuTemperatureKeys();
-            if (discovered == null) {
-                LOG.debug("GPU temperature key discovery did not complete; using the fallback list this time.");
-                return SMC_KEYS_GPU_TEMP_AS;
-            }
-            LOG.debug("Discovered {} GPU temperature keys: {}", discovered.size(), discovered);
-            gpuTemperatureKeys = discovered;
-            return discovered;
-        }
+        return GPU_KEYS.get(SmcUtil::discoverGpuTemperatureKeys);
     }
 
     /**
@@ -377,31 +331,7 @@ public final class SmcUtil {
      * @return The keys to read for fan speeds, never null
      */
     public static List<String> getFanSpeedKeys() {
-        List<String> keys = fanSpeedKeys;
-        if (keys != null) {
-            return keys;
-        }
-        synchronized (FAN_KEY_LOCK) {
-            if (fanSpeedKeys != null) {
-                return fanSpeedKeys;
-            }
-            // Read the config lazily rather than at class initialization, so GlobalConfig.set() still takes effect.
-            List<String> configured = SmcKeyIndex
-                    .parseConfiguredKeys(GlobalConfig.get(GlobalConfig.OSHI_OS_MAC_SENSORS_FANSPEED_KEYS, ""));
-            if (!configured.isEmpty()) {
-                LOG.debug("Using configured fan speed keys {}", configured);
-                fanSpeedKeys = configured;
-                return configured;
-            }
-            List<String> discovered = discoverFanSpeedKeys();
-            if (discovered == null) {
-                LOG.debug("Fan speed key discovery did not complete; reporting no fans this time.");
-                return Collections.emptyList();
-            }
-            LOG.debug("Using {} fan speed keys: {}", discovered.size(), discovered);
-            fanSpeedKeys = discovered;
-            return discovered;
-        }
+        return FAN_KEYS.get(SmcUtil::discoverFanSpeedKeys);
     }
 
     /**
@@ -467,18 +397,10 @@ public final class SmcUtil {
      * @return The first reading at or above {@link #MIN_PLAUSIBLE_VOLTAGE}, or 0 if no key returned one
      */
     public static double smcGetFirstVoltage(IOConnect conn, List<String> keys) {
-        for (String key : keys) {
+        return SmcKeyIndex.firstPlausible(keys, key -> {
             double raw = smcGetFloat(conn, key);
-            if (raw == 0d) {
-                continue;
-            }
-            double volts = SmcSensorValues.scaleVoltage(raw, smcGetDataType(conn, key));
-            if (isPlausibleVoltage(volts)) {
-                return volts;
-            }
-            LOG.debug("Ignoring implausible voltage {} from SMC key {}.", volts, key);
-        }
-        return 0d;
+            return raw == 0d ? 0d : SmcSensorValues.scaleVoltage(raw, smcGetDataType(conn, key));
+        }, SmcUtil::isPlausibleVoltage, "voltage");
     }
 
     /**

--- a/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/mac/MacSensorsPlausibilityTest.java
@@ -271,9 +271,11 @@ class MacSensorsPlausibilityTest {
         IOKit.IOConnect conn = SmcUtil.smcOpen();
         assumeTrue(conn != null, "SMC unavailable");
         try {
-            // Skips on Intel, where VP0C is absent (its data type reads empty).
+            // VP0C is chip-specific, not simply Apple Silicon versus Intel: it reads 0.75 V on an M3 Pro but is
+            // absent on an M2 Max, whose 53 V keys contain no identified core voltage at all. So skip when the key
+            // is absent, without inferring which chip that implies.
             assumeTrue(!SmcUtil.smcGetDataType(conn, SmcUtil.SMC_KEY_CPU_VOLTAGE_AS).isEmpty(),
-                    "VP0C unavailable (Intel)");
+                    "VP0C absent on this chip");
             double volts = SmcUtil.smcGetFirstVoltage(conn, SmcUtil.getCpuVoltageKeys());
             assertThat("Apple Silicon core voltage must read plausibly", volts,
                     is(greaterThanOrEqualTo(SmcUtil.MIN_PLAUSIBLE_VOLTAGE)));


### PR DESCRIPTION
Cleaning up after ourselves. The sensor work in #3531, #3535, #3536 and #3545 grew `SmcUtil` and `SmcUtilFFM` in parallel, and they had become the 5th-largest duplication cluster in the project at **253 lines** — absent from the audit roadmap because it did not exist when the roadmap was written.

## Where the duplication actually was

Not in the native calls. Sonar pointed at three blocks, all in **key-list management**:

| block | contents |
|---|---|
| `SmcUtil 338-398` | `getGpuTemperatureKeys` + `getFanSpeedKeys` |
| `SmcUtil 413-459` | `discoverFanSpeedKeys` tail + `getCpuVoltageKeys` |
| `SmcUtil 470-487` | `smcGetFirstVoltage` |

Both backends had the same three-step resolution twice over — once for GPU temperature, once for fan speeds: a config property naming the keys outright, then discovery from the key index, then a fallback that must **not** be cached so a later call retries. Four copies of the same double-checked-locking skeleton, four volatile fields, four `S3077` suppressions.

## What changed

**`SmcKeyCache`** in oshi-common holds that resolution once. Each backend now supplies only the discovery:

```java
public static List<String> getGpuTemperatureKeys() {
    return GPU_KEYS.get(SmcUtil::discoverGpuTemperatureKeys);
}
```

The null-versus-empty distinction is preserved and documented on the type: a completed discovery is cached *including one that legitimately found nothing*, while an incomplete one is not. Three of the four `S3077` suppressions are gone with the fields.

**`SmcKeyIndex.firstPlausible`**, symmetric with the `maxPlausible` already there, absorbs the two first-plausible scans. `smcGetFirstTemperature` and `smcGetFirstVoltage` differed only in how a reading is obtained — the voltage path needs a second read for the key's data type in order to scale it — so passing the reader as a lambda leaves each backend with just the read.

| | before | after |
|---|---|---|
| `SmcUtil` | 596 | **518** |
| `SmcUtilFFM` | 622 | **545** |

No change to the public surface of either.

## A suppression cleanup that fell out

Adding a test to `oshi.util.common.platform.mac` failed at runtime: the package has **no `opens` line** in `module-info.test`. That is precisely *why* the two existing tests there were `public` and carried `S5786` suppressions asserting JPMS required it — a claim I wrote in #3540 and had to correct once already in `d89f6b6fb0`.

Rather than add a third suppression, I added the missing `opens` line. With the package opened, `public` really is redundant, so `SmcKeyIndexTest` and `SmcSensorValuesTest` are now package-private and both suppressions are removed. Root cause instead of a workaround.

## Tests

- **`SmcKeyCacheTest`** (new, hardware-free): a completed discovery is cached and runs once; an incomplete one falls back and is retried, not cached; an *empty* completed discovery is cached because it is a real answer; configured keys bypass discovery entirely; all-malformed config falls through to discovery rather than being read as an empty key list; the fallback is handed back by identity, which is how callers tell "fell back" from "discovered". Uses test-only property names so it cannot race the parallel suite.
- **`SmcKeyIndexTest`**: `firstPlausible` returns the first rather than the best (what distinguishes it from `maxPlausible`), skips a leading sentinel, handles nothing-usable and empty lists, and agrees with `maxPlausible` on a single key.

Full gate green plus a clean full-reactor `install`, 0 tests failed. Validated live on an M2 Max: `NativeComparisonTest` passes including `sensors()` and `gpuTemperatureKeys()`, so the two backends still agree on the discovered key lists, and the Mac-only `MacSensorsPlausibilityTest`/`FFMTest` pairs pass all 18 tests each.

One observation, unrelated and pre-existing: `testAppleSiliconVoltageKeyReadsPlausibly` skips on this M2 Max with *"VP0C unavailable (Intel)"*. I confirmed it does the same on unmodified `master`, so it is not from this change — but the message is misleading, since VP0C is the Apple Silicon key and it is simply returning 0 here.

No CHANGELOG — no user-observable behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when discovering and caching Mac SMC temperature and fan-speed sensors.
  * Added safer fallback behavior when sensor discovery is incomplete or unavailable.
  * Sensor readings now skip implausible values and use the first valid reading.
* **Tests**
  * Expanded coverage for sensor discovery, cache/retry behavior, fallback handling, and plausible readings.
  * Updated Mac plausibility tests to better handle chip-specific voltage-key availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->