### PR TITLE
Bound the varargs test helpers on the last index they read

### DIFF
--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGpuStatsTest.java
@@ -111,9 +111,11 @@ class MacGpuStatsTest {
         }
     }
 
+    // The varargs are key/value pairs, so the loop is bounded on the value index rather than the key index: a caller
+    // that passes a stray trailing key gets one fewer entry instead of running off the end.
     private static Map<String, Long> stats(Object... keyValues) {
         Map<String, Long> map = new HashMap<>();
-        for (int i = 0; i < keyValues.length; i += 2) {
+        for (int i = 0; i + 1 < keyValues.length; i += 2) {
             map.put((String) keyValues[i], (Long) keyValues[i + 1]);
         }
         return map;

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroupTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroupTest.java
@@ -77,9 +77,11 @@ class WindowsLogicalVolumeGroupTest {
         };
     }
 
+    // The varargs of these helpers are fixed-size groups, so each loop is bounded on the last index it reads rather
+    // than on the first: a caller that passes a partial group gets one fewer row instead of running off the end.
     private static WmiResult<StoragePoolProperty> pools(String... namesAndIds) {
         List<Map<StoragePoolProperty, Object>> rows = new ArrayList<>();
-        for (int i = 0; i < namesAndIds.length; i += 2) {
+        for (int i = 0; i + 1 < namesAndIds.length; i += 2) {
             Map<StoragePoolProperty, Object> row = new EnumMap<>(StoragePoolProperty.class);
             row.put(StoragePoolProperty.FRIENDLYNAME, namesAndIds[i]);
             row.put(StoragePoolProperty.OBJECTID, objectId("SP", namesAndIds[i + 1]));
@@ -90,7 +92,7 @@ class WindowsLogicalVolumeGroupTest {
 
     private static WmiResult<VirtualDiskProperty> virtualDisks(String... namesSpAndVd) {
         List<Map<VirtualDiskProperty, Object>> rows = new ArrayList<>();
-        for (int i = 0; i < namesSpAndVd.length; i += 3) {
+        for (int i = 0; i + 2 < namesSpAndVd.length; i += 3) {
             Map<VirtualDiskProperty, Object> row = new EnumMap<>(VirtualDiskProperty.class);
             row.put(VirtualDiskProperty.FRIENDLYNAME, namesSpAndVd[i]);
             // A VD ObjectId carries the storage pool GUID followed by the virtual disk GUID
@@ -102,7 +104,7 @@ class WindowsLogicalVolumeGroupTest {
 
     private static WmiResult<PhysicalDiskProperty> physicalDisks(String... nameLocationAndId) {
         List<Map<PhysicalDiskProperty, Object>> rows = new ArrayList<>();
-        for (int i = 0; i < nameLocationAndId.length; i += 3) {
+        for (int i = 0; i + 2 < nameLocationAndId.length; i += 3) {
             Map<PhysicalDiskProperty, Object> row = new EnumMap<>(PhysicalDiskProperty.class);
             row.put(PhysicalDiskProperty.FRIENDLYNAME, nameLocationAndId[i]);
             row.put(PhysicalDiskProperty.PHYSICALLOCATION, nameLocationAndId[i + 1]);
@@ -114,7 +116,7 @@ class WindowsLogicalVolumeGroupTest {
 
     private static WmiResult<StoragePoolToPhysicalDiskProperty> poolToDisk(String... spAndPdGuids) {
         List<Map<StoragePoolToPhysicalDiskProperty, Object>> rows = new ArrayList<>();
-        for (int i = 0; i < spAndPdGuids.length; i += 2) {
+        for (int i = 0; i + 1 < spAndPdGuids.length; i += 2) {
             Map<StoragePoolToPhysicalDiskProperty, Object> row = new EnumMap<>(StoragePoolToPhysicalDiskProperty.class);
             row.put(StoragePoolToPhysicalDiskProperty.STORAGEPOOL, objectId("SP", spAndPdGuids[i]));
             row.put(StoragePoolToPhysicalDiskProperty.PHYSICALDISK, objectId("PD", spAndPdGuids[i + 1]));


### PR DESCRIPTION
CodeQL Code Quality reported seven `java/index-out-of-bounds` findings (severity error) across the two test files added in #3543 and #3546:

- `MacGpuStatsTest.java:117`
- `WindowsLogicalVolumeGroupTest.java:85`, `:97` (×2), `:108`, `:109`, `:120`

Each is the same shape. A private varargs helper walks its arguments in fixed-size groups, striding by two or three, but bounds the loop on the *first* index of the group rather than the last. Reading `namesAndIds[i + 1]` under a loop guarded only by `i < namesAndIds.length` runs off the end whenever the caller passes a partial group.

Unlike the `useless-null-check` and `dereferenced-value-may-be-null` findings on these files, this one is not a false positive. Every call site today passes a complete multiple, so nothing can throw as written, but the helpers make no such guarantee and the finding will resurface each time the files move.

Bounding each loop on the last index it reads is what CodeQL's range analysis needs to see, and it turns a would-be `ArrayIndexOutOfBoundsException` into one fewer row for a caller that miscounts — which a test's own assertions will catch immediately.

The two production stride loops were checked and left alone:

- `ParseUtil.hexStringToByteArray` already rejects odd-length input with an explicit `(len & 0x1) != 0` guard.
- `HkeyPerformanceDataUtil.buildCounterIndexMap` starts at `i = 1` and reads backwards to `i - 1`, so both indices are always in range.

Neither was flagged, and both are correct as written.

Test-only, so no CHANGELOG entry.

Full gate green on `oshi-common`: spotless, checkstyle, install, forbiddenapis, javadoc, and 1264 tests successful / 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture handling for incomplete input data.
  * Prevented errors when trailing or unmatched test parameters are provided.
  * Added safer handling for incomplete storage and graphics test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->