### PR TITLE
Stop AIX reporting the current instant as its boot time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,16 @@ Reducing this duplication has been a sustained effort in the project, so **defau
 rather than copying. A change that adds parallel logic to both implementations will be asked to
 justify why it is not shared.
 
+**Before writing any parsing helper, check whether `ParseUtil` already has one.** It is the home for
+general parsing primitives — numbers, sizes, frequencies, hex, delimited fields, and dates
+(`parseDateToEpoch`, `parseCimDateTimeToOffset`, `parseYearlessDateToEpoch`). The duplication is
+easy to miss because the two copies live in per-platform drivers that you would never read side by
+side: the AIX and generic-UNIX `who` readers each grew their own copy of "parse a `MMM d HH:mm`
+timestamp that carries no year, defaulting to the current year and subtracting one if that lands in
+the future" before it was hoisted. If a command on one OS emits a format, a command on another
+probably does too, so put the format parser in `ParseUtil` and leave only the
+command-specific regex in the driver.
+
 Runtime configuration lives in `oshi-common/src/main/resources/oshi.properties`, read through
 `oshi.util.GlobalConfig` or overridden with Java system properties. Configuration is read at
 startup, is not thread-safe, and is not re-read during operation. Add new settings there rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 7.4.4 (in progress)
 
-* Your contribution here!
+##### Bug Fixes and Improvements
+
+* [#3561](https://github.com/oshi/oshi/pull/3561): Fix AIX reporting the current instant as its boot time, and an uptime of zero, when the `uptime` command transiently failed; parse the year-less `who -b` format AIX 7.3 emits, and add `ParseUtil.parseYearlessDateToEpoch` - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24), 7.4.3 (2027-07-31)
 

--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -8,7 +8,9 @@
     <suppress checks=".*" files="[\\/]comparison[\\/].*"/>
 
     <!-- Intentional style breaks -->
-    <suppress checks="ConstantName" files="ParseUtil\.java" lines="116-136"/>
+    <!-- Legacy lowercase public Pattern constants, kept for API compatibility. Line-keyed, so adding an import to
+         ParseUtil shifts them out of range and fails the build; re-check the bounds when this file moves. -->
+    <suppress checks="ConstantName" files="ParseUtil\.java" lines="117-137"/>
     <suppress checks="VisibilityModifier" files="SmcUtil\.java"/>
 
     <!-- JNA convention  -->

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Who.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Who.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
 
 /**
  * Utility to query logged in users.
@@ -26,6 +27,13 @@ public final class Who {
     private static final Pattern BOOT_FORMAT_AIX = Pattern.compile("\\D+(\\d{4}-\\d{2}-\\d{2})\\s+(\\d{2}:\\d{2}).*");
     private static final DateTimeFormatter BOOT_DATE_FORMAT_AIX = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm",
             Locale.ROOT);
+
+    // AIX 7.3 defaults to a month-name form that carries no year, in both the C and en_US locales:
+    // system boot Feb 13 23:31
+    // The day is space-padded, so the groups are rejoined with single spaces to match the pattern below.
+    private static final Pattern BOOT_FORMAT_AIX_NO_YEAR = Pattern
+            .compile("\\D+?([A-Z][a-z]{2})\\s+(\\d{1,2})\\s+(\\d{2}:\\d{2}).*");
+    private static final String BOOT_NO_YEAR_PATTERN_AIX = "MMM d HH:mm";
 
     private Who() {
     }
@@ -47,9 +55,22 @@ public final class Who {
      * Parses the {@code who -b} output line into a boot time in milliseconds since the epoch.
      *
      * @param s a line of {@code who -b} output
-     * @return boot time in milliseconds since the epoch, or 0 if the line does not match the expected format
+     * @return boot time in milliseconds since the epoch, or 0 if the line does not match either expected format
      */
     public static long parseBootTime(String s) {
+        // The zone is explicit because the year resolution below and the epoch conversion must agree on it
+        return parseBootTime(s, LocalDateTime.now(ZoneId.systemDefault()));
+    }
+
+    /**
+     * Parses the {@code who -b} output line into a boot time in milliseconds since the epoch, resolving the year of the
+     * month-name format relative to the given moment.
+     *
+     * @param s   a line of {@code who -b} output
+     * @param now the moment to resolve a year-less timestamp against
+     * @return boot time in milliseconds since the epoch, or 0 if the line does not match either expected format
+     */
+    static long parseBootTime(String s, LocalDateTime now) {
         Matcher m = BOOT_FORMAT_AIX.matcher(s);
         if (m.matches()) {
             try {
@@ -58,6 +79,13 @@ public final class Who {
             } catch (DateTimeParseException | NullPointerException e) {
                 // Shouldn't happen with regex matching
             }
+        }
+        m = BOOT_FORMAT_AIX_NO_YEAR.matcher(s);
+        if (m.matches()) {
+            // A system up for more than a year cannot be resolved from this format, which is why the caller prefers
+            // the unambiguous uptime duration when it has one.
+            return ParseUtil.parseYearlessDateToEpoch(m.group(1) + " " + m.group(2) + " " + m.group(3),
+                    BOOT_NO_YEAR_PATTERN_AIX, now);
         }
         return 0L;
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOperatingSystem.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -51,7 +52,10 @@ public abstract class AixOperatingSystem extends AbstractOperatingSystem {
     private final Supplier<List<ApplicationInfo>> installedAppsSupplier = Memoizer
             .memoize(AixInstalledApps::queryInstalledApps, installedAppsExpiration());
 
-    private static final long BOOTTIME = querySystemBootTimeMillis() / 1000L;
+    // Boot time is constant, but the commands it is read from can fail transiently on a busy system. Caching only a
+    // successful reading means such a failure is retried on the next call, rather than pinning the boot time to the
+    // moment this class happened to load for the life of the JVM.
+    private static final AtomicLong BOOT_TIME_SECONDS = new AtomicLong(0L);
 
     @Override
     public String queryManufacturer() {
@@ -160,20 +164,59 @@ public abstract class AixOperatingSystem extends AbstractOperatingSystem {
 
     @Override
     public long getSystemUptime() {
-        return System.currentTimeMillis() / 1000L - BOOTTIME;
+        long bootTime = bootTimeSeconds();
+        return bootTime > 0L ? System.currentTimeMillis() / 1000L - bootTime : 0L;
     }
 
     @Override
     public long getSystemBootTime() {
-        return BOOTTIME;
+        return bootTimeSeconds();
+    }
+
+    /**
+     * Returns the cached boot time, querying it on first use and on any call that follows a failed query.
+     * <p>
+     * The cache is static so that the JNA and FFM subclasses report an identical boot time rather than each deriving
+     * one from a separately-timed {@code uptime} reading, whose resolution is only a minute.
+     *
+     * @return boot time in seconds since the epoch, or 0 if it could not be determined
+     */
+    private static long bootTimeSeconds() {
+        long cached = BOOT_TIME_SECONDS.get();
+        if (cached > 0L) {
+            return cached;
+        }
+        long queried = querySystemBootTimeMillis() / 1000L;
+        if (queried > 0L) {
+            // Only the first successful query wins, so concurrent callers agree on one value
+            BOOT_TIME_SECONDS.compareAndSet(0L, queried);
+            return BOOT_TIME_SECONDS.get();
+        }
+        return 0L;
     }
 
     private static long querySystemBootTimeMillis() {
-        long bootTime = Who.queryBootTime();
-        if (bootTime >= 1000L) {
-            return bootTime;
+        return resolveBootTimeMillis(Who.queryBootTime(), Uptime.queryUpTime(), System.currentTimeMillis());
+    }
+
+    /**
+     * Resolves a boot time from the two available sources.
+     *
+     * @param whoBootTimeMillis boot time reported by {@code who -b}, or 0 if unavailable
+     * @param upTimeMillis      up time reported by {@code uptime}, or 0 if unavailable
+     * @param nowMillis         the current time in milliseconds since the epoch
+     * @return boot time in milliseconds since the epoch, or 0 if neither source produced a usable value
+     */
+    static long resolveBootTimeMillis(long whoBootTimeMillis, long upTimeMillis, long nowMillis) {
+        // The uptime command reports a duration, which is unambiguous, so it is preferred. A zero up time means the
+        // query failed, not that the system booted this instant: subtracting it would report the current moment as
+        // the boot time and pin uptime to zero.
+        if (upTimeMillis > 0L) {
+            return nowMillis - upTimeMillis;
         }
-        return System.currentTimeMillis() - Uptime.queryUpTime();
+        // who -b reports a timestamp, whose AIX format may omit the year and so has to be resolved by assuming the
+        // boot was within the last 365 days. Only consulted when the uptime command gave nothing.
+        return whoBootTimeMillis >= 1000L ? whoBootTimeMillis : 0L;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -1554,4 +1554,40 @@ public final class ParseUtil {
             return 0;
         }
     }
+
+    /**
+     * Parses a timestamp that carries no year into an epoch time, resolving it to the most recent occurrence at or
+     * before {@code now}.
+     * <p>
+     * Several UNIX commands report timestamps without a year, such as the {@code MMM d HH:mm} form of {@code who} and
+     * {@code who -b}. Defaulting to the current year alone is not enough: read in January, a December timestamp would
+     * resolve to a date eleven months in the future, so anything later than {@code now} is taken to be last year's.
+     * This cannot resolve a timestamp more than a year old, which is indistinguishable from a recent one.
+     * <p>
+     * Month names are parsed as English, which is what the C locale these commands are read under emits.
+     *
+     * @param dateString  the timestamp to parse, carrying no year
+     * @param datePattern the expected format pattern, for example {@code "MMM d HH:mm"}
+     * @param now         the moment to resolve the missing year against
+     * @return the epoch time in milliseconds since January 1, 1970, UTC. Returns {@code 0} if parsing fails.
+     */
+    public static long parseYearlessDateToEpoch(String dateString, String datePattern, LocalDateTime now) {
+        if (dateString == null || dateString.isEmpty() || datePattern.isEmpty()) {
+            return 0;
+        }
+        try {
+            DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(datePattern)
+                    .parseDefaulting(ChronoField.YEAR, now.getYear()).parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                    .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0).parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+                    .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0).toFormatter(Locale.US);
+            LocalDateTime localDateTime = LocalDateTime.parse(dateString, formatter);
+            if (localDateTime.isAfter(now)) {
+                localDateTime = localDateTime.minusYears(1);
+            }
+            return localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        } catch (DateTimeParseException e) {
+            LOG.trace("Unable to parse yearless date string: {}", dateString);
+            return 0;
+        }
+    }
 }

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -18,6 +18,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1564,6 +1565,11 @@ public final class ParseUtil {
      * resolve to a date eleven months in the future, so anything later than {@code now} is taken to be last year's.
      * This cannot resolve a timestamp more than a year old, which is indistinguishable from a recent one.
      * <p>
+     * February 29 is handled by parsing strictly and reparsing against the previous year, rather than by subtracting
+     * one from the result: the default resolver would quietly clamp a leap day to the 28th in a non-leap current year,
+     * and subtracting a year from a valid one would do the same. A leap day valid in neither candidate year yields
+     * {@code 0}.
+     * <p>
      * Month names are parsed as English, which is what the C locale these commands are read under emits.
      *
      * @param dateString  the timestamp to parse, carrying no year
@@ -1575,19 +1581,35 @@ public final class ParseUtil {
         if (dateString == null || dateString.isEmpty() || datePattern.isEmpty()) {
             return 0;
         }
+        LocalDateTime thisYear = parseWithDefaultYear(dateString, datePattern, now.getYear());
+        if (thisYear != null && !thisYear.isAfter(now)) {
+            return thisYear.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        }
+        // Either the timestamp falls later in the year than now, so it can only be last year's, or it is not a valid
+        // date in the current year at all: February 29 outside a leap year, which the strict parse above rejects.
+        // Reparsing handles both, and keeps a real leap day intact where subtracting a year would shift it to the
+        // 28th.
+        LocalDateTime lastYear = parseWithDefaultYear(dateString, datePattern, now.getYear() - 1);
+        if (lastYear != null) {
+            return lastYear.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        }
+        LOG.trace("Unable to parse yearless date string: {}", dateString);
+        return 0;
+    }
+
+    private static LocalDateTime parseWithDefaultYear(String dateString, String datePattern, int year) {
         try {
+            // STRICT, because the default SMART style silently clamps February 29 to the 28th in a non-leap year
+            // instead of rejecting it, which would resolve a genuine leap day to the wrong date rather than letting
+            // the caller retry against the previous year
             DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(datePattern)
-                    .parseDefaulting(ChronoField.YEAR, now.getYear()).parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                    .parseDefaulting(ChronoField.YEAR, year).parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
                     .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0).parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
-                    .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0).toFormatter(Locale.US);
-            LocalDateTime localDateTime = LocalDateTime.parse(dateString, formatter);
-            if (localDateTime.isAfter(now)) {
-                localDateTime = localDateTime.minusYears(1);
-            }
-            return localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+                    .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0).toFormatter(Locale.US)
+                    .withResolverStyle(ResolverStyle.STRICT);
+            return LocalDateTime.parse(dateString, formatter);
         } catch (DateTimeParseException e) {
-            LOG.trace("Unable to parse yearless date string: {}", dateString);
-            return 0;
+            return null;
         }
     }
 }

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Who.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Who.java
@@ -5,22 +5,16 @@
 package oshi.util.driver.unix;
 
 import java.time.LocalDateTime;
-import java.time.Year;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoField;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.os.OSSession;
 import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
 
 /**
  * Utility to query logged in users using the {@code who} command with Unix date format parsing.
@@ -32,9 +26,7 @@ public final class Who {
     // middle 12 characters from Thu Nov 24 18:22:48 1986
     private static final Pattern WHO_FORMAT_UNIX = Pattern
             .compile("(\\S+)\\s+(\\S+)\\s+(\\S+)\\s+(\\d+)\\s+(\\d{2}:\\d{2})\\s*(?:\\((.+)\\))?");
-    private static final DateTimeFormatter WHO_DATE_FORMAT_UNIX = new DateTimeFormatterBuilder()
-            .appendPattern("MMM d HH:mm").parseDefaulting(ChronoField.YEAR, Year.now(ZoneId.systemDefault()).getValue())
-            .toFormatter(Locale.US);
+    private static final String WHO_DATE_PATTERN_UNIX = "MMM d HH:mm";
 
     private Who() {
     }
@@ -62,19 +54,13 @@ public final class Who {
     public static boolean matchUnix(List<OSSession> whoList, String s) {
         Matcher m = WHO_FORMAT_UNIX.matcher(s);
         if (m.matches()) {
-            try {
-                // Missing year, parse date time with current year
-                LocalDateTime login = LocalDateTime.parse(m.group(3) + " " + m.group(4) + " " + m.group(5),
-                        WHO_DATE_FORMAT_UNIX);
-                // If this date is in the future, subtract a year
-                if (login.isAfter(LocalDateTime.now(ZoneId.systemDefault()))) {
-                    login = login.minus(1, ChronoUnit.YEARS);
-                }
-                long millis = login.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            // The who output carries no year. Resolving it against the moment of the call rather than a year captured
+            // when this class loaded keeps a long-running JVM correct across a new year.
+            long millis = ParseUtil.parseYearlessDateToEpoch(m.group(3) + " " + m.group(4) + " " + m.group(5),
+                    WHO_DATE_PATTERN_UNIX, LocalDateTime.now(ZoneId.systemDefault()));
+            if (millis > 0) {
                 whoList.add(new OSSession(m.group(1), m.group(2), millis, m.group(6) == null ? "" : m.group(6)));
                 return true;
-            } catch (DateTimeParseException | NullPointerException e) {
-                // shouldn't happen if regex matches and OS is producing sensible dates
             }
         }
         return false;

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/UptimeAndBootTimeTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/UptimeAndBootTimeTest.java
@@ -50,6 +50,31 @@ class UptimeAndBootTimeTest {
     }
 
     @Test
+    void testParseBootTimeNoYear() {
+        // AIX 7.3 prints a month name and no year. This is the exact line an AIX 7.3.0.0 box emits, trailing padding
+        // included, captured from `who -b | od -c`.
+        LocalDateTime now = LocalDateTime.of(2026, 8, 2, 16, 3);
+        long ms = Who.parseBootTime("   .        system boot Feb 13 23:31                     ", now);
+        assertThat(ms, is(zonedMillis(LocalDateTime.of(2026, 2, 13, 23, 31))));
+
+        // A month later in the year than "now" cannot be this year, so it must have been last year
+        assertThat(Who.parseBootTime("   .        system boot Nov 30 04:05", now),
+                is(zonedMillis(LocalDateTime.of(2025, 11, 30, 4, 5))));
+
+        // A single-digit day is padded with a space in this format
+        assertThat(Who.parseBootTime("   .        system boot Jul  4 08:00", now),
+                is(zonedMillis(LocalDateTime.of(2026, 7, 4, 8, 0))));
+
+        // The four-digit form still wins when present, regardless of the reference moment
+        assertThat(Who.parseBootTime("   .        system boot 2020-06-16 09:12", now),
+                is(zonedMillis(LocalDateTime.of(2020, 6, 16, 9, 12))));
+    }
+
+    private static long zonedMillis(LocalDateTime dateTime) {
+        return dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    }
+
+    @Test
     @EnabledOnOs(OS.AIX)
     void testQueryBootTime() {
         long msSinceEpoch = Who.queryBootTime();

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixOperatingSystemTest.java
@@ -46,4 +46,27 @@ class AixOperatingSystemTest {
                 is(empty()));
         assertThat(AixOperatingSystem.parseServices(Collections.emptyList()), is(empty()));
     }
+
+    @Test
+    void testResolveBootTimeMillis() {
+        long now = 1_600_000_000_000L;
+        long whoBootTime = 1_500_000_000_000L;
+        long upTime = 10_000_000L;
+
+        // The up time duration is unambiguous, so it wins even when who -b also parsed
+        assertThat(AixOperatingSystem.resolveBootTimeMillis(whoBootTime, upTime, now), is(now - upTime));
+        assertThat(AixOperatingSystem.resolveBootTimeMillis(0L, upTime, now), is(now - upTime));
+        // who -b is consulted only when the uptime command gave nothing
+        assertThat(AixOperatingSystem.resolveBootTimeMillis(whoBootTime, 0L, now), is(whoBootTime));
+    }
+
+    @Test
+    void testResolveBootTimeMillisTreatsZeroUpTimeAsUnknown() {
+        long now = 1_600_000_000_000L;
+        // who -b unparseable (its AIX output carries no year) and the uptime command failed. Reporting now - 0 would
+        // claim the system booted this instant and pin uptime to zero, so both failing must yield "unknown" instead.
+        assertThat(AixOperatingSystem.resolveBootTimeMillis(0L, 0L, now), is(0L));
+        // A who -b value below the 1000 ms floor is treated as unusable rather than as a boot time in 1970
+        assertThat(AixOperatingSystem.resolveBootTimeMillis(999L, 0L, now), is(0L));
+    }
 }

--- a/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
@@ -996,6 +996,33 @@ class ParseUtilTest {
     }
 
     @Test
+    void testParseYearlessDateToEpoch() {
+        LocalDateTime now = LocalDateTime.of(2026, Month.AUGUST, 2, 16, 3);
+
+        // Earlier in the same year, so the current year applies
+        assertThat("Parse MMM d HH:mm earlier this year",
+                ParseUtil.parseYearlessDateToEpoch("Feb 13 23:31", "MMM d HH:mm", now),
+                is(LocalDateTime.of(2026, Month.FEBRUARY, 13, 23, 31).atZone(ZoneId.systemDefault()).toInstant()
+                        .toEpochMilli()));
+
+        // Later in the year than now, so it cannot be this year and must be last year's
+        assertThat("Parse MMM d HH:mm later in the year",
+                ParseUtil.parseYearlessDateToEpoch("Nov 30 04:05", "MMM d HH:mm", now),
+                is(LocalDateTime.of(2025, Month.NOVEMBER, 30, 4, 5).atZone(ZoneId.systemDefault()).toInstant()
+                        .toEpochMilli()));
+
+        // Fields the pattern does not supply default to zero rather than failing
+        assertThat("Parse MMM d with no time", ParseUtil.parseYearlessDateToEpoch("Mar 9", "MMM d", now),
+                is(LocalDate.of(2026, Month.MARCH, 9).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()));
+
+        assertThat("Parse empty date string", ParseUtil.parseYearlessDateToEpoch("", "MMM d HH:mm", now), is(0L));
+        assertThat("Parse empty pattern", ParseUtil.parseYearlessDateToEpoch("Feb 13 23:31", "", now), is(0L));
+        assertThat("Parse null date string", ParseUtil.parseYearlessDateToEpoch(null, "MMM d HH:mm", now), is(0L));
+        assertThat("Parse unmatched format",
+                ParseUtil.parseYearlessDateToEpoch("not a date", "MMM d HH:mm", now), is(0L));
+    }
+
+    @Test
     void testDecodeIntOrDefault() {
         assertThat(ParseUtil.decodeIntOrDefault("0x1A", -1), is(26));
         assertThat(ParseUtil.decodeIntOrDefault("26", -1), is(26));

--- a/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
@@ -1034,6 +1034,11 @@ class ParseUtilTest {
                         LocalDateTime.of(2024, Month.JUNE, 15, 10, 0)),
                 is(LocalDateTime.of(2024, Month.FEBRUARY, 29, 12, 0).atZone(ZoneId.systemDefault()).toInstant()
                         .toEpochMilli()));
+        // April has 30 days in every year, so neither candidate can resolve it. The default resolver style would
+        // have normalized this to April 30 instead of rejecting it.
+        assertThat("Parse a day-of-month that exists in no year",
+                ParseUtil.parseYearlessDateToEpoch("Apr 31 12:00", "MMM d HH:mm", now), is(0L));
+
         assertThat("Parse empty pattern", ParseUtil.parseYearlessDateToEpoch("Feb 13 23:31", "", now), is(0L));
         assertThat("Parse null date string", ParseUtil.parseYearlessDateToEpoch(null, "MMM d HH:mm", now), is(0L));
         assertThat("Parse unmatched format", ParseUtil.parseYearlessDateToEpoch("not a date", "MMM d HH:mm", now),

--- a/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
@@ -1007,19 +1007,37 @@ class ParseUtilTest {
 
         // Later in the year than now, so it cannot be this year and must be last year's
         assertThat("Parse MMM d HH:mm later in the year",
-                ParseUtil.parseYearlessDateToEpoch("Nov 30 04:05", "MMM d HH:mm", now),
-                is(LocalDateTime.of(2025, Month.NOVEMBER, 30, 4, 5).atZone(ZoneId.systemDefault()).toInstant()
-                        .toEpochMilli()));
+                ParseUtil.parseYearlessDateToEpoch("Nov 30 04:05", "MMM d HH:mm", now), is(LocalDateTime
+                        .of(2025, Month.NOVEMBER, 30, 4, 5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()));
 
         // Fields the pattern does not supply default to zero rather than failing
         assertThat("Parse MMM d with no time", ParseUtil.parseYearlessDateToEpoch("Mar 9", "MMM d", now),
                 is(LocalDate.of(2026, Month.MARCH, 9).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()));
 
         assertThat("Parse empty date string", ParseUtil.parseYearlessDateToEpoch("", "MMM d HH:mm", now), is(0L));
+
+        // A leap day does not exist in a non-leap current year, so defaulting the year fails outright rather than
+        // landing in the future. 2025 is not a leap year and 2024 is, so it resolves against the previous year.
+        assertThat("Parse Feb 29 in a non-leap current year",
+                ParseUtil.parseYearlessDateToEpoch("Feb 29 12:00", "MMM d HH:mm",
+                        LocalDateTime.of(2025, Month.JUNE, 15, 10, 0)),
+                is(LocalDateTime.of(2024, Month.FEBRUARY, 29, 12, 0).atZone(ZoneId.systemDefault()).toInstant()
+                        .toEpochMilli()));
+
+        // Neither 2027 nor 2026 is a leap year, so the timestamp cannot be resolved at all
+        assertThat("Parse Feb 29 when neither candidate year is a leap year", ParseUtil.parseYearlessDateToEpoch(
+                "Feb 29 12:00", "MMM d HH:mm", LocalDateTime.of(2027, Month.JUNE, 15, 10, 0)), is(0L));
+
+        // A real leap day earlier in a leap year keeps its date rather than being shifted to the 28th
+        assertThat("Parse Feb 29 in a leap current year",
+                ParseUtil.parseYearlessDateToEpoch("Feb 29 12:00", "MMM d HH:mm",
+                        LocalDateTime.of(2024, Month.JUNE, 15, 10, 0)),
+                is(LocalDateTime.of(2024, Month.FEBRUARY, 29, 12, 0).atZone(ZoneId.systemDefault()).toInstant()
+                        .toEpochMilli()));
         assertThat("Parse empty pattern", ParseUtil.parseYearlessDateToEpoch("Feb 13 23:31", "", now), is(0L));
         assertThat("Parse null date string", ParseUtil.parseYearlessDateToEpoch(null, "MMM d HH:mm", now), is(0L));
-        assertThat("Parse unmatched format",
-                ParseUtil.parseYearlessDateToEpoch("not a date", "MMM d HH:mm", now), is(0L));
+        assertThat("Parse unmatched format", ParseUtil.parseYearlessDateToEpoch("not a date", "MMM d HH:mm", now),
+                is(0L));
     }
 
     @Test


### PR DESCRIPTION
An AIX CI run reported `Uptime: 0 days, 00:00:02` and a boot time twenty seconds in the past, four minutes after the same box had correctly reported 166 days. The machine had not rebooted — the serial number and UUID are identical across both readings, and it is at 169 days now.

## The zero-uptime fallback

`AixOperatingSystem` derived its boot time as `currentTimeMillis() - Uptime.queryUpTime()`. That query returns `0` both when the system just booted and when the `uptime` command could not be run, so a transient failure on a loaded shared box produced a boot time of "now" and an uptime of zero.

Two things made that worse than a one-off bad reading:

- The value was cached in a `static final` field computed at class load, so a single failure poisoned the boot time for the life of the JVM.
- Class load happens during test startup, when the machine is busiest.

`resolveBootTimeMillis` now treats a zero uptime as unknown rather than as a valid duration, and the cache stores only a successful reading, so a failed query is retried on the next call. The cache stays static so the JNA and FFM backends report an identical boot time rather than each deriving one from a separately-timed reading of a minute-resolution source — `NativeComparisonTest` asserts they are equal.

The `uptime` command is now preferred over `who -b`: it reports a duration, which is unambiguous, where `who -b` reports a timestamp whose AIX format may carry no year.

## The `who -b` format has never parsed on AIX

`who -b` on AIX 7.3 prints, in both the C and en_US locales:

```
   .        system boot Feb 13 23:31
```

`BOOT_FORMAT_AIX` has only ever matched a four-digit `yyyy-MM-dd` date — in every revision since the original 2020 AIX port, confirmed with `git log -p`. So the primary source has never parsed on this box, leaving the `uptime` command as the only one. Both forms are now accepted. The year-less one resolves to the most recent occurrence, which cannot disambiguate a system up more than a year, and is why it is consulted only after the unambiguous duration.

## Hoisting rather than duplicating

Resolving a year-less timestamp already existed in the generic UNIX `who` reader, which parses the same `MMM d HH:mm` form. Rather than write a second copy, the logic is hoisted to `ParseUtil.parseYearlessDateToEpoch` and both drivers call it.

That also fixes a latent bug in the generic reader: its default year was captured in a `static` formatter when the class loaded, so it would have gone stale in a JVM running across a new year.

`AGENTS.md` gains a note to check `ParseUtil` before writing a parsing helper — this duplication was easy to miss because the two copies lived in per-platform drivers nobody would read side by side.

## Verification

Checked against the real `gcc119` AIX 7.3.0.0 box over ssh. The test fixture is the exact line it emits, trailing padding included, captured with `who -b | od -c`. Locale sensitivity was ruled out by running `who -b` under both `LC_ALL=C` and `LC_ALL=en_US`.

Full gate green on all 8 modules: spotless, checkstyle, install, forbiddenapis, javadoc, and 1504 tests successful / 0 failed.

The AIX-specific paths cannot be exercised by CI on this host; the parse seams are covered by fixture tests, and the cfarm AIX job will exercise the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AIX boot-time and uptime detection, including support for boot timestamps without a year.
  - Uses reliable uptime data when available and falls back to boot records when necessary.
  - Prevents incorrect uptime values when boot time cannot be determined.
  - Improved handling of yearless Unix session timestamps, including year rollover, leap days, and invalid input.

- **Documentation**
  - Added release notes covering the AIX boot-time and uptime improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->