### PR TITLE
Cut the Maven Central publishing footprint by 64%

### DIFF
--- a/.github/workflows/dist-release.yaml
+++ b/.github/workflows/dist-release.yaml
@@ -19,9 +19,12 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Fully qualify the ref: actions/checkout resolves an unqualified name by
+      # looking for a branch before a tag, so a branch sharing a release tag's
+      # name would package the wrong commit. Both values here are always tags.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: refs/tags/${{ github.event.release.tag_name || inputs.tag }}
           persist-credentials: false
       - name: Setup Java
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5

--- a/.github/workflows/dist-release.yaml
+++ b/.github/workflows/dist-release.yaml
@@ -1,0 +1,44 @@
+name: Attach dist archive to GitHub Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build and attach (e.g. oshi-parent-7.4.5)'
+        required: true
+
+permissions: {}
+
+jobs:
+  dist:
+    if: github.repository_owner == 'oshi'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          persist-credentials: false
+      - name: Setup Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          cache: maven
+          distribution: temurin
+          java-version: 25
+      # -am builds oshi-common/core/core-ffm, which the assembly's moduleSet
+      # (useAllReactorProjects) requires. JDK 25 is needed: oshi-dist and
+      # oshi-core-ffm are in the java25 profile.
+      - name: Build dist archive
+        run: >
+          ./mvnw -B -pl oshi-dist -am package
+          -DskipTests -Djacoco.skip=true -Dmaven.javadoc.skip=true
+          --settings ./.mvn/settings.xml
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: gh release upload "$TAG" --clobber oshi-dist/target/oshi-dist-*.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ correct.
 | `oshi-demo` | Proof-of-concept examples, jbang catalog entries. |
 | `oshi-metrics` | Micrometer bindings. Java 17+. |
 | `oshi-benchmark` | JMH benchmarks and the `oshi.comparison` cross-implementation tests. Java 25+. |
-| `oshi-dist` | Distribution zip assembly. |
+| `oshi-dist` | Distribution zip assembly (a single `.zip`, excluding `oshi-demo`). |
 | `config/` | Checkstyle, import-control, forbidden-apis, license header, formatter, Sonar config. |
 | `src/site/` | Maven site sources (`SampleOutput.md`, project listings). |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 7.4.5 (in progress)
 
