### PR TITLE
Share the Windows OS layer between the backends and fix the FFM process lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,38 @@ it. To make code testable, extract the parsing from the acquisition: a method th
 `List<String>` or `String` and returns a parsed result, called by a thin method that does the
 `readFile`/`runNative`. Test the parse method against fixture data.
 
+#### A new test package needs an entry in `module-info.test`
+
+Tests run on the **module path**, patched into the module under test. JUnit instantiates a test
+class reflectively, so the package has to be open to it — and the `opens` for tests lives in
+`src/test/java/module-info.test`, not in `src/main/java/module-info.java`. That file holds the raw
+JVM options the plugin passes to the test run.
+
+**Adding a test in a package that no existing test uses means adding a line to that module's
+`module-info.test`:**
+
+```
+--add-opens
+  com.github.oshi/oshi.software.os.windows=org.junit.platform.commons
+```
+
+The module name is `com.github.oshi` for `oshi-core`, `com.github.oshi.ffm` for `oshi-core-ffm`, and
+`com.github.oshi.common` for `oshi-common`. The same file is also where `--add-reads`,
+`--add-modules`, and `--enable-native-access` for tests are declared.
+
+⚠️ **A missing entry fails only on the platform that actually runs the test.** A test guarded by
+`@EnabledOnOs(OS.WINDOWS)` is skipped at the container level everywhere else — before JUnit ever
+tries to construct it — so a full green build on Linux or macOS proves nothing about the opens.
+The failure surfaces in CI as:
+
+```
+[X] Unable to make oshi.software.os.windows.SomeTest() accessible:
+    module com.github.oshi does not "opens oshi.software.os.windows" to module org.junit.platform.commons
+```
+
+To check the wiring from any platform, drop an unconditional throwaway test in the new package,
+confirm it runs, and delete it.
+
 ## Hard rules that CI enforces
 
 **Language level.** `oshi-common` and `oshi-core` compile with `release 8`. No `var`, no `List.of`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ JVM options the plugin passes to the test run.
 **Adding a test in a package that no existing test uses means adding a line to that module's
 `module-info.test`:**
 
