### PR TITLE
Read the OpenBSD host name natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#3561](https://github.com/oshi/oshi/pull/3561): Fix AIX reporting the current instant as its boot time, and an uptime of zero, when the `uptime` command transiently failed; parse the year-less `who -b` format AIX 7.3 emits, and add `ParseUtil.parseYearlessDateToEpoch` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3562](https://github.com/oshi/oshi/pull/3562): Make Linux `getMaxFreq()` reproducible by resolving it from the cpufreq policy, `lshw`, and the vendor frequency rather than folding in a live frequency reading, returning -1 when none of those reports a maximum - [@dbwiddis](https://github.com/dbwiddis).
 * [#3564](https://github.com/oshi/oshi/pull/3564): Fix Linux `getSoftOpenFileLimit()` returning -1 for a process whose hard open-file limit is `unlimited`, discarding a valid soft limit - [@dbwiddis](https://github.com/dbwiddis).
+* [#3566](https://github.com/oshi/oshi/pull/3566): Read the OpenBSD host name from `gethostname` rather than resolving it, so `getHostName()` no longer reports `localhost` on a host whose name is not resolvable - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24), 7.4.3 (2027-07-31)
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdNetworkParams.java
@@ -9,10 +9,18 @@ import oshi.software.common.AbstractNetworkParams;
 import oshi.util.ExecutingCommand;
 
 /**
- * OpenBsdNetworkParams class.
+ * Abstract base for the OpenBSD NetworkParams. Holds the command-line gateway lookup and the host name fallback; the
+ * JNA and FFM subclasses supply the {@code gethostname} binding.
  */
 @ThreadSafe
-public class OpenBsdNetworkParams extends AbstractNetworkParams {
+public abstract class OpenBsdNetworkParams extends AbstractNetworkParams {
+
+    @Override
+    public String getHostName() {
+        String hn = queryHostName();
+        return hn != null ? hn : super.getHostName();
+    }
+
     @Override
     public String getIpv4DefaultGateway() {
         return searchGateway(ExecutingCommand.runNative("route -n get default"));
@@ -22,4 +30,12 @@ public class OpenBsdNetworkParams extends AbstractNetworkParams {
     public String getIpv6DefaultGateway() {
         return searchGateway(ExecutingCommand.runNative("route -n get default"));
     }
+
+    /**
+     * Reads the host name from libc, avoiding the name resolution that the {@link AbstractNetworkParams} fallback
+     * performs.
+     *
+     * @return the native host name, or {@code null} to fall back to the InetAddress lookup
+     */
+    protected abstract String queryHostName();
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
@@ -57,9 +57,7 @@ public abstract class OpenBsdOperatingSystem extends BsdOperatingSystem {
     }
 
     @Override
-    public NetworkParams getNetworkParams() {
-        return new OpenBsdNetworkParams();
-    }
+    public abstract NetworkParams getNetworkParams();
 
     @Override
     protected List<OSProcess> getProcessListFromPS(int pid) {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/openbsd/OpenBsdLibcFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/openbsd/OpenBsdLibcFunctions.java
@@ -37,6 +37,9 @@ public final class OpenBsdLibcFunctions extends PosixLibcFunctions {
     /** {@code getrlimit} resource: maximum number of open file descriptors. OpenBSD value (8). */
     public static final int RLIMIT_NOFILE = 8;
 
+    /** Maximum host name length, for sizing the {@code gethostname} buffer. */
+    public static final int HOST_NAME_MAX = 255;
+
     // int sysctl(int *name, u_int namelen, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
     private static final MethodHandle sysctl = LINKER.downcallHandle(LIBC.findOrThrow("sysctl"),
             FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, ADDRESS, ADDRESS, SIZE_T), CAPTURE_CALL_STATE);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdNetworkParamsFFM.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.unix.openbsd;
+
+import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
+import static oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions.HOST_NAME_MAX;
+
+import java.lang.foreign.MemorySegment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
+import oshi.software.common.os.unix.openbsd.OpenBsdNetworkParams;
+import oshi.util.LogLevel;
+
+/**
+ * FFM-backed OpenBSD network params. The gateway lookup and the {@code getHostName} fallback live on
+ * {@link OpenBsdNetworkParams}; only the {@code gethostname} binding is FFM-specific.
+ */
+@ThreadSafe
+public class OpenBsdNetworkParamsFFM extends OpenBsdNetworkParams {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenBsdNetworkParamsFFM.class);
+
+    @Override
+    protected String queryHostName() {
+        return callInArenaOrDefault(arena -> {
+            MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
+            if (0 != OpenBsdLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
+                return null;
+            }
+            return buf.getString(0);
+        }, LOG, LogLevel.WARN, "Failed to get hostname", null);
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
@@ -16,6 +16,7 @@ import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.openbsd.OpenBsdOperatingSystem;
 import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.util.LogLevel;
 
@@ -24,6 +25,11 @@ import oshi.util.LogLevel;
  */
 @ThreadSafe
 public class OpenBsdOperatingSystemFFM extends OpenBsdOperatingSystem {
+
+    @Override
+    public NetworkParams getNetworkParams() {
+        return new OpenBsdNetworkParamsFFM();
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenBsdOperatingSystemFFM.class);
 

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdNetworkParamsJNA.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.unix.openbsd;
+
+import static com.sun.jna.platform.unix.LibCAPI.HOST_NAME_MAX;
+
+import com.sun.jna.Native;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.jna.platform.unix.OpenBsdLibc;
+import oshi.software.common.os.unix.openbsd.OpenBsdNetworkParams;
+
+/**
+ * JNA-backed OpenBSD network params. The gateway lookup and the {@code getHostName} fallback live on
+ * {@link OpenBsdNetworkParams}; only the {@code gethostname} binding is JNA-specific.
+ */
+@ThreadSafe
+public class OpenBsdNetworkParamsJNA extends OpenBsdNetworkParams {
+
+    private static final OpenBsdLibc LIBC = OpenBsdLibc.INSTANCE;
+
+    @Override
+    protected String queryHostName() {
+        byte[] hostnameBuffer = new byte[HOST_NAME_MAX + 1];
+        if (0 != LIBC.gethostname(hostnameBuffer, hostnameBuffer.length)) {
+            return null;
+        }
+        return Native.toString(hostnameBuffer);
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemJNA.java
@@ -11,6 +11,7 @@ import oshi.jna.platform.unix.OpenBsdLibc;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.openbsd.OpenBsdOperatingSystem;
 import oshi.software.os.FileSystem;
+import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
 
@@ -19,6 +20,11 @@ import oshi.util.platform.unix.openbsd.OpenBsdSysctlUtil;
  */
 @ThreadSafe
 public class OpenBsdOperatingSystemJNA extends OpenBsdOperatingSystem {
+
+    @Override
+    public NetworkParams getNetworkParams() {
+        return new OpenBsdNetworkParamsJNA();
+    }
 
     @Override
     protected String querySysctl(int[] mib, String def) {


### PR DESCRIPTION
OpenBSD had no `getHostName()` override, so it fell through to `AbstractNetworkParams`, which calls `InetAddress.getLocalHost()`. That **resolves** the name rather than just reading it, so on a host whose hostname is not resolvable — routine in a container, or with no `/etc/hosts` entry — it throws `UnknownHostException`, degrades to `getLoopbackAddress()`, and reports **`localhost`** instead of the real name. It can also block on a DNS timeout. `gethostname(2)` is a plain syscall with neither failure mode.

Every other platform already prefers the native call and keeps the JDK lookup as its fallback:

| Native `gethostname` | JDK `InetAddress` |
|---|---|
| Linux, macOS, AIX, FreeBSD, DragonFly, Solaris, Windows, **OpenBSD (this PR)** | NetBSD |

## Shape

Follows the FreeBSD pattern exactly: `OpenBsdNetworkParams` becomes abstract with a `queryHostName()` hook and the prefer-native-fall-back-to-super override; thin JNA and FFM subclasses supply the binding. `getNetworkParams()` moves from the shared OS base to the two backend subclasses, which is what lets them differ.

The FFM half only became possible with #3565 — OpenBSD never bound `gethostname` itself and now inherits it from `PosixLibcFunctions`.

## What is deliberately not done

**NetBSD stays on the JDK path.** Its OS class is concrete with no FFM subclass, and there is no `NetBsdLibcFunctions` at all, because pkgsrc has no JDK 25 and its FFM backend takes the no-native route on purpose. Giving it a native host name would mean building that whole layer for one function. The JDK path cannot break when JDK 25 does arrive. Tracked on #3348.

**DragonFly needs nothing** — it returns `FreeBsdNetworkParams{JNA,FFM}` and already has the native call.

## On verification

OpenBSD is the best-covered of the three platforms for this change: CI runs it on **JDK 25 with aggregate coverage**, so both backends exercise the new path on the next run. That is a stronger position than DragonFly, whose FFM code is untested on-platform because its runner is JDK 21 — and which already ships this same native call.

Full gate green from clean: install, spotless, checkstyle, forbiddenapis, javadoc, 1509 tests / 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenBSD host names are now retrieved directly from the system, improving accuracy and avoiding name-resolution issues.
  - Added support for retrieving OpenBSD network parameters across both native integration modes.
  - Hostname lookup gracefully falls back when the direct system query is unavailable.

- **Documentation**
  - Added the change to the version 7.4.4 changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->