-* Your contribution here!
+##### Bug Fixes and Improvements
+
+* [#3589](https://github.com/oshi/oshi/pull/3589): Reduce OSHI's Maven Central publishing footprint by 64% to stay within Sonatype's per-organization limits. `oshi-dist` now ships a single `.zip` rather than three identical archives in three compression formats, and no longer bundles `oshi-demo` or its `jfreechart` and `jackson` dependencies, so downloading it to put `oshi-core` on a classpath no longer drags in example-only code. The zip is now also attached to each GitHub release. Test-javadoc jars are no longer published, `oshi-common`'s javadoc is no longer duplicated into the `oshi-core` and `oshi-core-ffm` javadoc jars (the published site remains fully cross-linked), and `oshi-benchmark` is no longer published at all - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.4.0 (2026-07-08), 7.4.1 (2026-07-18), 7.4.2 (2026-07-24), 7.4.3 (2026-07-31), 7.4.4 (2026-08-06)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Usage
 -----
 1. Include OSHI and its dependencies on your classpath.
    - We strongly recommend you add `oshi-core` (and/or `oshi-core-ffm`) as a dependency to your project dependency manager such as Maven or Gradle. Transitive dependencies (including `oshi-common` and JNA) are resolved automatically.
-   - If you manage JAR files manually, download all needed JARs from the [oshi-dist](https://repo1.maven.org/maven2/com/github/oshi/oshi-dist/) zip files. See [UPGRADING.md](UPGRADING.md#project-dependencies) for details.
+   - If you manage JAR files manually, download all needed JARs from the [oshi-dist](https://repo1.maven.org/maven2/com/github/oshi/oshi-dist/) zip file, also attached to each [GitHub release](https://github.com/oshi/oshi/releases). It contains `oshi-common`, `oshi-core`, and `oshi-core-ffm` plus their runtime dependencies; the `oshi-demo` examples and their dependencies are not included. See [UPGRADING.md](UPGRADING.md#project-dependencies) for details.
    - For Windows, consider the optional `jLibreHardwareMonitor` dependency if you need sensor information. Note the binary DLLs in this dependency are licensed under MPL 2.0.
    - For Android, you'll need to add the [AAR artifact for JNA](https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android) and exclude OSHI's transitive (JAR) dependency.
    - See the [FAQ](FAQ.md#how-do-i-resolve-jna-noclassdeffounderror-or-nosuchmethoderror-issues) if you encounter `NoClassDefFoundError` or `NoSuchMethodError` problems.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -83,6 +83,21 @@ See [this page](https://central.sonatype.org/pages/apache-maven.html#performing-
     * Push your local `site` branch upstream
 
 * Add a title and release notes [to the tag](https://github.com/oshi/oshi/tags) on GitHub and publish the release to make it current.
+    * Publishing fires the `Attach dist archive to GitHub Release` workflow, which rebuilds
+      `oshi-dist-x.x.x.zip` from the tag and uploads it as a release asset. **The workflow must
+      already be on master before `release:prepare` cuts the tag**, or the checked-out tag will not
+      contain it and nothing will fire.
+    * If the workflow fails or the tag predates it, re-run it with an explicit tag:
+      ```sh
+      gh workflow run dist-release.yaml -f tag=oshi-parent-x.x.x
+      ```
+    * Or upload by hand from the `release:perform` build, which runs in `target/checkout`:
+      ```sh
+      gh release upload oshi-parent-x.x.x target/checkout/oshi-dist/target/oshi-dist-x.x.x.zip
+      ```
+    * The rebuilt jars are functionally identical to Central's but not byte-identical: the manifest
+      carries a `Build-Time` and no `project.build.outputTimestamp` is set, so checksums differ. The
+      zip is also on Central, which remains the authoritative copy.
 
 ### Ongoing Maintenance
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -14,7 +14,7 @@ Starting with version 6.12.0, OSHI was split from a single `oshi-core` artifact 
 - **`oshi-core`** — JNA-based implementation (depends on `oshi-common`).
 - **`oshi-core-ffm`** — FFM-based implementation (depends on `oshi-common`, requires JDK 25+).
 
-Both `oshi-core` and `oshi-core-ffm` declare a transitive dependency on `oshi-common`, so dependency managers resolve it automatically. If you use raw JAR files, you must include `oshi-common` on the classpath alongside your chosen implementation module. All needed JARs are available in the [oshi-dist](https://repo1.maven.org/maven2/com/github/oshi/oshi-dist/) zip files on Maven Central.
+Both `oshi-core` and `oshi-core-ffm` declare a transitive dependency on `oshi-common`, so dependency managers resolve it automatically. If you use raw JAR files, you must include `oshi-common` on the classpath alongside your chosen implementation module. All needed JARs are available in the [oshi-dist](https://repo1.maven.org/maven2/com/github/oshi/oshi-dist/) zip file on Maven Central, also attached to each [GitHub release](https://github.com/oshi/oshi/releases).
 
 ---
 

--- a/oshi-benchmark/pom.xml
+++ b/oshi-benchmark/pom.xml
@@ -22,9 +22,10 @@
         <native.access.modules>ALL-UNNAMED</native.access.modules>
         <shade.phase>none</shade.phase>
         <uberjar.name>benchmarks</uberjar.name>
-        <!-- Exclude this benchmark/comparison module from SonarCloud: it is not published, and its comparison tests
-        only compile under the native-comparison profile, so the default Sonar build has no test binaries for it (the
-        source of a "sonar.java.test.binaries" warning). -->
+        <!-- Exclude this benchmark/comparison module from SonarCloud: it is not published (see excludeArtifacts on
+        central-publishing-maven-plugin in the parent pom), and its comparison tests only compile under the
+        native-comparison profile, so the default Sonar build has no test binaries for it (the source of a
+        "sonar.java.test.binaries" warning). -->
         <sonar.skip>true</sonar.skip>
     </properties>
 
@@ -156,14 +157,6 @@
                     <!-- Exclude JMH-generated sources from javadoc -->
                     <excludePackageNames>*.jmh_generated</excludePackageNames>
                 </configuration>
-                <executions>
-                    <execution>
-                        <!-- Override release profile: all test classes are
-                             package-private so test-jar finds nothing to document. -->
-                        <id>attach-test-javadocs</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/oshi-core-ffm/pom.xml
+++ b/oshi-core-ffm/pom.xml
@@ -101,16 +101,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <includeDependencySources>true</includeDependencySources>
-                    <dependencySourceIncludes>
-                        <dependencySourceInclude>com.github.oshi:oshi-common</dependencySourceInclude>
-                    </dependencySourceIncludes>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>de.sormuras.junit</groupId>
                 <artifactId>junit-platform-maven-plugin</artifactId>
                 <configuration>
@@ -126,6 +116,9 @@
     </build>
     <reporting>
         <plugins>
+            <!-- Inline oshi-common's javadoc into the site so the published site is self-contained and
+            cross-linked. Deliberately NOT done in <build>: reporting configuration does not inherit from
+            build, so the attached -javadoc.jar stays free of a duplicate copy of oshi-common's pages. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -129,16 +129,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <includeDependencySources>true</includeDependencySources>
-                    <dependencySourceIncludes>
-                        <dependencySourceInclude>com.github.oshi:oshi-common</dependencySourceInclude>
-                    </dependencySourceIncludes>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>
                 <executions>
@@ -164,6 +154,9 @@
     </build>
     <reporting>
         <plugins>
+            <!-- Inline oshi-common's javadoc into the site so the published site is self-contained and
+            cross-linked. Deliberately NOT done in <build>: reporting configuration does not inherit from
+            build, so the attached -javadoc.jar stays free of a duplicate copy of oshi-common's pages. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/oshi-dist/pom.xml
+++ b/oshi-dist/pom.xml
@@ -12,7 +12,7 @@
     <packaging>pom</packaging>
 
     <name>oshi-dist</name>
-    <description>OSHI JAR files packaged in zip, tar.gz, and tar.bz2 formats.</description>
+    <description>OSHI JAR files and their dependencies packaged in a zip file.</description>
 
     <!-- These dependency declarations are only required to sort this project to the end of the line in the multimodule build. -->
     <dependencies>
@@ -31,11 +31,6 @@
             <artifactId>oshi-core-ffm</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>oshi-demo</artifactId>
-            <version>${project.version}</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -45,7 +40,6 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
-                    <tarLongFileMode>posix</tarLongFileMode>
                     <descriptors>
                         <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
                     </descriptors>

--- a/oshi-dist/src/assembly/assembly.xml
+++ b/oshi-dist/src/assembly/assembly.xml
@@ -5,8 +5,6 @@
     xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
     <id>distribution</id>
     <formats>
-        <format>tar.gz</format>
-        <format>tar.bz2</format>
         <format>zip</format>
     </formats>
     <!-- Root of archive has files -->
@@ -31,7 +29,9 @@
             <destName>license.txt</destName>
         </file>
     </files>
-    <!-- Include module jars in root level -->
+    <!-- Include module jars in root level. Deliberately excludes oshi-demo: it is example code
+    rather than something to put on a classpath, and bundling it would drag its jfreechart and
+    jackson dependencies into lib/ for everyone. -->
     <moduleSets>
         <moduleSet>
             <!-- Enable access to all projects in the current multimodule build! -->
@@ -41,7 +41,6 @@
                 <include>com.github.oshi:oshi-common</include>
                 <include>com.github.oshi:oshi-core</include>
                 <include>com.github.oshi:oshi-core-ffm</include>
-                <include>com.github.oshi:oshi-demo</include>
             </includes>
             <binaries>
                 <includeDependencies>false</includeDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -999,6 +999,12 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
+                    <!-- Local-only JMH harness with no consumer value; keeping it out of the release also
+                    keeps us under Sonatype's per-organization monthly publishing limits. Matched on
+                    artifactId only, and silent when it matches, so verify the staged bundle after edits. -->
+                    <excludeArtifacts>
+                        <excludeArtifact>oshi-benchmark</excludeArtifact>
+                    </excludeArtifacts>
                 </configuration>
             </plugin>
         </plugins>
@@ -1308,12 +1314,6 @@
                                 <id>attach-javadocs</id>
                                 <goals>
                                     <goal>jar</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>attach-test-javadocs</id>
-                                <goals>
-                                    <goal>test-jar</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -62,7 +62,7 @@ Usage
 -----
 1. Include OSHI and its dependencies on your classpath.
    - We strongly recommend you add `oshi-core` (and/or `oshi-core-ffm`) as a dependency to your project dependency manager such as Maven or Gradle. Transitive dependencies (including `oshi-common` and JNA) are resolved automatically.
-   - If you manage JAR files manually, download all needed JARs from the [oshi-dist](https://repo1.maven.org/maven2/com/github/oshi/oshi-dist/) zip files. See [UPGRADING.md](https://github.com/oshi/oshi/blob/master/UPGRADING.md#project-dependencies) for details.
+   - If you manage JAR files manually, download all needed JARs from the [oshi-dist](https://repo1.maven.org/maven2/com/github/oshi/oshi-dist/) zip file, also attached to each [GitHub release](https://github.com/oshi/oshi/releases). It contains `oshi-common`, `oshi-core`, and `oshi-core-ffm` plus their runtime dependencies; the `oshi-demo` examples and their dependencies are not included. See [UPGRADING.md](https://github.com/oshi/oshi/blob/master/UPGRADING.md#project-dependencies) for details.
    - For Windows, consider the optional `jLibreHardwareMonitor` dependency if you need sensor information. Note the binary DLLs in this dependency are licensed under MPL 2.0.
    - For Android, you'll need to add the [AAR artifact for JNA](https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android) and exclude OSHI's transitive (JAR) dependency.
    - See the [FAQ](https://github.com/oshi/oshi/blob/master/FAQ.md#how-do-i-resolve-jna-noclassdeffounderror-or-nosuchmethoderror-issues) if you encounter `NoClassDefFoundError` or `NoSuchMethodError` problems.


### PR DESCRIPTION
Sonatype is [enforcing per-organization publishing limits](https://central.sonatype.org/publish/maven-central-publishing-limits/) on Maven Central — 78 MB release size, 1167 files, 7 releases per month, evaluated on three-month averages. Soft limits (warnings only) have been in effect since 2026-06-16; **rate limiting begins 2026-10-01.**

The 7.4.4 release consumed 48.91 MB across 198 files. At that rate three releases in a month is nearly double the size cap, so this trims what we publish without giving up anything a consumer uses.

## Result

Measured against a staged `central-bundle.zip`, not estimated:

| | 7.4.4 | after | |
|---|---|---|---|
| release size | 46.61 MB | **16.94 MB** | −64% |
| artifacts | 33 | 23 | |
| files | 198 | 138 | −30% |

Scaling by the sidecar overhead implied by Sonatype's own 48.91 MB figure for 7.4.4 gives ~17.8 MB per release: three releases a month sits at **68% of the size cap** (was 188%), four at 91%. Release count and file count were never close to their limits and now sit at 24% and 28%.

## What changed, largest saving first

1. **`oshi-dist` ships one `.zip` instead of three archives.** The `.zip`, `.tar.gz` and `.tar.bz2` held byte-identical content at ~9 MB each, so two thirds of `oshi-dist`'s 27.01 MB was pure compression-format duplication.

2. **`oshi-dist` no longer bundles `oshi-demo`.** This is a correctness fix as much as a size one — anyone downloading the archive to put `oshi-core` on a classpath was also getting `jfreechart` and three `jackson` artifacts from example-only code. The archive is now 27.01 MB → 4.94 MB and contains exactly `oshi-common`, `oshi-core`, `oshi-core-ffm`, `license.txt`, and `lib/`{`jna-jpms`, `jna-platform-jpms`, `slf4j-api`}. Side benefit: no published OSHI artifact redistributes Jackson bytes any more, so a Jackson CVE becomes an ordinary Renovate bump in demo code.

3. **`oshi-common`'s javadoc is no longer inlined into the `oshi-core` / `oshi-core-ffm` javadoc jars**, where it was more than half of each: 6.23 → 1.93 MB and 6.26 → 1.97 MB. `oshi-common` publishes its own javadoc jar and IDEs resolve javadoc per-artifact, so IDE users see no change. Only a standalone unzipped browse of one jar loses cross-links. Matches what jackson-databind and micrometer-core do.

   The `<reporting>` copies are deliberately kept, with a comment explaining why. Reporting configuration does not inherit from `<build>`, so **the published site stays self-contained and fully cross-linked** — verified below.

4. **No more `test-javadoc` jars.** A survey of 20 well-known Central artifacts found 0/10 peers publishing javadoc for their own tests; this was the one genuinely off-pattern thing we shipped. Sonatype's [reduction guide](https://central.sonatype.org/publish/reducing-publishing-usage/) names "tool-generated supplementary files" as reduction candidates while explicitly protecting sources and javadoc jars, which are otherwise untouched here.

5. **`oshi-benchmark` is no longer published**, via `excludeArtifacts`. Its own pom already claimed it wasn't.

Also: **the dist zip is now attached to each GitHub release**, which previously carried no assets beyond GitHub's auto-generated source tarballs.

## Verification

- **Staged bundle** in a throwaway worktree at version 99.9.9, deploying to an unreachable `centralBaseUrl` so the bundle is written but not uploaded: 0 `test-javadoc` entries, 0 `oshi-benchmark` entries, exactly one `oshi-dist` `.zip`. 115 entries = 23 artifacts × 5 (gpg skipped), matching the predicted count.
- **Archive contents**: 8 entries, no `jfreechart`/`jackson`/`oshi-demo`, and no `.tar.*` produced. Dropping the module from the `moduleSet` removed its transitive deps from `lib/` on its own, so no explicit `dependencySet` excludes were needed.
- **Site javadoc still inlines**: `oshi-core/target/site/apidocs/com.github.oshi.common/oshi/util/ParseUtil.html` exists, while the *published* `oshi-core-javadoc.jar` no longer contains `oshi/util/ParseUtil.html`. That split is the whole basis of change 3.
- **`-Prelease clean install` passes.** This was the real risk: `javadoc:jar` runs only in the `release` profile and is stricter about unresolved `{@link}`s than the `javadoc:javadoc` report goal used in the normal gate.
- Full gate green (`spotless:check`, `checkstyle:check`, `forbiddenapis:check`+`testCheck`, `javadoc:javadoc`, `verify-slf4j-17`), and `mvn test -Paggregate-coverage` passes.
- The new workflow's exact build command was run locally and produces a zip matching its upload glob.

No Java source is touched — this is poms, an assembly descriptor, one new workflow, and docs.

## ⚠️ Sequencing

`dist-release.yaml` triggers on `release: published`, which per RELEASING.md is the last manual release step. **It must be merged before the next `release:prepare` cuts a tag**, or the checked-out tag won't contain it and nothing fires. `RELEASING.md` documents that, plus a `gh workflow run dist-release.yaml -f tag=...` retry (which also backfills older tags) and a manual `gh release upload` fallback.

Since the zip remains on Central, a missed asset is a cosmetic gap rather than a distribution outage. Rebuilt jars are functionally identical to Central's but not byte-identical — the manifest carries a `Build-Time` and no `project.build.outputTimestamp` is set — so the Central copy stays authoritative.

## One caveat

`excludeArtifacts` **logs nothing when it matches** (unlike `skipPublishing`), so a typo there fails open and publishes the module anyway. Bundle inspection is the only check; worth re-running the staged-bundle step if that config is ever edited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Releases now provide a single `oshi-dist` ZIP containing OSHI modules and runtime dependencies.
  - Distribution archives are automatically attached to GitHub Releases.

- **Improvements**
  - Demo components and dependencies are excluded from distribution archives.
  - Benchmark artifacts and test Javadocs are no longer published.
  - Javadoc packaging is streamlined to reduce duplication.

- **Documentation**
  - Updated download, upgrade, and release instructions to explain the new distribution format and GitHub Release availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->