### PR TITLE
Fix remaining Error Prone javadoc-shape findings, suppress MissingSummary, escalate cleared checks to ERROR

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
@@ -122,8 +122,8 @@ public abstract class AixOSProcess extends AbstractProcOSProcess {
 
     /**
      * Applies the perfstat-derived CPU and memory quartet to this process. Concrete subclasses arrange a
-     * {@code Quartet&lt;ucpu_time(ms), scpu_time(ms), real_inuse(bytes), proc_real_mem_data+text(bytes)&gt;} from their
-     * data source and call this. Returns true on success; sets {@code state = INVALID} and returns false otherwise.
+     * {@code Quartet<ucpu_time(ms), scpu_time(ms), real_inuse(bytes), proc_real_mem_data+text(bytes)>} from their data
+     * source and call this. Returns true on success; sets {@code state = INVALID} and returns false otherwise.
      *
      * @param cpuMem the quartet of (userTime, kernelTime, residentSetSize, privateResidentMemory)
      * @return {@code true} if attributes were updated

--- a/oshi-common/src/main/java/oshi/util/FileSystemUtil.java
+++ b/oshi-common/src/main/java/oshi/util/FileSystemUtil.java
@@ -85,7 +85,7 @@ public final class FileSystemUtil {
     }
 
     /**
-     * Checks if {@code text} matches any of @param patterns}.
+     * Checks if {@code text} matches any of {@code patterns}.
      *
      * @param text     The text to be matched.
      * @param patterns List of patterns.

--- a/oshi-common/src/test/java/oshi/util/GlobalConfigTest.java
+++ b/oshi-common/src/test/java/oshi/util/GlobalConfigTest.java
@@ -184,8 +184,6 @@ class GlobalConfigTest {
     }
 
     static final class GlobalConfigAsserter {
-        private static final String FAILURE_MESSAGE_TEMPLATE = "property: %s value for def: %s should be";
-        private static final String DEFAULT_FAILURE_MESSAGE_TEMPLATE = "Property: %s default value def: %s should be";
         private final String property;
 
         private GlobalConfigAsserter(String property) {
@@ -220,11 +218,11 @@ class GlobalConfigTest {
         }
 
         private String failureMessage(Object def) {
-            return format(Locale.ROOT, FAILURE_MESSAGE_TEMPLATE, property, def);
+            return format(Locale.ROOT, "property: %s value for def: %s should be", property, def);
         }
 
         private String defaultFailureMessage(Object def) {
-            return format(Locale.ROOT, DEFAULT_FAILURE_MESSAGE_TEMPLATE, PROPERTY, def);
+            return format(Locale.ROOT, "Property: %s default value def: %s should be", PROPERTY, def);
         }
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/unix/aix/perfstat/PerfstatCpuFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/unix/aix/perfstat/PerfstatCpuFFM.java
@@ -149,7 +149,7 @@ public final class PerfstatCpuFFM {
     /**
      * Returns the affinity mask derived from the number of CPUs reported by {@code perfstat_cpu_total}.
      *
-     * @return mask, or {@code -1L} if {@code ncpus &gt; 63}
+     * @return mask, or {@code -1L} if {@code ncpus > 63}
      */
     public static long queryCpuAffinityMask() {
         int cpus = queryCpuTotal().ncpus;

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/HkeyPerformanceDataUtilFFM.java
@@ -258,7 +258,7 @@ public final class HkeyPerformanceDataUtilFFM extends HkeyPerformanceDataUtil {
         }, null, LOG, "Error reading performance data from registry for {}.");
     }
 
