### PR TITLE
Fix Error Prone BadImport findings for ProcessorCache.Type

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.ExceptionUtil;
 import oshi.util.ExecutingCommand;
@@ -400,7 +399,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
         try (Stream<Path> path = Files.list(Paths.get(cachePath))) {
             path.filter(p -> p.toString().startsWith(indexPrefix)).forEach(c -> {
                 int level = FileUtil.getIntFromFile(c + "/level"); // 1
-                Type type = parseCacheType(FileUtil.getStringFromFile(c + "/type")); // Data
+                ProcessorCache.Type type = parseCacheType(FileUtil.getStringFromFile(c + "/type")); // Data
                 int associativity = FileUtil.getIntFromFile(c + "/ways_of_associativity"); // 8
                 int lineSize = FileUtil.getIntFromFile(c + "/coherency_line_size"); // 64
                 long size = ParseUtil.parseDecimalMemorySizeToBinary(FileUtil.getStringFromFile(c + "/size")); // 32K
@@ -501,7 +500,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     static Set<ProcessorCache> mapCachesFromLscpu(List<String> lscpu) {
         Set<ProcessorCache> caches = new HashSet<>();
         int level = 0;
-        Type type = null;
+        ProcessorCache.Type type = null;
         int associativity = 0;
         int lineSize = 0;
         long size = 0L;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.ExecutingCommand;
 import oshi.util.FormatUtil;
@@ -517,19 +516,19 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
         for (int i = 0; i < perflevels; i++) {
             int size = sysctlIntNoWarn("hw.perflevel" + i + ".l1icachesize", 0);
             if (size > 0) {
-                caches.add(new ProcessorCache(1, l1associativity, linesize, size, Type.INSTRUCTION));
+                caches.add(new ProcessorCache(1, l1associativity, linesize, size, ProcessorCache.Type.INSTRUCTION));
             }
             size = sysctlIntNoWarn("hw.perflevel" + i + ".l1dcachesize", 0);
             if (size > 0) {
-                caches.add(new ProcessorCache(1, l1associativity, linesize, size, Type.DATA));
+                caches.add(new ProcessorCache(1, l1associativity, linesize, size, ProcessorCache.Type.DATA));
             }
             size = sysctlIntNoWarn("hw.perflevel" + i + ".l2cachesize", 0);
             if (size > 0) {
-                caches.add(new ProcessorCache(2, l2associativity, linesize, size, Type.UNIFIED));
+                caches.add(new ProcessorCache(2, l2associativity, linesize, size, ProcessorCache.Type.UNIFIED));
             }
             size = sysctlIntNoWarn("hw.perflevel" + i + ".l3cachesize", 0);
             if (size > 0) {
-                caches.add(new ProcessorCache(3, 0, linesize, size, Type.UNIFIED));
+                caches.add(new ProcessorCache(3, 0, linesize, size, ProcessorCache.Type.UNIFIED));
             }
         }
         return caches;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
@@ -18,7 +18,6 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -170,15 +169,15 @@ public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
                 case "I-cache":
                     return new ProcessorCache(1, ParseUtil.getFirstIntValue(split[2]),
                             ParseUtil.getFirstIntValue(split[1]), ParseUtil.parseDecimalMemorySizeToBinary(split[0]),
-                            Type.INSTRUCTION);
+                            ProcessorCache.Type.INSTRUCTION);
                 case "D-cache":
                     return new ProcessorCache(1, ParseUtil.getFirstIntValue(split[2]),
                             ParseUtil.getFirstIntValue(split[1]), ParseUtil.parseDecimalMemorySizeToBinary(split[0]),
-                            Type.DATA);
+                            ProcessorCache.Type.DATA);
                 default:
                     return new ProcessorCache(ParseUtil.getFirstIntValue(split[3]),
                             ParseUtil.getFirstIntValue(split[2]), ParseUtil.getFirstIntValue(split[1]),
-                            ParseUtil.parseDecimalMemorySizeToBinary(split[0]), Type.UNIFIED);
+                            ParseUtil.parseDecimalMemorySizeToBinary(split[0]), ProcessorCache.Type.UNIFIED);
             }
         }
         return null;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.aix.Lssrad;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.Constants;
 import oshi.util.ExecutingCommand;
