### PR TITLE
Fix Error Prone bug-risk tail: ModifyCollectionInEnhancedForLoop, EqualsGetClass, DuplicateBranches, InconsistentCapitalization

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractLogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractLogicalVolumeGroup.java
@@ -5,6 +5,7 @@
 package oshi.hardware.common;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -29,10 +30,11 @@ public class AbstractLogicalVolumeGroup implements LogicalVolumeGroup {
      */
     protected AbstractLogicalVolumeGroup(String name, Map<String, Set<String>> lvMap, Set<String> pvSet) {
         this.name = name;
+        Map<String, Set<String>> unmodifiableValues = new HashMap<>();
         for (Entry<String, Set<String>> entry : lvMap.entrySet()) {
-            lvMap.put(entry.getKey(), Collections.unmodifiableSet(entry.getValue()));
+            unmodifiableValues.put(entry.getKey(), Collections.unmodifiableSet(entry.getValue()));
         }
-        this.lvMap = Collections.unmodifiableMap(lvMap);
+        this.lvMap = Collections.unmodifiableMap(unmodifiableValues);
         this.pvSet = Collections.unmodifiableSet(pvSet);
     }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
@@ -117,26 +117,26 @@ final class LinuxFirmware extends AbstractFirmware {
     /**
      * Parse vcgencmd version output for Raspberry Pi firmware info.
      *
-     * @param vcgencmd output of {@code vcgencmd version}
+     * @param output output of {@code vcgencmd version}
      * @return parsed firmware strings
      */
-    static VcGenCmdStrings queryVcGenCmd(List<String> vcgencmd) {
+    static VcGenCmdStrings queryVcGenCmd(List<String> output) {
         String vcReleaseDate = null;
         String vcManufacturer = null;
         String vcVersion = null;
 
-        if (vcgencmd.size() >= 3) {
+        if (output.size() >= 3) {
             // First line is date
             vcReleaseDate = ExceptionUtil.getOrDefault(
-                    () -> DateTimeFormatter.ISO_LOCAL_DATE.format(VCGEN_FORMATTER.parse(vcgencmd.get(0))),
+                    () -> DateTimeFormatter.ISO_LOCAL_DATE.format(VCGEN_FORMATTER.parse(output.get(0))),
                     Constants.UNKNOWN);
             // Second line is copyright
-            String[] copyright = ParseUtil.whitespaces.split(vcgencmd.get(1).trim(), -1);
+            String[] copyright = ParseUtil.whitespaces.split(output.get(1).trim(), -1);
             vcManufacturer = copyright.length > 0 && !copyright[copyright.length - 1].isEmpty()
                     ? copyright[copyright.length - 1]
                     : Constants.UNKNOWN;
             // Third line is version
-            vcVersion = vcgencmd.get(2).replace("version ", "");
+            vcVersion = output.get(2).replace("version ", "");
             return new VcGenCmdStrings(vcReleaseDate, vcManufacturer, vcVersion, "RPi", "Bootloader");
         }
         return new VcGenCmdStrings(null, null, null, null, null);

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
@@ -70,9 +70,9 @@ public abstract class MacOperatingSystem extends AbstractOperatingSystem {
     /**
      * Creates a MacOperatingSystem.
      *
-     * @param maxproc the maximum number of processes
+     * @param maxProc the maximum number of processes
      */
-    protected MacOperatingSystem(int maxproc) {
+    protected MacOperatingSystem(int maxProc) {
         String version = System.getProperty("os.version");
         int verMajor = ParseUtil.getFirstIntValue(version);
         int verMinor = ParseUtil.getNthIntValue(version, 2);
@@ -86,7 +86,7 @@ public abstract class MacOperatingSystem extends AbstractOperatingSystem {
         this.osXVersion = version;
         this.major = verMajor;
         this.minor = verMinor;
-        this.maxProc = maxproc;
+        this.maxProc = maxProc;
     }
 
     static String resolveVersion(String osVersion, String swVersOutput) {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/CoreFoundation.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/CoreFoundation.java
@@ -153,7 +153,7 @@ public interface CoreFoundation {
             if (this == o) {
                 return true;
             }
-            if (o == null || getClass() != o.getClass()) {
+            if (!(o instanceof CFTypeRef)) {
                 return false;
             }
             CFTypeRef cfTypeRef = (CFTypeRef) o;

--- a/oshi-core-ffm/src/test/java/oshi/ffm/platform/mac/CoreFoundationTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/platform/mac/CoreFoundationTest.java
@@ -76,6 +76,12 @@ class CoreFoundationTest {
             assertThat(str1.equals(str3), is(false));
             assertThat(str1.equals(null), is(false));
             assertThat(str1.equals(str1), is(true));
+            // A base-typed wrapper around the same segment compares equal in both directions. Not
+            // try-with-resources: str1 already owns release of the underlying native object.
+            var typeAlias = new CFTypeRef(str1.segment());
+            assertThat(typeAlias.equals(str1), is(true));
+            assertThat(str1.equals(typeAlias), is(true));
+            assertThat(typeAlias.hashCode(), is(str1.hashCode()));
             // Null refs are equal to each other
             var nullRef1 = new CFTypeRef(NULL);
             var nullRef2 = new CFTypeRef(NULL);

--- a/oshi-core-ffm/src/test/java/oshi/ffm/util/FileUtilFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/util/FileUtilFFMTest.java
@@ -46,14 +46,18 @@ class FileUtilFFMTest {
     @Test
     void testReadPointerFromBuffer() {
         ByteBuffer buff = ByteBuffer.allocate(8).order(ByteOrder.nativeOrder());
-        buff.putLong(0x0000_0000_DEAD_BEEFL);
+        // Non-zero high 32 bits so the 32-bit and 64-bit read paths produce distinguishable values
+        long written = 0x1234_5678_DEAD_BEEFL;
+        buff.putLong(written);
         buff.flip();
+        // Read the first 4 bytes the same way the 32-bit path does, so the expectation is endian-agnostic
+        long expected32Bit = Integer.toUnsignedLong(buff.duplicate().getInt());
         long value = FileUtilFFM.readPointerFromBuffer(buff);
         if (ForeignFunctions.NATIVE_POINTER_SIZE == 4) {
-            // 32-bit: reads 4 bytes as unsigned
-            assertEquals(0xDEAD_BEEFL, value);
+            // 32-bit: reads only the first 4 bytes, as unsigned
+            assertEquals(expected32Bit, value);
         } else {
-            assertEquals(0x0000_0000_DEAD_BEEFL, value);
+            assertEquals(written, value);
         }
     }
 


### PR DESCRIPTION
## Summary

- **`ModifyCollectionInEnhancedForLoop`** (`AbstractLogicalVolumeGroup`): the constructor called `lvMap.put(entry.getKey(), ...)` on an existing key while iterating `lvMap.entrySet()`. This happens to be safe today only because every current caller (`LinuxLogicalVolumeGroup`, `MacLogicalVolumeGroup`, `WindowsLogicalVolumeGroup`) passes a plain `HashMap`, where replacing an *existing* key's value isn't a structural modification and doesn't trip `ConcurrentModificationException`. Nothing in the constructor's `Map<String, Set<String>>` parameter type guarantees that, so a future caller passing a different `Map` implementation could break. Now builds a fresh map for the wrapped values instead of mutating the caller's map during iteration.
- **`EqualsGetClass`** (`CoreFoundation.CFTypeRef`): `equals()` used `getClass() != o.getClass()`. None of `CFTypeRef`'s ~9 subclasses (`CFStringRef`, `CFArrayRef`, `CFDictionaryRef`, etc.) add instance state beyond the inherited `MemorySegment`, so there's no equals-contract hazard from allowing cross-subtype comparison — but the `getClass()` check meant a `CFTypeRef`-typed reference and a `CFStringRef` wrapping the *same* native segment would never compare equal, even though `CFEqual` would say they're the same object. Switched to `instanceof`.
- **`DuplicateBranches`** (`FileUtilFFMTest`): `testReadPointerFromBuffer` wrote `0x0000_0000_DEAD_BEEFL` — a value with zero high 32 bits — so the 32-bit-path assertion (`0xDEAD_BEEFL`) and 64-bit-path assertion (`0x0000_0000_DEAD_BEEFL`) were numerically identical. The test passed but exercised nothing about the 32-bit read path specifically; a real bug there (wrong 4 bytes, wrong endianness handling) would have slipped through. Now writes a value with non-zero high bits and derives the 32-bit expectation from reading the buffer's first 4 bytes directly, so the test is correct regardless of native byte order.
- **`InconsistentCapitalization`** (`LinuxFirmware`, `MacOperatingSystem`): harmless (one's a `static` method parameter unrelated to an instance field it happens to resemble; the other is a completely ordinary constructor-parameter-to-field assignment) but needlessly confusing to a reader. Renamed rather than suppressed.

## Test plan
- [x] `./mvnw clean install -Perror-prone -DskipTests`: 0 ERROR; all 4 categories → 0
- [x] `./mvnw -pl oshi-common,oshi-core,oshi-core-ffm -am test`: 0 tests failed (including the corrected `FileUtilFFMTest`)
- [x] `./mvnw checkstyle:check`, `forbiddenapis:check`, `clean compile javadoc:javadoc`: all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logical volume group state handling to prevent unexpected changes to externally provided data.
  * Improved compatibility when comparing related macOS system references.
  * Strengthened pointer value handling on 64-bit systems for more accurate results.

* **Tests**
  * Expanded platform-specific validation for full-width pointer values and native byte ordering.

* **Maintenance**
  * Clarified internal naming and documentation without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->