### PR TITLE
Fix remaining Error Prone findings: API-shape + mechanical cleanup

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -291,11 +291,14 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
         SSE2(58, "sse2"), SS(59, "ss"), HTT(60, "htt", "ht"), TM(61, "tm"), IA64(62, "ia64"), PBE(63, "pbe");
 
         private final int bit;
-        private final String[] names;
+        // List is flagged as mutable on its face, but this field is final and always assigned an
+        // unmodifiableList in the constructor below, never reassigned.
+        @SuppressWarnings("ImmutableEnumChecker")
+        private final List<String> names;
 
         CpuidFeature(int bit, String... names) {
             this.bit = bit;
-            this.names = names;
+            this.names = Collections.unmodifiableList(Arrays.asList(names));
         }
     }
 
@@ -392,7 +395,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
                 // High-efficiency CPU (LITTLE): Cortex-A53, Cortex-A55
                 if (isHybrid && ((idStr.startsWith("ARM Cortex") && ParseUtil.getFirstIntValue(idStr) >= 70)
                         || (idStr.startsWith("Apple")
-                                && (idStr.contains("Firestorm") || (idStr.contains("Avalanche")))))) {
+                                && (idStr.contains("Firestorm") || idStr.contains("Avalanche"))))) {
                     efficiency = 1;
                 }
                 physProcs.add(new PhysicalProcessor(pkgId, coreId, efficiency, idStr));

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
@@ -342,7 +342,7 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
         /** Time spent doing I/Os in milliseconds. */
         ACTIVE_MS(9);
 
-        private int order;
+        private final int order;
 
         /**
          * Gets the field order index.

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -478,7 +478,7 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
 
         private final int order;
 
-        public int getOrder() {
+        int getOrder() {
             return this.order;
         }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSThread.java
@@ -131,7 +131,7 @@ public class LinuxOSThread extends AbstractOSThread {
             this.order = order;
         }
 
-        public int getOrder() {
+        int getOrder() {
             return this.order;
         }
     }

--- a/oshi-common/src/main/java/oshi/software/os/OperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/os/OperatingSystem.java
@@ -78,7 +78,14 @@ public interface OperatingSystem {
         /**
          * No sorting
          */
-        public static final Comparator<OSProcess> NO_SORTING = (p1, p2) -> 0;
+        public static final Comparator<OSProcess> NO_SORTING = ProcessSorting::noSorting;
+
+        // a no-op comparator is expected to ignore both arguments
+        @SuppressWarnings("UnusedVariable")
+        private static int noSorting(OSProcess p1, OSProcess p2) {
+            return 0;
+        }
+
         /**
          * Sort by decreasing cumulative CPU percentage
          */

