### PR TITLE
Replace two duplicated parse helpers with their ParseUtil equivalents

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxVirtualMemory.java
@@ -87,17 +87,17 @@ final class LinuxVirtualMemory extends AbstractVirtualMemory {
         long commitLimit = 0L;
 
         for (String checkLine : procMemInfo) {
-            String[] memorySplit = ParseUtil.whitespaces.split(checkLine);
+            String[] memorySplit = ParseUtil.whitespaces.split(checkLine, 2);
             if (memorySplit.length > 1) {
                 switch (memorySplit[0]) {
                     case "SwapTotal:":
-                        swapTotal = parseMeminfo(memorySplit);
+                        swapTotal = ParseUtil.parseDecimalMemorySizeToBinary(memorySplit[1]);
                         break;
                     case "SwapFree:":
-                        swapFree = parseMeminfo(memorySplit);
+                        swapFree = ParseUtil.parseDecimalMemorySizeToBinary(memorySplit[1]);
                         break;
                     case "CommitLimit:":
-                        commitLimit = parseMeminfo(memorySplit);
+                        commitLimit = ParseUtil.parseDecimalMemorySizeToBinary(memorySplit[1]);
                         break;
                     default:
                         // do nothing with other lines
@@ -138,22 +138,5 @@ final class LinuxVirtualMemory extends AbstractVirtualMemory {
             }
         }
         return new Pair<>(swapPagesIn, swapPagesOut);
-    }
-
-    /**
-     * Parses lines from the display of /proc/meminfo
-     *
-     * @param memorySplit Array of Strings representing the 3 columns of /proc/meminfo
-     * @return value, multiplied by 1024 if kB is specified
-     */
-    private static long parseMeminfo(String[] memorySplit) {
-        if (memorySplit.length < 2) {
-            return 0L;
-        }
-        long memory = ParseUtil.parseLongOrDefault(memorySplit[1], 0L);
-        if (memorySplit.length > 2 && "kB".equals(memorySplit[2])) {
-            memory *= 1024;
-        }
-        return memory;
     }
 }

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -9,6 +9,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.IntBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -1222,6 +1223,29 @@ public final class ParseUtil {
         // 20480 = 0x5000 should be 0x0050 = 80
         // 47873 = 0xBB01 should be 0x01BB = 443
         return port >> 8 & 0xff | port << 8 & 0xff00;
+    }
+
+    /**
+     * Converts the 16 bytes of an IPv6 address, offset two bytes into the given array, to the 4-element int array
+     * expected by {@link #parseUtAddrV6toIP}.
+     * <p>
+     * Per the {@code WTS_INFO_CLASS} docs, the IP address is offset by two bytes from the start of the {@code Address}
+     * member of the {@code WTS_CLIENT_ADDRESS} structure.
+     *
+     * @param address a byte array holding a big-endian IPv6 address in bytes 2 through 17, such as the 20-byte
+     *                {@code WTS_CLIENT_ADDRESS} {@code Address} member
+     * @return a 4-element int array for {@link #parseUtAddrV6toIP}
+     * @throws IllegalArgumentException if the array holds fewer than 18 bytes
+     */
+    public static int[] parseIPv6BytesToIntArray(byte[] address) {
+        if (address == null || address.length < 18) {
+            throw new IllegalArgumentException("address must have at least 18 elements");
+        }
+        IntBuffer intBuf = ByteBuffer.wrap(Arrays.copyOfRange(address, 2, 18)).order(ByteOrder.BIG_ENDIAN)
+                .asIntBuffer();
+        int[] array = new int[intBuf.remaining()];
+        intBuf.get(array);
+        return array;
     }
 
     /**

--- a/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
@@ -768,6 +768,27 @@ class ParseUtilTest {
     }
 
     @Test
+    void testParseIPv6BytesToIntArray() {
+        // WTS_CLIENT_ADDRESS Address member: 2 bytes of padding, then 16 bytes of big-endian IPv6, then trailing bytes
+        byte[] address = new byte[20];
+        byte[] v6Bytes = { 0x20, 0x01, 0x0d, (byte) 0xb8, (byte) 0x85, (byte) 0xa3, 0, 0, 0, 0, (byte) 0x8a, 0x2e, 0x03,
+                0x70, 0x73, 0x34 };
+        System.arraycopy(v6Bytes, 0, address, 2, 16);
+        int[] parsed = ParseUtil.parseIPv6BytesToIntArray(address);
+        assertThat("Should decode to 4 ints", parsed.length, is(4));
+        assertThat("Round trip through parseUtAddrV6toIP failed", ParseUtil.parseUtAddrV6toIP(parsed),
+                is("2001:db8:85a3::8a2e:370:7334"));
+        // All zeros
+        assertThat("Zero address failed", ParseUtil.parseUtAddrV6toIP(ParseUtil.parseIPv6BytesToIntArray(new byte[20])),
+                is("::"));
+        // Exactly 18 bytes is sufficient
+        assertThat("18-byte array should parse", ParseUtil.parseIPv6BytesToIntArray(new byte[18]).length, is(4));
+        // Too short, and null
+        assertThrows(IllegalArgumentException.class, () -> ParseUtil.parseIPv6BytesToIntArray(new byte[17]));
+        assertThrows(IllegalArgumentException.class, () -> ParseUtil.parseIPv6BytesToIntArray(null));
+    }
+
+    @Test
     void testHexStringToInt() {
         assertThat("Parsing ff failed", ParseUtil.hexStringToInt("ff", 0), is(255));
         assertThat("Parsing 830f53a0 failed", ParseUtil.hexStringToInt("830f53a0", 0), is(-2096147552));

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/SessionWtsDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/SessionWtsDataFFM.java
@@ -15,9 +15,6 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -167,7 +164,7 @@ public final class SessionWtsDataFFM {
                                 host = "Illegal length IP Array";
                             }
                         } else if (addrFamily == AF_INET6) {
-                            int[] ipArray = convertBytesToInts(address);
+                            int[] ipArray = ParseUtil.parseIPv6BytesToIntArray(address);
                             host = ParseUtil.parseUtAddrV6toIP(ipArray);
                         }
                         sessions.add(new OSSession(userName, device, logonTime, host));
@@ -180,13 +177,5 @@ public final class SessionWtsDataFFM {
             // Silently return what we have
         }
         return sessions;
-    }
-
-    private static int[] convertBytesToInts(byte[] address) {
-        IntBuffer intBuf = ByteBuffer.wrap(Arrays.copyOfRange(address, 2, 18)).order(ByteOrder.BIG_ENDIAN)
-                .asIntBuffer();
-        int[] array = new int[intBuf.remaining()];
-        intBuf.get(array);
-        return array;
     }
 }

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/SessionWtsData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/SessionWtsData.java
@@ -6,9 +6,6 @@ package oshi.driver.windows.registry;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -138,7 +135,7 @@ public final class SessionWtsData {
                                             }
                                         } else if (addr.AddressFamily == IPHlpAPI.AF_INET6) {
                                             // Get ints for address parsing
-                                            int[] ipArray = convertBytesToInts(addr.Address);
+                                            int[] ipArray = ParseUtil.parseIPv6BytesToIntArray(addr.Address);
                                             host = ParseUtil.parseUtAddrV6toIP(ipArray);
                                         }
                                         sessions.add(new OSSession(userName, device, logonTime, host));
@@ -155,20 +152,4 @@ public final class SessionWtsData {
         return sessions;
     }
 
-    /**
-     * Per WTS_INFO_CLASS docs, the IP address is offset by two bytes from the start of the Address member of the
-     * WTS_CLIENT_ADDRESS structure. Also contrary to docs, IPv4 is not a null terminated string.
-     * <p>
-     * This method converts the byte[20] to an int[4] parseable by existing code
-     *
-     * @param address The 20-byte array from the WTS_CLIENT_ADDRESS structure
-     * @return A 4-int array for {@link ParseUtil#parseUtAddrV6toIP}
-     */
-    private static int[] convertBytesToInts(byte[] address) {
-        IntBuffer intBuf = ByteBuffer.wrap(Arrays.copyOfRange(address, 2, 18)).order(ByteOrder.BIG_ENDIAN)
-                .asIntBuffer();
-        int[] array = new int[intBuf.remaining()];
-        intBuf.get(array);
-        return array;
-    }
 }


