### PR TITLE
Wire Error Prone into the build as groundwork for jSpecify

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,12 +56,14 @@ jobs:
             echo "unix=false" >> "$GITHUB_OUTPUT"
           fi
 
-  # Static analysis: formatting, style, API restrictions, and javadoc link validity.
-  # Runs once on ubuntu/JDK 25 (javadoc for oshi-core-ffm requires JDK 25).
-  lint:
+  # Static analysis, split into parallel jobs so no single job's sequential Maven
+  # invocations dominate the critical path.
+
+  # Formatting and style — the fastest of the static-analysis jobs.
+  lint-format:
     if: github.event.action != 'labeled' || github.event.label.name == 'full-coverage'
     runs-on: ubuntu-latest
-    name: Lint (Spotless, Checkstyle, ForbiddenAPIs, Javadoc)
+    name: Lint (Spotless, Checkstyle)
     permissions:
       contents: read
     steps:
@@ -81,12 +83,60 @@ jobs:
         run: ./mvnw spotless:check
       - name: Checkstyle
         run: ./mvnw checkstyle:check
+
+  # API restrictions, javadoc, and SLF4J compatibility.
+  # Runs on ubuntu/JDK 25 (javadoc for oshi-core-ffm requires JDK 25).
+  lint-verify:
+    if: github.event.action != 'labeled' || github.event.label.name == 'full-coverage'
+    runs-on: ubuntu-latest
+    name: Lint (ForbiddenAPIs, Javadoc, SLF4J)
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: 25
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Install (release profile, catches javadoc-jar errors javadoc:javadoc misses)
+        # -Prelease exercises the same attach-javadocs execution used at release:perform time,
+        # which RELEASING.md notes is stricter than the javadoc:javadoc report goal below about
+        # unresolved {@link} references. -Dgpg.skip=true skips only the release profile's signing
+        # step (no key is configured here); its source-jar attachment is harmless.
+        run: ./mvnw -Prelease install -DskipTests -Dgpg.skip=true -q
       - name: Forbidden APIs
         run: ./mvnw forbiddenapis:check forbiddenapis:testCheck
-      - name: Javadoc
-        run: ./mvnw javadoc:javadoc -DskipTests
       - name: Verify SLF4J 1.7 API compatibility
         run: ./mvnw -Pverify-slf4j-17 clean compile
+
+  # Error Prone: groundwork for jSpecify nullability annotations (NullAway, the Error Prone
+  # check that will enforce them once added, needs Error Prone wired in first). Reports findings
+  # without blocking the PR until the initial backlog is triaged.
+  error-prone:
+    if: github.event.action != 'labeled' || github.event.label.name == 'full-coverage'
+    runs-on: ubuntu-latest
+    name: Error Prone (informational)
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: 25
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Error Prone
+        continue-on-error: true
+        run: ./mvnw install -DskipTests -Perror-prone
 
   test:
     if: github.event.action != 'labeled' || github.event.label.name == 'full-coverage'

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/oshi-benchmark/pom.xml
+++ b/oshi-benchmark/pom.xml
@@ -123,7 +123,10 @@
                     <jdkToolchain>
                         <version>25</version>
                     </jdkToolchain>
-                    <annotationProcessorPaths>
+                    <!-- combine.children="append" so this list adds to, rather than replaces,
+                         the error-prone profile's error_prone_core path (Maven's default merge
+                         for list-valued plugin config is child-replaces-parent). -->
+                    <annotationProcessorPaths combine.children="append">
                         <path>
                             <groupId>org.openjdk.jmh</groupId>
                             <artifactId>jmh-generator-annprocess</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,10 @@
         <!-- Compile versions -->
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <!-- Groundwork for jSpecify nullability annotations: NullAway (the Error Prone check that
+        will enforce them) requires Error Prone as its host platform. Only wired up behind the
+        error-prone profile for now; see pom.xml profile "error-prone". -->
+        <error-prone.version>2.50.0</error-prone.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <restrict-imports-enforcer-rule.version>3.0.0</restrict-imports-enforcer-rule.version>
@@ -1197,6 +1201,42 @@
             <properties>
                 <jna.aggregate.skip>false</jna.aggregate.skip>
             </properties>
