### PR TITLE
Hoist the MacDisplay CoreFoundation helpers into CFUtil/CFUtilFFM

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/CFUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/CFUtilFFM.java
@@ -7,6 +7,8 @@ package oshi.ffm.util.platform.mac;
 import java.lang.foreign.MemorySegment;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.ffm.platform.mac.CoreFoundation.CFDictionaryRef;
+import oshi.ffm.platform.mac.CoreFoundation.CFNumberRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFStringRef;
 import oshi.util.Constants;
 
@@ -55,5 +57,55 @@ public final class CFUtilFFM {
      */
     public static CFStringRef stringToCFString(String str) {
         return CFStringRef.createCFString(str);
+    }
+
+    /**
+     * Reads a nested dictionary value from a CFDictionary by key.
+     * <p>
+     * {@code CFDictionaryGetValue} returns a borrowed reference, so the returned dictionary must <em>not</em> be
+     * released.
+     *
+     * @param dict the dictionary to read from
+     * @param key  the string key to look up
+     * @return the value as a {@link CFDictionaryRef}, or {@code null} if the key is absent
+     */
+    public static CFDictionaryRef getDictionary(CFDictionaryRef dict, String key) {
+        try (CFStringRef k = CFStringRef.createCFString(key)) {
+            MemorySegment v = dict.getValue(k);
+            return v == null || v.equals(MemorySegment.NULL) ? null : new CFDictionaryRef(v);
+        }
+    }
+
+    /**
+     * Reads a string value from a CFDictionary by key.
+     * <p>
+     * {@code CFDictionaryGetValue} returns a borrowed reference, so the underlying value must <em>not</em> be released.
+     *
+     * @param dict the dictionary to read from
+     * @param key  the string key to look up
+     * @return the value as a {@link String}, or {@code null} if the key is absent
+     */
+    public static String getString(CFDictionaryRef dict, String key) {
+        try (CFStringRef k = CFStringRef.createCFString(key)) {
+            MemorySegment v = dict.getValue(k);
+            return v == null || v.equals(MemorySegment.NULL) ? null : new CFStringRef(v).stringValue();
+        }
+    }
+
+    /**
+     * Reads a long value from a CFDictionary by key.
+     * <p>
+     * {@code CFDictionaryGetValue} returns a borrowed reference, so the underlying value must <em>not</em> be released.
+     * The value is read as a 64-bit integer.
+     *
+     * @param dict the dictionary to read from
+     * @param key  the string key to look up
+     * @return the value as a {@link Long}, or {@code null} if the key is absent
+     */
+    public static Long getLong(CFDictionaryRef dict, String key) {
+        try (CFStringRef k = CFStringRef.createCFString(key)) {
+            MemorySegment v = dict.getValue(k);
+            return v == null || v.equals(MemorySegment.NULL) ? null : new CFNumberRef(v).longValue();
+        }
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
@@ -17,13 +17,13 @@ import oshi.annotation.concurrent.Immutable;
 import oshi.ffm.platform.mac.CoreFoundation.CFBooleanRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFDataRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFDictionaryRef;
-import oshi.ffm.platform.mac.CoreFoundation.CFNumberRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFStringRef;
 import oshi.ffm.platform.mac.CoreFoundationFunctions;
 import oshi.ffm.platform.mac.CoreGraphicsFunctions;
 import oshi.ffm.platform.mac.IOKit.IOIterator;
 import oshi.ffm.platform.mac.IOKit.IORegistryEntry;
 import oshi.ffm.platform.mac.ObjCFunctions;
+import oshi.ffm.util.platform.mac.CFUtilFFM;
 import oshi.ffm.util.platform.mac.IOKitUtilFFM;
 import oshi.hardware.Display;
 import oshi.hardware.DisplayInfo;
@@ -160,15 +160,15 @@ final class MacDisplayFFM extends AbstractDisplay {
     // Maps an Apple Silicon DisplayAttributes dictionary onto a synthetic DisplayInfo via EdidUtil, enriched with
     // native resolution and device name from the framebuffer node and CoreGraphics.
     private static DisplayInfo synthesize(IORegistryEntry fb, CFDictionaryRef attrs) {
-        CFDictionaryRef product = cfDictGetDictionary(attrs, "ProductAttributes");
+        CFDictionaryRef product = CFUtilFFM.getDictionary(attrs, "ProductAttributes");
         if (product == null) {
             return null;
         }
-        Long legacyMfg = cfDictGetLong(product, "LegacyManufacturerID");
-        Long week = cfDictGetLong(product, "WeekOfManufacture");
-        Long year = cfDictGetLong(product, "YearOfManufacture");
-        String model = cfDictGetString(product, "ProductName");
-        String serial = cfDictGetString(product, "AlphanumericSerialNumber");
+        Long legacyMfg = CFUtilFFM.getLong(product, "LegacyManufacturerID");
+        Long week = CFUtilFFM.getLong(product, "WeekOfManufacture");
+        Long year = CFUtilFFM.getLong(product, "YearOfManufacture");
+        String model = CFUtilFFM.getString(product, "ProductName");
+        String serial = CFUtilFFM.getString(product, "AlphanumericSerialNumber");
         // Native pixel resolution from the framebuffer node.
         Long displayWidth = fb.getLongProperty("DisplayWidth");
         Long displayHeight = fb.getLongProperty("DisplayHeight");
@@ -290,29 +290,5 @@ final class MacDisplayFFM extends AbstractDisplay {
             }
         }
         return null;
-    }
-
-    // CFDictionary accessors. CFDictionaryGetValue returns a borrowed reference: the returned wrappers must NOT be
-    // released.
-
-    private static CFDictionaryRef cfDictGetDictionary(CFDictionaryRef dict, String key) {
-        try (CFStringRef k = CFStringRef.createCFString(key)) {
-            MemorySegment v = dict.getValue(k);
-            return v == null || v.equals(MemorySegment.NULL) ? null : new CFDictionaryRef(v);
-        }
-    }
-
-    private static String cfDictGetString(CFDictionaryRef dict, String key) {
-        try (CFStringRef k = CFStringRef.createCFString(key)) {
-            MemorySegment v = dict.getValue(k);
-            return v == null || v.equals(MemorySegment.NULL) ? null : new CFStringRef(v).stringValue();
-        }
-    }
-
-    private static Long cfDictGetLong(CFDictionaryRef dict, String key) {
-        try (CFStringRef k = CFStringRef.createCFString(key)) {
-            MemorySegment v = dict.getValue(k);
-            return v == null || v.equals(MemorySegment.NULL) ? null : new CFNumberRef(v).longValue();
-        }
     }
 }

--- a/oshi-core-ffm/src/test/java/module-info.test
+++ b/oshi-core-ffm/src/test/java/module-info.test
@@ -5,6 +5,8 @@
 --add-opens
   com.github.oshi.ffm/oshi.ffm.platform.mac=org.junit.platform.commons
 --add-opens
+  com.github.oshi.ffm/oshi.ffm.util.platform.mac=org.junit.platform.commons
+--add-opens
   com.github.oshi.ffm/oshi.hardware.platform.unix.dragonflybsd=org.junit.platform.commons
 --add-opens
   com.github.oshi.ffm/oshi.ffm.util.platform.unix.freebsd=org.junit.platform.commons

--- a/oshi-core-ffm/src/test/java/oshi/ffm/util/platform/mac/CFUtilFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/util/platform/mac/CFUtilFFMTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.util.platform.mac;
+
+import static java.lang.foreign.MemorySegment.NULL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.condition.OS;
+
+import oshi.ffm.platform.mac.CoreFoundation;
+import oshi.ffm.platform.mac.CoreFoundation.CFDictionaryRef;
+import oshi.ffm.platform.mac.CoreFoundation.CFMutableDictionaryRef;
+import oshi.ffm.platform.mac.CoreFoundation.CFNumberRef;
+import oshi.ffm.platform.mac.CoreFoundation.CFStringRef;
+import oshi.ffm.platform.mac.CoreFoundationFunctions;
+import oshi.util.Constants;
+
+/**
+ * Tests for {@link CFUtilFFM} using real native CoreFoundation calls.
+ */
+@EnabledOnOs(OS.MAC)
+@EnabledForJreRange(min = JRE.JAVA_25)
+class CFUtilFFMTest {
+
+    private static final SymbolLookup CF_LOOKUP = SymbolLookup
+            .libraryLookup("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation", Arena.global());
+
+    @Test
+    void testCfPointerToString() {
+        try (CFStringRef s = CFStringRef.createCFString("hello")) {
+            assertThat(CFUtilFFM.cfPointerToString(s.segment()), is("hello"));
+        }
+        // Null segment yields the "unknown" sentinel, or empty when returnUnknown is false
+        assertThat(CFUtilFFM.cfPointerToString(NULL), is(Constants.UNKNOWN));
+        assertThat(CFUtilFFM.cfPointerToString(NULL, false), is(""));
+    }
+
+    @Test
+    void testStringToCFString() {
+        try (CFStringRef s = CFUtilFFM.stringToCFString("round-trip")) {
+            assertThat(s.isNull(), is(false));
+            assertThat(s.stringValue(), is("round-trip"));
+        }
+    }
+
+    @Test
+    void testGetString() throws Throwable {
+        try (CFMutableDictionaryRef dict = newDict();
+                CFStringRef key = CFStringRef.createCFString("model");
+                CFStringRef value = CFStringRef.createCFString("Studio Display")) {
+            dict.setValue(key, value);
+            assertThat(CFUtilFFM.getString(dict, "model"), is("Studio Display"));
+            // Absent key returns null
+            assertThat(CFUtilFFM.getString(dict, "missing"), is(nullValue()));
+        }
+    }
+
+    @Test
+    void testGetLong() throws Throwable {
+        try (Arena arena = Arena.ofConfined();
+                CFMutableDictionaryRef dict = newDict();
+                CFStringRef key = CFStringRef.createCFString("year")) {
+            MemorySegment allocator = CoreFoundationFunctions.CFAllocatorGetDefault();
+            MemorySegment valuePtr = arena.allocate(ValueLayout.JAVA_LONG);
+            valuePtr.set(ValueLayout.JAVA_LONG, 0, 2026L);
+            MemorySegment numSeg = CoreFoundationFunctions.CFNumberCreate(allocator,
+                    CoreFoundation.kCFNumberLongLongType, valuePtr);
+            try (CFNumberRef value = new CFNumberRef(numSeg)) {
+                dict.setValue(key, value);
+                assertThat(CFUtilFFM.getLong(dict, "year"), is(2026L));
+                // Absent key returns null
+                assertThat(CFUtilFFM.getLong(dict, "missing"), is(nullValue()));
+            }
+        }
+    }
+
+    @Test
+    void testGetDictionary() throws Throwable {
+        try (CFMutableDictionaryRef outer = newDict();
+                CFMutableDictionaryRef inner = newDict();
+                CFStringRef outerKey = CFStringRef.createCFString("ProductAttributes");
+                CFStringRef innerKey = CFStringRef.createCFString("ProductName");
+                CFStringRef innerValue = CFStringRef.createCFString("Pro Display XDR")) {
+            inner.setValue(innerKey, innerValue);
+            outer.setValue(outerKey, inner);
+
+            CFDictionaryRef nested = CFUtilFFM.getDictionary(outer, "ProductAttributes");
+            assertThat(nested, is(notNullValue()));
+            assertThat(CFUtilFFM.getString(nested, "ProductName"), is("Pro Display XDR"));
+
+            // Absent key returns null
+            assertThat(CFUtilFFM.getDictionary(outer, "missing"), is(nullValue()));
+        }
+    }
+
+    private static CFMutableDictionaryRef newDict() throws Throwable {
+        MemorySegment allocator = CoreFoundationFunctions.CFAllocatorGetDefault();
+        MemorySegment keyCallbacks = CF_LOOKUP.findOrThrow("kCFTypeDictionaryKeyCallBacks");
+        MemorySegment valCallbacks = CF_LOOKUP.findOrThrow("kCFTypeDictionaryValueCallBacks");
+        return new CFMutableDictionaryRef(
+                CoreFoundationFunctions.CFDictionaryCreateMutable(allocator, 0, keyCallbacks, valCallbacks));
+    }
+}

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
@@ -34,6 +34,7 @@ import oshi.jna.platform.mac.CoreGraphicsExt;
 import oshi.jna.platform.mac.ObjCRuntime;
 import oshi.util.EdidUtil;
 import oshi.util.ExceptionUtil;
+import oshi.util.platform.mac.CFUtil;
 
 /**
  * A Display
@@ -214,21 +215,21 @@ final class MacDisplayJNA extends AbstractDisplay {
     // Maps an Apple Silicon DisplayAttributes dictionary onto a synthetic DisplayInfo via EdidUtil, enriched with
     // native resolution and device name from the framebuffer node and CoreGraphics.
     private static DisplayInfo synthesize(IORegistryEntry fb, CFDictionaryRef attrs) {
-        CFDictionaryRef product = cfDictGetDictionary(attrs, "ProductAttributes");
+        CFDictionaryRef product = CFUtil.getDictionary(attrs, "ProductAttributes");
         if (product == null) {
             return null;
         }
-        Long legacyMfg = cfDictGetLong(product, "LegacyManufacturerID");
-        Long week = cfDictGetLong(product, "WeekOfManufacture");
-        Long year = cfDictGetLong(product, "YearOfManufacture");
-        String model = cfDictGetString(product, "ProductName");
-        String serial = cfDictGetString(product, "AlphanumericSerialNumber");
+        Long legacyMfg = CFUtil.getLong(product, "LegacyManufacturerID");
+        Long week = CFUtil.getLong(product, "WeekOfManufacture");
+        Long year = CFUtil.getLong(product, "YearOfManufacture");
+        String model = CFUtil.getString(product, "ProductName");
+        String serial = CFUtil.getString(product, "AlphanumericSerialNumber");
         // Native pixel resolution from the framebuffer node.
-        Long displayWidth = cfRegistryEntryGetLong(fb, "DisplayWidth");
-        Long displayHeight = cfRegistryEntryGetLong(fb, "DisplayHeight");
+        Long displayWidth = fb.getLongProperty("DisplayWidth");
+        Long displayHeight = fb.getLongProperty("DisplayHeight");
         // Device tree name for fallback model name.
         String fallbackName = null;
-        String ioNameMatched = cfRegistryEntryGetString(fb, "IONameMatched");
+        String ioNameMatched = fb.getStringProperty("IONameMatched");
         if (ioNameMatched != null) {
             String shortName = ioNameMatched.contains(",") ? ioNameMatched.substring(0, ioNameMatched.indexOf(','))
                     : ioNameMatched;
@@ -336,83 +337,5 @@ final class MacDisplayJNA extends AbstractDisplay {
             cfKey.release();
         }
         return null;
-    }
-
-    // Reads a long value from an IORegistryEntry property.
-    private static Long cfRegistryEntryGetLong(IORegistryEntry entry, String key) {
-        CFStringRef k = CFStringRef.createCFString(key);
-        try {
-            CFTypeRef ref = entry.createCFProperty(k);
-            if (ref == null) {
-                return null;
-            }
-            try {
-                CFNumberRef num = new CFNumberRef(ref.getPointer());
-                LongByReference out = new LongByReference();
-                CF.CFNumberGetValue(num, K_CF_NUMBER_SINT64, out);
-                return out.getValue();
-            } finally {
-                ref.release();
-            }
-        } finally {
-            k.release();
-        }
-    }
-
-    // Reads a string value from an IORegistryEntry property.
-    private static String cfRegistryEntryGetString(IORegistryEntry entry, String key) {
-        CFStringRef k = CFStringRef.createCFString(key);
-        try {
-            CFTypeRef ref = entry.createCFProperty(k);
-            if (ref == null) {
-                return null;
-            }
-            try {
-                return new CFStringRef(ref.getPointer()).stringValue();
-            } finally {
-                ref.release();
-            }
-        } finally {
-            k.release();
-        }
-    }
-
-    // CFDictionary accessors. CFDictionaryGetValue returns a borrowed reference: the returned values must NOT be
-    // released.
-
-    private static CFDictionaryRef cfDictGetDictionary(CFDictionaryRef dict, String key) {
-        CFStringRef k = CFStringRef.createCFString(key);
-        try {
-            Pointer v = CF.CFDictionaryGetValue(dict, k);
-            return v == null ? null : new CFDictionaryRef(v);
-        } finally {
-            k.release();
-        }
-    }
-
-    private static String cfDictGetString(CFDictionaryRef dict, String key) {
-        CFStringRef k = CFStringRef.createCFString(key);
-        try {
-            Pointer v = CF.CFDictionaryGetValue(dict, k);
-            return v == null ? null : new CFStringRef(v).stringValue();
-        } finally {
-            k.release();
-        }
-    }
-
-    private static Long cfDictGetLong(CFDictionaryRef dict, String key) {
-        CFStringRef k = CFStringRef.createCFString(key);
-        try {
-            Pointer v = CF.CFDictionaryGetValue(dict, k);
-            if (v == null) {
-                return null;
-            }
-            CFNumberRef num = new CFNumberRef(v);
-            LongByReference out = new LongByReference();
-            CF.CFNumberGetValue(num, K_CF_NUMBER_SINT64, out);
-            return out.getValue();
-        } finally {
-            k.release();
-        }
     }
 }

--- a/oshi-core/src/main/java/oshi/util/platform/mac/CFUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/CFUtil.java
@@ -1,20 +1,25 @@
 /*
- * Copyright 2021-2022 The OSHI Project Contributors
+ * Copyright 2021-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.util.platform.mac;
 
 import com.sun.jna.Pointer;
+import com.sun.jna.platform.mac.CoreFoundation;
+import com.sun.jna.platform.mac.CoreFoundation.CFDictionaryRef;
+import com.sun.jna.platform.mac.CoreFoundation.CFNumberRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFStringRef;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.Constants;
 
 /**
- * CF String retrieving
+ * CoreFoundation utility methods
  */
 @ThreadSafe
 public final class CFUtil {
+
+    private static final CoreFoundation CF = CoreFoundation.INSTANCE;
 
     private CFUtil() {
     }
@@ -48,4 +53,62 @@ public final class CFUtil {
         return s;
     }
 
+    /**
+     * Reads a nested dictionary value from a CFDictionary by key.
+     * <p>
+     * {@code CFDictionaryGetValue} returns a borrowed reference, so the returned dictionary must <em>not</em> be
+     * released.
+     *
+     * @param dict the dictionary to read from
+     * @param key  the string key to look up
+     * @return the value as a {@link CFDictionaryRef}, or {@code null} if the key is absent
+     */
+    public static CFDictionaryRef getDictionary(CFDictionaryRef dict, String key) {
+        CFStringRef k = CFStringRef.createCFString(key);
+        try {
+            Pointer v = CF.CFDictionaryGetValue(dict, k);
+            return v == null ? null : new CFDictionaryRef(v);
+        } finally {
+            k.release();
+        }
+    }
+
+    /**
+     * Reads a string value from a CFDictionary by key.
+     * <p>
+     * {@code CFDictionaryGetValue} returns a borrowed reference, so the underlying value must <em>not</em> be released.
+     *
+     * @param dict the dictionary to read from
+     * @param key  the string key to look up
+     * @return the value as a {@link String}, or {@code null} if the key is absent
+     */
+    public static String getString(CFDictionaryRef dict, String key) {
+        CFStringRef k = CFStringRef.createCFString(key);
+        try {
+            Pointer v = CF.CFDictionaryGetValue(dict, k);
+            return v == null ? null : new CFStringRef(v).stringValue();
+        } finally {
+            k.release();
+        }
+    }
+
+    /**
+     * Reads a long value from a CFDictionary by key.
+     * <p>
+     * {@code CFDictionaryGetValue} returns a borrowed reference, so the underlying value must <em>not</em> be released.
+     * The value is read as a 64-bit integer.
+     *
+     * @param dict the dictionary to read from
+     * @param key  the string key to look up
+     * @return the value as a {@link Long}, or {@code null} if the key is absent
+     */
+    public static Long getLong(CFDictionaryRef dict, String key) {
+        CFStringRef k = CFStringRef.createCFString(key);
+        try {
+            Pointer v = CF.CFDictionaryGetValue(dict, k);
+            return v == null ? null : new CFNumberRef(v).longValue();
+        } finally {
+            k.release();
+        }
+    }
 }

--- a/oshi-core/src/test/java/oshi/util/platform/mac/CFUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/mac/CFUtilTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.util.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.mac.CoreFoundation;
+import com.sun.jna.platform.mac.CoreFoundation.CFDictionaryRef;
+import com.sun.jna.platform.mac.CoreFoundation.CFIndex;
+import com.sun.jna.platform.mac.CoreFoundation.CFMutableDictionaryRef;
+import com.sun.jna.platform.mac.CoreFoundation.CFNumberRef;
+import com.sun.jna.platform.mac.CoreFoundation.CFStringRef;
+import com.sun.jna.ptr.LongByReference;
+
+import oshi.util.Constants;
+
+/**
+ * Tests for {@link CFUtil} using real native CoreFoundation calls.
+ */
+@EnabledOnOs(OS.MAC)
+@DisabledIfSystemProperty(named = "os.name", matches = "(?i).*netbsd.*")
+class CFUtilTest {
+
+    private static final CoreFoundation CF = CoreFoundation.INSTANCE;
+
+    // CFEqual-based key/value callbacks so lookups match by string content, not pointer identity, as real IOKit
+    // dictionaries do. Reuse the NativeLibrary already backing CoreFoundation.INSTANCE rather than loading a second.
+    private static final Pointer KEY_CALLBACKS = Native.getNativeLibrary(CF)
+            .getGlobalVariableAddress("kCFTypeDictionaryKeyCallBacks");
+    private static final Pointer VALUE_CALLBACKS = Native.getNativeLibrary(CF)
+            .getGlobalVariableAddress("kCFTypeDictionaryValueCallBacks");
+
+    @Test
+    void testCfPointerToString() {
+        CFStringRef s = CFStringRef.createCFString("hello");
+        try {
+            assertThat(CFUtil.cfPointerToString(s.getPointer()), is("hello"));
+        } finally {
+            s.release();
+        }
+        // Null pointer yields the "unknown" sentinel, or empty when returnUnknown is false
+        assertThat(CFUtil.cfPointerToString(null), is(Constants.UNKNOWN));
+        assertThat(CFUtil.cfPointerToString(null, false), is(""));
+    }
+
+    @Test
+    void testGetString() {
+        CFMutableDictionaryRef dict = newDict();
+        CFStringRef key = CFStringRef.createCFString("model");
+        CFStringRef value = CFStringRef.createCFString("Studio Display");
+        try {
+            dict.setValue(key, value);
+            assertThat(CFUtil.getString(dict, "model"), is("Studio Display"));
+            // Absent key returns null
+            assertThat(CFUtil.getString(dict, "missing"), is(nullValue()));
+        } finally {
+            value.release();
+            key.release();
+            dict.release();
+        }
+    }
+
+    @Test
+    void testGetLong() {
+        CFMutableDictionaryRef dict = newDict();
+        CFStringRef key = CFStringRef.createCFString("year");
+        LongByReference valuePtr = new LongByReference(2026L);
+        CFNumberRef value = CF.CFNumberCreate(null, CoreFoundation.CFNumberType.kCFNumberLongLongType.typeIndex(),
+                valuePtr);
+        try {
+            dict.setValue(key, value);
+            assertThat(CFUtil.getLong(dict, "year"), is(2026L));
+            // Absent key returns null
+            assertThat(CFUtil.getLong(dict, "missing"), is(nullValue()));
+        } finally {
+            value.release();
+            key.release();
+            dict.release();
+        }
+    }
+
+    @Test
+    void testGetDictionary() {
+        CFMutableDictionaryRef outer = newDict();
+        CFMutableDictionaryRef inner = newDict();
+        CFStringRef outerKey = CFStringRef.createCFString("ProductAttributes");
+        CFStringRef innerKey = CFStringRef.createCFString("ProductName");
+        CFStringRef innerValue = CFStringRef.createCFString("Pro Display XDR");
+        try {
+            inner.setValue(innerKey, innerValue);
+            outer.setValue(outerKey, inner);
+
+            CFDictionaryRef nested = CFUtil.getDictionary(outer, "ProductAttributes");
+            assertThat(nested, is(notNullValue()));
+            assertThat(CFUtil.getString(nested, "ProductName"), is("Pro Display XDR"));
+
+            // Absent key returns null
+            assertThat(CFUtil.getDictionary(outer, "missing"), is(nullValue()));
+        } finally {
+            innerValue.release();
+            innerKey.release();
+            outerKey.release();
+            inner.release();
+            outer.release();
+        }
+    }
+
+    private static CFMutableDictionaryRef newDict() {
+        return CF.CFDictionaryCreateMutable(CF.CFAllocatorGetDefault(), new CFIndex(0), KEY_CALLBACKS, VALUE_CALLBACKS);
+    }
+}


### PR DESCRIPTION
## Summary

`MacDisplayJNA` and `MacDisplayFFM` are among the highest-uncovered classes on Codecov, because CI has no display hardware to exercise them. Sitting inside them were several general-purpose CoreFoundation helpers that were untestable only by virtue of where they lived. This moves them out to the per-backend CF utility class.

Two distinct kinds of duplication were in there, and they get different treatment:

**`cfDictGet{Dictionary,String,Long}`** — general CFDictionary accessors, with a full copy in each twin. Hoisted to `CFUtil.getDictionary/getString/getLong` (JNA) and `CFUtilFFM.*` (FFM). They can't go to `oshi-common`, which may not reference JNA or FFM types, so one utility class per backend is as far as they can travel.

**`cfRegistryEntryGetLong` / `cfRegistryEntryGetString`** (JNA only) — these were reimplementing jna-platform's built-in `IORegistryEntry.getLongProperty` / `getStringProperty`, which the FFM twin was *already* calling. Deleted in favor of the built-ins. That removes the duplication and closes a quiet twin divergence: both implementations now read registry properties through the same path.

Net: `MacDisplayJNA` −97/+15, `MacDisplayFFM` −38/+9, with the shared logic in one tested place per backend.

The JNA and FFM sides are committed separately so `NativeComparisonTest` has a chance to flag drift between them, rather than a symmetric change passing silently.

## Tests

`CFUtilTest` and `CFUtilFFMTest` build a real native CFDictionary and round-trip values through the new accessors.

One subtlety worth recording for whoever writes the next CF test: the dictionary must be created with the CFEqual-based `kCFTypeDictionaryKeyCallBacks`/`kCFTypeDictionaryValueCallBacks`. With `null` callbacks CoreFoundation matches keys by *pointer identity*, so a freshly created `CFStringRef` for the same text does not hit — and the string cases can pass anyway on interning luck while the dictionary case fails. The FFM test package also needed an `--add-opens` line in `module-info.test`.

## Verification

Ran both `SystemInfoTest` entry points on an Apple Silicon host with an external monitor plus the built-in panel. Both displays are reported on both paths, and the two display sections are byte-for-byte identical:

```
Displays:
 Display 0:
  Manuf. ID=DEL, Product ID=a0df, Digital, Serial=0FDL, ManufDate=3/2017, EDID v1.3
  80 x 33 cm (31.5 x 13.0 in)
  Preferred Timing: Clock 319MHz, Active Pixels 3440x1440
  Serial Number: FR3PK73D0FDL
  Monitor Name: DELL U3417W
  Range Limits: Field Rate 48-85 Hz vertical, 30-89 Hz horizontal, Max clock: 320 MHz
 Display 1:
  Manuf. ID=APP, Product ID=a050, Digital, Serial=FD626D62, ManufDate=1/1990, EDID v1.4
  34 x 22 cm (13.4 x 8.7 in)
  Preferred Resolution: 3456x2234
  Monitor Name: Built-in Retina Display
  Serial Number: FD626D62
```

This covers the changed code end to end: Display 0 comes through the real-EDID path, and Display 1 is the synthesized built-in panel, which exercises every hoisted method — `getDictionary` resolving `ProductAttributes`, `getLong`/`getString` pulling the fields out of it, and the jna-platform built-ins producing the native resolution and name.

Full gate green on macOS / JDK 25: spotless, checkstyle, `clean install` with tests (0 failed), forbiddenapis, javadoc. Intel Mac and the pre-Apple-Silicon `IODisplayConnect` path are unverified — I have no Intel hardware.

No CHANGELOG entry: pure refactor plus test-only additions, no user-visible behavior change.

## Context

This is likely the first of a few. The same pattern — a utility-shaped helper buried in a focused class, untested because its host can't run on CI — shows up elsewhere; the parse helpers in the command-line-processing drivers look like the next candidates. Happy to split those off separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of Apple Silicon display information on macOS.
  * Improved handling of missing or nested display properties, reducing errors when system metadata is incomplete.

* **Refactor**
  * Standardized macOS system-property extraction for more consistent display details across supported runtime implementations.

* **Tests**
  * Added macOS integration coverage for display metadata, numeric values, nested properties, missing values, and native resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->