### PR TITLE
Inherit the DragonFly BSD hardware layer from FreeBSD's

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerFFM.java
@@ -4,98 +4,20 @@
  */
 package oshi.hardware.platform.unix.dragonflybsd;
 
-import java.util.List;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor;
-import oshi.hardware.ComputerSystem;
-import oshi.hardware.Display;
-import oshi.hardware.GlobalMemory;
-import oshi.hardware.GraphicsCard;
-import oshi.hardware.HWDiskStore;
-import oshi.hardware.NetworkIF;
-import oshi.hardware.PowerSource;
-import oshi.hardware.Printer;
-import oshi.hardware.Sensors;
-import oshi.hardware.SoundCard;
-import oshi.hardware.UsbDevice;
-import oshi.hardware.common.AbstractHardwareAbstractionLayer;
-import oshi.hardware.common.platform.unix.BsdNetworkIF;
-import oshi.hardware.common.platform.unix.UnixDisplay;
-import oshi.hardware.common.platform.unix.freebsd.FreeBsdGraphicsCard;
-import oshi.hardware.common.platform.unix.freebsd.FreeBsdSoundCard;
-import oshi.hardware.common.platform.unix.freebsd.FreeBsdUsbDevice;
-import oshi.hardware.platform.unix.CupsPrinterFFM;
-import oshi.hardware.platform.unix.freebsd.FreeBsdComputerSystemFFM;
-import oshi.hardware.platform.unix.freebsd.FreeBsdGlobalMemoryFFM;
-import oshi.hardware.platform.unix.freebsd.FreeBsdHWDiskStoreFFM;
-import oshi.hardware.platform.unix.freebsd.FreeBsdPowerSourceFFM;
-import oshi.hardware.platform.unix.freebsd.FreeBsdSensorsFFM;
+import oshi.hardware.platform.unix.freebsd.FreeBsdHardwareAbstractionLayerFFM;
 
 /**
- * FFM-backed DragonFly BSD HAL. Uses FreeBSD FFM implementations where behavior is identical; overrides
- * {@link #createProcessor()} to return the DragonFly-specific CPU implementation.
+ * DragonFly BSD hardware abstraction layer. Every component behaves as FreeBSD's does except the processor, which reads
+ * its tick counters from {@code kern.cputime} rather than {@code kern.cp_time}, so this inherits the FreeBSD wiring and
+ * replaces only that one.
  */
 @ThreadSafe
