### PR TITLE
Synchronize the BSD ps-family updateAttributes instead of suppressing S3078

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
@@ -170,15 +170,17 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
     /**
      * Populates this process's attributes from a parsed {@code ps} row. Shared by every BSD platform; differences in
      * the available columns are handled by checking which keys are present in the map.
+     * <p>
+     * Synchronized because it is the only writer of this object's fields, reached both from {@link #updateAttributes()}
+     * and from each platform's constructor. The lock makes the whole field set update atomically, so two concurrent
+     * refreshes cannot interleave values from two different {@code ps} samples, and it makes the read-modify-write in
+     * {@link #monotonic(long, long)} safe: without it, two racing clamps can both read the same previous value and the
+     * lower one can land last, reintroducing the decrease the clamp exists to prevent.
      *
      * @param psMap the parsed {@code ps} columns for this process
      * @return {@code true} once the attributes are populated
      */
-    // S3078: the monotonic() clamps read and write a volatile long, but this method makes ~20 unsynchronized
-    // volatile writes and OSProcess documents that concurrent updateAttributes() callers must synchronize
-    // externally. Both racing writers only ever raise the value, so a lost clamp keeps a real ps reading.
-    @SuppressWarnings("java:S3078")
-    protected boolean updateAttributes(Map<BsdPsKeyword, String> psMap) {
+    protected synchronized boolean updateAttributes(Map<BsdPsKeyword, String> psMap) {
         long now = System.currentTimeMillis();
         this.state = getStateFromOutput(psMap.get(BsdPsKeyword.STATE).charAt(0));
         this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PPID), 0);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSThread.java
