### PR TITLE
Triage Error Prone MixedMutabilityReturnType warnings

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxPowerSource.java
@@ -194,7 +194,7 @@ public class LinuxPowerSource extends AbstractPowerSource {
                 }
             }
         }
-        return psList;
+        return Collections.unmodifiableList(psList);
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNF.java
@@ -5,6 +5,7 @@
 package oshi.hardware.common.platform.linux.nativefree;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -75,7 +76,7 @@ public final class LinuxUsbDeviceNF {
             }
             devices.add(new UdevUsbDevice(syspath, product, manufacturer, idVendor, idProduct, serial, parentSyspath));
         }
-        return devices;
+        return unmodifiableList(devices);
     }
 
     private static String emptyToNull(String value) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
@@ -5,6 +5,7 @@
 package oshi.hardware.common.platform.mac;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -182,7 +183,7 @@ public final class MacUsbDevice extends AbstractUsbDevice {
             controllerDevices.add(buildDeviceTree(controller, "0000", "0000", nameMap, vendorMap, vendorIdMap,
                     productIdMap, serialMap, hubMap, MacUsbDevice::new));
         }
-        return controllerDevices;
+        return unmodifiableList(controllerDevices);
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdGraphicsCard.java
@@ -105,6 +105,6 @@ public final class BsdGraphicsCard extends AbstractGraphicsCard {
                     productId.isEmpty() ? UNKNOWN_PCI_ID : productId, vendorId.isEmpty() ? UNKNOWN_PCI_ID : vendorId,
                     versionInfo.isEmpty() ? Constants.UNKNOWN : versionInfo, 0L));
         }
-        return cardList;
+        return Collections.unmodifiableList(cardList);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdGraphicsCard.java
@@ -102,6 +102,6 @@ public class FreeBsdGraphicsCard extends AbstractGraphicsCard {
                     vendorId.isEmpty() ? Constants.UNKNOWN : vendorId,
                     versionInfo.isEmpty() ? Constants.UNKNOWN : versionInfo, 0L));
         }
-        return cardList;
+        return Collections.unmodifiableList(cardList);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdUsbDevice.java
@@ -127,6 +127,6 @@ public class FreeBsdUsbDevice extends AbstractUsbDevice {
             controllerDevices.add(buildDeviceTree(parent, "0000", "0000", nameMap, vendorMap, vendorIdMap, productIdMap,
                     serialMap, hubMap, FreeBsdUsbDevice::new));
         }
-        return controllerDevices;
+        return Collections.unmodifiableList(controllerDevices);
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisUsbDevice.java
@@ -6,6 +6,7 @@ package oshi.hardware.common.platform.unix.solaris;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableList;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -129,6 +130,6 @@ public class SolarisUsbDevice extends AbstractUsbDevice {
                         productIdMap, emptyMap(), hubMap, SolarisUsbDevice::new));
             }
         }
-        return controllerDevices;
+        return unmodifiableList(controllerDevices);
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -104,7 +104,7 @@ public final class MacInstalledApps {
                     }
                 }
 
-                return new ArrayList<>(appInfoSet);
+                return Collections.unmodifiableList(new ArrayList<>(appInfoSet));
             }
         } catch (Exception e) {
             LOG.trace("Unable to read installed apps: " + e.getMessage(), e);
@@ -176,7 +176,7 @@ public final class MacInstalledApps {
         for (String dictInner : dictBlocks) {
             out.add(parseDict(dictInner));
         }
-        return out;
+        return Collections.unmodifiableList(out);
     }
 
     static Map<String, String> parseDict(String dictInner) {

--- a/oshi-common/src/main/java/oshi/util/FileUtil.java
+++ b/oshi-common/src/main/java/oshi/util/FileUtil.java
@@ -125,7 +125,7 @@ public final class FileUtil {
                     }
                     lines.add(line);
                 }
-                return lines;
+                return Collections.unmodifiableList(lines);
             } catch (IOException e) {
                 if (reportError) {
                     LOG.error("Error reading file {}. {}", filename, e.getMessage());

--- a/oshi-common/src/main/java/oshi/util/driver/linux/DrmEdid.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/DrmEdid.java
@@ -64,6 +64,6 @@ public final class DrmEdid {
                 }
             }
         }
-        return displays;
+        return Collections.unmodifiableList(displays);
     }
 }

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
@@ -63,6 +63,6 @@ public final class Xrandr {
                 sb = null;
             }
         }
-        return displays;
+        return Collections.unmodifiableList(displays);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
@@ -325,7 +325,7 @@ public final class IOReportClientFFM implements IOReportSampler {
                     }
                 }
             }
-            return result;
+            return Collections.unmodifiableMap(result);
         }
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
@@ -182,7 +182,7 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
             return Collections.emptyList();
         }
         finalizePartitions(result);
-        return result;
+        return Collections.unmodifiableList(result);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreFFM.java
@@ -85,7 +85,7 @@ public final class WindowsHWDiskStoreFFM extends WindowsHWDiskStore {
                 ds.setPartitionList(buildPartitionList(maps, ds.getName()));
                 result.add(ds);
             }
