### PR TITLE
Fix three JNA/FFM twin divergences on the file-system and network paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#3564](https://github.com/oshi/oshi/pull/3564): Fix Linux `getSoftOpenFileLimit()` returning -1 for a process whose hard open-file limit is `unlimited`, discarding a valid soft limit - [@dbwiddis](https://github.com/dbwiddis).
 * [#3566](https://github.com/oshi/oshi/pull/3566): Read the OpenBSD host name from `gethostname` rather than resolving it, so `getHostName()` no longer reports `localhost` on a host whose name is not resolvable - [@dbwiddis](https://github.com/dbwiddis).
 * [#3568](https://github.com/oshi/oshi/pull/3568): Fix the Windows FFM `getProcess(pid)` and `getProcesses(pids)` returning a process that `getProcesses()` does not list, reporting a recently exited process as running with no path, no threads, and no CPU time - [@dbwiddis](https://github.com/dbwiddis).
+* [#3569](https://github.com/oshi/oshi/pull/3569): Fix three JNA/FFM divergences on the file-system and network paths: the macOS FFM file store never bailed when the DiskArbitration session failed to open (the guard tested a foreign pointer for Java `null`, which it can never be); Windows volumes whose mount-point list exceeds the buffer were dropped rather than re-read on `ERROR_MORE_DATA` (missing entirely on JNA, keyed on the wrong error code on FFM); and the Windows FFM TCP/UDP connection queries could transiently return no connections under connection churn, where JNA retries on `ERROR_INSUFFICIENT_BUFFER` - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24), 7.4.3 (2027-07-31)
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
@@ -67,6 +67,13 @@ public final class IPHlpAPIUtilFFM {
 
     private static final Logger LOG = LoggerFactory.getLogger(IPHlpAPIUtilFFM.class);
 
+    /**
+     * Maximum number of times a connection-table fetch is retried after {@code ERROR_INSUFFICIENT_BUFFER}. The table
+     * can grow between sizing and fetching, but a table that keeps outgrowing the just-measured size this many times in
+     * a row is treated as a failure rather than reallocating from the arena indefinitely.
+     */
+    private static final int MAX_BUFFER_RETRIES = 5;
+
     private IPHlpAPIUtilFFM() {
     }
 
@@ -208,7 +215,7 @@ public final class IPHlpAPIUtilFFM {
             ret = GetExtendedTcpTable(buffer, sizeSegment, 0, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
             // The table can grow between sizing and fetching under connection churn; retry with the newly reported
             // size on ERROR_INSUFFICIENT_BUFFER rather than throwing and returning no connections.
-            while (ret == ERROR_INSUFFICIENT_BUFFER) {
+            for (int retry = 0; ret == ERROR_INSUFFICIENT_BUFFER && retry < MAX_BUFFER_RETRIES; retry++) {
                 size = sizeSegment.get(JAVA_INT, 0);
                 buffer = arena.allocate(size);
                 ret = GetExtendedTcpTable(buffer, sizeSegment, 0, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
@@ -266,7 +273,7 @@ public final class IPHlpAPIUtilFFM {
             ret = GetExtendedTcpTable(buffer, sizeSegment, 0, AF_INET6, TCP_TABLE_OWNER_PID_ALL, 0);
             // The table can grow between sizing and fetching under connection churn; retry with the newly reported
             // size on ERROR_INSUFFICIENT_BUFFER rather than throwing and returning no connections.
-            while (ret == ERROR_INSUFFICIENT_BUFFER) {
+            for (int retry = 0; ret == ERROR_INSUFFICIENT_BUFFER && retry < MAX_BUFFER_RETRIES; retry++) {
                 size = sizeSegment.get(JAVA_INT, 0);
                 buffer = arena.allocate(size);
                 ret = GetExtendedTcpTable(buffer, sizeSegment, 0, AF_INET6, TCP_TABLE_OWNER_PID_ALL, 0);
@@ -331,7 +338,7 @@ public final class IPHlpAPIUtilFFM {
             ret = GetExtendedUdpTable(buffer, sizeSegment, 0, AF_INET, UDP_TABLE_OWNER_PID, 0);
             // The table can grow between sizing and fetching under connection churn; retry with the newly reported
             // size on ERROR_INSUFFICIENT_BUFFER rather than throwing and returning no connections.
-            while (ret == ERROR_INSUFFICIENT_BUFFER) {
+            for (int retry = 0; ret == ERROR_INSUFFICIENT_BUFFER && retry < MAX_BUFFER_RETRIES; retry++) {
                 size = sizeSegment.get(JAVA_INT, 0);
                 buffer = arena.allocate(size);
                 ret = GetExtendedUdpTable(buffer, sizeSegment, 0, AF_INET, UDP_TABLE_OWNER_PID, 0);
@@ -382,7 +389,7 @@ public final class IPHlpAPIUtilFFM {
             ret = GetExtendedUdpTable(buffer, sizeSegment, 0, AF_INET6, UDP_TABLE_OWNER_PID, 0);
             // The table can grow between sizing and fetching under connection churn; retry with the newly reported
             // size on ERROR_INSUFFICIENT_BUFFER rather than throwing and returning no connections.
-            while (ret == ERROR_INSUFFICIENT_BUFFER) {
+            for (int retry = 0; ret == ERROR_INSUFFICIENT_BUFFER && retry < MAX_BUFFER_RETRIES; retry++) {
                 size = sizeSegment.get(JAVA_INT, 0);
                 buffer = arena.allocate(size);
                 ret = GetExtendedUdpTable(buffer, sizeSegment, 0, AF_INET6, UDP_TABLE_OWNER_PID, 0);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
@@ -206,6 +206,13 @@ public final class IPHlpAPIUtilFFM {
             MemorySegment buffer = arena.allocate(size);
 
             ret = GetExtendedTcpTable(buffer, sizeSegment, 0, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
+            // The table can grow between sizing and fetching under connection churn; retry with the newly reported
+            // size on ERROR_INSUFFICIENT_BUFFER rather than throwing and returning no connections.
+            while (ret == ERROR_INSUFFICIENT_BUFFER) {
+                size = sizeSegment.get(JAVA_INT, 0);
+                buffer = arena.allocate(size);
+                ret = GetExtendedTcpTable(buffer, sizeSegment, 0, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
+            }
             if (ret != ERROR_SUCCESS) {
                 throw new Win32Exception(ret);
             }
@@ -257,6 +264,13 @@ public final class IPHlpAPIUtilFFM {
             MemorySegment buffer = arena.allocate(size);
 
             ret = GetExtendedTcpTable(buffer, sizeSegment, 0, AF_INET6, TCP_TABLE_OWNER_PID_ALL, 0);
+            // The table can grow between sizing and fetching under connection churn; retry with the newly reported
+            // size on ERROR_INSUFFICIENT_BUFFER rather than throwing and returning no connections.
+            while (ret == ERROR_INSUFFICIENT_BUFFER) {
+                size = sizeSegment.get(JAVA_INT, 0);
+                buffer = arena.allocate(size);
+                ret = GetExtendedTcpTable(buffer, sizeSegment, 0, AF_INET6, TCP_TABLE_OWNER_PID_ALL, 0);
+            }
             if (ret != ERROR_SUCCESS) {
                 throw new Win32Exception(ret);
             }
@@ -315,6 +329,13 @@ public final class IPHlpAPIUtilFFM {
             MemorySegment buffer = arena.allocate(size);
 
             ret = GetExtendedUdpTable(buffer, sizeSegment, 0, AF_INET, UDP_TABLE_OWNER_PID, 0);
+            // The table can grow between sizing and fetching under connection churn; retry with the newly reported
+            // size on ERROR_INSUFFICIENT_BUFFER rather than throwing and returning no connections.
+            while (ret == ERROR_INSUFFICIENT_BUFFER) {
+                size = sizeSegment.get(JAVA_INT, 0);
+                buffer = arena.allocate(size);
+                ret = GetExtendedUdpTable(buffer, sizeSegment, 0, AF_INET, UDP_TABLE_OWNER_PID, 0);
+            }
             if (ret != ERROR_SUCCESS) {
                 throw new Win32Exception(ret);
             }
@@ -359,6 +380,13 @@ public final class IPHlpAPIUtilFFM {
             MemorySegment buffer = arena.allocate(size);
 
             ret = GetExtendedUdpTable(buffer, sizeSegment, 0, AF_INET6, UDP_TABLE_OWNER_PID, 0);
+            // The table can grow between sizing and fetching under connection churn; retry with the newly reported
+            // size on ERROR_INSUFFICIENT_BUFFER rather than throwing and returning no connections.
+            while (ret == ERROR_INSUFFICIENT_BUFFER) {
+                size = sizeSegment.get(JAVA_INT, 0);
+                buffer = arena.allocate(size);
+                ret = GetExtendedUdpTable(buffer, sizeSegment, 0, AF_INET6, UDP_TABLE_OWNER_PID, 0);
+            }
             if (ret != ERROR_SUCCESS) {
                 throw new Win32Exception(ret);
             }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
@@ -85,7 +85,7 @@ public class MacFileSystemFFM extends MacFileSystem {
             @SuppressWarnings("resource") // CFAllocatorGetDefault returns a borrowed singleton
             CFAllocatorRef allocator = new CFAllocatorRef(CFAllocatorGetDefault());
             try (DASessionRef session = new DASessionRef(DASessionCreate(allocator.segment()))) {
-                if (session.segment() == null) {
+                if (session.isNull()) {
                     LOG.error("Unable to open session to DiskArbitration framework.");
                     return fsList;
                 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -30,6 +30,7 @@ import oshi.driver.windows.perfmon.ProcessInformationFFM;
 import oshi.driver.windows.wmi.Win32LogicalDiskFFM;
 import oshi.ffm.NativeHandle;
 import oshi.ffm.platform.windows.Kernel32FFM;
+import oshi.ffm.platform.windows.WinErrorFFM;
 import oshi.software.common.os.windows.WindowsFileSystem;
 import oshi.software.os.OSFileStore;
 import oshi.util.ParseUtil;
@@ -178,9 +179,10 @@ public class WindowsFileSystemFFM extends WindowsFileSystem {
                     int mountBufSize = BUFSIZE;
                     var pathNamesResult = Kernel32FFM.GetVolumePathNamesForVolumeName(toWideString(arena, volume),
                             mountBuf, mountBufSize, returnLengthBuf);
-                    // ERROR_MORE_DATA
+                    // GetVolumePathNamesForVolumeName reports a too-small buffer with ERROR_MORE_DATA, not
+                    // ERROR_INSUFFICIENT_BUFFER; on that code retry with the length it wrote to returnLengthBuf.
                     if ((pathNamesResult.isEmpty() || pathNamesResult.getAsInt() == 0)
-                            && Kernel32FFM.GetLastError().orElse(0) == 0x7A) {
+                            && Kernel32FFM.GetLastError().orElse(0) == WinErrorFFM.ERROR_MORE_DATA) {
                         mountBufSize = returnLengthBuf.get(JAVA_INT, 0);
                         mountBuf = arena.allocate(mountBufSize * JAVA_CHAR.byteSize());
                         pathNamesResult = Kernel32FFM.GetVolumePathNamesForVolumeName(toWideString(arena, volume),

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.WinBase;
+import com.sun.jna.platform.win32.WinError;
 import com.sun.jna.platform.win32.WinNT;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -150,7 +151,8 @@ public class WindowsFileSystemJNA extends WindowsFileSystem {
         if (WinBase.INVALID_HANDLE_VALUE.equals(hVol)) {
             return fs;
         }
-        try (CloseableIntByReference pFlags = new CloseableIntByReference()) {
+        try (CloseableIntByReference pFlags = new CloseableIntByReference();
+                CloseableIntByReference pMountLen = new CloseableIntByReference()) {
             do {
                 fstype = new char[16];
                 name = new char[BUFSIZE];
@@ -167,8 +169,16 @@ public class WindowsFileSystemJNA extends WindowsFileSystem {
                     continue;
                 }
                 final int flags = pFlags.getValue();
-                if (!Kernel32.INSTANCE.GetVolumePathNamesForVolumeName(volume, mount, BUFSIZE, null)) {
-                    continue;
+                // GetVolumePathNamesForVolumeName reports a too-small buffer with ERROR_MORE_DATA and writes the
+                // required length; retry once with a right-sized buffer rather than dropping the volume.
+                if (!Kernel32.INSTANCE.GetVolumePathNamesForVolumeName(volume, mount, mount.length, pMountLen)) {
+                    if (Kernel32.INSTANCE.GetLastError() != WinError.ERROR_MORE_DATA) {
+                        continue;
+                    }
+                    mount = new char[pMountLen.getValue()];
+                    if (!Kernel32.INSTANCE.GetVolumePathNamesForVolumeName(volume, mount, mount.length, pMountLen)) {
+                        continue;
+                    }
                 }
 
                 strMount = Native.toString(mount);

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsJNA.java
@@ -55,6 +55,13 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
 
     private static final boolean IS_VISTA_OR_GREATER = VersionHelpers.IsWindowsVistaOrGreater();
 
+    /**
+     * Maximum number of times a connection-table fetch is retried after {@code ERROR_INSUFFICIENT_BUFFER}. The table
+     * can grow between sizing and fetching, but a table that outgrows the buffer this many times in a row is treated as
+     * a failure rather than retried indefinitely.
+     */
+    private static final int MAX_BUFFER_RETRIES = 5;
+
     @Override
     public TcpStats getTCPv4Stats() {
         try (CloseableMibTcpStats stats = new CloseableMibTcpStats()) {
@@ -113,6 +120,10 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
             int size = sizePtr.getValue();
             Memory buf = new Memory(size);
             try {
+                // The table can grow between sizing and fetching under connection churn; retry on
+                // ERROR_INSUFFICIENT_BUFFER, but bound the retries so a persistently growing table fails through the
+                // empty-list return rather than looping indefinitely.
+                int retries = 0;
                 do {
                     ret = IPHLP.GetExtendedTcpTable(buf, sizePtr, false, AF_INET, TCP_TABLE_OWNER_PID_ALL, 0);
                     if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
@@ -120,7 +131,7 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
                         buf.close();
                         buf = new Memory(size);
                     }
-                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
+                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER && ++retries <= MAX_BUFFER_RETRIES);
                 if (ret == WinError.ERROR_SUCCESS) {
                     MIB_TCPTABLE_OWNER_PID tcpTable = new MIB_TCPTABLE_OWNER_PID(buf);
                     for (int i = 0; i < tcpTable.dwNumEntries; i++) {
@@ -148,6 +159,10 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
             int size = sizePtr.getValue();
             Memory buf = new Memory(size);
             try {
+                // The table can grow between sizing and fetching under connection churn; retry on
+                // ERROR_INSUFFICIENT_BUFFER, but bound the retries so a persistently growing table fails through the
+                // empty-list return rather than looping indefinitely.
+                int retries = 0;
                 do {
                     ret = IPHLP.GetExtendedTcpTable(buf, sizePtr, false, AF_INET6, TCP_TABLE_OWNER_PID_ALL, 0);
                     if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
@@ -155,7 +170,7 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
                         buf.close();
                         buf = new Memory(size);
                     }
-                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
+                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER && ++retries <= MAX_BUFFER_RETRIES);
                 if (ret == WinError.ERROR_SUCCESS) {
                     MIB_TCP6TABLE_OWNER_PID tcpTable = new MIB_TCP6TABLE_OWNER_PID(buf);
                     for (int i = 0; i < tcpTable.dwNumEntries; i++) {
@@ -182,6 +197,10 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
             int size = sizePtr.getValue();
             Memory buf = new Memory(size);
             try {
+                // The table can grow between sizing and fetching under connection churn; retry on
+                // ERROR_INSUFFICIENT_BUFFER, but bound the retries so a persistently growing table fails through the
+                // empty-list return rather than looping indefinitely.
+                int retries = 0;
                 do {
                     ret = IPHLP.GetExtendedUdpTable(buf, sizePtr, false, AF_INET, UDP_TABLE_OWNER_PID, 0);
                     if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
@@ -189,7 +208,7 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
                         buf.close();
                         buf = new Memory(size);
                     }
-                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
+                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER && ++retries <= MAX_BUFFER_RETRIES);
                 if (ret == WinError.ERROR_SUCCESS) {
                     MIB_UDPTABLE_OWNER_PID udpTable = new MIB_UDPTABLE_OWNER_PID(buf);
                     for (int i = 0; i < udpTable.dwNumEntries; i++) {
@@ -215,6 +234,10 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
             int size = sizePtr.getValue();
             Memory buf = new Memory(size);
             try {
+                // The table can grow between sizing and fetching under connection churn; retry on
+                // ERROR_INSUFFICIENT_BUFFER, but bound the retries so a persistently growing table fails through the
+                // empty-list return rather than looping indefinitely.
+                int retries = 0;
                 do {
                     ret = IPHLP.GetExtendedUdpTable(buf, sizePtr, false, AF_INET6, UDP_TABLE_OWNER_PID, 0);
                     if (ret == WinError.ERROR_INSUFFICIENT_BUFFER) {
@@ -222,7 +245,7 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
                         buf.close();
                         buf = new Memory(size);
                     }
-                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER);
+                } while (ret == WinError.ERROR_INSUFFICIENT_BUFFER && ++retries <= MAX_BUFFER_RETRIES);
                 if (ret == WinError.ERROR_SUCCESS) {
                     MIB_UDP6TABLE_OWNER_PID udpTable = new MIB_UDP6TABLE_OWNER_PID(buf);
                     for (int i = 0; i < udpTable.dwNumEntries; i++) {


### PR DESCRIPTION
Found by a normalized set-difference sweep over the JNA/FFM twin pairs — stripping the `JNA`/`FFM` suffixes, reducing each side to its logic lines, and `comm`-ing the two. This surfaces divergences that duplication detection structurally cannot: a duplicate-block matcher discards exactly the differing lines, which is where these bugs live. All three are edge-case guards present on one twin and missing (or misconfigured) on the other; none is reachable on the happy path, which is why they survived.

### 1. macOS FFM file store — dead DiskArbitration null guard
`MacFileSystemFFM` guarded the DiskArbitration session with `session.segment() == null`. `DASessionCreate` is an `ADDRESS` downcall, so on failure it returns `MemorySegment.NULL`, never Java `null` — the guard was dead and the "Unable to open session" bail never fired. This was the only `segment() == null` in the whole FFM module; the sibling `MacHWDiskStoreFFM` already uses `isNull()`. The JNA twin bails correctly. Fixed to `session.isNull()`.

### 2. Windows file system — mount-point list buffer overflow
A volume whose mount-point list exceeds the buffer was dropped from the results:
- **JNA** (`WindowsFileSystemJNA`) had no retry at all and passed `null` for the return-length pointer. Now retries once with a right-sized buffer on `ERROR_MORE_DATA`.
- **FFM** (`WindowsFileSystemFFM`) *had* a retry, but keyed it on `0x7A` (`ERROR_INSUFFICIENT_BUFFER`), whereas `GetVolumePathNamesForVolumeName` reports a short buffer with `ERROR_MORE_DATA` (234) — so its retry never fired either. Now uses the correct named constant.

### 3. Windows FFM TCP/UDP connections — no size-race retry
`IPHlpAPIUtilFFM`'s four connection queries sized once then fetched once, throwing `Win32Exception` on `ERROR_INSUFFICIENT_BUFFER`. Under connection churn the table can grow between the two calls, transiently reporting no connections for that family. The JNA twin loops on `ERROR_INSUFFICIENT_BUFFER`; the FFM queries now do the same.

### Verification
Built and tested on macOS (JDK 25+ toolchain, so the FFM module is compiled): `spotless:apply`, `checkstyle:check`, `install` (tests green), and `forbiddenapis:check` all pass on `oshi-core`/`oshi-core-ffm`. The Windows paths compile but are not executable from this host; CI covers Windows. The `javadoc:javadoc` aggregator step fails identically on clean `master` (a named/unnamed-module reactor-composition issue, unrelated to these changes, which add only line comments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS file-system session failure handling.
  * Improved Windows volume and mount-path enumeration when additional buffer space is required.
  * Added bounded retries for Windows TCP and UDP connection queries when data exceeds the initial buffer size.
  * Prevented repeated retry attempts from continuing indefinitely during Windows network connection queries.
  * Standardized Windows error handling for volume path and network connection operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->