@@ -53,14 +53,16 @@ public abstract class BsdOSThread extends AbstractOSThread {
     /**
      * Populates this thread's attributes from a parsed {@code ps} thread row. Shared by every BSD platform; differences
      * in the available columns are handled by checking which keys are present in the map.
+     * <p>
+     * Synchronized for the same reasons as {@link BsdOSProcess#updateAttributes(Map)}: it is the only writer of this
+     * object's fields, reached both from {@link #updateAttributes()} and from each platform's constructor, and the lock
+     * both makes the field set update atomically and makes the {@link BsdOSProcess#monotonic(long, long)}
+     * read-modify-write safe against a racing refresh.
      *
      * @param threadMap the parsed {@code ps} columns for this thread
      * @return {@code true} once the attributes are populated
      */
-    // S3078: see BsdOSProcess.updateAttributes(Map) - the monotonic() clamps read and write a volatile long, but
-    // the field is one of many written unsynchronized here and racing writers only ever raise the value.
-    @SuppressWarnings("java:S3078")
-    protected boolean updateAttributes(Map<BsdPsThreadKeyword, String> threadMap) {
+    protected synchronized boolean updateAttributes(Map<BsdPsThreadKeyword, String> threadMap) {
         // Thread id: lwp (FreeBSD), tid (OpenBSD/DragonFly), or lid (NetBSD)
         this.threadId = ParseUtil.parseIntOrDefault(threadIdValue(threadMap), 0);
         this.state = BsdOSProcess.getStateFromOutput(threadMap.get(BsdPsThreadKeyword.STATE).charAt(0));

--- a/oshi-common/src/main/java/oshi/software/os/OSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSProcess.java
@@ -32,6 +32,16 @@ import oshi.annotation.concurrent.ThreadSafe;
  * <b>Platform note:</b> Process CPU usage sums ticks across all processors and may exceed 100% for multi-threaded
  * processes (consistent with {@code top} on Unix). To match the Windows Task Manager, which scales to the system,
  * divide by {@link oshi.hardware.CentralProcessor#getLogicalProcessorCount()}.
+ * <p>
+ * <b>Refreshing:</b> {@link #updateAttributes()} is intended for a single process being individually monitored. When
+ * refreshing more than a few processes it is more efficient to re-query the full list from
+ * {@link OperatingSystem#getProcesses()} and correlate the results against the previous set, since on many platforms
+ * the full list must be queried to provide any individual result.
+ * <p>
+ * Thread safe for the designed use of retrieving the most recent data. Users should be aware that the
+ * {@link #updateAttributes()} method may update attributes, and should externally synchronize such usage to ensure
+ * consistent calculations: a getter called before an intervening update and one called after it report values from two
+ * different samples.
  */
 @PublicApi
 @ThreadSafe

--- a/oshi-common/src/main/java/oshi/software/os/OSThread.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSThread.java
@@ -14,6 +14,16 @@ import oshi.software.os.OSProcess.State;
  * <p>
  * Threads are obtained from {@link oshi.software.os.OSProcess#getThreadDetails()}. Each thread belongs to a parent
  * process identified by {@link #getOwningProcessId()}.
+ * <p>
+ * <b>Refreshing:</b> {@link #updateAttributes()} is intended for a single thread being individually monitored. When
+ * refreshing more than a few threads it is more efficient to re-query the full list from
+ * {@link OSProcess#getThreadDetails()} and correlate the results against the previous set, since on many platforms the
+ * owning process's full thread list must be queried to provide any individual result.
+ * <p>
+ * Thread safe for the designed use of retrieving the most recent data. Users should be aware that the
+ * {@link #updateAttributes()} method may update attributes, and should externally synchronize such usage to ensure
+ * consistent calculations: a getter called before an intervening update and one called after it report values from two
+ * different samples.
  *
  * @see oshi.software.os.OSProcess#getThreadDetails()
  */


### PR DESCRIPTION
Resolves the two Coverity `VOLATILE_ATOMICITY` findings on the BSD monotonic clamps (CID 1677110, CID 1677109) and the matching Sonar `java:S3078` reports, by taking a lock rather than suppressing.

## Why not dismiss

The race is real and defeats the clamp it sits on. Two refreshes can both read the same previous value; if the lower one lands last, the reported CPU time decreases — exactly what `monotonic()` was added to prevent in #3574. Before that fix these were plain volatile writes, which are atomic; the clamp introduced the read-modify-write.

Impact is small (a lost clamp still leaves a genuine `ps` reading), but the fix is cheap enough that suppressing was the worse trade.

## Why `synchronized`

`AixHWDiskStore.updateAttributes()` already performs the same monotonic read-modify-write under `synchronized`, and is the only one of the 44 `updateAttributes()` implementations Coverity does **not** flag. This follows a pattern already in the tree.

The lock goes on the protected `updateAttributes(Map)` overload rather than the public no-arg method, because that overload is the sole writer of these fields and is reached from two directions — the public refresh, and each platform's constructor on the bulk `ps`-list path (10 call sites). It also covers the read-modify-write in `OpenBsdOSProcess.updateThreadCount()`.

Cost is irrelevant against the `fork`/`exec` of `ps` that precedes it, and it makes the whole ~20-field set update atomically, so concurrent refreshes can no longer interleave values from two different `ps` samples. Checked for nested locking: the only methods called inside are `queryStartTimeMillis()` (a no-op default; DragonFly reads `/proc`) and `updateThreadCount()` (a no-op default; OpenBSD/NetBSD run `ps`). Neither acquires another object's monitor.

`synchronized` is not part of the method signature, so japicmp stays at `0.0.1`.

## The suppression comments were citing a contract that did not exist

Both removed annotations justified themselves with:

> `OSProcess documents that concurrent updateAttributes() callers must synchronize externally`

It does not. That language lives only on `NetworkIF` and `HWDiskStore`. This PR adds it to `OSProcess` and `OSThread`, along with the "re-query the full list" guidance already stated authoritatively in `PERFORMANCE.md`.

That contract is worth keeping even with the lock, because it addresses a different problem: a *reader* calling two getters across an intervening update still sees two samples. That is true on every platform, lock or not.

## Scope

Deliberately limited to the BSD `ps`-family. AIX and Solaris read `/proc/<pid>/psinfo` binary structs via their `PsInfo` drivers rather than parsing `ps` output, so `BsdOSProcess`/`BsdOSThread` are the entire family — and the entire set of Coverity findings.

This is the first slice of a consistency arc across all 44 implementations, which diverge on four axes (synchronization 1-in-44, the documented contract on 2 of 6 interfaces, polling guidance on 1.5 of 6, and two independent spellings of "monotonic"). The remaining process/thread implementations and the `OSFileStore`/`HWDiskStore`/`NetworkIF`/`PowerSource` layer are queued for the next minor version, deliberately kept out of a release branch.

## Verification

Full gate green from a clean root build: spotless, sortpom, checkstyle (0 violations), install, forbiddenapis, javadoc. Tests 1311 / 119 / 96 / 30, 0 failed.

Behavior is unchanged on every platform — this only constrains interleaving.

## Note

Coverity understands lock-guarded read-modify-writes, so both CIDs should clear. Sonar `java:S3078` may be more syntactic; if it re-fires under the lock, the suppression can go back — but with a justification that is actually true this time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when refreshing BSD process and thread information, helping prevent mixed or out-of-sync attribute values during concurrent updates.

- **Documentation**
  - Added guidance on refreshing process and thread data, including recommendations for monitoring multiple items efficiently and safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->