-```
+```text
 --add-opens
   com.github.oshi/oshi.software.os.windows=org.junit.platform.commons
 ```
@@ -154,7 +154,7 @@ The module name is `com.github.oshi` for `oshi-core`, `com.github.oshi.ffm` for 
 tries to construct it — so a full green build on Linux or macOS proves nothing about the opens.
 The failure surfaces in CI as:
 
-```
+```text
 [X] Unable to make oshi.software.os.windows.SomeTest() accessible:
     module com.github.oshi does not "opens oshi.software.os.windows" to module org.junit.platform.commons
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#3562](https://github.com/oshi/oshi/pull/3562): Make Linux `getMaxFreq()` reproducible by resolving it from the cpufreq policy, `lshw`, and the vendor frequency rather than folding in a live frequency reading, returning -1 when none of those reports a maximum - [@dbwiddis](https://github.com/dbwiddis).
 * [#3564](https://github.com/oshi/oshi/pull/3564): Fix Linux `getSoftOpenFileLimit()` returning -1 for a process whose hard open-file limit is `unlimited`, discarding a valid soft limit - [@dbwiddis](https://github.com/dbwiddis).
 * [#3566](https://github.com/oshi/oshi/pull/3566): Read the OpenBSD host name from `gethostname` rather than resolving it, so `getHostName()` no longer reports `localhost` on a host whose name is not resolvable - [@dbwiddis](https://github.com/dbwiddis).
+* [#3568](https://github.com/oshi/oshi/pull/3568): Fix the Windows FFM `getProcess(pid)` and `getProcesses(pids)` returning a process that `getProcesses()` does not list, reporting a recently exited process as running with no path, no threads, and no CPU time - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24), 7.4.3 (2027-07-31)
 

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOperatingSystem.java
@@ -8,8 +8,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.wmi.Win32OperatingSystem.OSVersionProperty;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.os.OperatingSystem.OSVersionInfo;
+import oshi.util.Constants;
 import oshi.util.GlobalConfig;
+import oshi.util.tuples.Pair;
 
 /**
  * Common base class for Windows operating system implementations.
@@ -30,6 +36,71 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
     @Override
     protected String queryManufacturer() {
         return "Microsoft";
+    }
+
+    /**
+     * Queries WMI for the operating system version, service pack, suite mask, and build number.
+     *
+     * @return The {@code Win32_OperatingSystem} query result
+     */
+    protected abstract WmiResult<OSVersionProperty> queryOsVersion();
+
+    @Override
+    protected Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
+        String servicePack = "";
+        int suiteMask = 0;
+        String buildNumber = "";
+        WmiResult<OSVersionProperty> versionInfo = queryOsVersion();
+        if (versionInfo.getResultCount() > 0) {
+            servicePack = WmiUtil.getString(versionInfo, OSVersionProperty.CSDVERSION, 0);
+            suiteMask = WmiUtil.getUint32(versionInfo, OSVersionProperty.SUITEMASK, 0);
+            buildNumber = WmiUtil.getString(versionInfo, OSVersionProperty.BUILDNUMBER, 0);
+        }
+        return parseVersionInfo(System.getProperty("os.name"), servicePack, suiteMask, buildNumber);
+    }
+
+    /**
+     * Assembles the family and version information from the raw values reported by the JDK and by WMI.
+     *
+     * @param osName      The value of the {@code os.name} system property
+     * @param servicePack The service pack name, empty or {@link Constants#UNKNOWN} if none
+     * @param suiteMask   The suite mask bitmask
+     * @param buildNumber The build number reported by WMI
+     * @return A pair of the family name and the version information
+     */
+    static Pair<String, OSVersionInfo> parseVersionInfo(String osName, String servicePack, int suiteMask,
+            String buildNumber) {
+        String version = osName.startsWith("Windows ") ? osName.substring(8) : osName;
+        if (!servicePack.isEmpty() && !Constants.UNKNOWN.equals(servicePack)) {
+            version = version + " " + servicePack.replace("Service Pack ", "SP");
+        }
+        return new Pair<>("Windows",
+                new OSVersionInfo(resolveVersionAlias(version, buildNumber), parseCodeName(suiteMask), buildNumber));
+    }
+
+    /**
+     * Maps the version name reported by the JDK to the name of the release that actually shipped with the given build
+     * number. Older JDKs predate Windows 11 and the Server releases after 2016, so {@code os.name} reports them under
+     * the name of the last release the JDK knew about.
+     *
+     * @param version     The version name derived from {@code os.name}
+     * @param buildNumber The build number reported by WMI
+     * @return The version name of the release matching {@code buildNumber}
+     */
+    static String resolveVersionAlias(String version, String buildNumber) {
+        if ("10".equals(version) && buildNumber.compareTo("22000") >= 0) {
+            return "11";
+        }
+        if ("Server 2016".equals(version) && buildNumber.compareTo("17762") > 0) {
+            version = "Server 2019";
+        }
+        if ("Server 2019".equals(version) && buildNumber.compareTo("20347") > 0) {
+            version = "Server 2022";
+        }
+        if ("Server 2022".equals(version) && buildNumber.compareTo("26039") > 0) {
+            version = "Server 2025";
+        }
+        return version;
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOperatingSystem.java
@@ -4,14 +4,29 @@
  */
 package oshi.software.common.os.windows;
 
+import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
+import static oshi.util.Memoizer.defaultExpiration;
+import static oshi.util.Memoizer.memoize;
+
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
+import oshi.driver.common.windows.registry.WtsInfo;
 import oshi.driver.common.windows.wmi.Win32OperatingSystem.OSVersionProperty;
 import oshi.driver.common.windows.wmi.WmiResult;
 import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.software.common.AbstractOperatingSystem;
+import oshi.software.os.OSProcess;
 import oshi.software.os.OperatingSystem.OSVersionInfo;
 import oshi.util.Constants;
 import oshi.util.GlobalConfig;
@@ -32,6 +47,154 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
     /** Whether to check thread states to determine if a process is suspended. */
     protected static final boolean USE_PROCSTATE_SUSPENDED = GlobalConfig
             .get(GlobalConfig.OSHI_OS_WINDOWS_PROCSTATE_SUSPENDED, false);
+
+    /*
+     * Cache full process stats queries. The second query only populates if the first one returns nothing.
+     */
+    private final Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromRegistry = memoize(
+            () -> buildProcessMapFromRegistry(null), defaultExpiration());
+    private final Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromPerfCounters = memoize(
+            () -> buildProcessMapFromPerfCounters(null), defaultExpiration());
+    /*
+     * Cache full thread stats queries. Only used if USE_PROCSTATE_SUSPENDED is set true.
+     */
+    private final Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromRegistry = memoize(
+            () -> buildThreadMapFromRegistry(null), defaultExpiration());
+    private final Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromPerfCounters = memoize(
+            () -> buildThreadMapFromPerfCounters(null), defaultExpiration());
+
+    /**
+     * Reads process performance data from {@code HKEY_PERFORMANCE_DATA}.
+     *
+     * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
+     * @return A map of process ID to performance counter block, or {@code null} if the registry data is unavailable
+     */
+    protected abstract Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids);
+
+    /**
+     * Reads process performance data from performance counters, with a WMI backup.
+     *
+     * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
+     * @return A map of process ID to performance counter block
+     */
+    protected abstract Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids);
+
+    /**
+     * Reads thread performance data from {@code HKEY_PERFORMANCE_DATA}.
+     *
+     * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
+     * @return A map of thread ID to performance counter block, or {@code null} if the registry data is unavailable
+     */
+    protected abstract Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids);
+
+    /**
+     * Reads thread performance data from performance counters, with a WMI backup.
+     *
+     * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
+     * @return A map of thread ID to performance counter block
+     */
+    protected abstract Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids);
+
+    /**
+     * Reads process information from the Windows Terminal Service, with a WMI backup.
+     *
+     * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
+     * @return A map of process ID to terminal service information
+     */
+    protected abstract Map<Integer, WtsInfo> queryProcessWtsMap(Collection<Integer> pids);
+
+    /**
+     * Maps every process ID to the ID of its parent.
+     *
+     * @return A map of process ID to parent process ID
+     */
+    protected abstract Map<Integer, Integer> queryParentPidMap();
+
+    /**
+     * Creates a backend-specific process object from data already fetched for the whole process list.
+     *
+     * @param pid           The process ID
+     * @param processMap    A map of process ID to performance counter block
+     * @param processWtsMap A map of process ID to terminal service information
+     * @param threadMap     A map of thread ID to performance counter block, or {@code null} if thread states are not
+     *                      being collected
+     * @return The process
+     */
+    protected abstract OSProcess createOSProcess(int pid, Map<Integer, ProcessPerfCounterBlock> processMap,
+            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap);
+
+    @Override
+    public List<OSProcess> getProcesses(Collection<Integer> pids) {
+        return processMapToList(pids);
+    }
+
+    @Override
+    protected List<OSProcess> queryAllProcesses() {
+        return processMapToList(null);
+    }
+
+    @Override
+    public OSProcess getProcess(int pid) {
+        List<OSProcess> procList = processMapToList(Collections.singletonList(pid));
+        return procList.isEmpty() ? null : procList.get(0);
+    }
+
+    @Override
+    protected List<OSProcess> queryChildProcesses(int parentPid) {
+        return processMapToList(getChildrenOrDescendants(queryParentPidMap(), parentPid, false));
+    }
+
+    @Override
+    protected List<OSProcess> queryDescendantProcesses(int parentPid) {
+        return processMapToList(getChildrenOrDescendants(queryParentPidMap(), parentPid, true));
+    }
+
+    /**
+     * Fetches the cached performance data for all processes, from the registry if it is available and from performance
+     * counters otherwise.
+     *
+     * @return A map of process ID to performance counter block, empty if neither source returned data
+     */
+    protected Map<Integer, ProcessPerfCounterBlock> getCachedProcessMap() {
+        return resolveProcessMap(null);
+    }
+
+    private Map<Integer, ProcessPerfCounterBlock> resolveProcessMap(Collection<Integer> pids) {
+        // Get data from the registry if possible
+        Map<Integer, ProcessPerfCounterBlock> processMap = processMapFromRegistry.get();
+        // otherwise performance counters with WMI backup
+        if (processMap == null || processMap.isEmpty()) {
+            processMap = (pids == null) ? processMapFromPerfCounters.get() : buildProcessMapFromPerfCounters(pids);
+        }
+        return processMap == null ? Collections.emptyMap() : processMap;
+    }
+
+    private List<OSProcess> processMapToList(Collection<Integer> pids) {
+        Map<Integer, ProcessPerfCounterBlock> processMap = resolveProcessMap(pids);
+        Map<Integer, ThreadPerfCounterBlock> threadMap = null;
+        if (USE_PROCSTATE_SUSPENDED) {
+            // Get data from the registry if possible
+            threadMap = threadMapFromRegistry.get();
+            // otherwise performance counters with WMI backup
+            if (threadMap == null || threadMap.isEmpty()) {
+                threadMap = (pids == null) ? threadMapFromPerfCounters.get() : buildThreadMapFromPerfCounters(pids);
+            }
+        }
+
+        Map<Integer, WtsInfo> processWtsMap = queryProcessWtsMap(pids);
+
+        // Intersect with the WTS keys whether or not pids were requested. The perf counter map is memoized, so it can
+        // name a process that has since exited; WTS is queried fresh and will not. Keying off the WTS map keeps
+        // getProcess(pid) from returning a process that getProcesses() would not list.
+        Set<Integer> mapKeys = new HashSet<>(processWtsMap.keySet());
+        mapKeys.retainAll(processMap.keySet());
+
+        final Map<Integer, ProcessPerfCounterBlock> finalProcessMap = processMap;
+        final Map<Integer, ThreadPerfCounterBlock> finalThreadMap = threadMap;
+        return mapKeys.stream().parallel()
+                .map(pid -> createOSProcess(pid, finalProcessMap, processWtsMap, finalThreadMap)).filter(VALID_PROCESS)
+                .collect(Collectors.toList());
+    }
 
     @Override
     protected String queryManufacturer() {

--- a/oshi-common/src/test/java/oshi/software/common/os/windows/WindowsOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/windows/WindowsOperatingSystemTest.java
@@ -9,6 +9,9 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import oshi.software.os.OperatingSystem.OSVersionInfo;
+import oshi.util.tuples.Pair;
+
 class WindowsOperatingSystemTest {
 
     @Test
@@ -38,5 +41,72 @@ class WindowsOperatingSystemTest {
         assertThat(WindowsOperatingSystem.parseCodeName(allBits),
                 is("Enterprise,BackOffice,Communications Server,Datacenter,Home,Web Server,Storage Server,"
                         + "Compute Cluster,Home Server"));
+    }
+
+    @Test
+    void testResolveVersionAliasWindows11() {
+        assertThat("Build 22000 is the first Windows 11 build",
+                WindowsOperatingSystem.resolveVersionAlias("10", "22000"), is("11"));
+        assertThat("Later builds are still Windows 11", WindowsOperatingSystem.resolveVersionAlias("10", "26100"),
+                is("11"));
+        assertThat("Earlier builds remain Windows 10", WindowsOperatingSystem.resolveVersionAlias("10", "19045"),
+                is("10"));
+    }
+
+    @Test
+    void testResolveVersionAliasServer() {
+        assertThat("Build 17763 is Server 2019", WindowsOperatingSystem.resolveVersionAlias("Server 2016", "17763"),
+                is("Server 2019"));
+        assertThat("Build 20348 is Server 2022", WindowsOperatingSystem.resolveVersionAlias("Server 2016", "20348"),
+                is("Server 2022"));
+        assertThat("Build 26100 is Server 2025", WindowsOperatingSystem.resolveVersionAlias("Server 2016", "26100"),
+                is("Server 2025"));
+        assertThat("Build 14393 remains Server 2016",
+                WindowsOperatingSystem.resolveVersionAlias("Server 2016", "14393"), is("Server 2016"));
+    }
+
+    @Test
+    void testResolveVersionAliasUnmapped() {
+        assertThat("A version with no alias is returned unchanged",
+                WindowsOperatingSystem.resolveVersionAlias("8.1", "9600"), is("8.1"));
+    }
+
+    @Test
+    void testParseVersionInfoStripsWindowsPrefix() {
+        Pair<String, OSVersionInfo> pair = WindowsOperatingSystem.parseVersionInfo("Windows 10", "", 0, "19045");
+        assertThat("Family is always Windows", pair.getA(), is("Windows"));
+        OSVersionInfo version = pair.getB();
+        assertThat("The \"Windows \" prefix is stripped", version.getVersion(), is("10"));
+        assertThat("An empty suite mask yields an empty code name", version.getCodeName(), is(""));
+        assertThat("The build number is passed through", version.getBuildNumber(), is("19045"));
+    }
+
+    @Test
+    void testParseVersionInfoAbbreviatesServicePack() {
+        OSVersionInfo version = WindowsOperatingSystem
+                .parseVersionInfo("Windows 7", "Service Pack 1", 0x00000200, "7601").getB();
+        assertThat("Service Pack is abbreviated to SP", version.getVersion(), is("7 SP1"));
+        assertThat("The suite mask is decoded", version.getCodeName(), is("Home"));
+    }
+
+    @Test
+    void testParseVersionInfoIgnoresAbsentServicePack() {
+        assertThat("An empty service pack is not appended",
+                WindowsOperatingSystem.parseVersionInfo("Windows 10", "", 0, "19045").getB().getVersion(), is("10"));
+        assertThat("An unknown service pack is not appended",
+                WindowsOperatingSystem.parseVersionInfo("Windows 10", "unknown", 0, "19045").getB().getVersion(),
+                is("10"));
+    }
+
+    @Test
+    void testParseVersionInfoAppliesAlias() {
+        assertThat("A Windows 10 name with a Windows 11 build is aliased",
+                WindowsOperatingSystem.parseVersionInfo("Windows 10", "", 0, "22631").getB().getVersion(), is("11"));
+    }
+
+    @Test
+    void testParseVersionInfoWithoutWindowsPrefix() {
+        assertThat("A name without the prefix is used as-is",
+                WindowsOperatingSystem.parseVersionInfo("Windows", "", 0, "").getB().getVersion(), is("Windows"));
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/WindowsForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/WindowsForeignFunctions.java
@@ -18,6 +18,8 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.nio.charset.StandardCharsets;
 
+import org.slf4j.Logger;
+
 import oshi.ffm.ForeignFunctions;
 
 /**
@@ -57,6 +59,29 @@ public abstract class WindowsForeignFunctions extends ForeignFunctions {
      */
     public static boolean isSuccess(int winBool) {
         return winBool != 0;
+    }
+
+    /**
+     * Passes through the result of a Windows API call, logging the name of the function and the value of
+     * {@code GetLastError()} if it failed. Intended to be used as a guard condition so that the failure branch of a
+     * native call is a single expression:
+     *
+     * <pre>
+     * if (!succeededOrLog(Advapi32FFM.OpenProcessToken(hProcess, access, hToken), LOG, "OpenProcessToken")) {
+     *     return false;
+     * }
+     * </pre>
+     *
+     * @param success  the result of the native call
+     * @param logger   the logger of the calling class, so the message is attributed to the caller
+     * @param function the name of the native function that was called
+     * @return {@code success}, unchanged
+     */
+    public static boolean succeededOrLog(boolean success, Logger logger, String function) {
+        if (!success) {
+            logger.error("{} failed, error: {}", function, Kernel32FFM.GetLastError().orElse(-1));
+        }
+        return success;
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -14,7 +14,6 @@ import static oshi.ffm.platform.windows.WinNTFFM.PERFORMANCE_INFORMATION;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.setupTokenPrivileges;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.succeededOrLog;
-import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
 import static oshi.util.LogLevel.ERROR;
 import static oshi.util.Memoizer.installedAppsExpiration;
 
@@ -25,13 +24,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -274,81 +270,35 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
                 .orElseGet(() -> new WindowsOSThreadFFM(proc.getProcessID(), tid, null, null));
     }
 
-    private final Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromRegistry = Memoizer
-            .memoize(WindowsOperatingSystemFFM::queryProcessMapFromRegistry, Memoizer.defaultExpiration());
-    private final Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromPerfCounters = Memoizer
-            .memoize(WindowsOperatingSystemFFM::queryProcessMapFromPerfCounters, Memoizer.defaultExpiration());
-    private final Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromRegistry = Memoizer
-            .memoize(WindowsOperatingSystemFFM::queryThreadMapFromRegistry, Memoizer.defaultExpiration());
-    private final Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromPerfCounters = Memoizer
-            .memoize(WindowsOperatingSystemFFM::queryThreadMapFromPerfCounters, Memoizer.defaultExpiration());
-
     @Override
-    public List<OSProcess> getProcesses(Collection<Integer> pids) {
-        return processMapToList(pids);
+    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids) {
+        return ProcessPerformanceDataFFM.buildProcessMapFromRegistry(pids);
     }
 
     @Override
-    public List<OSProcess> queryAllProcesses() {
-        return processMapToList(null);
+    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids) {
+        return ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(pids);
     }
 
     @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procList = processMapToList(List.of(pid));
-        return procList.isEmpty() ? null : procList.get(0);
+    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
+        return ThreadPerformanceDataFFM.buildThreadMapFromRegistry(pids);
     }
 
-    private List<OSProcess> processMapToList(Collection<Integer> pids) {
-        // Get data from the registry if possible
-        Map<Integer, ProcessPerfCounterBlock> processMap = processMapFromRegistry.get();
-        // otherwise performance counters with WMI backup
-        if (processMap == null || processMap.isEmpty()) {
-            processMap = (pids == null) ? processMapFromPerfCounters.get()
-                    : ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(pids);
-        }
-        Map<Integer, ThreadPerfCounterBlock> threadMap = null;
-        if (USE_PROCSTATE_SUSPENDED) {
-            // Get data from the registry if possible
-            threadMap = threadMapFromRegistry.get();
-            // otherwise performance counters with WMI backup
-            if (threadMap == null || threadMap.isEmpty()) {
-                threadMap = (pids == null) ? threadMapFromPerfCounters.get()
-                        : ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids);
-            }
-        }
-
-        Map<Integer, WtsInfo> processWtsMap = ProcessWtsDataFFM.queryProcessWtsMap(pids);
-
-        // Intersect with the WTS keys whether or not pids were requested. The perf counter map is memoized, so it can
-        // name a process that has since exited; WTS is queried fresh and will not. Keying off the WTS map keeps
-        // getProcess(pid) from returning a process that getProcesses() would not list.
-        Set<Integer> mapKeys = new HashSet<>(processWtsMap.keySet());
-        mapKeys.retainAll(processMap.keySet());
-
-        final Map<Integer, ProcessPerfCounterBlock> finalProcessMap = processMap;
-        final Map<Integer, ThreadPerfCounterBlock> finalThreadMap = threadMap;
-        return mapKeys.stream().parallel()
-                .map(pid -> new WindowsOSProcessFFM(pid, this, finalProcessMap, processWtsMap, finalThreadMap))
-                .filter(VALID_PROCESS).collect(Collectors.toList());
+    @Override
+    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids) {
+        return ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids);
     }
 
-    private static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromRegistry() {
-        return ProcessPerformanceDataFFM.buildProcessMapFromRegistry(null);
+    @Override
+    protected Map<Integer, WtsInfo> queryProcessWtsMap(Collection<Integer> pids) {
+        return ProcessWtsDataFFM.queryProcessWtsMap(pids);
     }
 
-    // Package-private: only reached in production when the registry query fails, so tested directly
-    static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromPerfCounters() {
-        return ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(null);
-    }
-
-    private static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromRegistry() {
-        return ThreadPerformanceDataFFM.buildThreadMapFromRegistry(null);
-    }
-
-    // Package-private: only reached in production when the registry query fails, so tested directly
-    static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromPerfCounters() {
-        return ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(null);
+    @Override
+    protected OSProcess createOSProcess(int pid, Map<Integer, ProcessPerfCounterBlock> processMap,
+            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
+        return new WindowsOSProcessFFM(pid, this, processMap, processWtsMap, threadMap);
     }
 
     @Override
@@ -367,30 +317,15 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
         return jvmBitness;
     }
 
+    /**
+     * Unlike the JNA backend, which takes a live ToolHelp32 snapshot, this derives each process's parent from the
+     * cached performance counter data rather than enumerating every process a second time.
+     */
     @Override
-    protected List<OSProcess> queryChildProcesses(int parentPid) {
-        Map<Integer, Integer> parentPidMap = getParentPidMap();
-        Set<Integer> descendantPids = getChildrenOrDescendants(parentPidMap, parentPid, false);
-        return processMapToList(descendantPids);
-    }
-
-    @Override
-    protected List<OSProcess> queryDescendantProcesses(int parentPid) {
-        Map<Integer, Integer> parentPidMap = getParentPidMap();
-        Set<Integer> descendantPids = getChildrenOrDescendants(parentPidMap, parentPid, true);
-        return processMapToList(descendantPids);
-    }
-
-    private Map<Integer, Integer> getParentPidMap() {
+    protected Map<Integer, Integer> queryParentPidMap() {
         Map<Integer, Integer> parentPidMap = new HashMap<>();
-        Map<Integer, ProcessPerfCounterBlock> processMap = processMapFromRegistry.get();
-        if (processMap == null || processMap.isEmpty()) {
-            processMap = processMapFromPerfCounters.get();
-        }
-        if (processMap != null) {
-            for (Map.Entry<Integer, ProcessPerfCounterBlock> entry : processMap.entrySet()) {
-                parentPidMap.put(entry.getKey(), entry.getValue().getParentProcessID());
-            }
+        for (Map.Entry<Integer, ProcessPerfCounterBlock> entry : getCachedProcessMap().entrySet()) {
+            parentPidMap.put(entry.getKey(), entry.getValue().getParentProcessID());
         }
         return parentPidMap;
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -10,10 +10,10 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 import static oshi.ffm.ForeignFunctions.callInArenaBooleanOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaIntOrDefault;
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
-import static oshi.ffm.platform.windows.Kernel32FFM.GetLastError;
 import static oshi.ffm.platform.windows.WinNTFFM.PERFORMANCE_INFORMATION;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.readWideString;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.setupTokenPrivileges;
+import static oshi.ffm.platform.windows.WindowsForeignFunctions.succeededOrLog;
 import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
 import static oshi.util.LogLevel.ERROR;
 import static oshi.util.Memoizer.installedAppsExpiration;
@@ -69,10 +69,7 @@ import oshi.software.os.OSService;
 import oshi.software.os.OSService.State;
 import oshi.software.os.OSSession;
 import oshi.software.os.OSThread;
-import oshi.software.os.OperatingSystem.OSVersionInfo;
-import oshi.util.GlobalConfig;
 import oshi.util.Memoizer;
-import oshi.util.tuples.Pair;
 
 @ThreadSafe
 public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
@@ -96,28 +93,19 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
             if (hProcess.isEmpty()) {
                 return false;
             }
-            boolean success = Advapi32FFM.OpenProcessToken(hProcess.get(),
-                    WinNTFFM.TOKEN_QUERY | WinNTFFM.TOKEN_ADJUST_PRIVILEGES, hTokenPtr);
-            if (!success) {
-                LOG.error("OpenProcessToken failed, error: {}", GetLastError());
+            if (!succeededOrLog(
+                    Advapi32FFM.OpenProcessToken(hProcess.get(),
+                            WinNTFFM.TOKEN_QUERY | WinNTFFM.TOKEN_ADJUST_PRIVILEGES, hTokenPtr),
+                    LOG, "OpenProcessToken")) {
                 return false;
             }
             try (NativeHandle hToken = NativeHandle.of(hTokenPtr.get(ADDRESS, 0), Kernel32FFM::CloseHandle)) {
                 MemorySegment luid = arena.allocate(WinNTFFM.LUID);
-                success = Advapi32FFM.LookupPrivilegeValue("SeDebugPrivilege", luid, arena);
-                if (!success) {
-                    LOG.error("LookupPrivilegeValue failed, error: {}", GetLastError());
-                    return false;
-                }
-
-                MemorySegment tkp = setupTokenPrivileges(arena, luid);
-                success = Advapi32FFM.AdjustTokenPrivileges(hToken.get(), tkp);
-                if (!success) {
-                    LOG.error("AdjustTokenPrivileges failed, error: {}", GetLastError());
-                    return false;
-                }
-
-                return true;
+                return succeededOrLog(Advapi32FFM.LookupPrivilegeValue("SeDebugPrivilege", luid, arena), LOG,
+                        "LookupPrivilegeValue")
+                        && succeededOrLog(
+                                Advapi32FFM.AdjustTokenPrivileges(hToken.get(), setupTokenPrivileges(arena, luid)), LOG,
+                                "AdjustTokenPrivileges");
             }
         }, LOG, ERROR, "enableDebugPrivilege exception", false);
     }
@@ -170,9 +158,10 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
 
                 MemorySegment lpServices = arena.allocate(bytesNeeded);
                 lpResumeHandle.set(JAVA_INT, 0, 0);
-                if (!Advapi32FFM.EnumServicesStatusEx(hSCManager, 0, SERVICE_WIN32, SERVICE_STATE_ALL, lpServices,
-                        bytesNeeded, pcbBytesNeeded, lpServicesReturned, lpResumeHandle, MemorySegment.NULL)) {
-                    LOG.error("EnumServicesStatusEx failed, error: {}", Kernel32FFM.GetLastError());
+                if (!succeededOrLog(
+                        Advapi32FFM.EnumServicesStatusEx(hSCManager, 0, SERVICE_WIN32, SERVICE_STATE_ALL, lpServices,
+                                bytesNeeded, pcbBytesNeeded, lpServicesReturned, lpResumeHandle, MemorySegment.NULL),
+                        LOG, "EnumServicesStatusEx")) {
                     return Collections.emptyList();
                 }
 
@@ -261,8 +250,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
             int size = (int) PERFORMANCE_INFORMATION.byteSize();
             perfInfo.set(JAVA_INT, PERFORMANCE_INFORMATION.byteOffset(MemoryLayout.PathElement.groupElement("cb")),
                     size);
-            if (!PsapiFFM.GetPerformanceInfo(perfInfo, size)) {
-                LOG.error("Failed to get Performance Info. Error code: {}", GetLastError());
+            if (!succeededOrLog(PsapiFFM.GetPerformanceInfo(perfInfo, size), LOG, "GetPerformanceInfo")) {
                 return 0;
             }
             return perfInfo.get(JAVA_INT,
@@ -285,9 +273,6 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
         return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
                 .orElseGet(() -> new WindowsOSThreadFFM(proc.getProcessID(), tid, null, null));
     }
-
-    private static final boolean USE_PROCSTATE_SUSPENDED = GlobalConfig
-            .get(GlobalConfig.OSHI_OS_WINDOWS_PROCSTATE_SUSPENDED, false);
 
     private final Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromRegistry = Memoizer
             .memoize(WindowsOperatingSystemFFM::queryProcessMapFromRegistry, Memoizer.defaultExpiration());
@@ -335,17 +320,11 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
 
         Map<Integer, WtsInfo> processWtsMap = ProcessWtsDataFFM.queryProcessWtsMap(pids);
 
-        // Determine which PIDs to process: requested pids filtered by available data, or all available
-        Set<Integer> mapKeys;
-        if (pids == null) {
-            // All processes: use intersection of WTS and processMap (WTS enrichment required for full data)
-            mapKeys = new HashSet<>(processWtsMap.keySet());
-            mapKeys.retainAll(processMap.keySet());
-        } else {
-            // Specific PIDs: filter by what's available in processMap
-            mapKeys = new HashSet<>(pids);
-            mapKeys.retainAll(processMap.keySet());
-        }
+        // Intersect with the WTS keys whether or not pids were requested. The perf counter map is memoized, so it can
+        // name a process that has since exited; WTS is queried fresh and will not. Keying off the WTS map keeps
+        // getProcess(pid) from returning a process that getProcesses() would not list.
+        Set<Integer> mapKeys = new HashSet<>(processWtsMap.keySet());
+        mapKeys.retainAll(processMap.keySet());
 
         final Map<Integer, ProcessPerfCounterBlock> finalProcessMap = processMap;
         final Map<Integer, ThreadPerfCounterBlock> finalThreadMap = threadMap;
@@ -358,7 +337,8 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
         return ProcessPerformanceDataFFM.buildProcessMapFromRegistry(null);
     }
 
-    private static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromPerfCounters() {
+    // Package-private: only reached in production when the registry query fails, so tested directly
+    static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromPerfCounters() {
         return ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(null);
     }
 
@@ -366,42 +346,14 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
         return ThreadPerformanceDataFFM.buildThreadMapFromRegistry(null);
     }
 
-    private static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromPerfCounters() {
+    // Package-private: only reached in production when the registry query fails, so tested directly
+    static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromPerfCounters() {
         return ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(null);
     }
 
     @Override
-    protected Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        String version = System.getProperty("os.name");
-        if (version.startsWith("Windows ")) {
-            version = version.substring(8);
-        }
-        String sp = null;
-        int suiteMask = 0;
-        String buildNumber = "";
-        WmiResult<OSVersionProperty> versionInfo = Win32OperatingSystemFFM.queryOsVersion();
-        if (versionInfo.getResultCount() > 0) {
-            sp = WmiUtil.getString(versionInfo, OSVersionProperty.CSDVERSION, 0);
-            if (!sp.isEmpty() && !"unknown".equals(sp)) {
-                version = version + " " + sp.replace("Service Pack ", "SP");
-            }
-            suiteMask = WmiUtil.getUint32(versionInfo, OSVersionProperty.SUITEMASK, 0);
-            buildNumber = WmiUtil.getString(versionInfo, OSVersionProperty.BUILDNUMBER, 0);
-        }
-        String codeName = parseCodeName(suiteMask);
-        if ("10".equals(version) && buildNumber.compareTo("22000") >= 0) {
-            version = "11";
-        }
-        if ("Server 2016".equals(version) && buildNumber.compareTo("17762") > 0) {
-            version = "Server 2019";
-        }
-        if ("Server 2019".equals(version) && buildNumber.compareTo("20347") > 0) {
-            version = "Server 2022";
-        }
-        if ("Server 2022".equals(version) && buildNumber.compareTo("26039") > 0) {
-            version = "Server 2025";
-        }
-        return new Pair<>("Windows", new OSVersionInfo(version, codeName, buildNumber));
+    protected WmiResult<OSVersionProperty> queryOsVersion() {
+        return Win32OperatingSystemFFM.queryOsVersion();
     }
 
     @Override

--- a/oshi-core-ffm/src/test/java/module-info.test
+++ b/oshi-core-ffm/src/test/java/module-info.test
@@ -21,7 +21,11 @@
 --add-opens
   com.github.oshi.ffm/oshi.driver.unix.aix.perfstat=org.junit.platform.commons
 --add-opens
+  com.github.oshi.ffm/oshi.ffm.platform.windows=org.junit.platform.commons
+--add-opens
   com.github.oshi.ffm/oshi.ffm.platform.windows.com=org.junit.platform.commons
+--add-opens
+  com.github.oshi.ffm/oshi.software.os.windows=org.junit.platform.commons
 --add-opens
   com.github.oshi.ffm/oshi.ffm.util.platform.windows=org.junit.platform.commons
 --add-opens

--- a/oshi-core-ffm/src/test/java/oshi/ffm/platform/windows/WindowsForeignFunctionsTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/platform/windows/WindowsForeignFunctionsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.condition.OS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@EnabledForJreRange(min = JRE.JAVA_25)
+@EnabledOnOs(OS.WINDOWS)
+class WindowsForeignFunctionsTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsForeignFunctionsTest.class);
+
+    @Test
+    void testSucceededOrLogPassesThrough() {
+        assertThat("A successful call is reported as successful",
+                WindowsForeignFunctions.succeededOrLog(true, LOG, "SucceedingFunction"), is(true));
+        assertThat("A failed call is reported as failed and logs GetLastError",
+                WindowsForeignFunctions.succeededOrLog(false, LOG, "FailingFunction"), is(false));
+    }
+
+    @Test
+    void testIsSuccess() {
+        assertThat("A zero BOOL is false", WindowsForeignFunctions.isSuccess(0), is(false));
+        assertThat("A nonzero BOOL is true", WindowsForeignFunctions.isSuccess(1), is(true));
+    }
+}

--- a/oshi-core-ffm/src/test/java/oshi/software/os/windows/WindowsOperatingSystemFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/software/os/windows/WindowsOperatingSystemFFMTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.oneOf;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
@@ -18,6 +19,8 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
+import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.software.os.OSProcess;
 
 @EnabledForJreRange(min = JRE.JAVA_25)
@@ -53,11 +56,19 @@ class WindowsOperatingSystemFFMTest {
     }
 
     @Test
-    void testQueryMapsFromPerfCounters() {
+    void testBuildMapsFromPerfCounters() {
         assertThat("Process map from performance counters should not be null",
-                WindowsOperatingSystemFFM.queryProcessMapFromPerfCounters(), is(notNullValue()));
+                os.buildProcessMapFromPerfCountersForTest(), is(notNullValue()));
         assertThat("Thread map from performance counters should not be null",
-                WindowsOperatingSystemFFM.queryThreadMapFromPerfCounters(), is(notNullValue()));
+                os.buildThreadMapFromPerfCountersForTest(), is(notNullValue()));
+    }
+
+    @Test
+    void testQueryParentPidMap() {
+        Map<Integer, Integer> parentPidMap = os.queryParentPidMapForTest();
+        assertThat("Parent pid map should not be null", parentPidMap, is(notNullValue()));
+        assertThat("Parent pid map should include the current process", parentPidMap.containsKey(os.getProcessId()),
+                is(true));
     }
 
     private static final class TestWindowsOperatingSystemFFM extends WindowsOperatingSystemFFM {
@@ -71,6 +82,18 @@ class WindowsOperatingSystemFFMTest {
 
         private List<OSProcess> queryDescendantProcessesForTest(int parentPid) {
             return queryDescendantProcesses(parentPid);
+        }
+
+        private Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCountersForTest() {
+            return buildProcessMapFromPerfCounters(null);
+        }
+
+        private Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCountersForTest() {
+            return buildThreadMapFromPerfCounters(null);
+        }
+
+        private Map<Integer, Integer> queryParentPidMapForTest() {
+            return queryParentPidMap();
         }
     }
 }

--- a/oshi-core-ffm/src/test/java/oshi/software/os/windows/WindowsOperatingSystemFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/software/os/windows/WindowsOperatingSystemFFMTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.os.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.oneOf;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.software.os.OSProcess;
+
+@EnabledForJreRange(min = JRE.JAVA_25)
+@EnabledOnOs(OS.WINDOWS)
+class WindowsOperatingSystemFFMTest {
+
+    private final TestWindowsOperatingSystemFFM os = new TestWindowsOperatingSystemFFM();
+
+    @Test
+    void testQueryBitness() {
+        assertThat("64-bit JVM bitness should be returned directly", os.queryBitnessForTest(64), is(64));
+        assertThat("32-bit JVM bitness should be 32 or 64", os.queryBitnessForTest(32), is(oneOf(32, 64)));
+    }
+
+    @Test
+    void testQueryChildProcesses() {
+        int pid = os.getProcessId();
+        assertThat("Current process id should be positive", pid, is(greaterThan(0)));
+        List<OSProcess> childProcesses = os.queryChildProcessesForTest(pid);
+        assertThat("Child process query should not be null", childProcesses, is(notNullValue()));
+        assertThat("Child process query should include the queried process",
+                childProcesses.stream().anyMatch(p -> p.getProcessID() == pid), is(true));
+    }
+
+    @Test
+    void testQueryDescendantProcesses() {
+        int pid = os.getProcessId();
+        assertThat("Current process id should be positive", pid, is(greaterThan(0)));
+        List<OSProcess> descendantProcesses = os.queryDescendantProcessesForTest(pid);
+        assertThat("Descendant process query should not be null", descendantProcesses, is(notNullValue()));
+        assertThat("Descendant process query should include the queried process",
+                descendantProcesses.stream().anyMatch(p -> p.getProcessID() == pid), is(true));
+    }
+
+    @Test
+    void testQueryMapsFromPerfCounters() {
+        assertThat("Process map from performance counters should not be null",
+                WindowsOperatingSystemFFM.queryProcessMapFromPerfCounters(), is(notNullValue()));
+        assertThat("Thread map from performance counters should not be null",
+                WindowsOperatingSystemFFM.queryThreadMapFromPerfCounters(), is(notNullValue()));
+    }
+
+    private static final class TestWindowsOperatingSystemFFM extends WindowsOperatingSystemFFM {
+        private int queryBitnessForTest(int jvmBitness) {
+            return queryBitness(jvmBitness);
+        }
+
+        private List<OSProcess> queryChildProcessesForTest(int parentPid) {
+            return queryChildProcesses(parentPid);
+        }
+
+        private List<OSProcess> queryDescendantProcessesForTest(int parentPid) {
+            return queryDescendantProcesses(parentPid);
+        }
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
@@ -79,10 +79,8 @@ import oshi.software.os.OSService;
 import oshi.software.os.OSService.State;
 import oshi.software.os.OSSession;
 import oshi.software.os.OSThread;
-import oshi.util.Constants;
 import oshi.util.GlobalConfig;
 import oshi.util.Memoizer;
-import oshi.util.tuples.Pair;
 
 /**
  * Microsoft Windows, commonly referred to as Windows, is a group of several proprietary graphical operating system
@@ -133,39 +131,8 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
             WindowsOperatingSystemJNA::queryThreadMapFromPerfCounters, defaultExpiration());
 
     @Override
-    public Pair<String, OSVersionInfo> queryFamilyVersionInfo() {
-        String version = System.getProperty("os.name");
-        if (version.startsWith("Windows ")) {
-            version = version.substring(8);
-        }
-
-        String sp = null;
-        int suiteMask = 0;
-        String buildNumber = "";
-        WmiResult<OSVersionProperty> versionInfo = Win32OperatingSystemJNA.queryOsVersion();
-        if (versionInfo.getResultCount() > 0) {
-            sp = WmiUtil.getString(versionInfo, OSVersionProperty.CSDVERSION, 0);
-            if (!sp.isEmpty() && !Constants.UNKNOWN.equals(sp)) {
-                version = version + " " + sp.replace("Service Pack ", "SP");
-            }
-            suiteMask = WmiUtil.getUint32(versionInfo, OSVersionProperty.SUITEMASK, 0);
-            buildNumber = WmiUtil.getString(versionInfo, OSVersionProperty.BUILDNUMBER, 0);
-        }
-        String codeName = parseCodeName(suiteMask);
-        // Older JDKs don't recognize Win11 and Server2022
-        if ("10".equals(version) && buildNumber.compareTo("22000") >= 0) {
-            version = "11";
-        }
-        if ("Server 2016".equals(version) && buildNumber.compareTo("17762") > 0) {
-            version = "Server 2019";
-        }
-        if ("Server 2019".equals(version) && buildNumber.compareTo("20347") > 0) {
-            version = "Server 2022";
-        }
-        if ("Server 2022".equals(version) && buildNumber.compareTo("26039") > 0) {
-            version = "Server 2025";
-        }
-        return new Pair<>("Windows", new OSVersionInfo(version, codeName, buildNumber));
+    protected WmiResult<OSVersionProperty> queryOsVersion() {
+        return Win32OperatingSystemJNA.queryOsVersion();
     }
 
     @Override
@@ -283,7 +250,8 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
         return ProcessPerformanceDataJNA.buildProcessMapFromRegistry(null);
     }
 
-    private static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromPerfCounters() {
+    // Package-private: only reached in production when the registry query fails, so tested directly
+    static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromPerfCounters() {
         return ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(null);
     }
 
@@ -291,7 +259,8 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
         return ThreadPerformanceDataJNA.buildThreadMapFromRegistry(null);
     }
 
-    private static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromPerfCounters() {
+    // Package-private: only reached in production when the registry query fails, so tested directly
+    static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromPerfCounters() {
         return ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(null);
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
@@ -7,23 +7,17 @@ package oshi.software.os.windows;
 import static oshi.software.os.OSService.State.OTHER;
 import static oshi.software.os.OSService.State.RUNNING;
 import static oshi.software.os.OSService.State.STOPPED;
-import static oshi.software.os.OperatingSystem.ProcessFiltering.VALID_PROCESS;
-import static oshi.util.Memoizer.defaultExpiration;
 import static oshi.util.Memoizer.installedAppsExpiration;
 import static oshi.util.Memoizer.memoize;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,21 +108,36 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
     private final Supplier<List<ApplicationInfo>> installedAppsSupplier = Memoizer
             .memoize(WindowsInstalledAppsJNA::queryInstalledApps, installedAppsExpiration());
 
-    /*
-     * Cache full process stats queries. Second query will only populate if first one returns null.
-     */
-    private Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromRegistry = memoize(
-            WindowsOperatingSystemJNA::queryProcessMapFromRegistry, defaultExpiration());
-    private Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromPerfCounters = memoize(
-            WindowsOperatingSystemJNA::queryProcessMapFromPerfCounters, defaultExpiration());
-    /*
-     * Cache full thread stats queries. Second query will only populate if first one returns null. Only used if
-     * USE_PROCSTATE_SUSPENDED is set true.
-     */
-    private Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromRegistry = memoize(
-            WindowsOperatingSystemJNA::queryThreadMapFromRegistry, defaultExpiration());
-    private Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromPerfCounters = memoize(
-            WindowsOperatingSystemJNA::queryThreadMapFromPerfCounters, defaultExpiration());
+    @Override
+    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids) {
+        return ProcessPerformanceDataJNA.buildProcessMapFromRegistry(pids);
+    }
+
+    @Override
+    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids) {
+        return ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(pids);
+    }
+
+    @Override
+    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
+        return ThreadPerformanceDataJNA.buildThreadMapFromRegistry(pids);
+    }
+
+    @Override
+    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids) {
+        return ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids);
+    }
+
+    @Override
+    protected Map<Integer, WtsInfo> queryProcessWtsMap(Collection<Integer> pids) {
+        return ProcessWtsData.queryProcessWtsMap(pids);
+    }
+
+    @Override
+    protected OSProcess createOSProcess(int pid, Map<Integer, ProcessPerfCounterBlock> processMap,
+            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
+        return new WindowsOSProcessJNA(pid, this, processMap, processWtsMap, threadMap);
+    }
 
     @Override
     protected WmiResult<OSVersionProperty> queryOsVersion() {
@@ -170,28 +179,7 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
     }
 
     @Override
-    public List<OSProcess> getProcesses(Collection<Integer> pids) {
-        return processMapToList(pids);
-    }
-
-    @Override
-    public List<OSProcess> queryAllProcesses() {
-        return processMapToList(null);
-    }
-
-    @Override
-    public List<OSProcess> queryChildProcesses(int parentPid) {
-        Set<Integer> descendantPids = getChildrenOrDescendants(getParentPidsFromSnapshot(), parentPid, false);
-        return processMapToList(descendantPids);
-    }
-
-    @Override
-    public List<OSProcess> queryDescendantProcesses(int parentPid) {
-        Set<Integer> descendantPids = getChildrenOrDescendants(getParentPidsFromSnapshot(), parentPid, true);
-        return processMapToList(descendantPids);
-    }
-
-    private static Map<Integer, Integer> getParentPidsFromSnapshot() {
+    protected Map<Integer, Integer> queryParentPidMap() {
         Map<Integer, Integer> parentPidMap = new HashMap<>();
         // Get processes from ToolHelp API for parent PID
         try (CloseablePROCESSENTRY32ByReference processEntry = new CloseablePROCESSENTRY32ByReference()) {
@@ -207,61 +195,6 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
             }
         }
         return parentPidMap;
-    }
-
-    @Override
-    public OSProcess getProcess(int pid) {
-        List<OSProcess> procList = processMapToList(Arrays.asList(pid));
-        return procList.isEmpty() ? null : procList.get(0);
-    }
-
-    private List<OSProcess> processMapToList(Collection<Integer> pids) {
-        // Get data from the registry if possible
-        Map<Integer, ProcessPerfCounterBlock> processMap = processMapFromRegistry.get();
-        // otherwise performance counters with WMI backup
-        if (processMap == null || processMap.isEmpty()) {
-            processMap = (pids == null) ? processMapFromPerfCounters.get()
-                    : ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(pids);
-        }
-        Map<Integer, ThreadPerfCounterBlock> threadMap = null;
-        if (USE_PROCSTATE_SUSPENDED) {
-            // Get data from the registry if possible
-            threadMap = threadMapFromRegistry.get();
-            // otherwise performance counters with WMI backup
-            if (threadMap == null || threadMap.isEmpty()) {
-                threadMap = (pids == null) ? threadMapFromPerfCounters.get()
-                        : ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids);
-            }
-        }
-
-        Map<Integer, WtsInfo> processWtsMap = ProcessWtsData.queryProcessWtsMap(pids);
-
-        Set<Integer> mapKeys = new HashSet<>(processWtsMap.keySet());
-        mapKeys.retainAll(processMap.keySet());
-
-        final Map<Integer, ProcessPerfCounterBlock> finalProcessMap = processMap;
-        final Map<Integer, ThreadPerfCounterBlock> finalThreadMap = threadMap;
-        return mapKeys.stream().parallel()
-                .map(pid -> new WindowsOSProcessJNA(pid, this, finalProcessMap, processWtsMap, finalThreadMap))
-                .filter(VALID_PROCESS).collect(Collectors.toList());
-    }
-
-    private static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromRegistry() {
-        return ProcessPerformanceDataJNA.buildProcessMapFromRegistry(null);
-    }
-
-    // Package-private: only reached in production when the registry query fails, so tested directly
-    static Map<Integer, ProcessPerfCounterBlock> queryProcessMapFromPerfCounters() {
-        return ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(null);
-    }
-
-    private static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromRegistry() {
-        return ThreadPerformanceDataJNA.buildThreadMapFromRegistry(null);
-    }
-
-    // Package-private: only reached in production when the registry query fails, so tested directly
-    static Map<Integer, ThreadPerfCounterBlock> queryThreadMapFromPerfCounters() {
-        return ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(null);
     }
 
     @Override

--- a/oshi-core/src/test/java/module-info.test
+++ b/oshi-core/src/test/java/module-info.test
@@ -49,6 +49,8 @@
 --add-opens
   com.github.oshi/oshi.driver.windows.wmi=org.junit.platform.commons
 --add-opens
+  com.github.oshi/oshi.software.os.windows=org.junit.platform.commons
+--add-opens
   com.github.oshi/oshi.jna.util=org.junit.platform.commons
 
 --add-modules

--- a/oshi-core/src/test/java/oshi/software/os/windows/WindowsOperatingSystemJNATest.java
+++ b/oshi-core/src/test/java/oshi/software/os/windows/WindowsOperatingSystemJNATest.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.ffm;
+package oshi.software.os.windows;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -13,19 +13,18 @@ import static org.hamcrest.Matchers.oneOf;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 
 import oshi.software.os.OSProcess;
-import oshi.software.os.windows.WindowsOperatingSystemFFM;
 
-@EnabledForJreRange(min = JRE.JAVA_25)
+/**
+ * Tests the JNA Windows operating system backend, mirroring {@code WindowsOperatingSystemFFMTest}.
+ */
 @EnabledOnOs(OS.WINDOWS)
-class WindowsOperatingSystemFFMTest {
+class WindowsOperatingSystemJNATest {
 
-    private final TestWindowsOperatingSystemFFM os = new TestWindowsOperatingSystemFFM();
+    private final TestWindowsOperatingSystemJNA os = new TestWindowsOperatingSystemJNA();
 
     @Test
     void testQueryBitness() {
@@ -37,33 +36,29 @@ class WindowsOperatingSystemFFMTest {
     void testQueryChildProcesses() {
         int pid = os.getProcessId();
         assertThat("Current process id should be positive", pid, is(greaterThan(0)));
-        List<OSProcess> childProcesses = os.queryChildProcessesForTest(pid);
+        List<OSProcess> childProcesses = os.queryChildProcesses(pid);
         assertThat("Child process query should not be null", childProcesses, is(notNullValue()));
-        assertThat("Child process query should include the queried process",
-                childProcesses.stream().anyMatch(p -> p.getProcessID() == pid), is(true));
     }
 
     @Test
     void testQueryDescendantProcesses() {
         int pid = os.getProcessId();
         assertThat("Current process id should be positive", pid, is(greaterThan(0)));
-        List<OSProcess> descendantProcesses = os.queryDescendantProcessesForTest(pid);
+        List<OSProcess> descendantProcesses = os.queryDescendantProcesses(pid);
         assertThat("Descendant process query should not be null", descendantProcesses, is(notNullValue()));
-        assertThat("Descendant process query should include the queried process",
-                descendantProcesses.stream().anyMatch(p -> p.getProcessID() == pid), is(true));
     }
 
-    private static final class TestWindowsOperatingSystemFFM extends WindowsOperatingSystemFFM {
+    @Test
+    void testQueryMapsFromPerfCounters() {
+        assertThat("Process map from performance counters should not be null",
+                WindowsOperatingSystemJNA.queryProcessMapFromPerfCounters(), is(notNullValue()));
+        assertThat("Thread map from performance counters should not be null",
+                WindowsOperatingSystemJNA.queryThreadMapFromPerfCounters(), is(notNullValue()));
+    }
+
+    private static final class TestWindowsOperatingSystemJNA extends WindowsOperatingSystemJNA {
         private int queryBitnessForTest(int jvmBitness) {
             return queryBitness(jvmBitness);
-        }
-
-        private List<OSProcess> queryChildProcessesForTest(int parentPid) {
-            return queryChildProcesses(parentPid);
-        }
-
-        private List<OSProcess> queryDescendantProcessesForTest(int parentPid) {
-            return queryDescendantProcesses(parentPid);
         }
     }
 }

--- a/oshi-core/src/test/java/oshi/software/os/windows/WindowsOperatingSystemJNATest.java
+++ b/oshi-core/src/test/java/oshi/software/os/windows/WindowsOperatingSystemJNATest.java
@@ -11,11 +11,14 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.oneOf;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
+import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.software.os.OSProcess;
 
 /**
@@ -36,29 +39,61 @@ class WindowsOperatingSystemJNATest {
     void testQueryChildProcesses() {
         int pid = os.getProcessId();
         assertThat("Current process id should be positive", pid, is(greaterThan(0)));
-        List<OSProcess> childProcesses = os.queryChildProcesses(pid);
+        List<OSProcess> childProcesses = os.queryChildProcessesForTest(pid);
         assertThat("Child process query should not be null", childProcesses, is(notNullValue()));
+        assertThat("Child process query should include the queried process",
+                childProcesses.stream().anyMatch(p -> p.getProcessID() == pid), is(true));
     }
 
     @Test
     void testQueryDescendantProcesses() {
         int pid = os.getProcessId();
         assertThat("Current process id should be positive", pid, is(greaterThan(0)));
-        List<OSProcess> descendantProcesses = os.queryDescendantProcesses(pid);
+        List<OSProcess> descendantProcesses = os.queryDescendantProcessesForTest(pid);
         assertThat("Descendant process query should not be null", descendantProcesses, is(notNullValue()));
+        assertThat("Descendant process query should include the queried process",
+                descendantProcesses.stream().anyMatch(p -> p.getProcessID() == pid), is(true));
     }
 
     @Test
-    void testQueryMapsFromPerfCounters() {
+    void testBuildMapsFromPerfCounters() {
         assertThat("Process map from performance counters should not be null",
-                WindowsOperatingSystemJNA.queryProcessMapFromPerfCounters(), is(notNullValue()));
+                os.buildProcessMapFromPerfCountersForTest(), is(notNullValue()));
         assertThat("Thread map from performance counters should not be null",
-                WindowsOperatingSystemJNA.queryThreadMapFromPerfCounters(), is(notNullValue()));
+                os.buildThreadMapFromPerfCountersForTest(), is(notNullValue()));
+    }
+
+    @Test
+    void testQueryParentPidMap() {
+        Map<Integer, Integer> parentPidMap = os.queryParentPidMapForTest();
+        assertThat("Parent pid map should not be null", parentPidMap, is(notNullValue()));
+        assertThat("Parent pid map should include the current process", parentPidMap.containsKey(os.getProcessId()),
+                is(true));
     }
 
     private static final class TestWindowsOperatingSystemJNA extends WindowsOperatingSystemJNA {
         private int queryBitnessForTest(int jvmBitness) {
             return queryBitness(jvmBitness);
+        }
+
+        private List<OSProcess> queryChildProcessesForTest(int parentPid) {
+            return queryChildProcesses(parentPid);
+        }
+
+        private List<OSProcess> queryDescendantProcessesForTest(int parentPid) {
+            return queryDescendantProcesses(parentPid);
+        }
+
+        private Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCountersForTest() {
+            return buildProcessMapFromPerfCounters(null);
+        }
+
+        private Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCountersForTest() {
+            return buildThreadMapFromPerfCounters(null);
+        }
+
+        private Map<Integer, Integer> queryParentPidMapForTest() {
+            return queryParentPidMap();
         }
     }
 }


### PR DESCRIPTION
Two commits: the first fixes a divergence between the Windows backends and shares the version parsing; the second removes the duplication that let the divergence happen.

## The bug

`WindowsOperatingSystemFFM.processMapToList` filtered an explicit pid request against the perf counter map alone, skipping the WTS map that the all-processes path intersects with. Both backends agree when `pids == null`; only the explicit-pid path differed.

The perf counter map is memoized (300 ms by default) and always fetched for every pid, so it can still name a process that has since exited. `WindowsOSProcess.updateAttributes` explicitly tolerates a null `WtsInfo`, and `WindowsOSProcessFFM` ignores a failed `OpenProcess`, so the state stayed `RUNNING` and `ProcessFiltering.VALID_PROCESS` passed it through. The caller got a process reporting `RUNNING` with an empty path, zero threads, zero virtual size and zero CPU time.

Put plainly: `getProcess(pid)` could return a process that `getProcesses()` would not list. FFM now intersects with the freshly queried WTS keys either way, matching JNA.

It arrived with the FFM port of `WindowsOSProcess` (#3126), whose description lists "PID filtering" as a fix, so it was deliberate rather than an oversight — but the comment on the `pids == null` branch already said WTS enrichment was required for full data, which is just as true for an explicit pid.

## Sharing the code

`queryFamilyVersionInfo` and `processMapToList` were both duplicated between the twins, and `processMapToList` is exactly where they drifted apart. Both now live in the common `WindowsOperatingSystem` base.

The version logic is split so the parsing is separable from the acquisition: `parseVersionInfo` and `resolveVersionAlias` are pure and unit tested on every platform rather than only under Windows CI. That also settles JNA comparing the service pack against `Constants.UNKNOWN` where FFM used an `"unknown"` literal.

The process plumbing takes seven one-line hooks per backend: the four registry/perf-counter map builders, the WTS query, the parent pid map, and an `OSProcess` factory. Because the builders take the pid collection, the four `queryXMapFromY()` wrappers that existed only as memoizer method references are gone.

`queryParentPidMap` is the one genuine difference and stays a hook: JNA takes a live ToolHelp32 snapshot, FFM derives parents from the cached perf counter data. The reason is recorded on the FFM override.

## Also

- `WindowsForeignFunctions.succeededOrLog` replaces the repeated "log `GetLastError` and bail" guard, and fixes five FFM sites that logged the `OptionalInt` wrapper instead of the error code.
- `resolveProcessMap` returns an empty map rather than null when neither source has data — reachable on both backends before.
- Dropped the FFM copy of `USE_PROCSTATE_SUSPENDED`, which shadowed the identical inherited constant.
- Added `WindowsOperatingSystemJNATest` mirroring the FFM backend's test, and moved `WindowsOperatingSystemFFMTest` into the package of the class under test.

## Compatibility

`queryAllProcesses`, `queryChildProcesses`, `queryDescendantProcesses` and `queryFamilyVersionInfo` are `protected` on the base; they were `public` on the concrete classes only because each override widened them. `getProcesses(Collection)` and `getProcess(int)` remain public, and the `OperatingSystem` interface is unchanged.

## Verification

Full clean reactor build, tests, checkstyle, forbidden-apis and javadoc pass locally on macOS. **The Windows paths themselves are unverified** — I cannot run them here, so the process behavior rests on Windows CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows process lookups so recently exited or unavailable processes are no longer reported as running with incomplete metadata.
  - Improved process and thread information retrieval across supported Windows backends.
  - Improved child and descendant process queries.
  - Improved Windows version and service-pack identification, including Windows 11 and Windows Server releases.
  - Added clearer diagnostics when Windows system calls fail.

- **Release Notes**
  - Updated the changelog for version 7.4.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->