### PR TITLE
Fix trivial -Xlint:all and Sonar findings

### DIFF
--- a/oshi-core-ffm/src/main/java/module-info.java
+++ b/oshi-core-ffm/src/main/java/module-info.java
@@ -34,5 +34,5 @@ module com.github.oshi.ffm {
     // dependencies
     requires transitive com.github.oshi.common;
     requires transitive java.desktop;
-    requires org.slf4j;
+    requires transitive org.slf4j;
 }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/LogicalProcessorInformationFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/LogicalProcessorInformationFFM.java
@@ -93,6 +93,7 @@ public final class LogicalProcessorInformationFFM {
                     case RELATION_CACHE -> parseCache(buffer, offset, caches);
                     case RELATION_PROCESSOR_PACKAGE -> parsePackage(buffer, offset, packages);
                     default -> {
+                        // Ignore unsupported relationship types
                     }
                 }
                 offset += size;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
@@ -256,7 +256,7 @@ public final class KstatUtilFFM {
             MemorySegment named = data.reinterpret(KSTAT_NAMED_LAYOUT.byteSize());
             byte dt = namedDataType(named);
             return switch (dt) {
-                case KSTAT_DATA_INT32 -> (long) namedValueInt32(named);
+                case KSTAT_DATA_INT32 -> namedValueInt32(named);
                 case KSTAT_DATA_UINT32 -> FormatUtil.getUnsignedInt(namedValueInt32(named));
                 case KSTAT_DATA_INT64, KSTAT_DATA_UINT64 -> namedValueInt64(named);
                 default -> {

--- a/oshi-core-ffm/src/test/java/oshi/ffm/SystemInfoTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/SystemInfoTest.java
@@ -55,6 +55,9 @@ public class SystemInfoTest {
 
     private static final Logger logger = LoggerFactory.getLogger(SystemInfoTest.class);
 
+    SystemInfoTest() {
+    }
+
     @Test
     void testPlatformEnum() {
         assertThat("Unsupported OS", PlatformEnum.getCurrentPlatform(), is(not(PlatformEnum.UNKNOWN)));

--- a/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/LogicalProcessorInformation.java
@@ -93,7 +93,7 @@ public final class LogicalProcessorInformation {
                     numaNodes.add((NUMA_NODE_RELATIONSHIP) info);
                     break;
                 default:
-                    // Ignore Group info
+                    // Ignore unsupported relationship types
                     break;
             }
         }

--- a/oshi-demo/src/main/java/oshi/demo/gui/FileStorePanel.java
+++ b/oshi-demo/src/main/java/oshi/demo/gui/FileStorePanel.java
@@ -57,7 +57,7 @@ public class FileStorePanel extends OshiJPanel { // NOSONAR java:S110
 
     private void init(FileSystem fs) {
         List<OSFileStore> fileStores = fs.getFileStores();
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({ "unchecked", "rawtypes" })
         DefaultPieDataset<String>[] fsData = new DefaultPieDataset[fileStores.size()];
         JFreeChart[] fsCharts = new JFreeChart[fsData.length];
 
@@ -112,7 +112,7 @@ public class FileStorePanel extends OshiJPanel { // NOSONAR java:S110
                     "Available: " + FormatUtil.formatBytes(usable) + "/" + FormatUtil.formatBytes(total)));
             fsCharts[i].setSubtitles(subtitles);
             fsData[i].setValue(USED, (double) total - usable);
-            fsData[i].setValue(AVAILABLE, (double) usable);
+            fsData[i].setValue(AVAILABLE, (double) usable); // NOSONAR java:S1905 - LongDoubleConversion
             i++;
         }
         return true;

--- a/oshi-demo/src/main/java/oshi/demo/gui/MemoryPanel.java
+++ b/oshi-demo/src/main/java/oshi/demo/gui/MemoryPanel.java
@@ -120,10 +120,10 @@ public class MemoryPanel extends OshiJPanel { // NOSONAR java:S110
     private static void updateDatasets(GlobalMemory memory, DefaultPieDataset<String> physMemData,
             DefaultPieDataset<String> virtMemData) {
         physMemData.setValue(USED, (double) memory.getTotal() - memory.getAvailable());
-        physMemData.setValue(AVAILABLE, (double) memory.getAvailable());
+        physMemData.setValue(AVAILABLE, (double) memory.getAvailable()); // NOSONAR java:S1905 - LongDoubleConversion
 
         VirtualMemory virtualMemory = memory.getVirtualMemory();
-        virtMemData.setValue(USED, (double) virtualMemory.getSwapUsed());
+        virtMemData.setValue(USED, (double) virtualMemory.getSwapUsed()); // NOSONAR java:S1905 - LongDoubleConversion
         virtMemData.setValue(AVAILABLE, (double) virtualMemory.getSwapTotal() - virtualMemory.getSwapUsed());
     }
 


### PR DESCRIPTION
## Summary
Two small, unrelated cleanup batches surfaced while auditing warnings after #3606:

**-Xlint:all** (a one-off diagnostic sweep, not build-enforced - see discussion in #3606's follow-up):
- `FileStorePanel`: suppress `rawtypes` alongside the existing `unchecked` suppression on the same generic-array-creation idiom.
- `SystemInfoTest` (FFM): add an explicit package-private constructor so the exported `oshi.ffm` package doesn't expose a default public one.
- `oshi-core-ffm`'s `module-info.java`: widen `requires org.slf4j` to `transitive` - `ForeignFunctions`' public `callInArena*OrDefault` methods take a `Logger` parameter directly (unlike other modules, where `Logger` is only ever a private field), so consumers of the module genuinely need readability to `org.slf4j` too.

**Sonar findings** from the latest `master` analysis:
- `S108`: comment the intentionally-empty `default` arm in `LogicalProcessorInformationFFM`, matching the JNA twin's existing `// Ignore Group info` comment.
- `S1905`: drop the genuinely-redundant `int`-to-`long` cast in `KstatUtilFFM` (the JNA twin already omits it).
- The three `long`-to-`double` casts Sonar also flagged (`FileStorePanel`, `MemoryPanel` x2) are **not** redundant - removing them trips Error Prone's `LongDoubleConversion` check, which we escalated to `ERROR` severity in #3606 specifically to catch this kind of precision loss. Kept the casts, suppressed with `NOSONAR` instead.

**Deliberately left alone:** `S9149` (22 of 27 findings) - `MSFTStorageFFM`/`JNA` and about 8 similar class-pairs redeclare identical static methods from their `oshi-common` base class, purely so each backend module can reference a locally-named class instead of importing the shared one directly. Real callers exist for every one of them (e.g. `WindowsLogicalVolumeGroupFFM`/`JNA`), so this isn't dead code - fixing it means deleting ~9 shim class-pairs and repointing callers at the shared base classes across both twins. That's a separate, larger PR, not a trivial-fixes one.

## Test plan
- [x] `./mvnw clean install -Perror-prone -DskipTests`: 0 warnings, 0 errors, all 8 modules
- [x] `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`: BUILD SUCCESS
- [x] Verified the 3 long-to-double NOSONAR suppressions are necessary by removing the casts and confirming Error Prone's `LongDoubleConversion` fails the build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of signed Solaris system statistics values.
  * Made the SLF4J dependency available transitively to consuming modules.

* **Documentation**
  * Clarified that unsupported processor relationship information is intentionally ignored.
  * Documented numeric conversions used in storage and memory displays.

* **Chores**
  * Refined static-analysis suppressions and test setup without changing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->