### PR TITLE
Fix the Linux soft open-file limit when the hard limit is unlimited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ##### Bug Fixes and Improvements
 
-* [#3564](https://github.com/oshi/oshi/pull/3564): Fix Linux `getSoftOpenFileLimit()` returning -1 for a process whose hard open-file limit is `unlimited`, discarding a valid soft limit - [@dbwiddis](https://github.com/dbwiddis).
-
 * [#3561](https://github.com/oshi/oshi/pull/3561): Fix AIX reporting the current instant as its boot time, and an uptime of zero, when the `uptime` command transiently failed; parse the year-less `who -b` format AIX 7.3 emits, and add `ParseUtil.parseYearlessDateToEpoch` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3562](https://github.com/oshi/oshi/pull/3562): Make Linux `getMaxFreq()` reproducible by resolving it from the cpufreq policy, `lshw`, and the vendor frequency rather than folding in a live frequency reading, returning -1 when none of those reports a maximum - [@dbwiddis](https://github.com/dbwiddis).
+* [#3564](https://github.com/oshi/oshi/pull/3564): Fix Linux `getSoftOpenFileLimit()` returning -1 for a process whose hard open-file limit is `unlimited`, discarding a valid soft limit - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24), 7.4.3 (2027-07-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ##### Bug Fixes and Improvements
 
+* [#3564](https://github.com/oshi/oshi/pull/3564): Fix Linux `getSoftOpenFileLimit()` returning -1 for a process whose hard open-file limit is `unlimited`, discarding a valid soft limit - [@dbwiddis](https://github.com/dbwiddis).
+
 * [#3561](https://github.com/oshi/oshi/pull/3561): Fix AIX reporting the current instant as its boot time, and an uptime of zero, when the `uptime` command transiently failed; parse the year-less `who -b` format AIX 7.3 emits, and add `ParseUtil.parseYearlessDateToEpoch` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3562](https://github.com/oshi/oshi/pull/3562): Make Linux `getMaxFreq()` reproducible by resolving it from the cpufreq policy, `lshw`, and the vendor frequency rather than folding in a live frequency reading, returning -1 when none of those reports a maximum - [@dbwiddis](https://github.com/dbwiddis).
 

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -485,8 +485,8 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
      * Gets the open file limit for a process.
      *
      * @param processId the process ID
-     * @param index     the limit index (soft=0, hard=1)
-     * @return the file limit
+     * @param index     {@code 1} for the soft limit, {@code 2} for the hard limit
+     * @return the file limit, or {@code -1} if unavailable
      */
     protected long getProcessOpenFileLimit(long processId, int index) {
         return ProcLimits.queryOpenFileLimit(processId, index);

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -41,6 +40,7 @@ import oshi.util.PrivilegedUtil;
 import oshi.util.UserGroupInfo;
 import oshi.util.Util;
 import oshi.util.driver.linux.proc.ProcessStat;
+import oshi.util.driver.unix.ProcLimits;
 import oshi.util.linux.ProcPath;
 
 /**
@@ -489,25 +489,6 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
      * @return the file limit
      */
     protected long getProcessOpenFileLimit(long processId, int index) {
-        final String limitsPath = String.format(Locale.ROOT, "/proc/%d/limits", processId);
-        if (!Files.exists(Paths.get(limitsPath))) {
-            return -1; // not supported
-        }
-        final List<String> lines = FileUtil.readFile(limitsPath);
-        final Optional<String> maxOpenFilesLine = lines.stream().filter(line -> line.startsWith("Max open files"))
-                .findFirst();
-        if (!maxOpenFilesLine.isPresent()) {
-            return -1;
-        }
-        final String line = maxOpenFilesLine.get();
-        if (line.contains("unlimited")) {
-            return -1;
-        }
-        // Split all non-Digits away -> ["", "{soft-limit}", "{hard-limit}"]
-        final String[] split = line.split("\\D+");
-        if (split.length <= index) {
-            return -1;
-        }
-        return ParseUtil.parseLongOrDefault(split[index], -1);
+        return ProcLimits.queryOpenFileLimit(processId, index);
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
@@ -12,19 +12,15 @@ import static oshi.software.os.OSProcess.State.WAITING;
 import static oshi.software.os.OSProcess.State.ZOMBIE;
 import static oshi.util.Memoizer.memoize;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOSProcess;
 import oshi.util.ExecutingCommand;
-import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
+import oshi.util.driver.unix.ProcLimits;
 
 /**
  * Abstract base shared by the BSD-family OSProcess implementations (FreeBSD, OpenBSD, DragonFly, NetBSD). Holds the
@@ -340,22 +336,7 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
      * @return the limit, or {@code -1} if unavailable
      */
     protected static long getProcessOpenFileLimit(long processId, int index) {
-        final String limitsPath = String.format(Locale.ROOT, "/proc/%d/limits", processId);
-        if (!Files.exists(Paths.get(limitsPath))) {
-            return -1; // not supported
-        }
-        final List<String> lines = FileUtil.readFile(limitsPath);
-        final Optional<String> maxOpenFilesLine = lines.stream().filter(line -> line.startsWith("Max open files"))
-                .findFirst();
-        if (!maxOpenFilesLine.isPresent()) {
-            return -1;
-        }
-        // Split all non-Digits away -> ["", "{soft-limit}, "{hard-limit}"]
-        final String[] split = maxOpenFilesLine.get().split("\\D+");
-        if (split.length <= index) {
-            return -1;
-        }
-        return ParseUtil.parseLongOrDefault(split[index], -1);
+        return ProcLimits.queryOpenFileLimit(processId, index);
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/driver/unix/ProcLimits.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/ProcLimits.java
@@ -59,7 +59,8 @@ public final class ProcLimits {
         }
         // Split all non-digits away -> ["", "{soft-limit}", "{hard-limit}", ""]
         final String[] split = maxOpenFilesLine.get().split("\\D+");
-        if (split.length <= index) {
+        // Element 0 is the empty string left of the label, so a usable index is 1 or 2
+        if (index < 1 || split.length <= index) {
             return -1;
         }
         return ParseUtil.parseLongOrDefault(split[index], -1);

--- a/oshi-common/src/main/java/oshi/util/driver/unix/ProcLimits.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/ProcLimits.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.driver.unix;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.FileUtil;
+import oshi.util.ParseUtil;
+
+/**
+ * Utility to read process resource limits from {@code /proc/<pid>/limits}, which Linux and the BSDs with a mounted
+ * procfs both provide in the same format.
+ */
+@ThreadSafe
+public final class ProcLimits {
+
+    private ProcLimits() {
+    }
+
+    /**
+     * Queries {@code /proc/<pid>/limits} for a process's open file limit.
+     *
+     * @param processId the process ID
+     * @param index     {@code 1} for the soft limit, {@code 2} for the hard limit
+     * @return the limit, or {@code -1} if procfs is not mounted, the row is absent, or that field is unlimited
+     */
+    public static long queryOpenFileLimit(long processId, int index) {
+        final String limitsPath = String.format(Locale.ROOT, "/proc/%d/limits", processId);
+        if (!Files.exists(Paths.get(limitsPath))) {
+            return -1; // not supported
+        }
+        return parseOpenFileLimit(FileUtil.readFile(limitsPath), index);
+    }
+
+    /**
+     * Parses the open file limit out of {@code /proc/<pid>/limits} content. Split from the file read so it can be
+     * tested against fixture data on any operating system.
+     * <p>
+     * A field reading {@code unlimited} contributes no digits, so it is absent from the split and yields {@code -1} for
+     * that index alone. The other field is still returned: a process whose hard limit is unlimited normally still has a
+     * real soft limit.
+     *
+     * @param lines the lines of {@code /proc/<pid>/limits}
+     * @param index {@code 1} for the soft limit, {@code 2} for the hard limit
+     * @return the limit, or {@code -1} if there is no {@code Max open files} row or that field is unlimited
+     */
+    public static long parseOpenFileLimit(List<String> lines, int index) {
+        final Optional<String> maxOpenFilesLine = lines.stream().filter(line -> line.startsWith("Max open files"))
+                .findFirst();
+        if (!maxOpenFilesLine.isPresent()) {
+            return -1;
+        }
+        // Split all non-digits away -> ["", "{soft-limit}", "{hard-limit}", ""]
+        final String[] split = maxOpenFilesLine.get().split("\\D+");
+        if (split.length <= index) {
+            return -1;
+        }
+        return ParseUtil.parseLongOrDefault(split[index], -1);
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/driver/unix/ProcLimitsTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/ProcLimitsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.driver.unix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ProcLimits}, driven by real {@code /proc/<pid>/limits} content.
+ */
+class ProcLimitsTest {
+
+    private static final int SOFT = 1;
+    private static final int HARD = 2;
+
+    private static final String HEADER = "Limit                     Soft Limit           Hard Limit           Units";
+
+    private static List<String> limits(String maxOpenFilesRow) {
+        return Arrays.asList(HEADER, "Max cpu time              unlimited            unlimited            seconds",
+                maxOpenFilesRow, "Max processes             31573                31573                processes");
+    }
+
+    @Test
+    void testBothLimitsNumeric() {
+        List<String> lines = limits(
+                "Max open files            1024                 4096                 files            ");
+        assertThat("soft limit", ProcLimits.parseOpenFileLimit(lines, SOFT), is(1024L));
+        assertThat("hard limit", ProcLimits.parseOpenFileLimit(lines, HARD), is(4096L));
+    }
+
+    @Test
+    void testHardUnlimitedKeepsSoftLimit() {
+        // A root process after `ulimit -Hn unlimited` still has a real soft limit. Reading the row as a whole and
+        // bailing out on the word "unlimited" anywhere in it discarded that soft limit and returned -1.
+        List<String> lines = limits(
+                "Max open files            1024                 unlimited            files            ");
+        assertThat("soft limit survives an unlimited hard limit", ProcLimits.parseOpenFileLimit(lines, SOFT),
+                is(1024L));
+        assertThat("unlimited hard limit is unknown", ProcLimits.parseOpenFileLimit(lines, HARD), is(-1L));
+    }
+
+    @Test
+    void testBothUnlimited() {
+        List<String> lines = limits(
+                "Max open files            unlimited            unlimited            files            ");
+        assertThat("soft limit", ProcLimits.parseOpenFileLimit(lines, SOFT), is(-1L));
+        assertThat("hard limit", ProcLimits.parseOpenFileLimit(lines, HARD), is(-1L));
+    }
+
+    @Test
+    void testRowAbsentOrEmpty() {
+        List<String> noRow = Arrays.asList(HEADER,
+                "Max processes             31573                31573                processes");
+        assertThat("no Max open files row", ProcLimits.parseOpenFileLimit(noRow, SOFT), is(-1L));
+        assertThat("empty input", ProcLimits.parseOpenFileLimit(Collections.emptyList(), SOFT), is(-1L));
+    }
+
+    @Test
+    void testIndexBeyondTheRow() {
+        // Only one numeric field present, so the hard limit index is past the end of the split
+        List<String> lines = limits("Max open files            1024                 unlimited            files");
+        assertThat(ProcLimits.parseOpenFileLimit(lines, 3), is(-1L));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/driver/unix/ProcLimitsTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/ProcLimitsTest.java
@@ -69,4 +69,13 @@ class ProcLimitsTest {
         List<String> lines = limits("Max open files            1024                 unlimited            files");
         assertThat(ProcLimits.parseOpenFileLimit(lines, 3), is(-1L));
     }
+
+    @Test
+    void testIndexBelowTheFirstField() {
+        // Element 0 is the empty string to the left of the label, and anything lower would index out of bounds
+        List<String> lines = limits(
+                "Max open files            1024                 4096                 files            ");
+        assertThat("index 0 is the label remnant", ProcLimits.parseOpenFileLimit(lines, 0), is(-1L));
+        assertThat("negative index", ProcLimits.parseOpenFileLimit(lines, -1), is(-1L));
+    }
 }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacNetworkParamsJNA.java
@@ -53,7 +53,7 @@ final class MacNetworkParamsJNA extends MacNetworkParams {
                 }
                 return "";
             }
-            try (Addrinfo info = new Addrinfo(ptr.getValue())) { // NOSONAR
+            try (Addrinfo info = new Addrinfo(ptr.getValue())) {
                 String canonname = info.ai_canonname == null ? "" : info.ai_canonname.trim();
                 SYS.freeaddrinfo(ptr.getValue());
                 return canonname;

--- a/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParamsJNA.java
@@ -43,7 +43,7 @@ public class FreeBsdNetworkParamsJNA extends FreeBsdNetworkParams {
                     }
                     return "";
                 }
-                try (Addrinfo info = new Addrinfo(ptr.getValue())) { // NOSONAR
+                try (Addrinfo info = new Addrinfo(ptr.getValue())) {
                     String canonname = info.ai_canonname == null ? "" : info.ai_canonname.trim();
                     LIBC.freeaddrinfo(ptr.getValue());
                     return canonname;


### PR DESCRIPTION
Extracting a test seam for `getProcessOpenFileLimit` turned up a bug and a duplicate, so the fix, the dedup and the tests land together.

## The bug

`LinuxOSProcess` guarded the parse with a check on the whole row:

```java
if (line.contains("unlimited")) {
    return -1;
}
```

That discards **both** fields whenever **either** is unlimited. A root process after `ulimit -Hn unlimited` has:

```
Max open files            1024                 unlimited            files
```

and `getSoftOpenFileLimit()` returned -1 rather than 1024.

| `/proc/<pid>/limits` row | soft before / after | hard before / after |
|---|---|---|
| `1024  4096` | 1024 / 1024 | 4096 / 4096 |
| `1024  unlimited` | **-1** / **1024** | -1 / -1 |
| `unlimited  unlimited` | -1 / -1 | -1 / -1 |

The guard is also unnecessary for the case it was presumably written for: an all-unlimited row contributes no digits, so `split("\\D+")` gives `["", ""]` and both indices already fall through to -1. Removing it fixes the middle row and changes nothing else.

## The duplicate

`BsdOSProcess` had the same parse **without** that guard, so it was already correct. The two copies are now one — `ProcLimits` in `oshi.util.driver.unix`, alongside the other cross-UNIX command drivers, since `/proc/<pid>/limits` has the same format on Linux and on the BSDs with a mounted procfs. Neither caller changed signature or visibility; both delegate.

## The seam

The parse is split from the file read, so `ProcLimitsTest` drives it from fixture rows on any OS — no Linux needed. Verified non-vacuous: restoring the old guard fails `testHardUnlimitedKeepsSoftLimit`, so it is a real regression test rather than a restatement of current behaviour.

## Incidental

`LinuxOSProcess` javadoc claimed `soft=0, hard=1`. Every caller passes 1 and 2, and splitting a real row yields `["", soft, hard, ""]`, so 1 and 2 are right — `BsdOSProcess` already documented it correctly.

Two vestigial `NOSONAR` comments removed from the `Addrinfo` try-with-resources in `MacNetworkParamsJNA` and `FreeBsdNetworkParamsJNA`. Commit `40e5ee069e` shows they were attached to the *pre*-try-with-resources form, so they suppressed a resource leak that wrapping the statement had already fixed, and have suppressed nothing since.

## Verification

Full gate green from clean: install, spotless, checkstyle, forbiddenapis, javadoc, and 1509 tests successful / 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed open-file-limit detection on Linux and BSD systems when the hard limit is unlimited but the soft limit remains numeric.
  - Improved handling of missing, empty, or unavailable process limit information.

- **Tests**
  - Added coverage for numeric, unlimited, missing, and invalid open-file-limit values.

- **Chores**
  - Removed obsolete static-analysis suppression comments and unused code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->