### PR TITLE
Add errorprone-slf4j checks and fix the SLF4J misuse they found

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -100,14 +100,14 @@ public final class MacInstalledApps {
                         appInfoSet.add(new ApplicationInfo(dictValues.get("_name"), version, vendor, lastModifiedEpoch,
                                 additionalInfo));
                     } catch (Exception e) {
-                        LOG.trace("Unable to parse dict values: " + e.getMessage() + " - " + dictValues, e);
+                        LOG.trace("Unable to parse dict values: {}", dictValues, e);
                     }
                 }
 
                 return Collections.unmodifiableList(new ArrayList<>(appInfoSet));
             }
         } catch (Exception e) {
-            LOG.trace("Unable to read installed apps: " + e.getMessage(), e);
+            LOG.trace("Unable to read installed apps", e);
         }
         return Collections.emptyList();
     }

--- a/oshi-common/src/main/java/oshi/util/LogUtil.java
+++ b/oshi-common/src/main/java/oshi/util/LogUtil.java
@@ -63,6 +63,9 @@ public final class LogUtil {
      * @param msg   the log message, with {@code {}} placeholders for the arguments
      * @param args  the arguments to substitute into the message
      */
+    // Forwarding the caller's message is the entire point of this method, so the format string cannot be a constant
+    // here; the callers are the ones that must pass one.
+    @SuppressWarnings("Slf4jFormatShouldBeConst")
     public static void logAtLevel(Logger log, LogLevel level, String msg, Object... args) {
         switch (level) {
             case ERROR:

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -55,7 +55,9 @@ public final class ParseUtil {
 
     private static final Charset CP1252 = Charset.forName("Windows-1252");
 
-    private static final String DEFAULT_LOG_MSG = "{} didn't parse. Returning default. {}";
+    // The exception is passed as the trailing argument with no matching placeholder, so SLF4J attaches it as the
+    // event's cause rather than substituting it. A second "{}" here would be left in the output literally.
+    private static final String DEFAULT_LOG_MSG = "{} didn't parse. Returning default.";
 
     /*
      * Used for matching

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
@@ -61,6 +61,9 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
     private static final Class<?>[] EMPTY_CLASS_ARRAY = new Class<?>[0];
     private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
+    private static final String COM_EXCEPTION_FMT = "COM exception querying {}, which might not be on your system."
+            + " Will not attempt to query it again. Error was {}: {}";
+
     // Factory to create this or a subclass
     private static Class<? extends WmiQueryHandlerFFM> customClass = null;
 
@@ -419,13 +422,11 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
      * @param ex    a FfmComException object
      */
     protected void handleComException(WbemcliUtilFFM.WmiQuery<?> query, FfmComException ex) {
-        String msg = "COM exception querying {}, which might not be on your system."
-                + " Will not attempt to query it again. Error was {}: {}";
-        Object[] args = { query.getWmiClassName(), ex.getHresult(), ex.getMessage() };
-        if ("MSAcpi_ThermalZoneTemperature".equals(query.getWmiClassName())) {
-            LOG.debug(msg, args);
+        String className = query.getWmiClassName();
+        if ("MSAcpi_ThermalZoneTemperature".equals(className)) {
+            LOG.debug(COM_EXCEPTION_FMT, className, ex.getHresult(), ex.getMessage());
         } else {
-            LOG.warn(msg, args);
+            LOG.warn(COM_EXCEPTION_FMT, className, ex.getHresult(), ex.getMessage());
         }
     }
 

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -143,8 +143,8 @@ public final class SmcUtil {
                 if (result == 0) {
                     return new IOConnect(connPtr.getValue());
                 } else if (LOG.isErrorEnabled()) {
-                    LOG.error(String.format(Locale.ROOT, "Unable to open connection to AppleSMC service. Error: 0x%08x",
-                            result));
+                    LOG.error("Unable to open connection to AppleSMC service. Error: 0x{}",
+                            String.format(Locale.ROOT, "%08x", result));
                 }
             } finally {
                 smcService.release();

--- a/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryHandler.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryHandler.java
@@ -56,6 +56,9 @@ public class WmiQueryHandler implements WmiQueryExecutor {
     private static final Class<?>[] EMPTY_CLASS_ARRAY = new Class<?>[0];
     private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
+    private static final String COM_EXCEPTION_FMT = "COM exception querying {}, which might not be on your system."
+            + " Will not attempt to query it again. Error was {}: {}";
+
     // Factory to create this or a subclass
     private static Class<? extends WmiQueryHandler> customClass = null;
 
@@ -201,14 +204,12 @@ public class WmiQueryHandler implements WmiQueryExecutor {
      * @param ex    a {@link com.sun.jna.platform.win32.COM.COMException} object.
      */
     protected void handleComException(WbemcliUtil.WmiQuery<?> query, COMException ex) {
-        String msg = "COM exception querying {}, which might not be on your system."
-                + " Will not attempt to query it again. Error was {}: {}";
-        Object[] args = { query.getWmiClassName(), ex.getHresult() == null ? null : ex.getHresult().intValue(),
-                ex.getMessage() };
-        if ("MSAcpi_ThermalZoneTemperature".equals(query.getWmiClassName())) {
-            LOG.debug(msg, args);
+        String className = query.getWmiClassName();
+        Integer hresult = ex.getHresult() == null ? null : ex.getHresult().intValue();
+        if ("MSAcpi_ThermalZoneTemperature".equals(className)) {
+            LOG.debug(COM_EXCEPTION_FMT, className, hresult, ex.getMessage());
         } else {
-            LOG.warn(msg, args);
+            LOG.warn(COM_EXCEPTION_FMT, className, hresult, ex.getMessage());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
         will enforce them) requires Error Prone as its host platform. Only wired up behind the
         error-prone profile for now; see pom.xml profile "error-prone". -->
         <error-prone.version>2.50.0</error-prone.version>
+        <!-- Error Prone plugin adding SLF4J-specific checks (placeholder/argument agreement, constant format
+        strings, logger field shape). Registers itself through META-INF/services, so it only needs to be on the
+        annotationProcessorPath; its checks are then configured with -Xep like any other. Compiled against an
+        older error_prone_check_api than ${error-prone.version} but declares it compileOnly, so it contributes
+        no transitive dependency; verified working against 2.50.0. -->
+        <errorprone-slf4j.version>0.1.29</errorprone-slf4j.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <restrict-imports-enforcer-rule.version>3.0.0</restrict-imports-enforcer-rule.version>
@@ -1240,14 +1246,40 @@
                                 failure, via the same javac behavior that already blocks the build on Error
                                 Prone's own ERROR-severity checks - without reaching for -Werror, which would
                                 fail on every javac warning, including several lint categories nothing here has
-                                ever triaged. -->
-                                <arg>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF -Xep:MissingSummary:OFF -Xep:StringSplitter:ERROR -Xep:EnumOrdinal:ERROR -Xep:OperatorPrecedence:ERROR -Xep:MixedMutabilityReturnType:ERROR -Xep:ReferenceEquality:ERROR -Xep:BoxingComparator:ERROR -Xep:NarrowCalculation:ERROR -Xep:LongDoubleConversion:ERROR -Xep:IntLiteralCast:ERROR -Xep:UnnecessaryLongToIntConversion:ERROR -Xep:IntLongMath:ERROR -Xep:BadImport:ERROR -Xep:ModifyCollectionInEnhancedForLoop:ERROR -Xep:EqualsGetClass:ERROR -Xep:DuplicateBranches:ERROR -Xep:InconsistentCapitalization:ERROR -Xep:NonApiType:ERROR -Xep:InvalidParam:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:UnnecessaryLambda:ERROR -Xep:UnnecessaryParentheses:ERROR -Xep:AssignmentExpression:ERROR -Xep:UnusedVariable:ERROR -Xep:PatternMatchingInstanceof:ERROR -Xep:EscapedEntity:ERROR -Xep:NotJavadoc:ERROR -Xep:AlmostJavadoc:ERROR -Xep:InvalidInlineTag:ERROR -Xep:InlineFormatString:ERROR</arg>
+                                ever triaged.
+
+                                The Slf4j* checks come from the errorprone-slf4j plugin rather than
+                                error_prone_core, and unlike core's defaults three of them (PlaceholderMismatch,
+                                FormatShouldBeConst, DoNotLogMessageOfExceptionExplicitly) already default to
+                                ERROR; the :ERROR below is therefore explicit-not-escalating for those, and a
+                                genuine escalation for LoggerShouldBePrivate/ShouldBeFinal/IllegalPassedClass,
+                                whose backlog was zero when the plugin was adopted.
+
+                                Two are OFF as findings the project rejects rather than a backlog to drain:
+                                LoggerShouldBeNonStatic fires on all ~200 `private static final Logger LOG`
+                                fields, whose staticness is deliberate, and SignOnlyFormat only ever flagged the
+                                horizontal-rule separator lines the SystemInfoTest mains print.
+
+                                DoNotLogMessageOfExceptionExplicitly is deliberately demoted to WARN rather than
+                                left at its default ERROR: its ~70-site backlog is a real one the project intends
+                                to drain (passing the throwable instead of its message keeps the stack trace, is
+                                null-safe where getMessage() is not, and defers all rendering when the level is
+                                disabled), but the fixes change log output across every platform and belong in
+                                their own change. WARN keeps the backlog visible without blocking; escalate to
+                                ERROR once it is drained. Note the severity token Error Prone accepts is WARN,
+                                not WARNING. -->
+                                <arg>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF -Xep:MissingSummary:OFF -Xep:StringSplitter:ERROR -Xep:EnumOrdinal:ERROR -Xep:OperatorPrecedence:ERROR -Xep:MixedMutabilityReturnType:ERROR -Xep:ReferenceEquality:ERROR -Xep:BoxingComparator:ERROR -Xep:NarrowCalculation:ERROR -Xep:LongDoubleConversion:ERROR -Xep:IntLiteralCast:ERROR -Xep:UnnecessaryLongToIntConversion:ERROR -Xep:IntLongMath:ERROR -Xep:BadImport:ERROR -Xep:ModifyCollectionInEnhancedForLoop:ERROR -Xep:EqualsGetClass:ERROR -Xep:DuplicateBranches:ERROR -Xep:InconsistentCapitalization:ERROR -Xep:NonApiType:ERROR -Xep:InvalidParam:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:UnnecessaryLambda:ERROR -Xep:UnnecessaryParentheses:ERROR -Xep:AssignmentExpression:ERROR -Xep:UnusedVariable:ERROR -Xep:PatternMatchingInstanceof:ERROR -Xep:EscapedEntity:ERROR -Xep:NotJavadoc:ERROR -Xep:AlmostJavadoc:ERROR -Xep:InvalidInlineTag:ERROR -Xep:InlineFormatString:ERROR -Xep:Slf4jLoggerShouldBeNonStatic:OFF -Xep:Slf4jSignOnlyFormat:OFF -Xep:Slf4jDoNotLogMessageOfExceptionExplicitly:WARN -Xep:Slf4jPlaceholderMismatch:ERROR -Xep:Slf4jFormatShouldBeConst:ERROR -Xep:Slf4jLoggerShouldBePrivate:ERROR -Xep:Slf4jLoggerShouldBeFinal:ERROR -Xep:Slf4jIllegalPassedClass:ERROR</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>
                                     <groupId>com.google.errorprone</groupId>
                                     <artifactId>error_prone_core</artifactId>
                                     <version>${error-prone.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>jp.skypencil.errorprone.slf4j</groupId>
+                                    <artifactId>errorprone-slf4j</artifactId>
+                                    <version>${errorprone-slf4j.version}</version>
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>


### PR DESCRIPTION
Adds the [errorprone-slf4j](https://github.com/KengoTODA/errorprone-slf4j) plugin (`jp.skypencil.errorprone.slf4j`, Apache-2.0) to the `error-prone` profile, and fixes everything it found except one deferred category.

It registers itself through `META-INF/services`, so it only needs to be on the `annotationProcessorPath`; its checks are then configured with `-Xep` like any core check. It declares `error_prone_check_api` as `compileOnly`, so it contributes no transitive dependency, and it is build-time only — nothing ships.

### Check configuration

| Check | Setting | Why |
|---|---|---|
| `Slf4jPlaceholderMismatch` | ERROR | 13 findings, fixed below |
| `Slf4jFormatShouldBeConst` | ERROR | 12 findings, fixed below |
| `Slf4jLoggerShouldBePrivate` | ERROR | zero findings — regression guard |
| `Slf4jLoggerShouldBeFinal` | ERROR | zero findings — regression guard |
| `Slf4jIllegalPassedClass` | ERROR | zero findings — regression guard |
| `Slf4jDoNotLogMessageOfExceptionExplicitly` | **WARN** | 74-site backlog, deferred to a follow-up |
| `Slf4jLoggerShouldBeNonStatic` | OFF | fires on all ~200 `private static final Logger LOG` fields |
| `Slf4jSignOnlyFormat` | OFF | only flagged the horizontal-rule separators the `SystemInfoTest` mains print |

The three escalated-to-ERROR guards follow the same per-check pattern as #3606. Note the severity token Error Prone accepts is `WARN`, not `WARNING`.

### `Slf4jPlaceholderMismatch` — 13 sites, one constant

`ParseUtil.DEFAULT_LOG_MSG` was `\"{} didn't parse. Returning default. {}\"`, with the exception passed as the second argument. SLF4J trims a trailing `Throwable` out of the substitution arguments **unconditionally**, regardless of placeholder count, so the exception was attached as the event's cause (stack trace and all) while the second placeholder was emitted literally:

```
message  : abc didn't parse. Returning default. {}
throwable: NumberFormatException (stack trace printed)
```

Verified directly against `slf4j-api` 1.7.36 and 2.0.18. Dropping the placeholder leaves throwable handling exactly as it was and removes the stray `{}` from all 13 call sites, which are otherwise untouched.

### `Slf4jFormatShouldBeConst` — 12 sites

- **`MacInstalledApps`** (×2) concatenated `e.getMessage()` into the message *and* passed the exception, duplicating the text alongside the stack trace.
- **`SmcUtil`** wrapped the entire message in `String.format` for a single `%08x` field. The constant is now the format string and only the hex value is formatted.
- **`WmiQueryHandler`** and its FFM twin built the format in a local. Hoisted to a constant and expanded the `Object[]` into varargs — with the format resolvable, `Slf4jPlaceholderMismatch` cannot count elements of an `Object[]` variable, so keeping the array just trades one finding for another. Making the arguments explicit also exposed four `DoNotLogMessageOfExceptionExplicitly` sites the check could not see through the array, **including the JNA twin's, which had been invisible while the FFM twin's were reported** — hence 74 deferred sites rather than 70.
- **`LogUtil.logAtLevel`** forwards a caller-supplied message by design, so it carries `@SuppressWarnings` rather than a fix.

### Deferred to a follow-up

`Slf4jDoNotLogMessageOfExceptionExplicitly`, 74 sites across 44 files, sits at WARN so the backlog stays visible without blocking. Passing the throwable instead of `e.getMessage()` keeps the stack trace and cause chain, is null-safe (a bare `new IOException()` currently logs the literal `null`), and is cheaper when the level is disabled, since `getMessage()` is evaluated at the call site regardless. But it changes log output on every platform and the JNA/FFM twins have to move together, so it belongs in its own change. That check escalates to ERROR once drained.

### Verification

- `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc` — clean, 1559 tests successful, 0 failed (macOS/aarch64/JDK 26).
- `./mvnw clean install -DskipTests -Perror-prone` — green, with only the deferred check's WARNING-severity findings and no other Error Prone output.
- Full Linux CI green on my fork, including the Error Prone and SLF4J-1.7 lint jobs: dbwiddis/oshi/actions/runs/31820498107.

No `CHANGELOG.md` entry: this is build tooling plus log-message hygiene, with no API or behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging for application discovery, parsing, hardware monitoring, and Windows system queries.
  * Preserved clearer exception details and appropriate warning or debug severity across platform-specific operations.

* **Chores**
  * Added automated checks to help maintain consistent and reliable logging practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->