### PR TITLE
Triage Error Prone OperatorPrecedence warnings

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/gpu/DxgiUtil.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/gpu/DxgiUtil.java
@@ -72,7 +72,7 @@ public final class DxgiUtil {
             long total = 0L;
             int size = Math.min(bytes.length, 8);
             for (int i = 0; i < size; i++) {
-                total = total << 8 | bytes[size - i - 1] & 0xff;
+                total = (total << 8) | (bytes[size - i - 1] & 0xff);
             }
             return total;
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -57,7 +57,7 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
             }
         }
         String machine = BsdSysctlUtil.sysctl("hw.machine", "");
-        boolean cpu64bit = machine != null && machine.contains("64")
+        boolean cpu64bit = (machine != null && machine.contains("64"))
                 || ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
 
         return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
@@ -79,7 +79,7 @@ public abstract class OpenBsdCentralProcessor extends BsdCentralProcessor {
         }
         mib = new int[] { CTL_HW, HW_MACHINE };
         String machine = sysctl(mib, "");
-        boolean cpu64bit = machine != null && machine.contains("64")
+        boolean cpu64bit = (machine != null && machine.contains("64"))
                 || ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
         String processorID = String.format(Locale.ROOT, "%08x%08x", cpufeature, cpuid);
 
@@ -89,9 +89,9 @@ public abstract class OpenBsdCentralProcessor extends BsdCentralProcessor {
 
     static Triplet<Integer, Integer, Integer> cpuidToFamilyModelStepping(int cpuid) {
         // family is bits 27:20 | 11:8
-        int family = cpuid >> 16 & 0xff0 | cpuid >> 8 & 0xf;
+        int family = ((cpuid >> 16) & 0xff0) | ((cpuid >> 8) & 0xf);
         // model is bits 19:16 | 7:4
-        int model = cpuid >> 12 & 0xf0 | cpuid >> 4 & 0xf;
+        int model = ((cpuid >> 12) & 0xf0) | ((cpuid >> 4) & 0xf);
         // stepping is bits 3:0
         int stepping = cpuid & 0xf;
         return new Triplet<>(family, model, stepping);

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxFileSystem.java
@@ -183,8 +183,8 @@ public abstract class LinuxFileSystem extends AbstractFileSystem {
             // Skip non-local drives if requested, and exclude pseudo file systems
             boolean isLocal = !NETWORK_FS_TYPES.contains(type);
             if ((localOnly && !isLocal)
-                    || !path.equals("/") && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path,
-                            volume, FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES))) {
+                    || (!path.equals("/") && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path,
+                            volume, FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES)))) {
                 continue;
             }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
@@ -92,9 +92,9 @@ public class AixFileSystem extends AbstractFileSystem {
 
                 // Skip non-local drives if requested, and exclude pseudo file systems
                 boolean isLocal = !NETWORK_FS_TYPES.contains(type);
-                if ((localOnly && !isLocal) || !path.equals("/")
+                if ((localOnly && !isLocal) || (!path.equals("/")
                         && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path, volume,
-                                FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES))) {
+                                FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES)))) {
                     continue;
                 }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystem.java
@@ -70,8 +70,8 @@ public abstract class FreeBsdFileSystem extends AbstractFileSystem {
             // Skip non-local drives if requested, and exclude pseudo file systems
             boolean isLocal = !NETWORK_FS_TYPES.contains(type);
             if ((localOnly && !isLocal)
-                    || !path.equals("/") && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path,
-                            volume, FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES))) {
+                    || (!path.equals("/") && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path,
+                            volume, FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES)))) {
                 continue;
             }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
@@ -78,9 +78,9 @@ public class NetBsdFileSystem extends AbstractFileSystem {
 
                 // Skip non-local drives if requested, and exclude pseudo file systems
                 boolean isLocal = !NETWORK_FS_TYPES.contains(type);
-                if ((localOnly && !isLocal) || !path.equals("/")
+                if ((localOnly && !isLocal) || (!path.equals("/")
                         && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path, volume,
-                                FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES))) {
+                                FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES)))) {
                     continue;
                 }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
@@ -115,9 +115,9 @@ public abstract class OpenBsdFileSystem extends AbstractFileSystem {
 
                 // Skip non-local drives if requested, and exclude pseudo file systems
                 boolean isLocal = !NETWORK_FS_TYPES.contains(type);
-                if ((localOnly && !isLocal) || !path.equals("/")
+                if ((localOnly && !isLocal) || (!path.equals("/")
                         && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path, volume,
-                                FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES))) {
+                                FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES)))) {
                     continue;
                 }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisFileSystem.java