+        </profile>
+        <profile>
+            <!-- Groundwork for jSpecify nullability annotations: wires Error Prone into the
+            compiler, the host platform NullAway (an Error Prone check) will use to enforce
+            jSpecify annotations once those land. Opt-in and non-blocking for now — no annotations
+            exist yet, so this only exercises Error Prone's own default bug-pattern checks.
+            Requires JDK 21+ to run (independent of the release target being compiled) and the
+            JPMS add-exports/add-opens flags in .mvn/jvm.config. -->
+            <id>error-prone</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-Xlint:-options</arg>
+                                <arg>-XDcompilePolicy=simple</arg>
+                                <arg>--should-stop=ifError=FLOW</arg>
+                                <!-- Skip annotation-processor-generated sources (e.g. JMH's
+                                generated benchmark harness in oshi-benchmark) - findings there
+                                are in code we don't write or maintain. -->
+                                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.*
+                                    -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF</arg>
+                            </compilerArgs>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>${error-prone.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>checks</id>


### PR DESCRIPTION
## Summary

Groundwork for the jSpecify nullability-annotations proposal, without adding any `@Nullable`/`@NonNull` markers yet. NullAway — the Error Prone check that will eventually enforce jSpecify annotations — requires Error Prone as its host platform, so this PR wires Error Prone into the build now so any pre-existing findings can be triaged ahead of the follow-on jSpecify/NullAway PR.

- Adds an opt-in `error-prone` Maven profile (repo-wide, one block in the root `pom.xml`) that activates `-Xplugin:ErrorProne` via `error_prone_core:2.50.0`. Not active on a normal build.
- Adds `.mvn/jvm.config` with the `--add-exports`/`--add-opens` JPMS flags Error Prone's in-process javac plugin needs (JEP 396).
- Excludes annotation-processor-generated sources (`-XepExcludedPaths`) so findings in JMH's auto-generated benchmark harness (not code we own) don't show up.
- Disables `InlineMeSuggester`/`DoNotCallSuggester` — they suggest Google-specific `@InlineMe`/`@DoNotCall` annotations this project doesn't use.
- Fixes a real wiring bug in `oshi-benchmark/pom.xml`: its own `annotationProcessorPaths` (for JMH's processor) was silently replacing rather than merging with the profile's `error_prone_core` path; fixed with `combine.children="append"`.
- Splits the CI `lint` job into `lint-format` (Spotless/Checkstyle) and `lint-verify` (ForbiddenAPIs/SLF4J), since it was growing long, and swaps `javadoc:javadoc` for the stricter release-profile javadoc check (`-Prelease install -Dgpg.skip=true`) that `RELEASING.md` notes catches unresolved `{@link}`s the normal gate tolerates — this project has been bitten by javadoc errors that only surfaced at `release:perform` time.
- Adds a new `error-prone` CI job, informational only (`continue-on-error: true`) — nothing here blocks the PR check yet, including the small number of real ERROR-severity findings the tool already surfaced (`BanJNDI`, `MemorySegmentReferenceEquality`, `ReturnValueIgnored`). No fixing in this PR; that's follow-on work.

No CHANGELOG entry — pure CI/build tooling, no user-visible change.

## Next steps (follow-on PRs, not this one)

1. Fix the small set of real ERROR-severity findings and drop `continue-on-error: true`, so ERROR-severity findings block (javac's own default) while WARNING-severity findings stay non-blocking for ongoing triage.
2. Add `org.jspecify:jspecify` + `com.uber.nullaway:nullaway`, start marking packages `@NullMarked` beginning with `oshi-common`'s shared interfaces/abstract classes, then push outward to `oshi-core`/`oshi-core-ffm` keeping twins in sync.
3. Batch-fix the remaining WARNING-severity backlog (~200 findings, mostly `StringSplitter`, `MissingSummary`, `EnumOrdinal`, `MixedMutabilityReturnType`), by module or by check.

## Test plan

- [x] `./mvnw clean install -DskipTests` (no profile) — unaffected, confirms Error Prone stays fully opt-in
- [x] `./mvnw clean install -DskipTests -Perror-prone -fn` (whole reactor) — plugin activates on every module, findings are real code (not generated sources), no false "plug-in not found" errors
- [x] `./mvnw -Prelease install -DskipTests -Dgpg.skip=true` — succeeds without a signing key, produces `*-javadoc.jar`/`*-sources.jar` for every module
- [x] `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc` — full gate passes, no reformatting needed
- [x] `.github/workflows/pr.yaml` parses as valid YAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Added optional Error Prone static analysis for detecting potential Java issues.
  * Improved validation coverage for formatting, style, forbidden APIs, release compatibility, and SLF4J usage.
  * Added compiler configuration required for broader Java analysis compatibility.

* **Build Improvements**
  * Preserved inherited annotation processors while adding benchmark-specific processors.
  * Streamlined documentation validation through the release build profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->