### PR TITLE
Mirror the ADL Overdrive fixes from the FFM twin back to JNA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#3573](https://github.com/oshi/oshi/pull/3573): Report Linux VRAM from NVML rather than summing the prefetchable PCI BARs, which measures the card's address aperture (capped at 256 MiB without Resizable BAR) instead of its memory size - [@Krillsson](https://github.com/Krillsson).
 * [#3574](https://github.com/oshi/oshi/pull/3574): Never report a decrease in a BSD process's or thread's kernel or user time across `updateAttributes()`. DragonFly's `ps` `TIME` column sums only the currently live LWPs, so an exiting thread takes its accumulated CPU time out of the process total - [@dbwiddis](https://github.com/dbwiddis).
 * [#3577](https://github.com/oshi/oshi/pull/3577): Fix macOS `OSProcess#getArguments()` and `getEnvironmentVariables()` corrupting every entry after one containing a non-ASCII character. The `KERN_PROCARGS2` parser advanced its offset by each entry's length in characters rather than bytes, landing mid-character and returning garbage in place of the remaining arguments - [@dbwiddis](https://github.com/dbwiddis).
+* [#3578](https://github.com/oshi/oshi/pull/3578): Fix the Windows JNA AMD GPU path reporting a power draw of -1 on Overdrive 6-era Radeon cards. Power draw is read through the Overdrive 6 API but was gated on Overdrive N support, rejecting the cards that implement the call; the Overdrive capability check also ignored the library's `supported` flag - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2027-07-24), 7.4.3 (2027-07-31)
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardFFM.java
@@ -154,7 +154,9 @@ final class WindowsGraphicsCardFFM extends WindowsGraphicsCard {
         result.addAll(cardList);
 
         if (result.isEmpty()) {
-            return getGraphicsCardsFromWmi(dxgiAdapters, lhmParentMap);
+            // Adapters are removed from remainingDxgi only after a card is successfully constructed, so an
+            // adapter whose registry reads threw is still available to the WMI fallback here.
+            return getGraphicsCardsFromWmi(remainingDxgi, lhmParentMap);
         }
         return result;
     }

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/Adl.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/Adl.java
@@ -5,12 +5,12 @@
 package oshi.jna.platform.windows;
 
 import com.sun.jna.Library;
-import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * JNA bindings for the AMD Display Library (ADL) on Windows. This class should be considered non-API as it may be
@@ -20,6 +20,7 @@ public interface Adl {
 
     int ADL_OK = 0;
     int ADL_OVERDRIVE_VERSION_N = 8;
+    int ADL_OVERDRIVE_VERSION_6 = 6;
     int ADL_FAN_SPEED_MODE_PERCENT = 1;
     int ADL_OVERDRIVE_TEMPERATURE_EDGE = 1;
 

--- a/oshi-core/src/main/java/oshi/util/gpu/AdlUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/AdlUtilJNA.java
@@ -91,6 +91,7 @@ public final class AdlUtilJNA {
     }
 
     // Lazy adapter enumeration state — written once, read-only thereafter
+    private static final Object ENUM_LOCK = new Object();
     private static volatile boolean adaptersEnumerated = false;
     private static final AtomicReference<Map<Integer, Integer>> BUS_TO_INDEX = new AtomicReference<>(
             Collections.emptyMap());
@@ -140,13 +141,19 @@ public final class AdlUtilJNA {
         if (adaptersEnumerated) {
             return;
         }
-        Map<Integer, Integer> result = enumerateAdapters(context);
-        if (result != null) {
-            BUS_TO_INDEX.set(result);
-            adaptersEnumerated = true;
-            LOG.debug("ADL enumerated {} adapter(s)", BUS_TO_INDEX.get().size());
-        } else {
-            LOG.debug("ADL adapter enumeration failed; will retry on next call");
+        // Double-checked locking so concurrent callers enumerate at most once
+        synchronized (ENUM_LOCK) {
+            if (adaptersEnumerated) {
+                return;
+            }
+            Map<Integer, Integer> result = enumerateAdapters(context);
+            if (result != null) {
+                BUS_TO_INDEX.set(result);
+                adaptersEnumerated = true;
+                LOG.debug("ADL enumerated {} adapter(s)", BUS_TO_INDEX.get().size());
+            } else {
+                LOG.debug("ADL adapter enumeration failed; will retry on next call");
+            }
         }
     }
 
@@ -176,11 +183,19 @@ public final class AdlUtilJNA {
     }
 
     private static boolean supportsOverdriveN(Pointer context, int adapterIndex) {
+        return supportsOverdriveVersion(context, adapterIndex, Adl.ADL_OVERDRIVE_VERSION_N);
+    }
+
+    private static boolean supportsOverdrive6(Pointer context, int adapterIndex) {
+        return supportsOverdriveVersion(context, adapterIndex, Adl.ADL_OVERDRIVE_VERSION_6);
+    }
+
+    private static boolean supportsOverdriveVersion(Pointer context, int adapterIndex, int minVersion) {
         IntByReference supported = new IntByReference();
         IntByReference enabled = new IntByReference();
         IntByReference version = new IntByReference();
         if (Holder.LIB.ADL2_Overdrive_Caps(context, adapterIndex, supported, enabled, version) == Adl.ADL_OK) {
-            return version.getValue() >= Adl.ADL_OVERDRIVE_VERSION_N;
+            return supported.getValue() != 0 && version.getValue() >= minVersion;
         }
         return false;
     }
@@ -301,8 +316,8 @@ public final class AdlUtilJNA {
     }
 
     /**
-     * Returns GPU power draw in watts, or -1 if unavailable. Uses Overdrive 6 power API which is available on Overdrive
-     * N adapters. Power is reported in units of 1/256 watts.
+     * Returns GPU power draw in watts, or -1 if unavailable. Uses the Overdrive 6 power API, which is available on
+     * Overdrive 6 and newer adapters. Power is reported in units of 1/256 watts.
      *
      * @param adapterIndex ADL adapter index
      * @return power in watts or -1
@@ -316,7 +331,9 @@ public final class AdlUtilJNA {
             return -1d;
         }
         try {
-            if (!supportsOverdriveN(ctx, adapterIndex)) {
+            // Power draw uses the Overdrive 6 API, so gate on OD6 (or newer) rather than Overdrive N. This
+            // no longer rejects OD6-only cards; the return code still guards cards that don't implement the call.
+            if (!supportsOverdrive6(ctx, adapterIndex)) {
                 return -1d;
             }
             IntByReference power = new IntByReference();


### PR DESCRIPTION
Found by a normalized JNA/FFM twin diff over the Windows and GPU clusters, following up on #3569 and #3577.

## AdlUtilJNA never received #3490's fixes

PR #3490 fixed three defects in `AdlUtilFFM`. None were mirrored to the JNA twin, so `oshi-core` has carried them since:

* **`getPowerDraw` returns -1 on Overdrive 6-era Radeon cards.** Power is read through `ADL2_Overdrive6_CurrentPower_Get`, but the call was gated on Overdrive N (version 8) support — so exactly the cards that implement the OD6 power API but predate OD N were rejected before reaching it, and `GpuStats#getPowerDraw()` returned -1 instead of real wattage. Now gated on Overdrive 6; the return code still guards cards that do not implement the call. This is the only user-visible change.
* **The Overdrive capability check ignored `iSupported`.** `ADL2_Overdrive_Caps`'s `iSupported` out-parameter was allocated and never read, so a card reporting a version but no Overdrive support was treated as supported. Both are now checked, through a shared `supportsOverdriveVersion(context, adapterIndex, minVersion)` helper matching the twin's shape.
* **`ensureAdaptersEnumerated` was check-then-act on a `@ThreadSafe` class.** Two concurrent callers could both enumerate and both publish to `BUS_TO_INDEX`. Now double-checked locking on a dedicated lock, as the twin does.

`Adl.java` gains `ADL_OVERDRIVE_VERSION_6 = 6` for the new gate.

#3490's overflow guard has no JNA counterpart — JNA sizes the buffer from `Structure.size()` rather than manual `int` arithmetic, so there is nothing to overflow.

## A divergence in the opposite direction

`WindowsGraphicsCardFFM` passed the full DXGI adapter list to the WMI fallback where the JNA twin deliberately passes the match-and-consume copy. Adapters are removed from that copy only after a card is successfully constructed, so an adapter whose registry reads threw stays available to the fallback. FFM reaches this path precisely by swallowing the registry-walk failure, which is when it matters. Too marginal to describe in the changelog, so this PR's entry covers the ADL fix only.

## Why not hoist the shared logic

`oshi-common` may not reference `com.sun.jna`, and neither may `oshi-core-ffm`. The ADL constants and gating logic are necessarily duplicated across the two implementations, so the JNA side is patched in place to match the reviewed twin.

## Verification

Compiles clean; `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check` and `javadoc:javadoc` all pass locally on macOS/JDK 25. Spotless also reordered a pre-existing import block in `Adl.java`.

These are Windows-only paths, not executable from a macOS host, and the power-draw fix additionally needs an AMD GPU — so it is not runtime-verified. The correctness argument is that #3490 already made these exact three changes to the FFM twin and they were reviewed and merged; the JNA half was simply missed. Windows CI dispatched against this branch is green on all six JDK/runner combinations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows AMD GPU power-draw detection for older Radeon cards using Overdrive 6.
  * Improved GPU adapter detection to prevent duplicate or missed graphics cards.
  * Corrected capability checks for AMD GPU monitoring features.
  * Improved reliability when enumerating AMD GPU adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->