### PR TITLE
Cover the WMI CIM type conversions and fix a null query handle

### DIFF
--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
@@ -14,9 +14,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.platform.win32.COM.Wbemcli;
-import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiQuery;
-import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
 import com.sun.jna.platform.win32.PdhUtil;
 import com.sun.jna.platform.win32.PdhUtil.PdhException;
 import com.sun.jna.platform.win32.VersionHelpers;
@@ -25,6 +22,10 @@ import com.sun.jna.platform.win32.Win32Exception;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.PdhCounterProperty;
 import oshi.driver.common.windows.perfmon.PerfCounter;
+import oshi.driver.common.windows.wmi.WmiConstants;
+import oshi.driver.common.windows.wmi.WmiQuery;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.driver.common.windows.wmi.WmiUtil;
 
 /**
  * Enables queries of Performance Counters using wild cards to filter instances
@@ -123,20 +124,36 @@ public final class PerfCounterQuery {
     public static <T extends Enum<T>> Map<T, Long> queryValuesFromWMI(Class<T> propertyEnum, String wmiClass) {
         WmiQuery<T> query = new WmiQuery<>(wmiClass, propertyEnum);
         WmiResult<T> result = Objects.requireNonNull(WmiQueryHandler.createInstance()).queryWMI(query);
+        return mapValuesFromResult(propertyEnum, result);
+    }
+
+    /**
+     * Maps a WMI result's first row to longs, converting each property according to its CIM type.
+     * <p>
+     * Split from the query so it can be tested against a stubbed result: real WMI data exercises whichever CIM type the
+     * queried class happens to use, leaving the other conversions unreached.
+     *
+     * @param <T>          The enum type of {@code propertyEnum}
+     * @param propertyEnum the property enum
+     * @param result       the query result
+     * @return an {@link EnumMap} of the values indexed by {@code propertyEnum}, empty if the result had no rows
+     * @throws ClassCastException if a property has a CIM type this does not convert
+     */
+    static <T extends Enum<T>> Map<T, Long> mapValuesFromResult(Class<T> propertyEnum, WmiResult<T> result) {
         EnumMap<T, Long> valueMap = new EnumMap<>(propertyEnum);
         if (result.getResultCount() > 0) {
             for (T prop : propertyEnum.getEnumConstants()) {
                 switch (result.getCIMType(prop)) {
-                    case Wbemcli.CIM_UINT16:
+                    case WmiConstants.CIM_UINT16:
                         valueMap.put(prop, (long) WmiUtil.getUint16(result, prop, 0));
                         break;
-                    case Wbemcli.CIM_UINT32:
+                    case WmiConstants.CIM_UINT32:
                         valueMap.put(prop, WmiUtil.getUint32asLong(result, prop, 0));
                         break;
-                    case Wbemcli.CIM_UINT64:
+                    case WmiConstants.CIM_UINT64:
                         valueMap.put(prop, WmiUtil.getUint64(result, prop, 0));
                         break;
-                    case Wbemcli.CIM_DATETIME:
+                    case WmiConstants.CIM_DATETIME:
                         valueMap.put(prop, WmiUtil.getDateTime(result, prop, 0).toInstant().toEpochMilli());
                         break;
                     default:

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQuery.java
@@ -137,6 +137,11 @@ public final class PerfCounterQuery {
      * @param propertyEnum the property enum
      * @param result       the query result
      * @return an {@link EnumMap} of the values indexed by {@code propertyEnum}, empty if the result had no rows
+     *         <p>
+     *         Note that {@code WmiUtil} here is {@link oshi.driver.common.windows.wmi.WmiUtil}, imported so it shadows
+     *         the same-named class in this package. That one takes JNA's result type; this takes the backend-neutral
+     *         interface, which is what makes this testable.
+     *
      * @throws ClassCastException if a property has a CIM type this does not convert
      */
     static <T extends Enum<T>> Map<T, Long> mapValuesFromResult(Class<T> propertyEnum, WmiResult<T> result) {

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQueryHandler.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQueryHandler.java
@@ -77,7 +77,9 @@ public final class PerfCounterQueryHandler implements AutoCloseable {
                 success = PerfDataUtil.removeCounter(href);
             }
         }
-        if (counterHandleMap.isEmpty()) {
+        // The query is only opened when the first counter is added, so it may never have existed: removing a counter
+        // that was never added leaves an empty map with a null handle. removeAllCounters() guards this the same way.
+        if (counterHandleMap.isEmpty() && this.queryHandle != null) {
             PerfDataUtil.closeQuery(this.queryHandle);
             this.queryHandle.close();
             this.queryHandle = null;

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -17,9 +17,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jna.platform.win32.COM.Wbemcli;
-import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiQuery;
-import com.sun.jna.platform.win32.COM.WbemcliUtil.WmiResult;
 import com.sun.jna.platform.win32.PdhUtil;
 import com.sun.jna.platform.win32.PdhUtil.PdhEnumObjectItems;
 import com.sun.jna.platform.win32.PdhUtil.PdhException;
@@ -27,6 +24,10 @@ import com.sun.jna.platform.win32.PdhUtil.PdhException;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.PdhCounterWildcardProperty;
 import oshi.driver.common.windows.perfmon.PerfCounter;
+import oshi.driver.common.windows.wmi.WmiConstants;
+import oshi.driver.common.windows.wmi.WmiQuery;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.util.GlobalConfig;
 import oshi.util.Util;
 import oshi.util.tuples.Pair;
@@ -210,10 +211,28 @@ public final class PerfCounterWildcardQuery {
      */
     public static <T extends Enum<T>> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromWMI(
             Class<T> propertyEnum, String wmiClass) {
-        List<String> instances = new ArrayList<>();
-        EnumMap<T, List<Long>> valuesMap = new EnumMap<>(propertyEnum);
         WmiQuery<T> query = new WmiQuery<>(wmiClass, propertyEnum);
         WmiResult<T> result = Objects.requireNonNull(WmiQueryHandler.createInstance()).queryWMI(query);
+        return mapInstancesAndValuesFromResult(propertyEnum, result);
+    }
+
+    /**
+     * Maps a WMI result to its instance names and per-instance values, converting each property according to its CIM
+     * type. The first property of the enum names the instance; the rest are values.
+     * <p>
+     * Split from the query so it can be tested against a stubbed result: real WMI data exercises whichever CIM type the
+     * queried class happens to use, leaving the other conversions unreached.
+     *
+     * @param <T>          The enum type of {@code propertyEnum}
+     * @param propertyEnum the property enum
+     * @param result       the query result
+     * @return the instance names and the values indexed by {@code propertyEnum}, both empty if the result had no rows
+     * @throws ClassCastException if a property has a CIM type this does not convert
+     */
+    static <T extends Enum<T>> Pair<List<String>, Map<T, List<Long>>> mapInstancesAndValuesFromResult(
+            Class<T> propertyEnum, WmiResult<T> result) {
+        List<String> instances = new ArrayList<>();
+        EnumMap<T, List<Long>> valuesMap = new EnumMap<>(propertyEnum);
         if (result.getResultCount() > 0) {
             for (T prop : propertyEnum.getEnumConstants()) {
                 // First element is instance name
@@ -225,16 +244,16 @@ public final class PerfCounterWildcardQuery {
                     List<Long> values = new ArrayList<>();
                     for (int i = 0; i < result.getResultCount(); i++) {
                         switch (result.getCIMType(prop)) {
-                            case Wbemcli.CIM_UINT16:
+                            case WmiConstants.CIM_UINT16:
                                 values.add((long) WmiUtil.getUint16(result, prop, i));
                                 break;
-                            case Wbemcli.CIM_UINT32:
+                            case WmiConstants.CIM_UINT32:
                                 values.add(WmiUtil.getUint32asLong(result, prop, i));
                                 break;
-                            case Wbemcli.CIM_UINT64:
+                            case WmiConstants.CIM_UINT64:
                                 values.add(WmiUtil.getUint64(result, prop, i));
                                 break;
-                            case Wbemcli.CIM_DATETIME:
+                            case WmiConstants.CIM_DATETIME:
                                 values.add(WmiUtil.getDateTime(result, prop, i).toInstant().toEpochMilli());
                                 break;
                             default:

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -227,6 +227,11 @@ public final class PerfCounterWildcardQuery {
      * @param propertyEnum the property enum
      * @param result       the query result
      * @return the instance names and the values indexed by {@code propertyEnum}, both empty if the result had no rows
+     *         <p>
+     *         Note that {@code WmiUtil} here is {@link oshi.driver.common.windows.wmi.WmiUtil}, imported so it shadows
+     *         the same-named class in this package. That one takes JNA's result type; this takes the backend-neutral
+     *         interface, which is what makes this testable.
+     *
      * @throws ClassCastException if a property has a CIM type this does not convert
      */
     static <T extends Enum<T>> Pair<List<String>, Map<T, List<Long>>> mapInstancesAndValuesFromResult(

--- a/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterQueryHandlerTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterQueryHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.driver.common.windows.perfmon.PerfCounter;
+
+/**
+ * Tests the counter bookkeeping that needs no PDH query.
+ * <p>
+ * Adding a counter opens the query natively, so these cover only the paths before that happens: a handler that has
+ * never opened one. Those paths are pure Java and so run on any OS.
+ */
+class PerfCounterQueryHandlerTest {
+
+    private static PerfCounter counter(String name) {
+        return new PerfCounter("Processor", "_Total", name);
+    }
+
+    /**
+     * Removing a counter that was never added must report failure rather than throw. The query handle is only created
+     * when the first counter is added, so it is still null here, and the cleanup that runs once the map is empty used
+     * to dereference it.
+     */
+    @Test
+    void testRemovingAnUnknownCounterFromAFreshHandler() {
+        try (PerfCounterQueryHandler handler = new PerfCounterQueryHandler()) {
+            assertThat("Nothing was removed, so the result is false", handler.removeCounterFromQuery(counter("A")),
+                    is(false));
+        }
+    }
+
+    /**
+     * The same path reached twice. Each call leaves the map empty, so each reruns the cleanup branch.
+     */
+    @Test
+    void testRemovingRepeatedlyIsSafe() {
+        try (PerfCounterQueryHandler handler = new PerfCounterQueryHandler()) {
+            handler.removeCounterFromQuery(counter("A"));
+            assertThat(handler.removeCounterFromQuery(counter("A")), is(false));
+            assertThat(handler.removeCounterFromQuery(counter("B")), is(false));
+        }
+    }
+
+    /**
+     * Removing all counters from a handler that never opened a query is the guarded equivalent, and was already safe.
+     * Kept alongside so the two cleanup paths are covered together.
+     */
+    @Test
+    void testRemoveAllCountersOnAFreshHandler() {
+        try (PerfCounterQueryHandler handler = new PerfCounterQueryHandler()) {
+            assertDoesNotThrow(handler::removeAllCounters);
+        }
+    }
+
+    @Test
+    void testCloseOnAFreshHandlerIsSafe() {
+        assertDoesNotThrow(() -> new PerfCounterQueryHandler().close());
+    }
+}

--- a/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterQueryTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterQueryTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_DATETIME;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT16;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT32;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT64;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_BSTR;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_I4;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.driver.common.windows.wmi.WmiResult;
+
+/**
+ * Tests the CIM type conversions in the WMI value mapping.
+ * <p>
+ * A real query returns whichever CIM type the queried performance class happens to use, so on hardware only one of the
+ * four conversions is ever reached. Stubbing the result reaches all of them, and the unsupported-type path too.
+ * <p>
+ * Windows only, unlike the wildcard equivalent: {@link PerfCounterQuery} caches
+ * {@code VersionHelpers.IsWindowsVistaOrGreater()} in a static field, so the class cannot be loaded on another OS.
+ */
+@EnabledOnOs(OS.WINDOWS)
+class PerfCounterQueryTest {
+
+    private enum Prop {
+        U16, U32, U64, WHEN;
+    }
+
+    /** A single-row WMI result stub. */
+    private static final class StubResult implements WmiResult<Prop> {
+        private final Map<Prop, Integer> cimTypes = new EnumMap<>(Prop.class);
+        private final Map<Prop, Integer> vtTypes = new EnumMap<>(Prop.class);
+        private final Map<Prop, Object> values = new EnumMap<>(Prop.class);
+        private int rows;
+
+        private StubResult put(Prop p, int cim, int vt, Object value) {
+            cimTypes.put(p, cim);
+            vtTypes.put(p, vt);
+            values.put(p, value);
+            rows = 1;
+            return this;
+        }
+
+        @Override
+        public int getResultCount() {
+            return rows;
+        }
+
+        @Override
+        public Object getValue(Prop property, int index) {
+            return values.get(property);
+        }
+
+        @Override
+        public int getVtType(Prop property) {
+            return vtTypes.getOrDefault(property, 0);
+        }
+
+        @Override
+        public int getCIMType(Prop property) {
+            return cimTypes.getOrDefault(property, 0);
+        }
+    }
+
+    // One value per supported CIM type. WMI reports UINT64 as a string and datetimes in CIM format.
+    private static StubResult oneRow() {
+        return new StubResult().put(Prop.U16, CIM_UINT16, VT_I4, 16).put(Prop.U32, CIM_UINT32, VT_I4, 32)
+                .put(Prop.U64, CIM_UINT64, VT_BSTR, "64")
+                .put(Prop.WHEN, CIM_DATETIME, VT_BSTR, "20240115143000.000000+000");
+    }
+
+    @Test
+    void testEachCimTypeIsConverted() {
+        Map<Prop, Long> values = PerfCounterQuery.mapValuesFromResult(Prop.class, oneRow());
+        assertThat("UINT16 widens to long", values.get(Prop.U16), is(16L));
+        assertThat("UINT32 widens unsigned", values.get(Prop.U32), is(32L));
+        assertThat("UINT64 is parsed from its string form", values.get(Prop.U64), is(64L));
+        assertThat("DATETIME becomes epoch milliseconds", values.get(Prop.WHEN), is(1705329000000L));
+    }
+
+    @Test
+    void testUnsignedIntegersAreNotSignExtended() {
+        // 0xFFFFFFFF arrives as -1 in a 32-bit slot; as an unsigned CIM_UINT32 it must read as 4294967295.
+        StubResult result = new StubResult().put(Prop.U16, CIM_UINT16, VT_I4, 0).put(Prop.U32, CIM_UINT32, VT_I4, -1)
+                .put(Prop.U64, CIM_UINT64, VT_BSTR, "0")
+                .put(Prop.WHEN, CIM_DATETIME, VT_BSTR, "20240115143000.000000+000");
+        assertThat(PerfCounterQuery.mapValuesFromResult(Prop.class, result).get(Prop.U32), is(4294967295L));
+    }
+
+    @Test
+    void testAnUnsupportedCimTypeIsRejected() {
+        // CIM_SINT32 is a type the mapping does not convert; it must fail loudly rather than silently drop the value.
+        StubResult result = new StubResult().put(Prop.U16, 3, VT_I4, 1);
+        assertThrows(ClassCastException.class, () -> PerfCounterQuery.mapValuesFromResult(Prop.class, result));
+    }
+
+    @Test
+    void testNoRowsYieldsAnEmptyMap() {
+        assertThat(PerfCounterQuery.mapValuesFromResult(Prop.class, new StubResult()).isEmpty(), is(true));
+    }
+}

--- a/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterQueryTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterQueryTest.java
@@ -5,7 +5,11 @@
 package oshi.util.platform.windows;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static oshi.driver.common.windows.wmi.WmiConstants.CIM_DATETIME;
 import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT16;
@@ -110,5 +114,33 @@ class PerfCounterQueryTest {
     @Test
     void testNoRowsYieldsAnEmptyMap() {
         assertThat(PerfCounterQuery.mapValuesFromResult(Prop.class, new StubResult()).isEmpty(), is(true));
+    }
+
+    /**
+     * The properties of {@code Win32_OperatingSystem} that this mapping converts, one per supported CIM type. Chosen
+     * because a single real class covers all four, so no string property is present to hit the unsupported-type throw.
+     */
+    private enum OsProp {
+        OSTYPE, NUMBEROFPROCESSES, FREEPHYSICALMEMORY, LASTBOOTUPTIME;
+    }
+
+    /**
+     * Runs the real query, rather than a stub, against a class that genuinely holds all four types.
+     * <p>
+     * The stubbed tests above encode assumptions about how WMI represents each type -- that a UINT64 arrives as a
+     * string in a BSTR, that a DATETIME arrives in CIM format. The production code assumes the same, so those tests and
+     * the code could agree with each other and both be wrong. This one takes the assumption out of the loop.
+     */
+    @Test
+    void testAgainstRealWmiDataCoveringEveryType() {
+        Map<OsProp, Long> values = PerfCounterQuery.queryValuesFromWMI(OsProp.class, "Win32_OperatingSystem");
+        assertThat("Win32_OperatingSystem should always return a row", values.keySet(),
+                containsInAnyOrder(OsProp.values()));
+        assertThat("OSType is a small enumeration value", values.get(OsProp.OSTYPE), is(greaterThan(0L)));
+        assertThat("A running system has processes", values.get(OsProp.NUMBEROFPROCESSES), is(greaterThan(0L)));
+        assertThat("Free memory is reported in kilobytes", values.get(OsProp.FREEPHYSICALMEMORY), is(greaterThan(0L)));
+        long boot = values.get(OsProp.LASTBOOTUPTIME);
+        assertThat("Boot time is a plausible epoch millisecond value in the past", boot,
+                is(both(greaterThan(946684800000L)).and(lessThanOrEqualTo(System.currentTimeMillis()))));
     }
 }

--- a/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterWildcardQueryTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterWildcardQueryTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_DATETIME;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_STRING;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT16;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT32;
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT64;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_BSTR;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_I4;
+
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.util.tuples.Pair;
+
+/**
+ * Tests the CIM type conversions in the wildcard WMI mapping.
+ * <p>
+ * A real query returns whichever CIM type the queried performance class happens to use, so on hardware only one of the
+ * four conversions is ever reached. Stubbing the result reaches all of them, and the unsupported-type path too.
+ */
+class PerfCounterWildcardQueryTest {
+
+    /** First constant names the instance; the rest are values, one per CIM type the mapping converts. */
+    private enum Prop {
+        NAME, U16, U32, U64, WHEN;
+    }
+
+    /** A WMI result stub: per-property CIM/VT types and one value per row. */
+    private static final class StubResult implements WmiResult<Prop> {
+        private final Map<Prop, Integer> cimTypes = new EnumMap<>(Prop.class);
+        private final Map<Prop, Integer> vtTypes = new EnumMap<>(Prop.class);
+        private final Map<Prop, List<Object>> values = new EnumMap<>(Prop.class);
+        private int rows;
+
+        private StubResult put(Prop p, int cim, int vt, Object... rowValues) {
+            cimTypes.put(p, cim);
+            vtTypes.put(p, vt);
+            values.put(p, Arrays.asList(rowValues));
+            rows = Math.max(rows, rowValues.length);
+            return this;
+        }
+
+        @Override
+        public int getResultCount() {
+            return rows;
+        }
+
+        @Override
+        public Object getValue(Prop property, int index) {
+            List<Object> v = values.get(property);
+            return v == null || index >= v.size() ? null : v.get(index);
+        }
+
+        @Override
+        public int getVtType(Prop property) {
+            return vtTypes.getOrDefault(property, 0);
+        }
+
+        @Override
+        public int getCIMType(Prop property) {
+            return cimTypes.getOrDefault(property, 0);
+        }
+    }
+
+    // Two instances, one per supported CIM type. WMI reports UINT64 as a string and datetimes in CIM format.
+    private static StubResult twoInstances() {
+        return new StubResult().put(Prop.NAME, CIM_STRING, VT_BSTR, "cpu0", "cpu1")
+                .put(Prop.U16, CIM_UINT16, VT_I4, 16, 17).put(Prop.U32, CIM_UINT32, VT_I4, 32, 33)
+                .put(Prop.U64, CIM_UINT64, VT_BSTR, "64", "65")
+                .put(Prop.WHEN, CIM_DATETIME, VT_BSTR, "20240115143000.000000+000", "20240115143001.000000+000");
+    }
+
+    private static Pair<List<String>, Map<Prop, List<Long>>> map(StubResult result) {
+        return PerfCounterWildcardQuery.mapInstancesAndValuesFromResult(Prop.class, result);
+    }
+
+    @Test
+    void testEachCimTypeIsConverted() {
+        Map<Prop, List<Long>> values = map(twoInstances()).getB();
+        assertThat("UINT16 widens to long", values.get(Prop.U16), contains(16L, 17L));
+        assertThat("UINT32 widens unsigned", values.get(Prop.U32), contains(32L, 33L));
+        assertThat("UINT64 is parsed from its string form", values.get(Prop.U64), contains(64L, 65L));
+        assertThat("DATETIME becomes epoch milliseconds", values.get(Prop.WHEN),
+                contains(1705329000000L, 1705329001000L));
+    }
+
+    @Test
+    void testFirstPropertyNamesTheInstances() {
+        Pair<List<String>, Map<Prop, List<Long>>> mapped = map(twoInstances());
+        assertThat(mapped.getA(), contains("cpu0", "cpu1"));
+        assertThat("The instance name is not also a value", mapped.getB().containsKey(Prop.NAME), is(false));
+    }
+
+    @Test
+    void testUnsignedIntegersAreNotSignExtended() {
+        // 0xFFFFFFFF arrives as -1 in a 32-bit slot; as an unsigned CIM_UINT32 it must read as 4294967295.
+        StubResult result = new StubResult().put(Prop.NAME, CIM_STRING, VT_BSTR, "cpu0")
+                .put(Prop.U16, CIM_UINT16, VT_I4, 0).put(Prop.U32, CIM_UINT32, VT_I4, -1)
+                .put(Prop.U64, CIM_UINT64, VT_BSTR, "0")
+                .put(Prop.WHEN, CIM_DATETIME, VT_BSTR, "20240115143000.000000+000");
+        assertThat(map(result).getB().get(Prop.U32), contains(4294967295L));
+    }
+
+    @Test
+    void testAnUnsupportedCimTypeIsRejected() {
+        // CIM_SINT32 is a type the mapping does not convert; it must fail loudly rather than silently drop the value.
+        StubResult result = new StubResult().put(Prop.NAME, CIM_STRING, VT_BSTR, "cpu0").put(Prop.U16, 3, VT_I4, 1);
+        assertThrows(ClassCastException.class, () -> map(result));
+    }
+
+    @Test
+    void testNoRowsYieldsNoInstancesAndNoValues() {
+        Pair<List<String>, Map<Prop, List<Long>>> mapped = map(new StubResult());
+        assertThat(mapped.getA(), is(empty()));
+        assertThat(mapped.getB().isEmpty(), is(true));
+    }
+}


### PR DESCRIPTION
The three uncovered spots you pointed at. One of them was a bug.

## `PerfCounterQueryHandler.removeCounterFromQuery` — NPE

```java
if (counterHandleMap.isEmpty()) {
    PerfDataUtil.closeQuery(this.queryHandle);   // closeQuery does q.getValue()
    this.queryHandle.close();
```

The query handle is only created when the **first counter is added**, so it is still null on a fresh handler. Removing a counter that was never added — or removing one twice — leaves the map empty and reaches `closeQuery(null)`, which dereferences its argument.

`removeAllCounters()` in the same class already guards this with `if (this.queryHandle != null)`. The guard is now on both.

It has **no caller in the project**, which is exactly why it was uncovered and why nobody hit it. It is public API on a public class, so a consumer could.

## The CIM type conversions — 1 of 4 branches reached

Both `queryValuesFromWMI` and `queryInstancesAndValuesFromWMI` convert four CIM types, but a real query returns whichever type the queried performance class happens to use, so only one branch is ever exercised on hardware. Each now splits the mapping from the query, so it can be driven by a stubbed result.

New coverage: all four conversions (UINT16, UINT32, UINT64 parsed from its string form, DATETIME to epoch millis), unsigned widening (`-1` in a 32-bit slot reading as `4294967295` rather than sign-extending), the unsupported-type `ClassCastException`, the no-rows case, and for the wildcard version that the first property names the instances and is not also emitted as a value.

## Why the interface swap was needed

JNA's `WbemcliUtil.WmiResult` has a public constructor but its `add` is **private**, so a result cannot be populated from outside JNA's own package — there is no way to stub it. The methods now take the `WmiResult` interface from oshi-common instead.

That is not a new abstraction: newer JNA code such as `MSFTStorageJNA` already uses it, and `WmiQueryHandler` already offers the overload returning it, so this brings these two in line with the rest.

**Behaviour is unchanged.** I diffed the two `WmiUtil` implementations — `getUint16`, `getUint32asLong`, `getUint64`, `getDateTime` are line-for-line identical apart from whether the constants are qualified (`Wbemcli.CIM_UINT16` vs a static import), and the constant values match (`CIM_UINT16=18`, `UINT32=19`, `UINT64=21`, `DATETIME=101`, `VT_BSTR=8`).

## Where each test runs

| test | runs |
|---|---|
| `PerfCounterQueryHandlerTest` | everywhere |
| `PerfCounterWildcardQueryTest` | everywhere |
| `PerfCounterQueryTest` | **Windows only** |

`PerfCounterQuery` caches `VersionHelpers.IsWindowsVistaOrGreater()` in a `static final` field, so loading the class off Windows throws `UnsatisfiedLinkError` — I verified this rather than assumed it, along with the other three classes, which do load. The wildcard class has no such static, hence the difference. The Windows-only tests still count toward coverage via the Windows CI runner.

I also verified the handler guard is load-bearing by removing it and re-running: both new tests fail.

## Not attempted

No FFM counterpart to mirror. `PerfCounterQueryFFM.queryValuesFromWMI` has no CIM switch at all — it reads through `IWbemClassObjectFFM.getLong(pObject, prop.name(), arena)` — so this is JNA-only, consistent with the audit's finding that the WMI/COM twins are structurally different rather than duplicated.

Full gate green plus a clean full-reactor `install`, 0 tests failed.

No CHANGELOG: the NPE is on a method with no in-project caller, so no shipped behaviour changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows performance-counter query cleanup so removing counters before any query is opened is safe and does not leave stale handles.
  * Updated Windows WMI-backed performance-counter and wildcard querying to use a shared WMI abstraction, improving consistent CIM type conversions (including unsigned and datetime-to-epoch-millis handling).
* **Tests**
  * Added Windows tests covering pre-handle counter bookkeeping, CIM value conversion (including empty results and unsupported types), and an integration-style check using real `Win32_OperatingSystem` data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->