@@ -79,8 +79,8 @@ public abstract class SolarisFileSystem extends AbstractFileSystem {
             // Skip non-local drives if requested, and exclude pseudo file systems
             boolean isLocal = !NETWORK_FS_TYPES.contains(type);
             if ((localOnly && !isLocal)
-                    || !path.equals("/") && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path,
-                            volume, FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES))) {
+                    || (!path.equals("/") && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path,
+                            volume, FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES)))) {
                 continue;
             }
 

--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -233,8 +233,8 @@ public final class EdidUtil {
 
     public static String getPreferredResolution(byte[] edid) {
         int dtd = DESCRIPTOR_OFFSET;
-        int horizontalRes = (edid[dtd + 4] & 0xF0) << 4 | edid[dtd + 2] & 0xFF;
-        int verticalRes = (edid[dtd + 7] & 0xF0) << 4 | edid[dtd + 5] & 0xFF;
+        int horizontalRes = ((edid[dtd + 4] & 0xF0) << 4) | (edid[dtd + 2] & 0xFF);
+        int verticalRes = ((edid[dtd + 7] & 0xF0) << 4) | (edid[dtd + 5] & 0xFF);
         return horizontalRes + "x" + verticalRes;
     }
 
@@ -390,7 +390,7 @@ public final class EdidUtil {
                     "Serial number must be an unsigned 32-bit value (0-4294967295): " + serial);
         }
         for (int i = 0; i < 4; i++) {
-            edid[SERIAL_NUMBER_OFFSET + i] = (byte) (serial >> 8 * i & 0xFF);
+            edid[SERIAL_NUMBER_OFFSET + i] = (byte) ((serial >> (8 * i)) & 0xFF);
         }
     }
 