### PR DESCRIPTION
## Summary

Two private helpers reimplemented logic that already existed elsewhere. Follow-up to #3579, continuing the sweep for private helpers that `ParseUtil` already covers.

### `LinuxVirtualMemory.parseMeminfo` → `ParseUtil.parseDecimalMemorySizeToBinary`

`parseMeminfo` multiplied a `/proc/meminfo` value by 1024 when its unit column was `"kB"`. `LinuxGlobalMemory`, parsing the *same file*, already used `ParseUtil.parseDecimalMemorySizeToBinary` for exactly this. The two siblings now agree.

The split limit had to change from unlimited to 2, matching `LinuxGlobalMemory`, so the value and unit reach `parseDecimalMemorySizeToBinary` as one string. I verified equivalence across the realistic inputs rather than by eye:

| input | old | new |
|---|---|---|
| `SwapTotal:       2000000 kB` | 2048000000 | 2048000000 |
| `SwapTotal:       2000000` (no unit) | 2000000 | 2000000 |
| `SwapTotal:\t2000000\tkB` (tabs) | 2048000000 | 2048000000 |
| `SwapTotal:       garbage kB` | 0 | 0 |
| `SwapTotal:` (malformed, single field) | skipped | skipped |
| `SwapTotal:  9007199254740992 kB` (overflows long) | same | same |
| `SwapTotal:       2000000 MB` | 2000000 | 2097152000000 |

The last row is the only divergence. The kernel never emits `MB` for these fields — they are always `kB` — and on that hypothetical input the new behavior is the more correct of the two.

### `convertBytesToInts` → `ParseUtil.parseIPv6BytesToIntArray`

`SessionWtsData` and `SessionWtsDataFFM` each carried a byte-identical copy converting the `WTS_CLIENT_ADDRESS` `Address` member to the `int[4]` that `ParseUtil.parseUtAddrV6toIP` consumes — the JNA copy's javadoc already pointed at `ParseUtil#parseUtAddrV6toIP` as its only consumer, so that is where it now lives. Both twins share the conversion instead of maintaining separate copies.

One small hardening while hoisting: a length guard so a short array throws `IllegalArgumentException` with a clear message rather than `IndexOutOfBoundsException` from `Arrays.copyOfRange`, matching how the adjacent `parseUtAddrV6toIP` rejects a wrong-length input.

No user-visible behavior change, so no CHANGELOG entry.

## Verification

Full gate green: `clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check` plus `javadoc:javadoc`, 0 tests failed across all modules. New `testParseIPv6BytesToIntArray` confirmed executing (`[OK]` in the console-launcher output, not just present in the source). Fork CI green on **Windows** — which covers the `SessionWtsData` paths I cannot exercise on macOS — and on Linux, which covers the `/proc/meminfo` change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux virtual memory reporting by consistently interpreting memory values from system information.
  * Improved IPv6 client address handling for Windows session data, including padded address structures and zero addresses.
* **Tests**
  * Added coverage for IPv6 byte-array conversion, valid boundary inputs, and invalid null or undersized inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->