### PR TITLE
Hoist the macOS disk-type classification into MacHWDiskStore

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacHWDiskStore.java
@@ -40,6 +40,24 @@ public abstract class MacHWDiskStore extends AbstractHWDiskStore {
     }
 
     /**
+     * Classifies a disk from the IOKit {@code Medium Type} device characteristic.
+     *
+     * @param mediumType the {@code Medium Type} value from the device's {@code Device Characteristics} dictionary, or
+     *                   {@code null} if the property is absent
+     * @return {@code "SSD"}, {@code "HDD"}, or {@code "Unknown"} if the medium type is absent or unrecognized
+     */
+    protected static String parseMediumType(String mediumType) {
+        if (mediumType != null) {
+            if (mediumType.contains("Solid State") || mediumType.contains("SSD")) {
+                return "SSD";
+            } else if (mediumType.contains("Rotational")) {
+                return "HDD";
+            }
+        }
+        return "Unknown";
+    }
+
+    /**
      * Strings to convert to CFStringRef for pointer lookups.
      */
     protected enum CFKey {

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacHWDiskStoreTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacHWDiskStoreTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.mac;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the shared macOS disk classification logic without a Mac. The IOKit traversal that fetches the medium type
+ * cannot run in a unit test, so the classification is separated from the acquisition and tested here.
+ */
+class MacHWDiskStoreTest {
+
+    @Test
+    void testParseMediumTypeSolidState() {
+        // The spelling IOKit actually publishes for flash media
+        assertThat(MacHWDiskStore.parseMediumType("Solid State"), is("SSD"));
+        assertThat(MacHWDiskStore.parseMediumType("SSD"), is("SSD"));
+    }
+
+    @Test
+    void testParseMediumTypeRotational() {
+        assertThat(MacHWDiskStore.parseMediumType("Rotational"), is("HDD"));
+    }
+
+    @Test
+    void testParseMediumTypeMatchesSubstring() {
+        // The property is matched by substring, so surrounding text must not defeat it
+        assertThat(MacHWDiskStore.parseMediumType("Apple Solid State Media"), is("SSD"));
+        assertThat(MacHWDiskStore.parseMediumType("Rotational Media"), is("HDD"));
+    }
+
+    @Test
+    void testParseMediumTypeAbsent() {
+        // A null medium type is the normal result for a device that does not publish the characteristic
+        assertThat(MacHWDiskStore.parseMediumType(null), is("Unknown"));
+    }
+
+    @Test
+    void testParseMediumTypeUnrecognized() {
+        assertThat(MacHWDiskStore.parseMediumType(""), is("Unknown"));
+        assertThat(MacHWDiskStore.parseMediumType("Optical"), is("Unknown"));
+    }
+
+    @Test
+    void testParseMediumTypeIsCaseSensitive() {
+        // IOKit publishes these in title case; document that no case folding is applied
+        assertThat(MacHWDiskStore.parseMediumType("solid state"), is("Unknown"));
+        assertThat(MacHWDiskStore.parseMediumType("rotational"), is("Unknown"));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -388,46 +388,40 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
                 if (removable != null && removable) {
                     return "Removable";
                 }
-                // Traverse up: IOMedia -> IOBlockStorageDriver -> IOBlockStorageDevice
-                IORegistryEntry driver = media.getParentEntry("IOService");
-                if (driver != null) {
-                    try (driver) {
-                        IORegistryEntry device = driver.getParentEntry("IOService");
-                        if (device != null) {
-                            try (device) {
-                                MemorySegment propsSeg = device.createCFProperties();
-                                if (!propsSeg.equals(MemorySegment.NULL)) {
-                                    try (CFDictionaryRef props = new CFDictionaryRef(propsSeg)) {
-                                        try (CFStringRef devCharKey = CFStringRef
-                                                .createCFString("Device Characteristics")) {
-                                            MemorySegment charSeg = props.getValue(devCharKey);
-                                            if (!charSeg.equals(MemorySegment.NULL)) {
-                                                try (CFStringRef medTypeKey = CFStringRef
-                                                        .createCFString("Medium Type")) {
-                                                    MemorySegment typeSeg = CFDictionaryRef.getValue(charSeg,
-                                                            medTypeKey);
-                                                    if (!typeSeg.equals(MemorySegment.NULL)) {
-                                                        String type = CFStringRef.stringValue(typeSeg);
-                                                        if (type != null) {
-                                                            if (type.contains("Solid State") || type.contains("SSD")) {
-                                                                return "SSD";
-                                                            } else if (type.contains("Rotational")) {
-                                                                return "HDD";
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                return parseMediumType(queryMediumType(media));
+            }
+        }
+    }
+
+    /**
+     * Reads the {@code Medium Type} device characteristic by traversing up from the IOMedia node to the block storage
+     * device, which is where the characteristic is published.
+     *
+     * @param media the IOMedia registry entry
+     * @return the {@code Medium Type} string, or {@code null} if any step of the traversal finds nothing
+     */
+    private static String queryMediumType(IORegistryEntry media) {
+        // Traverse up: IOMedia -> IOBlockStorageDriver -> IOBlockStorageDevice
+        IORegistryEntry driver = media.getParentEntry("IOService");
+        if (driver == null) {
+            return null;
+        }
+        try (driver) {
+            IORegistryEntry device = driver.getParentEntry("IOService");
+            if (device == null) {
+                return null;
+            }
+            try (device) {
+                MemorySegment propsSeg = device.createCFProperties();
+                if (propsSeg.equals(MemorySegment.NULL)) {
+                    return null;
+                }
+                try (CFDictionaryRef props = new CFDictionaryRef(propsSeg)) {
+                    CFDictionaryRef characteristics = CFUtilFFM.getDictionary(props, "Device Characteristics");
+                    return characteristics == null ? null : CFUtilFFM.getString(characteristics, "Medium Type");
                 }
             }
         }
-        return "Unknown";
     }
 
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
@@ -380,70 +380,59 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
         }
         try {
             IORegistryEntry media = iter.next();
-            if (media != null) {
-                try {
-                    // Check removable at the IOMedia level
-                    Boolean removable = media.getBooleanProperty("Removable");
-                    if (removable != null && removable) {
-                        return "Removable";
-                    }
-                    // Traverse up: IOMedia -> IOBlockStorageDriver -> IOBlockStorageDevice
-                    IORegistryEntry driver = media.getParentEntry("IOService");
-                    if (driver != null) {
-                        try {
-                            IORegistryEntry device = driver.getParentEntry("IOService");
-                            if (device != null) {
-                                try {
-                                    CFMutableDictionaryRef props = device.createCFProperties();
-                                    if (props != null) {
-                                        try {
-                                            CFStringRef devCharKey = CFStringRef
-                                                    .createCFString("Device Characteristics");
-                                            try {
-                                                Pointer charDict = props.getValue(devCharKey);
-                                                if (charDict != null) {
-                                                    CFDictionaryRef characteristics = new CFDictionaryRef(charDict);
-                                                    CFStringRef medTypeKey = CFStringRef.createCFString("Medium Type");
-                                                    try {
-                                                        Pointer mediumType = characteristics.getValue(medTypeKey);
-                                                        if (mediumType != null) {
-                                                            String type = CFUtil.cfPointerToString(mediumType);
-                                                            if (type != null) {
-                                                                if (type.contains("Solid State")
-                                                                        || type.contains("SSD")) {
-                                                                    return "SSD";
-                                                                } else if (type.contains("Rotational")) {
-                                                                    return "HDD";
-                                                                }
-                                                            }
-                                                        }
-                                                    } finally {
-                                                        medTypeKey.release();
-                                                    }
-                                                }
-                                            } finally {
-                                                devCharKey.release();
-                                            }
-                                        } finally {
-                                            props.release();
-                                        }
-                                    }
-                                } finally {
-                                    device.release();
-                                }
-                            }
-                        } finally {
-                            driver.release();
-                        }
-                    }
-                } finally {
-                    media.release();
+            if (media == null) {
+                return "Unknown";
+            }
+            try {
+                // Check removable at the IOMedia level
+                Boolean removable = media.getBooleanProperty("Removable");
+                if (removable != null && removable) {
+                    return "Removable";
                 }
+                return parseMediumType(queryMediumType(media));
+            } finally {
+                media.release();
             }
         } finally {
             iter.release();
         }
-        return "Unknown";
+    }
+
+    /**
+     * Reads the {@code Medium Type} device characteristic by traversing up from the IOMedia node to the block storage
+     * device, which is where the characteristic is published.
+     *
+     * @param media the IOMedia registry entry
+     * @return the {@code Medium Type} string, or {@code null} if any step of the traversal finds nothing
+     */
+    private static String queryMediumType(IORegistryEntry media) {
+        // Traverse up: IOMedia -> IOBlockStorageDriver -> IOBlockStorageDevice
+        IORegistryEntry driver = media.getParentEntry("IOService");
+        if (driver == null) {
+            return null;
+        }
+        try {
+            IORegistryEntry device = driver.getParentEntry("IOService");
+            if (device == null) {
+                return null;
+            }
+            try {
+                CFMutableDictionaryRef props = device.createCFProperties();
+                if (props == null) {
+                    return null;
+                }
+                try {
+                    CFDictionaryRef characteristics = CFUtil.getDictionary(props, "Device Characteristics");
+                    return characteristics == null ? null : CFUtil.getString(characteristics, "Medium Type");
+                } finally {
+                    props.release();
+                }
+            } finally {
+                device.release();
+            }
+        } finally {
+            driver.release();
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

Follow-on to #3570, applying the CoreFoundation helpers merged there. `MacHWDiskStore`'s `detectDiskType` was the most vivid case of a pure classifier buried under native traversal: both twins walked eight levels deep — IOMedia → IOBlockStorageDriver → IOBlockStorageDevice → `Device Characteristics` dictionary → `Medium Type` string — before applying a two-line string rule at the center.

Split into acquisition and logic:

- **`MacHWDiskStore.parseMediumType`** (new, in `oshi-common`) — the pure `String → "SSD"/"HDD"/"Unknown"` classifier, mirroring the existing `WindowsHWDiskStore.parseWindowsMediaType` precedent right next to it. Now unit-tested.
- **`queryMediumType`** (per backend) — the traversal, flattened from ~40 deeply-nested lines to a linear walk using the `CFUtil`/`CFUtilFFM.getDictionary`+`getString` accessors from #3570. Each twin then does `parseMediumType(queryMediumType(media))`.

Behavior is unchanged: the removable check is untouched, and an absent or unrecognized medium type still yields `"Unknown"` — which is the normal result for APFS synthesized volumes, not an error.

Net: JNA −59/+48, FFM −37/+31, with the classification rule in one tested place instead of two.

## Tests

`MacHWDiskStoreTest` covers `parseMediumType`: the `Solid State`/`SSD`/`Rotational` matches, substring matching within a longer string, the title-case sensitivity IOKit's values rely on, and the `null` (characteristic absent) path.

## Verification

Ran both `SystemInfoTest` entry points on an Apple Silicon host. Disk types are unchanged and identical across backends — the physical whole disk reports SSD (where the Device Characteristics traversal succeeds) and the APFS containers report Unknown:

```
 disk0: (model: APPLE SSD AP0512Z ... type: SSD) size: 500.3 GB ...
 disk1: (model: APPLE SSD AP0512Z ... type: Unknown) size: 524.3 MB ...
 disk3: (model: APPLE SSD AP0512Z ... type: Unknown) size: 494.4 GB ...
```

The two commits are split by backend, and I ran `NativeComparisonTest` locally at the **JNA-only** commit — with the rewired JNA classification compared against the still-unmodified FFM implementation, `diskStores()` passed on real hardware. That's the check the split is for: it confirms the refactored side agrees with an independent implementation, not just with its own twin. (CI runs `diskStores()` against both sides moved together, so this intermediate run is the only place the assertion has a divergent pair to catch.)

Full gate green on macOS / JDK 25: spotless, checkstyle, `clean install` with tests (0 failed), forbiddenapis, javadoc.

No CHANGELOG entry: pure refactor plus test-only additions, no user-visible behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS disk type detection for SSDs, HDDs, removable media, and unknown devices.
  - Added safer handling for missing, null, or unrecognized disk information.
  - Ensured consistent disk classification across supported macOS integration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->