@@ -439,7 +439,7 @@ public final class EdidUtil {
      * @param digital Whether the EDID represents a digital monitor
      */
     public static void setDigital(byte[] edid, boolean digital) {
-        edid[VIDEO_PARAMS_OFFSET] = (byte) (edid[VIDEO_PARAMS_OFFSET] & 0x7F | (digital ? 0x80 : 0x00));
+        edid[VIDEO_PARAMS_OFFSET] = (byte) ((edid[VIDEO_PARAMS_OFFSET] & 0x7F) | (digital ? 0x80 : 0x00));
     }
 
     /**
@@ -491,9 +491,9 @@ public final class EdidUtil {
         int vertical = ParseUtil.parseIntOrDefault(resolution.substring(x + 1), 0);
         int dtd = DESCRIPTOR_OFFSET;
         edid[dtd + 2] = (byte) (horizontal & 0xFF);
-        edid[dtd + 4] = (byte) (edid[dtd + 4] & 0x0F | horizontal >> 4 & 0xF0);
+        edid[dtd + 4] = (byte) ((edid[dtd + 4] & 0x0F) | ((horizontal >> 4) & 0xF0));
         edid[dtd + 5] = (byte) (vertical & 0xFF);
-        edid[dtd + 7] = (byte) (edid[dtd + 7] & 0x0F | vertical >> 4 & 0xF0);
+        edid[dtd + 7] = (byte) ((edid[dtd + 7] & 0x0F) | ((vertical >> 4) & 0xF0));
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -407,9 +407,9 @@ public final class ParseUtil {
         long total = 0L;
         for (int i = 0; i < size; i++) {
             if (bigEndian) {
-                total = total << 8 | bytes[i] & 0xff;
+                total = (total << 8) | (bytes[i] & 0xff);
             } else {
-                total = total << 8 | bytes[size - i - 1] & 0xff;
+                total = (total << 8) | (bytes[size - i - 1] & 0xff);
             }
         }
         return total;
@@ -793,7 +793,7 @@ public final class ParseUtil {
                 // Doesn't impact parsing, ignore
                 delimCurrent = false;
             } else if (c >= '0' && c <= '9' && !dashSeen) {
-                if (power > 18 || power == 17 && c == '9' && parsed[parsedIndex] > 223_372_036_854_775_807L) {
+                if (power > 18 || (power == 17 && c == '9' && parsed[parsedIndex] > 223_372_036_854_775_807L)) {
                     parsed[parsedIndex] = Long.MAX_VALUE;
                 } else {
                     parsed[parsedIndex] += (c - '0') * ParseUtil.POWERS_OF_TEN[power++];
@@ -1226,7 +1226,7 @@ public final class ParseUtil {
     public static int bigEndian16ToLittleEndian(int port) {
         // 20480 = 0x5000 should be 0x0050 = 80
         // 47873 = 0xBB01 should be 0x01BB = 443
-        return port >> 8 & 0xff | port << 8 & 0xff00;
+        return ((port >> 8) & 0xff) | ((port << 8) & 0xff00);
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
@@ -105,9 +105,9 @@ public class MacFileSystemFFM extends MacFileSystem {
 
                         // Skip non-local drives if requested, and exclude pseudo file systems
                         boolean isLocal = (flags & MNT_LOCAL) != 0;
-                        if ((localOnly && !isLocal) || !path.equals("/")
+                        if ((localOnly && !isLocal) || (!path.equals("/")
                                 && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path, volume,
-                                        FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES))) {
+                                        FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES)))) {
                             continue;
                         }
 

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
@@ -87,9 +87,9 @@ public class MacFileSystemJNA extends MacFileSystem {
                     final int flags = fs[f].f_flags;
                     boolean isLocal = (flags & MNT_LOCAL) != 0;
                     // Skip non-local drives if requested, and exclude pseudo file systems
-                    if ((localOnly && !isLocal) || !path.equals("/")
+                    if ((localOnly && !isLocal) || (!path.equals("/")
                             && (PSEUDO_FS_TYPES.contains(type) || FileSystemUtil.isFileStoreExcluded(path, volume,
-                                    FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES))) {
+                                    FS_PATH_INCLUDES, FS_PATH_EXCLUDES, FS_VOLUME_INCLUDES, FS_VOLUME_EXCLUDES)))) {
                         continue;
                     }
 

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
@@ -81,7 +81,7 @@ public class MacInternetProtocolStatsJNA extends MacInternetProtocolStats {
     private static IPConnection queryIPConnection(int pid, int fd) {
         try (CloseableSocketFdInfo si = new CloseableSocketFdInfo()) {
             int ret = SystemB.INSTANCE.proc_pidfdinfo(pid, fd, PROC_PIDFDSOCKETINFO, si, si.size());
-            if (si.size() == ret && si.psi.soi_family == AF_INET || si.psi.soi_family == AF_INET6) {
+            if (si.size() == ret && (si.psi.soi_family == AF_INET || si.psi.soi_family == AF_INET6)) {
                 InSockInfo ini;
                 String type;
                 TcpState state;


### PR DESCRIPTION
## Summary
- Real bug fixed: `MacInternetProtocolStatsJNA.queryIPConnection`'s `si.size() == ret && si.psi.soi_family == AF_INET || si.psi.soi_family == AF_INET6` parses (per Java precedence, `&&` binds tighter than `||`) as `(size == ret && family == AF_INET) || family == AF_INET6` — the size/return-value check only guarded the `AF_INET` branch. An `AF_INET6` socket was processed even when `proc_pidfdinfo` failed to fill the struct. The FFM twin already gets this right via two separate early-returns (checks `ret` unconditionally, then checks family). Fixed JNA to require both: `si.size() == ret && (si.psi.soi_family == AF_INET || si.psi.soi_family == AF_INET6)`.
- The other 28 `OperatorPrecedence` findings are bit-math/boolean expressions that already evaluate correctly under Java's real precedence rules — byte-accumulation shifts (`DxgiUtil`, `ParseUtil`), EDID bit-packing (`EdidUtil`), x86 family/model decode (`OpenBsdCentralProcessor`), a repeated `(localOnly && !isLocal) || path-is-not-root && (pseudo-fs-or-excluded)` filesystem-skip check duplicated across 8 per-OS `FileSystem` implementations, and a `cpu64bit` OR check duplicated across NetBSD/OpenBSD. Verified each against its doc comment/native semantics before treating as cosmetic; added grouping parens to make the existing (correct) evaluation order explicit, no behavior change.

## Test plan
- [x] `./mvnw clean install -Perror-prone -DskipTests`: 0 ERROR, `OperatorPrecedence` 29 → 0
- [x] `./mvnw -pl oshi-common,oshi-core,oshi-core-ffm -am test`: 0 tests failed
- [x] `./mvnw checkstyle:check`, `forbiddenapis:check`, `clean compile javadoc:javadoc`: all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem filtering so root mounts remain available while pseudo-filesystems and configured exclusions are handled consistently across supported platforms.
  * Corrected network connection processing to apply successful socket-information checks consistently for IPv4 and IPv6 connections.
  * Improved handling of null or unavailable machine architecture information on OpenBSD and NetBSD.

* **Refactor**
  * Clarified expression grouping throughout hardware detection, graphics memory parsing, display data decoding, and filesystem processing without changing expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->