### PR TITLE
Enforce javadoc presence in checkstyle, correctness in doclint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,8 +158,21 @@ remove unused imports — but you do need to *add* the ones you use. New files g
 header (`Copyright 2026 The OSHI Project Contributors` / `SPDX-License-Identifier: MIT`), even when
 copied from an older file; spotless maintains end years on existing files.
 
-**Javadoc.** Every public member needs javadoc. Do not use fully-qualified class names in code or in
-javadoc — including inside `{@link ...}`. Import the type and link the simple name.
+**Javadoc.** Every public and protected type and method needs javadoc. Do not use fully-qualified class names in
+code or in javadoc — including inside `{@link ...}`. Import the type and link the simple name.
+
+Two tools split the job. **Checkstyle owns presence** (`MissingJavadocType`, `MissingJavadocMethod` at
+`scope=protected`); **doclint owns correctness** — the javadoc plugin runs `-Xdoclint:all,-missing`, so bad tags,
+broken `{@link}` and malformed HTML still fail the build. `missing` is off there because it also demands a comment
+on every protected field of the C-struct mirrors and on every implicit constructor: ~580 sites of no value to a
+reader. Fields are deliberately not checked (no `MissingJavadocVariable`), and the `jna`/`ffm` binding packages and
+the `*JNA.java`/`*FFM.java` backend twins are suppressed — a twin's only undocumented member is a public
+constructor that forwards to the abstract parent's, which *is* documented.
+
+⚠️ **Checkstyle caches results per file in `target/checkstyle-cachefile`, so a second run only re-checks what
+changed.** Measuring a rule change without `mvn clean` first will report a fraction of the real violations and look
+like a fix. The same trap applies to `javadoc:javadoc`, which silently skips when `target/reports` is already
+populated. Always `clean` before believing either number.
 
 **Suppressing a warning.** Both tools have one house style. Never add a line range to
 `config/checkstyle-suppressions.xml` — a range breaks the moment anything above it shifts, including a

--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -26,6 +26,14 @@
     <suppress checks="InterfaceIsType" files="[\\/]ffm[\\/].*"/>
     <suppress checks="ConstantName" files="[\\/]ffm[\\/].*"/>
     <suppress checks="(MissingJavadocType|MissingJavadocMethod)" files="[\\/]ffm[\\/].*"/>
+    <!-- Backend twins. Their only undocumented members are a public constructor forwarding to the abstract
+         parent's (which is documented) and public static query methods. FUTURE WORK: those statics are a
+         structural signal rather than a doc gap - a public member here that is neither an @Override nor a
+         constructor marks a backend split done with parallel helpers instead of a shared seam. Some are
+         vestigial forwarders over a seam that already exists (ThreadInformationJNA only binds
+         PerfCounterQueryExecutorJNA.INSTANCE and adds nothing); others have no seam at all (HkeyUserData,
+         SessionWtsData and NetSessionData, whose combining logic is duplicated in both getSessions()
+         overrides). Align those and this suppression can go. -->
     <suppress checks="(MissingJavadocType|MissingJavadocMethod)" files=".*(JNA|FFM)\.java"/>
     <suppress checks="MethodName" files="[\\/]ffm[\\/].*"/>
     <suppress checks="ParameterName" files="[\\/]ffm[\\/].*"/>

--- a/config/checkstyle-suppressions.xml
+++ b/config/checkstyle-suppressions.xml
@@ -15,6 +15,8 @@
     <suppress checks="VisibilityModifier" files="[\\/]jna[\\/].*"/>
 
     <suppress checks="ConstantName" files="[\\/]jna[\\/].*"/>
+    <!-- Native mappings mirror C headers field for field; javadoc on each would restate the header. -->
+    <suppress checks="(MissingJavadocType|MissingJavadocMethod)" files="[\\/]jna[\\/].*"/>
     <suppress checks="MemberName" files="[\\/]jna[\\/].*"/>
     <suppress checks="MethodName" files="[\\/]jna[\\/].*"/>
     <suppress checks="ParameterName" files="[\\/]jna[\\/].*"/>
@@ -23,6 +25,8 @@
     <!-- FFM convention -->
     <suppress checks="InterfaceIsType" files="[\\/]ffm[\\/].*"/>
     <suppress checks="ConstantName" files="[\\/]ffm[\\/].*"/>
+    <suppress checks="(MissingJavadocType|MissingJavadocMethod)" files="[\\/]ffm[\\/].*"/>
+    <suppress checks="(MissingJavadocType|MissingJavadocMethod)" files=".*(JNA|FFM)\.java"/>
     <suppress checks="MethodName" files="[\\/]ffm[\\/].*"/>
     <suppress checks="ParameterName" files="[\\/]ffm[\\/].*"/>
     <suppress checks="RecordComponentName" files=".*FFM\.java"/>
@@ -100,7 +104,7 @@
     <!-- Imports for classes linked in javadocs -->
     <suppress checks="UnusedImports" files="(CentralProcessor|OSDesktopWindow|OSProcess)\.java"/>
     <!-- Test files -->
-    <suppress checks="(JavadocPackage|MemberName|ConstantName|StaticVariableName)" files="(.*Test|TestConstants)\.java"/>
+    <suppress checks="(JavadocPackage|MissingJavadocType|MissingJavadocMethod|MemberName|ConstantName|StaticVariableName)" files="(.*Test|TestConstants)\.java"/>
     <suppress checks="(ConstantName|VisibilityModifier)" files="SystemInfoTest\.java"/>
     <suppress checks="(VisibilityModifier)" files="OperatingSystemTest\.java"/>
 </suppressions>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -344,8 +344,10 @@
       <property name="target"
                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
-    <!-- Correctness of javadoc that exists: @param/@return must match the signature. Tags are required, which is
-         what the previously-duplicated bare JavadocMethod module already enforced at every scope. -->
+    <!-- Correctness of javadoc that exists: @param/@return must match the signature, and both are required. That
+         is what the previously-duplicated bare JavadocMethod module already enforced at every scope. allowedAnnotations
+         skips the check entirely for the methods it lists, which is deliberate: an @Override inherits its
+         documentation from the supertype, and a @Test method documents itself by name. -->
     <module name="JavadocMethod">
       <property name="accessModifiers" value="public, protected"/>
       <property name="allowedAnnotations" value="Override, Test"/>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -52,8 +52,19 @@
     </module>
 
     <module name="InvalidJavadocPosition"/>
-    <module name="JavadocMethod"/>
     <module name="JavadocType"/>
+
+    <!-- Presence of javadoc. doclint's "missing" group is switched off in the javadoc plugin because it also
+         demands a comment on every protected struct-mirror field and implicit constructor; these two scope the
+         requirement to the API a caller or subclasser actually reads. Deliberately no MissingJavadocVariable. -->
+    <module name="MissingJavadocType">
+      <property name="scope" value="protected"/>
+    </module>
+    <module name="MissingJavadocMethod">
+      <property name="scope" value="protected"/>
+      <property name="allowMissingPropertyJavadoc" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+    </module>
 
     <module name="ConstantName"/>
     <module name="LocalFinalVariableName"/>
@@ -333,10 +344,10 @@
       <property name="target"
                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
+    <!-- Correctness of javadoc that exists: @param/@return must match the signature. Tags are required, which is
+         what the previously-duplicated bare JavadocMethod module already enforced at every scope. -->
     <module name="JavadocMethod">
