### PR TITLE
Triage Error Prone EnumOrdinal warnings

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -409,6 +409,8 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * @param caches A set of unique caches.
      * @return A list sorted by level (desc), type, and size (desc)
      */
+    // Type.ordinal() is intentional: declaration order (UNIFIED, INSTRUCTION, DATA) defines the sort order
+    @SuppressWarnings("EnumOrdinal")
     public static List<ProcessorCache> orderedProcCaches(Set<ProcessorCache> caches) {
         return caches.stream().sorted(Comparator.comparing(
                 c -> -1000 * c.getLevel() + 100 * c.getType().ordinal() - Integer.highestOneBit(c.getCacheSize())))

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
@@ -75,11 +75,16 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
     protected static final int SECTORSIZE = 512;
 
     /** Ordering array for parsing udev stat fields. */
-    protected static final int[] UDEV_STAT_ORDERS = new int[UdevStat.values().length];
-    static {
+    protected static final int[] UDEV_STAT_ORDERS = buildUdevStatOrders();
+
+    // UdevStat.ordinal() only indexes this class's own lookup table, built from UdevStat.values() itself
+    @SuppressWarnings("EnumOrdinal")
+    private static int[] buildUdevStatOrders() {
+        int[] orders = new int[UdevStat.values().length];
         for (UdevStat stat : UdevStat.values()) {
-            UDEV_STAT_ORDERS[stat.ordinal()] = stat.getOrder();
+            orders[stat.ordinal()] = stat.getOrder();
         }
+        return orders;
     }
 
     /** Number of fields in udev stat output. */
@@ -135,6 +140,8 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
      * @param store   the disk store to update
      * @param devstat the stat string from sysfs or /proc/diskstats
      */
+    // UdevStat.ordinal() only indexes UDEV_STAT_ORDERS/devstatArray, both built from UdevStat.values() itself
+    @SuppressWarnings("EnumOrdinal")
     protected static void computeDiskStats(LinuxHWDiskStore store, String devstat) {
         long[] devstatArray = ParseUtil.parseStringToLongArray(devstat, UDEV_STAT_ORDERS, UDEV_STAT_LENGTH, ' ');
         store.setDiskStats(devstatArray[UdevStat.READS.ordinal()],

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
@@ -278,14 +278,14 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
 
     private static long[] ticksFromRow(CpuTickRow row) {
         long[] ticks = new long[TickType.values().length];
-        ticks[TickType.USER.ordinal()] = row.user * 1000L / USER_HZ;
+        ticks[TickType.USER.getIndex()] = row.user * 1000L / USER_HZ;
         // Skip NICE
-        ticks[TickType.SYSTEM.ordinal()] = row.sys * 1000L / USER_HZ;
-        ticks[TickType.IDLE.ordinal()] = row.idle * 1000L / USER_HZ;
-        ticks[TickType.IOWAIT.ordinal()] = row.wait * 1000L / USER_HZ;
-        ticks[TickType.IRQ.ordinal()] = row.devintrs * 1000L / USER_HZ;
-        ticks[TickType.SOFTIRQ.ordinal()] = row.softintrs * 1000L / USER_HZ;
-        ticks[TickType.STEAL.ordinal()] = (row.idle_stolen_purr + row.busy_stolen_purr) * 1000L / USER_HZ;
+        ticks[TickType.SYSTEM.getIndex()] = row.sys * 1000L / USER_HZ;
+        ticks[TickType.IDLE.getIndex()] = row.idle * 1000L / USER_HZ;
+        ticks[TickType.IOWAIT.getIndex()] = row.wait * 1000L / USER_HZ;
+        ticks[TickType.IRQ.getIndex()] = row.devintrs * 1000L / USER_HZ;
+        ticks[TickType.SOFTIRQ.getIndex()] = row.softintrs * 1000L / USER_HZ;
+        ticks[TickType.STEAL.getIndex()] = (row.idle_stolen_purr + row.busy_stolen_purr) * 1000L / USER_HZ;
         return ticks;
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -55,14 +55,18 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
             false);
 
     // Get a list of orders to pass to ParseUtil
-    private static final int[] PROC_PID_STAT_ORDERS = new int[ProcPidStat.values().length];
+    private static final int[] PROC_PID_STAT_ORDERS = buildProcPidStatOrders();
 
-    static {
+    // ProcPidStat.ordinal() only indexes this class's own lookup table, built from ProcPidStat.values() itself
+    @SuppressWarnings("EnumOrdinal")
+    private static int[] buildProcPidStatOrders() {
+        int[] orders = new int[ProcPidStat.values().length];
         for (ProcPidStat stat : ProcPidStat.values()) {
             // The PROC_PID_STAT enum indices are 1-indexed.
             // Subtract one to get a zero-based index
-            PROC_PID_STAT_ORDERS[stat.ordinal()] = stat.getOrder() - 1;
+            orders[stat.ordinal()] = stat.getOrder() - 1;
         }
+        return orders;
     }
 
     private final LinuxOperatingSystem os;
@@ -325,6 +329,8 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
         return null;
     }
 
+    // ProcPidStat.ordinal() only indexes statArray, built from ProcPidStat.values() itself via PROC_PID_STAT_ORDERS
+    @SuppressWarnings("EnumOrdinal")
     private boolean updateAttributesFromProc() {
         String procPidExe = String.format(Locale.ROOT, ProcPath.PID_EXE, getProcessID());
         try {

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSThread.java
@@ -21,13 +21,18 @@ import oshi.util.linux.ProcPath;
 @ThreadSafe
 public class LinuxOSThread extends AbstractOSThread {
 
-    private static final int[] PROC_TASK_STAT_ORDERS = new int[LinuxOSThread.ThreadPidStat.values().length];
-    static {
-        for (LinuxOSThread.ThreadPidStat stat : LinuxOSThread.ThreadPidStat.values()) {
+    private static final int[] PROC_TASK_STAT_ORDERS = buildProcTaskStatOrders();
+
+    // ThreadPidStat.ordinal() only indexes this class's own lookup table, built from ThreadPidStat.values() itself
+    @SuppressWarnings("EnumOrdinal")
+    private static int[] buildProcTaskStatOrders() {
+        int[] orders = new int[ThreadPidStat.values().length];
+        for (ThreadPidStat stat : ThreadPidStat.values()) {
             // The PROC_PID_STAT enum indices are 1-indexed.
             // Subtract one to get a zero-based index
-            PROC_TASK_STAT_ORDERS[stat.ordinal()] = stat.getOrder() - 1;
+            orders[stat.ordinal()] = stat.getOrder() - 1;
         }
+        return orders;
     }
 
     private final LinuxOperatingSystem os;
@@ -46,6 +51,9 @@ public class LinuxOSThread extends AbstractOSThread {
         updateAttributes();
     }
 
+    // ThreadPidStat.ordinal() only indexes statArray, built from ThreadPidStat.values() itself via
+    // PROC_TASK_STAT_ORDERS
+    @SuppressWarnings("EnumOrdinal")
     @Override
     public boolean updateAttributes() {
         this.name = FileUtil.getStringFromFile(

--- a/oshi-common/src/main/java/oshi/util/PlatformEnum.java
+++ b/oshi-common/src/main/java/oshi/util/PlatformEnum.java
@@ -139,6 +139,9 @@ public enum PlatformEnum {
      *               {@code Platform.getOSType()} return values.
      * @return the value corresponding to the specified platform type
      */
+    // ordinal() is intentional here: this enum's declaration order is defined (see class javadoc) to match
+    // JNA's Platform.getOSType() values, so osType is itself an ordinal into this enum.
+    @SuppressWarnings("EnumOrdinal")
     public static PlatformEnum getValue(int osType) {
         if (osType < 0 || osType >= UNKNOWN.ordinal()) {
             return UNKNOWN;

--- a/oshi-common/src/test/java/oshi/util/PlatformEnumTest.java
+++ b/oshi-common/src/test/java/oshi/util/PlatformEnumTest.java
@@ -37,6 +37,8 @@ class PlatformEnumTest {
         assertThat(PlatformEnum.getValue(2), is(PlatformEnum.WINDOWS));
     }
 
+    // ordinal() is intentional: exercises PlatformEnum.getValue's own documented ordinal-based lookup
+    @SuppressWarnings("EnumOrdinal")
     @Test
     void testGetValueOutOfRange() {
         assertThat(PlatformEnum.getValue(-1), is(PlatformEnum.UNKNOWN));

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfCounterWildcardQueryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfCounterWildcardQueryFFM.java
@@ -128,6 +128,9 @@ public final class PerfCounterWildcardQueryFFM {
      * @return A pair containing a list of instances and an {@link EnumMap} of the corresponding values indexed by
      *         {@code propertyEnum} on success, or an empty list and empty map if the WMI query failed.
      */
+    // ordinal() == 0 is intentional: PdhCounterWildcardProperty's contract requires the first declared
+    // enum constant to be the instance filter (see PdhCounterWildcardProperty javadoc).
+    @SuppressWarnings("EnumOrdinal")
     public static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromWMI(
             Class<T> propertyEnum, String perfWmiClass) {
         T[] props = propertyEnum.getEnumConstants();

--- a/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
@@ -76,8 +76,10 @@ public final class LogicalProcessorInformation {
                     break;
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationCache:
                     CACHE_RELATIONSHIP cache = (CACHE_RELATIONSHIP) info;
+                    Type[] types = Type.values();
+                    Type cacheType = cache.type >= 0 && cache.type < types.length ? types[cache.type] : Type.UNIFIED;
                     caches.add(new ProcessorCache(cache.level, cache.associativity, cache.lineSize, cache.cacheSize,
-                            Type.values()[cache.type]));
+                            cacheType));
                     break;
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore:
                     PROCESSOR_RELATIONSHIP core = ((PROCESSOR_RELATIONSHIP) info);

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -234,6 +234,9 @@ public final class PerfCounterWildcardQuery {
      *
      * @throws ClassCastException if a property has a CIM type this does not convert
      */
+    // ordinal() == 0 is intentional: PdhCounterWildcardProperty's contract requires the first declared
+    // enum constant to be the instance filter (see PdhCounterWildcardProperty javadoc).
+    @SuppressWarnings("EnumOrdinal")
     static <T extends Enum<T>> Pair<List<String>, Map<T, List<Long>>> mapInstancesAndValuesFromResult(
             Class<T> propertyEnum, WmiResult<T> result) {
         List<String> instances = new ArrayList<>();


### PR DESCRIPTION
## Summary
- `AixCentralProcessor.ticksFromRow` used `TickType.ordinal()` where `TickType.getIndex()` (already used everywhere else, e.g. `CpuStat`) is the intended stable index — real fix, no behavior change since the values are currently identical by construction.
- The remaining `EnumOrdinal` findings are self-contained lookup tables (`UdevStat`, `ProcPidStat`, `ThreadPidStat` — private enums whose ordinal only indexes a same-sized array built by the same class) or documented native-order contracts (`PlatformEnum`'s declaration order matching JNA's `Platform.getOSType()`, `PdhCounterWildcardProperty`'s "first enum element is the instance filter" contract, `ProcessorCache.Type`'s declaration-order sort weight). Suppressed with `@SuppressWarnings("EnumOrdinal")` plus a one-line comment explaining why, scoped to the narrowest enclosing method (two static-initializer sites were refactored into small private builder methods since a static block can't itself carry an annotation).
- Found and fixed a latent bug along the way: `LogicalProcessorInformation` (JNA) indexed `ProcessorCache.Type` with `Type.values()[cache.type]` and no bounds check, so an unexpected native cache-type value would throw `ArrayIndexOutOfBoundsException`. Its FFM twin already guards this with a bounds check + `UNIFIED` fallback; brought JNA in line with it.

## Test plan
- [x] `./mvnw clean install -Perror-prone -DskipTests`: 0 ERROR, `EnumOrdinal` findings 39 → 0, total WARNING count 223 → 184 (matches)
- [x] `./mvnw -pl oshi-common,oshi-core,oshi-core-ffm -am test`: 0 tests failed
- [x] `./mvnw checkstyle:check`, `forbiddenapis:check`, `javadoc:javadoc`: all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows cache detection by safely handling invalid cache type values, preventing processing failures.
  * Preserved accurate CPU tick calculations on AIX systems.

* **Refactor**
  * Improved internal platform statistics mapping and validation without changing expected behavior.

* **Documentation**
  * Added clarifying documentation for platform-specific hardware and performance counter mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->