-public final class DragonFlyBsdHardwareAbstractionLayerFFM extends AbstractHardwareAbstractionLayer {
-
-    @Override
-    public ComputerSystem createComputerSystem() {
-        return new FreeBsdComputerSystemFFM();
-    }
-
-    @Override
-    public GlobalMemory createMemory() {
-        return new FreeBsdGlobalMemoryFFM();
-    }
+public final class DragonFlyBsdHardwareAbstractionLayerFFM extends FreeBsdHardwareAbstractionLayerFFM {
 
     @Override
     public CentralProcessor createProcessor() {
         return new DragonFlyBsdCentralProcessorFFM();
-    }
-
-    @Override
-    public Sensors createSensors() {
-        return new FreeBsdSensorsFFM();
-    }
-
-    @Override
-    public List<PowerSource> getPowerSources() {
-        return FreeBsdPowerSourceFFM.getPowerSources();
-    }
-
-    @Override
-    public List<HWDiskStore> getDiskStores() {
-        return FreeBsdHWDiskStoreFFM.getDisks();
-    }
-
-    @Override
-    protected List<Display> createDisplays() {
-        return UnixDisplay.getDisplays();
-    }
-
-    @Override
-    public List<NetworkIF> getNetworkIFs(boolean includeLocalInterfaces) {
-        return BsdNetworkIF.getNetworks(includeLocalInterfaces);
-    }
-
-    @Override
-    protected List<UsbDevice> createUsbDevices() {
-        return FreeBsdUsbDevice.getUsbDevices();
-    }
-
-    @Override
-    protected List<SoundCard> createSoundCards() {
-        return FreeBsdSoundCard.getSoundCards();
-    }
-
-    @Override
-    protected List<GraphicsCard> createGraphicsCards() {
-        return FreeBsdGraphicsCard.getGraphicsCards();
-    }
-
-    @Override
-    public List<Printer> getPrinters() {
-        return CupsPrinterFFM.getPrinters();
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHardwareAbstractionLayerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHardwareAbstractionLayerFFM.java
@@ -32,7 +32,7 @@ import oshi.hardware.platform.unix.CupsPrinterFFM;
  * BSD-shared display/network/USB/sound/graphics classes come from {@code oshi-common}.
  */
 @ThreadSafe
-public final class FreeBsdHardwareAbstractionLayerFFM extends AbstractHardwareAbstractionLayer {
+public class FreeBsdHardwareAbstractionLayerFFM extends AbstractHardwareAbstractionLayer {
 
     @Override
     public ComputerSystem createComputerSystem() {

--- a/oshi-core-ffm/src/test/java/module-info.test
+++ b/oshi-core-ffm/src/test/java/module-info.test
@@ -5,6 +5,8 @@
 --add-opens
   com.github.oshi.ffm/oshi.ffm.platform.mac=org.junit.platform.commons
 --add-opens
+  com.github.oshi.ffm/oshi.hardware.platform.unix.dragonflybsd=org.junit.platform.commons
+--add-opens
   com.github.oshi.ffm/oshi.ffm.util.platform.unix.freebsd=org.junit.platform.commons
 --add-opens
   com.github.oshi.ffm/oshi.ffm.util.platform.unix.openbsd=org.junit.platform.commons

--- a/oshi-core-ffm/src/test/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerFFMTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.dragonflybsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.platform.unix.freebsd.FreeBsdHardwareAbstractionLayerFFM;
+
+/**
+ * DragonFly BSD wires every hardware component the way FreeBSD does except the processor, so its hardware abstraction
+ * layer inherits the FreeBSD one. These guard that relationship, which no runtime test can: the components themselves
+ * need a BSD to construct.
+ */
+class DragonFlyBsdHardwareAbstractionLayerFFMTest {
+
+    @Test
+    void testInheritsTheFreeBsdWiring() {
+        assertThat(new DragonFlyBsdHardwareAbstractionLayerFFM(),
+                is(instanceOf(FreeBsdHardwareAbstractionLayerFFM.class)));
+    }
+
+    /**
+     * The one component DragonFly must not inherit. Its processor reads tick counters from {@code kern.cputime} where
+     * FreeBSD reads {@code kern.cp_time}, so dropping this override would silently report FreeBSD's counters.
+     */
+    @Test
+    void testProcessorIsOverridden() {
+        assertDoesNotThrow(() -> DragonFlyBsdHardwareAbstractionLayerFFM.class.getDeclaredMethod("createProcessor"),
+                "DragonFly must declare its own createProcessor, not inherit FreeBSD's");
+    }
+
+    /**
+     * The point of inheriting: these must not be copied back in. A re-declared method here would silently diverge from
+     * the FreeBSD one it was copied from.
+     */
+    @Test
+    void testEverythingElseIsInherited() {
+        for (String method : new String[] { "createComputerSystem", "createMemory", "createSensors", "createDisplays",
+                "createUsbDevices", "createSoundCards", "createGraphicsCards" }) {
+            assertThrows(NoSuchMethodException.class,
+                    () -> DragonFlyBsdHardwareAbstractionLayerFFM.class.getDeclaredMethod(method),
+                    method + " must be inherited from FreeBSD, not redeclared");
+        }
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerJNA.java
@@ -4,97 +4,20 @@
  */
 package oshi.hardware.platform.unix.dragonflybsd;
 
-import java.util.List;
-
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.CentralProcessor;
-import oshi.hardware.ComputerSystem;
-import oshi.hardware.Display;
-import oshi.hardware.GlobalMemory;
-import oshi.hardware.GraphicsCard;
-import oshi.hardware.HWDiskStore;
-import oshi.hardware.NetworkIF;
-import oshi.hardware.PowerSource;
-import oshi.hardware.Printer;
-import oshi.hardware.Sensors;
-import oshi.hardware.SoundCard;
-import oshi.hardware.UsbDevice;
-import oshi.hardware.common.AbstractHardwareAbstractionLayer;
-import oshi.hardware.common.platform.unix.BsdNetworkIF;
-import oshi.hardware.common.platform.unix.UnixDisplay;
-import oshi.hardware.common.platform.unix.freebsd.FreeBsdGraphicsCard;
-import oshi.hardware.common.platform.unix.freebsd.FreeBsdSoundCard;
-import oshi.hardware.common.platform.unix.freebsd.FreeBsdUsbDevice;
-import oshi.hardware.platform.unix.CupsPrinterJNA;
-import oshi.hardware.platform.unix.freebsd.FreeBsdComputerSystemJNA;
-import oshi.hardware.platform.unix.freebsd.FreeBsdGlobalMemoryJNA;
-import oshi.hardware.platform.unix.freebsd.FreeBsdHWDiskStoreJNA;
-import oshi.hardware.platform.unix.freebsd.FreeBsdPowerSourceJNA;
-import oshi.hardware.platform.unix.freebsd.FreeBsdSensorsJNA;
+import oshi.hardware.platform.unix.freebsd.FreeBsdHardwareAbstractionLayerJNA;
 
 /**
- * DragonFlyBsdHardwareAbstractionLayerJNA class. Uses FreeBSD implementations where behavior is identical.
+ * DragonFly BSD hardware abstraction layer. Every component behaves as FreeBSD's does except the processor, which reads
+ * its tick counters from {@code kern.cputime} rather than {@code kern.cp_time}, so this inherits the FreeBSD wiring and
+ * replaces only that one.
  */
 @ThreadSafe
-public final class DragonFlyBsdHardwareAbstractionLayerJNA extends AbstractHardwareAbstractionLayer {
-
-    @Override
-    public ComputerSystem createComputerSystem() {
-        return new FreeBsdComputerSystemJNA();
-    }
-
-    @Override
-    public GlobalMemory createMemory() {
-        return new FreeBsdGlobalMemoryJNA();
-    }
+public final class DragonFlyBsdHardwareAbstractionLayerJNA extends FreeBsdHardwareAbstractionLayerJNA {
 
     @Override
     public CentralProcessor createProcessor() {
         return new DragonFlyBsdCentralProcessorJNA();
-    }
-
-    @Override
-    public Sensors createSensors() {
-        return new FreeBsdSensorsJNA();
-    }
-
-    @Override
-    public List<PowerSource> getPowerSources() {
-        return FreeBsdPowerSourceJNA.getPowerSources();
-    }
-
-    @Override
-    public List<HWDiskStore> getDiskStores() {
-        return FreeBsdHWDiskStoreJNA.getDisks();
-    }
-
-    @Override
-    protected List<Display> createDisplays() {
-        return UnixDisplay.getDisplays();
-    }
-
-    @Override
-    public List<NetworkIF> getNetworkIFs(boolean includeLocalInterfaces) {
-        return BsdNetworkIF.getNetworks(includeLocalInterfaces);
-    }
-
-    @Override
-    protected List<UsbDevice> createUsbDevices() {
-        return FreeBsdUsbDevice.getUsbDevices();
-    }
-
-    @Override
-    protected List<SoundCard> createSoundCards() {
-        return FreeBsdSoundCard.getSoundCards();
-    }
-
-    @Override
-    protected List<GraphicsCard> createGraphicsCards() {
-        return FreeBsdGraphicsCard.getGraphicsCards();
-    }
-
-    @Override
-    public List<Printer> getPrinters() {
-        return CupsPrinterJNA.getPrinters();
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHardwareAbstractionLayerJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdHardwareAbstractionLayerJNA.java
@@ -31,7 +31,7 @@ import oshi.hardware.platform.unix.CupsPrinterJNA;
  * FreeBsdHardwareAbstractionLayerJNA class.
  */
 @ThreadSafe
-public final class FreeBsdHardwareAbstractionLayerJNA extends AbstractHardwareAbstractionLayer {
+public class FreeBsdHardwareAbstractionLayerJNA extends AbstractHardwareAbstractionLayer {
 
     @Override
     public ComputerSystem createComputerSystem() {

--- a/oshi-core/src/test/java/module-info.test
+++ b/oshi-core/src/test/java/module-info.test
@@ -27,6 +27,8 @@
 --add-opens
   com.github.oshi/oshi.driver.unix.freebsd=org.junit.platform.commons
 --add-opens
+  com.github.oshi/oshi.hardware.platform.unix.dragonflybsd=org.junit.platform.commons
+--add-opens
   com.github.oshi/oshi.util.platform.unix.dragonflybsd=org.junit.platform.commons
 --add-opens
   com.github.oshi/oshi.util.platform.unix.freebsd=org.junit.platform.commons

--- a/oshi-core/src/test/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerJNATest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdHardwareAbstractionLayerJNATest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.platform.unix.dragonflybsd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.hardware.platform.unix.freebsd.FreeBsdHardwareAbstractionLayerJNA;
+
+/**
+ * DragonFly BSD wires every hardware component the way FreeBSD does except the processor, so its hardware abstraction
+ * layer inherits the FreeBSD one. These guard that relationship, which no runtime test can: the components themselves
+ * need a BSD to construct.
+ */
+class DragonFlyBsdHardwareAbstractionLayerJNATest {
+
+    @Test
+    void testInheritsTheFreeBsdWiring() {
+        assertThat(new DragonFlyBsdHardwareAbstractionLayerJNA(),
+                is(instanceOf(FreeBsdHardwareAbstractionLayerJNA.class)));
+    }
+
+    /**
+     * The one component DragonFly must not inherit. Its processor reads tick counters from {@code kern.cputime} where
+     * FreeBSD reads {@code kern.cp_time}, so dropping this override would silently report FreeBSD's counters.
+     */
+    @Test
+    void testProcessorIsOverridden() {
+        assertDoesNotThrow(() -> DragonFlyBsdHardwareAbstractionLayerJNA.class.getDeclaredMethod("createProcessor"),
+                "DragonFly must declare its own createProcessor, not inherit FreeBSD's");
+    }
+
+    /**
+     * The point of inheriting: these must not be copied back in. A re-declared method here would silently diverge from
+     * the FreeBSD one it was copied from.
+     */
+    @Test
+    void testEverythingElseIsInherited() {
+        for (String method : new String[] { "createComputerSystem", "createMemory", "createSensors", "createDisplays",
+                "createUsbDevices", "createSoundCards", "createGraphicsCards" }) {
+            assertThrows(NoSuchMethodException.class,
+                    () -> DragonFlyBsdHardwareAbstractionLayerJNA.class.getDeclaredMethod(method),
+                    method + " must be inherited from FreeBSD, not redeclared");
+        }
+    }
+}


### PR DESCRIPTION
Audit item 15, the half of it that turned out to be real. 8 files, 122+/167−.

## Your suspicion was half right

The cluster is 172 duplicated lines across four files, and it splits into two axes with opposite answers. All twelve methods, in all four classes:

| methods | varies by |
|---|---|
| 5 — `createDisplays`, `getNetworkIFs`, `createUsbDevices`, `createSoundCards`, `createGraphicsCards` | **nothing** — identical in all four, all call shared oshi-common classes |
| 6 — `createComputerSystem`, `createMemory`, `createSensors`, `getPowerSources`, `getDiskStores`, `getPrinters` | backend suffix only; **DragonFly reuses FreeBSD's types verbatim** |
| 1 — `createProcessor` | platform |

**Not actionable: the JNA↔FFM axis**, which is what "BSD HAL twins" implies. Seven of twelve methods differ by which backend's types they build — that is what a hardware layer is *for*. Sharing the other five would need a per-platform base holding five one-line delegations, the exact shape audit item 4 already declined across every platform as "~0 net LOC, heavy file churn". Left alone.

**Actionable: the cross-platform axis**, which the roadmap never named. DragonFly's layer is FreeBSD's with one method changed.

## What changed

`DragonFlyBsdHardwareAbstractionLayer{JNA,FFM}` now extend their FreeBSD counterparts and override only `createProcessor`. That is the same relationship `DragonFlyBsdCentralProcessor{JNA,FFM}` already has with `FreeBsdCentralProcessor{JNA,FFM}`, so it is the established pattern rather than a new one — and the DragonFly layer's own javadoc already claimed it *"uses FreeBSD implementations where behavior is identical"*; the code just expressed that by copying.

| | before | after |
|---|---|---|
| `DragonFlyBsdHardwareAbstractionLayerJNA` | 100 | **23** |
| `DragonFlyBsdHardwareAbstractionLayerFFM` | 101 | **23** |

The FreeBSD layers lose `final`. Dispatch is unaffected: `AbstractHardwareAbstractionLayer` memoizes through `this::createProcessor`, a bound method reference, so the override still wins.

## The override is now load-bearing

Inheriting the wiring makes the one remaining override **silently deletable**. DragonFly's processor reads tick counters from `kern.cputime` where FreeBSD reads `kern.cp_time`, so losing the override would report the wrong counters with no error — and since these components need a BSD to construct, no runtime test can catch it. `NativeComparisonTest` could not either: if both backends lost it they would agree and pass.

So each backend gets a structural test: the layer inherits FreeBSD's, `createProcessor` is still declared, and the other seven are *not* copied back in. I verified both failure modes actually fail:

| deliberate break | result |
|---|---|
| drop the `createProcessor` override | `testProcessorIsOverridden` fails (`NoSuchMethodException`) |
| copy `createMemory` back in | `testEverythingElseIsInherited` fails |

This is the same trap as #3547, where making `readFirmware` concrete left FreeBSD's `dmidecode` override silently deletable. Needed two new `--add-opens` lines, one per module.

## Note on method

My usual false-twin check — diff the twins with the `JNA`/`FFM` suffixes stripped — was **useless here and nearly misleading**: it reported the two FreeBSD layers as differing only in a copyright year, which looks like a smoking gun but is an artifact, since stripping the suffix erases exactly the difference that is supposed to exist. That check only works when the twins reference a *shared* util, as OpenBSD's ComputerSystem did in #3550.

Full gate green plus a clean full-reactor `install`, 0 tests failed. DragonFly runtime is CI-only and `unix.yaml` is manual-dispatch; the wiring is unchanged method-for-method, and the structural tests run everywhere.

No CHANGELOG — no user-observable behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * DragonFly BSD hardware detection now reuses the shared FreeBSD implementation for most hardware components.
  * DragonFly BSD retains platform-specific processor detection and tick-counter handling.
  * Improved consistency across both supported hardware access backends.

* **Tests**
  * Added coverage verifying DragonFly BSD component inheritance and processor-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->