### PR TITLE
Call the inherited POSIX bindings through their declaring class

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
@@ -12,7 +12,6 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.os.unix.bsd.BsdOperatingSystem;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.os.InternetProtocolStats;
-import oshi.software.os.NetworkParams;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSThread;
 import oshi.util.ExecutingCommand;
@@ -55,9 +54,6 @@ public abstract class OpenBsdOperatingSystem extends BsdOperatingSystem {
     public InternetProtocolStats getInternetProtocolStats() {
         return new OpenBsdInternetProtocolStats();
     }
-
-    @Override
-    public abstract NetworkParams getNetworkParams();
 
     @Override
     protected List<OSProcess> getProcessListFromPS(int pid) {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.ffm.platform.linux.LinuxLibcFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.software.common.os.linux.LinuxNetworkParams;
 
 /**
@@ -31,7 +32,7 @@ final class LinuxNetworkParamsFFM extends LinuxNetworkParams {
     public String getHostName() {
         String hostname = callInArenaOrDefault(arena -> {
             MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
-            if (0 == LinuxLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
+            if (0 == PosixLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
                 return buf.getString(0);
             }
             return null;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.linux.LinuxLibcFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.software.common.os.linux.LinuxOSProcess;
 import oshi.software.common.os.linux.LinuxOperatingSystem;
 
@@ -47,9 +48,9 @@ public class LinuxOSProcessFFM extends LinuxOSProcess {
     @Override
     protected long queryRlimitSoft() {
         long limit = callInArenaLongOrDefault(arena -> {
-            MemorySegment rlim = arena.allocate(LinuxLibcFunctions.RLIMIT_LAYOUT);
-            if (0 == LinuxLibcFunctions.getrlimit(LinuxLibcFunctions.RLIMIT_NOFILE, rlim)) {
-                return LinuxLibcFunctions.rlimitCur(rlim);
+            MemorySegment rlim = arena.allocate(PosixLibcFunctions.RLIMIT_LAYOUT);
+            if (0 == PosixLibcFunctions.getrlimit(LinuxLibcFunctions.RLIMIT_NOFILE, rlim)) {
+                return PosixLibcFunctions.rlimitCur(rlim);
             }
             return -1L;
         }, LOG, WARN, "FFM getrlimit failed", -1L);
@@ -59,9 +60,9 @@ public class LinuxOSProcessFFM extends LinuxOSProcess {
     @Override
     protected long queryRlimitHard() {
         long limit = callInArenaLongOrDefault(arena -> {
-            MemorySegment rlim = arena.allocate(LinuxLibcFunctions.RLIMIT_LAYOUT);
-            if (0 == LinuxLibcFunctions.getrlimit(LinuxLibcFunctions.RLIMIT_NOFILE, rlim)) {
-                return LinuxLibcFunctions.rlimitMax(rlim);
+            MemorySegment rlim = arena.allocate(PosixLibcFunctions.RLIMIT_LAYOUT);
+            if (0 == PosixLibcFunctions.getrlimit(LinuxLibcFunctions.RLIMIT_NOFILE, rlim)) {
+                return PosixLibcFunctions.rlimitMax(rlim);
             }
             return -1L;
         }, LOG, WARN, "FFM getrlimit failed", -1L);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixNetworkParamsFFM.java
@@ -11,7 +11,7 @@ import java.lang.foreign.MemorySegment;
 import java.nio.charset.StandardCharsets;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.ffm.platform.unix.aix.AixLibcFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.software.common.os.unix.aix.AixNetworkParams;
 
 /**
@@ -24,7 +24,7 @@ final class AixNetworkParamsFFM extends AixNetworkParams {
     public String getHostName() {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment buf = arena.allocate(HOST_NAME_BUF_SIZE);
-            if (AixLibcFunctions.gethostname(buf, HOST_NAME_BUF_SIZE) != 0) {
+            if (PosixLibcFunctions.gethostname(buf, HOST_NAME_BUF_SIZE) != 0) {
                 return super.getHostName();
             }
             int len = 0;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOSProcessFFM.java
@@ -20,7 +20,7 @@ import oshi.driver.common.unix.aix.AixPerfstatProcess;
 import oshi.driver.common.unix.aix.AixPsInfo;
 import oshi.driver.unix.aix.PsInfoFFM;
 import oshi.driver.unix.aix.perfstat.PerfstatCpuFFM;
-import oshi.ffm.platform.unix.aix.AixLibcFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.software.common.os.unix.aix.AixOSProcess;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Quartet;
@@ -52,8 +52,8 @@ public final class AixOSProcessFFM extends AixOSProcess {
     protected long queryRlimitNofile(boolean soft) {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment rlim = arena.allocate(RLIMIT_LAYOUT);
-            if (AixLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) == 0) {
-                return soft ? AixLibcFunctions.rlimitCur(rlim) : AixLibcFunctions.rlimitMax(rlim);
+            if (PosixLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) == 0) {
+                return soft ? PosixLibcFunctions.rlimitCur(rlim) : PosixLibcFunctions.rlimitMax(rlim);
             }
         } catch (Throwable _) {
             // fall through

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/aix/AixOperatingSystemFFM.java
@@ -12,6 +12,7 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.aix.AixPerfstatProcess;
 import oshi.driver.unix.aix.perfstat.PerfstatConfigFFM;
 import oshi.driver.unix.aix.perfstat.PerfstatProcessFFM;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.ffm.platform.unix.aix.AixLibcFunctions;
 import oshi.software.common.os.unix.aix.AixOperatingSystem;
 import oshi.software.os.InternetProtocolStats;
@@ -52,7 +53,7 @@ public final class AixOperatingSystemFFM extends AixOperatingSystem {
     @Override
     public int getProcessId() {
         try {
-            return AixLibcFunctions.getpid();
+            return PosixLibcFunctions.getpid();
         } catch (Throwable _) {
             return 0;
         }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOSProcess;
@@ -58,7 +59,7 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
     protected Map<String, String> queryEnvironmentVariables() {
         // DragonFlyBSD's /proc does not expose environ for other processes.
         // For the current process, use Java's System.getenv().
-        int self = callInArenaIntOrDefault(arena -> FreeBsdLibcFunctions.getpid(), LOG, LogLevel.WARN, "getpid failed",
+        int self = callInArenaIntOrDefault(arena -> PosixLibcFunctions.getpid(), LOG, LogLevel.WARN, "getpid failed",
                 -1);
         if (getProcessID() == self) {
             return System.getenv();
@@ -74,8 +75,8 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
     @Override
     protected long queryRlimitNofile(boolean soft) {
         return callInArenaOrDefault(arena -> {
-            MemorySegment rlim = arena.allocate(FreeBsdLibcFunctions.RLIMIT_LAYOUT);
-            if (FreeBsdLibcFunctions.getrlimit(FreeBsdLibcFunctions.RLIMIT_NOFILE, rlim) != 0) {
+            MemorySegment rlim = arena.allocate(PosixLibcFunctions.RLIMIT_LAYOUT);
+            if (PosixLibcFunctions.getrlimit(FreeBsdLibcFunctions.RLIMIT_NOFILE, rlim) != 0) {
                 return -1L;
             }
             return rlim.get(JAVA_LONG, soft ? 0 : Long.BYTES);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOperatingSystemFFM.java
@@ -17,8 +17,8 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.freebsd.WhoFFM;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.ffm.platform.unix.dragonflybsd.DragonFlyBsdLibcFunctions;
-import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
 import oshi.software.common.os.unix.dragonflybsd.DragonFlyBsdOperatingSystem;
@@ -67,7 +67,7 @@ public class DragonFlyBsdOperatingSystemFFM extends DragonFlyBsdOperatingSystem 
 
     @Override
     public int getProcessId() {
-        return callInArenaIntOrDefault(arena -> FreeBsdLibcFunctions.getpid(), LOG, LogLevel.WARN, "getpid failed", 0);
+        return callInArenaIntOrDefault(arena -> PosixLibcFunctions.getpid(), LOG, LogLevel.WARN, "getpid failed", 0);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdNetworkParamsFFM.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.software.common.os.unix.freebsd.FreeBsdNetworkParams;
 import oshi.util.LogLevel;
@@ -62,7 +63,7 @@ public class FreeBsdNetworkParamsFFM extends FreeBsdNetworkParams {
     protected String queryHostName() {
         return callInArenaOrDefault(arena -> {
             MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
-            if (0 != FreeBsdLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
+            if (0 != PosixLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
                 return null;
             }
             return buf.getString(0);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOSProcessFFM.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
@@ -110,10 +111,10 @@ public class FreeBsdOSProcessFFM extends FreeBsdOSProcess {
     protected long queryRlimitNofile(boolean soft) {
         return callInArenaLongOrDefault(arena -> {
             MemorySegment rlim = arena.allocate(RLIMIT_LAYOUT);
-            if (FreeBsdLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) != 0) {
+            if (PosixLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) != 0) {
                 return -1L;
             }
-            return soft ? FreeBsdLibcFunctions.rlimitCur(rlim) : FreeBsdLibcFunctions.rlimitMax(rlim);
+            return soft ? PosixLibcFunctions.rlimitCur(rlim) : PosixLibcFunctions.rlimitMax(rlim);
         }, LOG, WARN, "getrlimit(RLIMIT_NOFILE) failed", -1L);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdOperatingSystemFFM.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.freebsd.WhoFFM;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.ffm.platform.unix.freebsd.FreeBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.freebsd.BsdSysctlUtilFFM;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
@@ -63,7 +64,7 @@ public class FreeBsdOperatingSystemFFM extends FreeBsdOperatingSystem {
 
     @Override
     public int getProcessId() {
-        return callInArenaIntOrDefault(arena -> FreeBsdLibcFunctions.getpid(), LOG, LogLevel.WARN, "getpid failed", 0);
+        return callInArenaIntOrDefault(arena -> PosixLibcFunctions.getpid(), LOG, LogLevel.WARN, "getpid failed", 0);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdNetworkParamsFFM.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.software.common.os.unix.openbsd.OpenBsdNetworkParams;
 import oshi.util.LogLevel;
 
@@ -30,7 +30,7 @@ public class OpenBsdNetworkParamsFFM extends OpenBsdNetworkParams {
     protected String queryHostName() {
         return callInArenaOrDefault(arena -> {
             MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
-            if (0 != OpenBsdLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
+            if (0 != PosixLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
                 return null;
             }
             return buf.getString(0);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOSProcessFFM.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.ForeignFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
@@ -137,11 +138,11 @@ public class OpenBsdOSProcessFFM extends oshi.software.common.os.unix.openbsd.Op
     @Override
     protected long queryRlimitNofile(boolean soft) {
         return ForeignFunctions.callInArenaLongOrDefault(arena -> {
-            MemorySegment rlim = arena.allocate(OpenBsdLibcFunctions.RLIMIT_LAYOUT);
-            if (OpenBsdLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) != 0) {
+            MemorySegment rlim = arena.allocate(PosixLibcFunctions.RLIMIT_LAYOUT);
+            if (PosixLibcFunctions.getrlimit(RLIMIT_NOFILE, rlim) != 0) {
                 return -1L;
             }
-            return soft ? OpenBsdLibcFunctions.rlimitCur(rlim) : OpenBsdLibcFunctions.rlimitMax(rlim);
+            return soft ? PosixLibcFunctions.rlimitCur(rlim) : PosixLibcFunctions.rlimitMax(rlim);
         }, LOG, oshi.util.LogLevel.WARN, "Failed getrlimit", -1L);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/openbsd/OpenBsdOperatingSystemFFM.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.ForeignFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.ffm.platform.unix.openbsd.OpenBsdLibcFunctions;
 import oshi.ffm.util.platform.unix.openbsd.OpenBsdSysctlUtilFFM;
 import oshi.software.common.os.unix.bsd.BsdPsKeyword;
@@ -45,7 +46,7 @@ public class OpenBsdOperatingSystemFFM extends OpenBsdOperatingSystem {
 
     @Override
     public int getProcessId() {
-        return ForeignFunctions.callInArenaIntOrDefault(arena -> OpenBsdLibcFunctions.getpid(), LOG, LogLevel.WARN,
+        return ForeignFunctions.callInArenaIntOrDefault(arena -> PosixLibcFunctions.getpid(), LOG, LogLevel.WARN,
                 "getpid failed", 0);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisNetworkParamsFFM.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.ffm.platform.unix.solaris.SolarisLibcFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.software.common.os.unix.solaris.SolarisNetworkParams;
 
 /**
@@ -28,7 +28,7 @@ final class SolarisNetworkParamsFFM extends SolarisNetworkParams {
     public String getHostName() {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
-            int rc = SolarisLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L);
+            int rc = PosixLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L);
             if (rc == 0) {
                 return buf.getString(0);
             }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisOSProcessFFM.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.solaris.PsInfoFFM;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.ffm.platform.unix.solaris.SolarisLibcFunctions;
 import oshi.software.common.os.unix.solaris.SolarisOSProcess;
 import oshi.software.os.OSThread;
@@ -67,11 +68,11 @@ public final class SolarisOSProcessFFM extends SolarisOSProcess {
 
     private static long rlimitNofile(boolean soft) {
         return callInArenaLongOrDefault(arena -> {
-            MemorySegment rlim = arena.allocate(SolarisLibcFunctions.RLIMIT_LAYOUT);
-            if (SolarisLibcFunctions.getrlimit(SolarisLibcFunctions.RLIMIT_NOFILE, rlim) != 0) {
+            MemorySegment rlim = arena.allocate(PosixLibcFunctions.RLIMIT_LAYOUT);
+            if (PosixLibcFunctions.getrlimit(SolarisLibcFunctions.RLIMIT_NOFILE, rlim) != 0) {
                 return -1L;
             }
-            return soft ? SolarisLibcFunctions.rlimitCur(rlim) : SolarisLibcFunctions.rlimitMax(rlim);
+            return soft ? PosixLibcFunctions.rlimitCur(rlim) : PosixLibcFunctions.rlimitMax(rlim);
         }, LOG, WARN, "getrlimit failed", -1L);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/solaris/SolarisOperatingSystemFFM.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.unix.solaris.WhoFFM;
 import oshi.ffm.ForeignFunctions;
+import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.ffm.platform.unix.solaris.LibKstatFunctions;
 import oshi.ffm.platform.unix.solaris.SolarisLibcFunctions;
 import oshi.ffm.util.platform.unix.solaris.KstatUtilFFM;
@@ -48,7 +49,7 @@ public class SolarisOperatingSystemFFM extends SolarisOperatingSystem {
 
     @Override
     public int getProcessId() {
-        return ForeignFunctions.callInArenaIntOrDefault(arena -> SolarisLibcFunctions.getpid(), LOG, LogLevel.WARN,
+        return ForeignFunctions.callInArenaIntOrDefault(arena -> PosixLibcFunctions.getpid(), LOG, LogLevel.WARN,
                 "getpid failed", 0);
     }
 


### PR DESCRIPTION
Sonar raised 34 findings against the `PosixLibcFunctions` hoist in #3565. Both actionable groups fixed; the third skipped with precedent.

## S3252 × 33 — static access through a subclass

Consumers reached the inherited members through the per-platform subclass, so `LinuxLibcFunctions.getrlimit(...)` read as though Linux had its own binding. They now name the declaring class, which also makes the split visible at the call site:

```java
PosixLibcFunctions.getrlimit(LinuxLibcFunctions.RLIMIT_NOFILE, rlim)
```

Shared call, platform-specific constant. **`RLIMIT_NOFILE` is deliberately left qualified by the subclass** — its value is 7/7/8/8/5 and requalifying it would be wrong.

33 references across 16 files, matching Sonar’s count exactly. Static imports are untouched: Sonar did not flag them, and whether to repoint them is a separate question.

## S3038 × 1 — useless redeclaration

`OpenBsdOperatingSystem` redeclared `getNetworkParams` as abstract when #3566 moved it to the backend subclasses. Neither `AbstractOperatingSystem` nor `BsdOperatingSystem` implements it, so the interface method was already abstract the whole way down and the redeclaration forced nothing. Verified before removing, since re-abstracting a concrete supertype method *would* have been load-bearing.

## S125 × 3 — not changed

The C signature comments in `PosixLibcFunctions`:

```java
// pid_t getpid(void);
// int getrlimit(int resource, struct rlimit *rlim);
// int gethostname(char *name, size_t namelen);
```

That style documents the native signature above each binding and is used throughout the FFM mapping layer. The identical comments in `FreeBsdLibcFunctions` (8), `SolarisLibcFunctions` (4) and `AixLibcFunctions` (3) are already resolved **WONTFIX**. These are flagged only because the file is new, so dismissing them matches the established precedent rather than diverging from the convention in one file.

## Verification

Full gate green from clean: install, spotless, checkstyle, forbiddenapis, javadoc, 1509 tests / 0 failed. Pure requalification — no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of hostname, process ID, and process-limit retrieval across supported Unix platforms.
  - Preserved existing fallback behavior and error handling while standardizing platform compatibility.
  - Removed an obsolete OpenBSD network-parameter API declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->