### PR TITLE
Triage Error Prone ReferenceEquality and numeric boxing/narrowing warnings

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lspv.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lspv.java
@@ -46,7 +46,7 @@ public final class Lspv {
     public static List<HWPartition> queryLogicalVolumes(String device, Map<String, Pair<Integer, Integer>> majMinMap) {
         return PARTITION_CACHE.computeIfAbsent(device,
                 d -> Collections.unmodifiableList(computeLogicalVolumes(d, majMinMap).stream()
-                        .sorted(Comparator.comparing(HWPartition::getMinor).thenComparing(HWPartition::getName))
+                        .sorted(Comparator.comparingInt(HWPartition::getMinor).thenComparing(HWPartition::getName))
                         .collect(Collectors.toList())));
     }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -412,7 +412,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
     // Type.ordinal() is intentional: declaration order (UNIFIED, INSTRUCTION, DATA) defines the sort order
     @SuppressWarnings("EnumOrdinal")
     public static List<ProcessorCache> orderedProcCaches(Set<ProcessorCache> caches) {
-        return caches.stream().sorted(Comparator.comparing(
+        return caches.stream().sorted(Comparator.comparingInt(
                 c -> -1000 * c.getLevel() + 100 * c.getType().ordinal() - Integer.highestOneBit(c.getCacheSize())))
                 .collect(Collectors.toList());
     }

--- a/oshi-common/src/test/java/oshi/util/PrivilegedUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/PrivilegedUtilTest.java
@@ -198,6 +198,8 @@ class PrivilegedUtilTest {
         assertThat(result.length, is(0));
     }
 
+    // == is intentional: checks whether the memoized supplier returned the same cached instance
+    @SuppressWarnings("ReferenceEquality")
     @Test
     void testCommandAllowlistCaching() {
         // Memoized suppliers cache based on time expiration, not config changes
@@ -207,6 +209,8 @@ class PrivilegedUtilTest {
         assertThat(allowlist1 == allowlist2 || allowlist1.equals(allowlist2), is(true));
     }
 
+    // == is intentional: checks whether the memoized supplier returned the same cached instance
+    @SuppressWarnings("ReferenceEquality")
     @Test
     void testFileAllowlistCaching() {
         // Memoized suppliers cache based on time expiration, not config changes

--- a/oshi-common/src/test/java/oshi/util/UtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/UtilTest.java
@@ -70,13 +70,13 @@ class UtilTest {
 
     @Test
     void testIsSessionValid() {
-        assertThat("Session is invalid because user is empty", Util.isSessionValid("", "device", (long) 0), is(false));
-        assertThat("Session is invalid because device is empty", Util.isSessionValid("user", "", (long) 0), is(false));
+        assertThat("Session is invalid because user is empty", Util.isSessionValid("", "device", 0L), is(false));
+        assertThat("Session is invalid because device is empty", Util.isSessionValid("user", "", 0L), is(false));
         assertThat("Session is invalid because loginTime is greater than current system time",
                 Util.isSessionValid("user", "device", Long.MAX_VALUE), is(false));
         assertThat("Session is invalid because loginTime is lesser than zero",
                 Util.isSessionValid("user", "device", Long.MIN_VALUE), is(false));
         assertThat("Session is valid because all the arguments are appropriate",
-                Util.isSessionValid("user", "device", (long) 999999999), is(true));
+                Util.isSessionValid("user", "device", 999999999L), is(true));
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/LogicalProcessorInformationFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/LogicalProcessorInformationFFM.java
@@ -109,11 +109,11 @@ public final class LogicalProcessorInformationFFM {
         }
 
         // Sort cores by group*64 + trailing zeros of mask
-        cores.sort(Comparator.comparing(c -> c[0] * 64L + Long.numberOfTrailingZeros(c[1])));
+        cores.sort(Comparator.comparingLong(c -> c[0] * 64L + Long.numberOfTrailingZeros(c[1])));
         // Sort packages by first group affinity
-        packages.sort(Comparator.comparing(p -> p.get(0)[0] * 64L + Long.numberOfTrailingZeros(p.get(0)[1])));
+        packages.sort(Comparator.comparingLong(p -> p.get(0)[0] * 64L + Long.numberOfTrailingZeros(p.get(0)[1])));
         // Sort numa nodes by node number
-        numaNodes.sort(Comparator.comparing(n -> n[0]));
+        numaNodes.sort(Comparator.comparingLong(n -> n[0]));
 
         // Fetch processorIDs from WMI
         Map<Integer, String> processorIdMap = new HashMap<>();

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
@@ -119,6 +119,8 @@ public final class Advapi32UtilFFM {
      * @return array of subkey names
      * @throws Throwable if the native call fails
      */
+    // maxNameLen is a Windows registry key-name length (bounded well under 32K), can't overflow int
+    @SuppressWarnings("NarrowCalculation")
     public static String[] registryGetKeys(MemorySegment hKey) throws Throwable {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment lpcSubKeys = arena.allocate(JAVA_INT);
@@ -468,9 +470,8 @@ public final class Advapi32UtilFFM {
                     while (offset < read) {
                         MemorySegment eventRecord = buffer.asSlice(offset, WinNTFFM.EVENTLOGRECORD.byteSize());
 
-                        int eventId = eventRecord.get(JAVA_INT, (int) offsetEventId);
-                        long timeGenerated = Integer
-                                .toUnsignedLong(eventRecord.get(JAVA_INT, (int) offsetTimeGenerated));
+                        int eventId = eventRecord.get(JAVA_INT, offsetEventId);
+                        long timeGenerated = Integer.toUnsignedLong(eventRecord.get(JAVA_INT, offsetTimeGenerated));
 
                         if (eventId == 12) { // system boot
                             return timeGenerated;
@@ -482,7 +483,7 @@ public final class Advapi32UtilFFM {
                         }
 
                         // Advance to next record
-                        int length = eventRecord.get(JAVA_INT, (int) offsetLength);
+                        int length = eventRecord.get(JAVA_INT, offsetLength);
                         offset += length;
                     }
                 }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
@@ -100,6 +100,8 @@ public class MacInternetProtocolStatsFFM extends MacInternetProtocolStats {
         }, LOG, TRACE, "Failed to enumerate IP connections", conns);
     }
 
+    // i is bounded by numStructs (a process's fd count), can't overflow int when multiplied by structSize
+    @SuppressWarnings("NarrowCalculation")
     private static List<Integer> queryFdList(int pid, Arena arena) {
         List<Integer> fdList = new ArrayList<>();
         return getOrDefault(() -> {
@@ -195,6 +197,8 @@ public class MacInternetProtocolStatsFFM extends MacInternetProtocolStats {
         }, null, LOG, TRACE, "Failed to query IP connection details");
     }
 
+    // i is 0-3 (fixed 4-element array), can't overflow int
+    @SuppressWarnings("NarrowCalculation")
     private static byte[] parseIntArrayToIP(MemorySegment segment, long offset) {
         int[] array = new int[4];
         for (int i = 0; i < 4; i++) {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
@@ -100,6 +100,8 @@ public class MacOperatingSystemFFM extends MacOperatingSystem {
         return WhoFFM.queryUtxent();
     }
 
+    // numberOfProcesses is a live process count (thousands at most), can't overflow int when scaled by INT_SIZE
+    @SuppressWarnings("NarrowCalculation")
     @Override
     public List<OSProcess> queryAllProcesses() {
         return callInArenaOrDefault(arena -> {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -336,7 +336,7 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
                     if (envSize > 0 && envSize < Integer.MAX_VALUE) {
                         MemorySegment envAddress = upp.get(ADDRESS, UPP_ENVIRONMENT_OFFSET);
                         if (envAddress.address() != 0) {
-                            MemorySegment envBuffer = arena.allocate((int) envSize);
+                            MemorySegment envBuffer = arena.allocate(envSize);
                             if (Kernel32FFM.ReadProcessMemory(h.get(), envAddress, envBuffer, envSize, bytesRead)
                                     && bytesRead.get(JAVA_LONG, 0) > 0) {
                                 char[] env = new char[(int) (envSize / 2)];

--- a/oshi-core-ffm/src/test/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFMLegacyTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFMLegacyTest.java
@@ -63,6 +63,6 @@ class WindowsCentralProcessorFFMLegacyTest {
         long modernTotal = LongStream.of(modern).sum();
         assertThat("legacy total ticks", legacyTotal, greaterThan(0L));
         // Both measure cumulative CPU time since boot; a generous tolerance catches a rotted binding without flaking
-        assertThat((double) legacyTotal, closeTo(modernTotal, modernTotal * 0.5));
+        assertThat((double) legacyTotal, closeTo((double) modernTotal, modernTotal * 0.5));
     }
 }

--- a/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
@@ -101,16 +101,17 @@ public final class LogicalProcessorInformation {
         // for consistent use across the API. Here we sort so core, cache, and package
         // numbers increment consistently with processor numbers/bitmasks, ordered in
         // processor groups.
-        cores.sort(Comparator.comparing(c -> c.group * 64L + Long.numberOfTrailingZeros(c.mask.longValue())));
+        cores.sort(Comparator.comparingLong(c -> c.group * 64L + Long.numberOfTrailingZeros(c.mask.longValue())));
 
         // if package in multiple groups will still use first group for sorting
-        packages.sort(Comparator.comparing(p -> p[0].group * 64L + Long.numberOfTrailingZeros(p[0].mask.longValue())));
+        packages.sort(
+                Comparator.comparingLong(p -> p[0].group * 64L + Long.numberOfTrailingZeros(p[0].mask.longValue())));
 
         // Iterate Logical Processors and use bitmasks to match packages, cores,
         // and NUMA nodes. Perfmon instances are numa node + processor number, so we
         // iterate by numa node so the returned list will properly index perfcounter
         // numa/proc-per-numa indices with all numa nodes grouped together
-        numaNodes.sort(Comparator.comparing(n -> n.nodeNumber));
+        numaNodes.sort(Comparator.comparingInt(n -> n.nodeNumber));
 
         // Fetch the processorIDs from WMI
         Map<Integer, String> processorIdMap = new HashMap<>();

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/dragonflybsd/DragonFlyBsdCentralProcessorJNA.java
@@ -43,6 +43,8 @@ public class DragonFlyBsdCentralProcessorJNA extends FreeBsdCentralProcessorJNA 
         return ticks;
     }
 
+    // CP_* constants are 0-4 and UINT64_SIZE is 8, so these products can't overflow int
+    @SuppressWarnings("NarrowCalculation")
     @Override
     public long[][] queryProcessorCpuLoadTicks() {
         long[][] ticks = new long[getLogicalProcessorCount()][CentralProcessor.TickType.values().length];

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
@@ -41,6 +41,8 @@ import oshi.util.Constants;
 public final class WindowsPowerSourceJNA extends WindowsPowerSource {
 
     private static final GUID GUID_DEVCLASS_BATTERY = GUID.fromString("{72631E54-78A4-11D0-BCF7-00AA00B7B32A}");
+    // == is intentional: DEFAULT is JNA's own reference to one of the UNICODE/ASCII singleton constants
+    @SuppressWarnings("ReferenceEquality")
     private static final int CHAR_WIDTH = W32APITypeMapper.DEFAULT == W32APITypeMapper.UNICODE ? 2 : 1;
     private static final boolean X64 = Platform.is64Bit();
 

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
@@ -183,7 +183,7 @@ public class MacOSProcessJNA extends MacOSProcess {
             this.bitness = (taskAllInfo.pbsd.pbi_flags & P_LP64) == 0 ? 32 : 64;
             this.majorFaults = taskAllInfo.ptinfo.pti_pageins;
             // testing using getrusage confirms pti_faults includes both major and minor
-            this.minorFaults = taskAllInfo.ptinfo.pti_faults - taskAllInfo.ptinfo.pti_pageins; // NOSONAR java:S2184
+            this.minorFaults = taskAllInfo.ptinfo.pti_faults - this.majorFaults; // NOSONAR java:S2184
             // getrusage(RUSAGE_SELF) aggregates across all threads for current process
             if (getProcessID() == this.os.getProcessId()) {
                 SystemB.Rusage rusage = new SystemB.Rusage();

--- a/oshi-core/src/test/java/oshi/hardware/platform/windows/WindowsCentralProcessorLegacyTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/windows/WindowsCentralProcessorLegacyTest.java
@@ -63,6 +63,6 @@ class WindowsCentralProcessorLegacyTest {
         long modernTotal = LongStream.of(modern).sum();
         assertThat("legacy total ticks", legacyTotal, greaterThan(0L));
         // Both measure cumulative CPU time since boot; a generous tolerance catches a rotted binding without flaking
-        assertThat((double) legacyTotal, closeTo(modernTotal, modernTotal * 0.5));
+        assertThat((double) legacyTotal, closeTo((double) modernTotal, modernTotal * 0.5));
     }
 }

--- a/oshi-demo/src/main/java/oshi/demo/OshiGui.java
+++ b/oshi-demo/src/main/java/oshi/demo/OshiGui.java
@@ -83,6 +83,8 @@ public class OshiGui {
         menuBar.add(getJMenu("Network", 'N', "Network Params and Interfaces", new InterfacePanel(si)));
     }
 
+    // != is intentional: checks whether this exact panel instance is already displayed
+    @SuppressWarnings("ReferenceEquality")
     private JButton getJMenu(String title, char mnemonic, String toolTip, OshiJPanel panel) {
         JButton button = new JButton(title);
         button.setMnemonic(mnemonic);

--- a/oshi-demo/src/main/java/oshi/demo/gui/FileStorePanel.java
+++ b/oshi-demo/src/main/java/oshi/demo/gui/FileStorePanel.java
@@ -112,7 +112,7 @@ public class FileStorePanel extends OshiJPanel { // NOSONAR java:S110
                     "Available: " + FormatUtil.formatBytes(usable) + "/" + FormatUtil.formatBytes(total)));
             fsCharts[i].setSubtitles(subtitles);
             fsData[i].setValue(USED, (double) total - usable);
-            fsData[i].setValue(AVAILABLE, usable);
+            fsData[i].setValue(AVAILABLE, (double) usable);
             i++;
         }
         return true;

--- a/oshi-demo/src/main/java/oshi/demo/gui/MemoryPanel.java
+++ b/oshi-demo/src/main/java/oshi/demo/gui/MemoryPanel.java
@@ -120,10 +120,10 @@ public class MemoryPanel extends OshiJPanel { // NOSONAR java:S110
     private static void updateDatasets(GlobalMemory memory, DefaultPieDataset<String> physMemData,
             DefaultPieDataset<String> virtMemData) {
         physMemData.setValue(USED, (double) memory.getTotal() - memory.getAvailable());
-        physMemData.setValue(AVAILABLE, memory.getAvailable());
+        physMemData.setValue(AVAILABLE, (double) memory.getAvailable());
 
         VirtualMemory virtualMemory = memory.getVirtualMemory();
-        virtMemData.setValue(USED, virtualMemory.getSwapUsed());
+        virtMemData.setValue(USED, (double) virtualMemory.getSwapUsed());
         virtMemData.setValue(AVAILABLE, (double) virtualMemory.getSwapTotal() - virtualMemory.getSwapUsed());
     }
 


### PR DESCRIPTION
## Summary

Per-category breakdown:

- **ReferenceEquality (4):** all intentional; verified and suppressed with justification. Two are test assertions checking whether a memoized supplier returned the same cached `Set` instance. One is `W32APITypeMapper.DEFAULT == W32APITypeMapper.UNICODE` in `WindowsPowerSourceJNA` — confirmed against JNA's own source that `DEFAULT` is a direct reference to one of the `UNICODE`/`ASCII` singleton constants, so `==` is exactly JNA's documented idiom. One is a Swing `Component` identity check in the demo GUI (`contentPane.getComponent(0) != panel`) — checking whether this exact panel instance is already displayed, not a value comparison.
- **BoxingComparator (8):** `Comparator.comparing(...)` with an `int`/`long`-returning key extractor was boxing unnecessarily on every comparison. Switched to `comparingInt`/`comparingLong` in `Lspv`, `AbstractCentralProcessor.orderedProcCaches`, and both `LogicalProcessorInformation`/`LogicalProcessorInformationFFM` twins.
- **NarrowCalculation (9):** all false positives — every flagged product involves small, OS-bounded quantities (open-file-descriptor counts, process counts, tiny fixed struct-offset constants like `CP_USER * UINT64_SIZE` where both operands are ≤8) that cannot realistically approach `int` overflow. Suppressed with the specific bound documented at each site rather than guessed at generically.
- **LongDoubleConversion (5) / IntLiteralCast (3):** missing explicit casts on intentional `long`→`double` widening (test tolerance comparisons, demo GUI chart values) and `int`-literal-cast-to-`long` in a test; made the cast explicit or replaced with a typed literal (`0L` instead of `(long) 0`). No behavior change.
- **UnnecessaryLongToIntConversion (4):** removed pointless `(int)` casts on `long` values immediately passed to a `long`-typed parameter (`MemorySegment.get`'s offset, `Arena.allocate`'s size) — the narrowing served no purpose and the widen-back was implicit anyway.
- **IntLongMath (1):** `MacOSProcessJNA.updateAttributes` computed `pti_faults - pti_pageins` in `int` arithmetic (both are native `int32_t` struct fields) before assigning to the `long minorFaults` field. Its FFM twin already avoids this shape by subtracting from `this.majorFaults` (already `long`) instead of re-reading the raw `int` field — changed JNA to match, which removes the pattern entirely rather than suppressing it.

## Test plan
- [x] `./mvnw clean install -Perror-prone -DskipTests`: 0 ERROR; `ReferenceEquality`/`BoxingComparator`/`NarrowCalculation`/`LongDoubleConversion`/`UnnecessaryLongToIntConversion`/`IntLiteralCast`/`IntLongMath` all → 0
- [x] `./mvnw -pl oshi-common,oshi-core,oshi-core-ffm -am test`: 0 tests failed
- [x] `./mvnw checkstyle:check`, `forbiddenapis:check`, `clean compile javadoc:javadoc`: all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric sorting for partitions, processor information, caches, and NUMA data.
  * Corrected macOS process minor-fault reporting.
  * Preserved large Windows environment sizes without narrowing values.
  * Improved consistency of CPU statistics comparisons across legacy and modern implementations.

* **Improvements**
  * Improved accuracy and reliability of memory, swap, storage, and processor data displayed in the demo interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->