### PR TITLE
Fix Error Prone ERROR-severity findings, make error-prone job blocking

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -115,12 +115,13 @@ jobs:
         run: ./mvnw -Pverify-slf4j-17 clean compile
 
   # Error Prone: groundwork for jSpecify nullability annotations (NullAway, the Error Prone
-  # check that will enforce them once added, needs Error Prone wired in first). Reports findings
-  # without blocking the PR until the initial backlog is triaged.
+  # check that will enforce them once added, needs Error Prone wired in first). ERROR-severity
+  # findings block the PR (javac's own default behavior); WARNING-severity findings don't, and
+  # accumulate for ongoing triage.
   error-prone:
     if: github.event.action != 'labeled' || github.event.label.name == 'full-coverage'
     runs-on: ubuntu-latest
-    name: Error Prone (informational)
+    name: Error Prone
     permissions:
       contents: read
     steps:
@@ -135,7 +136,6 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
       - name: Error Prone
-        continue-on-error: true
         run: ./mvnw install -DskipTests -Perror-prone
 
   test:

--- a/oshi-benchmark/pom.xml
+++ b/oshi-benchmark/pom.xml
@@ -123,10 +123,7 @@
                     <jdkToolchain>
                         <version>25</version>
                     </jdkToolchain>
-                    <!-- combine.children="append" so this list adds to, rather than replaces,
-                         the error-prone profile's error_prone_core path (Maven's default merge
-                         for list-valued plugin config is child-replaces-parent). -->
-                    <annotationProcessorPaths combine.children="append">
+                    <annotationProcessorPaths>
                         <path>
                             <groupId>org.openjdk.jmh</groupId>
                             <artifactId>jmh-generator-annprocess</artifactId>
@@ -204,6 +201,28 @@
     </build>
 
     <profiles>
+        <profile>
+            <!-- Opt out of the root error-prone profile: this module's maven-compiler-plugin
+            config above forks a separate javac process for its JDK toolchain, and a forked
+            invocation doesn't preserve a multi-option -Xplugin value as one token the way
+            in-process compilation does elsewhere in the reactor, breaking Error Prone's own
+            "-Xep:Check:OFF"-style flags. Not worth extra plumbing for a JMH-only module that never
+            carries jSpecify annotations - restore the plain compilerArgs baseline instead. -->
+            <id>error-prone</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-Xlint:-options</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>native-comparison</id>
             <properties>