--- a/oshi-common/src/test/java/oshi/driver/common/unix/bsd/disk/DisklabelTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/bsd/disk/DisklabelTest.java
@@ -37,8 +37,11 @@ import oshi.util.tuples.Quartet;
 class DisklabelTest {
 
     /** Returns deterministic (major,minor) without calling stat(1). */
-    private static final BiFunction<String, String, Pair<Integer, Integer>> ZERO_MAJOR_MINOR = (d, n) -> new Pair<>(0,
-            0);
+    private static final BiFunction<String, String, Pair<Integer, Integer>> ZERO_MAJOR_MINOR = DisklabelTest::zeroMajorMinor;
+
+    private static Pair<Integer, Integer> zeroMajorMinor(String device, String name) {
+        return new Pair<>(0, 0);
+    }
 
     @Test
     void testParseDiskParamsExtractsHeaderAndPartitions() {

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
@@ -33,7 +33,7 @@ class LinuxGraphicsCardTest {
      */
     private static class StubGraphicsCard extends LinuxGraphicsCard {
         StubGraphicsCard(String name, String deviceId, String vendor, String versionInfo, long vram,
-                         String drmDevicePath, String driverName, String pciBusId) {
+                String drmDevicePath, String driverName, String pciBusId) {
             super(name, deviceId, vendor, versionInfo, vram, drmDevicePath, driverName, pciBusId);
         }
     }
@@ -41,7 +41,7 @@ class LinuxGraphicsCardTest {
     @Test
     void testConstructorAndGetters() {
         StubGraphicsCard card = new StubGraphicsCard("RTX 4090", "0x2684", "NVIDIA", "Rev: 01", 24576L,
-            "/sys/class/drm/card0/device", "nvidia", "0000:01:00.0");
+                "/sys/class/drm/card0/device", "nvidia", "0000:01:00.0");
         assertThat(card.getName(), is("RTX 4090"));
         assertThat(card.getDeviceId(), is("0x2684"));
         assertThat(card.getVendor(), is("NVIDIA"));
@@ -55,7 +55,7 @@ class LinuxGraphicsCardTest {
     @Test
     void testAttrsConstructorAndGetters() {
         LinuxGraphicsCard.Attrs attrs = new LinuxGraphicsCard.Attrs("RX 7900", "0x744c", "AMD", "Rev: c1", 20480L,
-            "/sys/class/drm/card1/device", "amdgpu", "0000:03:00.0");
+                "/sys/class/drm/card1/device", "amdgpu", "0000:03:00.0");
         assertThat(attrs.getName(), is("RX 7900"));
         assertThat(attrs.getDeviceId(), is("0x744c"));
         assertThat(attrs.getVendor(), is("AMD"));
@@ -69,7 +69,7 @@ class LinuxGraphicsCardTest {
     @Test
     void testFindDrmInfoNonexistentPath(@TempDir Path tempDir) {
         Triplet<String, String, String> result = LinuxGraphicsCard.findDrmInfo("01:00.0",
-            tempDir.resolve("does-not-exist").toString());
+                tempDir.resolve("does-not-exist").toString());
         assertThat(result.getA(), is(""));
         assertThat(result.getB(), is(""));
         assertThat(result.getC(), is(""));
@@ -177,7 +177,7 @@ class LinuxGraphicsCardTest {
      * @throws IOException if file creation fails
      */
     private static void createCardWithDriver(Path drmDir, String cardName, String driverName, String slotName)
-        throws IOException {
+            throws IOException {
         Path deviceDir = drmDir.resolve(cardName + "/device");
         Files.createDirectories(deviceDir);
         // Create a fake driver target and symlink
@@ -194,22 +194,33 @@ class LinuxGraphicsCardTest {
 
     // Fixture: lspci -vnnmm output with one VGA card
     private static final List<String> LSPCI_VNNMM = Arrays.asList("Slot:\t01:00.0",
-        "Class:\tVGA compatible controller [0300]", "Vendor:\tNVIDIA Corporation [10de]",
-        "Device:\tGA102 [GeForce RTX 3090] [2204]", "SVendor:\tASUS [1043]",
-        "SDevice:\tGA102 [GeForce RTX 3090] [8687]", "Rev:\ta1", "");
+            "Class:\tVGA compatible controller [0300]", "Vendor:\tNVIDIA Corporation [10de]",
+            "Device:\tGA102 [GeForce RTX 3090] [2204]", "SVendor:\tASUS [1043]",
+            "SDevice:\tGA102 [GeForce RTX 3090] [8687]", "Rev:\ta1", "");
 
-    private static final Function<LinuxGraphicsCard.Attrs, GraphicsCard> STUB_FACTORY = attrs -> new StubGraphicsCard(
-        attrs.getName(), attrs.getDeviceId(), attrs.getVendor(), attrs.getVersionInfo(), attrs.getVram(),
-        attrs.getDrmDevicePath(), attrs.getDriverName(), attrs.getPciBusId());
+    private static final Function<LinuxGraphicsCard.Attrs, GraphicsCard> STUB_FACTORY = LinuxGraphicsCardTest::stubGraphicsCard;
+
+    private static GraphicsCard stubGraphicsCard(LinuxGraphicsCard.Attrs attrs) {
+        return new StubGraphicsCard(attrs.getName(), attrs.getDeviceId(), attrs.getVendor(), attrs.getVersionInfo(),
+                attrs.getVram(), attrs.getDrmDevicePath(), attrs.getDriverName(), attrs.getPciBusId());
+    }
 
     // No-op lookups for pure parsing tests
-    private static final ToLongFunction<String> NO_VRAM = slot -> 0L;
-    private static final Function<String, Triplet<String, String, String>> NO_DRM = slot -> new Triplet<>("", "", "");
+    private static final ToLongFunction<String> NO_VRAM = LinuxGraphicsCardTest::noVram;
+    private static final Function<String, Triplet<String, String, String>> NO_DRM = LinuxGraphicsCardTest::noDrm;
+
+    private static long noVram(String slot) {
+        return 0L;
+    }
+
+    private static Triplet<String, String, String> noDrm(String slot) {
+        return new Triplet<>("", "", "");
+    }
 
     @Test
     void testGetGraphicsCardsFromLspciSingleCard() {
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(LSPCI_VNNMM, STUB_FACTORY, NO_VRAM,
-            NO_DRM);
+                NO_DRM);
         assertThat(cards.size(), is(1));
         GraphicsCard card = cards.get(0);
         assertThat(card.getName(), is("GA102 [GeForce RTX 3090]"));
@@ -221,16 +232,16 @@ class LinuxGraphicsCardTest {
     @Test
     void testGetGraphicsCardsFromLspciEmpty() {
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(Collections.emptyList(), STUB_FACTORY,
-            NO_VRAM, NO_DRM);
+                NO_VRAM, NO_DRM);
         assertThat(cards, is(empty()));
     }
 
     @Test
     void testGetGraphicsCardsFromLspciTwoCards() {
         List<String> twoCards = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
-            "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1", "",
-            "Slot:\t00:02.0", "Class:\tVGA compatible controller [0300]", "Vendor:\tIntel Corporation [8086]",
-            "Device:\tUHD Graphics 630 [3E92]", "Rev:\t00", "");
+                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1", "",
+                "Slot:\t00:02.0", "Class:\tVGA compatible controller [0300]", "Vendor:\tIntel Corporation [8086]",
+                "Device:\tUHD Graphics 630 [3E92]", "Rev:\t00", "");
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(twoCards, STUB_FACTORY, NO_VRAM, NO_DRM);
         assertThat(cards.size(), is(2));
         assertThat(cards.get(0).getName(), is("GA102 [GeForce RTX 3090]"));
@@ -241,7 +252,7 @@ class LinuxGraphicsCardTest {
     @Test
     void testGetGraphicsCardsFromLspci3DController() {
         List<String> threeD = Arrays.asList("Slot:\t01:00.0", "Class:\t3D controller [0302]",
-            "Vendor:\tNVIDIA Corporation [10de]", "Device:\tTesla V100 [1db4]", "");
+                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tTesla V100 [1db4]", "");
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(threeD, STUB_FACTORY, NO_VRAM, NO_DRM);
         assertThat(cards.size(), is(1));
         assertThat(cards.get(0).getName(), is("Tesla V100"));
@@ -250,9 +261,9 @@ class LinuxGraphicsCardTest {
     @Test
     void testGetGraphicsCardsFromLspciPassesEachSlotToLookups() {
         List<String> twoCards = Arrays.asList("Slot:\t00:02.0", "Class:\tVGA compatible controller [0300]",
-            "Vendor:\tIntel Corporation [8086]", "Device:\tUHD Graphics 630 [3E92]", "Rev:\t00", "",
-            "Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]", "Vendor:\tNVIDIA Corporation [10de]",
-            "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1", "");
+                "Vendor:\tIntel Corporation [8086]", "Device:\tUHD Graphics 630 [3E92]", "Rev:\t00", "",
+                "Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]", "Vendor:\tNVIDIA Corporation [10de]",
+                "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1", "");
 
         List<String> drmSlots = new ArrayList<>();
         List<String> vramSlots = new ArrayList<>();
@@ -277,12 +288,12 @@ class LinuxGraphicsCardTest {
         // PCI class 0x0000 renders as "Non-VGA unclassified device", which contains "VGA"; 0x1180 is a signal
         // processing controller. Neither is a graphics card and neither may reach the DRM lookup.
         List<String> mixed = Arrays.asList("Slot:\t00:13.0", "Class:\tNon-VGA unclassified device [0000]",
-            "Vendor:\tIntel Corporation [8086]",
-            "Device:\t100 Series/C230 Series Chipset Family Integrated Sensor Hub [a135]", "Rev:\t31", "",
-            "Slot:\t00:11.0", "Class:\tSignal processing controller [1180]", "Vendor:\tIntel Corporation [8086]",
-            "Device:\tIntegrated Sensor Hub [a135]", "Rev:\t31", "", "Slot:\t01:00.0",
-            "Class:\tVGA compatible controller [0300]", "Vendor:\tNVIDIA Corporation [10de]",
-            "Device:\tGP107GL [Quadro P400] [1cb3]", "Rev:\ta1", "");
+                "Vendor:\tIntel Corporation [8086]",
+                "Device:\t100 Series/C230 Series Chipset Family Integrated Sensor Hub [a135]", "Rev:\t31", "",
+                "Slot:\t00:11.0", "Class:\tSignal processing controller [1180]", "Vendor:\tIntel Corporation [8086]",
+                "Device:\tIntegrated Sensor Hub [a135]", "Rev:\t31", "", "Slot:\t01:00.0",
+                "Class:\tVGA compatible controller [0300]", "Vendor:\tNVIDIA Corporation [10de]",
+                "Device:\tGP107GL [Quadro P400] [1cb3]", "Rev:\ta1", "");
         List<String> drmSlots = new ArrayList<>();
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(mixed, STUB_FACTORY, NO_VRAM, slot -> {
             drmSlots.add(slot);
@@ -315,9 +326,9 @@ class LinuxGraphicsCardTest {
     void testGetGraphicsCardsFromLspciNewRecordClearsPreviousCardState() {
         // The second card omits Vendor and Rev, so any value it reports for them would be leaked from the first card
         List<String> lspci = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
-            "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGP107GL [Quadro P400] [1cb3]", "Rev:\ta1", "",
-            "Slot:\t00:02.0", "Class:\tVGA compatible controller [0300]",
-            "Device:\tASPEED Graphics Family [2000]", "");
+                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGP107GL [Quadro P400] [1cb3]", "Rev:\ta1", "",
+                "Slot:\t00:02.0", "Class:\tVGA compatible controller [0300]", "Device:\tASPEED Graphics Family [2000]",
+                "");
         List<String> drmSlots = new ArrayList<>();
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(lspci, STUB_FACTORY, NO_VRAM, slot -> {
             drmSlots.add(slot);
@@ -339,7 +350,7 @@ class LinuxGraphicsCardTest {
     void testGetGraphicsCardsFromLspciValuelessClassLine() {
         // A "Class:" line with no value must not be treated as a display controller
         List<String> lspci = Arrays.asList("Slot:\t01:00.0", "Class:", "Vendor:\tNVIDIA Corporation [10de]",
-            "Device:\tGP107GL [Quadro P400] [1cb3]", "");
+                "Device:\tGP107GL [Quadro P400] [1cb3]", "");
         assertThat(LinuxGraphicsCard.getGraphicsCardsFromLspci(lspci, STUB_FACTORY, NO_VRAM, NO_DRM), is(empty()));
     }
 
@@ -350,9 +361,9 @@ class LinuxGraphicsCardTest {
     @Test
     void testQueryLspciMemorySize() {
         List<String> lspciV = Arrays.asList("01:00.0 VGA compatible controller: NVIDIA Corporation",
-            "\tMemory at f6000000 (32-bit, non-prefetchable) [size=16M]",
-            "\tMemory at e0000000 (64-bit, prefetchable) [size=256M]",
-            "\tMemory at f0000000 (64-bit, prefetchable) [size=32M]", "\tI/O ports at e000 [size=128]");
+                "\tMemory at f6000000 (32-bit, non-prefetchable) [size=16M]",
+                "\tMemory at e0000000 (64-bit, prefetchable) [size=256M]",
+                "\tMemory at f0000000 (64-bit, prefetchable) [size=32M]", "\tI/O ports at e000 [size=128]");
         long vram = LinuxGraphicsCard.queryLspciMemorySize(lspciV);
         // 256M + 32M = 288M
         assertThat(vram, is(256L * 1024 * 1024 + 32L * 1024 * 1024));
@@ -361,7 +372,7 @@ class LinuxGraphicsCardTest {
     @Test
     void testQueryLspciMemorySizeNoPrefetchable() {
         List<String> noPrefetch = Arrays.asList("01:00.0 VGA compatible controller: Intel",
-            "\tMemory at f6000000 (32-bit, non-prefetchable) [size=16M]");
+                "\tMemory at f6000000 (32-bit, non-prefetchable) [size=16M]");
         assertThat(LinuxGraphicsCard.queryLspciMemorySize(noPrefetch), is(0L));
     }
 
@@ -374,7 +385,7 @@ class LinuxGraphicsCardTest {
     void testGetGraphicsCardsFromLspciVendorWithoutBracket() {
         // A Vendor line whose value has no "[hex]" id does not parse as machine-readable; the raw text is used
         List<String> lspci = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
-            "Vendor:\tRedHat, Inc.", "Device:\tVirtio GPU [1050]", "");
+                "Vendor:\tRedHat, Inc.", "Device:\tVirtio GPU [1050]", "");
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(lspci, STUB_FACTORY, NO_VRAM, NO_DRM);
         assertThat(cards.size(), is(1));
         assertThat(cards.get(0).getVendor(), is("RedHat, Inc."));
@@ -385,7 +396,7 @@ class LinuxGraphicsCardTest {
     void testGetGraphicsCardsFromLspciNoTrailingBlankLine() {
         // Output that ends mid-card (no terminating blank line) still flushes the last card
         List<String> lspci = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
-            "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1");
+                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1");
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(lspci, STUB_FACTORY, NO_VRAM, NO_DRM);
         assertThat(cards.size(), is(1));
         assertThat(cards.get(0).getName(), is("GA102 [GeForce RTX 3090]"));
@@ -399,15 +410,15 @@ class LinuxGraphicsCardTest {
     // Fixture: `lshw -C display` output (real structure) with two display nodes. The second card has no bus info so
     // its DRM lookup is with a null slot; resources memory ranges drive the VRAM total.
     private static final List<String> LSHW = Arrays.asList("  *-display",
-        "       description: VGA compatible controller", "       product: GA102 [GeForce RTX 3090]",
-        "       vendor: NVIDIA Corporation", "       physical id: 0", "       bus info: pci@0000:01:00.0",
-        "       version: a1", "       width: 64 bits", "       clock: 33MHz",
-        "       capabilities: pm msi pciexpress vga_controller bus_master cap_list rom",
-        "       configuration: driver=nvidia latency=0",
-        "       resources: irq:178 memory:f6000000-f6ffffff memory:e0000000-efffffff", "  *-display",
-        "       description: VGA compatible controller", "       product: UHD Graphics 630",
-        "       vendor: Intel Corporation", "       physical id: 2",
-        "       resources: irq:24 memory:db000000-dbffffff");
+            "       description: VGA compatible controller", "       product: GA102 [GeForce RTX 3090]",
+            "       vendor: NVIDIA Corporation", "       physical id: 0", "       bus info: pci@0000:01:00.0",
+            "       version: a1", "       width: 64 bits", "       clock: 33MHz",
+            "       capabilities: pm msi pciexpress vga_controller bus_master cap_list rom",
+            "       configuration: driver=nvidia latency=0",
+            "       resources: irq:178 memory:f6000000-f6ffffff memory:e0000000-efffffff", "  *-display",
+            "       description: VGA compatible controller", "       product: UHD Graphics 630",
+            "       vendor: Intel Corporation", "       physical id: 2",
+            "       resources: irq:24 memory:db000000-dbffffff");
 
     @Test
     void testGetGraphicsCardsFromLshwTwoCards() {
@@ -432,6 +443,6 @@ class LinuxGraphicsCardTest {
     @Test
     void testGetGraphicsCardsFromLshwEmpty() {
         assertThat(LinuxGraphicsCard.getGraphicsCardsFromLshw(Collections.emptyList(), STUB_FACTORY, NO_DRM),
-            is(empty()));
+                is(empty()));
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGpuStatsTest.java
@@ -154,17 +154,18 @@ class MacGpuStatsTest {
 
     @Test
     void testUtilizationPrefersCoreThenDeviceThenSentinel() {
-        StubGpuStats withBoth = new StubGpuStats(false, "both card", nullFactory(),
+        StubGpuStats withBoth = new StubGpuStats(false, "both card", MacGpuStatsTest::nullSampler,
                 stats(CORE_UTIL, 0xFFFFFFFFL, DEVICE_UTIL, 17L), -1d);
         assertThat("core utilization wins", withBoth.getGpuUtilization(), is(closeTo(100d, 0.001d)));
 
-        StubGpuStats deviceOnly = new StubGpuStats(false, "device card", nullFactory(), stats(DEVICE_UTIL, 17L), -1d);
+        StubGpuStats deviceOnly = new StubGpuStats(false, "device card", MacGpuStatsTest::nullSampler,
+                stats(DEVICE_UTIL, 17L), -1d);
         assertThat("device utilization is used unscaled", deviceOnly.getGpuUtilization(), is(17d));
 
-        StubGpuStats neither = new StubGpuStats(false, "neither card", nullFactory(), stats(), -1d);
+        StubGpuStats neither = new StubGpuStats(false, "neither card", MacGpuStatsTest::nullSampler, stats(), -1d);
         assertThat("no key yields the sentinel", neither.getGpuUtilization(), is(-1d));
 
-        StubGpuStats unreadable = new StubGpuStats(false, "unreadable card", nullFactory(), null, -1d);
+        StubGpuStats unreadable = new StubGpuStats(false, "unreadable card", MacGpuStatsTest::nullSampler, null, -1d);
         assertThat("an unreadable dictionary yields the sentinel", unreadable.getGpuUtilization(), is(-1d));
     }
 
@@ -173,33 +174,39 @@ class MacGpuStatsTest {
         // Apple Silicon reports GPU memory as a share of unified memory under a different key than discrete VRAM.
         Map<String, Long> both = stats(VRAM_INTEL, 100L, VRAM_APPLE, 200L);
         assertThat("Apple Silicon prefers the unified memory key",
-                new StubGpuStats(true, "vram a", nullFactory(), both, -1d).getVramUsed(), is(200L));
+                new StubGpuStats(true, "vram a", MacGpuStatsTest::nullSampler, both, -1d).getVramUsed(), is(200L));
         assertThat("Intel prefers the discrete VRAM key",
-                new StubGpuStats(false, "vram b", nullFactory(), both, -1d).getVramUsed(), is(100L));
+                new StubGpuStats(false, "vram b", MacGpuStatsTest::nullSampler, both, -1d).getVramUsed(), is(100L));
 
         // Each key is the other's fallback.
         assertThat("Apple Silicon falls back to the discrete key",
-                new StubGpuStats(true, "vram c", nullFactory(), stats(VRAM_INTEL, 100L), -1d).getVramUsed(), is(100L));
+                new StubGpuStats(true, "vram c", MacGpuStatsTest::nullSampler, stats(VRAM_INTEL, 100L), -1d)
+                        .getVramUsed(),
+                is(100L));
         assertThat("Intel falls back to the unified key",
-                new StubGpuStats(false, "vram d", nullFactory(), stats(VRAM_APPLE, 200L), -1d).getVramUsed(), is(200L));
+                new StubGpuStats(false, "vram d", MacGpuStatsTest::nullSampler, stats(VRAM_APPLE, 200L), -1d)
+                        .getVramUsed(),
+                is(200L));
         assertThat("neither key yields the sentinel",
-                new StubGpuStats(false, "vram e", nullFactory(), stats(), -1d).getVramUsed(), is(-1L));
+                new StubGpuStats(false, "vram e", MacGpuStatsTest::nullSampler, stats(), -1d).getVramUsed(), is(-1L));
     }
 
     @Test
     void testTemperaturePrefersSmcOnAppleSilicon() {
-        StubGpuStats apple = new StubGpuStats(true, "smc card", nullFactory(), stats(TEMPERATURE, 55L), 61.5d);
+        StubGpuStats apple = new StubGpuStats(true, "smc card", MacGpuStatsTest::nullSampler, stats(TEMPERATURE, 55L),
+                61.5d);
         assertThat("a plausible SMC reading wins", apple.getTemperature(), is(61.5d));
         assertThat("the accelerator was not consulted", apple.perfStatQueries, is(0));
 
-        StubGpuStats noSmc = new StubGpuStats(true, "no smc card", nullFactory(), stats(TEMPERATURE, 55L), 0d);
+        StubGpuStats noSmc = new StubGpuStats(true, "no smc card", MacGpuStatsTest::nullSampler,
+                stats(TEMPERATURE, 55L), 0d);
         assertThat("an unavailable SMC reading falls through", noSmc.getTemperature(), is(55d));
     }
 
     @Test
     void testTemperatureLatchesOnlyOnAMissingKey() {
         // A dictionary present but lacking the key means this card has no such sensor: latch it off.
-        StubGpuStats missingKey = new StubGpuStats(false, "latch card", nullFactory(), stats(), -1d);
+        StubGpuStats missingKey = new StubGpuStats(false, "latch card", MacGpuStatsTest::nullSampler, stats(), -1d);
         assertThat("missing key yields the sentinel", missingKey.getTemperature(), is(-1d));
         assertThat("the first call queried", missingKey.perfStatQueries, is(1));
         assertThat("still the sentinel", missingKey.getTemperature(), is(-1d));
@@ -209,7 +216,7 @@ class MacGpuStatsTest {
     @Test
     void testTemperatureDoesNotLatchOnAnUnreadableDictionary() {
         // A missing accelerator entry can be transient (driver reset, eGPU unplugged), so it must stay retryable.
-        StubGpuStats unreadable = new StubGpuStats(false, "transient card", nullFactory(), null, -1d);
+        StubGpuStats unreadable = new StubGpuStats(false, "transient card", MacGpuStatsTest::nullSampler, null, -1d);
         assertThat("unreadable yields the sentinel", unreadable.getTemperature(), is(-1d));
         assertThat("unreadable still yields the sentinel", unreadable.getTemperature(), is(-1d));
         assertThat("the lookup is retried", unreadable.perfStatQueries, is(2));
@@ -217,7 +224,7 @@ class MacGpuStatsTest {
 
     @Test
     void testUnsupportedMetricsReturnSentinels() {
-        StubGpuStats gpu = new StubGpuStats(true, "sentinel card", nullFactory(), stats(), -1d);
+        StubGpuStats gpu = new StubGpuStats(true, "sentinel card", MacGpuStatsTest::nullSampler, stats(), -1d);
         assertThat("clock is unavailable on macOS", gpu.getCoreClockMhz(), is(-1L));
         assertThat("memory clock is unavailable on macOS", gpu.getMemoryClockMhz(), is(-1L));
         assertThat("fan speed is unavailable on macOS", gpu.getFanSpeedPercent(), is(-1d));
@@ -238,7 +245,7 @@ class MacGpuStatsTest {
 
     @Test
     void testMatchesNameIgnoresCaseAndTrademarks() {
-        StubGpuStats gpu = new StubGpuStats(false, "Radeon Pro 5500M", nullFactory(), stats(), -1d);
+        StubGpuStats gpu = new StubGpuStats(false, "Radeon Pro 5500M", MacGpuStatsTest::nullSampler, stats(), -1d);
         assertThat("exact match", gpu.matchesName("radeon pro 5500m"), is(true));
         assertThat("case is ignored", gpu.matchesName("RADEON PRO 5500M"), is(true));
         assertThat("trademark symbols are stripped", gpu.matchesName("Radeon™ Pro 5500M"), is(true));
@@ -249,7 +256,7 @@ class MacGpuStatsTest {
         assertThat("empty does not match", gpu.matchesName(""), is(false));
     }
 
-    private static Supplier<IOReportSampler> nullFactory() {
-        return () -> null;
+    private static IOReportSampler nullSampler() {
+        return null;
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/LogicalProcessorInformationFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/LogicalProcessorInformationFFM.java
@@ -88,20 +88,12 @@ public final class LogicalProcessorInformationFFM {
                 int size = buffer.get(ValueLayout.JAVA_INT, offset + 4L);
 
                 switch (relationship) {
-                    case RELATION_PROCESSOR_CORE:
-                        parseProcessorCore(buffer, offset, cores);
-                        break;
-                    case RELATION_NUMA_NODE:
-                        parseNumaNode(buffer, offset, numaNodes);
-                        break;
-                    case RELATION_CACHE:
-                        parseCache(buffer, offset, caches);
-                        break;
-                    case RELATION_PROCESSOR_PACKAGE:
-                        parsePackage(buffer, offset, packages);
-                        break;
-                    default:
-                        break;
+                    case RELATION_PROCESSOR_CORE -> parseProcessorCore(buffer, offset, cores);
+                    case RELATION_NUMA_NODE -> parseNumaNode(buffer, offset, numaNodes);
+                    case RELATION_CACHE -> parseCache(buffer, offset, caches);
+                    case RELATION_PROCESSOR_PACKAGE -> parsePackage(buffer, offset, packages);
+                    default -> {
+                    }
                 }
                 offset += size;
             }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/solaris/LibKstatFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/solaris/LibKstatFunctions.java
@@ -401,6 +401,8 @@ public final class LibKstatFunctions extends ForeignFunctions {
      * @param named segment reinterpreted to {@link #KSTAT_NAMED_LAYOUT}
      * @return the record name
      */
+    // "name" above refers to the native struct field, not this method's `named` parameter
+    @SuppressWarnings("InvalidParam")
     public static String namedName(MemorySegment named) {
         return named.getString(KSTAT_NAMED_NAME_OFFSET);
     }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
@@ -216,23 +216,18 @@ public final class KstatUtilFFM {
             }
             MemorySegment named = data.reinterpret(KSTAT_NAMED_LAYOUT.byteSize());
             byte dt = namedDataType(named);
-            switch (dt) {
-                case KSTAT_DATA_CHAR:
-                    return namedValueChar(named);
-                case KSTAT_DATA_INT32:
-                    return Integer.toString(namedValueInt32(named));
-                case KSTAT_DATA_UINT32:
-                    return FormatUtil.toUnsignedString(namedValueInt32(named));
-                case KSTAT_DATA_INT64:
-                    return Long.toString(namedValueInt64(named));
-                case KSTAT_DATA_UINT64:
-                    return FormatUtil.toUnsignedString(namedValueInt64(named));
-                case KSTAT_DATA_STRING:
-                    return namedValueString(named);
-                default:
+            return switch (dt) {
+                case KSTAT_DATA_CHAR -> namedValueChar(named);
+                case KSTAT_DATA_INT32 -> Integer.toString(namedValueInt32(named));
+                case KSTAT_DATA_UINT32 -> FormatUtil.toUnsignedString(namedValueInt32(named));
+                case KSTAT_DATA_INT64 -> Long.toString(namedValueInt64(named));
+                case KSTAT_DATA_UINT64 -> FormatUtil.toUnsignedString(namedValueInt64(named));
+                case KSTAT_DATA_STRING -> namedValueString(named);
+                default -> {
                     LOG.error("Unimplemented kstat data type {}", dt);
-                    return "";
-            }
+                    yield "";
+                }
+            };
         }, "", LOG, WARN, "kstat_data_lookup failed for key {}", name);
     }
 
@@ -260,17 +255,15 @@ public final class KstatUtilFFM {
             }
             MemorySegment named = data.reinterpret(KSTAT_NAMED_LAYOUT.byteSize());
             byte dt = namedDataType(named);
-            switch (dt) {
-                case KSTAT_DATA_INT32:
-                    return namedValueInt32(named);
-                case KSTAT_DATA_UINT32:
-                    return FormatUtil.getUnsignedInt(namedValueInt32(named));
-                case KSTAT_DATA_INT64, KSTAT_DATA_UINT64:
-                    return namedValueInt64(named);
-                default:
+            return switch (dt) {
+                case KSTAT_DATA_INT32 -> (long) namedValueInt32(named);
+                case KSTAT_DATA_UINT32 -> FormatUtil.getUnsignedInt(namedValueInt32(named));
+                case KSTAT_DATA_INT64, KSTAT_DATA_UINT64 -> namedValueInt64(named);
+                default -> {
                     LOG.error("Unimplemented or non-numeric kstat data type {}", dt);
-                    return 0L;
-            }
+                    yield 0L;
+                }
+            };
         }, 0L, LOG, WARN, "kstat_data_lookup failed for key {}", name);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WbemcliUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WbemcliUtilFFM.java
@@ -238,43 +238,22 @@ public final class WbemcliUtilFFM {
                 int vt = getVt(getResult.variant());
                 int cimType = getResult.cimType();
                 switch (vt) {
-                    case VT_BSTR:
-                        result.add(vt, cimType, property, getBstrVal(getResult.variant(), arena));
-                        break;
-                    case VT_I4, VT_INT, VT_UI4, VT_UINT:
-                        result.add(vt, cimType, property, getIntVal(getResult.variant()));
-                        break;
-                    case VT_I8, VT_UI8:
-                        result.add(vt, cimType, property, getLongVal(getResult.variant()));
-                        break;
-                    case VT_I2:
-                        result.add(vt, cimType, property, (int) getShortVal(getResult.variant()));
-                        break;
-                    case VT_UI2:
-                        result.add(vt, cimType, property, getShortVal(getResult.variant()) & 0xFFFF);
-                        break;
-                    case VT_I1:
-                        result.add(vt, cimType, property, (int) getByteVal(getResult.variant()));
-                        break;
-                    case VT_UI1:
-                        result.add(vt, cimType, property, getByteVal(getResult.variant()) & 0xFF);
-                        break;
-                    case VT_BOOL:
-                        result.add(vt, cimType, property, getBoolVal(getResult.variant()));
-                        break;
-                    case VT_R4:
-                        result.add(vt, cimType, property, getFloatVal(getResult.variant()));
-                        break;
-                    case VT_R8:
-                        result.add(vt, cimType, property, getDoubleVal(getResult.variant()));
-                        break;
-                    case VT_NULL, VT_EMPTY:
-                        result.add(vt, cimType, property, null);
-                        break;
-                    default:
+                    case VT_BSTR -> result.add(vt, cimType, property, getBstrVal(getResult.variant(), arena));
+                    case VT_I4, VT_INT, VT_UI4, VT_UINT -> result.add(vt, cimType, property,
+                            getIntVal(getResult.variant()));
+                    case VT_I8, VT_UI8 -> result.add(vt, cimType, property, getLongVal(getResult.variant()));
+                    case VT_I2 -> result.add(vt, cimType, property, (int) getShortVal(getResult.variant()));
+                    case VT_UI2 -> result.add(vt, cimType, property, getShortVal(getResult.variant()) & 0xFFFF);
+                    case VT_I1 -> result.add(vt, cimType, property, (int) getByteVal(getResult.variant()));
+                    case VT_UI1 -> result.add(vt, cimType, property, getByteVal(getResult.variant()) & 0xFF);
+                    case VT_BOOL -> result.add(vt, cimType, property, getBoolVal(getResult.variant()));
+                    case VT_R4 -> result.add(vt, cimType, property, getFloatVal(getResult.variant()));
+                    case VT_R8 -> result.add(vt, cimType, property, getDoubleVal(getResult.variant()));
+                    case VT_NULL, VT_EMPTY -> result.add(vt, cimType, property, null);
+                    default -> {
                         LOG.debug("Unhandled VT type {} for property {}", vt, property.name());
                         result.add(VT_EMPTY, cimType, property, null);
-                        break;
+                    }
                 }
             } finally {
                 clear(getResult.variant());

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
@@ -214,18 +214,13 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
             if (shouldCacheFailure(query.getNameSpace())) {
                 int hresult = e.getHresult();
                 switch (hresult) {
-                    case WbemcliFFM.WBEM_E_INVALID_NAMESPACE:
-                        LOG.warn("COM exception: Invalid Namespace {}", query.getNameSpace());
-                        break;
-                    case WbemcliFFM.WBEM_E_INVALID_CLASS:
-                        LOG.warn("COM exception: Invalid Class {}", query.getWmiClassName());
-                        break;
-                    case WbemcliFFM.WBEM_E_INVALID_QUERY:
-                        LOG.warn("COM exception: Invalid Query for {}", query.getWmiClassName());
-                        break;
-                    default:
-                        handleComException(query, e);
-                        break;
+                    case WbemcliFFM.WBEM_E_INVALID_NAMESPACE -> LOG.warn("COM exception: Invalid Namespace {}",
+                            query.getNameSpace());
+                    case WbemcliFFM.WBEM_E_INVALID_CLASS -> LOG.warn("COM exception: Invalid Class {}",
+                            query.getWmiClassName());
+                    case WbemcliFFM.WBEM_E_INVALID_QUERY -> LOG.warn("COM exception: Invalid Query for {}",
+                            query.getWmiClassName());
+                    default -> handleComException(query, e);
                 }
                 failedWmiClassNames.add(query.getWmiClassName());
             }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -98,7 +98,7 @@ public class WindowsFileSystemFFM extends WindowsFileSystem {
     @Override
     public List<OSFileStore> getFileStores(boolean localOnly) {
         // Create list to hold results
-        ArrayList<OSFileStore> result;
+        List<OSFileStore> result;
 
         // Begin with all the local volumes
         result = getLocalVolumes(null);
@@ -141,8 +141,8 @@ public class WindowsFileSystemFFM extends WindowsFileSystem {
      * @param volumeToMatch an optional string to filter match, null otherwise
      * @return A list of {@link OSFileStore} objects representing all local mounted volumes
      */
-    static ArrayList<OSFileStore> getLocalVolumes(String volumeToMatch) {
-        ArrayList<OSFileStore> fs = new ArrayList<>();
+    static List<OSFileStore> getLocalVolumes(String volumeToMatch) {
+        List<OSFileStore> fs = new ArrayList<>();
 
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment volumeNameBuf = arena.allocate(BUFSIZE * JAVA_CHAR.byteSize());

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -171,18 +171,11 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
                     int currentState = lpServices.get(JAVA_INT, base + CURRENT_STATE_OFFSET);
                     int processId = lpServices.get(JAVA_INT, base + PROCESS_ID_OFFSET);
 
-                    State state;
-                    switch (currentState) {
-                        case 1:
-                            state = State.STOPPED;
-                            break;
-                        case 4:
-                            state = State.RUNNING;
-                            break;
-                        default:
-                            state = State.OTHER;
-                            break;
-                    }
+                    State state = switch (currentState) {
+                        case 1 -> State.STOPPED;
+                        case 4 -> State.RUNNING;
+                        default -> State.OTHER;
+                    };
                     svcArray.add(new OSService(displayName, processId, state));
                 }
                 return Collections.unmodifiableList(svcArray);

--- a/oshi-core/src/main/java/oshi/driver/linux/WhoJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/linux/WhoJNA.java
@@ -47,6 +47,8 @@ public final class WhoJNA {
      *
      * @return A list of logged in user sessions
      */
+    // assignment-in-condition is the standard idiom for "loop while getutxent() returns non-null"
+    @SuppressWarnings("AssignmentExpression")
     public static synchronized List<OSSession> queryUtxent() {
         // Try systemd first if available
         if (useSystemd) {

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/IOReport.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/IOReport.java
@@ -7,10 +7,10 @@ package oshi.jna.platform.mac;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
-import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.platform.mac.CoreFoundation.CFDictionaryRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFStringRef;
 import com.sun.jna.platform.mac.CoreFoundation.CFTypeRef;
+import com.sun.jna.ptr.PointerByReference;
 
 /**
  * IOReport is a private Apple framework that provides access to hardware performance counters, including GPU residency
@@ -55,6 +55,8 @@ public interface IOReport extends Library {
      * @param b     source channel descriptor
      * @param null3 reserved, pass {@code null}
      */
+    // "null" above is the value to pass, not a mis-reference to the null3 parameter's name
+    @SuppressWarnings("InvalidParam")
     void IOReportMergeChannels(CFDictionaryRef a, CFDictionaryRef b, CFTypeRef null3);
 
     /**

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
@@ -91,7 +91,7 @@ public class WindowsFileSystemJNA extends WindowsFileSystem {
     @Override
     public List<OSFileStore> getFileStores(boolean localOnly) {
         // Create list to hold results
-        ArrayList<OSFileStore> result;
+        List<OSFileStore> result;
 
         // Begin with all the local volumes
         result = getLocalVolumes(null);
@@ -129,8 +129,8 @@ public class WindowsFileSystemJNA extends WindowsFileSystem {
      * @param volumeToMatch an optional string to filter match, null otherwise
      * @return A list of {@link OSFileStore} objects representing all local mounted volumes
      */
-    static ArrayList<OSFileStore> getLocalVolumes(String volumeToMatch) {
-        ArrayList<OSFileStore> fs;
+    static List<OSFileStore> getLocalVolumes(String volumeToMatch) {
+        List<OSFileStore> fs;
         String volume;
         String strFsType;
         String strName;

--- a/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryHandler.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryHandler.java
@@ -219,11 +219,10 @@ public class WmiQueryHandler implements WmiQueryExecutor {
      * @throws COMException if COM initialization fails with an unexpected error
      */
     public boolean initCOM() {
-        boolean comInit = false;
         // Step 1: --------------------------------------------------
         // Initialize COM. ------------------------------------------
         int threading = getComThreading();
-        comInit = initCOM(threading);
+        boolean comInit = initCOM(threading);
         if (!comInit) {
             // Only switch if another thread hasn't already switched away from our value
             int switched = switchComThreadingFrom(threading);

--- a/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
@@ -306,7 +306,6 @@ class OperatingSystemTest {
         // Zero
         int matchedChild = 0;
         int matchedDescendant = 0;
-        int descendantNotLessThanChild = 0;
         if (zeroChildMap.size() > 9) {
             int total = 0;
             for (Integer i : zeroChildMap.keySet()) {
@@ -331,7 +330,7 @@ class OperatingSystemTest {
         // One child
         matchedChild = 0;
         matchedDescendant = 0;
-        descendantNotLessThanChild = 0;
+        int descendantNotLessThanChild = 0;
         if (oneChildMap.size() > 9) {
             int total = 0;
             for (Integer i : oneChildMap.keySet()) {

--- a/oshi-metrics/src/main/java/oshi/metrics/DiskMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/DiskMetrics.java
@@ -49,7 +49,7 @@ public class DiskMetrics implements MeterBinder {
     // Intentionally retained though never read: holds a strong reference to the disk stores so the GC cannot clear
     // the WeakReferences that Micrometer's FunctionCounter keeps to them (see bindTo). Removing this would silently
     // break the disk metrics after a garbage collection.
-    @SuppressWarnings("java:S1068") // intentionally unused field — see above
+    @SuppressWarnings({ "java:S1068", "UnusedVariable" }) // intentionally unused field — see above
     private List<HWDiskStore> diskStores;
 
     /**

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import oshi.SystemInfo;
-import oshi.software.os.OperatingSystem;
 import oshi.spi.SystemInfoProvider;
 import oshi.util.PlatformEnum;
 
@@ -31,13 +30,11 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 class OshiMetricsTest {
 
     private static MeterRegistry registry;
-    private static OperatingSystem os;
 
     @BeforeAll
     static void setUp() {
         registry = new SimpleMeterRegistry();
         SystemInfoProvider si = new SystemInfo();
-        os = si.getOperatingSystem();
         OshiMetrics.bindTo(registry, si);
     }
 


### PR DESCRIPTION
## Summary

Combines two lower-risk tail groups per triage discussion on #3600-3603: API-shape findings that only look like public API (verified none touch `@PublicApi` or the `oshi.hardware`/`oshi.software.os` semver surface), plus purely mechanical syntax modernization.

**API-shape (`NonApiType`, `InvalidParam`, `EffectivelyPrivate`, `ImmutableEnumChecker`)** — checked each site's actual visibility before fixing:
- `WindowsFileSystemJNA`/`WindowsFileSystemFFM`'s `getLocalVolumes`: package-private (not even accessible outside the package), returns `ArrayList` where only `List` interface methods are ever used on the result — narrowed to `List`.
- `LinuxOSProcess`/`LinuxOSThread`: `public int getOrder()` on a `private` nested enum — the `public` modifier is a no-op since the enum itself can't be referenced outside the enclosing class. Dropped it.
- `AbstractCentralProcessor.CpuidFeature.names`: `String[]` → `Collections.unmodifiableList(Arrays.asList(...))`, suppressed the one further warning about `List` not being a nominally-immutable type (no Guava dependency to satisfy that literally).
- `LinuxHWDiskStore.UdevStat.order`: added the missing `final` — assigned once, in the constructor, never reassigned.
- `LibKstatFunctions`/`IOReport` javadoc: suppressed — `{@code name}`/`{@code null}` in the doc text refer to a native struct field name and a value-to-pass respectively, unrelated to the similarly-spelled parameter (`named`/`null3`) the checker flagged them against.

**Mechanical cleanup (`StatementSwitchToExpressionSwitch`, `UnnecessaryLambda`, `UnnecessaryParentheses`, `AssignmentExpression`, `UnusedVariable`)**:
- 6 statement switches converted to arrow-style switch statements/expressions (`oshi-core-ffm`, Java 25 — no fallthrough existed before, so no behavior change).
- 5 lambdas stored in test constants or returned from a helper method replaced with method references to a directly-implemented method (per the checker's own suggested fix).
- `WhoJNA`'s `while (nonNull(ut = LIBC.getutxent()))` is the standard C-iterator-style idiom; suppressed rather than restructured.
- Removed a redundant parenthesized subexpression (`AbstractCentralProcessor`), a dead initial value unconditionally overwritten before any read (`WmiQueryHandler.initCOM`), and a test field assigned in `@BeforeAll` but never read anywhere (`OshiMetricsTest`).
- `OperatingSystemTest.descendantNotLessThanChild`: traced all three per-category blocks before touching this — the variable *is* correctly used and asserted on in two of the three blocks; only its very first initializer (before an unrelated block that never touches it) was dead. Moved the declaration to where it's first actually needed rather than leaving a redundant reset.
- `DiskMetrics.diskStores` was already correctly documented as an intentional GC anchor (holds a strong reference so Micrometer's `WeakReference` doesn't get collected), but the existing `@SuppressWarnings` only carried Sonar's rule id (`java:S1068`), not Error Prone's own check name — added it.

## Test plan
- [x] `./mvnw clean install -Perror-prone -DskipTests`: 0 ERROR; all listed categories → 0
- [x] `./mvnw -pl oshi-common,oshi-core,oshi-core-ffm,oshi-metrics -am test`: 0 tests failed
- [x] `./mvnw checkstyle:check`, `forbiddenapis:check`, `clean compile javadoc:javadoc`: all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Modernized internal control-flow and collection declarations without changing runtime behavior.
  - Improved immutability and visibility safeguards across hardware, operating-system, and platform integrations.
  - Preserved existing processor, disk, process, filesystem, WMI, and service-state handling.

- **Tests**
  - Simplified test helpers and fixtures while retaining existing assertions and coverage.
  - Standardized test formatting and removed unused setup code.

- **Chores**
  - Added clarifying comments and warning suppressions for intentional platform-specific code patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->