-    /*
+    /**
      * Registry entries subordinate to HKEY_PERFORMANCE_TEXT key reference the text strings that describe counters in US
      * English. Not supported in Windows 2000.
      *
@@ -268,7 +268,7 @@ public final class HkeyPerformanceDataUtilFFM extends HkeyPerformanceDataUtil {
      * These pairs are translated to a map for later lookup.
      *
      * @return An unmodifiable map containing counter name strings as keys and indices as integer values if the key is
-     * read successfully; an empty map otherwise.
+     *         read successfully; an empty map otherwise.
      */
     private static Map<String, Integer> mapCounterIndicesFromRegistry() {
         try {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/linux/SystemdFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/linux/SystemdFunctions.java
@@ -100,7 +100,7 @@ public final class SystemdFunctions extends ForeignFunctions {
     }
 
     /**
-     * Calls {@code sd_session_get_username(session, &amp;username)}.
+     * Calls {@code sd_session_get_username(session, &username)}.
      *
      * @param session     session ID segment (null-terminated)
      * @param usernamePtr pointer-to-pointer output segment
@@ -112,7 +112,7 @@ public final class SystemdFunctions extends ForeignFunctions {
     }
 
     /**
-     * Calls {@code sd_session_get_start_time(session, &amp;usec)}.
+     * Calls {@code sd_session_get_start_time(session, &usec)}.
      *
      * @param session session ID segment (null-terminated)
      * @param usecPtr pointer to uint64_t output
@@ -124,7 +124,7 @@ public final class SystemdFunctions extends ForeignFunctions {
     }
 
     /**
-     * Calls {@code sd_session_get_tty(session, &amp;tty)}.
+     * Calls {@code sd_session_get_tty(session, &tty)}.
      *
      * @param session session ID segment (null-terminated)
      * @param ttyPtr  pointer-to-pointer output segment
@@ -136,7 +136,7 @@ public final class SystemdFunctions extends ForeignFunctions {
     }
 
     /**
-     * Calls {@code sd_session_get_remote_host(session, &amp;remote_host)}.
+     * Calls {@code sd_session_get_remote_host(session, &remote_host)}.
      *
      * @param session       session ID segment (null-terminated)
      * @param remoteHostPtr pointer-to-pointer output segment

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdSensorsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdSensorsFFM.java
@@ -35,7 +35,7 @@ public class FreeBsdSensorsFFM extends FreeBsdSensors {
         return queryKldloadCoretemp();
     }
 
-    /*
+    /**
      * If user has loaded coretemp module via kldload coretemp, sysctl call will return temperature
      *
      * @return Temperature if successful, otherwise NaN

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdSensorsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/freebsd/FreeBsdSensorsJNA.java
@@ -27,19 +27,18 @@ public class FreeBsdSensorsJNA extends FreeBsdSensors {
         return queryKldloadCoretemp();
     }
 
-    /*
+    /**
      * If user has loaded coretemp module via kldload coretemp, sysctl call will return temperature
      *
      * @return Temperature if successful, otherwise NaN
      */
     private static double queryKldloadCoretemp() {
-        String name = "dev.cpu.%d.temperature";
         try (CloseableSizeTByReference size = new CloseableSizeTByReference(FreeBsdLibc.INT_SIZE)) {
             int cpu = 0;
             double sumTemp = 0d;
             try (Memory p = new Memory(size.longValue())) {
-                while (0 == FreeBsdLibc.INSTANCE.sysctlbyname(String.format(Locale.ROOT, name, cpu), p, size, null,
-                        size_t.ZERO)) {
+                while (0 == FreeBsdLibc.INSTANCE.sysctlbyname(String.format(Locale.ROOT, "dev.cpu.%d.temperature", cpu),
+                        p, size, null, size_t.ZERO)) {
                     sumTemp += p.getInt(0) / 10d - 273.15;
                     cpu++;
                 }

--- a/oshi-demo/src/main/java/oshi/demo/ComputerID.java
+++ b/oshi-demo/src/main/java/oshi/demo/ComputerID.java
@@ -35,19 +35,11 @@ public class ComputerID {
                     "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF", "00000000-0000-0000-0000-000000000000"));
 
     /**
-     * <p>
-     * main.
-     * </p>
-     *
-     * @param args an array of {@link java.lang.String} objects.
-     */
-    @SuppressForbidden(reason = "Using System.out in a demo class")
-
-    /**
      * Entry point.
      *
      * @param args command line arguments
      */
+    @SuppressForbidden(reason = "Using System.out in a demo class")
     public static void main(String[] args) {
         String unknownHash = String.format(Locale.ROOT, "%08x", Constants.UNKNOWN.hashCode());
 

--- a/oshi-demo/src/main/java/oshi/demo/DetectVM.java
+++ b/oshi-demo/src/main/java/oshi/demo/DetectVM.java
@@ -50,17 +50,11 @@ public class DetectVM {
             "Linux Containers", "LXC" };
 
     /**
-     * The main method, executing the {@link #identifyVM} method.
+     * Entry point, executing the {@link #identifyVM} method.
      *
      * @param args Arguments, ignored.
      */
     @SuppressForbidden(reason = "Using System.out in a demo class")
-
-    /**
-     * Entry point.
-     *
-     * @param args command line arguments
-     */
     public static void main(String[] args) {
         String vmString = identifyVM();
 

--- a/oshi-demo/src/main/java/oshi/demo/DiskStoreForPath.java
+++ b/oshi-demo/src/main/java/oshi/demo/DiskStoreForPath.java
@@ -32,18 +32,12 @@ public class DiskStoreForPath {
     }
 
     /**
-     * Main method
+     * Entry point.
      *
      * @param args Optional file path
      * @throws URISyntaxException on invalid path
      */
     @SuppressForbidden(reason = "Using System.out in a demo class")
-
-    /**
-     * Entry point.
-     *
-     * @param args command line arguments
-     */
     public static void main(String[] args) throws URISyntaxException {
         // Use the arg as a file path or get this class's path
         String filePath = args.length > 0 ? args[0]

--- a/oshi-demo/src/main/java/oshi/demo/Json.java
+++ b/oshi-demo/src/main/java/oshi/demo/Json.java
@@ -25,19 +25,11 @@ public class Json {
     }
 
     /**
-     * <p>
-     * main.
-     * </p>
-     *
-     * @param args an array of {@link java.lang.String} objects.
-     */
-    @SuppressForbidden(reason = "Using System.out in a demo class")
-
-    /**
      * Entry point.
      *
      * @param args command line arguments
      */
+    @SuppressForbidden(reason = "Using System.out in a demo class")
     public static void main(String[] args) {
         // Jackson ObjectMapper
         ObjectMapper mapper = new ObjectMapper();

--- a/pom.xml
+++ b/pom.xml
@@ -1230,7 +1230,18 @@
                                 <arg>100000</arg>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
-                                <arg>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF</arg>
+                                <!-- MissingSummary demands a prose summary fragment distinct from the @return
+                                block; Checkstyle's Missing*Javadoc checks don't require that phrasing, and the
+                                project doesn't want to enforce it separately via Error Prone.
+
+                                Everything below :ERROR defaults to WARNING severity, but the entire backlog for
+                                these specific checks is zero across the reactor as of the #3594-3605 triage.
+                                Escalating them turns a regression in any one of these categories into a build
+                                failure, via the same javac behavior that already blocks the build on Error
+                                Prone's own ERROR-severity checks - without reaching for -Werror, which would
+                                fail on every javac warning, including several lint categories nothing here has
+                                ever triaged. -->
+                                <arg>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF -Xep:MissingSummary:OFF -Xep:StringSplitter:ERROR -Xep:EnumOrdinal:ERROR -Xep:OperatorPrecedence:ERROR -Xep:MixedMutabilityReturnType:ERROR -Xep:ReferenceEquality:ERROR -Xep:BoxingComparator:ERROR -Xep:NarrowCalculation:ERROR -Xep:LongDoubleConversion:ERROR -Xep:IntLiteralCast:ERROR -Xep:UnnecessaryLongToIntConversion:ERROR -Xep:IntLongMath:ERROR -Xep:BadImport:ERROR -Xep:ModifyCollectionInEnhancedForLoop:ERROR -Xep:EqualsGetClass:ERROR -Xep:DuplicateBranches:ERROR -Xep:InconsistentCapitalization:ERROR -Xep:NonApiType:ERROR -Xep:InvalidParam:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:UnnecessaryLambda:ERROR -Xep:UnnecessaryParentheses:ERROR -Xep:AssignmentExpression:ERROR -Xep:UnusedVariable:ERROR -Xep:PatternMatchingInstanceof:ERROR -Xep:EscapedEntity:ERROR -Xep:NotJavadoc:ERROR -Xep:AlmostJavadoc:ERROR -Xep:InvalidInlineTag:ERROR -Xep:InlineFormatString:ERROR</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>


### PR DESCRIPTION
## Summary
Closes out the Error Prone WARNING backlog left after #3594-3605:

- **EscapedEntity** (6): HTML entities inside `{@code}`/`{@literal}` render literally in Javadoc output; use the bare `<`/`>`/`&` characters instead.
- **NotJavadoc** (4): four `oshi-demo` `main()` methods carried a stale duplicate `/**` block left behind from an older doc pass, sandwiched around `@SuppressForbidden`. Removed the stale block, keeping (and where useful, merging in) the more accurate one.
- **AlmostJavadoc** (3): three private helper methods had genuine `@return`-bearing doc comments opened with `/*` instead of `/**`.
- **InvalidInlineTag** (1): a stray `@param patterns}` that should have been `{@code patterns}`.
- **InlineFormatString** (1): a single-use format-string constant, inlined into its one call site.

Then, since the whole backlog is at zero:
- Suppress **MissingSummary** globally - it demands a summary fragment distinct from the `@return` block, which Checkstyle's javadoc checks don't require and the project doesn't want to enforce separately.
- Escalate every other check with findings in this triage arc to `ERROR` severity, so a regression fails the build via the same javac mechanism already blocking on Error Prone's built-in ERROR-severity checks - narrower than `-Werror`, which would also fail on javac warning categories (deprecation, unchecked, etc.) nothing here has ever triaged.

## Test plan
- [x] `./mvnw clean compile -Perror-prone`: 0 warnings, 0 errors, across all 8 modules
- [x] `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`: BUILD SUCCESS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified and standardized documentation across operating system, hardware, utility, and system integration features.
  * Improved descriptions for demonstration application entry points and optional command-line arguments.
  * Documented behavior when registry data is unavailable.

* **Chores**
  * Strengthened build-time static analysis checks to identify documentation and code-quality issues earlier.
  * Improved internal test code readability without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->