--- a/oshi-benchmark/src/main/java/oshi/benchmark/MonitoringFootprintReport.java
+++ b/oshi-benchmark/src/main/java/oshi/benchmark/MonitoringFootprintReport.java
@@ -71,7 +71,7 @@ public final class MonitoringFootprintReport {
     // Retained bytes of `copies` poll results held from a single reused SystemInfo
     private static double resultKb(Function<SystemInfo, Object> read) {
         SystemInfo si = new SystemInfo();
-        read.apply(si); // realize the subsystem graph so only per-result allocations are measured below
+        var _ = read.apply(si); // realize the subsystem graph so only per-result allocations are measured below
         Object[] hold = new Object[RESULT_COPIES];
         long before = usedBytes();
         for (int i = 0; i < RESULT_COPIES; i++) {
@@ -95,7 +95,9 @@ public final class MonitoringFootprintReport {
 
         record Metric(String name, Function<SystemInfo, Object> read) {
             Consumer<SystemInfo> realize() {
-                return read::apply;
+                return si -> {
+                    var _ = read.apply(si); // realize the subsystem graph; only the side effect matters here
+                };
             }
         }
         Metric[] metrics = { new Metric("cpuTicks", si -> si.getHardware().getProcessor().getSystemCpuLoadTicks()),
@@ -105,7 +107,7 @@ public final class MonitoringFootprintReport {
         // Warm up class loading, native libraries, and JIT before measuring (see PERFORMANCE.md cold-start note)
         for (int i = 0; i < WARMUP; i++) {
             for (Metric m : metrics) {
-                m.read().apply(new SystemInfo());
+                var _ = m.read().apply(new SystemInfo());
             }
         }
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
@@ -94,7 +94,7 @@ public final class IPHlpAPIUtilFFM {
                     FIXED_INFO_LAYOUT.byteOffset(PathElement.groupElement("DnsServerList")),
                     IP_ADDR_STRING_LAYOUT.byteSize());
 
-            while (dnsServerList != NULL) {
+            while (dnsServerList.address() != 0) {
                 MemorySegment ipStringSeg = dnsServerList
                         .asSlice(IP_ADDR_STRING_LAYOUT.byteOffset(PathElement.groupElement("IpAddress")), 16);
 

--- a/oshi-demo/src/main/java/oshi/demo/jmx/demo/Client.java
+++ b/oshi-demo/src/main/java/oshi/demo/jmx/demo/Client.java
@@ -45,10 +45,13 @@ public class Client {
      * @throws AttributeNotFoundException   if attribute not found
      */
     @SuppressForbidden(reason = "Using System.out in a demo class")
+    @SuppressWarnings("BanJNDI")
     public static void main(String[] args) throws IOException, MalformedObjectNameException, ReflectionException,
             InstanceNotFoundException, MBeanException, AttributeNotFoundException {
 
-        // The address of the connector server
+        // The address of the connector server. JMX-over-RMI inherently resolves through JNDI;
+        // this targets OshiJMXServer, this demo's own companion server on a hardcoded localhost
+        // address, not attacker-controlled input.
         JMXServiceURL address = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:8888/server");
         // Map for custom properties key values
         Map<String, ?> environment = null;

--- a/pom.xml
+++ b/pom.xml
@@ -1205,10 +1205,15 @@
         <profile>
             <!-- Groundwork for jSpecify nullability annotations: wires Error Prone into the
             compiler, the host platform NullAway (an Error Prone check) will use to enforce
-            jSpecify annotations once those land. Opt-in and non-blocking for now — no annotations
-            exist yet, so this only exercises Error Prone's own default bug-pattern checks.
-            Requires JDK 21+ to run (independent of the release target being compiled) and the
-            JPMS add-exports/add-opens flags in .mvn/jvm.config. -->
+            jSpecify annotations once those land. ERROR-severity findings block the build (javac's
+            own default behavior); WARNING-severity findings don't, and accumulate for ongoing
+            triage. Requires JDK 21+ to run (independent of the release target being compiled) and
+            the JPMS add-exports/add-opens flags in .mvn/jvm.config. oshi-benchmark opts out (see
+            its own pom.xml) - its maven-compiler-plugin config forks a separate javac process for
+            its JDK toolchain, and a forked invocation doesn't preserve a multi-option -Xplugin
+            value as one token the way in-process compilation does, breaking Error Prone's own
+            "-Xep:Check:OFF"-style flags; it's also JMH-only and never carries jSpecify
+            annotations, so it isn't worth the extra plumbing to fix. -->
             <id>error-prone</id>
             <build>
                 <plugins>
@@ -1220,11 +1225,7 @@
                                 <arg>-Xlint:-options</arg>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
-                                <!-- Skip annotation-processor-generated sources (e.g. JMH's
-                                generated benchmark harness in oshi-benchmark) - findings there
-                                are in code we don't write or maintain. -->
-                                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.*
-                                    -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF</arg>
+                                <arg>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>


### PR DESCRIPTION
## Summary

Follow-on to #3594 (Error Prone groundwork). Fixes the small set of real ERROR-severity findings that tool surfaced, then removes `continue-on-error: true` from the `error-prone` CI job — from here on, ERROR-severity findings block the PR (javac's own default behavior for a compile error), while WARNING-severity findings still don't, and remain queued for the larger ongoing triage.

- **`oshi-core-ffm`** — `IPHlpAPIUtilFFM.getDnsServers()`: the DNS-list loop's `while` guard compared a `MemorySegment` by reference against `MemorySegment.NULL`. A `.asSlice()`/`.get()`/`.reinterpret()` result is never the literal `NULL` singleton object, even at address 0, so the condition was always true and the loop's real termination relied entirely on an inner `.address() == 0` break already present a few lines down. No observable behavior change (that inner break already worked), but this removes the latent risk of an infinite loop if it's ever touched. Fixed to compare `.address() != 0`, matching the existing check already used later in the same loop. Checked the JNA twin (`WindowsNetworkParamsJNA`) — no equivalent bug there, since JNA's structure auto-mapping genuinely returns Java `null` for a null pointer field, unlike FFM's `MemorySegment` value type.
- **`oshi-demo`** — suppresses `BanJNDI` in the JMX `Client` demo: it connects to `OshiJMXServer`, this demo's own companion server on a hardcoded `localhost:8888`, not attacker-controlled input. JMX-over-RMI inherently resolves through JNDI; there's no way to demonstrate this connectivity without it.
- **`oshi-benchmark`** — `MonitoringFootprintReport`: three call sites intentionally discard a `Function.apply()` return value purely for its side effect (realizing a lazily-computed subsystem graph, or JIT/class-loading warm-up). Made the discard explicit with Java 21's unnamed-variable syntax (`var _ = ...`), matching Error Prone's own suggested fix text.
- **CI**: drop `continue-on-error: true` on the `error-prone` job now that the ERROR backlog is clear.

No CHANGELOG entry — none of these are observable user-visible behavior changes (the FFM fix hardens a dead-condition risk without changing output; the rest is demo/benchmark code and CI config).

## Test plan

- [x] `./mvnw clean install -DskipTests -Perror-prone` (whole reactor) — BUILD SUCCESS, 0 ERROR-severity findings (209 WARNING findings remain, queued for follow-on triage)
- [x] `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc` — full gate passes, no reformatting needed
- [x] `./mvnw test -pl oshi-core-ffm -am` — passes
- [ ] Not verified on real Windows hardware with 2+ configured DNS servers (the scenario the loop is about) — no Windows machine available; verified the fix is behavior-preserving by tracing the loop logic instead (see commit message)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows DNS server discovery so all configured entries can be processed correctly.
  - Improved benchmark setup and warmup reliability without changing measured behavior.

- **Developer Experience**
  - Clarified the JMX demo’s local connection requirements and security-warning handling.

- **Quality**
  - CI now checks generated code and blocks pull requests for critical static-analysis findings, while non-critical warnings remain informational.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->