@@ -178,23 +177,23 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
         List<ProcessorCache> caches = new ArrayList<>();
         switch (powerVersion) {
             case 7:
-                caches.add(new ProcessorCache(3, 8, 128, (2 * 32) << 20, Type.UNIFIED));
-                caches.add(new ProcessorCache(2, 8, 128, 256 << 10, Type.UNIFIED));
-                caches.add(new ProcessorCache(1, 8, 128, 32 << 10, Type.DATA));
-                caches.add(new ProcessorCache(1, 4, 128, 32 << 10, Type.INSTRUCTION));
+                caches.add(new ProcessorCache(3, 8, 128, (2 * 32) << 20, ProcessorCache.Type.UNIFIED));
+                caches.add(new ProcessorCache(2, 8, 128, 256 << 10, ProcessorCache.Type.UNIFIED));
+                caches.add(new ProcessorCache(1, 8, 128, 32 << 10, ProcessorCache.Type.DATA));
+                caches.add(new ProcessorCache(1, 4, 128, 32 << 10, ProcessorCache.Type.INSTRUCTION));
                 break;
             case 8:
-                caches.add(new ProcessorCache(4, 8, 128, (16 * 16) << 20, Type.UNIFIED));
-                caches.add(new ProcessorCache(3, 8, 128, 40 << 20, Type.UNIFIED));
-                caches.add(new ProcessorCache(2, 8, 128, 512 << 10, Type.UNIFIED));
-                caches.add(new ProcessorCache(1, 8, 128, 64 << 10, Type.DATA));
-                caches.add(new ProcessorCache(1, 8, 128, 32 << 10, Type.INSTRUCTION));
+                caches.add(new ProcessorCache(4, 8, 128, (16 * 16) << 20, ProcessorCache.Type.UNIFIED));
+                caches.add(new ProcessorCache(3, 8, 128, 40 << 20, ProcessorCache.Type.UNIFIED));
+                caches.add(new ProcessorCache(2, 8, 128, 512 << 10, ProcessorCache.Type.UNIFIED));
+                caches.add(new ProcessorCache(1, 8, 128, 64 << 10, ProcessorCache.Type.DATA));
+                caches.add(new ProcessorCache(1, 8, 128, 32 << 10, ProcessorCache.Type.INSTRUCTION));
                 break;
             case 9:
-                caches.add(new ProcessorCache(3, 20, 128, (cores * 10) << 20, Type.UNIFIED));
-                caches.add(new ProcessorCache(2, 8, 128, 512 << 10, Type.UNIFIED));
-                caches.add(new ProcessorCache(1, 8, 128, 32 << 10, Type.DATA));
-                caches.add(new ProcessorCache(1, 8, 128, 32 << 10, Type.INSTRUCTION));
+                caches.add(new ProcessorCache(3, 20, 128, (cores * 10) << 20, ProcessorCache.Type.UNIFIED));
+                caches.add(new ProcessorCache(2, 8, 128, 512 << 10, ProcessorCache.Type.UNIFIED));
+                caches.add(new ProcessorCache(1, 8, 128, 32 << 10, ProcessorCache.Type.DATA));
+                caches.add(new ProcessorCache(1, 8, 128, 32 << 10, ProcessorCache.Type.INSTRUCTION));
                 break;
             default:
                 // Don't guess

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
@@ -327,17 +326,20 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
         for (String checkLine : lscpu) {
             if (checkLine.contains("L1d cache:")) {
                 caches.add(new ProcessorCache(1, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()), Type.DATA));
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()),
+                        ProcessorCache.Type.DATA));
             } else if (checkLine.contains("L1i cache:")) {
                 caches.add(new ProcessorCache(1, 0, 0,
                         ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()),
-                        Type.INSTRUCTION));
+                        ProcessorCache.Type.INSTRUCTION));
             } else if (checkLine.contains("L2 cache:")) {
                 caches.add(new ProcessorCache(2, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()), Type.UNIFIED));
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()),
+                        ProcessorCache.Type.UNIFIED));
             } else if (checkLine.contains("L3 cache:")) {
                 caches.add(new ProcessorCache(3, 0, 0,
-                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()), Type.UNIFIED));
+                        ParseUtil.parseDecimalMemorySizeToBinary(checkLine.split(":", -1)[1].trim()),
+                        ProcessorCache.Type.UNIFIED));
             }
         }
         return orderedProcCaches(caches);

