### PR TITLE
Share the TCP state and CUPS printer state lookups between the backends

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/CupsPrinter.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/CupsPrinter.java
@@ -6,6 +6,7 @@ package oshi.hardware.common.platform.unix;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.UnaryOperator;
 
@@ -13,6 +14,7 @@ import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Printer;
 import oshi.hardware.common.AbstractPrinter;
 import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
 import oshi.util.driver.unix.Lpstat;
 
 /**
@@ -37,6 +39,43 @@ public abstract class CupsPrinter extends AbstractPrinter {
     protected CupsPrinter(String name, String driverName, String description, PrinterStatus status, String statusReason,
             boolean isDefault, boolean isLocal, String portName) {
         super(name, driverName, description, status, statusReason, isDefault, isLocal, portName);
+    }
+
+    /** CUPS {@code ipp_pstate_t} value for an idle printer. */
+    private static final int IPP_PRINTER_IDLE = 3;
+    /** CUPS {@code ipp_pstate_t} value for a printer processing a job. */
+    private static final int IPP_PRINTER_PROCESSING = 4;
+    /** CUPS {@code ipp_pstate_t} value for a stopped printer. */
+    private static final int IPP_PRINTER_STOPPED = 5;
+
+    /**
+     * Maps a CUPS printer state and its state reasons to a {@link PrinterStatus}. An error or fault in the reasons
+     * takes precedence over the numeric state, matching the CUPS {@code ipp_pstate_t} values.
+     *
+     * @param state        the CUPS {@code printer-state} value as a string, or empty if unavailable
+     * @param stateReasons the CUPS {@code printer-state-reasons} value, or empty/{@code "none"} if there are none
+     * @return the mapped {@link PrinterStatus}, or {@link PrinterStatus#UNKNOWN} if the state is empty or unrecognized
+     */
+    protected static PrinterStatus parseStateFromCups(String state, String stateReasons) {
+        if (!stateReasons.isEmpty() && !"none".equals(stateReasons)) {
+            String lower = stateReasons.toLowerCase(Locale.ROOT);
+            if (lower.contains("error") || lower.contains("fault")) {
+                return PrinterStatus.ERROR;
+            }
+        }
+        if (state.isEmpty()) {
+            return PrinterStatus.UNKNOWN;
+        }
+        switch (ParseUtil.parseIntOrDefault(state, -1)) {
+            case IPP_PRINTER_IDLE:
+                return PrinterStatus.IDLE;
+            case IPP_PRINTER_PROCESSING:
+                return PrinterStatus.PRINTING;
+            case IPP_PRINTER_STOPPED:
+                return PrinterStatus.OFFLINE;
+            default:
+                return PrinterStatus.UNKNOWN;
+        }
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInternetProtocolStats.java
@@ -4,19 +4,6 @@
  */
 package oshi.software.common.os.linux;
 
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
-import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_1;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_2;
-import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
-import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
-import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
-import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
-import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
-import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
-
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
@@ -161,7 +148,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
                 if (split.length > 9) {
                     Pair<byte[], Integer> lAddr = parseIpAddr(split[1]);
                     Pair<byte[], Integer> fAddr = parseIpAddr(split[2]);
-                    TcpState state = stateLookup(ParseUtil.hexStringToInt(split[3], 0));
+                    TcpState state = TcpState.fromLinuxState(ParseUtil.hexStringToInt(split[3], 0));
                     Pair<Integer, Integer> txQrxQ = parseHexColonHex(split[4]);
                     long inode = ParseUtil.parseLongOrDefault(split[9], 0);
                     conns.add(new IPConnection(protocol + ipver, lAddr.getA(), lAddr.getB(), fAddr.getA(), fAddr.getB(),
@@ -199,35 +186,5 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
             return new Pair<>(first, second);
         }
         return new Pair<>(0, 0);
-    }
-
-    private static TcpState stateLookup(int state) {
-        switch (state) {
-            case 0x01:
-                return ESTABLISHED;
-            case 0x02:
-                return SYN_SENT;
-            case 0x03:
-                return SYN_RECV;
-            case 0x04:
-                return FIN_WAIT_1;
-            case 0x05:
-                return FIN_WAIT_2;
-            case 0x06:
-                return TIME_WAIT;
-            case 0x07:
-                return CLOSED;
-            case 0x08:
-                return CLOSE_WAIT;
-            case 0x09:
-                return LAST_ACK;
-            case 0x0A:
-                return LISTEN;
-            case 0x0B:
-                return CLOSING;
-            case 0x00:
-            default:
-                return UNKNOWN;
-        }
     }
 }

--- a/oshi-common/src/main/java/oshi/software/os/InternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/os/InternetProtocolStats.java
@@ -358,6 +358,115 @@ public interface InternetProtocolStats {
         TIME_WAIT,
         /** No state. */
         NONE;
+
+        /**
+         * Maps a BSD TCP state code to a {@link TcpState}. This is the ordering defined by the BSD {@code tcp_fsm.h}
+         * {@code TCPS_*} constants, as reported by the macOS {@code tcpsi_state} field.
+         *
+         * @param state the BSD TCP state code
+         * @return the corresponding {@link TcpState}, or {@link #UNKNOWN} if the code is not recognized
+         */
+        public static TcpState fromBsdState(int state) {
+            switch (state) {
+                case 0:
+                    return CLOSED;
+                case 1:
+                    return LISTEN;
+                case 2:
+                    return SYN_SENT;
+                case 3:
+                    return SYN_RECV;
+                case 4:
+                    return ESTABLISHED;
+                case 5:
+                    return CLOSE_WAIT;
+                case 6:
+                    return FIN_WAIT_1;
+                case 7:
+                    return CLOSING;
+                case 8:
+                    return LAST_ACK;
+                case 9:
+                    return FIN_WAIT_2;
+                case 10:
+                    return TIME_WAIT;
+                default:
+                    return UNKNOWN;
+            }
+        }
+
+        /**
+         * Maps a Windows {@code MIB_TCP_STATE} code to a {@link TcpState}. This 1-based enumeration is defined by the
+         * Windows IP Helper API; the DELETE_TCB pseudo-state (12) is treated as {@link #CLOSED}.
+         *
+         * @param state the Windows {@code MIB_TCP_STATE} code
+         * @return the corresponding {@link TcpState}, or {@link #UNKNOWN} if the code is not recognized
+         */
+        public static TcpState fromWindowsMibState(int state) {
+            switch (state) {
+                case 1:
+                case 12:
+                    return CLOSED;
+                case 2:
+                    return LISTEN;
+                case 3:
+                    return SYN_SENT;
+                case 4:
+                    return SYN_RECV;
+                case 5:
+                    return ESTABLISHED;
+                case 6:
+                    return FIN_WAIT_1;
+                case 7:
+                    return FIN_WAIT_2;
+                case 8:
+                    return CLOSE_WAIT;
+                case 9:
+                    return CLOSING;
+                case 10:
+                    return LAST_ACK;
+                case 11:
+                    return TIME_WAIT;
+                default:
+                    return UNKNOWN;
+            }
+        }
+
+        /**
+         * Maps a Linux TCP state code to a {@link TcpState}. This is the ordering defined by the Linux kernel
+         * {@code TCP_*} constants, as reported in the state field of {@code /proc/net/tcp} and {@code /proc/net/tcp6}.
+         *
+         * @param state the Linux TCP state code
+         * @return the corresponding {@link TcpState}, or {@link #UNKNOWN} if the code is not recognized
+         */
+        public static TcpState fromLinuxState(int state) {
+            switch (state) {
+                case 0x01:
+                    return ESTABLISHED;
+                case 0x02:
+                    return SYN_SENT;
+                case 0x03:
+                    return SYN_RECV;
+                case 0x04:
+                    return FIN_WAIT_1;
+                case 0x05:
+                    return FIN_WAIT_2;
+                case 0x06:
+                    return TIME_WAIT;
+                case 0x07:
+                    return CLOSED;
+                case 0x08:
+                    return CLOSE_WAIT;
+                case 0x09:
+                    return LAST_ACK;
+                case 0x0A:
+                    return LISTEN;
+                case 0x0B:
+                    return CLOSING;
+                default:
+                    return UNKNOWN;
+            }
+        }
     }
 
     /**

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/CupsPrinterTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/CupsPrinterTest.java
@@ -86,4 +86,39 @@ class CupsPrinterTest {
         assertThat(printers.get(0).getName(), is("MyPrinter"));
         assertThat(printers.get(0).getStatus(), is(PrinterStatus.PRINTING));
     }
+
+    @Test
+    void testParseStateFromCupsIppStates() {
+        // CUPS ipp_pstate_t: 3 = idle, 4 = processing, 5 = stopped
+        assertThat(CupsPrinter.parseStateFromCups("3", "none"), is(PrinterStatus.IDLE));
+        assertThat(CupsPrinter.parseStateFromCups("4", "none"), is(PrinterStatus.PRINTING));
+        assertThat(CupsPrinter.parseStateFromCups("5", "none"), is(PrinterStatus.OFFLINE));
+    }
+
+    @Test
+    void testParseStateFromCupsErrorReasonsTakePrecedence() {
+        // An error or fault in the reasons overrides an otherwise healthy numeric state
+        assertThat(CupsPrinter.parseStateFromCups("3", "media-empty-error"), is(PrinterStatus.ERROR));
+        assertThat(CupsPrinter.parseStateFromCups("4", "cover-open-fault"), is(PrinterStatus.ERROR));
+        // Matching is case-insensitive
+        assertThat(CupsPrinter.parseStateFromCups("3", "Toner-Empty-ERROR"), is(PrinterStatus.ERROR));
+    }
+
+    @Test
+    void testParseStateFromCupsNonErrorReasonsIgnored() {
+        // Reasons that are neither error nor fault leave the numeric state in control
+        assertThat(CupsPrinter.parseStateFromCups("3", "toner-low"), is(PrinterStatus.IDLE));
+        assertThat(CupsPrinter.parseStateFromCups("5", "paused"), is(PrinterStatus.OFFLINE));
+    }
+
+    @Test
+    void testParseStateFromCupsUnknown() {
+        // Empty state, unrecognized state, and unparseable state all yield UNKNOWN
+        assertThat(CupsPrinter.parseStateFromCups("", "none"), is(PrinterStatus.UNKNOWN));
+        assertThat(CupsPrinter.parseStateFromCups("", ""), is(PrinterStatus.UNKNOWN));
+        assertThat(CupsPrinter.parseStateFromCups("9", "none"), is(PrinterStatus.UNKNOWN));
+        assertThat(CupsPrinter.parseStateFromCups("bogus", "none"), is(PrinterStatus.UNKNOWN));
+        // An empty state still defers to an error reason
+        assertThat(CupsPrinter.parseStateFromCups("", "hardware-error"), is(PrinterStatus.ERROR));
+    }
 }

--- a/oshi-common/src/test/java/oshi/software/os/InternetProtocolStatsTest.java
+++ b/oshi-common/src/test/java/oshi/software/os/InternetProtocolStatsTest.java
@@ -71,4 +71,63 @@ class InternetProtocolStatsTest {
         assertThat(TcpState.valueOf("UNKNOWN"), is(TcpState.UNKNOWN));
         assertThrows(IllegalArgumentException.class, () -> TcpState.valueOf("INVALID"));
     }
+
+    @Test
+    void testFromBsdState() {
+        // BSD tcp_fsm.h TCPS_* ordering, as reported by the macOS tcpsi_state field
+        assertThat(TcpState.fromBsdState(0), is(TcpState.CLOSED));
+        assertThat(TcpState.fromBsdState(1), is(TcpState.LISTEN));
+        assertThat(TcpState.fromBsdState(2), is(TcpState.SYN_SENT));
+        assertThat(TcpState.fromBsdState(3), is(TcpState.SYN_RECV));
+        assertThat(TcpState.fromBsdState(4), is(TcpState.ESTABLISHED));
+        assertThat(TcpState.fromBsdState(5), is(TcpState.CLOSE_WAIT));
+        assertThat(TcpState.fromBsdState(6), is(TcpState.FIN_WAIT_1));
+        assertThat(TcpState.fromBsdState(7), is(TcpState.CLOSING));
+        assertThat(TcpState.fromBsdState(8), is(TcpState.LAST_ACK));
+        assertThat(TcpState.fromBsdState(9), is(TcpState.FIN_WAIT_2));
+        assertThat(TcpState.fromBsdState(10), is(TcpState.TIME_WAIT));
+        // Out-of-range codes fall through to UNKNOWN
+        assertThat(TcpState.fromBsdState(-1), is(TcpState.UNKNOWN));
+        assertThat(TcpState.fromBsdState(11), is(TcpState.UNKNOWN));
+    }
+
+    @Test
+    void testFromWindowsMibState() {
+        // Windows MIB_TCP_STATE is 1-based; note the FIN_WAIT and CLOSE_WAIT ordering differs from BSD
+        assertThat(TcpState.fromWindowsMibState(1), is(TcpState.CLOSED));
+        assertThat(TcpState.fromWindowsMibState(2), is(TcpState.LISTEN));
+        assertThat(TcpState.fromWindowsMibState(3), is(TcpState.SYN_SENT));
+        assertThat(TcpState.fromWindowsMibState(4), is(TcpState.SYN_RECV));
+        assertThat(TcpState.fromWindowsMibState(5), is(TcpState.ESTABLISHED));
+        assertThat(TcpState.fromWindowsMibState(6), is(TcpState.FIN_WAIT_1));
+        assertThat(TcpState.fromWindowsMibState(7), is(TcpState.FIN_WAIT_2));
+        assertThat(TcpState.fromWindowsMibState(8), is(TcpState.CLOSE_WAIT));
+        assertThat(TcpState.fromWindowsMibState(9), is(TcpState.CLOSING));
+        assertThat(TcpState.fromWindowsMibState(10), is(TcpState.LAST_ACK));
+        assertThat(TcpState.fromWindowsMibState(11), is(TcpState.TIME_WAIT));
+        // The DELETE_TCB pseudo-state (12) maps to CLOSED
+        assertThat(TcpState.fromWindowsMibState(12), is(TcpState.CLOSED));
+        // 0 is not a valid MIB state, and codes past the enum fall through to UNKNOWN
+        assertThat(TcpState.fromWindowsMibState(0), is(TcpState.UNKNOWN));
+        assertThat(TcpState.fromWindowsMibState(13), is(TcpState.UNKNOWN));
+    }
+
+    @Test
+    void testFromLinuxState() {
+        // Linux kernel TCP_* ordering, as reported in /proc/net/tcp (hex)
+        assertThat(TcpState.fromLinuxState(0x01), is(TcpState.ESTABLISHED));
+        assertThat(TcpState.fromLinuxState(0x02), is(TcpState.SYN_SENT));
+        assertThat(TcpState.fromLinuxState(0x03), is(TcpState.SYN_RECV));
+        assertThat(TcpState.fromLinuxState(0x04), is(TcpState.FIN_WAIT_1));
+        assertThat(TcpState.fromLinuxState(0x05), is(TcpState.FIN_WAIT_2));
+        assertThat(TcpState.fromLinuxState(0x06), is(TcpState.TIME_WAIT));
+        assertThat(TcpState.fromLinuxState(0x07), is(TcpState.CLOSED));
+        assertThat(TcpState.fromLinuxState(0x08), is(TcpState.CLOSE_WAIT));
+        assertThat(TcpState.fromLinuxState(0x09), is(TcpState.LAST_ACK));
+        assertThat(TcpState.fromLinuxState(0x0A), is(TcpState.LISTEN));
+        assertThat(TcpState.fromLinuxState(0x0B), is(TcpState.CLOSING));
+        // 0x00 is not a valid state, and codes past the enum fall through to UNKNOWN
+        assertThat(TcpState.fromLinuxState(0x00), is(TcpState.UNKNOWN));
+        assertThat(TcpState.fromLinuxState(0x0C), is(TcpState.UNKNOWN));
+    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
@@ -32,18 +32,6 @@ import static oshi.ffm.platform.windows.WinErrorFFM.ERROR_INSUFFICIENT_BUFFER;
 import static oshi.ffm.platform.windows.WinErrorFFM.ERROR_SUCCESS;
 import static oshi.ffm.platform.windows.WindowsForeignFunctions.readAnsiString;
 import static oshi.software.os.InternetProtocolStats.TcpState;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
-import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_1;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_2;
-import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
-import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
-import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
-import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
-import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
-import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
 
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
@@ -247,7 +235,8 @@ public final class IPHlpAPIUtilFFM {
 
                 conns.add(new IPConnection("tcp4", ParseUtil.parseIntToIP(localAddr),
                         ParseUtil.bigEndian16ToLittleEndian(localPortBE), ParseUtil.parseIntToIP(remoteAddr),
-                        ParseUtil.bigEndian16ToLittleEndian(remotePortBE), stateLookup(state), 0, 0, pid));
+                        ParseUtil.bigEndian16ToLittleEndian(remotePortBE), TcpState.fromWindowsMibState(state), 0, 0,
+                        pid));
             }
             return conns;
         }, LOG, LogLevel.DEBUG, "queryTCPv4Connections failed", Collections.emptyList());
@@ -312,7 +301,8 @@ public final class IPHlpAPIUtilFFM {
                         MIB_TCP6ROW_OWNER_PID_LAYOUT.byteOffset(PathElement.groupElement("dwOwningPid")));
 
                 conns.add(new IPConnection("tcp6", localAddr, ParseUtil.bigEndian16ToLittleEndian(localPortBE),
-                        remoteAddr, ParseUtil.bigEndian16ToLittleEndian(remotePortBE), stateLookup(state), 0, 0, pid));
+                        remoteAddr, ParseUtil.bigEndian16ToLittleEndian(remotePortBE),
+                        TcpState.fromWindowsMibState(state), 0, 0, pid));
             }
             return conns;
         }, LOG, LogLevel.DEBUG, "queryTCPv6Connections failed", Collections.emptyList());
@@ -422,35 +412,6 @@ public final class IPHlpAPIUtilFFM {
             }
             return conns;
         }, LOG, LogLevel.DEBUG, "queryUDPv6Connections failed", Collections.emptyList());
-    }
-
-    private static TcpState stateLookup(int state) {
-        switch (state) {
-            case 1, 12:
-                return CLOSED;
-            case 2:
-                return LISTEN;
-            case 3:
-                return SYN_SENT;
-            case 4:
-                return SYN_RECV;
-            case 5:
-                return ESTABLISHED;
-            case 6:
-                return FIN_WAIT_1;
-            case 7:
-                return FIN_WAIT_2;
-            case 8:
-                return CLOSE_WAIT;
-            case 9:
-                return CLOSING;
-            case 10:
-                return LAST_ACK;
-            case 11:
-                return TIME_WAIT;
-            default:
-                return UNKNOWN;
-        }
     }
 
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/CupsPrinterFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/CupsPrinterFFM.java
@@ -11,7 +11,6 @@ import static oshi.util.LogLevel.WARN;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,25 +100,4 @@ public final class CupsPrinterFFM extends CupsPrinter {
         }, LOG, WARN, "Failed to query printers from libcups", printers);
     }
 
-    private static PrinterStatus parseStateFromCups(String state, String stateReasons) {
-        if (!stateReasons.isEmpty() && !"none".equals(stateReasons)) {
-            String lower = stateReasons.toLowerCase(Locale.ROOT);
-            if (lower.contains("error") || lower.contains("fault")) {
-                return PrinterStatus.ERROR;
-            }
-        }
-        if (state.isEmpty()) {
-            return PrinterStatus.UNKNOWN;
-        }
-        switch (ParseUtil.parseIntOrDefault(state, -1)) {
-            case CupsFunctions.IPP_PRINTER_IDLE:
-                return PrinterStatus.IDLE;
-            case CupsFunctions.IPP_PRINTER_PROCESSING:
-                return PrinterStatus.PRINTING;
-            case CupsFunctions.IPP_PRINTER_STOPPED:
-                return PrinterStatus.OFFLINE;
-            default:
-                return PrinterStatus.UNKNOWN;
-        }
-    }
 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
@@ -40,19 +40,7 @@ import static oshi.ffm.platform.mac.MacSystem.TCP_SOCK_INFO;
 import static oshi.ffm.platform.mac.MacSystemFunctions.proc_listpids;
 import static oshi.ffm.platform.mac.MacSystemFunctions.proc_pidfdinfo;
 import static oshi.ffm.platform.mac.MacSystemFunctions.proc_pidinfo;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
-import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_1;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_2;
-import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
-import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
 import static oshi.software.os.InternetProtocolStats.TcpState.NONE;
-import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
-import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
-import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
-import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
 import static oshi.util.ExceptionUtil.getOrDefault;
 import static oshi.util.LogLevel.TRACE;
 import static oshi.util.ParseUtil.parseIntToIP;
@@ -160,7 +148,7 @@ public class MacInternetProtocolStatsFFM extends MacInternetProtocolStats {
                     MemorySegment tcpsi = psi.asSlice(protoOffset);
                     ini = tcpsi.asSlice(TCP_SOCK_INFO.byteOffset(TCPSI_INI));
                     int tcpState = tcpsi.get(JAVA_INT, TCP_SOCK_INFO.byteOffset(TCPSI_STATE));
-                    state = stateLookup(tcpState);
+                    state = TcpState.fromBsdState(tcpState);
                 }
                 case SOCKINFO_IN -> {
                     type = "udp";
@@ -213,23 +201,6 @@ public class MacInternetProtocolStatsFFM extends MacInternetProtocolStats {
             array[i] = segment.get(JAVA_INT, offset + i * 4);
         }
         return ParseUtil.parseIntArrayToIP(array);
-    }
-
-    private static TcpState stateLookup(int state) {
-        return switch (state) {
-            case 0 -> CLOSED;
-            case 1 -> LISTEN;
-            case 2 -> SYN_SENT;
-            case 3 -> SYN_RECV;
-            case 4 -> ESTABLISHED;
-            case 5 -> CLOSE_WAIT;
-            case 6 -> FIN_WAIT_1;
-            case 7 -> CLOSING;
-            case 8 -> LAST_ACK;
-            case 9 -> FIN_WAIT_2;
-            case 10 -> TIME_WAIT;
-            default -> UNKNOWN;
-        };
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/CupsPrinterJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/CupsPrinterJNA.java
@@ -6,7 +6,6 @@ package oshi.hardware.platform.unix;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,26 +109,4 @@ public final class CupsPrinterJNA extends CupsPrinter {
         return value != null ? value : "";
     }
 
-    private static PrinterStatus parseStateFromCups(String state, String stateReasons) {
-        if (!stateReasons.isEmpty() && !"none".equals(stateReasons)) {
-            String lower = stateReasons.toLowerCase(Locale.ROOT);
-            if (lower.contains("error") || lower.contains("fault")) {
-                return PrinterStatus.ERROR;
-            }
-        }
-        if (state.isEmpty()) {
-            return PrinterStatus.UNKNOWN;
-        }
-        int stateInt = ParseUtil.parseIntOrDefault(state, -1);
-        switch (stateInt) {
-            case Cups.IPP_PRINTER_IDLE:
-                return PrinterStatus.IDLE;
-            case Cups.IPP_PRINTER_PROCESSING:
-                return PrinterStatus.PRINTING;
-            case Cups.IPP_PRINTER_STOPPED:
-                return PrinterStatus.OFFLINE;
-            default:
-                return PrinterStatus.UNKNOWN;
-        }
-    }
 }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
@@ -13,19 +13,7 @@ import static com.sun.jna.platform.mac.SystemB.PROC_PIDLISTFDS;
 import static com.sun.jna.platform.mac.SystemB.PROX_FDTYPE_SOCKET;
 import static com.sun.jna.platform.mac.SystemB.SOCKINFO_IN;
 import static com.sun.jna.platform.mac.SystemB.SOCKINFO_TCP;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
-import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_1;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_2;
-import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
-import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
 import static oshi.software.os.InternetProtocolStats.TcpState.NONE;
-import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
-import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
-import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
-import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -101,7 +89,7 @@ public class MacInternetProtocolStatsJNA extends MacInternetProtocolStats {
                     si.psi.soi_proto.setType("pri_tcp");
                     si.psi.soi_proto.read();
                     ini = si.psi.soi_proto.pri_tcp.tcpsi_ini;
-                    state = stateLookup(si.psi.soi_proto.pri_tcp.tcpsi_state);
+                    state = TcpState.fromBsdState(si.psi.soi_proto.pri_tcp.tcpsi_state);
                     type = "tcp";
                 } else if (si.psi.soi_kind == SOCKINFO_IN) {
                     si.psi.soi_proto.setType("pri_in");
@@ -137,35 +125,6 @@ public class MacInternetProtocolStatsJNA extends MacInternetProtocolStats {
             }
         }
         return null;
-    }
-
-    private static TcpState stateLookup(int state) {
-        switch (state) {
-            case 0:
-                return CLOSED;
-            case 1:
-                return LISTEN;
-            case 2:
-                return SYN_SENT;
-            case 3:
-                return SYN_RECV;
-            case 4:
-                return ESTABLISHED;
-            case 5:
-                return CLOSE_WAIT;
-            case 6:
-                return FIN_WAIT_1;
-            case 7:
-                return CLOSING;
-            case 8:
-                return LAST_ACK;
-            case 9:
-                return FIN_WAIT_2;
-            case 10:
-                return TIME_WAIT;
-            default:
-                return UNKNOWN;
-        }
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsJNA.java
@@ -8,18 +8,6 @@ import static com.sun.jna.platform.win32.IPHlpAPI.AF_INET;
 import static com.sun.jna.platform.win32.IPHlpAPI.AF_INET6;
 import static com.sun.jna.platform.win32.IPHlpAPI.TCP_TABLE_CLASS.TCP_TABLE_OWNER_PID_ALL;
 import static com.sun.jna.platform.win32.IPHlpAPI.UDP_TABLE_CLASS.UDP_TABLE_OWNER_PID;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSED;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSE_WAIT;
-import static oshi.software.os.InternetProtocolStats.TcpState.CLOSING;
-import static oshi.software.os.InternetProtocolStats.TcpState.ESTABLISHED;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_1;
-import static oshi.software.os.InternetProtocolStats.TcpState.FIN_WAIT_2;
-import static oshi.software.os.InternetProtocolStats.TcpState.LAST_ACK;
-import static oshi.software.os.InternetProtocolStats.TcpState.LISTEN;
-import static oshi.software.os.InternetProtocolStats.TcpState.SYN_RECV;
-import static oshi.software.os.InternetProtocolStats.TcpState.SYN_SENT;
-import static oshi.software.os.InternetProtocolStats.TcpState.TIME_WAIT;
-import static oshi.software.os.InternetProtocolStats.TcpState.UNKNOWN;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -139,8 +127,8 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
                         conns.add(new IPConnection("tcp4", ParseUtil.parseIntToIP(row.dwLocalAddr),
                                 ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort),
                                 ParseUtil.parseIntToIP(row.dwRemoteAddr),
-                                ParseUtil.bigEndian16ToLittleEndian(row.dwRemotePort), stateLookup(row.dwState), 0, 0,
-                                row.dwOwningPid));
+                                ParseUtil.bigEndian16ToLittleEndian(row.dwRemotePort),
+                                TcpState.fromWindowsMibState(row.dwState), 0, 0, row.dwOwningPid));
                     }
                 }
             } finally {
@@ -177,8 +165,8 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
                         MIB_TCP6ROW_OWNER_PID row = tcpTable.table[i];
                         conns.add(new IPConnection("tcp6", row.LocalAddr,
                                 ParseUtil.bigEndian16ToLittleEndian(row.dwLocalPort), row.RemoteAddr,
-                                ParseUtil.bigEndian16ToLittleEndian(row.dwRemotePort), stateLookup(row.State), 0, 0,
-                                row.dwOwningPid));
+                                ParseUtil.bigEndian16ToLittleEndian(row.dwRemotePort),
+                                TcpState.fromWindowsMibState(row.State), 0, 0, row.dwOwningPid));
                     }
                 }
             } finally {
@@ -260,35 +248,5 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
             }
         }
         return conns;
-    }
-
-    private static TcpState stateLookup(int state) {
-        switch (state) {
-            case 1:
-            case 12:
-                return CLOSED;
-            case 2:
-                return LISTEN;
-            case 3:
-                return SYN_SENT;
-            case 4:
-                return SYN_RECV;
-            case 5:
-                return ESTABLISHED;
-            case 6:
-                return FIN_WAIT_1;
-            case 7:
-                return FIN_WAIT_2;
-            case 8:
-                return CLOSE_WAIT;
-            case 9:
-                return CLOSING;
-            case 10:
-                return LAST_ACK;
-            case 11:
-                return TIME_WAIT;
-            default:
-                return UNKNOWN;
-        }
     }
 }


### PR DESCRIPTION
Continues the effort to move utility-style helpers out of focused classes and into shared, testable homes. Two related state-mapping lookups had been duplicated across the JNA and FFM backends.

### TCP state

Five private copies of an `int` → `TcpState` switch had accumulated, in three mutually incompatible numbering schemes:

| Scheme | Source | Notable difference |
|---|---|---|
| BSD | `tcp_fsm.h`, via macOS `tcpsi_state` | `5` = `CLOSE_WAIT` |
| Windows | `MIB_TCP_STATE`, 1-based | `5` = `ESTABLISHED`; both `1` and the `DELETE_TCB` pseudo-state `12` → `CLOSED` |
| Linux | kernel `TCP_*`, hex, from `/proc/net/tcp` | `0x01` = `ESTABLISHED` |

Because the schemes disagree on which integer means which state, they can't collapse into a single `fromInt` — that would silently mislabel connections. Instead this adds three named factory methods to the public `TcpState` enum (`fromBsdState`, `fromWindowsMibState`, `fromLinuxState`), each documenting its source and the fallthrough to `UNKNOWN`, and deletes the five copies.

The enum is the only home reachable from all five call sites: the Mac twins share a base class, but Windows JNA extends `AbstractInternetProtocolStats` while the Windows FFM copy lives in `IPHlpAPIUtilFFM`. A `TcpStateUtil` class would also have worked, but puts the mapping further from the type it returns for no benefit.

### CUPS printer state

`CupsPrinterJNA` and `CupsPrinterFFM` each carried an identical `ipp_pstate_t` → `PrinterStatus` mapping, differing only in which class held the constants (`Cups` vs `CupsFunctions`, both `3`/`4`/`5`). Hoisted into the shared `CupsPrinter` base.

Unlike the `TcpState` change, this one can't be split per backend: raising the parent's copy to `protected` makes each child's leftover `private` copy an illegal weaker-access override, so the parent and both children move in one commit.

### Behavior and versioning

Both twin pairs agreed before this change, so this is a dedup rather than a behavior fix — hence no CHANGELOG entry. It also needs no minor bump: japicmp classifies a static method added to an enum as `METHOD_ADDED_TO_PUBLIC_CLASS`, a patch-level change, since an enum is a class rather than an interface and adding a static can't break a caller. `japicmp:cmp` reports the modified enum as `(compatible)` with `Semantic versioning suggestion: 0.0.1`.

New tests cover every valid code for all three TCP schemes plus out-of-range fallthrough, and the CUPS idle/processing/stopped states, the precedence of an `error`/`fault` reason over the numeric state, and the empty and unrecognized cases.

### Verification

The commits are split so that the middle one converts only `oshi-common` and the JNA backend, leaving the FFM copies in place. `NativeComparisonTest` was run **at that intermediate commit** on macOS with real TCP connections — one backend on the new shared mappers, the other on its original private copies — and `internetProtocolConnections()`, `internetProtocolStats()`, and `printers()` all agreed, confirming the shared mappers reproduce the old per-backend behavior exactly. It was then re-run on the final tree, also green.

Full CI (Lint, Windows, macOS, Linux JDK 21/25/26, FreeBSD, OpenBSD, OpenIndiana, all under `JNA==FFM`) was run green on a fork PR before opening this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved TCP connection status reporting across Linux, macOS, and Windows.
  - Added consistent handling for recognized and unrecognized TCP states, with unknown values reported safely.
  - Enhanced printer status detection, including error and fault conditions.

- **Bug Fixes**
  - Improved interpretation of CUPS printer states and reasons.
  - Corrected Windows TCP state handling, including closed connections.

- **Tests**
  - Added coverage for platform-specific TCP states and printer status parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->