### PR TITLE
Share the POSIX libc bindings across the UNIX FFM classes

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/linux/LinuxLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/linux/LinuxLibcFunctions.java
@@ -24,7 +24,7 @@ import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import oshi.ffm.ForeignFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 
 /**
  * FFM bindings for Linux libc functions used by OSHI.
@@ -32,7 +32,7 @@ import oshi.ffm.ForeignFunctions;
  * Covers: {@code getpid}, {@code gettid}, {@code syscall}, {@code getloadavg}, {@code sysinfo}, {@code statvfs},
  * {@code gethostname}, {@code getaddrinfo}/{@code freeaddrinfo}/{@code gai_strerror}, and {@code getrlimit}.
  */
-public final class LinuxLibcFunctions extends ForeignFunctions {
+public final class LinuxLibcFunctions extends PosixLibcFunctions {
 
     private LinuxLibcFunctions() {
     }
@@ -119,17 +119,6 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
     private static final VarHandle STATVFS_F_FFREE = STATVFS_LAYOUT
             .varHandle(MemoryLayout.PathElement.groupElement("f_ffree"));
 
-    /**
-     * {@code struct rlimit} layout: two {@code unsigned long} fields.
-     */
-    public static final StructLayout RLIMIT_LAYOUT = MemoryLayout.structLayout(JAVA_LONG.withName("rlim_cur"),
-            JAVA_LONG.withName("rlim_max"));
-
-    private static final VarHandle RLIMIT_CUR = RLIMIT_LAYOUT
-            .varHandle(MemoryLayout.PathElement.groupElement("rlim_cur"));
-    private static final VarHandle RLIMIT_MAX = RLIMIT_LAYOUT
-            .varHandle(MemoryLayout.PathElement.groupElement("rlim_max"));
-
     /** Size of {@code struct rusage} on LP64 Linux (18 longs = 144 bytes). */
     public static final long RUSAGE_SIZE = 144L;
     /** Byte offset of {@code ru_nvcsw} in {@code struct rusage} (16th long). */
@@ -215,17 +204,14 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
     private static final MethodHandle setutxent;
     private static final MethodHandle getutxent;
     private static final MethodHandle endutxent;
-    private static final MethodHandle getpid;
     private static final MethodHandle gettid;
     private static final MethodHandle syscall;
     private static final MethodHandle getloadavg;
     private static final MethodHandle sysinfo;
     private static final MethodHandle statvfs;
-    private static final MethodHandle gethostname;
     private static final MethodHandle getaddrinfo;
     private static final MethodHandle freeaddrinfo;
     private static final MethodHandle gai_strerror;
-    private static final MethodHandle getrlimit;
     private static final MethodHandle getrusage;
 
     private static final boolean HAS_GETTID;
@@ -238,7 +224,6 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
         setutxent = LINKER.downcallHandle(libc.findOrThrow("setutxent"), FunctionDescriptor.ofVoid());
         getutxent = LINKER.downcallHandle(libc.findOrThrow("getutxent"), FunctionDescriptor.of(ADDRESS));
         endutxent = LINKER.downcallHandle(libc.findOrThrow("endutxent"), FunctionDescriptor.ofVoid());
-        getpid = LINKER.downcallHandle(libc.findOrThrow("getpid"), FunctionDescriptor.of(JAVA_INT));
         // syscall(SYS_GETTID) — declare with one fixed arg; no extra args needed for gettid
         syscall = LINKER.downcallHandle(libc.findOrThrow("syscall"), FunctionDescriptor.of(JAVA_LONG, JAVA_LONG),
                 Linker.Option.firstVariadicArg(1));
@@ -246,15 +231,11 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
                 FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT));
         sysinfo = LINKER.downcallHandle(libc.findOrThrow("sysinfo"), FunctionDescriptor.of(JAVA_INT, ADDRESS));
         statvfs = LINKER.downcallHandle(libc.findOrThrow("statvfs"), FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
-        gethostname = LINKER.downcallHandle(libc.findOrThrow("gethostname"),
-                FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_LONG));
         getaddrinfo = LINKER.downcallHandle(libc.findOrThrow("getaddrinfo"),
                 FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
         freeaddrinfo = LINKER.downcallHandle(libc.findOrThrow("freeaddrinfo"), FunctionDescriptor.ofVoid(ADDRESS));
         gai_strerror = LINKER.downcallHandle(libc.findOrThrow("gai_strerror"),
                 FunctionDescriptor.of(ADDRESS, JAVA_INT));
-        getrlimit = LINKER.downcallHandle(libc.findOrThrow("getrlimit"),
-                FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
         getrusage = LINKER.downcallHandle(libc.findOrThrow("getrusage"),
                 FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
 
@@ -361,16 +342,6 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
         int tvSec = (int) UTMPX_TV_SEC.get(ut, 0L);
         int tvUsec = (int) UTMPX_TV_USEC.get(ut, 0L);
         return tvSec * 1000L + tvUsec / 1000L;
-    }
-
-    /**
-     * Calls {@code getpid()}.
-     *
-     * @return the process ID of the calling process
-     * @throws Throwable if the native call fails
-     */
-    public static int getpid() throws Throwable {
-        return (int) getpid.invokeExact();
     }
 
     /**
@@ -496,17 +467,6 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
     }
 
     /**
-     * Calls {@code gethostname(char *name, size_t len)}.
-     *
-     * @param buf segment of at least {@code len} bytes
-     * @param len buffer length
-     * @return 0 on success, -1 on error
-     */
-    public static int gethostname(MemorySegment buf, long len) throws Throwable {
-        return (int) gethostname.invokeExact(buf, len);
-    }
-
-    /**
      * Calls {@code getaddrinfo(node, service, hints, res)}.
      *
      * @param node    hostname segment (null-terminated UTF-8)
@@ -559,17 +519,6 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
     }
 
     /**
-     * Calls {@code getrlimit(int resource, struct rlimit *rlim)}.
-     *
-     * @param resource resource constant (e.g. {@link #RLIMIT_NOFILE})
-     * @param rlim     segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return 0 on success, -1 on error
-     */
-    public static int getrlimit(int resource, MemorySegment rlim) throws Throwable {
-        return (int) getrlimit.invokeExact(resource, rlim);
-    }
-
-    /**
      * Calls {@code getrusage(who, rusage)}.
      *
      * @param who    RUSAGE_SELF (0)
@@ -581,23 +530,4 @@ public final class LinuxLibcFunctions extends ForeignFunctions {
         return (int) getrusage.invokeExact(who, rusage);
     }
 
-    /**
-     * Reads {@code rlim_cur} from a rlimit segment.
-     *
-     * @param rlim segment populated by {@link #getrlimit(int, MemorySegment)}
-     * @return the soft resource limit
-     */
-    public static long rlimitCur(MemorySegment rlim) {
-        return (long) RLIMIT_CUR.get(rlim, 0L);
-    }
-
-    /**
-     * Reads {@code rlim_max} from a rlimit segment.
-     *
-     * @param rlim segment populated by {@link #getrlimit(int, MemorySegment)}
-     * @return the hard resource limit
-     */
-    public static long rlimitMax(MemorySegment rlim) {
-        return (long) RLIMIT_MAX.get(rlim, 0L);
-    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/linux/LinuxLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/linux/LinuxLibcFunctions.java
@@ -16,7 +16,6 @@ import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
-import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 import java.util.Locale;
@@ -29,8 +28,9 @@ import oshi.ffm.platform.unix.PosixLibcFunctions;
 /**
  * FFM bindings for Linux libc functions used by OSHI.
  * <p>
- * Covers: {@code getpid}, {@code gettid}, {@code syscall}, {@code getloadavg}, {@code sysinfo}, {@code statvfs},
- * {@code gethostname}, {@code getaddrinfo}/{@code freeaddrinfo}/{@code gai_strerror}, and {@code getrlimit}.
+ * Covers: {@code gettid}, {@code syscall}, {@code getloadavg}, {@code sysinfo}, {@code statvfs}, the
+ * {@code getaddrinfo}/{@code freeaddrinfo}/{@code gai_strerror} surface, and {@code getrusage}. The POSIX bindings
+ * ({@code getpid}, {@code getrlimit}, {@code gethostname}) are inherited from {@link PosixLibcFunctions}.
  */
 public final class LinuxLibcFunctions extends PosixLibcFunctions {
 
@@ -217,32 +217,28 @@ public final class LinuxLibcFunctions extends PosixLibcFunctions {
     private static final boolean HAS_GETTID;
 
     static {
-        // libc is always linked into the JVM process; use the linker's default lookup
-        // rather than libraryLookup("c") which fails on Linux (libc.so vs libc.so.6).
-        SymbolLookup libc = LINKER.defaultLookup();
-
-        setutxent = LINKER.downcallHandle(libc.findOrThrow("setutxent"), FunctionDescriptor.ofVoid());
-        getutxent = LINKER.downcallHandle(libc.findOrThrow("getutxent"), FunctionDescriptor.of(ADDRESS));
-        endutxent = LINKER.downcallHandle(libc.findOrThrow("endutxent"), FunctionDescriptor.ofVoid());
+        setutxent = LINKER.downcallHandle(LIBC.findOrThrow("setutxent"), FunctionDescriptor.ofVoid());
+        getutxent = LINKER.downcallHandle(LIBC.findOrThrow("getutxent"), FunctionDescriptor.of(ADDRESS));
+        endutxent = LINKER.downcallHandle(LIBC.findOrThrow("endutxent"), FunctionDescriptor.ofVoid());
         // syscall(SYS_GETTID) — declare with one fixed arg; no extra args needed for gettid
-        syscall = LINKER.downcallHandle(libc.findOrThrow("syscall"), FunctionDescriptor.of(JAVA_LONG, JAVA_LONG),
+        syscall = LINKER.downcallHandle(LIBC.findOrThrow("syscall"), FunctionDescriptor.of(JAVA_LONG, JAVA_LONG),
                 Linker.Option.firstVariadicArg(1));
-        getloadavg = LINKER.downcallHandle(libc.findOrThrow("getloadavg"),
+        getloadavg = LINKER.downcallHandle(LIBC.findOrThrow("getloadavg"),
                 FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT));
-        sysinfo = LINKER.downcallHandle(libc.findOrThrow("sysinfo"), FunctionDescriptor.of(JAVA_INT, ADDRESS));
-        statvfs = LINKER.downcallHandle(libc.findOrThrow("statvfs"), FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
-        getaddrinfo = LINKER.downcallHandle(libc.findOrThrow("getaddrinfo"),
+        sysinfo = LINKER.downcallHandle(LIBC.findOrThrow("sysinfo"), FunctionDescriptor.of(JAVA_INT, ADDRESS));
+        statvfs = LINKER.downcallHandle(LIBC.findOrThrow("statvfs"), FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS));
+        getaddrinfo = LINKER.downcallHandle(LIBC.findOrThrow("getaddrinfo"),
                 FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
-        freeaddrinfo = LINKER.downcallHandle(libc.findOrThrow("freeaddrinfo"), FunctionDescriptor.ofVoid(ADDRESS));
-        gai_strerror = LINKER.downcallHandle(libc.findOrThrow("gai_strerror"),
+        freeaddrinfo = LINKER.downcallHandle(LIBC.findOrThrow("freeaddrinfo"), FunctionDescriptor.ofVoid(ADDRESS));
+        gai_strerror = LINKER.downcallHandle(LIBC.findOrThrow("gai_strerror"),
                 FunctionDescriptor.of(ADDRESS, JAVA_INT));
-        getrusage = LINKER.downcallHandle(libc.findOrThrow("getrusage"),
+        getrusage = LINKER.downcallHandle(LIBC.findOrThrow("getrusage"),
                 FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
 
         MethodHandle hGettid = null;
         boolean hasGettid = false;
         try {
-            hGettid = LINKER.downcallHandle(libc.findOrThrow("gettid"), FunctionDescriptor.of(JAVA_INT));
+            hGettid = LINKER.downcallHandle(LIBC.findOrThrow("gettid"), FunctionDescriptor.of(JAVA_INT));
             hasGettid = true;
         } catch (Throwable e) {
             LOG.debug("gettid not found in libc, will use syscall fallback. {}", e.toString());

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/PosixLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/PosixLibcFunctions.java
@@ -44,9 +44,12 @@ public abstract class PosixLibcFunctions extends ForeignFunctions {
     protected PosixLibcFunctions() {
     }
 
-    // libc is already loaded into the JVM process, so defaultLookup() finds it without the libc.so versioning
-    // pitfalls that SymbolLookup.libraryLookup("c") hits on some platforms.
-    private static final SymbolLookup LIBC = LINKER.defaultLookup();
+    /**
+     * The libc symbol lookup, shared with the per-platform subclasses. libc is already loaded into the JVM process, so
+     * {@code defaultLookup()} finds it without the {@code libc.so} versioning pitfalls that
+     * {@code SymbolLookup.libraryLookup("c")} hits on some platforms.
+     */
+    protected static final SymbolLookup LIBC = LINKER.defaultLookup();
 
     /** Layout of {@code struct rlimit}: two {@code rlim_t} (LP64 long) fields. */
     public static final StructLayout RLIMIT_LAYOUT = MemoryLayout.structLayout(JAVA_LONG.withName("rlim_cur"),

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/PosixLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/PosixLibcFunctions.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.platform.unix;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+
+import oshi.ffm.ForeignFunctions;
+
+/**
+ * FFM bindings for the libc functions POSIX requires every UNIX to provide, shared by the per-platform
+ * {@code *LibcFunctions} classes.
+ * <p>
+ * <strong>Membership rule: POSIX-mandated functions only.</strong> These handles are resolved with {@code findOrThrow}
+ * in a static initializer, so a symbol missing on any one platform would raise {@code ExceptionInInitializerError}
+ * there and take every other member of this class down with it. Being POSIX-mandated is what guarantees the symbol
+ * exists everywhere, so it is the criterion for belonging here rather than a stylistic preference.
+ * <p>
+ * {@code getloadavg} is the cautionary example: it looks like a peer of these, and four of the six platforms bind it,
+ * but it is a BSD extension rather than POSIX and AIX does not have it (AIX reads load average from
+ * {@code perfstat_cpu_total} instead). It therefore stays in the per-platform classes.
+ * <p>
+ * Values that POSIX names but does not fix stay per-platform too: {@code RLIMIT_NOFILE} is 7 on Linux and AIX, 8 on the
+ * BSDs, and 5 on Solaris/illumos, so each subclass declares its own.
+ */
+public abstract class PosixLibcFunctions extends ForeignFunctions {
+
+    /**
+     * Constructs a new {@code PosixLibcFunctions}. Subclasses are utility holders and are never instantiated; this
+     * exists only so they can inherit the members below.
+     */
+    protected PosixLibcFunctions() {
+    }
+
+    // libc is already loaded into the JVM process, so defaultLookup() finds it without the libc.so versioning
+    // pitfalls that SymbolLookup.libraryLookup("c") hits on some platforms.
+    private static final SymbolLookup LIBC = LINKER.defaultLookup();
+
+    /** Layout of {@code struct rlimit}: two {@code rlim_t} (LP64 long) fields. */
+    public static final StructLayout RLIMIT_LAYOUT = MemoryLayout.structLayout(JAVA_LONG.withName("rlim_cur"),
+            JAVA_LONG.withName("rlim_max"));
+
+    private static final VarHandle RLIMIT_CUR = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_cur"));
+    private static final VarHandle RLIMIT_MAX = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_max"));
+
+    // pid_t getpid(void);
+    private static final MethodHandle getpid = LINKER.downcallHandle(LIBC.findOrThrow("getpid"),
+            FunctionDescriptor.of(JAVA_INT));
+
+    /**
+     * Calls {@code getpid()}.
+     *
+     * @return the process ID of the calling process
+     * @throws Throwable on FFM invocation error
+     */
+    public static int getpid() throws Throwable {
+        return (int) getpid.invokeExact();
+    }
+
+    // int getrlimit(int resource, struct rlimit *rlim);
+    private static final MethodHandle getrlimit = LINKER.downcallHandle(LIBC.findOrThrow("getrlimit"),
+            FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
+
+    /**
+     * Calls {@code getrlimit(resource, rlim)}.
+     *
+     * @param resource resource constant; use the calling class's {@code RLIMIT_NOFILE}, whose value is
+     *                 platform-specific
+     * @param rlim     segment allocated with {@link #RLIMIT_LAYOUT}
+     * @return 0 on success, -1 on error
+     * @throws Throwable on FFM invocation error
+     */
+    public static int getrlimit(int resource, MemorySegment rlim) throws Throwable {
+        return (int) getrlimit.invokeExact(resource, rlim);
+    }
+
+    /**
+     * Reads {@code rlim_cur} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
+     *
+     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
+     * @return the soft resource limit
+     */
+    public static long rlimitCur(MemorySegment rlim) {
+        return (long) RLIMIT_CUR.get(rlim, 0L);
+    }
+
+    /**
+     * Reads {@code rlim_max} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
+     *
+     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
+     * @return the hard resource limit
+     */
+    public static long rlimitMax(MemorySegment rlim) {
+        return (long) RLIMIT_MAX.get(rlim, 0L);
+    }
+
+    // int gethostname(char *name, size_t namelen);
+    private static final MethodHandle gethostname = LINKER.downcallHandle(LIBC.findOrThrow("gethostname"),
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_LONG));
+
+    /**
+     * Calls {@code gethostname(name, namelen)}.
+     *
+     * @param name    buffer to receive the host name
+     * @param namelen size of the buffer in bytes
+     * @return 0 on success, -1 on error
+     * @throws Throwable on FFM invocation error
+     */
+    public static int gethostname(MemorySegment name, long namelen) throws Throwable {
+        return (int) gethostname.invokeExact(name, namelen);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/aix/AixLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/aix/AixLibcFunctions.java
@@ -9,16 +9,12 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
 import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.StructLayout;
 import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.VarHandle;
 
-import oshi.ffm.ForeignFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 
 /**
  * FFM bindings for AIX libc functions used by OSHI.
@@ -26,7 +22,7 @@ import oshi.ffm.ForeignFunctions;
  * Most performance and configuration data on AIX comes from {@code libperfstat} (see {@link PerfstatFunctions}); the
  * libc surface here is limited to thread/process IDs, hostname, and {@code getrlimit}.
  */
-public final class AixLibcFunctions extends ForeignFunctions {
+public final class AixLibcFunctions extends PosixLibcFunctions {
 
     private AixLibcFunctions() {
     }
@@ -37,29 +33,8 @@ public final class AixLibcFunctions extends ForeignFunctions {
     /** {@code getrlimit} resource: maximum number of open file descriptors. AIX value (7). */
     public static final int RLIMIT_NOFILE = 7;
 
-    /** Layout of AIX {@code struct rlimit}: two {@code rlim_t} (LP64 long) fields. */
-    public static final StructLayout RLIMIT_LAYOUT = MemoryLayout.structLayout(JAVA_LONG.withName("rlim_cur"),
-            JAVA_LONG.withName("rlim_max"));
-
-    private static final VarHandle RLIMIT_CUR = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_cur"));
-    private static final VarHandle RLIMIT_MAX = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_max"));
-
     // libc is already loaded into the JVM process; defaultLookup() avoids versioning pitfalls.
     private static final SymbolLookup LIBC = LINKER.defaultLookup();
-
-    // pid_t getpid(void);
-    private static final MethodHandle getpid = LINKER.downcallHandle(LIBC.findOrThrow("getpid"),
-            FunctionDescriptor.of(JAVA_INT));
-
-    /**
-     * Calls {@code getpid()}.
-     *
-     * @return the process ID of the calling process
-     * @throws Throwable on FFM invocation error
-     */
-    public static int getpid() throws Throwable {
-        return (int) getpid.invokeExact();
-    }
 
     // tid_t thread_self(void); // AIX-specific
     private static final MethodHandle thread_self = LINKER.downcallHandle(LIBC.findOrThrow("thread_self"),
@@ -73,42 +48,6 @@ public final class AixLibcFunctions extends ForeignFunctions {
      */
     public static int thread_self() throws Throwable {
         return (int) thread_self.invokeExact();
-    }
-
-    // int getrlimit(int resource, struct rlimit *rlim);
-    private static final MethodHandle getrlimit = LINKER.downcallHandle(LIBC.findOrThrow("getrlimit"),
-            FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
-
-    /**
-     * Calls {@code getrlimit(resource, rlim)}.
-     *
-     * @param resource resource constant (e.g. {@link #RLIMIT_NOFILE})
-     * @param rlim     segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return 0 on success, -1 on error
-     * @throws Throwable on FFM invocation error
-     */
-    public static int getrlimit(int resource, MemorySegment rlim) throws Throwable {
-        return (int) getrlimit.invokeExact(resource, rlim);
-    }
-
-    /**
-     * Reads {@code rlim_cur} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
-     *
-     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return the soft resource limit
-     */
-    public static long rlimitCur(MemorySegment rlim) {
-        return (long) RLIMIT_CUR.get(rlim, 0L);
-    }
-
-    /**
-     * Reads {@code rlim_max} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
-     *
-     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return the hard resource limit
-     */
-    public static long rlimitMax(MemorySegment rlim) {
-        return (long) RLIMIT_MAX.get(rlim, 0L);
     }
 
     // int open(const char *path, int flags);
@@ -160,19 +99,4 @@ public final class AixLibcFunctions extends ForeignFunctions {
         return (long) pread.invokeExact(fd, buf, count, offset);
     }
 
-    // int gethostname(char *name, size_t namelen);
-    private static final MethodHandle gethostname = LINKER.downcallHandle(LIBC.findOrThrow("gethostname"),
-            FunctionDescriptor.of(JAVA_INT, ADDRESS, SIZE_T));
-
-    /**
-     * Calls {@code gethostname(name, namelen)}.
-     *
-     * @param name    buffer for the hostname (allocated by caller)
-     * @param namelen size of {@code name} in bytes
-     * @return 0 on success, -1 on error
-     * @throws Throwable on FFM invocation error
-     */
-    public static int gethostname(MemorySegment name, long namelen) throws Throwable {
-        return (int) gethostname.invokeExact(name, namelen);
-    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/aix/AixLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/aix/AixLibcFunctions.java
@@ -10,7 +10,6 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
@@ -20,7 +19,9 @@ import oshi.ffm.platform.unix.PosixLibcFunctions;
  * FFM bindings for AIX libc functions used by OSHI.
  * <p>
  * Most performance and configuration data on AIX comes from {@code libperfstat} (see {@link PerfstatFunctions}); the
- * libc surface here is limited to thread/process IDs, hostname, and {@code getrlimit}.
+ * libc surface here is limited to {@code thread_self} and the {@code open}/{@code close}/{@code pread} trio used to
+ * read {@code /proc}. The POSIX bindings ({@code getpid}, {@code getrlimit}, {@code gethostname}) are inherited from
+ * {@link PosixLibcFunctions}.
  */
 public final class AixLibcFunctions extends PosixLibcFunctions {
 
@@ -32,9 +33,6 @@ public final class AixLibcFunctions extends PosixLibcFunctions {
 
     /** {@code getrlimit} resource: maximum number of open file descriptors. AIX value (7). */
     public static final int RLIMIT_NOFILE = 7;
-
-    // libc is already loaded into the JVM process; defaultLookup() avoids versioning pitfalls.
-    private static final SymbolLookup LIBC = LINKER.defaultLookup();
 
     // tid_t thread_self(void); // AIX-specific
     private static final MethodHandle thread_self = LINKER.downcallHandle(LIBC.findOrThrow("thread_self"),

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/freebsd/FreeBsdLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/freebsd/FreeBsdLibcFunctions.java
@@ -20,7 +20,7 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 
-import oshi.ffm.ForeignFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 
 /**
  * FFM bindings for FreeBSD libc functions used by OSHI.
@@ -30,7 +30,7 @@ import oshi.ffm.ForeignFunctions;
  * Additional libc bindings ({@code sysctl} with int MIB, {@code getpid}, {@code thr_self}, {@code getrlimit}) are added
  * in later phases alongside their first FFM consumer.
  */
-public final class FreeBsdLibcFunctions extends ForeignFunctions {
+public final class FreeBsdLibcFunctions extends PosixLibcFunctions {
 
     private FreeBsdLibcFunctions() {
     }
@@ -40,15 +40,6 @@ public final class FreeBsdLibcFunctions extends ForeignFunctions {
 
     /** {@code getrlimit} resource: maximum number of open file descriptors. FreeBSD-specific value (8). */
     public static final int RLIMIT_NOFILE = 8;
-
-    /**
-     * Layout of FreeBSD's {@code struct rlimit}: two {@code rlim_t} (LP64 long) fields.
-     */
-    public static final StructLayout RLIMIT_LAYOUT = MemoryLayout.structLayout(JAVA_LONG.withName("rlim_cur"),
-            JAVA_LONG.withName("rlim_max"));
-
-    private static final VarHandle RLIMIT_CUR = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_cur"));
-    private static final VarHandle RLIMIT_MAX = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_max"));
 
     /** {@code getaddrinfo} hint flag: return the canonical name in {@code ai_canonname}. */
     public static final int AI_CANONNAME = 2;
@@ -252,22 +243,6 @@ public final class FreeBsdLibcFunctions extends ForeignFunctions {
         return tvSec * 1000L + tvUsec / 1000L;
     }
 
-    // int gethostname(char *name, size_t namelen);
-    private static final MethodHandle gethostname = LINKER.downcallHandle(LIBC.findOrThrow("gethostname"),
-            FunctionDescriptor.of(JAVA_INT, ADDRESS, SIZE_T));
-
-    /**
-     * Calls {@code gethostname(name, namelen)}.
-     *
-     * @param buf segment of at least {@code len} bytes
-     * @param len buffer length
-     * @return 0 on success, -1 on error
-     * @throws Throwable on FFM invocation error
-     */
-    public static int gethostname(MemorySegment buf, long len) throws Throwable {
-        return (int) gethostname.invokeExact(buf, len);
-    }
-
     // int getaddrinfo(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res);
     private static final MethodHandle getaddrinfo = LINKER.downcallHandle(LIBC.findOrThrow("getaddrinfo"),
             FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
@@ -335,20 +310,6 @@ public final class FreeBsdLibcFunctions extends ForeignFunctions {
         return getStringFromNativePointer(canonPtr, arena);
     }
 
-    // pid_t getpid(void);
-    private static final MethodHandle getpid = LINKER.downcallHandle(LIBC.findOrThrow("getpid"),
-            FunctionDescriptor.of(JAVA_INT));
-
-    /**
-     * Calls {@code getpid()}.
-     *
-     * @return the process ID of the calling process
-     * @throws Throwable on FFM invocation error
-     */
-    public static int getpid() throws Throwable {
-        return (int) getpid.invokeExact();
-    }
-
     // int thr_self(long *id);
     private static final MethodHandle thr_self = LINKER.downcallHandle(LIBC.findOrThrow("thr_self"),
             FunctionDescriptor.of(JAVA_INT, ADDRESS));
@@ -387,39 +348,4 @@ public final class FreeBsdLibcFunctions extends ForeignFunctions {
         return (int) sysctl.invokeExact(callState, name, namelen, oldp, oldlenp, newp, newlen);
     }
 
-    // int getrlimit(int resource, struct rlimit *rlim);
-    private static final MethodHandle getrlimit = LINKER.downcallHandle(LIBC.findOrThrow("getrlimit"),
-            FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
-
-    /**
-     * Calls {@code getrlimit(resource, rlim)}.
-     *
-     * @param resource resource constant (e.g. {@link #RLIMIT_NOFILE})
-     * @param rlim     segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return 0 on success, -1 on error
-     * @throws Throwable on FFM invocation error
-     */
-    public static int getrlimit(int resource, MemorySegment rlim) throws Throwable {
-        return (int) getrlimit.invokeExact(resource, rlim);
-    }
-
-    /**
-     * Reads {@code rlim_cur} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
-     *
-     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return the soft resource limit
-     */
-    public static long rlimitCur(MemorySegment rlim) {
-        return (long) RLIMIT_CUR.get(rlim, 0L);
-    }
-
-    /**
-     * Reads {@code rlim_max} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
-     *
-     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return the hard resource limit
-     */
-    public static long rlimitMax(MemorySegment rlim) {
-        return (long) RLIMIT_MAX.get(rlim, 0L);
-    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/freebsd/FreeBsdLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/freebsd/FreeBsdLibcFunctions.java
@@ -15,7 +15,6 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
-import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
@@ -25,10 +24,10 @@ import oshi.ffm.platform.unix.PosixLibcFunctions;
 /**
  * FFM bindings for FreeBSD libc functions used by OSHI.
  * <p>
- * Covers {@code sysctlbyname}, {@code getloadavg}, the {@code utmpx} family, and the
- * {@code gethostname}/{@code getaddrinfo}/{@code freeaddrinfo}/{@code gai_strerror} surface used by network params.
- * Additional libc bindings ({@code sysctl} with int MIB, {@code getpid}, {@code thr_self}, {@code getrlimit}) are added
- * in later phases alongside their first FFM consumer.
+ * Covers {@code sysctl} with an int MIB, {@code sysctlbyname}, {@code getloadavg}, {@code thr_self}, the {@code utmpx}
+ * family, and the {@code getaddrinfo}/{@code freeaddrinfo}/{@code gai_strerror} surface used by network params. The
+ * POSIX bindings ({@code getpid}, {@code getrlimit}, {@code gethostname}) are inherited from
+ * {@link PosixLibcFunctions}.
  */
 public final class FreeBsdLibcFunctions extends PosixLibcFunctions {
 
@@ -116,10 +115,6 @@ public final class FreeBsdLibcFunctions extends PosixLibcFunctions {
     private static final long UTMPX_USER_OFFSET = UTMPX_LAYOUT.byteOffset(PathElement.groupElement("ut_user"));
     private static final long UTMPX_LINE_OFFSET = UTMPX_LAYOUT.byteOffset(PathElement.groupElement("ut_line"));
     private static final long UTMPX_HOST_OFFSET = UTMPX_LAYOUT.byteOffset(PathElement.groupElement("ut_host"));
-
-    // libc is already loaded into the JVM process; defaultLookup() avoids the libc.so vs libc.so.7 versioning pitfall
-    // that breaks SymbolLookup.libraryLookup("c") on FreeBSD.
-    private static final SymbolLookup LIBC = LINKER.defaultLookup();
 
     // int sysctlbyname(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
     private static final MethodHandle sysctlbyname = LINKER.downcallHandle(LIBC.findOrThrow("sysctlbyname"),

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/openbsd/OpenBsdLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/openbsd/OpenBsdLibcFunctions.java
@@ -13,7 +13,6 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
-import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
@@ -23,8 +22,9 @@ import oshi.ffm.platform.unix.PosixLibcFunctions;
 /**
  * FFM bindings for OpenBSD libc functions used by OSHI.
  * <p>
- * OpenBSD uses {@code sysctl(int *name, u_int namelen, ...)} exclusively (no {@code sysctlbyname}). Additional bindings
- * ({@code getthrid}, {@code getrlimit}) support process and resource limit queries.
+ * OpenBSD uses {@code sysctl(int *name, u_int namelen, ...)} exclusively (no {@code sysctlbyname}). Beyond that it
+ * binds only {@code getthrid} and {@code getloadavg}; the POSIX bindings ({@code getpid}, {@code getrlimit},
+ * {@code gethostname}) are inherited from {@link PosixLibcFunctions}.
  */
 public final class OpenBsdLibcFunctions extends PosixLibcFunctions {
 
@@ -36,9 +36,6 @@ public final class OpenBsdLibcFunctions extends PosixLibcFunctions {
 
     /** {@code getrlimit} resource: maximum number of open file descriptors. OpenBSD value (8). */
     public static final int RLIMIT_NOFILE = 8;
-
-    // libc is already loaded into the JVM process; defaultLookup() avoids versioning pitfalls.
-    private static final SymbolLookup LIBC = LINKER.defaultLookup();
 
     // int sysctl(int *name, u_int namelen, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
     private static final MethodHandle sysctl = LINKER.downcallHandle(LIBC.findOrThrow("sysctl"),

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/openbsd/OpenBsdLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/openbsd/OpenBsdLibcFunctions.java
@@ -18,7 +18,7 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 
-import oshi.ffm.ForeignFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 
 /**
  * FFM bindings for OpenBSD libc functions used by OSHI.
@@ -26,7 +26,7 @@ import oshi.ffm.ForeignFunctions;
  * OpenBSD uses {@code sysctl(int *name, u_int namelen, ...)} exclusively (no {@code sysctlbyname}). Additional bindings
  * ({@code getthrid}, {@code getrlimit}) support process and resource limit queries.
  */
-public final class OpenBsdLibcFunctions extends ForeignFunctions {
+public final class OpenBsdLibcFunctions extends PosixLibcFunctions {
 
     private OpenBsdLibcFunctions() {
     }
@@ -36,15 +36,6 @@ public final class OpenBsdLibcFunctions extends ForeignFunctions {
 
     /** {@code getrlimit} resource: maximum number of open file descriptors. OpenBSD value (8). */
     public static final int RLIMIT_NOFILE = 8;
-
-    /**
-     * Layout of OpenBSD's {@code struct rlimit}: two {@code rlim_t} (LP64 long) fields.
-     */
-    public static final StructLayout RLIMIT_LAYOUT = MemoryLayout.structLayout(JAVA_LONG.withName("rlim_cur"),
-            JAVA_LONG.withName("rlim_max"));
-
-    private static final VarHandle RLIMIT_CUR = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_cur"));
-    private static final VarHandle RLIMIT_MAX = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_max"));
 
     // libc is already loaded into the JVM process; defaultLookup() avoids versioning pitfalls.
     private static final SymbolLookup LIBC = LINKER.defaultLookup();
@@ -83,56 +74,6 @@ public final class OpenBsdLibcFunctions extends ForeignFunctions {
      */
     public static int getthrid() throws Throwable {
         return (int) getthrid.invokeExact();
-    }
-
-    // pid_t getpid(void);
-    private static final MethodHandle getpid = LINKER.downcallHandle(LIBC.findOrThrow("getpid"),
-            FunctionDescriptor.of(JAVA_INT));
-
-    /**
-     * Calls {@code getpid()}.
-     *
-     * @return the process ID of the calling process
-     * @throws Throwable on FFM invocation error
-     */
-    public static int getpid() throws Throwable {
-        return (int) getpid.invokeExact();
-    }
-
-    // int getrlimit(int resource, struct rlimit *rlim);
-    private static final MethodHandle getrlimit = LINKER.downcallHandle(LIBC.findOrThrow("getrlimit"),
-            FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
-
-    /**
-     * Calls {@code getrlimit(resource, rlim)}.
-     *
-     * @param resource resource constant (e.g. {@link #RLIMIT_NOFILE})
-     * @param rlim     segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return 0 on success, -1 on error
-     * @throws Throwable on FFM invocation error
-     */
-    public static int getrlimit(int resource, MemorySegment rlim) throws Throwable {
-        return (int) getrlimit.invokeExact(resource, rlim);
-    }
-
-    /**
-     * Reads {@code rlim_cur} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
-     *
-     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return the soft resource limit
-     */
-    public static long rlimitCur(MemorySegment rlim) {
-        return (long) RLIMIT_CUR.get(rlim, 0L);
-    }
-
-    /**
-     * Reads {@code rlim_max} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
-     *
-     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return the hard resource limit
-     */
-    public static long rlimitMax(MemorySegment rlim) {
-        return (long) RLIMIT_MAX.get(rlim, 0L);
     }
 
     // --- Sysctl MIB constants ---

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/solaris/SolarisLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/solaris/SolarisLibcFunctions.java
@@ -20,7 +20,7 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 
-import oshi.ffm.ForeignFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 
 /**
  * FFM bindings for Solaris/illumos libc functions used by OSHI.
@@ -29,7 +29,7 @@ import oshi.ffm.ForeignFunctions;
  * and {@code getrlimit}. The {@code RLIMIT_NOFILE} resource constant is {@code 5} on Solaris/illumos (not {@code 7} as
  * on Linux — see <a href="https://illumos.org/man/2/getrlimit">illumos getrlimit(2)</a>).
  */
-public final class SolarisLibcFunctions extends ForeignFunctions {
+public final class SolarisLibcFunctions extends PosixLibcFunctions {
 
     private SolarisLibcFunctions() {
     }
@@ -45,29 +45,8 @@ public final class SolarisLibcFunctions extends ForeignFunctions {
      */
     public static final int RLIMIT_NOFILE = 5;
 
-    /** Layout of Solaris/illumos {@code struct rlimit}: two {@code rlim_t} (LP64 long) fields. */
-    public static final StructLayout RLIMIT_LAYOUT = MemoryLayout.structLayout(JAVA_LONG.withName("rlim_cur"),
-            JAVA_LONG.withName("rlim_max"));
-
-    private static final VarHandle RLIMIT_CUR = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_cur"));
-    private static final VarHandle RLIMIT_MAX = RLIMIT_LAYOUT.varHandle(PathElement.groupElement("rlim_max"));
-
     // libc is already loaded into the JVM process; defaultLookup() avoids versioning pitfalls.
     private static final SymbolLookup LIBC = LINKER.defaultLookup();
-
-    // pid_t getpid(void);
-    private static final MethodHandle getpid = LINKER.downcallHandle(LIBC.findOrThrow("getpid"),
-            FunctionDescriptor.of(JAVA_INT));
-
-    /**
-     * Calls {@code getpid()}.
-     *
-     * @return the process ID of the calling process
-     * @throws Throwable on FFM invocation error
-     */
-    public static int getpid() throws Throwable {
-        return (int) getpid.invokeExact();
-    }
 
     // thread_t thr_self(void); // Solaris-specific
     private static final MethodHandle thr_self = LINKER.downcallHandle(LIBC.findOrThrow("thr_self"),
@@ -81,58 +60,6 @@ public final class SolarisLibcFunctions extends ForeignFunctions {
      */
     public static int thr_self() throws Throwable {
         return (int) thr_self.invokeExact();
-    }
-
-    // int getrlimit(int resource, struct rlimit *rlim);
-    private static final MethodHandle getrlimit = LINKER.downcallHandle(LIBC.findOrThrow("getrlimit"),
-            FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS));
-
-    /**
-     * Calls {@code getrlimit(resource, rlim)}.
-     *
-     * @param resource resource constant (e.g. {@link #RLIMIT_NOFILE})
-     * @param rlim     segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return 0 on success, -1 on error
-     * @throws Throwable on FFM invocation error
-     */
-    public static int getrlimit(int resource, MemorySegment rlim) throws Throwable {
-        return (int) getrlimit.invokeExact(resource, rlim);
-    }
-
-    /**
-     * Reads {@code rlim_cur} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
-     *
-     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return the soft resource limit
-     */
-    public static long rlimitCur(MemorySegment rlim) {
-        return (long) RLIMIT_CUR.get(rlim, 0L);
-    }
-
-    /**
-     * Reads {@code rlim_max} from an rlimit segment populated by {@link #getrlimit(int, MemorySegment)}.
-     *
-     * @param rlim segment allocated with {@link #RLIMIT_LAYOUT}
-     * @return the hard resource limit
-     */
-    public static long rlimitMax(MemorySegment rlim) {
-        return (long) RLIMIT_MAX.get(rlim, 0L);
-    }
-
-    // int gethostname(char *name, size_t namelen);
-    private static final MethodHandle gethostname = LINKER.downcallHandle(LIBC.findOrThrow("gethostname"),
-            FunctionDescriptor.of(JAVA_INT, ADDRESS, SIZE_T));
-
-    /**
-     * Calls {@code gethostname(name, namelen)}.
-     *
-     * @param name    buffer for the hostname (allocated by caller)
-     * @param namelen size of {@code name} in bytes
-     * @return 0 on success, -1 on error
-     * @throws Throwable on FFM invocation error
-     */
-    public static int gethostname(MemorySegment name, long namelen) throws Throwable {
-        return (int) gethostname.invokeExact(name, namelen);
     }
 
     // int getloadavg(double loadavg[], int nelem);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/solaris/SolarisLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/solaris/SolarisLibcFunctions.java
@@ -15,7 +15,6 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
-import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
@@ -25,9 +24,11 @@ import oshi.ffm.platform.unix.PosixLibcFunctions;
 /**
  * FFM bindings for Solaris/illumos libc functions used by OSHI.
  * <p>
- * Solaris uses kstat as its primary kernel-statistics interface, so the libc surface here is small: thread/process IDs
- * and {@code getrlimit}. The {@code RLIMIT_NOFILE} resource constant is {@code 5} on Solaris/illumos (not {@code 7} as
- * on Linux — see <a href="https://illumos.org/man/2/getrlimit">illumos getrlimit(2)</a>).
+ * Solaris uses kstat as its primary kernel-statistics interface, so the libc surface here is small: {@code thr_self},
+ * {@code getloadavg} and the {@code utmpx} family. The POSIX bindings ({@code getpid}, {@code getrlimit},
+ * {@code gethostname}) are inherited from {@link PosixLibcFunctions}. The {@code RLIMIT_NOFILE} resource constant is
+ * {@code 5} on Solaris/illumos (not {@code 7} as on Linux — see <a href="https://illumos.org/man/2/getrlimit">illumos
+ * getrlimit(2)</a>), so it stays declared here.
  */
 public final class SolarisLibcFunctions extends PosixLibcFunctions {
 
@@ -44,9 +45,6 @@ public final class SolarisLibcFunctions extends PosixLibcFunctions {
      * value.
      */
     public static final int RLIMIT_NOFILE = 5;
-
-    // libc is already loaded into the JVM process; defaultLookup() avoids versioning pitfalls.
-    private static final SymbolLookup LIBC = LINKER.defaultLookup();
 
     // thread_t thr_self(void); // Solaris-specific
     private static final MethodHandle thr_self = LINKER.downcallHandle(LIBC.findOrThrow("thr_self"),


### PR DESCRIPTION
Five of the six `*LibcFunctions` classes carried **byte-identical** bindings for `getpid`, `getrlimit` with its struct layout and both accessors, and `gethostname`. Verified identical rather than merely similarly named — the AIX and Solaris blocks diff clean against each other, and OpenBSD differs only by not binding `gethostname`.

They now live in `PosixLibcFunctions`, which the five extend. Java statics are inherited by name, so all **22 call sites compile unchanged**. Net −362/+134.

## The name states the membership rule

Handles resolve with `findOrThrow` in a static initializer, so a symbol missing on one platform raises `ExceptionInInitializerError` *there* and takes every other member of the class down with it. Being POSIX-mandated is what guarantees the symbol exists everywhere — that is the criterion for belonging, not a matter of taste, so the class is named for it.

## `getloadavg` is the counterexample, and it stays put

It looks like a peer of these and four of the six platforms bind it, but it is a **BSD extension, not POSIX, and AIX does not have it** — AIX reads load average from `perfstat_cpu_total`:

```java
long[] loadavg = queryCpuTotal().loadavg;
```

Hoisting it would have broken AIX at class load, on a platform that never asks for load average. Worth noting the comparison tests would *not* have caught that: they check values, and this fails before any value is produced, on a runner only cfarm exercises.

A `BsdLibcFunctions` tier to hold it was considered and rejected — it would hold exactly one member, and the shareable set does not otherwise cluster by family, since AIX and Solaris are identical to the BSDs for everything in the POSIX tier.

## What deliberately stays per-platform

`RLIMIT_NOFILE` — POSIX names it but does not fix its value: **7** on Linux and AIX, **8** on the BSDs, **5** on Solaris/illumos. Each subclass keeps its own, with the existing javadoc recording that JNA's inherited Linux value would query the wrong resource.

DragonFly BSD is untouched. It binds only `lwp_gettid`, so it has nothing to inherit and extending would bind three handles it never calls.

Linux needed one extra step: it assigns its handles in a `static {}` block rather than per-field initializers, so the three assignments came out along with the declarations.

## The JNA side needs no equivalent

jna-platform's `LibCAPI` already declares `gethostname`, `getrlimit` and `getloadavg`, and OSHI's own `CLibrary` declares `getpid`, so the platform interfaces inherit them. The only thing duplicated there is the `RLIMIT_NOFILE` constant, which must be. The asymmetry is structural: **JNA inherits its bindings, FFM hand-writes them** — the same function costs one inherited declaration there and ~12 lines per platform here.

## Verification

Full gate green from clean: install, spotless, checkstyle, forbiddenapis, javadoc, 1509 tests / 0 failed.

Local testing only proves compilation and that nothing else broke — these classes cannot load on macOS. The real check is the FreeBSD, OpenBSD and OpenIndiana JNA==FFM comparison jobs plus cfarm AIX, which is where a wrong descriptor or a missing symbol would surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified common POSIX system operations across supported Unix platforms.
  * Improved consistency for process identification, host-name retrieval, and resource-limit handling.
  * Preserved platform-specific system functionality while reducing differences between Unix environments.
  * Increased reliability and maintainability of system information access across Linux, AIX, FreeBSD, OpenBSD, and Solaris.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->