--- a/oshi-common/src/test/java/oshi/hardware/CentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/CentralProcessorTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import oshi.hardware.CentralProcessor.LogicalProcessor;
 import oshi.hardware.CentralProcessor.PhysicalProcessor;
 import oshi.hardware.CentralProcessor.ProcessorCache;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.CentralProcessor.ProcessorIdentifier;
 import oshi.hardware.CentralProcessor.TickType;
 import oshi.util.Constants;
@@ -65,20 +64,20 @@ class CentralProcessorTest {
 
     @Test
     void testProcessorCacheGetters() {
-        ProcessorCache cache = new ProcessorCache(2, 8, 64, 262144, Type.UNIFIED);
+        ProcessorCache cache = new ProcessorCache(2, 8, 64, 262144, ProcessorCache.Type.UNIFIED);
         assertThat(cache.getLevel(), is((byte) 2));
         assertThat(cache.getAssociativity(), is((byte) 8));
         assertThat(cache.getLineSize(), is((short) 64));
         assertThat(cache.getCacheSize(), is(262144));
-        assertThat(cache.getType(), is(Type.UNIFIED));
+        assertThat(cache.getType(), is(ProcessorCache.Type.UNIFIED));
         assertThat(cache.toString(), containsString("L2"));
     }
 
     @Test
     void testProcessorCacheEqualsAndHashCode() {
-        ProcessorCache a = new ProcessorCache(1, 4, 64, 32768, Type.DATA);
-        ProcessorCache b = new ProcessorCache(1, 4, 64, 32768, Type.DATA);
-        ProcessorCache c = new ProcessorCache(1, 4, 64, 32768, Type.INSTRUCTION);
+        ProcessorCache a = new ProcessorCache(1, 4, 64, 32768, ProcessorCache.Type.DATA);
+        ProcessorCache b = new ProcessorCache(1, 4, 64, 32768, ProcessorCache.Type.DATA);
+        ProcessorCache c = new ProcessorCache(1, 4, 64, 32768, ProcessorCache.Type.INSTRUCTION);
         assertThat(a, is(b));
         assertThat(a.hashCode(), is(b.hashCode()));
         assertThat(a, is(not(c)));
@@ -88,10 +87,10 @@ class CentralProcessorTest {
 
     @Test
     void testProcessorCacheTypeToString() {
-        assertThat(Type.UNIFIED.toString(), is("Unified"));
-        assertThat(Type.INSTRUCTION.toString(), is("Instruction"));
-        assertThat(Type.DATA.toString(), is("Data"));
-        assertThat(Type.TRACE.toString(), is("Trace"));
+        assertThat(ProcessorCache.Type.UNIFIED.toString(), is("Unified"));
+        assertThat(ProcessorCache.Type.INSTRUCTION.toString(), is("Instruction"));
+        assertThat(ProcessorCache.Type.DATA.toString(), is("Data"));
+        assertThat(ProcessorCache.Type.TRACE.toString(), is("Trace"));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractCentralProcessorTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import oshi.hardware.CentralProcessor.LogicalProcessor;
 import oshi.hardware.CentralProcessor.PhysicalProcessor;
 import oshi.hardware.CentralProcessor.ProcessorCache;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.CentralProcessor.ProcessorIdentifier;
 import oshi.hardware.CentralProcessor.TickType;
 import oshi.util.ParseUtil;
@@ -154,12 +153,12 @@ class AbstractCentralProcessorTest {
         // of the same level+type have different sizes but the same highestOneBit,
         // producing sort key ties (e.g., 131072 and 196608 both -> highestOneBit 131072)
         Set<ProcessorCache> caches = new HashSet<>();
-        ProcessorCache l2p = new ProcessorCache(2, 0, 128, 16777216, Type.UNIFIED);
-        ProcessorCache l2e = new ProcessorCache(2, 0, 128, 25165824, Type.UNIFIED);
-        ProcessorCache l1ip = new ProcessorCache(1, 0, 128, 131072, Type.INSTRUCTION);
-        ProcessorCache l1ie = new ProcessorCache(1, 0, 128, 196608, Type.INSTRUCTION);
-        ProcessorCache l1dp = new ProcessorCache(1, 0, 128, 131072, Type.DATA);
-        ProcessorCache l1de = new ProcessorCache(1, 0, 128, 196608, Type.DATA);
+        ProcessorCache l2p = new ProcessorCache(2, 0, 128, 16777216, ProcessorCache.Type.UNIFIED);
+        ProcessorCache l2e = new ProcessorCache(2, 0, 128, 25165824, ProcessorCache.Type.UNIFIED);
+        ProcessorCache l1ip = new ProcessorCache(1, 0, 128, 131072, ProcessorCache.Type.INSTRUCTION);
+        ProcessorCache l1ie = new ProcessorCache(1, 0, 128, 196608, ProcessorCache.Type.INSTRUCTION);
+        ProcessorCache l1dp = new ProcessorCache(1, 0, 128, 131072, ProcessorCache.Type.DATA);
+        ProcessorCache l1de = new ProcessorCache(1, 0, 128, 196608, ProcessorCache.Type.DATA);
         caches.add(l2p);
         caches.add(l2e);
         caches.add(l1ip);
@@ -199,7 +198,7 @@ class AbstractCentralProcessorTest {
                         new PhysicalProcessor(0, 1, 1, "P-core"), new PhysicalProcessor(0, 2, 0, "E-core"),
                         new PhysicalProcessor(0, 3, 0, "E-core"));
                 List<ProcessorCache> caches = Collections
-                        .singletonList(new ProcessorCache(2, 0, 64, 4 * 1024 * 1024, Type.UNIFIED));
+                        .singletonList(new ProcessorCache(2, 0, 64, 4 * 1024 * 1024, ProcessorCache.Type.UNIFIED));
                 return new Quartet<>(logProcs, physProcs, caches, Arrays.asList("sse", "avx"));
             }
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdCentralProcessorTest.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import oshi.hardware.CentralProcessor.ProcessorCache;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.hardware.common.platform.unix.BsdCentralProcessor.DmesgStrings;
 import oshi.util.tuples.Pair;
 
@@ -107,7 +106,7 @@ class BsdCentralProcessorTest {
     void testParseCacheStrDCache() {
         ProcessorCache cache = BsdCentralProcessor.parseCacheStr("32KB 64b/line 8-way D-cache");
         assertThat(cache, is(not(nullValue())));
-        assertThat(cache.getType(), is(Type.DATA));
+        assertThat(cache.getType(), is(ProcessorCache.Type.DATA));
         assertThat(cache.getLevel(), is((byte) 1));
         assertThat(cache.getAssociativity(), is((byte) 8));
         assertThat(cache.getLineSize(), is((short) 64));
@@ -118,7 +117,7 @@ class BsdCentralProcessorTest {
     void testParseCacheStrICache() {
         ProcessorCache cache = BsdCentralProcessor.parseCacheStr("48KB 64b/line 3-way L1 PIPT I-cache");
         assertThat(cache, is(not(nullValue())));
-        assertThat(cache.getType(), is(Type.INSTRUCTION));
+        assertThat(cache.getType(), is(ProcessorCache.Type.INSTRUCTION));
         assertThat(cache.getLevel(), is((byte) 1));
         assertThat(cache.getAssociativity(), is((byte) 3));
     }
@@ -127,7 +126,7 @@ class BsdCentralProcessorTest {
     void testParseCacheStrL2Unified() {
         ProcessorCache cache = BsdCentralProcessor.parseCacheStr("4MB 64b/line 16-way L2 cache");
         assertThat(cache, is(not(nullValue())));
-        assertThat(cache.getType(), is(Type.UNIFIED));
+        assertThat(cache.getType(), is(ProcessorCache.Type.UNIFIED));
         assertThat(cache.getLevel(), is((byte) 2));
         assertThat(cache.getAssociativity(), is((byte) 16));
         assertThat(cache.getLineSize(), is((short) 64));
@@ -138,7 +137,7 @@ class BsdCentralProcessorTest {
     void testParseCacheStrL3Unified() {
         ProcessorCache cache = BsdCentralProcessor.parseCacheStr("24MB 64b/line 12-way L3 cache");
         assertThat(cache, is(not(nullValue())));
-        assertThat(cache.getType(), is(Type.UNIFIED));
+        assertThat(cache.getType(), is(ProcessorCache.Type.UNIFIED));
         assertThat(cache.getLevel(), is((byte) 3));
         assertThat(cache.getAssociativity(), is((byte) 12));
     }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/LogicalProcessorInformationFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/LogicalProcessorInformationFFM.java
@@ -29,7 +29,6 @@ import oshi.ffm.platform.windows.VersionHelpersFFM;
 import oshi.hardware.CentralProcessor.LogicalProcessor;
 import oshi.hardware.CentralProcessor.PhysicalProcessor;
 import oshi.hardware.CentralProcessor.ProcessorCache;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.util.tuples.Triplet;
 
 /**
@@ -186,8 +185,8 @@ public final class LogicalProcessorInformationFFM {
         int lineSize = Short.toUnsignedInt(buffer.get(ValueLayout.JAVA_SHORT, dataOffset + 2));
         int cacheSize = buffer.get(ValueLayout.JAVA_INT, dataOffset + 4);
         int type = buffer.get(ValueLayout.JAVA_INT, dataOffset + 8);
-        Type[] types = Type.values();
-        Type cacheType = (type >= 0 && type < types.length) ? types[type] : Type.UNIFIED;
+        ProcessorCache.Type[] types = ProcessorCache.Type.values();
+        ProcessorCache.Type cacheType = (type >= 0 && type < types.length) ? types[type] : ProcessorCache.Type.UNIFIED;
         caches.add(new ProcessorCache(level, associativity, lineSize, cacheSize, cacheType));
     }
 

--- a/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
@@ -34,7 +34,6 @@ import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.hardware.CentralProcessor.LogicalProcessor;
 import oshi.hardware.CentralProcessor.PhysicalProcessor;
 import oshi.hardware.CentralProcessor.ProcessorCache;
-import oshi.hardware.CentralProcessor.ProcessorCache.Type;
 import oshi.util.platform.windows.WmiQueryExecutorJNA;
 import oshi.util.tuples.Triplet;
 
@@ -76,8 +75,9 @@ public final class LogicalProcessorInformation {
                     break;
                 case LOGICAL_PROCESSOR_RELATIONSHIP.RelationCache:
                     CACHE_RELATIONSHIP cache = (CACHE_RELATIONSHIP) info;
-                    Type[] types = Type.values();
-                    Type cacheType = cache.type >= 0 && cache.type < types.length ? types[cache.type] : Type.UNIFIED;
+                    ProcessorCache.Type[] types = ProcessorCache.Type.values();
+                    ProcessorCache.Type cacheType = cache.type >= 0 && cache.type < types.length ? types[cache.type]
+                            : ProcessorCache.Type.UNIFIED;
                     caches.add(new ProcessorCache(cache.level, cache.associativity, cache.lineSize, cache.cacheSize,
                             cacheType));
                     break;


### PR DESCRIPTION
## Summary
All 10 `BadImport` findings were the same shape: `import oshi.hardware.CentralProcessor.ProcessorCache.Type;` — importing the nested `Type` enum directly instead of referencing it as `ProcessorCache.Type`. Error Prone flags this because `Type` is common enough that a reader can't tell which "Type" is meant without checking the import.

- `LinuxCentralProcessor`, `MacCentralProcessor`, `AixCentralProcessor`, `BsdCentralProcessor`, `FreeBsdCentralProcessor`: removed the `Type` import and qualified the bare usages as `ProcessorCache.Type`. These didn't need a separate `ProcessorCache` import either — each already `extends AbstractCentralProcessor implements CentralProcessor`, so `ProcessorCache` (a nested type of `CentralProcessor`) is already inherited and visible unqualified, same as the existing unqualified `new ProcessorCache(...)` calls throughout these files.
- `LogicalProcessorInformation`/`LogicalProcessorInformationFFM`, and 3 tests (`CentralProcessorTest`, `AbstractCentralProcessorTest`, `BsdCentralProcessorTest`): these already imported `ProcessorCache` separately, so just dropped the redundant `Type` import and qualified usages.

Purely mechanical — no behavior change.

## Test plan
- [x] `./mvnw clean install -Perror-prone -DskipTests`: 0 ERROR, `BadImport` 10 → 0
- [x] `./mvnw -pl oshi-common,oshi-core,oshi-core-ffm -am test`: 0 tests failed
- [x] `./mvnw checkstyle:check`, `forbiddenapis:check`, `clean compile javadoc:javadoc`: all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized processor cache type references across supported platforms and Windows processing paths.
  * Preserved existing cache discovery, parsing, topology values, and fallback behavior.

* **Tests**
  * Updated cache-related tests to use the standardized type references.
  * No changes to public APIs or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->