### PR TITLE
Use pattern-matching instanceof in CFTypeRef.equals

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/CoreFoundation.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/CoreFoundation.java
@@ -153,10 +153,9 @@ public interface CoreFoundation {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof CFTypeRef)) {
+            if (!(o instanceof CFTypeRef cfTypeRef)) {
                 return false;
             }
-            CFTypeRef cfTypeRef = (CFTypeRef) o;
             if (isNull() || cfTypeRef.isNull()) {
                 return isNull() == cfTypeRef.isNull();
             }


### PR DESCRIPTION
## Summary
Small follow-up to #3603. Re-running the Error Prone triage after #3604 merged, a new (correct) finding showed up: `CFTypeRef.equals()`'s `instanceof CFTypeRef` check followed by a separate cast can be simplified to Java 16+ pattern-matching `instanceof`, which wasn't applicable before the `getClass()` → `instanceof` fix in #3603.

## Test plan
- [x] `./mvnw clean install -Perror-prone -DskipTests`: 0 ERROR, `PatternMatchingInstanceof` 1 → 0
- [x] `./mvnw -pl oshi-core-ffm -am test`: 0 tests failed (including `CoreFoundationTest`)
- [x] `./mvnw checkstyle:check`: passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal equality-checking logic without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->