### PR TITLE
Fix all Error Prone StringSplitter findings, fix silent -Xmaxwarns truncation

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lscfg.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lscfg.java
@@ -62,11 +62,11 @@ public final class Lscfg {
                 planeFlag = true;
             } else if (planeFlag) {
                 if (checkLine.contains(modelMarker)) {
-                    model = ParseUtil.removeLeadingDots(checkLine.split(modelMarker)[1].trim());
+                    model = ParseUtil.removeLeadingDots(checkLine.split(modelMarker, -1)[1].trim());
                 } else if (checkLine.contains(serialMarker)) {
-                    serialNumber = ParseUtil.removeLeadingDots(checkLine.split(serialMarker)[1].trim());
+                    serialNumber = ParseUtil.removeLeadingDots(checkLine.split(serialMarker, -1)[1].trim());
                 } else if (checkLine.contains(versionMarker)) {
-                    version = ParseUtil.removeLeadingDots(checkLine.split(versionMarker)[1].trim());
+                    version = ParseUtil.removeLeadingDots(checkLine.split(versionMarker, -1)[1].trim());
                 } else if (checkLine.contains(locationMarker)) {
                     break;
                 }
@@ -108,9 +108,9 @@ public final class Lscfg {
                 }
             }
             if (s.contains(modelMarker)) {
-                model = ParseUtil.removeLeadingDots(s.split(modelMarker)[1].trim());
+                model = ParseUtil.removeLeadingDots(s.split(modelMarker, -1)[1].trim());
             } else if (s.contains(serialMarker)) {
-                serial = ParseUtil.removeLeadingDots(s.split(serialMarker)[1].trim());
+                serial = ParseUtil.removeLeadingDots(s.split(serialMarker, -1)[1].trim());
             }
         }
         return new Pair<>(model, serial);

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lspv.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lspv.java
@@ -138,7 +138,7 @@ public final class Lspv {
         Map<String, String> typeMap = new HashMap<>();
         Map<String, Integer> ppMap = new HashMap<>();
         for (String s : lspvP) {
-            String[] split = ParseUtil.whitespaces.split(s.trim());
+            String[] split = ParseUtil.whitespaces.split(s.trim(), -1);
             if (split.length >= 6 && "used".equals(split[1])) {
                 // Region may have two words, so count from end
                 String name = split[split.length - 3];

--- a/oshi-common/src/main/java/oshi/driver/common/unix/bsd/Systat.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/bsd/Systat.java
@@ -60,7 +60,7 @@ public final class Systat {
         List<Double> allTemps = new ArrayList<>();
         List<Integer> fanRPMs = new ArrayList<>();
         for (String line : systatLines) {
-            String[] split = ParseUtil.whitespaces.split(line);
+            String[] split = ParseUtil.whitespaces.split(line, -1);
             if (split.length > 1) {
                 if (split[0].contains("cpu")) {
                     if (split[0].contains("temp0")) {
@@ -137,7 +137,7 @@ public final class Systat {
         int maxCapacity = 1;
         int designCapacity = 1;
         for (String line : systatLines) {
-            String[] split = ParseUtil.whitespaces.split(line);
+            String[] split = ParseUtil.whitespaces.split(line, -1);
             if (split.length > 1 && split[0].startsWith(name)) {
                 if (split[0].contains("volt0") || (split[0].contains("volt") && line.contains("current"))) {
                     voltage = ParseUtil.parseDoubleOrDefault(split[1], -1d);

--- a/oshi-common/src/main/java/oshi/driver/common/unix/bsd/disk/Disklabel.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/bsd/disk/Disklabel.java
@@ -75,13 +75,13 @@ public final class Disklabel {
         for (String line : disklabelLines) {
             if (line.contains(TOTAL_MARKER)) {
                 // Parse as long to avoid int overflow for disks larger than ~2 TiB at 512-byte sectors.
-                totalSectors = ParseUtil.parseLongOrDefault(line.split(TOTAL_MARKER)[1].trim(), 1L);
+                totalSectors = ParseUtil.parseLongOrDefault(line.split(TOTAL_MARKER, -1)[1].trim(), 1L);
             } else if (line.contains(BPS_MARKER)) {
                 bytesPerSector = ParseUtil.getFirstIntValue(line);
             } else if (line.contains(LABEL_MARKER)) {
-                label = line.split(LABEL_MARKER)[1].trim();
+                label = line.split(LABEL_MARKER, -1)[1].trim();
             } else if (line.contains(DUID_MARKER)) {
-                duid = line.split(DUID_MARKER)[1].trim();
+                duid = line.split(DUID_MARKER, -1)[1].trim();
             }
             if (line.trim().indexOf(':') == 1) {
                 // Partition rows have a single letter followed by a colon:
@@ -115,7 +115,7 @@ public final class Disklabel {
         List<HWPartition> partitions = new ArrayList<>();
         for (String line : dfLines) {
             if (line.startsWith("/dev/" + diskName)) {
-                String[] split = ParseUtil.whitespaces.split(line);
+                String[] split = ParseUtil.whitespaces.split(line, -1);
                 if (split.length > 5) {
                     String name = split[0].substring(5 + diskName.length());
                     Pair<Integer, Integer> majorMinor = majorMinorLookup.apply(diskName, name);

--- a/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/GeomDiskList.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/GeomDiskList.java
@@ -67,7 +67,7 @@ public final class GeomDiskList {
             if (diskName != null) {
                 line = line.trim();
                 if (line.startsWith("Mediasize:")) {
-                    String[] split = ParseUtil.whitespaces.split(line);
+                    String[] split = ParseUtil.whitespaces.split(line, -1);
                     if (split.length > 1) {
                         mediaSize = ParseUtil.parseLongOrDefault(split[1], 0L);
                     }

--- a/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/GeomPartList.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/freebsd/disk/GeomPartList.java
@@ -96,7 +96,7 @@ public final class GeomPartList {
                 }
                 // If we don't have a valid partition, don't parse anything until we do.
                 if (partName != null) {
-                    String[] split = ParseUtil.whitespaces.split(line);
+                    String[] split = ParseUtil.whitespaces.split(line, -1);
                     if (split.length >= 2) {
                         if (line.startsWith("Mediasize:")) {
                             size = ParseUtil.parseLongOrDefault(split[1], 0L);

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Iostat.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/disk/Iostat.java
@@ -73,10 +73,10 @@ public final class Iostat {
         for (int i = 0; i < mountNames.size() && i < mountPoints.size(); i++) {
             // Map disk
             disk = mountNames.get(i);
-            String[] diskSplit = disk.split(",");
+            String[] diskSplit = disk.split(",", -1);
             if (diskSplit.length >= 5 && !DEVICE_HEADER.equals(diskSplit[0])) {
                 String mount = mountPoints.get(i);
-                String[] mountSplit = mount.split(",");
+                String[] mountSplit = mount.split(",", -1);
                 if (mountSplit.length >= 5 && !DEVICE_HEADER.equals(mountSplit[4])) {
                     deviceMap.put(diskSplit[0], mountSplit[4]);
                 }
@@ -116,7 +116,7 @@ public final class Iostat {
             // The -r switch enables comma delimited for easy parsing!
             // No guarantees on which line the results appear so we'll nest
             // a loop iterating on the comma splits
-            String[] split = line.split(",");
+            String[] split = line.split(",", -1);
             for (String keyValue : split) {
                 keyValue = keyValue.trim();
                 // If entry is tne name of a disk, this is beginning of new
@@ -147,9 +147,9 @@ public final class Iostat {
                     product = keyValue.replace("Product:", "").trim();
                 } else if (keyValue.startsWith("Size:")) {
                     // Size: 1.23GB <1227563008 bytes>
-                    String[] bytes = keyValue.split("<");
+                    String[] bytes = keyValue.split("<", -1);
                     if (bytes.length > 1) {
-                        bytes = ParseUtil.whitespaces.split(bytes[1]);
+                        bytes = ParseUtil.whitespaces.split(bytes[1], -1);
                         size = ParseUtil.parseLongOrDefault(bytes[0], 0L);
                     }
                 }

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractGlobalMemory.java
@@ -69,7 +69,7 @@ public abstract class AbstractGlobalMemory implements GlobalMemory {
                     serialNumber = Constants.UNKNOWN;
                 }
             } else if (bank > 0) {
-                String[] split = line.trim().split(":");
+                String[] split = line.trim().split(":", -1);
                 if (split.length == 2) {
                     switch (split[0]) {
                         case "Bank Locator":

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractGlobalMemory.java
@@ -69,7 +69,8 @@ public abstract class AbstractGlobalMemory implements GlobalMemory {
                     serialNumber = Constants.UNKNOWN;
                 }
             } else if (bank > 0) {
-                String[] split = line.trim().split(":", -1);
+                // Limit 2 so a value containing a colon (e.g. a hex serial number) isn't split further.
+                String[] split = line.trim().split(":", 2);
                 if (split.length == 2) {
                     switch (split[0]) {
                         case "Bank Locator":

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractNetworkIF.java
@@ -113,7 +113,7 @@ public abstract class AbstractNetworkIF implements NetworkIF {
                 InetAddress address = interfaceAddress.getAddress();
                 if (!address.getHostAddress().isEmpty()) {
                     if (address.getHostAddress().contains(":")) {
-                        ipv6list.add(address.getHostAddress().split("%")[0]);
+                        ipv6list.add(address.getHostAddress().split("%", -1)[0]);
                         prefixLengthList.add(interfaceAddress.getNetworkPrefixLength());
                     } else {
                         ipv4list.add(address.getHostAddress());

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
@@ -170,7 +170,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
         boolean cpu64bit = false;
         StringBuilder armStepping = new StringBuilder(); // For ARM equivalent
         for (String line : cpuInfo) {
-            String[] splitLine = ParseUtil.whitespacesColonWhitespace.split(line);
+            String[] splitLine = ParseUtil.whitespacesColonWhitespace.split(line, -1);
             if (splitLine.length < 2) {
                 // special case
                 if (line.startsWith("CPU architecture: ")) {
@@ -519,32 +519,32 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
                 size = 0L;
             } else if (s.contains("one-size")) {
                 // "one-size": "65536",
-                String[] split = ParseUtil.notDigits.split(s);
+                String[] split = ParseUtil.notDigits.split(s, -1);
                 if (split.length > 1) {
                     size = ParseUtil.parseLongOrDefault(split[1], 0L);
                 }
             } else if (s.contains("ways")) {
                 // "ways": null,
                 // "ways": 4,
-                String[] split = ParseUtil.notDigits.split(s);
+                String[] split = ParseUtil.notDigits.split(s, -1);
                 if (split.length > 1) {
                     associativity = ParseUtil.parseIntOrDefault(split[1], 0);
                 }
             } else if (s.contains("type")) {
                 // "type": "Unified",
-                String[] split = s.split("\"");
+                String[] split = s.split("\"", -1);
                 if (split.length > 2) {
                     type = parseCacheType(split[split.length - 2]);
                 }
             } else if (s.contains("level")) {
                 // "level": 3,
-                String[] split = ParseUtil.notDigits.split(s);
+                String[] split = ParseUtil.notDigits.split(s, -1);
                 if (split.length > 1) {
                     level = ParseUtil.parseIntOrDefault(split[1], 0);
                 }
             } else if (s.contains("coherency-size")) {
                 // "coherency-size": 64
-                String[] split = ParseUtil.notDigits.split(s);
+                String[] split = ParseUtil.notDigits.split(s, -1);
                 if (split.length > 1) {
                     lineSize = ParseUtil.parseIntOrDefault(split[1], 0);
                 }
@@ -700,7 +700,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
             throw new IllegalArgumentException("Must include from one to three elements.");
         }
         double[] average = new double[nelem];
-        String[] parts = ParseUtil.whitespaces.split(loadavgContent.trim());
+        String[] parts = ParseUtil.whitespaces.split(loadavgContent.trim(), -1);
         for (int i = 0; i < nelem; i++) {
             average[i] = i < parts.length ? ParseUtil.parseDoubleOrDefault(parts[i], -1d) : -1d;
         }
@@ -754,7 +754,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
                 marker = "ID:";
                 procInfo = true;
             } else if (procInfo && checkLine.contains(marker)) {
-                return checkLine.split(marker)[1].trim();
+                return checkLine.split(marker, -1)[1].trim();
             }
         }
         // If we've gotten this far, dmidecode failed. Try cpuid.
@@ -780,7 +780,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
             if (checkLine.contains("eax=") && checkLine.trim().startsWith("0x00000001")) {
                 String eax = "";
                 String edx = "";
-                for (String register : ParseUtil.whitespaces.split(checkLine)) {
+                for (String register : ParseUtil.whitespaces.split(checkLine, -1)) {
                     if (register.startsWith("eax=")) {
                         eax = ParseUtil.removeMatchingString(register, "eax=0x");
                     } else if (register.startsWith("edx=")) {
@@ -818,7 +818,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
         int midrBytes = 0;
         // Build 32-bit MIDR
         if (stepping.startsWith("r") && stepping.contains("p")) {
-            String[] rev = stepping.substring(1).split("p");
+            String[] rev = stepping.substring(1).split("p", -1);
             // 3:0 – Revision: last n in rnpn
             midrBytes |= ParseUtil.parseLastInt(rev[1], 0);
             // 23:20 - Variant: first n in rnpn

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
@@ -131,7 +131,7 @@ final class LinuxFirmware extends AbstractFirmware {
                     () -> DateTimeFormatter.ISO_LOCAL_DATE.format(VCGEN_FORMATTER.parse(vcgencmd.get(0))),
                     Constants.UNKNOWN);
             // Second line is copyright
-            String[] copyright = ParseUtil.whitespaces.split(vcgencmd.get(1));
+            String[] copyright = ParseUtil.whitespaces.split(vcgencmd.get(1), -1);
             vcManufacturer = copyright.length > 0 && !copyright[copyright.length - 1].isEmpty()
                     ? copyright[copyright.length - 1]
                     : Constants.UNKNOWN;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
@@ -131,7 +131,7 @@ final class LinuxFirmware extends AbstractFirmware {
                     () -> DateTimeFormatter.ISO_LOCAL_DATE.format(VCGEN_FORMATTER.parse(vcgencmd.get(0))),
                     Constants.UNKNOWN);
             // Second line is copyright
-            String[] copyright = ParseUtil.whitespaces.split(vcgencmd.get(1), -1);
+            String[] copyright = ParseUtil.whitespaces.split(vcgencmd.get(1).trim(), -1);
             vcManufacturer = copyright.length > 0 && !copyright[copyright.length - 1].isEmpty()
                     ? copyright[copyright.length - 1]
                     : Constants.UNKNOWN;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
@@ -153,7 +153,7 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
         Map<String, String> mountsMap = new HashMap<>();
         List<String> mounts = FileUtil.readFile(ProcPath.MOUNTS);
         for (String mount : mounts) {
-            String[] split = ParseUtil.whitespaces.split(mount);
+            String[] split = ParseUtil.whitespaces.split(mount, -1);
             if (split.length < 2 || !split[0].startsWith(DevPath.DEV)) {
                 continue;
             }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroup.java
@@ -66,7 +66,7 @@ public class LinuxLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
     static Map<String, Set<String>> parsePhysicalVolumes(List<String> pvs) {
         Map<String, Set<String>> physicalVolumesMap = new HashMap<>();
         for (String s : pvs) {
-            String[] split = ParseUtil.whitespaces.split(s.trim());
+            String[] split = ParseUtil.whitespaces.split(s.trim(), -1);
             if (split.length == 2 && split[1].startsWith(DevPath.DEV)) {
                 physicalVolumesMap.computeIfAbsent(split[0], k -> new HashSet<>()).add(split[1]);
             }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxVirtualMemory.java
@@ -122,7 +122,7 @@ final class LinuxVirtualMemory extends AbstractVirtualMemory {
         long swapPagesIn = 0L;
         long swapPagesOut = 0L;
         for (String checkLine : procVmStat) {
-            String[] memorySplit = ParseUtil.whitespaces.split(checkLine);
+            String[] memorySplit = ParseUtil.whitespaces.split(checkLine, -1);
             if (memorySplit.length > 1) {
                 switch (memorySplit[0]) {
                     case "pswpin":

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHWDiskStoreNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHWDiskStoreNF.java
@@ -81,7 +81,7 @@ public final class LinuxHWDiskStoreNF extends LinuxHWDiskStore {
                     int major = 0;
                     int minor = 0;
                     if (devStr.contains(":")) {
-                        String[] majMin = devStr.split(":");
+                        String[] majMin = devStr.split(":", -1);
                         major = ParseUtil.parseIntOrDefault(majMin[0], 0);
                         minor = ParseUtil.parseIntOrDefault(majMin[1], 0);
                     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
@@ -93,7 +93,7 @@ public abstract class MacGlobalMemory extends AbstractGlobalMemory {
                     bankLabel = bankLabel.substring(0, colon - 1);
                 }
             } else if (bank > 0) {
-                String[] split = line.trim().split(":");
+                String[] split = line.trim().split(":", -1);
                 if (split.length == 2) {
                     switch (split[0]) {
                         case "Size":
@@ -127,7 +127,7 @@ public abstract class MacGlobalMemory extends AbstractGlobalMemory {
         } else {
             // Apple Silicon format: no BANK lines, parse top-level keys
             for (String line : lines) {
-                String[] split = line.trim().split(":");
+                String[] split = line.trim().split(":", -1);
                 if (split.length == 2) {
                     String key = split[0].trim();
                     String value = split[1].trim();

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGlobalMemory.java
@@ -93,7 +93,8 @@ public abstract class MacGlobalMemory extends AbstractGlobalMemory {
                     bankLabel = bankLabel.substring(0, colon - 1);
                 }
             } else if (bank > 0) {
-                String[] split = line.trim().split(":", -1);
+                // Limit 2 so a value containing a colon (e.g. a hex serial number) isn't split further.
+                String[] split = line.trim().split(":", 2);
                 if (split.length == 2) {
                     switch (split[0]) {
                         case "Size":
@@ -127,7 +128,8 @@ public abstract class MacGlobalMemory extends AbstractGlobalMemory {
         } else {
             // Apple Silicon format: no BANK lines, parse top-level keys
             for (String line : lines) {
-                String[] split = line.trim().split(":", -1);
+                // Limit 2 so a value containing a colon (e.g. a hex serial number) isn't split further.
+                String[] split = line.trim().split(":", 2);
                 if (split.length == 2) {
                     String key = split[0].trim();
                     String value = split[1].trim();

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
@@ -118,7 +118,7 @@ public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
             } else {
                 Matcher n = q.matcher(s);
                 if (n.matches()) {
-                    for (String cacheStr : n.group(2).split(",")) {
+                    for (String cacheStr : n.group(2).split(",", -1)) {
                         ProcessorCache cache = parseCacheStr(cacheStr);
                         if (cache != null) {
                             caches.add(cache);
@@ -127,7 +127,7 @@ public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
                 }
             }
             if (s.startsWith("cpu")) {
-                String[] ss = s.trim().split(": ");
+                String[] ss = s.trim().split(": ", -1);
                 if (ss.length == 2 && ss[1].split(",").length > 3) {
                     featureFlags.add(ss[1]);
                 }
@@ -164,7 +164,7 @@ public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
     }
 
     static ProcessorCache parseCacheStr(String cacheStr) {
-        String[] split = ParseUtil.whitespaces.split(cacheStr.trim());
+        String[] split = ParseUtil.whitespaces.split(cacheStr.trim(), -1);
         if (split.length > 3) {
             switch (split[split.length - 1]) {
                 case "I-cache":

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdFirmware.java
@@ -91,9 +91,9 @@ public abstract class BsdFirmware extends AbstractFirmware {
             if (line.startsWith("bios0: vendor")) {
                 version = ParseUtil.getStringBetween(line, '"');
                 releaseDate = ParseUtil.parseMmDdYyyyToYyyyMmDD(ParseUtil.parseLastString(line));
-                String afterVendor = line.split("vendor")[1].trim();
+                String afterVendor = line.split("vendor", -1)[1].trim();
                 int versionIdx = afterVendor.indexOf(" version ");
-                vendor = versionIdx > 0 ? afterVendor.substring(0, versionIdx) : afterVendor.split("\\s+")[0];
+                vendor = versionIdx > 0 ? afterVendor.substring(0, versionIdx) : afterVendor.split("\\s+", -1)[0];
             }
         }
         return new Triplet<>(vendor, version, releaseDate);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdNetworkIF.java
@@ -44,7 +44,7 @@ public final class BsdNetworkIF extends AbstractNetworkIF {
     public boolean updateAttributes() {
         String stats = ExecutingCommand.getAnswerAt("netstat -bI " + getName(), 1);
         this.timeStamp = System.currentTimeMillis();
-        String[] split = ParseUtil.whitespaces.split(stats);
+        String[] split = ParseUtil.whitespaces.split(stats, -1);
         if (split.length < 12) {
             // No update
             return false;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdUsbDevice.java
@@ -69,7 +69,7 @@ public final class BsdUsbDevice extends AbstractUsbDevice {
             } else if (line.startsWith("addr ")) {
                 if (line.indexOf(':') == 7 && line.indexOf(',') >= 18) {
                     key = parent + line.substring(0, 7);
-                    String[] split = line.substring(8).trim().split(",");
+                    String[] split = line.substring(8).trim().split(",", -1);
                     if (split.length > 1) {
                         String vendorStr = split[0].trim();
                         int idx1 = vendorStr.indexOf(':');

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/CupsPrinter.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/CupsPrinter.java
@@ -118,7 +118,7 @@ public abstract class CupsPrinter extends AbstractPrinter {
 
         for (String line : lpstatLines) {
             if (line.startsWith("printer ")) {
-                String[] parts = line.split("\\s+");
+                String[] parts = line.split("\\s+", -1);
                 if (parts.length >= 3) {
                     String name = parts[1];
                     PrinterStatus status = Lpstat.parseStatus(line);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
@@ -228,7 +228,7 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
         int idx = 0;
         for (final String checkLine : pmcycles) {
             if (checkLine.contains(freqMarker)) {
-                freqs[idx++] = ParseUtil.parseHertz(checkLine.split(freqMarker)[1].trim());
+                freqs[idx++] = ParseUtil.parseHertz(checkLine.split(freqMarker, -1)[1].trim());
                 if (idx >= freqs.length) {
                     break;
                 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixComputerSystem.java
@@ -104,27 +104,27 @@ public final class AixComputerSystem extends AbstractComputerSystem {
 
         for (final String checkLine : lsattr) {
             if (checkLine.startsWith(fwVersionMarker)) {
-                fwVersion = checkLine.split(fwVersionMarker)[1].trim();
+                fwVersion = checkLine.split(fwVersionMarker, -1)[1].trim();
                 int comma = fwVersion.indexOf(',');
                 if (comma > 0 && fwVersion.length() > comma) {
                     fwVendor = fwVersion.substring(0, comma);
                     fwVersion = fwVersion.substring(comma + 1);
                 }
-                fwVersion = ParseUtil.whitespaces.split(fwVersion)[0];
+                fwVersion = ParseUtil.whitespaces.split(fwVersion, -1)[0];
             } else if (checkLine.startsWith(modelMarker)) {
-                model = checkLine.split(modelMarker)[1].trim();
+                model = checkLine.split(modelMarker, -1)[1].trim();
                 int comma = model.indexOf(',');
                 if (comma > 0 && model.length() > comma) {
                     manufacturer = model.substring(0, comma);
                     model = model.substring(comma + 1);
                 }
-                model = ParseUtil.whitespaces.split(model)[0];
+                model = ParseUtil.whitespaces.split(model, -1)[0];
             } else if (checkLine.startsWith(systemIdMarker)) {
-                serialNumber = checkLine.split(systemIdMarker)[1].trim();
-                serialNumber = ParseUtil.whitespaces.split(serialNumber)[0];
+                serialNumber = checkLine.split(systemIdMarker, -1)[1].trim();
+                serialNumber = ParseUtil.whitespaces.split(serialNumber, -1)[0];
             } else if (checkLine.startsWith(uuidMarker)) {
-                uuid = checkLine.split(uuidMarker)[1].trim();
-                uuid = ParseUtil.whitespaces.split(uuid)[0];
+                uuid = checkLine.split(uuidMarker, -1)[1].trim();
+                uuid = ParseUtil.whitespaces.split(uuid, -1)[0];
             }
         }
         for (final String checkLine : lsmcode) {
@@ -133,7 +133,7 @@ public final class AixComputerSystem extends AbstractComputerSystem {
              System Firmware level is RG080425_d79e22_regatta
              */
             if (checkLine.startsWith(fwPlatformVersionMarker)) {
-                fwPlatformVersion = checkLine.split(fwPlatformVersionMarker)[1].trim();
+                fwPlatformVersion = checkLine.split(fwPlatformVersionMarker, -1)[1].trim();
                 break;
             }
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -327,23 +327,24 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
         for (String checkLine : lscpu) {
             if (checkLine.contains("L1d cache:")) {
                 caches.add(new ProcessorCache(1, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.DATA));
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()), Type.DATA));
             } else if (checkLine.contains("L1i cache:")) {
                 caches.add(new ProcessorCache(1, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.INSTRUCTION));
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()),
+                        Type.INSTRUCTION));
             } else if (checkLine.contains("L2 cache:")) {
                 caches.add(new ProcessorCache(2, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.UNIFIED));
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()), Type.UNIFIED));
             } else if (checkLine.contains("L3 cache:")) {
                 caches.add(new ProcessorCache(3, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":")[1].trim()), Type.UNIFIED));
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()), Type.UNIFIED));
             }
         }
         return orderedProcCaches(caches);
     }
 
     private List<LogicalProcessor> parseTopology() {
-        String[] topology = sysctlString("kern.sched.topology_spec", "").split("[\\n\\r]");
+        String[] topology = sysctlString("kern.sched.topology_spec", "").split("[\\n\\r]", -1);
         /*-
          * Sample output:
          *
@@ -390,7 +391,7 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
                 if (m.matches()) {
                     // If csv of hex values like "f,0,0,0", parse the first value
                     String csvMatch = m.group(1);
-                    String[] csvTokens = csvMatch.split(",");
+                    String[] csvTokens = csvMatch.split(",", -1);
                     String firstVal = csvTokens[0];
 
                     // Regex guarantees parsing digits so we won't get a
@@ -459,8 +460,8 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
         long max = -1L;
         String freqLevels = sysctlString("dev.cpu.0.freq_levels", "");
         // MHz/Watts pairs like: 2501/32000 2187/27125 2000/24000
-        for (String s : ParseUtil.whitespaces.split(freqLevels)) {
-            long freq = ParseUtil.parseLongOrDefault(s.split("/")[0], -1L);
+        for (String s : ParseUtil.whitespaces.split(freqLevels, -1)) {
+            long freq = ParseUtil.parseLongOrDefault(s.split("/", -1)[0], -1L);
             if (max < freq) {
                 max = freq;
             }
@@ -489,7 +490,7 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
                 marker = "ID:";
                 procInfo = true;
             } else if (procInfo && checkLine.contains(marker)) {
-                String[] parts = checkLine.split(marker);
+                String[] parts = checkLine.split(marker, -1);
                 if (parts.length > 1) {
                     return parts[1].trim();
                 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystem.java
@@ -113,15 +113,15 @@ public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
 
         for (final String checkLine : dmidecode) {
             if (checkLine.contains(manufacturerMarker)) {
-                manufacturer = checkLine.split(manufacturerMarker)[1].trim();
+                manufacturer = checkLine.split(manufacturerMarker, -1)[1].trim();
             } else if (checkLine.contains(productNameMarker)) {
-                model = checkLine.split(productNameMarker)[1].trim();
+                model = checkLine.split(productNameMarker, -1)[1].trim();
             } else if (checkLine.contains(serialNumMarker)) {
-                serialNumber = checkLine.split(serialNumMarker)[1].trim();
+                serialNumber = checkLine.split(serialNumMarker, -1)[1].trim();
             } else if (checkLine.contains(uuidMarker)) {
-                uuid = checkLine.split(uuidMarker)[1].trim();
+                uuid = checkLine.split(uuidMarker, -1)[1].trim();
             } else if (checkLine.contains(versionMarker)) {
-                version = checkLine.split(versionMarker)[1].trim();
+                version = checkLine.split(versionMarker, -1)[1].trim();
             }
         }
         return new Quintet<>(manufacturer, model, serialNumber, uuid, version);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmware.java
@@ -56,11 +56,11 @@ public class FreeBsdFirmware extends BsdFirmware {
 
         for (final String checkLine : dmidecode) {
             if (checkLine.contains(manufacturerMarker)) {
-                manufacturer = checkLine.split(manufacturerMarker)[1].trim();
+                manufacturer = checkLine.split(manufacturerMarker, -1)[1].trim();
             } else if (checkLine.contains(versionMarker)) {
-                version = checkLine.split(versionMarker)[1].trim();
+                version = checkLine.split(versionMarker, -1)[1].trim();
             } else if (checkLine.contains(releaseDateMarker)) {
-                releaseDate = checkLine.split(releaseDateMarker)[1].trim();
+                releaseDate = checkLine.split(releaseDateMarker, -1)[1].trim();
             }
         }
         releaseDate = ParseUtil.parseMmDdYyyyToYyyyMmDD(releaseDate);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdGraphicsCard.java
@@ -63,9 +63,9 @@ public class FreeBsdGraphicsCard extends AbstractGraphicsCard {
                             versionInfo.isEmpty() ? Constants.UNKNOWN : versionInfo, 0L));
                 }
                 // Parse this line
-                String[] split = ParseUtil.whitespaces.split(line);
+                String[] split = ParseUtil.whitespaces.split(line, -1);
                 for (String s : split) {
-                    String[] keyVal = s.split("=");
+                    String[] keyVal = s.split("=", -1);
                     if (keyVal.length > 1) {
                         if (keyVal[0].equals("class") && keyVal[1].length() >= 4) {
                             // class=0x030000

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
@@ -47,7 +47,7 @@ public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
         long now = System.currentTimeMillis();
         boolean diskFound = false;
         for (String line : output) {
-            String[] split = ParseUtil.whitespaces.split(line);
+            String[] split = ParseUtil.whitespaces.split(line, -1);
             if (split.length < 7 || !split[0].equals(getName())) {
                 continue;
             }
@@ -82,12 +82,12 @@ public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
         if (kernDisks.isEmpty()) {
             return diskList;
         }
-        List<String> devices = Arrays.asList(ParseUtil.whitespaces.split(kernDisks));
+        List<String> devices = Arrays.asList(ParseUtil.whitespaces.split(kernDisks, -1));
 
         List<String> iostat = ExecutingCommand.runNative("iostat -Ix");
         long now = System.currentTimeMillis();
         for (String line : iostat) {
-            String[] split = ParseUtil.whitespaces.split(line);
+            String[] split = ParseUtil.whitespaces.split(line, -1);
             if (split.length > 6 && devices.contains(split[0])) {
                 Triplet<String, String, Long> storeInfo = diskInfoMap.get(split[0]);
                 T store = (storeInfo == null) ? factory.create(split[0], Constants.UNKNOWN, Constants.UNKNOWN, 0L)

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdPowerSource.java
@@ -182,7 +182,7 @@ public abstract class FreeBsdPowerSource extends AbstractPowerSource {
         double psTimeRemainingInstant = psTimeRemainingEstimated;
         String time = psMap.get("Remaining time");
         if (time != null) {
-            String[] hhmm = time.split(":");
+            String[] hhmm = time.split(":", -1);
             if (hhmm.length == 2) {
                 psTimeRemainingInstant = 3600d * ParseUtil.parseIntOrDefault(hhmm[0], 0)
                         + 60d * ParseUtil.parseIntOrDefault(hhmm[1], 0);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdPowerSource.java
@@ -183,7 +183,7 @@ public abstract class FreeBsdPowerSource extends AbstractPowerSource {
         String time = psMap.get("Remaining time");
         if (time != null) {
             String[] hhmm = time.split(":", -1);
-            if (hhmm.length == 2) {
+            if (hhmm.length == 2 && !hhmm[1].isEmpty()) {
                 psTimeRemainingInstant = 3600d * ParseUtil.parseIntOrDefault(hhmm[0], 0)
                         + 60d * ParseUtil.parseIntOrDefault(hhmm[1], 0);
             }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdVirtualMemory.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdVirtualMemory.java
@@ -126,7 +126,7 @@ public abstract class FreeBsdVirtualMemory extends AbstractVirtualMemory {
      * @return the bytes used on this swap device
      */
     static long parseSwapUsed(String swapInfoRow) {
-        String[] split = ParseUtil.whitespaces.split(swapInfoRow);
+        String[] split = ParseUtil.whitespaces.split(swapInfoRow, -1);
         if (split.length < 5) {
             return 0L;
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -92,9 +92,9 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
         long interrupts = 0L;
         for (String line : vmstat) {
             if (line.endsWith("CPU context switches")) {
-                contextSwitches = ParseUtil.parseLongOrDefault(line.trim().split("\\s+")[0], 0L);
+                contextSwitches = ParseUtil.parseLongOrDefault(line.trim().split("\\s+", -1)[0], 0L);
             } else if (line.endsWith("device interrupts")) {
-                interrupts = ParseUtil.parseLongOrDefault(line.trim().split("\\s+")[0], 0L);
+                interrupts = ParseUtil.parseLongOrDefault(line.trim().split("\\s+", -1)[0], 0L);
             }
         }
         return new Pair<>(contextSwitches, interrupts);
@@ -110,7 +110,7 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
     static String[] parseFamilyModelStepping(List<String> dmesg) {
         for (String line : dmesg) {
             if (line.startsWith("cpu0:") && line.matches(".*\\d+-[\\da-fA-F]+-[\\da-fA-F]+.*")) {
-                String[] parts = line.split(",");
+                String[] parts = line.split(",", -1);
                 for (String part : parts) {
                     String trimmed = part.trim();
                     if (trimmed.matches("[\\da-fA-F]+-[\\da-fA-F]+-[\\da-fA-F]+")) {
@@ -182,9 +182,9 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
         if (colonIdx < 0) {
             return ticks;
         }
-        String[] pairs = cpTimeStr.substring(colonIdx + 1).split(",");
+        String[] pairs = cpTimeStr.substring(colonIdx + 1).split(",", -1);
         for (String pair : pairs) {
-            String[] kv = pair.trim().split("\\s*=\\s*");
+            String[] kv = pair.trim().split("\\s*=\\s*", -1);
             if (kv.length == 2) {
                 long val = ParseUtil.parseLongOrDefault(kv[1].trim(), 0L);
                 switch (kv[0].trim()) {
@@ -236,7 +236,7 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
         // Parse "vm.loadavg: 1.59 0.47 0.18"
         String loadavg = ExecutingCommand.getFirstAnswer("sysctl -n vm.loadavg");
         if (!loadavg.isEmpty()) {
-            String[] loads = ParseUtil.whitespaces.split(loadavg.trim());
+            String[] loads = ParseUtil.whitespaces.split(loadavg.trim(), -1);
             for (int i = 0; i < nelem && i < loads.length; i++) {
                 average[i] = ParseUtil.parseDoubleOrDefault(loads[i], -1d);
             }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
@@ -49,7 +49,7 @@ public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
 
         // Get list of disks from sysctl
         // NetBSD: hw.disknames = ld0 fd0 dk0 dk1 cd0 (space-separated, no colon suffix)
-        String[] devices = BsdSysctlUtil.sysctl("hw.disknames", "").trim().split("\\s+");
+        String[] devices = BsdSysctlUtil.sysctl("hw.disknames", "").trim().split("\\s+", -1);
         NetBsdHWDiskStore store;
         for (String diskName : devices) {
             // Try disklabel first (works for physical disks, not wedges)
@@ -103,7 +103,7 @@ public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
         long now = System.currentTimeMillis();
         boolean diskFound = false;
         for (String line : iostat.get()) {
-            String[] split = ParseUtil.whitespaces.split(line.trim());
+            String[] split = ParseUtil.whitespaces.split(line.trim(), -1);
             // iostat -x -I output (cumulative totals, 9 fields):
             // device read KB/t xfr time MB write KB/t xfr time MB
             // ld0 27.74 38896 14.03 1356 36.19 0 0.00 0.000

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
@@ -47,7 +47,7 @@ public final class NetBsdNetworkIF extends AbstractNetworkIF {
         // wm0 1500 <Link> 52:54:00:12:34:56 689584214 13656411
         String stats = ExecutingCommand.getAnswerAt("netstat -bI " + getName(), 1);
         this.timeStamp = System.currentTimeMillis();
-        String[] split = ParseUtil.whitespaces.split(stats);
+        String[] split = ParseUtil.whitespaces.split(stats, -1);
         if (split.length < 6) {
             return false;
         }
@@ -57,7 +57,7 @@ public final class NetBsdNetworkIF extends AbstractNetworkIF {
         // Get packet counts from netstat -iI <name> (without -b)
         // Name Mtu Network Address Ipkts Ierrs Opkts Oerrs Coll
         String pktStats = ExecutingCommand.getAnswerAt("netstat -iI " + getName(), 1);
-        String[] pktSplit = ParseUtil.whitespaces.split(pktStats);
+        String[] pktSplit = ParseUtil.whitespaces.split(pktStats, -1);
         if (pktSplit.length >= 9) {
             this.packetsRecv = ParseUtil.parseUnsignedLongOrDefault(pktSplit[4], 0L);
             this.inErrors = ParseUtil.parseUnsignedLongOrDefault(pktSplit[5], 0L);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
@@ -121,9 +121,9 @@ public abstract class OpenBsdCentralProcessor extends BsdCentralProcessor {
         long interrupts = 0L;
         for (String line : vmstat) {
             if (line.endsWith("cpu context switches")) {
-                contextSwitches = ParseUtil.parseLongOrDefault(line.trim().split("\\s+")[0], 0L);
+                contextSwitches = ParseUtil.parseLongOrDefault(line.trim().split("\\s+", -1)[0], 0L);
             } else if (line.endsWith("interrupts")) {
-                interrupts = ParseUtil.parseLongOrDefault(line.trim().split("\\s+")[0], 0L);
+                interrupts = ParseUtil.parseLongOrDefault(line.trim().split("\\s+", -1)[0], 0L);
             }
         }
         return new Pair<>(contextSwitches, interrupts);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
@@ -64,11 +64,11 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
         if (disknames.isEmpty()) {
             return diskList;
         }
-        String[] devices = disknames.split(",");
+        String[] devices = disknames.split(",", -1);
         T store;
         String diskName;
         for (String device : devices) {
-            diskName = device.split(":")[0];
+            diskName = device.split(":", -1)[0];
             if (diskName.isEmpty()) {
                 continue;
             }
@@ -115,7 +115,7 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
         long now = System.currentTimeMillis();
         boolean diskFound = false;
         for (String line : iostat.get()) {
-            String[] split = ParseUtil.whitespaces.split(line);
+            String[] split = ParseUtil.whitespaces.split(line, -1);
             if (split.length >= 6 && split[0].equals(getName())) {
                 diskFound = true;
                 this.readBytes = ParseUtil.parseMultipliedToLongs(split[1]);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessor.java
@@ -140,7 +140,7 @@ public abstract class SolarisCentralProcessor extends AbstractCentralProcessor {
             if (line.startsWith("lgroup")) {
                 lgroup = ParseUtil.getFirstIntValue(line);
             } else if (line.contains("CPUs:") || line.contains("CPU:")) {
-                for (Integer cpu : ParseUtil.parseHyphenatedIntList(line.split(":")[1])) {
+                for (Integer cpu : ParseUtil.parseHyphenatedIntList(line.split(":", -1)[1])) {
                     numaNodeMap.put(cpu, lgroup);
                 }
             }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -74,7 +74,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @return true if the OS version is at least {@code major.minor}
      */
     private static boolean isWindowsVersionOrGreater(int major, int minor) {
-        String[] parts = System.getProperty("os.version", "").split("\\.");
+        String[] parts = System.getProperty("os.version", "").split("\\.", -1);
         if (parts.length >= 2) {
             int osMajor = ParseUtil.parseIntOrDefault(parts[0], 0);
             int osMinor = ParseUtil.parseIntOrDefault(parts[1], 0);
@@ -157,7 +157,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @return the string following id
      */
     protected static String parseIdentifier(String identifier, String key) {
-        String[] idSplit = ParseUtil.whitespaces.split(identifier);
+        String[] idSplit = ParseUtil.whitespaces.split(identifier, -1);
         boolean found = false;
         for (String s : idSplit) {
             if (found) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroup.java
@@ -154,7 +154,7 @@ public class WindowsLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
                 // find matching logical volume
                 for (Entry<String, String> entry : vdMap.entrySet()) {
                     if (entry.getKey().contains(spObjectId)) {
-                        String vdObjectId = ParseUtil.whitespaces.split(entry.getKey())[0];
+                        String vdObjectId = ParseUtil.whitespaces.split(entry.getKey(), -1)[0];
                         logicalVolumeMap.put(entry.getValue() + " " + vdObjectId, physicalVolumeSet);
                     }
                 }

--- a/oshi-common/src/main/java/oshi/software/common/AbstractNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractNetworkParams.java
@@ -87,11 +87,11 @@ public abstract class AbstractNetworkParams implements NetworkParams {
         for (String line : lines) {
             String leftTrimmed = line.replaceFirst("^\\s+", "");
             if (leftTrimmed.startsWith("gateway:")) {
-                String[] split = ParseUtil.whitespaces.split(leftTrimmed);
+                String[] split = ParseUtil.whitespaces.split(leftTrimmed, -1);
                 if (split.length < 2) {
                     return "";
                 }
-                return split[1].split("%")[0];
+                return split[1].split("%", -1)[0];
             }
         }
         return "";

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxCgroupInfo.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxCgroupInfo.java
@@ -214,7 +214,7 @@ public class LinuxCgroupInfo implements CgroupInfo {
     static String resolveV1ControllerPath(List<String> selfCgroup, String controller) {
         for (String line : selfCgroup) {
             // v1 format: "hierarchy-id:controllers:path"
-            String[] parts = line.split(":");
+            String[] parts = line.split(":", -1);
             if (parts.length >= 3) {
                 String controllers = parts[1];
                 if (controllers.isEmpty()) {
@@ -222,7 +222,7 @@ public class LinuxCgroupInfo implements CgroupInfo {
                 }
                 String path = parts[2];
                 // Exact match: split comma-separated controllers
-                for (String c : controllers.split(",")) {
+                for (String c : controllers.split(",", -1)) {
                     if (c.equals(controller)) {
                         if (path.startsWith("/")) {
                             path = path.substring(1);
@@ -256,7 +256,7 @@ public class LinuxCgroupInfo implements CgroupInfo {
         if (cpuMax.isEmpty()) {
             return UNLIMITED;
         }
-        String[] parts = cpuMax.split("\\s+");
+        String[] parts = cpuMax.split("\\s+", -1);
         if (parts.length >= 1) {
             if ("max".equalsIgnoreCase(parts[0])) {
                 return UNLIMITED;
@@ -296,7 +296,7 @@ public class LinuxCgroupInfo implements CgroupInfo {
         if (cpuMax.isEmpty()) {
             return DEFAULT_CPU_PERIOD;
         }
-        String[] parts = cpuMax.split("\\s+");
+        String[] parts = cpuMax.split("\\s+", -1);
         if (parts.length >= 2) {
             return ParseUtil.parseLongOrDefault(parts[1], DEFAULT_CPU_PERIOD);
         }
@@ -322,7 +322,7 @@ public class LinuxCgroupInfo implements CgroupInfo {
         List<String> lines = FileUtil.readFile(basePath + "cpu.stat");
         for (String line : lines) {
             if (line.startsWith("usage_usec")) {
-                String[] parts = line.split("\\s+");
+                String[] parts = line.split("\\s+", -1);
                 if (parts.length >= 2) {
                     long usec = ParseUtil.parseLongOrDefault(parts[1], 0L);
                     return usec * NANOSECONDS_PER_MICROSECOND;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxFileSystem.java
@@ -159,7 +159,7 @@ public abstract class LinuxFileSystem extends AbstractFileSystem {
                 : Collections.emptyMap();
 
         for (String mount : mounts) {
-            String[] split = mount.split(" ");
+            String[] split = mount.split(" ", -1);
             // As reported in fstab(5) manpage, struct is:
             // 1st field is volume name
             // 2nd field is path with spaces escaped as \040
@@ -327,7 +327,7 @@ public abstract class LinuxFileSystem extends AbstractFileSystem {
     private static Map<String, Boolean> probeNfsHosts(List<String> mounts) {
         Set<String> hosts = new HashSet<>();
         for (String mount : mounts) {
-            String[] split = mount.split(" ");
+            String[] split = mount.split(" ", -1);
             if (split.length >= 6 && isNfsType(split[2])) {
                 String host = parseNfsAddr(split[3]);
                 if (host != null) {
@@ -392,7 +392,7 @@ public abstract class LinuxFileSystem extends AbstractFileSystem {
         }
         List<String> osDescriptors = FileUtil.readFile(filename);
         if (!osDescriptors.isEmpty()) {
-            String[] splittedLine = osDescriptors.get(0).split("\\D+");
+            String[] splittedLine = osDescriptors.get(0).split("\\D+", -1);
             return ParseUtil.parseLongOrDefault(splittedLine[index], 0L);
         }
         return 0L;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInternetProtocolStats.java
@@ -102,7 +102,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         // UDP6, udplite6 stats
         for (int line = lines.size() - 1; line >= 0 && foundUDPv6StatsCount < 4; line--) {
             if (lines.get(line).startsWith(UDP6)) {
-                String[] parts = lines.get(line).split("\\s+");
+                String[] parts = lines.get(line).split("\\s+", -1);
                 switch (parts[0]) {
                     case "Udp6InDatagrams":
                         inDatagrams = ParseUtil.parseLongOrDefault(parts[1], 0L);
@@ -144,7 +144,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         List<IPConnection> conns = new ArrayList<>();
         for (String s : FileUtil.readFile(ProcPath.NET + "/" + protocol + (ipver == 6 ? "6" : ""))) {
             if (s.indexOf(':') >= 0) {
-                String[] split = ParseUtil.whitespaces.split(s.trim());
+                String[] split = ParseUtil.whitespaces.split(s.trim(), -1);
                 if (split.length > 9) {
                     Pair<byte[], Integer> lAddr = parseIpAddr(split[1]);
                     Pair<byte[], Integer> fAddr = parseIpAddr(split[2]);

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxNetworkParams.java
@@ -39,7 +39,7 @@ public abstract class LinuxNetworkParams extends AbstractNetworkParams {
         int minMetric = Integer.MAX_VALUE;
 
         for (int i = 2; i < routes.size(); i++) {
-            String[] fields = ParseUtil.whitespaces.split(routes.get(i));
+            String[] fields = ParseUtil.whitespaces.split(routes.get(i), -1);
             if (fields.length > 4 && fields[0].equals(IPV4_DEFAULT_DEST)) {
                 boolean isGateway = fields[3].indexOf('G') != -1;
                 int metric = ParseUtil.parseIntOrDefault(fields[4], Integer.MAX_VALUE);
@@ -63,7 +63,7 @@ public abstract class LinuxNetworkParams extends AbstractNetworkParams {
         int minMetric = Integer.MAX_VALUE;
 
         for (int i = 2; i < routes.size(); i++) {
-            String[] fields = ParseUtil.whitespaces.split(routes.get(i));
+            String[] fields = ParseUtil.whitespaces.split(routes.get(i), -1);
             if (fields.length > 3 && fields[0].equals(IPV6_DEFAULT_DEST)) {
                 boolean isGateway = fields[2].indexOf('G') != -1;
                 int metric = ParseUtil.parseIntOrDefault(fields[3], Integer.MAX_VALUE);

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -289,7 +289,7 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         // Output:
         // pid 3283's current affinity mask: 3
         // pid 9726's current affinity mask: f
-        String[] split = ParseUtil.whitespaces.split(tasksetOutput);
+        String[] split = ParseUtil.whitespaces.split(tasksetOutput.trim(), -1);
         if (split.length == 0) {
             return 0;
         }
@@ -381,7 +381,7 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         this.virtualSize = statArray[ProcPidStat.VSZ.ordinal()];
         // Parse /proc/[pid]/statm for resident and shared pages (all in pages)
         // Fields: size resident shared text lib data dt
-        String[] statmFields = ParseUtil.whitespaces.split(statm);
+        String[] statmFields = ParseUtil.whitespaces.split(statm, -1);
         if (statmFields.length > 2) {
             long resident = ParseUtil.parseLongOrDefault(statmFields[1], 0L);
             long shared = ParseUtil.parseLongOrDefault(statmFields[2], 0L);
@@ -407,9 +407,9 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
 
         // Don't set open files or bitness or currentWorkingDirectory; fetch on demand.
 
-        this.userID = ParseUtil.whitespaces.split(status.getOrDefault("Uid", ""))[0];
+        this.userID = ParseUtil.whitespaces.split(status.getOrDefault("Uid", ""), -1)[0];
         // defer user lookup until asked
-        this.groupID = ParseUtil.whitespaces.split(status.getOrDefault("Gid", ""))[0];
+        this.groupID = ParseUtil.whitespaces.split(status.getOrDefault("Gid", ""), -1)[0];
         // defer group lookup until asked
         this.name = status.getOrDefault("Name", "");
         this.state = ProcessStat.getState(status.getOrDefault("State", "U").charAt(0));

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -102,7 +102,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
         String buildNumber = null;
         List<String> procVersion = FileUtil.readFile(ProcPath.VERSION);
         if (!procVersion.isEmpty()) {
-            String[] split = ParseUtil.whitespaces.split(procVersion.get(0));
+            String[] split = ParseUtil.whitespaces.split(procVersion.get(0), -1);
             for (String s : split) {
                 if (!"Linux".equals(s) && !"version".equals(s)) {
                     buildNumber = s;
@@ -563,7 +563,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
         List<OSService> services = new ArrayList<>();
         boolean systemctlFound = false;
         for (String str : systemctl) {
-            String[] split = ParseUtil.whitespaces.split(str);
+            String[] split = ParseUtil.whitespaces.split(str, -1);
             if (split.length >= 2 && split[0].endsWith(".service") && "enabled".equals(split[1])) {
                 // systemctl produced usable output; the /etc/init fallback is only for systems without systemctl,
                 // so mark it found even if every enabled unit turns out to be already running

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOperatingSystemNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOperatingSystemNF.java
@@ -111,9 +111,9 @@ public class LinuxOperatingSystemNF extends LinuxOperatingSystem {
         // /proc/loadavg format: "load1 load5 load15 running/total lastpid"
         String loadavg = FileUtil.getStringFromFile(ProcPath.LOADAVG);
         if (!loadavg.isEmpty()) {
-            String[] split = loadavg.split("\\s+");
+            String[] split = loadavg.split("\\s+", -1);
             if (split.length >= 4) {
-                String[] runTotal = split[3].split("/");
+                String[] runTotal = split[3].split("/", -1);
                 if (runTotal.length == 2) {
                     return ParseUtil.parseIntOrDefault(runTotal[1], 0);
                 }

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacNetworkParams.java
@@ -37,9 +37,9 @@ public abstract class MacNetworkParams extends AbstractNetworkParams {
         boolean v6Table = false;
         for (String line : lines) {
             if (v6Table && line.startsWith(DEFAULT_GATEWAY)) {
-                String[] fields = ParseUtil.whitespaces.split(line);
+                String[] fields = ParseUtil.whitespaces.split(line, -1);
                 if (fields.length > 2 && fields[2].contains("G")) {
-                    return fields[1].split("%")[0];
+                    return fields[1].split("%", -1)[0];
                 }
             } else if (line.startsWith(IPV6_ROUTE_HEADER)) {
                 v6Table = true;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
@@ -78,7 +78,7 @@ public class AixFileSystem extends AbstractFileSystem {
              */
             // Lines begin with optional node, which we don't use. To force sensible split
             // behavior, append any character at the beginning of the string
-            String[] split = ParseUtil.whitespaces.split("x" + fs);
+            String[] split = ParseUtil.whitespaces.split("x" + fs, -1);
             if (split.length > 7) {
                 // 1st field is volume name [0-index]
                 // 2nd field is mount point
@@ -159,7 +159,7 @@ public class AixFileSystem extends AbstractFileSystem {
              * NFS mounts appear as hostname:/path or ip:/path and are matched by FS_PATTERN
              */
             if (FS_PATTERN.matcher(line).find()) {
-                String[] split = ParseUtil.whitespaces.split(line);
+                String[] split = ParseUtil.whitespaces.split(line.trim(), -1);
                 // Columns: Filesystem, 512-blocks, Ifree (%n), Iused (%l)
                 if (split.length >= 4) {
                     long free = ParseUtil.parseLongOrDefault(split[split.length - 2], 0L);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixNetworkParams.java
@@ -44,7 +44,7 @@ public abstract class AixNetworkParams extends AbstractNetworkParams {
      */
     static String parseDefaultGateway(List<String> netstat) {
         for (String line : netstat) {
-            String[] split = ParseUtil.whitespaces.split(line);
+            String[] split = ParseUtil.whitespaces.split(line, -1);
             if (split.length > 7 && "default".equals(split[0])) {
                 return split[1];
             }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
@@ -157,7 +157,7 @@ public abstract class AixOSProcess extends AbstractProcOSProcess {
             this.privateResidentMemory = this.residentSetSize;
         }
         this.commandLineBackup = ParseUtil.decodeNulTerminated(info.pr_psargs, StandardCharsets.US_ASCII);
-        this.path = ParseUtil.whitespaces.split(commandLineBackup)[0];
+        this.path = ParseUtil.whitespaces.split(commandLineBackup, -1)[0];
         this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
         if (this.name.isEmpty()) {
             this.name = ParseUtil.decodeNulTerminated(info.pr_fname, StandardCharsets.US_ASCII);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOperatingSystem.java
@@ -252,7 +252,7 @@ public abstract class AixOperatingSystem extends AbstractOperatingSystem {
                 header = false;
                 continue;
             }
-            String[] serviceSplit = ParseUtil.whitespaces.split(systemService.trim());
+            String[] serviceSplit = ParseUtil.whitespaces.split(systemService.trim(), -1);
             if (systemService.contains("active")) {
                 if (serviceSplit.length == 4) {
                     services.add(

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
@@ -136,9 +136,9 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
         // Sample output:
         // pid 8 mask: 0, 1
         // cpuset: getaffinity: No such process
-        String[] split = cpuset.split(":");
+        String[] split = cpuset.split(":", -1);
         if (split.length > 1) {
-            String[] bits = split[1].split(",");
+            String[] bits = split[1].split(",", -1);
             for (String bit : bits) {
                 int bitToSet = ParseUtil.parseIntOrDefault(bit.trim(), -1);
                 if (bitToSet >= 0 && bitToSet < Long.SIZE) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOperatingSystem.java
@@ -156,7 +156,7 @@ public abstract class BsdOperatingSystem extends AbstractOperatingSystem {
      */
     protected static Pair<String, OSVersionInfo> buildFamilyVersionInfo(String family, String version,
             String versionInfo) {
-        String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
+        String buildNumber = versionInfo.split(":", -1)[0].replace(family, "").replace(version, "").trim();
         return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
     }
 
@@ -169,7 +169,7 @@ public abstract class BsdOperatingSystem extends AbstractOperatingSystem {
     protected static long queryBootTimeFromCommand() {
         // Boot time will be the first consecutive string of digits.
         return ParseUtil.parseLongOrDefault(
-                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
+                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",", -1)[0].replaceAll("\\D", ""),
                 System.currentTimeMillis() / 1000);
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/dragonflybsd/DragonFlyBsdOSProcess.java
@@ -95,9 +95,9 @@ public abstract class DragonFlyBsdOSProcess extends BsdOSProcess {
         List<String> status = FileUtil.readFile("/proc/" + pid + "/status", false);
         if (!status.isEmpty()) {
             // Format: name pid ... startSec,startUsec ...
-            String[] split = ParseUtil.whitespaces.split(status.get(0).trim());
+            String[] split = ParseUtil.whitespaces.split(status.get(0).trim(), -1);
             if (split.length >= 8) {
-                String[] timeParts = split[7].split(",");
+                String[] timeParts = split[7].split(",", -1);
                 long seconds = ParseUtil.parseLongOrDefault(timeParts[0], 0L);
                 if (seconds > 0) {
                     return seconds * 1000L;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystem.java
@@ -53,7 +53,7 @@ public abstract class FreeBsdFileSystem extends AbstractFileSystem {
 
         // Get mount table
         for (String fs : ExecutingCommand.runNative("mount -p")) {
-            String[] split = ParseUtil.whitespaces.split(fs);
+            String[] split = ParseUtil.whitespaces.split(fs, -1);
             if (split.length < 5) {
                 continue;
             }
@@ -162,7 +162,7 @@ public abstract class FreeBsdFileSystem extends AbstractFileSystem {
             /dev/twed0s1a   2026030 584112 1279836    31%    2751 279871    1%   /
             */
             if (!line.startsWith("Filesystem")) {
-                String[] split = ParseUtil.whitespaces.split(line);
+                String[] split = ParseUtil.whitespaces.split(line, -1);
                 if (split.length > 8) {
                     long ifree = ParseUtil.parseLongOrDefault(split[6], 0L);
                     long iused = ParseUtil.parseLongOrDefault(split[5], 0L);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
@@ -139,7 +139,7 @@ public class NetBsdFileSystem extends AbstractFileSystem {
             /dev/wd0d      6082908   3343172   2435592    58%   27813  386905     7%   /usr
             */
             if (!line.startsWith("Filesystem")) {
-                String[] split = ParseUtil.whitespaces.split(line);
+                String[] split = ParseUtil.whitespaces.split(line, -1);
                 if (split.length > 6) {
                     inodeUsedMap.put(split[0], ParseUtil.parseLongOrDefault(split[5], 0L));
                     inodeFreeMap.put(split[0], ParseUtil.parseLongOrDefault(split[6], 0L));

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -150,7 +150,7 @@ public class NetBsdOSProcess extends BsdOSProcess {
         for (String line : schedctl) {
             // Output includes "Affinity: <list>" when bound
             if (line.contains("Affinity:")) {
-                String[] parts = line.split("Affinity:")[1].trim().split("[,\\s]+");
+                String[] parts = line.split("Affinity:", -1)[1].trim().split("[,\\s]+", -1);
                 for (String part : parts) {
                     int bitToSet = ParseUtil.parseIntOrDefault(part.trim(), -1);
                     if (bitToSet >= 0) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOperatingSystem.java
@@ -38,7 +38,7 @@ public class NetBsdOperatingSystem extends BsdOperatingSystem {
         String family = BsdSysctlUtil.sysctl("kern.ostype", "NetBSD");
         String version = BsdSysctlUtil.sysctl("kern.osrelease", "");
         String versionInfo = BsdSysctlUtil.sysctl("kern.version", "");
-        String buildNumber = versionInfo.split(":")[0].replace(family, "").replace(version, "").trim();
+        String buildNumber = versionInfo.split(":", -1)[0].replace(family, "").replace(version, "").trim();
 
         return new Pair<>(family, new OSVersionInfo(version, null, buildNumber));
     }
@@ -103,7 +103,7 @@ public class NetBsdOperatingSystem extends BsdOperatingSystem {
     public int getProcessId() {
         // RuntimeMXBean name format is "pid@hostname"
         String name = ManagementFactory.getRuntimeMXBean().getName();
-        return ParseUtil.parseIntOrDefault(name.split("@")[0], -1);
+        return ParseUtil.parseIntOrDefault(name.split("@", -1)[0], -1);
     }
 
     @Override
@@ -125,7 +125,7 @@ public class NetBsdOperatingSystem extends BsdOperatingSystem {
     protected long queryBootTime() {
         // Boot time will be the first consecutive string of digits.
         return ParseUtil.parseLongOrDefault(
-                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
+                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",", -1)[0].replaceAll("\\D", ""),
                 System.currentTimeMillis() / 1000);
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
@@ -69,7 +69,7 @@ public abstract class OpenBsdFileSystem extends AbstractFileSystem {
         Map<String, Long> inodeUsedMap = new HashMap<>();
         for (String line : dfOutput) {
             if (!line.startsWith("Filesystem")) {
-                String[] split = ParseUtil.whitespaces.split(line);
+                String[] split = ParseUtil.whitespaces.split(line, -1);
                 if (split.length > 6) {
                     inodeUsedMap.put(split[0], ParseUtil.parseLongOrDefault(split[5], 0L));
                     inodeFreeMap.put(split[0], ParseUtil.parseLongOrDefault(split[6], 0L));

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdOperatingSystem.java
@@ -109,7 +109,7 @@ public abstract class OpenBsdOperatingSystem extends BsdOperatingSystem {
     protected long queryBootTime() {
         // Boot time will be the first consecutive string of digits.
         return ParseUtil.parseLongOrDefault(
-                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
+                ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",", -1)[0].replaceAll("\\D", ""),
                 System.currentTimeMillis() / 1000);
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisFileSystem.java
@@ -62,7 +62,7 @@ public abstract class SolarisFileSystem extends AbstractFileSystem {
 
         // Get mount table
         for (String fs : ExecutingCommand.runNative("cat /etc/mnttab")) { // NOSONAR java:S135
-            String[] split = ParseUtil.whitespaces.split(fs);
+            String[] split = ParseUtil.whitespaces.split(fs, -1);
             if (split.length < 5) {
                 continue;
             }
@@ -136,7 +136,7 @@ public abstract class SolarisFileSystem extends AbstractFileSystem {
                  ufs fstype       0x00000004 flag             255 filename length
             */
             if (line.startsWith("/")) {
-                key = ParseUtil.whitespaces.split(line)[0];
+                key = ParseUtil.whitespaces.split(line, -1)[0];
                 total = null;
             } else if (line.contains("available") && line.contains("total files")) {
                 total = ParseUtil.getTextBetweenStrings(line, "available", "total files").trim();

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
@@ -116,7 +116,7 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
             return 0L;
         } else if (cpuset.endsWith(".") && cpuset.contains("strongly bound to processor(s)")) {
             String parse = cpuset.substring(0, cpuset.length() - 1);
-            String[] split = ParseUtil.whitespaces.split(parse);
+            String[] split = ParseUtil.whitespaces.split(parse.trim(), -1);
             for (int i = split.length - 1; i >= 0; i--) {
                 int bitToSet = ParseUtil.parseIntOrDefault(split[i], -1);
                 if (bitToSet >= 0) {
@@ -139,7 +139,7 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
     static long parsePsrinfo(List<String> psrinfo) {
         long bitMask = 0L;
         for (String proc : psrinfo) {
-            String[] split = ParseUtil.whitespaces.split(proc);
+            String[] split = ParseUtil.whitespaces.split(proc, -1);
             int bitToSet = ParseUtil.parseIntOrDefault(split[0], -1);
             if (bitToSet >= 0) {
                 bitMask |= 1L << bitToSet;
@@ -177,7 +177,7 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
         this.userTime = info.pr_time.toMillis();
         // 80 character truncation but enough for path and name (usually)
         this.commandLineBackup = PsInfo.bytesToString(info.pr_psargs);
-        String[] parts = ParseUtil.whitespaces.split(commandLineBackup);
+        String[] parts = ParseUtil.whitespaces.split(commandLineBackup, -1);
         this.path = parts.length > 0 ? parts[0] : "";
         this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
         if (usage != null) {
@@ -253,7 +253,7 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
         }
         // Split all non-Digits away -> ["", "{soft-limit}, "{hard-limit}"]
         // A non-numeric limit (e.g. "nofiles(descriptors) 256 unlimited") yields fewer tokens
-        final String[] split = nofilesLine.get().split("\\D+");
+        final String[] split = nofilesLine.get().split("\\D+", -1);
         if (split.length <= index) {
             return -1;
         }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
@@ -251,8 +251,10 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
         if (!nofilesLine.isPresent()) {
             return -1;
         }
-        // Split all non-Digits away -> ["", "{soft-limit}, "{hard-limit}"]
-        // A non-numeric limit (e.g. "nofiles(descriptors) 256 unlimited") yields fewer tokens
+        // Split all non-digits away -> ["", "{soft-limit}", "{hard-limit}"]. -1 preserves the trailing empty
+        // token that a non-numeric limit produces (e.g. "nofiles(descriptors) 256 unlimited" -> ["", "256", ""],
+        // since "unlimited" is itself consumed as trailing non-digit delimiter text); parseLongOrDefault below
+        // then falls back to -1 for that position instead of throwing.
         final String[] split = nofilesLine.get().split("\\D+", -1);
         if (split.length <= index) {
             return -1;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystem.java
@@ -188,7 +188,7 @@ public abstract class SolarisOperatingSystem extends AbstractOperatingSystem {
                     services.add(new OSService(name, 0, STOPPED));
                 }
             } else if (line.startsWith(" ")) {
-                String[] split = ParseUtil.whitespaces.split(line.trim());
+                String[] split = ParseUtil.whitespaces.split(line.trim(), -1);
                 if (split.length == 3) {
                     services.add(new OSService(split[2], ParseUtil.parseIntOrDefault(split[1], 0), RUNNING));
                 }

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsNetworkParams.java
@@ -36,7 +36,7 @@ public abstract class WindowsNetworkParams extends AbstractNetworkParams {
     private static String parseIpv4Route() {
         List<String> lines = ExecutingCommand.runNative("route print -4 0.0.0.0");
         for (String line : lines) {
-            String[] fields = ParseUtil.whitespaces.split(line.trim());
+            String[] fields = ParseUtil.whitespaces.split(line.trim(), -1);
             if (fields.length > 2 && "0.0.0.0".equals(fields[0])) {
                 return fields[2];
             }
@@ -47,7 +47,7 @@ public abstract class WindowsNetworkParams extends AbstractNetworkParams {
     private static String parseIpv6Route() {
         List<String> lines = ExecutingCommand.runNative("route print -6 ::/0");
         for (String line : lines) {
-            String[] fields = ParseUtil.whitespaces.split(line.trim());
+            String[] fields = ParseUtil.whitespaces.split(line.trim(), -1);
             if (fields.length > 3 && "::/0".equals(fields[2])) {
                 return fields[3];
             }

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSThread.java
@@ -43,7 +43,7 @@ public abstract class WindowsOSThread extends AbstractOSThread {
      * @return the process name (portion before "/" in the thread name)
      */
     protected String getProcName() {
-        return this.name == null ? "" : this.name.split("/")[0];
+        return this.name == null ? "" : this.name.split("/", -1)[0];
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -248,7 +248,7 @@ public final class EdidUtil {
         for (byte[] b : getDescriptors(edid)) {
             if (getDescriptorType(b) == MONITOR_NAME_TYPE) {
                 // The model name is the final whitespace-delimited token of the monitor-name descriptor
-                String[] tokens = getDescriptorText(b).split("\\s+");
+                String[] tokens = getDescriptorText(b).split("\\s+", -1);
                 return tokens[tokens.length - 1].trim();
             }
         }
@@ -426,7 +426,7 @@ public final class EdidUtil {
      * @param version The version as a {@code major.minor} string (e.g. {@code "1.4"})
      */
     public static void setVersion(byte[] edid, String version) {
-        String[] parts = version.split("\\.");
+        String[] parts = version.split("\\.", -1);
         edid[VERSION_OFFSET] = (byte) ParseUtil.parseIntOrDefault(parts[0], 1);
         edid[VERSION_OFFSET + 1] = (byte) (parts.length > 1 ? ParseUtil.parseIntOrDefault(parts[1], 0) : 0);
     }

--- a/oshi-common/src/main/java/oshi/util/FileSystemUtil.java
+++ b/oshi-common/src/main/java/oshi/util/FileSystemUtil.java
@@ -71,7 +71,7 @@ public final class FileSystemUtil {
     public static List<PathMatcher> parseFileSystemConfig(String config) {
         FileSystem fs = FileSystems.getDefault(); // can't be closed
         List<PathMatcher> patterns = new ArrayList<>();
-        for (String item : config.split(",")) {
+        for (String item : config.split(",", -1)) {
             if (!item.isEmpty()) {
                 // Using glob: prefix as the defult unless user has specified glob or regex. See
                 // https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -290,7 +290,7 @@ public final class ParseUtil {
      * @return last space-delimited element
      */
     public static String parseLastString(String s) {
-        String[] ss = whitespaces.split(s);
+        String[] ss = whitespaces.split(s.trim(), -1);
         // guaranteed at least one element
         return ss[ss.length - 1];
     }
@@ -699,7 +699,7 @@ public final class ParseUtil {
      */
     public static int getNthIntValue(String line, int n) {
         // Split the string by non-digits,
-        String[] split = notDigits.split(startWithNotDigits.matcher(line).replaceFirst(""));
+        String[] split = notDigits.split(startWithNotDigits.matcher(line).replaceFirst(""), -1);
         if (split.length >= n) {
             return parseIntOrDefault(split[n - 1], 0);
         }
@@ -1113,12 +1113,12 @@ public final class ParseUtil {
     public static long parseLshwResourceString(String resources) {
         long bytes = 0L;
         // First split by whitespace
-        String[] resourceArray = whitespaces.split(resources);
+        String[] resourceArray = whitespaces.split(resources, -1);
         for (String r : resourceArray) {
             // Remove prefix
             if (r.startsWith("memory:")) {
                 // Split to low and high
-                String[] mem = r.substring(7).split("-");
+                String[] mem = r.substring(7).split("-", -1);
                 if (mem.length == 2) {
                     try {
                         // Parse the hex strings
@@ -1170,10 +1170,10 @@ public final class ParseUtil {
      */
     public static List<Integer> parseHyphenatedIntList(String str) {
         List<Integer> result = new ArrayList<>();
-        String[] csvTokens = str.split(",");
+        String[] csvTokens = str.split(",", -1);
         for (String csvToken : csvTokens) {
             csvToken = csvToken.trim();
-            for (String s : whitespaces.split(csvToken)) {
+            for (String s : whitespaces.split(csvToken, -1)) {
                 if (s.contains("-")) {
                     int first = getFirstIntValue(s);
                     int last = getNthIntValue(s, 2);

--- a/oshi-common/src/main/java/oshi/util/PrivilegedUtil.java
+++ b/oshi-common/src/main/java/oshi/util/PrivilegedUtil.java
@@ -81,7 +81,7 @@ public final class PrivilegedUtil {
         }
 
         // Extract the command name (first token)
-        String[] tokens = command.trim().split("\\s+");
+        String[] tokens = command.trim().split("\\s+", -1);
         if (tokens.length == 0) {
             return false;
         }

--- a/oshi-common/src/main/java/oshi/util/ProcUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ProcUtil.java
@@ -129,7 +129,7 @@ public final class ProcUtil {
         Map<String, Long> result = new HashMap<>();
         List<String> lines = FileUtil.readFile(procFile);
         for (String line : lines) {
-            String[] parts = separator.split(line, -1);
+            String[] parts = separator.split(line.trim(), -1);
 
             // This would happen if the line starts with the given separator (whitespace?)
             if (parts[0].isEmpty()) {

--- a/oshi-common/src/main/java/oshi/util/ProcUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ProcUtil.java
@@ -126,8 +126,19 @@ public final class ProcUtil {
      * @return a map of statistics and associated values
      */
     public static Map<String, Long> parseStatistics(String procFile, Pattern separator) {
+        return parseStatistics(FileUtil.readFile(procFile), separator);
+    }
+
+    /**
+     * Parses lines formatted as "statistic (long)value" to produce a simple mapping. Package-private for testing.
+     *
+     * @param lines     the lines to process
+     * @param separator a regex specifying the separator between statistic and value
+     * @return a map of statistics and associated values
+     * @see #parseStatistics(String, Pattern)
+     */
+    static Map<String, Long> parseStatistics(List<String> lines, Pattern separator) {
         Map<String, Long> result = new HashMap<>();
-        List<String> lines = FileUtil.readFile(procFile);
         for (String line : lines) {
             String[] parts = separator.split(line.trim(), -1);
 

--- a/oshi-common/src/main/java/oshi/util/ProcUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ProcUtil.java
@@ -129,7 +129,7 @@ public final class ProcUtil {
         Map<String, Long> result = new HashMap<>();
         List<String> lines = FileUtil.readFile(procFile);
         for (String line : lines) {
-            String[] parts = separator.split(line);
+            String[] parts = separator.split(line, -1);
 
             // This would happen if the line starts with the given separator (whitespace?)
             if (parts[0].isEmpty()) {

--- a/oshi-common/src/main/java/oshi/util/UserGroupInfo.java
+++ b/oshi-common/src/main/java/oshi/util/UserGroupInfo.java
@@ -83,7 +83,7 @@ public final class UserGroupInfo {
         Map<String, String> userMap = new ConcurrentHashMap<>();
         // see man 5 passwd for the fields
         for (String entry : passwd) {
-            String[] split = entry.split(":");
+            String[] split = entry.split(":", -1);
             if (split.length > 2) {
                 String userName = split[0];
                 String uid = split[2];
@@ -113,7 +113,7 @@ public final class UserGroupInfo {
         Map<String, String> groupMap = new ConcurrentHashMap<>();
         // see man 5 group for the fields
         for (String entry : group) {
-            String[] split = entry.split(":");
+            String[] split = entry.split(":", -1);
             if (split.length > 2) {
                 String groupName = split[0];
                 String gid = split[2];

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
@@ -291,7 +291,7 @@ public final class SmcKeyIndex {
             return Collections.emptyList();
         }
         List<String> keys = new ArrayList<>();
-        for (String token : csv.split(",")) {
+        for (String token : csv.split(",", -1)) {
             String key = token.trim();
             if (key.length() == KEY_LENGTH) {
                 keys.add(key);

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtil.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtil.java
@@ -53,7 +53,7 @@ public final class ProcstatUtil {
      */
     public static String parseCwdFromFstat(List<String> fstatLines) {
         for (String line : fstatLines) {
-            String[] split = ParseUtil.whitespaces.split(line.trim());
+            String[] split = ParseUtil.whitespaces.split(line.trim(), -1);
             if (split.length >= 8 && "wd".equals(split[4])) {
                 return split[split.length - 1];
             }
@@ -91,7 +91,7 @@ public final class ProcstatUtil {
     public static long parseOpenFiles(List<String> fstatLines) {
         long fd = 0L;
         for (String line : fstatLines) {
-            String[] split = ParseUtil.whitespaces.split(line.trim());
+            String[] split = ParseUtil.whitespaces.split(line.trim(), -1);
             if (split.length >= 8 && !"wd".equals(split[4]) && !"root".equals(split[4]) && !"text".equals(split[4])) {
                 fd++;
             }

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/FstatUtil.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/FstatUtil.java
@@ -41,7 +41,7 @@ public final class FstatUtil {
      */
     public static String parseCwdFromFstat(List<String> fstatLines) {
         for (String line : fstatLines) {
-            String[] split = line.trim().split("\\s+");
+            String[] split = line.trim().split("\\s+", -1);
             if (split.length > 4 && "wd".equals(split[3])) {
                 return split[4];
             }

--- a/oshi-common/src/main/java/oshi/util/driver/linux/Dmidecode.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Dmidecode.java
@@ -77,7 +77,7 @@ public final class Dmidecode {
         String marker = "Serial Number:";
         for (String checkLine : lines) {
             if (checkLine.contains(marker)) {
-                return checkLine.split(marker)[1].trim();
+                return checkLine.split(marker, -1)[1].trim();
             }
         }
         return null;
@@ -102,7 +102,7 @@ public final class Dmidecode {
         String marker = "UUID:";
         for (String checkLine : lines) {
             if (checkLine.contains(marker)) {
-                return checkLine.split(marker)[1].trim();
+                return checkLine.split(marker, -1)[1].trim();
             }
         }
         return null;
@@ -132,7 +132,7 @@ public final class Dmidecode {
 
         for (final String checkLine : lines) {
             if (checkLine.contains(biosMarker)) {
-                String[] biosArr = ParseUtil.whitespaces.split(checkLine);
+                String[] biosArr = ParseUtil.whitespaces.split(checkLine, -1);
                 if (biosArr.length >= 2) {
                     biosName = biosArr[0] + " " + biosArr[1];
                 }

--- a/oshi-common/src/main/java/oshi/util/driver/linux/Lshw.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Lshw.java
@@ -47,11 +47,11 @@ public final class Lshw {
 
         for (String checkLine : lines) {
             if (checkLine.contains(modelMarker)) {
-                model = checkLine.split(modelMarker)[1].trim();
+                model = checkLine.split(modelMarker, -1)[1].trim();
             } else if (checkLine.contains(serialMarker)) {
-                serial = checkLine.split(serialMarker)[1].trim();
+                serial = checkLine.split(serialMarker, -1)[1].trim();
             } else if (checkLine.contains(uuidMarker)) {
-                uuid = checkLine.split(uuidMarker)[1].trim();
+                uuid = checkLine.split(uuidMarker, -1)[1].trim();
             }
         }
         return new Triplet<>(model, serial, uuid);
@@ -103,7 +103,7 @@ public final class Lshw {
         String capacityMarker = "capacity:";
         for (String checkLine : lines) {
             if (checkLine.contains(capacityMarker)) {
-                return ParseUtil.parseHertz(checkLine.split(capacityMarker)[1].trim());
+                return ParseUtil.parseHertz(checkLine.split(capacityMarker, -1)[1].trim());
             }
         }
         return -1L;

--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/CpuInfo.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/CpuInfo.java
@@ -98,7 +98,7 @@ public final class CpuInfo {
         String pcSerialNumber = null;
 
         for (String line : cpuInfo) {
-            String[] splitLine = ParseUtil.whitespacesColonWhitespace.split(line);
+            String[] splitLine = ParseUtil.whitespacesColonWhitespace.split(line, -1);
             if (splitLine.length < 2) {
                 continue;
             }

--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/CpuStat.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/CpuStat.java
@@ -48,7 +48,7 @@ public final class CpuStat {
 
         // Split the line. Note the first (0) element is "cpu" so remaining
         // elements are offset by 1 from the enum index
-        String[] tickArr = ParseUtil.whitespaces.split(tickStr);
+        String[] tickArr = ParseUtil.whitespaces.split(tickStr, -1);
         if (tickArr.length <= TickType.IDLE.getIndex()) {
             // If ticks don't at least go user/nice/system/idle, abort
             return ticks;
@@ -92,7 +92,7 @@ public final class CpuStat {
                 // Split the line. Note the first (0) element is "cpu" so
                 // remaining
                 // elements are offset by 1 from the enum index
-                String[] tickArr = ParseUtil.whitespaces.split(stat);
+                String[] tickArr = ParseUtil.whitespaces.split(stat, -1);
                 if (tickArr.length <= TickType.IDLE.getIndex()) {
                     // If ticks don't at least go user/nice/system/idle, abort
                     return ticks;
@@ -130,7 +130,7 @@ public final class CpuStat {
     static long parseContextSwitches(List<String> procStat) {
         for (String stat : procStat) {
             if (stat.startsWith("ctxt ")) {
-                String[] ctxtArr = ParseUtil.whitespaces.split(stat);
+                String[] ctxtArr = ParseUtil.whitespaces.split(stat, -1);
                 if (ctxtArr.length == 2) {
                     return ParseUtil.parseLongOrDefault(ctxtArr[1], 0);
                 }
@@ -157,7 +157,7 @@ public final class CpuStat {
     static long parseInterrupts(List<String> procStat) {
         for (String stat : procStat) {
             if (stat.startsWith("intr ")) {
-                String[] intrArr = ParseUtil.whitespaces.split(stat);
+                String[] intrArr = ParseUtil.whitespaces.split(stat, -1);
                 if (intrArr.length > 2) {
                     return ParseUtil.parseLongOrDefault(intrArr[1], 0);
                 }
@@ -185,7 +185,7 @@ public final class CpuStat {
         // Boot time given by btime variable in /proc/stat.
         for (String stat : procStat) {
             if (stat.startsWith("btime")) {
-                String[] bTime = ParseUtil.whitespaces.split(stat);
+                String[] bTime = ParseUtil.whitespaces.split(stat, -1);
                 if (bTime.length >= 2) {
                     return ParseUtil.parseLongOrDefault(bTime[1], 0L);
                 }

--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/CpuStat.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/CpuStat.java
@@ -49,13 +49,15 @@ public final class CpuStat {
         // Split the line. Note the first (0) element is "cpu" so remaining
         // elements are offset by 1 from the enum index
         String[] tickArr = ParseUtil.whitespaces.split(tickStr, -1);
-        if (tickArr.length <= TickType.IDLE.getIndex()) {
+        // -1 preserves a trailing empty token from trailing whitespace; discount it so it can't count as a field.
+        int tickLen = tickArr.length > 0 && tickArr[tickArr.length - 1].isEmpty() ? tickArr.length - 1 : tickArr.length;
+        if (tickLen <= TickType.IDLE.getIndex()) {
             // If ticks don't at least go user/nice/system/idle, abort
             return ticks;
         }
         // Note tickArr is offset by 1 because first element is "cpu". Stop if a truncated line runs out of
         // fields, leaving the zero defaults for any missing values.
-        for (int i = 0; i < TickType.values().length && i + 1 < tickArr.length; i++) {
+        for (int i = 0; i < TickType.values().length && i + 1 < tickLen; i++) {
             ticks[i] = ParseUtil.parseLongOrDefault(tickArr[i + 1], 0L);
         }
         // Ignore guest or guest_nice, they are included in user/nice
@@ -93,13 +95,17 @@ public final class CpuStat {
                 // remaining
                 // elements are offset by 1 from the enum index
                 String[] tickArr = ParseUtil.whitespaces.split(stat, -1);
-                if (tickArr.length <= TickType.IDLE.getIndex()) {
+                // -1 preserves a trailing empty token from trailing whitespace; discount it so it can't count as
+                // a field.
+                int tickLen = tickArr.length > 0 && tickArr[tickArr.length - 1].isEmpty() ? tickArr.length - 1
+                        : tickArr.length;
+                if (tickLen <= TickType.IDLE.getIndex()) {
                     // If ticks don't at least go user/nice/system/idle, abort
                     return ticks;
                 }
                 // Note tickArr is offset by 1. Stop if a truncated line runs out of fields, leaving the zero
                 // defaults for any missing values.
-                for (int i = 0; i < TickType.values().length && i + 1 < tickArr.length; i++) {
+                for (int i = 0; i < TickType.values().length && i + 1 < tickLen; i++) {
                     ticks[cpu][i] = ParseUtil.parseLongOrDefault(tickArr[i + 1], 0L);
                 }
                 // Ignore guest or guest_nice, they are included in
@@ -131,7 +137,8 @@ public final class CpuStat {
         for (String stat : procStat) {
             if (stat.startsWith("ctxt ")) {
                 String[] ctxtArr = ParseUtil.whitespaces.split(stat, -1);
-                if (ctxtArr.length == 2) {
+                // >= rather than == so a trailing empty token from trailing whitespace doesn't drop a valid line.
+                if (ctxtArr.length >= 2) {
                     return ParseUtil.parseLongOrDefault(ctxtArr[1], 0);
                 }
             }

--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/DiskStats.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/DiskStats.java
@@ -132,7 +132,7 @@ public final class DiskStats {
         Map<String, Map<IoStat, Long>> diskStatMap = new HashMap<>();
         IoStat[] enumArray = IoStat.class.getEnumConstants();
         for (String stat : diskStats) {
-            String[] split = ParseUtil.whitespaces.split(stat.trim());
+            String[] split = ParseUtil.whitespaces.split(stat.trim(), -1);
             Map<IoStat, Long> statMap = new EnumMap<>(IoStat.class);
             String name = null;
             for (int i = 0; i < enumArray.length && i < split.length; i++) {

--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/ProcessStat.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/ProcessStat.java
@@ -376,7 +376,7 @@ public final class ProcessStat {
         String name = stat.substring(nameStart, nameEnd);
         Character state = stat.charAt(nameEnd + 2);
         // Split everything after the state
-        String[] split = ParseUtil.whitespaces.split(stat.substring(nameEnd + 4).trim());
+        String[] split = ParseUtil.whitespaces.split(stat.substring(nameEnd + 4).trim(), -1);
 
         Map<PidStat, Long> statMap = new EnumMap<>(PidStat.class);
         PidStat[] enumArray = PidStat.class.getEnumConstants();
@@ -401,7 +401,7 @@ public final class ProcessStat {
             return null;
         }
         // Split the fields
-        String[] split = ParseUtil.whitespaces.split(statm);
+        String[] split = ParseUtil.whitespaces.split(statm, -1);
 
         Map<PidStatM, Long> statmMap = new EnumMap<>(PidStatM.class);
         PidStatM[] enumArray = PidStatM.class.getEnumConstants();

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Lpstat.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Lpstat.java
@@ -103,7 +103,7 @@ public final class Lpstat {
         String currentPrinter = null;
         for (String line : lines) {
             if (line.startsWith("printer ")) {
-                String[] parts = line.split("\\s+");
+                String[] parts = line.split("\\s+", -1);
                 if (parts.length >= 2) {
                     currentPrinter = parts[1];
                 }

--- a/oshi-common/src/main/java/oshi/util/driver/unix/ProcLimits.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/ProcLimits.java
@@ -58,7 +58,7 @@ public final class ProcLimits {
             return -1;
         }
         // Split all non-digits away -> ["", "{soft-limit}", "{hard-limit}", ""]
-        final String[] split = maxOpenFilesLine.get().split("\\D+");
+        final String[] split = maxOpenFilesLine.get().split("\\D+", -1);
         // Element 0 is the empty string left of the label, so a usable index is 1 or 2
         if (index < 1 || split.length <= index) {
             return -1;

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Xwininfo.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Xwininfo.java
@@ -78,7 +78,7 @@ public final class Xwininfo {
             String stack = stacking.get(0);
             int bottom = stack.indexOf("0x");
             if (bottom >= 0) {
-                for (String id : stack.substring(bottom).split(", ")) {
+                for (String id : stack.substring(bottom).split(", ", -1)) {
                     zOrderMap.put(id, ++z);
                 }
             }

--- a/oshi-common/src/test/java/oshi/driver/common/unix/bsd/disk/DisklabelTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/bsd/disk/DisklabelTest.java
@@ -165,7 +165,7 @@ class DisklabelTest {
         String[] devices = disknames.isEmpty() ? new String[0] : disknames.split(",");
         boolean elevated = "0".equals(ExecutingCommand.getFirstAnswer("id -u"));
         for (String device : devices) {
-            String diskName = device.split(":")[0];
+            String diskName = device.split(":", -1)[0];
             Quartet<String, String, Long, List<HWPartition>> diskdata = Disklabel.getDiskParams(diskName);
             if (elevated) {
                 assertThat("Disk label is not null", diskdata.getA(), is(not(nullValue())));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxFirmwareTest.java
@@ -76,4 +76,13 @@ class LinuxFirmwareTest {
         assertThat(result.getManufacturer(), is("Broadcom"));
         assertThat(result.getVersion(), is("abc123"));
     }
+
+    @Test
+    void testQueryVcGenCmdParsesManufacturerWithTrailingWhitespace() {
+        // A trailing space on the copyright line must not be mistaken for an empty final token
+        List<String> trailingWhitespace = Arrays.asList("Jan 13 2013 16:24:29", "Copyright (c) 2012 Broadcom ",
+                "version abc123");
+        VcGenCmdStrings result = LinuxFirmware.queryVcGenCmd(trailingWhitespace);
+        assertThat(result.getManufacturer(), is("Broadcom"));
+    }
 }

--- a/oshi-common/src/test/java/oshi/util/ProcUtilsTest.java
+++ b/oshi-common/src/test/java/oshi/util/ProcUtilsTest.java
@@ -10,11 +10,16 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 
 @EnabledOnOs(OS.LINUX)
 class ProcUtilsTest {
@@ -67,6 +72,17 @@ class ProcUtilsTest {
         assertThat(results.get("Ip6OutMcastOctets"), is(45957L));
         assertThat(results.get("UdpLite6MemErrors"), is(1L));
         assertThat(results.get("IndentedEntry"), is(37L));
+    }
+
+    @Test
+    void testParseStatisticsWithTrailingWhitespace(@TempDir Path tempDir) throws IOException {
+        // A trailing space on the line must not prevent it from producing exactly two fields
+        Path procFile = tempDir.resolve("trailing-whitespace-stat");
+        Files.write(procFile, "SomeStatistic             12345 \n".getBytes(StandardCharsets.UTF_8));
+
+        Map<String, Long> results = ProcUtil.parseStatistics(procFile.toString());
+
+        assertThat(results.get("SomeStatistic"), is(12345L));
     }
 
 }

--- a/oshi-common/src/test/java/oshi/util/ProcUtilsTest.java
+++ b/oshi-common/src/test/java/oshi/util/ProcUtilsTest.java
@@ -10,16 +10,12 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-import org.junit.jupiter.api.io.TempDir;
 
 @EnabledOnOs(OS.LINUX)
 class ProcUtilsTest {
@@ -75,12 +71,10 @@ class ProcUtilsTest {
     }
 
     @Test
-    void testParseStatisticsWithTrailingWhitespace(@TempDir Path tempDir) throws IOException {
+    void testParseStatisticsWithTrailingWhitespace() {
         // A trailing space on the line must not prevent it from producing exactly two fields
-        Path procFile = tempDir.resolve("trailing-whitespace-stat");
-        Files.write(procFile, "SomeStatistic             12345 \n".getBytes(StandardCharsets.UTF_8));
-
-        Map<String, Long> results = ProcUtil.parseStatistics(procFile.toString());
+        Map<String, Long> results = ProcUtil
+                .parseStatistics(Collections.singletonList("SomeStatistic             12345 "), ParseUtil.whitespaces);
 
         assertThat(results.get("SomeStatistic"), is(12345L));
     }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessorFFM.java
@@ -103,7 +103,7 @@ final class SolarisCentralProcessorFFM extends SolarisCentralProcessor {
                 if (kc.read(ksp)) {
                     String suppFreq = KstatUtilFFM.dataLookupString(ksp, "supported_frequencies_Hz");
                     if (!suppFreq.isEmpty()) {
-                        for (String s : suppFreq.split(":")) {
+                        for (String s : suppFreq.split(":", -1)) {
                             long freq = ParseUtil.parseLongOrDefault(s, -1L);
                             if (max < freq) {
                                 max = freq;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
@@ -210,7 +210,7 @@ public class MacOSProcessFFM extends MacOSProcess {
             if (proc_pidpath(pid, pathBuf, PROC_PIDPATHINFO_MAXSIZE) > 0) {
                 this.path = pathBuf.getString(0).trim();
                 // Overwrite name with last part of path
-                String[] pathSplit = this.path.split("/");
+                String[] pathSplit = this.path.split("/", -1);
                 if (pathSplit.length > 0) {
                     this.name = pathSplit[pathSplit.length - 1];
                 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
@@ -70,7 +70,7 @@ public class MacOperatingSystemFFM extends MacOperatingSystem {
         // Boot time will be the first consecutive string of digits.
         if (bootTime == 0) {
             bootTime = ParseUtil.parseLongOrDefault(
-                    ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
+                    ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",", -1)[0].replaceAll("\\D", ""),
                     System.currentTimeMillis() / 1000);
         }
         BOOTTIME = bootTime;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -288,7 +288,7 @@ public class WindowsFileSystemFFM extends WindowsFileSystem {
                 } else {
                     // Network drive
                     volume = WmiUtil.getString(drives, LogicalDiskProperty.PROVIDERNAME, i);
-                    String[] split = volume.split("\\\\");
+                    String[] split = volume.split("\\\\", -1);
                     if (split.length > 1 && !split[split.length - 1].isEmpty()) {
                         description = split[split.length - 1];
                     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -288,9 +288,13 @@ public class WindowsFileSystemFFM extends WindowsFileSystem {
                 } else {
                     // Network drive
                     volume = WmiUtil.getString(drives, LogicalDiskProperty.PROVIDERNAME, i);
+                    // Last non-empty component, in case PROVIDERNAME ends with a trailing backslash
                     String[] split = volume.split("\\\\", -1);
-                    if (split.length > 1 && !split[split.length - 1].isEmpty()) {
-                        description = split[split.length - 1];
+                    for (int idx = split.length - 1; idx >= 0; idx--) {
+                        if (!split[idx].isEmpty()) {
+                            description = split[idx];
+                            break;
+                        }
                     }
                 }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisCentralProcessorJNA.java
@@ -170,7 +170,7 @@ final class SolarisCentralProcessorJNA extends SolarisCentralProcessor {
                 if (kc.read(ksp)) {
                     String suppFreq = KstatUtil.dataLookupString(ksp, "supported_frequencies_Hz");
                     if (!suppFreq.isEmpty()) {
-                        for (String s : suppFreq.split(":")) {
+                        for (String s : suppFreq.split(":", -1)) {
                             long freq = ParseUtil.parseLongOrDefault(s, -1L);
                             if (max < freq) {
                                 max = freq;

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
@@ -150,7 +150,7 @@ public class MacOSProcessJNA extends MacOSProcess {
                 if (0 < SystemB.INSTANCE.proc_pidpath(getProcessID(), buf, PROC_PIDPATHINFO_MAXSIZE)) {
                     this.path = buf.getString(0).trim();
                     // Overwrite name with last part of path
-                    String[] pathSplit = this.path.split("/");
+                    String[] pathSplit = this.path.split("/", -1);
                     if (pathSplit.length > 0) {
                         this.name = pathSplit[pathSplit.length - 1];
                     }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystemJNA.java
@@ -39,9 +39,9 @@ public class MacOperatingSystemJNA extends MacOperatingSystem {
             if (!SysctlUtil.sysctl("kern.boottime", tv) || tv.tv_sec.longValue() == 0L) {
                 // Usually this works. If it doesn't, fall back to text parsing.
                 // Boot time will be the first consecutive string of digits.
-                BOOTTIME = ParseUtil.parseLongOrDefault(
-                        ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",")[0].replaceAll("\\D", ""),
-                        System.currentTimeMillis() / 1000);
+                BOOTTIME = ParseUtil
+                        .parseLongOrDefault(ExecutingCommand.getFirstAnswer("sysctl -n kern.boottime").split(",", -1)[0]
+                                .replaceAll("\\D", ""), System.currentTimeMillis() / 1000);
             } else {
                 // tv now points to a 64-bit timeval structure for boot time.
                 // First 4 bytes are seconds, second 4 bytes are microseconds

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
@@ -236,9 +236,13 @@ public class WindowsFileSystemJNA extends WindowsFileSystem {
                 volume = Native.toString(chrVolume);
             } else {
                 volume = WmiUtil.getString(drives, LogicalDiskProperty.PROVIDERNAME, i);
+                // Last non-empty component, in case PROVIDERNAME ends with a trailing backslash
                 String[] split = volume.split("\\\\", -1);
-                if (split.length > 1 && !split[split.length - 1].isEmpty()) {
-                    description = split[split.length - 1];
+                for (int idx = split.length - 1; idx >= 0; idx--) {
+                    if (!split[idx].isEmpty()) {
+                        description = split[idx];
+                        break;
+                    }
                 }
             }
             int driveType = Kernel32.INSTANCE.GetDriveType(name);

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
@@ -236,7 +236,7 @@ public class WindowsFileSystemJNA extends WindowsFileSystem {
                 volume = Native.toString(chrVolume);
             } else {
                 volume = WmiUtil.getString(drives, LogicalDiskProperty.PROVIDERNAME, i);
-                String[] split = volume.split("\\\\");
+                String[] split = volume.split("\\\\", -1);
                 if (split.length > 1 && !split[split.length - 1].isEmpty()) {
                     description = split[split.length - 1];
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -1223,6 +1223,11 @@
                         <configuration>
                             <compilerArgs>
                                 <arg>-Xlint:-options</arg>
+                                <!-- javac's default -Xmaxwarns is 100 per module; Error Prone's findings are
+                                javac warnings, so without this a module with more findings than that silently
+                                drops the rest with no indication anything was truncated. -->
+                                <arg>-Xmaxwarns</arg>
+                                <arg>100000</arg>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
                                 <arg>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF</arg>


### PR DESCRIPTION
## Summary

Follow-on to #3594/#3595/#3596 (Error Prone groundwork). Requested triage of the WARNING-severity backlog by category, starting with the two the user specifically flagged: javadoc (`MissingSummary`, deferred to a follow-on PR) and `StringSplitter` (this PR).

**Important correction discovered while gathering baseline numbers:** `javac` defaults `-Xmaxwarns` to 100 per module. Error Prone's findings are javac warnings, so `oshi-common` (117+ findings) was silently truncating everything past the 100th with no indication anything was dropped. Every category count from the original triage was an undercount because of this - `StringSplitter` alone was **142** findings, not the 55 originally visible. Set `-Xmaxwarns` to a large value in the `error-prone` profile so the full picture is always visible going forward; this also revealed two previously-invisible categories (`EffectivelyPrivate`, `InvalidInlineTag`) and grew others substantially (`OperatorPrecedence` 4→29, `EnumOrdinal` 17→39, `MissingSummary` 33→41).

## StringSplitter (142/142 fixed)

Most sites are `String.split(regex)` with no explicit limit, which silently drops trailing empty strings - passing `-1` preserves them, satisfying the check. Each site was reviewed individually rather than applying `-1` uniformly, since `-1` is not a universally-safe substitute for the implicit `0` limit when a caller indexes the split result from the end or checks an exact length:

- Sites indexing the first element (`[0]`) or the element right after a marker (`[1]`) are unaffected by `-1`, or in the marker case actively benefit: a marker as the very last text on a line no longer throws `ArrayIndexOutOfBoundsException`, it now returns an empty string.
- Sites indexing from the end (`length-1`, `length==N` checks) only get `-1` where the input was already trimmed first or had an explicit `isEmpty()` guard, eliminating the trailing-whitespace case `-1` would otherwise affect.
- Four sites (`LinuxOSProcess.parseAffinityMask`, `AixFileSystem`'s inode parsing, `SolarisOSProcess`'s affinity parsing, and the shared `ParseUtil.parseLastString`) needed an explicit `.trim()` added alongside `-1`, since blindly adding `-1` there would have silently turned a correctly-parsed value into a wrong default (`0`) on trailing whitespace - exactly the regression risk with treating `-1` as a universal fix.
- A handful of `== 2` exact-length checks (`AbstractGlobalMemory`, `MacGlobalMemory`, `ProcUtil.parseStatistics`) now capture a key with an explicit empty value instead of silently dropping the line, matching existing precedent elsewhere in the codebase for this shape.

JNA/FFM twins (`SolarisCentralProcessor`, `MacOperatingSystem`, `MacOSProcess`, `WindowsFileSystem`) were fixed identically on both sides.

No CHANGELOG entry for the lint-motivated changes; the `ArrayIndexOutOfBoundsException`-prevention and `ParseUtil.parseLastString` hardening are edge-case fixes on malformed native output, not something normal use should encounter.

## Next steps (not this PR)

- Triage the remaining WARNING categories (`MissingSummary`, `EnumOrdinal`, `OperatorPrecedence`, `MixedMutabilityReturnType`, etc.) now that the true counts are visible.

## Test plan

- [x] `./mvnw clean install -DskipTests -Perror-prone`: `StringSplitter` count 142 → 0, BUILD SUCCESS
- [x] `./mvnw test` (whole reactor): 1558 tests, 0 failures
- [x] `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`: full gate clean, no reformatting needed beyond spotless's own line-wrapping of a few added `-1` arguments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system, hardware, network, storage, process, and filesystem information parsing across Linux, BSD, Solaris, AIX, macOS, and Windows.
  * Correctly handles missing values, trailing whitespace, empty fields, repeated delimiters, and values containing additional separators.
  * Improved reliability when reading operating-system command output and system configuration data.
* **Tests**
  * Added regression coverage for trailing whitespace and incomplete parsed values.
* **Chores**
  * Expanded compiler analysis limits so more warnings are reported during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->