-            return result;
+            return Collections.unmodifiableList(result);
         } catch (FfmComException e) {
             LOG.warn("COM exception: {}", e.getMessage());
             return Collections.emptyList();

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsFFM.java
@@ -12,6 +12,7 @@ import static oshi.ffm.util.platform.windows.IPHlpAPIUtilFFM.queryUDPv4Connectio
 import static oshi.ffm.util.platform.windows.IPHlpAPIUtilFFM.queryUDPv6Connections;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -36,7 +37,7 @@ public class WindowsInternetProtocolStatsFFM extends AbstractInternetProtocolSta
         conns.addAll(queryTCPv6Connections());
         conns.addAll(queryUDPv4Connections());
         conns.addAll(queryUDPv6Connections());
-        return conns;
+        return Collections.unmodifiableList(conns);
     }
 
     @Override

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -185,7 +185,7 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
                     }
                     svcArray.add(new OSService(displayName, processId, state));
                 }
-                return svcArray;
+                return Collections.unmodifiableList(svcArray);
             }
         }, LOG, ERROR, "Error enumerating services", Collections.emptyList());
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
@@ -150,7 +150,7 @@ public final class LinuxHWDiskStoreJNA extends LinuxHWDiskStore {
             udev.unref();
         }
         finalizePartitions(result);
-        return result;
+        return Collections.unmodifiableList(result);
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxUsbDeviceJNA.java
@@ -5,6 +5,7 @@
 package oshi.hardware.platform.linux;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
 import static oshi.software.os.linux.LinuxOperatingSystemJNA.HAS_UDEV;
 
 import java.util.ArrayList;
@@ -86,6 +87,6 @@ public final class LinuxUsbDeviceJNA {
         } finally {
             udev.unref();
         }
-        return devices;
+        return unmodifiableList(devices);
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
@@ -345,7 +345,7 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
                         diskList.add(diskStore);
                     }
                 }
-                return diskList;
+                return Collections.unmodifiableList(diskList);
             } finally {
                 session.release();
             }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsHWDiskStoreJNA.java
@@ -80,7 +80,7 @@ public final class WindowsHWDiskStoreJNA extends WindowsHWDiskStore {
                 ds.setPartitionList(buildPartitionList(maps, ds.getName()));
                 result.add(ds);
             }
-            return result;
+            return Collections.unmodifiableList(result);
         } catch (COMException e) {
             LOG.warn("COM exception: {}", e.getMessage());
             return Collections.emptyList();

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsInternetProtocolStatsJNA.java
@@ -94,7 +94,7 @@ public class WindowsInternetProtocolStatsJNA extends AbstractInternetProtocolSta
             conns.addAll(queryTCPv6Connections());
             conns.addAll(queryUDPv4Connections());
             conns.addAll(queryUDPv6Connections());
-            return conns;
+            return Collections.unmodifiableList(conns);
         }
         return Collections.emptyList();
     }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
@@ -368,7 +368,7 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
                 }
                 svcArray.add(new OSService(service.lpDisplayName, service.ServiceStatusProcess.dwProcessId, state));
             }
-            return svcArray;
+            return Collections.unmodifiableList(svcArray);
         } catch (com.sun.jna.platform.win32.Win32Exception ex) {
             LOG.error("Win32Exception: {}", ex.getMessage());
             return Collections.emptyList();


### PR DESCRIPTION
## Summary
- 21 methods returned `Collections.emptyList()`/`emptyMap()` on one path and a freshly-built mutable `ArrayList`/`HashMap` on another. Fixed by wrapping the mutable success path in `Collections.unmodifiableList`/`unmodifiableMap` — a zero-cost O(1) view, not a copy — so every return path is consistently immutable, rather than making the empty-path mutable (which would just add pointless per-call allocation, since `Collections.emptyList()`/`emptyMap()` are already free singleton immutable instances).
- This matters concretely, not just cosmetically: `AbstractHardwareAbstractionLayer` memoizes `getUsbDevices()`/`getGraphicsCards()` (`memoize(this::createX, slowExpiration())`), so `MacUsbDevice.getUsbDevices()` and both `GraphicsCard.getGraphicsCards()` implementations return the *same shared list instance* to every caller until the memo expires — an accidental mutation there would corrupt what every other caller sees.
- Also brought two twins in line that had the identical shape but weren't independently flagged by Error Prone (one because it's inside a lambda, so the checker didn't attribute the mixed-mutability to the enclosing method): `WindowsInternetProtocolStatsFFM.getConnections()` and `WindowsOperatingSystemFFM`'s `queryServicesFFM()`.

## Test plan
- [x] `./mvnw clean install -Perror-prone -DskipTests`: 0 ERROR, `MixedMutabilityReturnType` 21 → 0
- [x] `./mvnw -pl oshi-common,oshi-core,oshi-core-ffm -am test`: 0 tests failed
- [x] `./mvnw checkstyle:check`, `forbiddenapis:check`, `clean compile javadoc:javadoc`: all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data safety by making returned hardware, software, network, storage, display, and power-source collections read-only.
  - Prevented accidental modification of USB devices, graphics cards, installed applications, operating-system services, and parsed system data.
  - Applied consistent read-only behavior across supported Linux, macOS, Windows, BSD, Solaris, and Unix environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->