### PR TITLE
Sync linux.yaml's lint job with pr.yaml, add Error Prone

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -15,11 +15,13 @@ permissions:
   contents: read
 
 jobs:
-  # Static analysis: formatting, style, API restrictions, and javadoc link validity.
-  # Runs once on ubuntu/JDK 25 (javadoc for oshi-core-ffm requires JDK 25).
-  lint:
+  # Static analysis, split into parallel jobs so no single job's sequential Maven
+  # invocations dominate the critical path. Kept in sync with pr.yaml's lint jobs.
+
+  # Formatting and style — the fastest of the static-analysis jobs.
+  lint-format:
     runs-on: ubuntu-latest
-    name: Lint (Spotless, Checkstyle, ForbiddenAPIs, Javadoc)
+    name: Lint (Spotless, Checkstyle)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -37,10 +39,54 @@ jobs:
         run: ./mvnw spotless:check
       - name: Checkstyle
         run: ./mvnw checkstyle:check
+
+  # API restrictions, javadoc, and SLF4J compatibility.
+  # Runs on ubuntu/JDK 25 (javadoc for oshi-core-ffm requires JDK 25).
+  lint-verify:
+    runs-on: ubuntu-latest
+    name: Lint (ForbiddenAPIs, Javadoc, SLF4J)
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: 25
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Install (release profile, catches javadoc-jar errors javadoc:javadoc misses)
+        # -Prelease exercises the same attach-javadocs execution used at release:perform time,
+        # which RELEASING.md notes is stricter than the javadoc:javadoc report goal below about
+        # unresolved {@link} references. -Dgpg.skip=true skips only the release profile's signing
+        # step (no key is configured here); its source-jar attachment is harmless.
+        run: ./mvnw -Prelease install -DskipTests -Dgpg.skip=true -q
       - name: Forbidden APIs
         run: ./mvnw forbiddenapis:check forbiddenapis:testCheck
-      - name: Javadoc
-        run: ./mvnw javadoc:javadoc -DskipTests
+      - name: Verify SLF4J 1.7 API compatibility
+        run: ./mvnw -Pverify-slf4j-17 clean compile
+
+  # Error Prone: groundwork for jSpecify nullability annotations (NullAway, the Error Prone
+  # check that will enforce them once added, needs Error Prone wired in first). ERROR-severity
+  # findings fail this job (javac's own default behavior); WARNING-severity findings don't, and
+  # accumulate for ongoing triage.
+  error-prone:
+    runs-on: ubuntu-latest
+    name: Error Prone
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: 25
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Error Prone
+        run: ./mvnw install -DskipTests -Perror-prone
 
   # Runs full project on multiple JDKs
   testmatrix:


### PR DESCRIPTION
## Summary

`linux.yaml`'s push-to-master `lint` job hadn't been touched by either #3594 (Error Prone groundwork) or #3595 (fixing the ERROR-severity backlog), so it had drifted: still ran the plain `javadoc:javadoc` report goal instead of the stricter release-profile check `pr.yaml` now uses, and never ran Error Prone at all.

Split it into the same `lint-format`/`lint-verify`/`error-prone` jobs as `pr.yaml`, so push-to-master gets identical static analysis coverage to every PR, and a future change to one workflow doesn't silently leave the other behind.

Note: until #3595 merges, the new `error-prone` job here will show red on pushes to master (the 5 ERROR-severity findings it fixes aren't merged yet) — that's expected and self-resolves once #3595 lands, not a problem with this change.

No CHANGELOG entry — pure CI configuration.

## Test plan

- [x] YAML parses correctly
- [x] Job structure and commands are identical to `pr.yaml`'s current `lint-format`/`lint-verify`/`error-prone` jobs (verified by diff)
- [x] Confirmed locally that `./mvnw install -DskipTests -Perror-prone` currently fails on `master` with the known 5 ERROR findings (expected, pending #3595) and will pass once #3595 merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Linux continuous integration by separating formatting, verification, and static analysis checks.
  * Verification now includes release-profile, API usage, and logging compatibility checks.
  * Added static analysis coverage for JDK 25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->