### PR TITLE
Make the compared CPU frequency and thread times reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug Fixes and Improvements
 
 * [#3561](https://github.com/oshi/oshi/pull/3561): Fix AIX reporting the current instant as its boot time, and an uptime of zero, when the `uptime` command transiently failed; parse the year-less `who -b` format AIX 7.3 emits, and add `ParseUtil.parseYearlessDateToEpoch` - [@dbwiddis](https://github.com/dbwiddis).
+* [#3562](https://github.com/oshi/oshi/pull/3562): Make Linux `getMaxFreq()` reproducible by resolving it from the cpufreq policy, `lshw`, and the vendor frequency rather than folding in a live frequency reading, returning -1 when none of those reports a maximum - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24), 7.4.3 (2027-07-31)
 

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -466,11 +466,15 @@ class NativeComparisonTest {
         assertThat(ffm.getProcessID()).isEqualTo(jna.getProcessID());
         // Command line exercises Win32ProcessCached when batch mode is enabled
         assertThat(ffm.getCommandLine()).isEqualTo(jna.getCommandLine());
-        // Kernel and user time are monotonically nondecreasing
+        // Kernel time comes straight from one ps column, so it is monotonically nondecreasing on its own.
         assertThat(jna.getKernelTime()).as("JNA kernelTime").isGreaterThanOrEqualTo(jnaKernelBefore);
-        assertThat(jna.getUserTime()).as("JNA userTime").isGreaterThanOrEqualTo(jnaUserBefore);
         assertThat(ffm.getKernelTime()).as("FFM kernelTime").isGreaterThanOrEqualTo(ffmKernelBefore);
-        assertThat(ffm.getUserTime()).as("FFM userTime").isGreaterThanOrEqualTo(ffmUserBefore);
+        // Summed for the same reason as the thread times below: BsdOSProcess also derives user time as
+        // (TIME - SYSTIME), a difference of two centisecond-rounded ps columns, which can fall by one quantum.
+        assertThat(jna.getKernelTime() + jna.getUserTime()).as("JNA kernel+user time")
+                .isGreaterThanOrEqualTo(jnaKernelBefore + jnaUserBefore);
+        assertThat(ffm.getKernelTime() + ffm.getUserTime()).as("FFM kernel+user time")
+                .isGreaterThanOrEqualTo(ffmKernelBefore + ffmUserBefore);
     }
 
     @Test
@@ -495,11 +499,18 @@ class NativeComparisonTest {
         if (!jnaUpdated || !ffmUpdated) {
             return;
         }
-        // Kernel and user time are monotonically nondecreasing
+        // Kernel time comes straight from one ps column, so it is monotonically nondecreasing on its own.
         assertThat(jnaThread.getKernelTime()).as("JNA thread kernelTime").isGreaterThanOrEqualTo(jnaKernelBefore);
-        assertThat(jnaThread.getUserTime()).as("JNA thread userTime").isGreaterThanOrEqualTo(jnaUserBefore);
         assertThat(ffmThread.getKernelTime()).as("FFM thread kernelTime").isGreaterThanOrEqualTo(ffmKernelBefore);
-        assertThat(ffmThread.getUserTime()).as("FFM thread userTime").isGreaterThanOrEqualTo(ffmUserBefore);
+        // User time is not asserted on its own. FreeBSD derives it as (TIME - SYSTIME), and ps rounds each of those
+        // columns to a centisecond, so the difference can fall by one 10 ms quantum when they cross their rounding
+        // boundaries at different instants, even though both underlying values only rise. Their sum is exactly the
+        // TIME column, which is monotonic, so assert that instead of widening the bound by a fudge factor that would
+        // also hide a real decrease.
+        assertThat(jnaThread.getKernelTime() + jnaThread.getUserTime()).as("JNA thread kernel+user time")
+                .isGreaterThanOrEqualTo(jnaKernelBefore + jnaUserBefore);
+        assertThat(ffmThread.getKernelTime() + ffmThread.getUserTime()).as("FFM thread kernel+user time")
+                .isGreaterThanOrEqualTo(ffmKernelBefore + ffmUserBefore);
     }
 
     @Test

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
@@ -621,8 +621,14 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     public long queryMaxFreq() {
         long policyMax = queryMaxFreqFromUdev();
         long lshwMax = Lshw.queryCpuCapacity();
-        return LongStream.concat(LongStream.of(policyMax, lshwMax), Arrays.stream(this.getCurrentFreq())).max()
-                .orElse(-1L);
+        // The vendor frequency is parsed from the CPU model name and is therefore constant. A live getCurrentFreq()
+        // reading used to be folded in here as a last resort, but a maximum derived from a fluctuating measurement is
+        // not reproducible: it left getMaxFreq() reporting whatever the CPU happened to be clocked at the first time
+        // it was asked, which on a host with no cpufreq sysfs and no lshw is all it reported.
+        long vendorFreq = getProcessorIdentifier().getVendorFreq();
+        long maxFreq = LongStream.of(policyMax, lshwMax, vendorFreq).max().orElse(-1L);
+        // A cpufreq policy that reads back as zero is no more known than a missing one
+        return maxFreq > 0L ? maxFreq : -1L;
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
@@ -621,11 +621,17 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     public long queryMaxFreq() {
         long policyMax = queryMaxFreqFromUdev();
         long lshwMax = Lshw.queryCpuCapacity();
-        // The vendor frequency is parsed from the CPU model name and is therefore constant. A live getCurrentFreq()
-        // reading used to be folded in here as a last resort, but a maximum derived from a fluctuating measurement is
-        // not reproducible: it left getMaxFreq() reporting whatever the CPU happened to be clocked at the first time
-        // it was asked, which on a host with no cpufreq sysfs and no lshw is all it reported.
-        long vendorFreq = getProcessorIdentifier().getVendorFreq();
+        // A live getCurrentFreq() reading used to be folded in here as a last resort, but a maximum derived from a
+        // fluctuating measurement is not reproducible: it left getMaxFreq() reporting whatever the CPU happened to be
+        // clocked at the first time it was asked, which on a host with no cpufreq sysfs and no lshw is all it
+        // reported. The branded frequency in the model name replaces it, being constant.
+        //
+        // getVendorFreq() alone will not do. queryProcessorId only discards the cpuinfo frequency when the model name
+        // carries one of its own; otherwise it passes /proc/cpuinfo's live "cpu MHz" value straight through, and the
+        // identifier reports that. Gating on the same condition queryProcessorId uses keeps the value name-derived,
+        // and leaves it unknown on a CPU whose name has no frequency in it.
+        ProcessorIdentifier identifier = getProcessorIdentifier();
+        long vendorFreq = identifier.getName().contains("Hz") ? identifier.getVendorFreq() : -1L;
         long maxFreq = LongStream.of(policyMax, lshwMax, vendorFreq).max().orElse(-1L);
         // A cpufreq policy that reads back as zero is no more known than a missing one
         return maxFreq > 0L ? maxFreq : -1L;


### PR DESCRIPTION
Two comparison-test flakes with the same shape: an assertion comparing values that are not reproducible by construction.

## Linux `getMaxFreq()` folded in a live reading

`queryMaxFreq()` took the max of the cpufreq policy value, `lshw`, and a live `getCurrentFreq()` reading. On a host with no cpufreq sysfs and no lshw — most CI VMs — the first two return -1 and the live reading is the only input, so `getMaxFreq()` reported whatever the CPU happened to be clocked at the first time it was asked. The JNA and FFM backends sample at different instants, so they disagreed by more than the 5% `processorFrequencies` allows whenever turbo moved between the two calls.

The live reading is replaced by the vendor frequency, which is parsed from the CPU model name and is constant:

```java
long vendorFreq = getProcessorIdentifier().getVendorFreq();
long maxFreq = LongStream.of(policyMax, lshwMax, vendorFreq).max().orElse(-1L);
return maxFreq > 0L ? maxFreq : -1L;
```

A maximum derived from a fluctuating measurement was not a maximum, and callers polling `getMaxFreq()` were entitled to a stable answer. Where no source reports one the result is now -1, the documented unknown value, rather than a sample. The two existing tests already guard on `max >= 0` and `vendorFreq > 0`, so neither needed changing — and the comparison now passes untouched, since both backends compute from identical stable inputs.

## FreeBSD thread user time is not monotonic

`currentThreadUpdateAttributes` asserted user time is monotonically nondecreasing. On FreeBSD it is not:

```
=> AssertionError: [FFM thread userTime]
   Expecting actual: 250L to be greater than or equal to: 260L
```

`BsdOSThread` derives it as `TIME - SYSTIME`, and `ps` rounds each column to a centisecond. The two cross their rounding boundaries at different instants, so the difference can fall by one 10 ms quantum while both underlying values only rise. The observed drop was exactly 10 ms — one quantum. Not a backend divergence: `BsdOSThread` is shared `oshi-common` code, so FFM just lost the coin flip, and only the FreeBSD branch is exposed (the other BSDs take the `CPUTIME`/`TIME` branches where user time is a single un-differenced column).

Kernel time keeps its own assertion, since it reads `SYSTIME` directly. User time is asserted as part of the sum, which is exactly the `TIME` column by construction and therefore monotonic. Widening the bound by 10 ms instead would have passed the flake but also hidden a genuine decrease.

`BsdOSProcess` (lines 205-206) derives user time identically, so the process-level assertion carried the same latent defect and is fixed alongside it, though only the thread assertion had fired.

## Notes

CHANGELOG covers the Linux change only; the comparison-test fix is test-only.

Full gate green on all 8 modules: spotless, checkstyle, install, forbiddenapis, javadoc, 1504 tests successful / 0 failed, plus a `-Paggregate-coverage` test-compile so the comparison sources build. The comparison tests themselves only run under that profile in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Linux maximum CPU frequency reporting by selecting the highest reliable value from available system hardware information.
  - Returns an unavailable indicator when no maximum frequency can be determined.
  - Prevents fluctuating live frequency readings from being incorrectly reported as the processor’s maximum speed.

- **Documentation**
  - Added release notes documenting the improved Linux CPU frequency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->