-      <property name="accessModifiers" value="public"/>
-      <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingReturnTag" value="true"/>
+      <property name="accessModifiers" value="public, protected"/>
       <property name="allowedAnnotations" value="Override, Test"/>
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
     </module>

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/AixLwpsInfo.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/AixLwpsInfo.java
@@ -32,6 +32,11 @@ public class AixLwpsInfo {
     public int pr_onpro; // processor on which thread last ran
     public int pr_bindpro; // processor to which thread is bound
 
+    /**
+     * Constructs a new {@code AixLwpsInfo}.
+     *
+     * @param buff the buffer positioned at the start of the struct
+     */
     public AixLwpsInfo(ByteBuffer buff) {
         this.pr_lwpid = FileUtil.readLongFromBuffer(buff);
         this.pr_addr = FileUtil.readLongFromBuffer(buff);

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/AixPsInfo.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/AixPsInfo.java
@@ -49,6 +49,11 @@ public class AixPsInfo {
     public long[] pr__pad = new long[8]; // reserved for future use
     public AixLwpsInfo pr_lwp; // "representative" thread info
 
+    /**
+     * Constructs a new {@code AixPsInfo}.
+     *
+     * @param buff the buffer positioned at the start of the struct
+     */
     public AixPsInfo(ByteBuffer buff) {
         this.pr_flag = FileUtil.readIntFromBuffer(buff);
         this.pr_flag2 = FileUtil.readIntFromBuffer(buff);

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Timestruc.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Timestruc.java
@@ -17,6 +17,11 @@ public class Timestruc {
     public int tv_nsec; // nanoseconds
     public int pad; // alignment padding
 
+    /**
+     * Constructs a new {@code Timestruc}.
+     *
+     * @param buff the buffer positioned at the start of the struct
+     */
     public Timestruc(ByteBuffer buff) {
         this.tv_sec = FileUtil.readLongFromBuffer(buff);
         this.tv_nsec = FileUtil.readIntFromBuffer(buff);

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/SolarisLwpsInfo.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/SolarisLwpsInfo.java
@@ -39,6 +39,11 @@ public class SolarisLwpsInfo {
     public long pr_last_onproc;
     public byte[] pr_name = new byte[32];
 
+    /**
+     * Constructs a new {@code SolarisLwpsInfo}.
+     *
+     * @param buff the buffer positioned at the start of the struct
+     */
     public SolarisLwpsInfo(ByteBuffer buff) {
         this.pr_flag = FileUtil.readIntFromBuffer(buff);
         this.pr_lwpid = FileUtil.readIntFromBuffer(buff);

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/SolarisPrUsage.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/SolarisPrUsage.java
@@ -38,6 +38,11 @@ public class SolarisPrUsage {
     public long pr_ictx;
     public long pr_ioch; // chars read and written
 
+    /**
+     * Constructs a new {@code SolarisPrUsage}.
+     *
+     * @param buff the buffer positioned at the start of the struct
+     */
     public SolarisPrUsage(ByteBuffer buff) {
         this.pr_lwpid = FileUtil.readIntFromBuffer(buff);
         this.pr_count = FileUtil.readIntFromBuffer(buff);

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/SolarisPsInfo.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/SolarisPsInfo.java
@@ -50,6 +50,11 @@ public class SolarisPsInfo {
     public int pr_contract;
     public SolarisLwpsInfo pr_lwp;
 
+    /**
+     * Constructs a new {@code SolarisPsInfo}.
+     *
+     * @param buff the buffer positioned at the start of the struct
+     */
     public SolarisPsInfo(ByteBuffer buff) {
         this.pr_flag = FileUtil.readIntFromBuffer(buff);
         this.pr_nlwp = FileUtil.readIntFromBuffer(buff);

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/SolarisTimestruc.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/SolarisTimestruc.java
@@ -16,6 +16,11 @@ public class SolarisTimestruc {
     public long tv_sec; // seconds
     public long tv_nsec; // nanoseconds
 
+    /**
+     * Constructs a new {@code SolarisTimestruc}.
+     *
+     * @param buff the buffer positioned at the start of the struct
+     */
     public SolarisTimestruc(ByteBuffer buff) {
         this.tv_sec = FileUtil.readLongFromBuffer(buff);
         this.tv_nsec = FileUtil.readLongFromBuffer(buff);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacPowerSource.java
@@ -104,6 +104,32 @@ public abstract class MacPowerSource extends AbstractPowerSource {
     /** Creates a concrete (JNA or FFM) Mac power source from the computed battery fields. */
     @FunctionalInterface
     protected interface PowerSourceFactory {
+        /**
+         * Creates a platform-specific instance.
+         *
+         * @param psName                     the power source name
+         * @param psDeviceName               the power source device name
+         * @param psRemainingCapacityPercent the remaining capacity as a fraction of the maximum
+         * @param psTimeRemainingEstimated   the estimated time remaining in seconds
+         * @param psTimeRemainingInstant     the reported instantaneous time remaining in seconds
+         * @param psPowerUsageRate           the power usage rate in milliwatts
+         * @param psVoltage                  the voltage in volts
+         * @param psAmperage                 the amperage in milliamperes
+         * @param psPowerOnLine              whether external power is connected
+         * @param psCharging                 whether the power source is charging
+         * @param psDischarging              whether the power source is discharging
+         * @param psCapacityUnits            the units of the capacity values
+         * @param psCurrentCapacity          the current capacity
+         * @param psMaxCapacity              the maximum capacity
+         * @param psDesignCapacity           the design capacity
+         * @param psCycleCount               the charge cycle count
+         * @param psChemistry                the battery chemistry
+         * @param psManufactureDate          the manufacture date
+         * @param psManufacturer             the manufacturer
+         * @param psSerialNumber             the serial number
+         * @param psTemperature              the temperature in degrees Celsius
+         * @return the new instance
+         */
         MacPowerSource create(String psName, String psDeviceName, double psRemainingCapacityPercent,
                 double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate,
                 double psVoltage, double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdGraphicsCard.java
@@ -26,6 +26,15 @@ public final class BsdGraphicsCard extends AbstractGraphicsCard {
     private static final String UNKNOWN_PCI_ID = "0x0000";
     private static final Pattern PCI_DUMP_HEADER = Pattern.compile(" \\d+:\\d+:\\d+: (.+)");
 
+    /**
+     * Constructs a new {@code BsdGraphicsCard}.
+     *
+     * @param name        the device name
+     * @param deviceId    the device ID
+     * @param vendor      the vendor
+     * @param versionInfo the version information
+     * @param vram        the video memory in bytes
+     */
     public BsdGraphicsCard(String name, String deviceId, String vendor, String versionInfo, long vram) {
         super(name, deviceId, vendor, versionInfo, vram);
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdGraphicsCard.java
@@ -29,7 +29,7 @@ public final class BsdGraphicsCard extends AbstractGraphicsCard {
     /**
      * Constructs a new {@code BsdGraphicsCard}.
      *
-     * @param name        the device name
+     * @param name        the graphics card name
      * @param deviceId    the device ID
      * @param vendor      the vendor
      * @param versionInfo the version information

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdNetworkIF.java
@@ -19,6 +19,12 @@ import oshi.util.ParseUtil;
 @ThreadSafe
 public final class BsdNetworkIF extends AbstractNetworkIF {
 
+    /**
+     * Constructs a new {@code BsdNetworkIF}.
+     *
+     * @param netint the underlying network interface
+     * @throws InstantiationException if the instance could not be constructed
+     */
     public BsdNetworkIF(NetworkInterface netint) throws InstantiationException {
         super(netint);
         updateAttributes();

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdSoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdSoundCard.java
@@ -29,6 +29,13 @@ public final class BsdSoundCard extends AbstractSoundCard {
     private static final Pattern PCI_AT = Pattern
             .compile("(.+) at pci\\d+ dev \\d+ function \\d+ \"(.*)\" (rev .+):.*");
 
+    /**
+     * Constructs a new {@code BsdSoundCard}.
+     *
+     * @param kernelVersion the kernel version
+     * @param name          the device name
+     * @param codec         the codec
+     */
     public BsdSoundCard(String kernelVersion, String name, String codec) {
         super(kernelVersion, name, codec);
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdSoundCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdSoundCard.java
@@ -33,7 +33,7 @@ public final class BsdSoundCard extends AbstractSoundCard {
      * Constructs a new {@code BsdSoundCard}.
      *
      * @param kernelVersion the kernel version
-     * @param name          the device name
+     * @param name          the sound card name
      * @param codec         the codec
      */
     public BsdSoundCard(String kernelVersion, String name, String codec) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdUsbDevice.java
@@ -20,6 +20,17 @@ import oshi.util.ExecutingCommand;
 @Immutable
 public final class BsdUsbDevice extends AbstractUsbDevice {
 
+    /**
+     * Constructs a new {@code BsdUsbDevice}.
+     *
+     * @param name             the device name
+     * @param vendor           the vendor
+     * @param vendorId         the vendor ID
+     * @param productId        the product ID
+     * @param serialNumber     the serial number
+     * @param uniqueDeviceId   the unique device ID
+     * @param connectedDevices the devices connected to this one
+     */
     public BsdUsbDevice(String name, String vendor, String vendorId, String productId, String serialNumber,
             String uniqueDeviceId, List<UsbDevice> connectedDevices) {
         super(name, vendor, vendorId, productId, serialNumber, uniqueDeviceId, connectedDevices);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixBaseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixBaseboard.java
@@ -18,6 +18,14 @@ public final class UnixBaseboard extends AbstractBaseboard {
     private final String serialNumber;
     private final String version;
 
+    /**
+     * Constructs a new {@code UnixBaseboard}.
+     *
+     * @param manufacturer the manufacturer
+     * @param model        the model
+     * @param serialNumber the serial number
+     * @param version      the version
+     */
     public UnixBaseboard(String manufacturer, String model, String serialNumber, String version) {
         this.manufacturer = manufacturer;
         this.model = model;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixComputerSystem.java
@@ -27,6 +27,11 @@ public final class AixComputerSystem extends AbstractComputerSystem {
     private final Supplier<LsattrStrings> lsattrStrings = memoize(AixComputerSystem::readLsattr);
     private final Supplier<List<String>> lscfg;
 
+    /**
+     * Constructs a new {@code AixComputerSystem}.
+     *
+     * @param lscfg a supplier of {@code lscfg} output
+     */
     public AixComputerSystem(Supplier<List<String>> lscfg) {
         this.lscfg = lscfg;
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixGlobalMemory.java
@@ -30,6 +30,11 @@ public abstract class AixGlobalMemory extends AbstractGlobalMemory {
     /** Memoized hardware listing supplier from the owning HAL. */
     protected final Supplier<List<String>> lscfg;
 
+    /**
+     * Constructs a new {@code AixGlobalMemory}.
+     *
+     * @param lscfg a supplier of {@code lscfg} output
+     */
     protected AixGlobalMemory(Supplier<List<String>> lscfg) {
         this.lscfg = lscfg;
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixHWDiskStore.java
@@ -28,7 +28,7 @@ public abstract class AixHWDiskStore extends AbstractHWDiskStore {
     /**
      * Constructs a new {@code AixHWDiskStore}.
      *
-     * @param name   the device name
+     * @param name   the disk name
      * @param model  the model
      * @param serial the serial number
      * @param size   the size in bytes

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixHWDiskStore.java
@@ -25,6 +25,14 @@ public abstract class AixHWDiskStore extends AbstractHWDiskStore {
         public long time;
     }
 
+    /**
+     * Constructs a new {@code AixHWDiskStore}.
+     *
+     * @param name   the device name
+     * @param model  the model
+     * @param serial the serial number
+     * @param size   the size in bytes
+     */
     protected AixHWDiskStore(String name, String model, String serial, long size) {
         super(name, model, serial, size);
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixNetworkIF.java
@@ -29,6 +29,12 @@ public abstract class AixNetworkIF extends AbstractNetworkIF {
         public long speed;
     }
 
+    /**
+     * Constructs a new {@code AixNetworkIF}.
+     *
+     * @param netint the underlying network interface
+     * @throws InstantiationException if the instance could not be constructed
+     */
     protected AixNetworkIF(NetworkInterface netint) throws InstantiationException {
         super(netint);
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixPowerSource.java
@@ -21,7 +21,7 @@ public final class AixPowerSource extends AbstractPowerSource {
     /**
      * Constructs a new {@code AixPowerSource}.
      *
-     * @param name                     the device name
+     * @param name                     the power source name
      * @param deviceName               the device name
      * @param remainingCapacityPercent the remaining capacity as a fraction of the maximum
      * @param timeRemainingEstimated   the estimated time remaining in seconds

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixPowerSource.java
@@ -18,6 +18,31 @@ import oshi.hardware.common.AbstractPowerSource;
 @ThreadSafe
 public final class AixPowerSource extends AbstractPowerSource {
 
+    /**
+     * Constructs a new {@code AixPowerSource}.
+     *
+     * @param name                     the device name
+     * @param deviceName               the device name
+     * @param remainingCapacityPercent the remaining capacity as a fraction of the maximum
+     * @param timeRemainingEstimated   the estimated time remaining in seconds
+     * @param timeRemainingInstant     the reported instantaneous time remaining in seconds
+     * @param powerUsageRate           the power usage rate in milliwatts
+     * @param voltage                  the voltage in volts
+     * @param amperage                 the amperage in milliamperes
+     * @param powerOnLine              whether external power is connected
+     * @param charging                 whether the power source is charging
+     * @param discharging              whether the power source is discharging
+     * @param capacityUnits            the units of the capacity values
+     * @param currentCapacity          the current capacity
+     * @param maxCapacity              the maximum capacity
+     * @param designCapacity           the design capacity
+     * @param cycleCount               the charge cycle count
+     * @param chemistry                the battery chemistry
+     * @param manufactureDate          the manufacture date
+     * @param manufacturer             the manufacturer
+     * @param serialNumber             the serial number
+     * @param temperature              the temperature in degrees Celsius
+     */
     public AixPowerSource(String name, String deviceName, double remainingCapacityPercent,
             double timeRemainingEstimated, double timeRemainingInstant, double powerUsageRate, double voltage,
             double amperage, boolean powerOnLine, boolean charging, boolean discharging, CapacityUnits capacityUnits,

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixSensors.java
@@ -18,6 +18,11 @@ public final class AixSensors extends AbstractSensors {
 
     private final Supplier<List<String>> lscfg;
 
+    /**
+     * Constructs a new {@code AixSensors}.
+     *
+     * @param lscfg a supplier of {@code lscfg} output
+     */
     public AixSensors(Supplier<List<String>> lscfg) {
         this.lscfg = lscfg;
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixUsbDevice.java
@@ -23,6 +23,17 @@ import oshi.util.ParseUtil;
 @Immutable
 public class AixUsbDevice extends AbstractUsbDevice {
 
+    /**
+     * Constructs a new {@code AixUsbDevice}.
+     *
+     * @param name             the device name
+     * @param vendor           the vendor
+     * @param vendorId         the vendor ID
+     * @param productId        the product ID
+     * @param serialNumber     the serial number
+     * @param uniqueDeviceId   the unique device ID
+     * @param connectedDevices the devices connected to this one
+     */
     public AixUsbDevice(String name, String vendor, String vendorId, String productId, String serialNumber,
             String uniqueDeviceId, List<UsbDevice> connectedDevices) {
         super(name, vendor, vendorId, productId, serialNumber, uniqueDeviceId, connectedDevices);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystem.java
@@ -20,6 +20,10 @@ import oshi.util.ParseUtil;
 import oshi.util.Util;
 import oshi.util.tuples.Quintet;
 
+/**
+ * Abstract base for the FreeBSD ComputerSystem. Reads the manufacturer, model and serial from the kenv/dmidecode output
+ * the backends supply.
+ */
 @Immutable
 public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdGlobalMemory.java
@@ -14,6 +14,10 @@ import oshi.hardware.common.AbstractGlobalMemory;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
+/**
+ * Abstract base for the FreeBSD GlobalMemory. Holds the page-size and memory-total arithmetic; the JNA and FFM
+ * subclasses supply the sysctl reads.
+ */
 public abstract class FreeBsdGlobalMemory extends AbstractGlobalMemory {
 
     private final Supplier<Long> available = memoize(this::queryVmStats, defaultExpiration());

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
@@ -29,6 +29,14 @@ import oshi.util.tuples.Triplet;
 @ThreadSafe
 public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
 
+    /**
+     * Constructs a new {@code FreeBsdHWDiskStore}.
+     *
+     * @param name   the device name
+     * @param model  the model
+     * @param serial the serial number
+     * @param size   the size in bytes
+     */
     protected FreeBsdHWDiskStore(String name, String model, String serial, long size) {
         super(name, model, serial, size);
     }
@@ -108,6 +116,15 @@ public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
      */
     @FunctionalInterface
     protected interface DiskStoreFactory<T extends FreeBsdHWDiskStore> {
+        /**
+         * Creates a platform-specific instance.
+         *
+         * @param name   the device name
+         * @param model  the model
+         * @param serial the serial number
+         * @param size   the size in bytes
+         * @return the new instance
+         */
         T create(String name, String model, String serial, long size);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
@@ -32,7 +32,7 @@ public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
     /**
      * Constructs a new {@code FreeBsdHWDiskStore}.
      *
-     * @param name   the device name
+     * @param name   the disk name
      * @param model  the model
      * @param serial the serial number
      * @param size   the size in bytes
@@ -119,7 +119,7 @@ public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
         /**
          * Creates a platform-specific instance.
          *
-         * @param name   the device name
+         * @param name   the disk name
          * @param model  the model
          * @param serial the serial number
          * @param size   the size in bytes

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdPowerSource.java
@@ -24,6 +24,31 @@ import oshi.util.ParseUtil;
  */
 public abstract class FreeBsdPowerSource extends AbstractPowerSource {
 
+    /**
+     * Constructs a new {@code FreeBsdPowerSource}.
+     *
+     * @param psName                     the power source name
+     * @param psDeviceName               the power source device name
+     * @param psRemainingCapacityPercent the remaining capacity as a fraction of the maximum
+     * @param psTimeRemainingEstimated   the estimated time remaining in seconds
+     * @param psTimeRemainingInstant     the reported instantaneous time remaining in seconds
+     * @param psPowerUsageRate           the power usage rate in milliwatts
+     * @param psVoltage                  the voltage in volts
+     * @param psAmperage                 the amperage in milliamperes
+     * @param psPowerOnLine              whether external power is connected
+     * @param psCharging                 whether the power source is charging
+     * @param psDischarging              whether the power source is discharging
+     * @param psCapacityUnits            the units of the capacity values
+     * @param psCurrentCapacity          the current capacity
+     * @param psMaxCapacity              the maximum capacity
+     * @param psDesignCapacity           the design capacity
+     * @param psCycleCount               the charge cycle count
+     * @param psChemistry                the battery chemistry
+     * @param psManufactureDate          the manufacture date
+     * @param psManufacturer             the manufacturer
+     * @param psSerialNumber             the serial number
+     * @param psTemperature              the temperature in degrees Celsius
+     */
     protected FreeBsdPowerSource(String psName, String psDeviceName, double psRemainingCapacityPercent,
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
@@ -43,6 +68,32 @@ public abstract class FreeBsdPowerSource extends AbstractPowerSource {
      */
     @FunctionalInterface
     protected interface PowerSourceFactory<T extends FreeBsdPowerSource> {
+        /**
+         * Creates a platform-specific instance.
+         *
+         * @param psName                     the power source name
+         * @param psDeviceName               the power source device name
+         * @param psRemainingCapacityPercent the remaining capacity as a fraction of the maximum
+         * @param psTimeRemainingEstimated   the estimated time remaining in seconds
+         * @param psTimeRemainingInstant     the reported instantaneous time remaining in seconds
+         * @param psPowerUsageRate           the power usage rate in milliwatts
+         * @param psVoltage                  the voltage in volts
+         * @param psAmperage                 the amperage in milliamperes
+         * @param psPowerOnLine              whether external power is connected
+         * @param psCharging                 whether the power source is charging
+         * @param psDischarging              whether the power source is discharging
+         * @param psCapacityUnits            the units of the capacity values
+         * @param psCurrentCapacity          the current capacity
+         * @param psMaxCapacity              the maximum capacity
+         * @param psDesignCapacity           the design capacity
+         * @param psCycleCount               the charge cycle count
+         * @param psChemistry                the battery chemistry
+         * @param psManufactureDate          the manufacture date
+         * @param psManufacturer             the manufacturer
+         * @param psSerialNumber             the serial number
+         * @param psTemperature              the temperature in degrees Celsius
+         * @return the new instance
+         */
         T create(String psName, String psDeviceName, double psRemainingCapacityPercent, double psTimeRemainingEstimated,
                 double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage, double psAmperage,
                 boolean psPowerOnLine, boolean psCharging, boolean psDischarging, CapacityUnits psCapacityUnits,

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdSensors.java
@@ -6,6 +6,9 @@ package oshi.hardware.common.platform.unix.freebsd;
 
 import oshi.hardware.common.AbstractSensors;
 
+/**
+ * Abstract base for the FreeBSD Sensors. The JNA and FFM subclasses supply the coretemp and ACPI sysctl reads.
+ */
 public abstract class FreeBsdSensors extends AbstractSensors {
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdUsbDevice.java
@@ -25,6 +25,17 @@ import oshi.util.ParseUtil;
 @Immutable
 public class FreeBsdUsbDevice extends AbstractUsbDevice {
 
+    /**
+     * Constructs a new {@code FreeBsdUsbDevice}.
+     *
+     * @param name             the device name
+     * @param vendor           the vendor
+     * @param vendorId         the vendor ID
+     * @param productId        the product ID
+     * @param serialNumber     the serial number
+     * @param uniqueDeviceId   the unique device ID
+     * @param connectedDevices the devices connected to this one
+     */
     public FreeBsdUsbDevice(String name, String vendor, String vendorId, String productId, String serialNumber,
             String uniqueDeviceId, List<UsbDevice> connectedDevices) {
         super(name, vendor, vendorId, productId, serialNumber, uniqueDeviceId, connectedDevices);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdVirtualMemory.java
@@ -14,6 +14,10 @@ import oshi.hardware.common.AbstractVirtualMemory;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
+/**
+ * Abstract base for the FreeBSD VirtualMemory. Derives swap totals and paging counters from the vmstat and swapinfo
+ * output the backends supply.
+ */
 public abstract class FreeBsdVirtualMemory extends AbstractVirtualMemory {
 
     private final FreeBsdGlobalMemory global;
@@ -23,6 +27,11 @@ public abstract class FreeBsdVirtualMemory extends AbstractVirtualMemory {
     private final Supplier<Long> pagesIn = memoize(this::queryPagesIn, defaultExpiration());
     private final Supplier<Long> pagesOut = memoize(this::queryPagesOut, defaultExpiration());
 
+    /**
+     * Constructs a new {@code FreeBsdVirtualMemory}.
+     *
+     * @param global the backing global memory
+     */
     protected FreeBsdVirtualMemory(FreeBsdGlobalMemory global) {
         this.global = global;
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdVirtualMemory.java
@@ -15,8 +15,9 @@ import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
 /**
- * Abstract base for the FreeBSD VirtualMemory. Derives swap totals and paging counters from the vmstat and swapinfo
- * output the backends supply.
+ * Abstract base for the FreeBSD VirtualMemory. Swap total and the paging counters come from the sysctl hooks the
+ * subclasses implement ({@code vm.swap_total}, {@code vm.stats.vm.v_swappgsin} and {@code v_swappgsout}); swap usage is
+ * read here from {@code swapinfo -k}.
  */
 public abstract class FreeBsdVirtualMemory extends AbstractVirtualMemory {
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
@@ -19,6 +19,12 @@ import oshi.util.ParseUtil;
 @ThreadSafe
 public final class NetBsdNetworkIF extends AbstractNetworkIF {
 
+    /**
+     * Constructs a new {@code NetBsdNetworkIF}.
+     *
+     * @param netint the underlying network interface
+     * @throws InstantiationException if the instance could not be constructed
+     */
     public NetBsdNetworkIF(NetworkInterface netint) throws InstantiationException {
         super(netint);
         updateAttributes();

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdGlobalMemory.java
@@ -12,6 +12,10 @@ import java.util.function.Supplier;
 import oshi.hardware.VirtualMemory;
 import oshi.hardware.common.AbstractGlobalMemory;
 
+/**
+ * Abstract base for the OpenBSD GlobalMemory. Holds the page-size and memory-total arithmetic; the JNA and FFM
+ * subclasses supply the sysctl reads.
+ */
 public abstract class OpenBsdGlobalMemory extends AbstractGlobalMemory {
 
     private final Supplier<Long> available = memoize(this::queryAvailable, defaultExpiration());

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
@@ -34,7 +34,7 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
     /**
      * Constructs a new {@code OpenBsdHWDiskStore}.
      *
-     * @param name           the device name
+     * @param name           the disk name
      * @param model          the model
      * @param serial         the serial number
      * @param size           the size in bytes
@@ -143,7 +143,7 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
         /**
          * Creates a platform-specific instance.
          *
-         * @param name           the device name
+         * @param name           the disk name
          * @param model          the model
          * @param serial         the serial number
          * @param size           the size in bytes

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
@@ -31,6 +31,15 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
 
     private final Supplier<List<String>> iostat;
 
+    /**
+     * Constructs a new {@code OpenBsdHWDiskStore}.
+     *
+     * @param name           the device name
+     * @param model          the model
+     * @param serial         the serial number
+     * @param size           the size in bytes
+     * @param iostatSupplier a supplier of {@code iostat} output
+     */
     protected OpenBsdHWDiskStore(String name, String model, String serial, long size,
             Supplier<List<String>> iostatSupplier) {
         super(name, model, serial, size);
@@ -131,6 +140,16 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
      */
     @FunctionalInterface
     protected interface DiskStoreFactory<T extends OpenBsdHWDiskStore> {
+        /**
+         * Creates a platform-specific instance.
+         *
+         * @param name           the device name
+         * @param model          the model
+         * @param serial         the serial number
+         * @param size           the size in bytes
+         * @param iostatSupplier a supplier of {@code iostat} output
+         * @return the new instance
+         */
         T create(String name, String model, String serial, long size, Supplier<List<String>> iostatSupplier);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdVirtualMemory.java
@@ -27,6 +27,11 @@ public class OpenBsdVirtualMemory extends AbstractVirtualMemory {
             OpenBsdVirtualMemory::queryVmstat, defaultExpiration());
     private final Supplier<Integer> pgout = memoize(OpenBsdVirtualMemory::queryUvm, defaultExpiration());
 
+    /**
+     * Constructs a new {@code OpenBsdVirtualMemory}.
+     *
+     * @param global the backing global memory
+     */
     public OpenBsdVirtualMemory(OpenBsdGlobalMemory global) {
         this.global = global;
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystem.java
@@ -30,6 +30,7 @@ import oshi.util.Util;
  */
 @Immutable
 public class SolarisComputerSystem extends AbstractComputerSystem {
+    /** The SMBIOS structure types this class reads from the {@code smbios} output. */
     public enum SmbType {
         /**
          * BIOS

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisHWDiskStore.java
@@ -43,9 +43,26 @@ public abstract class SolarisHWDiskStore extends AbstractHWDiskStore {
     /** Creates a concrete (JNA or FFM) Solaris disk store. */
     @FunctionalInterface
     protected interface DiskStoreFactory {
+        /**
+         * Creates a platform-specific instance.
+         *
+         * @param name   the device name
+         * @param model  the model
+         * @param serial the serial number
+         * @param size   the size in bytes
+         * @return the new instance
+         */
         SolarisHWDiskStore create(String name, String model, String serial, long size);
     }
 
+    /**
+     * Constructs a new {@code SolarisHWDiskStore}.
+     *
+     * @param name   the device name
+     * @param model  the model
+     * @param serial the serial number
+     * @param size   the size in bytes
+     */
     protected SolarisHWDiskStore(String name, String model, String serial, long size) {
         super(name, model, serial, size);
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisHWDiskStore.java
@@ -46,7 +46,7 @@ public abstract class SolarisHWDiskStore extends AbstractHWDiskStore {
         /**
          * Creates a platform-specific instance.
          *
-         * @param name   the device name
+         * @param name   the disk name
          * @param model  the model
          * @param serial the serial number
          * @param size   the size in bytes
@@ -58,7 +58,7 @@ public abstract class SolarisHWDiskStore extends AbstractHWDiskStore {
     /**
      * Constructs a new {@code SolarisHWDiskStore}.
      *
-     * @param name   the device name
+     * @param name   the disk name
      * @param model  the model
      * @param serial the serial number
      * @param size   the size in bytes

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisNetworkIF.java
@@ -30,6 +30,12 @@ public abstract class SolarisNetworkIF extends AbstractNetworkIF {
         public long timeStamp;
     }
 
+    /**
+     * Constructs a new {@code SolarisNetworkIF}.
+     *
+     * @param netint the underlying network interface
+     * @throws InstantiationException if the instance could not be constructed
+     */
     protected SolarisNetworkIF(NetworkInterface netint) throws InstantiationException {
         super(netint);
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisPowerSource.java
@@ -48,6 +48,32 @@ public abstract class SolarisPowerSource extends AbstractPowerSource {
     /** Creates a concrete (JNA or FFM) Solaris power source from the computed battery fields. */
     @FunctionalInterface
     protected interface PowerSourceFactory {
+        /**
+         * Creates a platform-specific instance.
+         *
+         * @param psName                     the power source name
+         * @param psDeviceName               the power source device name
+         * @param psRemainingCapacityPercent the remaining capacity as a fraction of the maximum
+         * @param psTimeRemainingEstimated   the estimated time remaining in seconds
+         * @param psTimeRemainingInstant     the reported instantaneous time remaining in seconds
+         * @param psPowerUsageRate           the power usage rate in milliwatts
+         * @param psVoltage                  the voltage in volts
+         * @param psAmperage                 the amperage in milliamperes
+         * @param psPowerOnLine              whether external power is connected
+         * @param psCharging                 whether the power source is charging
+         * @param psDischarging              whether the power source is discharging
+         * @param psCapacityUnits            the units of the capacity values
+         * @param psCurrentCapacity          the current capacity
+         * @param psMaxCapacity              the maximum capacity
+         * @param psDesignCapacity           the design capacity
+         * @param psCycleCount               the charge cycle count
+         * @param psChemistry                the battery chemistry
+         * @param psManufactureDate          the manufacture date
+         * @param psManufacturer             the manufacturer
+         * @param psSerialNumber             the serial number
+         * @param psTemperature              the temperature in degrees Celsius
+         * @return the new instance
+         */
         SolarisPowerSource create(String psName, String psDeviceName, double psRemainingCapacityPercent,
                 double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate,
                 double psVoltage, double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
@@ -56,6 +82,31 @@ public abstract class SolarisPowerSource extends AbstractPowerSource {
                 String psSerialNumber, double psTemperature);
     }
 
+    /**
+     * Constructs a new {@code SolarisPowerSource}.
+     *
+     * @param psName                     the power source name
+     * @param psDeviceName               the power source device name
+     * @param psRemainingCapacityPercent the remaining capacity as a fraction of the maximum
+     * @param psTimeRemainingEstimated   the estimated time remaining in seconds
+     * @param psTimeRemainingInstant     the reported instantaneous time remaining in seconds
+     * @param psPowerUsageRate           the power usage rate in milliwatts
+     * @param psVoltage                  the voltage in volts
+     * @param psAmperage                 the amperage in milliamperes
+     * @param psPowerOnLine              whether external power is connected
+     * @param psCharging                 whether the power source is charging
+     * @param psDischarging              whether the power source is discharging
+     * @param psCapacityUnits            the units of the capacity values
+     * @param psCurrentCapacity          the current capacity
+     * @param psMaxCapacity              the maximum capacity
+     * @param psDesignCapacity           the design capacity
+     * @param psCycleCount               the charge cycle count
+     * @param psChemistry                the battery chemistry
+     * @param psManufactureDate          the manufacture date
+     * @param psManufacturer             the manufacturer
+     * @param psSerialNumber             the serial number
+     * @param psTemperature              the temperature in degrees Celsius
+     */
     protected SolarisPowerSource(String psName, String psDeviceName, double psRemainingCapacityPercent,
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisUsbDevice.java
@@ -26,6 +26,17 @@ public class SolarisUsbDevice extends AbstractUsbDevice {
 
     private static final String PCI_TYPE_USB = "000c";
 
+    /**
+     * Constructs a new {@code SolarisUsbDevice}.
+     *
+     * @param name             the device name
+     * @param vendor           the vendor
+     * @param vendorId         the vendor ID
+     * @param productId        the product ID
+     * @param serialNumber     the serial number
+     * @param uniqueDeviceId   the unique device ID
+     * @param connectedDevices the devices connected to this one
+     */
     public SolarisUsbDevice(String name, String vendor, String vendorId, String productId, String serialNumber,
             String uniqueDeviceId, List<UsbDevice> connectedDevices) {
         super(name, vendor, vendorId, productId, serialNumber, uniqueDeviceId, connectedDevices);

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSProcess.java
@@ -75,6 +75,14 @@ public abstract class MacOSProcess extends AbstractOSProcess {
     protected volatile long voluntaryContextSwitches;
     protected volatile long involuntaryContextSwitches;
 
+    /**
+     * Constructs a new {@code MacOSProcess}.
+     *
+     * @param pid   the process ID
+     * @param major the major version number
+     * @param minor the minor version number
+     * @param os    the owning operating system
+     */
     protected MacOSProcess(int pid, int major, int minor, MacOperatingSystem os) {
         super(pid);
         this.majorVersion = major;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/AbstractProcOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/AbstractProcOSProcess.java
@@ -57,6 +57,11 @@ public abstract class AbstractProcOSProcess extends AbstractOSProcess {
     protected volatile long residentSetSize;
     protected volatile long privateResidentMemory;
 
+    /**
+     * Constructs a new {@code AbstractProcOSProcess}.
+     *
+     * @param pid the process ID
+     */
     protected AbstractProcOSProcess(int pid) {
         super(pid);
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixInstalledApps.java
@@ -17,6 +17,9 @@ import oshi.util.Constants;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 
+/**
+ * Utility to query installed applications on AIX from {@code lslpp} output.
+ */
 public final class AixInstalledApps {
 
     private static final Pattern COLON_PATTERN = Pattern.compile(":");
@@ -24,6 +27,11 @@ public final class AixInstalledApps {
     private AixInstalledApps() {
     }
 
+    /**
+     * Queries {@code lslpp} for the installed filesets.
+     *
+     * @return the installed applications
+     */
     public static List<ApplicationInfo> queryInstalledApps() {
         // https://www.ibm.com/docs/en/aix/7.1.0?topic=l-lslpp-command
         List<String> output = ExecutingCommand.runNative("lslpp -Lc");

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSFileStore.java
@@ -17,7 +17,7 @@ public class AixOSFileStore extends AbstractOSFileStore {
     /**
      * Constructs a new {@code AixOSFileStore}.
      *
-     * @param name          the device name
+     * @param name          the file store name
      * @param volume        the volume name
      * @param label         the volume label
      * @param mount         the mount point

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSFileStore.java
@@ -14,6 +14,25 @@ import oshi.software.os.OSFileStore;
 @ThreadSafe
 public class AixOSFileStore extends AbstractOSFileStore {
 
+    /**
+     * Constructs a new {@code AixOSFileStore}.
+     *
+     * @param name          the device name
+     * @param volume        the volume name
+     * @param label         the volume label
+     * @param mount         the mount point
+     * @param options       the mount options
+     * @param uuid          the volume UUID
+     * @param local         whether the store is local
+     * @param logicalVolume the logical volume
+     * @param description   the description
+     * @param fsType        the fs type
+     * @param freeSpace     the free space in bytes
+     * @param usableSpace   the usable space in bytes
+     * @param totalSpace    the total space in bytes
+     * @param freeInodes    the free inode count
+     * @param totalInodes   the total inode count
+     */
     public AixOSFileStore(String name, String volume, String label, String mount, String options, String uuid,
             boolean local, String logicalVolume, String description, String fsType, long freeSpace, long usableSpace,
             long totalSpace, long freeInodes, long totalInodes) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
@@ -40,6 +40,14 @@ public abstract class AixOSProcess extends AbstractProcOSProcess {
     private final Supplier<AixPerfstatProcess[]> procCpu;
     private final AixOperatingSystem os;
 
+    /**
+     * Constructs a new {@code AixOSProcess}.
+     *
+     * @param pid     the process ID
+     * @param cpuMem  the CPU and memory counters for this process
+     * @param procCpu a supplier of the perfstat process array
+     * @param os      the owning operating system
+     */
     protected AixOSProcess(int pid, Quartet<Long, Long, Long, Long> cpuMem, Supplier<AixPerfstatProcess[]> procCpu,
             AixOperatingSystem os) {
         super(pid);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSThread.java
@@ -17,6 +17,12 @@ import oshi.software.os.OSProcess;
 @ThreadSafe
 public class AixOSThread extends AbstractOSThread {
 
+    /**
+     * Constructs a new {@code AixOSThread}.
+     *
+     * @param pid the process ID
+     * @param tid the thread ID
+     */
     public AixOSThread(int pid, int tid) {
         super(pid);
         this.threadId = tid;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
@@ -52,6 +52,11 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
     protected volatile long involuntaryContextSwitches;
     protected volatile String commandLineBackup;
 
+    /**
+     * Constructs a new {@code BsdOSProcess}.
+     *
+     * @param pid the process ID
+     */
     protected BsdOSProcess(int pid) {
         super(pid);
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSThread.java
@@ -23,6 +23,11 @@ import oshi.util.ParseUtil;
 @ThreadSafe
 public abstract class BsdOSThread extends AbstractOSThread {
 
+    /**
+     * Constructs a new {@code BsdOSThread}.
+     *
+     * @param processId the owning process ID
+     */
     protected BsdOSThread(int processId) {
         super(processId);
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
@@ -40,6 +40,10 @@ import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.dragonflybsd.ProcstatUtil;
 
+/**
+ * Abstract base for a DragonFly BSD OSProcess. Inherits the shared BSD {@code ps} parsing and adds the fields whose
+ * column set differs on DragonFly.
+ */
 public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
 
     /**
@@ -53,6 +57,11 @@ public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
     public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
+    /**
+     * Constructs a new {@code DragonFlyBsdOSProcess}.
+     *
+     * @param pid the process ID
+     */
     protected DragonFlyBsdOSProcess(int pid) {
         super(pid);
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSThread.java
@@ -40,11 +40,23 @@ public class DragonFlyBsdOSThread extends BsdOSThread {
     public static final String PS_THREAD_COLUMNS = PS_THREAD_KEYWORDS.stream().map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
+    /**
+     * Constructs a new {@code DragonFlyBsdOSThread}.
+     *
+     * @param processId the owning process ID
+     * @param threadMap the parsed {@code ps} columns for this thread
+     */
     public DragonFlyBsdOSThread(int processId, Map<BsdPsThreadKeyword, String> threadMap) {
         super(processId);
         updateAttributes(threadMap);
     }
 
+    /**
+     * Constructs a new {@code DragonFlyBsdOSThread}.
+     *
+     * @param processId the owning process ID
+     * @param threadId  the thread ID
+     */
     public DragonFlyBsdOSThread(int processId, int threadId) {
         super(processId);
         this.threadId = threadId;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystem.java
@@ -18,6 +18,10 @@ import oshi.util.FileSystemUtil;
 import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 
+/**
+ * Abstract base for the FreeBSD FileSystem. Parses the mount table and builds the file stores; the JNA and FFM
+ * subclasses supply the statfs reads.
+ */
 public abstract class FreeBsdFileSystem extends AbstractFileSystem {
 
     public static final String OSHI_FREEBSD_FS_PATH_EXCLUDES = "oshi.os.freebsd.filesystem.path.excludes";

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdInternetProtocolStats.java
@@ -6,5 +6,9 @@ package oshi.software.common.os.unix.freebsd;
 
 import oshi.software.common.AbstractInternetProtocolStats;
 
+/**
+ * Abstract base for the FreeBSD InternetProtocolStats. Parses the TCP and UDP counters from {@code netstat} output; the
+ * JNA and FFM subclasses supply the per-connection reads.
+ */
 public abstract class FreeBsdInternetProtocolStats extends AbstractInternetProtocolStats {
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdNetworkParams.java
@@ -7,6 +7,10 @@ package oshi.software.common.os.unix.freebsd;
 import oshi.software.common.AbstractNetworkParams;
 import oshi.util.ExecutingCommand;
 
+/**
+ * Abstract base for the FreeBSD NetworkParams. Resolves the host and domain names and the default gateways from command
+ * output; the JNA and FFM subclasses supply the resolver calls.
+ */
 public abstract class FreeBsdNetworkParams extends AbstractNetworkParams {
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSFileStore.java
@@ -18,6 +18,26 @@ public class FreeBsdOSFileStore extends AbstractOSFileStore {
 
     private final FreeBsdFileSystem fileSystem;
 
+    /**
+     * Constructs a new {@code FreeBsdOSFileStore}.
+     *
+     * @param fileSystem    the owning file system
+     * @param name          the device name
+     * @param volume        the volume name
+     * @param label         the volume label
+     * @param mount         the mount point
+     * @param options       the mount options
+     * @param uuid          the volume UUID
+     * @param local         whether the store is local
+     * @param logicalVolume the logical volume
+     * @param description   the description
+     * @param fsType        the fs type
+     * @param freeSpace     the free space in bytes
+     * @param usableSpace   the usable space in bytes
+     * @param totalSpace    the total space in bytes
+     * @param freeInodes    the free inode count
+     * @param totalInodes   the total inode count
+     */
     public FreeBsdOSFileStore(FreeBsdFileSystem fileSystem, String name, String volume, String label, String mount,
             String options, String uuid, boolean local, String logicalVolume, String description, String fsType,
             long freeSpace, long usableSpace, long totalSpace, long freeInodes, long totalInodes) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSFileStore.java
@@ -22,7 +22,7 @@ public class FreeBsdOSFileStore extends AbstractOSFileStore {
      * Constructs a new {@code FreeBsdOSFileStore}.
      *
      * @param fileSystem    the owning file system
-     * @param name          the device name
+     * @param name          the file store name
      * @param volume        the volume name
      * @param label         the volume label
      * @param mount         the mount point

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSProcess.java
@@ -42,6 +42,10 @@ import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.freebsd.ProcstatUtil;
 
+/**
+ * Abstract base for a FreeBSD OSProcess. Inherits the shared BSD {@code ps} parsing and adds the fields whose column
+ * set differs on FreeBSD.
+ */
 public abstract class FreeBsdOSProcess extends BsdOSProcess {
 
     /**
@@ -55,6 +59,11 @@ public abstract class FreeBsdOSProcess extends BsdOSProcess {
     public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
+    /**
+     * Constructs a new {@code FreeBsdOSProcess}.
+     *
+     * @param pid the process ID
+     */
     protected FreeBsdOSProcess(int pid) {
         super(pid);
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdOSThread.java
@@ -44,11 +44,23 @@ public class FreeBsdOSThread extends BsdOSThread {
     public static final String PS_THREAD_COLUMNS = PS_THREAD_KEYWORDS.stream().map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
+    /**
+     * Constructs a new {@code FreeBsdOSThread}.
+     *
+     * @param processId the owning process ID
+     * @param threadMap the parsed {@code ps} columns for this thread
+     */
     public FreeBsdOSThread(int processId, Map<BsdPsThreadKeyword, String> threadMap) {
         super(processId);
         updateAttributes(threadMap);
     }
 
+    /**
+     * Constructs a new {@code FreeBsdOSThread}.
+     *
+     * @param processId the owning process ID
+     * @param threadId  the thread ID
+     */
     public FreeBsdOSThread(int processId, int threadId) {
         super(processId);
         this.threadId = threadId;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSFileStore.java
@@ -17,7 +17,7 @@ public class NetBsdOSFileStore extends AbstractOSFileStore {
     /**
      * Constructs a new {@code NetBsdOSFileStore}.
      *
-     * @param name          the device name
+     * @param name          the file store name
      * @param volume        the volume name
      * @param label         the volume label
      * @param mount         the mount point

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSFileStore.java
@@ -14,6 +14,25 @@ import oshi.software.os.OSFileStore;
 @ThreadSafe
 public class NetBsdOSFileStore extends AbstractOSFileStore {
 
+    /**
+     * Constructs a new {@code NetBsdOSFileStore}.
+     *
+     * @param name          the device name
+     * @param volume        the volume name
+     * @param label         the volume label
+     * @param mount         the mount point
+     * @param options       the mount options
+     * @param uuid          the volume UUID
+     * @param local         whether the store is local
+     * @param logicalVolume the logical volume
+     * @param description   the description
+     * @param fsType        the fs type
+     * @param freeSpace     the free space in bytes
+     * @param usableSpace   the usable space in bytes
+     * @param totalSpace    the total space in bytes
+     * @param freeInodes    the free inode count
+     * @param totalInodes   the total inode count
+     */
     public NetBsdOSFileStore(String name, String volume, String label, String mount, String options, String uuid,
             boolean local, String logicalVolume, String description, String fsType, long freeSpace, long usableSpace,
             long totalSpace, long freeInodes, long totalInodes) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -61,6 +61,13 @@ public class NetBsdOSProcess extends BsdOSProcess {
 
     protected final NetBsdOperatingSystem os;
 
+    /**
+     * Constructs a new {@code NetBsdOSProcess}.
+     *
+     * @param pid   the process ID
+     * @param psMap the parsed {@code ps} columns for this process
+     * @param os    the owning operating system
+     */
     public NetBsdOSProcess(int pid, Map<BsdPsKeyword, String> psMap, NetBsdOperatingSystem os) {
         super(pid);
         this.os = os;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSThread.java
@@ -42,11 +42,23 @@ public class NetBsdOSThread extends BsdOSThread {
     public static final String PS_THREAD_COLUMNS = PS_THREAD_KEYWORDS.stream().map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
+    /**
+     * Constructs a new {@code NetBsdOSThread}.
+     *
+     * @param processId the owning process ID
+     * @param threadMap the parsed {@code ps} columns for this thread
+     */
     public NetBsdOSThread(int processId, Map<BsdPsThreadKeyword, String> threadMap) {
         super(processId);
         updateAttributes(threadMap);
     }
 
+    /**
+     * Constructs a new {@code NetBsdOSThread}.
+     *
+     * @param processId the owning process ID
+     * @param threadId  the thread ID
+     */
     public NetBsdOSThread(int processId, int threadId) {
         super(processId);
         this.threadId = threadId;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
@@ -18,6 +18,10 @@ import oshi.util.FileSystemUtil;
 import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 
+/**
+ * Abstract base for the OpenBSD FileSystem. Parses the mount table and builds the file stores; the JNA and FFM
+ * subclasses supply the statfs reads.
+ */
 public abstract class OpenBsdFileSystem extends AbstractFileSystem {
 
     public static final String OSHI_OPENBSD_FS_PATH_EXCLUDES = "oshi.os.openbsd.filesystem.path.excludes";

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSFileStore.java
@@ -22,7 +22,7 @@ public class OpenBsdOSFileStore extends AbstractOSFileStore {
      * Constructs a new {@code OpenBsdOSFileStore}.
      *
      * @param fileSystem    the owning file system
-     * @param name          the device name
+     * @param name          the file store name
      * @param volume        the volume name
      * @param label         the volume label
      * @param mount         the mount point

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSFileStore.java
@@ -18,6 +18,26 @@ public class OpenBsdOSFileStore extends AbstractOSFileStore {
 
     private final OpenBsdFileSystem fileSystem;
 
+    /**
+     * Constructs a new {@code OpenBsdOSFileStore}.
+     *
+     * @param fileSystem    the owning file system
+     * @param name          the device name
+     * @param volume        the volume name
+     * @param label         the volume label
+     * @param mount         the mount point
+     * @param options       the mount options
+     * @param uuid          the volume UUID
+     * @param local         whether the store is local
+     * @param logicalVolume the logical volume
+     * @param description   the description
+     * @param fsType        the fs type
+     * @param freeSpace     the free space in bytes
+     * @param usableSpace   the usable space in bytes
+     * @param totalSpace    the total space in bytes
+     * @param freeInodes    the free inode count
+     * @param totalInodes   the total inode count
+     */
     public OpenBsdOSFileStore(OpenBsdFileSystem fileSystem, String name, String volume, String label, String mount,
             String options, String uuid, boolean local, String logicalVolume, String description, String fsType,
             long freeSpace, long usableSpace, long totalSpace, long freeInodes, long totalInodes) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSProcess.java
@@ -40,6 +40,10 @@ import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
 import oshi.util.common.platform.unix.openbsd.FstatUtil;
 
+/**
+ * Abstract base for an OpenBSD OSProcess. Inherits the shared BSD {@code ps} parsing and adds the fields whose column
+ * set differs on OpenBSD.
+ */
 public abstract class OpenBsdOSProcess extends BsdOSProcess {
 
     /**
@@ -52,6 +56,11 @@ public abstract class OpenBsdOSProcess extends BsdOSProcess {
     public static final String PS_COMMAND_ARGS = PS_KEYWORDS.stream().map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
+    /**
+     * Constructs a new {@code OpenBsdOSProcess}.
+     *
+     * @param pid the process ID
+     */
     protected OpenBsdOSProcess(int pid) {
         super(pid);
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOSThread.java
@@ -42,11 +42,23 @@ public class OpenBsdOSThread extends BsdOSThread {
     public static final String PS_THREAD_COLUMNS = PS_THREAD_KEYWORDS.stream().map(Enum::name)
             .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
 
+    /**
+     * Constructs a new {@code OpenBsdOSThread}.
+     *
+     * @param processId the owning process ID
+     * @param threadMap the parsed {@code ps} columns for this thread
+     */
     public OpenBsdOSThread(int processId, Map<BsdPsThreadKeyword, String> threadMap) {
         super(processId);
         updateAttributes(threadMap);
     }
 
+    /**
+     * Constructs a new {@code OpenBsdOSThread}.
+     *
+     * @param processId the owning process ID
+     * @param threadId  the thread ID
+     */
     public OpenBsdOSThread(int processId, int threadId) {
         super(processId);
         this.threadId = threadId;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSFileStore.java
@@ -18,7 +18,7 @@ public class SolarisOSFileStore extends AbstractOSFileStore {
     /**
      * Constructs a new {@code SolarisOSFileStore}.
      *
-     * @param name          the device name
+     * @param name          the file store name
      * @param volume        the volume name
      * @param label         the volume label
      * @param mount         the mount point

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSFileStore.java
@@ -15,6 +15,25 @@ import oshi.software.os.OSFileStore;
 @ThreadSafe
 public class SolarisOSFileStore extends AbstractOSFileStore {
 
+    /**
+     * Constructs a new {@code SolarisOSFileStore}.
+     *
+     * @param name          the device name
+     * @param volume        the volume name
+     * @param label         the volume label
+     * @param mount         the mount point
+     * @param options       the mount options
+     * @param uuid          the volume UUID
+     * @param local         whether the store is local
+     * @param logicalVolume the logical volume
+     * @param description   the description
+     * @param fsType        the fs type
+     * @param freeSpace     the free space in bytes
+     * @param usableSpace   the usable space in bytes
+     * @param totalSpace    the total space in bytes
+     * @param freeInodes    the free inode count
+     * @param totalInodes   the total inode count
+     */
     public SolarisOSFileStore(String name, String volume, String label, String mount, String options, String uuid,
             boolean local, String logicalVolume, String description, String fsType, long freeSpace, long usableSpace,
             long totalSpace, long freeInodes, long totalInodes) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
@@ -44,6 +44,11 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
     private volatile long voluntaryContextSwitches;
     private volatile long involuntaryContextSwitches;
 
+    /**
+     * Constructs a new {@code SolarisOSProcess}.
+     *
+     * @param pid the process ID
+     */
     protected SolarisOSProcess(int pid) {
         super(pid);
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSThread.java
@@ -25,6 +25,12 @@ public abstract class SolarisOSThread extends AbstractOSThread {
     private final Supplier<SolarisLwpsInfo> lwpsinfo = memoize(this::queryLwpsInfo, defaultExpiration());
     private final Supplier<SolarisPrUsage> prusage = memoize(this::queryPrUsage, defaultExpiration());
 
+    /**
+     * Constructs a new {@code SolarisOSThread}.
+     *
+     * @param pid   the process ID
+     * @param lwpid the lightweight process ID
+     */
     protected SolarisOSThread(int pid, int lwpid) {
         super(pid);
         this.threadId = lwpid;

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/HkeyUserData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/HkeyUserData.java
@@ -38,6 +38,11 @@ public final class HkeyUserData {
     private HkeyUserData() {
     }
 
+    /**
+     * Queries the {@code HKEY_USERS} registry hive for logged-in user sessions.
+     *
+     * @return the user sessions
+     */
     public static List<OSSession> queryUserSessions() {
         List<OSSession> sessions = new ArrayList<>();
         for (String sidKey : Advapi32Util.registryGetKeys(WinReg.HKEY_USERS)) {

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/InstalledAppsData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/InstalledAppsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The OSHI Project Contributors
+ * Copyright 2025-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.registry;
@@ -25,6 +25,9 @@ import com.sun.jna.platform.win32.WinReg.HKEY;
 import oshi.software.os.ApplicationInfo;
 import oshi.util.platform.windows.RegistryUtil;
 
+/**
+ * Utility to read installed applications from the Windows uninstall registry keys.
+ */
 public final class InstalledAppsData {
 
     private InstalledAppsData() {
@@ -40,6 +43,11 @@ public final class InstalledAppsData {
         REGISTRY_PATHS.put(HKEY_CURRENT_USER, Arrays.asList("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall"));
     }
 
+    /**
+     * Queries the uninstall keys under both {@code HKEY_LOCAL_MACHINE} and {@code HKEY_CURRENT_USER}.
+     *
+     * @return the installed applications
+     */
     public static List<ApplicationInfo> queryInstalledApps() {
         Set<ApplicationInfo> appInfoSet = new LinkedHashSet<>();
 

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/NetSessionData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/NetSessionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows.registry;
@@ -27,6 +27,11 @@ public final class NetSessionData {
     private NetSessionData() {
     }
 
+    /**
+     * Queries {@code NetSessionEnum} for sessions established from remote machines.
+     *
+     * @return the user sessions
+     */
     public static List<OSSession> queryUserSessions() {
         List<OSSession> sessions = new ArrayList<>();
         try (CloseablePointerByReference bufptr = new CloseablePointerByReference();

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/SessionWtsData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/SessionWtsData.java
@@ -48,9 +48,10 @@ public final class SessionWtsData {
     }
 
     /**
-     * Queries the Remote Desktop Services API for logged-in user sessions.
+     * Queries the Remote Desktop Services API for active sessions connected over a remote protocol. Console sessions
+     * are skipped, having already been read from the registry.
      *
-     * @return the user sessions
+     * @return the active remote user sessions
      */
     public static List<OSSession> queryUserSessions() {
         List<OSSession> sessions = new ArrayList<>();

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/SessionWtsData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/SessionWtsData.java
@@ -47,6 +47,11 @@ public final class SessionWtsData {
     private SessionWtsData() {
     }
 
+    /**
+     * Queries the Remote Desktop Services API for logged-in user sessions.
+     *
+     * @return the user sessions
+     */
     public static List<OSSession> queryUserSessions() {
         List<OSSession> sessions = new ArrayList<>();
         if (IS_VISTA_OR_GREATER) {

--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,12 @@
                             <link>https://java-native-access.github.io/jna/${jna.version}/javadoc/</link>
                         </links>
                         <detectJavaApiLink>false</detectJavaApiLink>
+                        <!-- Presence of javadoc is enforced by checkstyle's MissingJavadocType/MissingJavadocMethod,
+                             which can be scoped to the API that matters. doclint keeps everything else: bad tags,
+                             broken references, malformed HTML. Without -missing it also demands a comment on every
+                             protected field of the C-struct mirrors and on every implicit constructor, which is
+                             ~1500 warnings of no value to a reader. -->
+                        <doclint>all,-missing</doclint>
                         <additionalJOptions>
                             <additionalJOption>-Xmaxwarns</additionalJOption>
                             <additionalJOption>1000</additionalJOption>


### PR DESCRIPTION
The Lint job logged **1565 javadoc warnings** on every run. GitHub caps annotations at 10 per check, so that list was pure noise and anything genuinely new was invisible behind it.

## The rule was being enforced by the wrong tool

Almost all of it was doclint's `missing` group demanding a comment on every protected field of the C-struct mirrors and every implicit constructor. That is not the rule this project wants — and it was also the only thing enforcing the rule it does want. Checkstyle had `JavadocMethod`, `JavadocType` and `JavadocPackage`, but those **validate javadoc that already exists**; presence lives in `MissingJavadocType`/`MissingJavadocMethod`, which were not enabled. Nothing would have caught a new undocumented public class.

The two now split the work:

- **Checkstyle owns presence** — `MissingJavadocType`/`MissingJavadocMethod` at `scope=protected`, matching the configuration used by [opensearch-project/flow-framework](https://github.com/opensearch-project/flow-framework/tree/main/config/checkstyle)
- **doclint owns correctness** — `-Xdoclint:all,-missing`, so bad tags, broken `{@link}` and malformed HTML still fail the build

Javadoc warnings drop **1565 → 8**, and the 8 are a pre-existing module-path note about JNA's javadoc being in the unnamed module.

## Scoping the 580 sites this surfaced

| Group | Count | Disposition |
|---|---|---|
| `jna`/`ffm` binding packages | 334 | Suppressed — mirror C headers field for field, already exempt from `ConstantName`, `MethodName`, `TypeName` for the same reason |
| `*JNA.java` / `*FFM.java` backend twins | 241 | Suppressed — see below |
| Real gaps | **81** | Written in this PR |

The twins are worth explaining. `@Override` is exempt, so almost all implementation code is already covered; what trips the check is the one member that cannot be `@Override` — the public constructor:

```java
public final class MacPowerSourceJNA extends MacPowerSource {
    public MacPowerSourceJNA(String psName, String psDeviceName, double psRemainingCapacityPercent, ...
```

It forwards the full field list to the abstract parent's constructor, which **is** documented here. Documenting 241 of those restates the shared base.

Fields are not checked at all — `MissingJavadocVariable` would want comments on 1293 struct mirrors.

## The 81

76 in `oshi-common` (constructors, factory methods, and 14 hand-written descriptions for the abstract platform bases) and 5 in the Windows registry drivers.

Also collapses a duplicate `JavadocMethod` module — one bare, one configured, both running — into a single one at public and protected scope, and extends the existing test-file suppression to the new checks.

## A measurement trap, now documented

Checkstyle caches per file in `target/checkstyle-cachefile`, so a second run only re-checks what changed; `javadoc:javadoc` likewise skips when `target/reports` is populated. Measuring either without a `clean` first reports a fraction of the real count and looks like a fix. This cost me several contradictory readings before I spotted it, so AGENTS.md now warns about it.

## Verification

Every number above is from a clean tree. Full gate green from clean: install, spotless, checkstyle, forbiddenapis, javadoc, and 1504 tests successful / 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Javadocs across platform-specific hardware, operating system, process, memory, storage, and session APIs.
  * Added clearer descriptions for constructors, parameters, return values, exceptions, and platform responsibilities.
  * Updated contributor guidance for documenting public and protected APIs.

* **Chores**
  * Improved documentation validation and Checkstyle coverage while preserving support for platform-specific and test sources.
  * Added a public OpenBSD thread-construction option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->