### PR TITLE
Fix two javac -Xlint findings and document a pre-release lint sweep

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,6 +18,7 @@ manually deployed using `mvn clean deploy`
 * Make sure tests pass on all configured CI operating systems.
 * Manually run tests on any non-CI-covered OS using `mvn clean test`.
 * Review [SonarQube](https://sonarcloud.io/dashboard?id=com.github.oshi%3Aoshi-parent) for any bugs.
+* Run the javac lint sweep described under [Pre-release bug hunt](#pre-release-bug-hunt) below.
 * Choose an appropriate [version number](https://semver.org/) for the release
     * Proactively change version numbers in the download links on [README.md](README.md).
     * Copy `README.md` to `src/site/markdown/index.md`, then apply the site transformations below.
@@ -50,6 +51,47 @@ manually deployed using `mvn clean deploy`
       javadoc is the usual culprit, and it will not surface until `release:perform`.
     * **Always `clean` first.** The javadoc goals skip when their output is already present, so a
       re-run without `clean` can report `BUILD SUCCESS` without checking anything.
+
+### Pre-release bug hunt
+
+Error Prone, SonarCloud, Coverity, and the `oshi.comparison` twin-agreement tests all run on every
+PR, so they need no pre-release step. The one bug-hunting signal that is **not** continuously
+enforced is javac's own `-Xlint`, and it is worth sweeping once per release.
+
+It is deliberately not wired into the build. `-Xlint:all` expands to a different set of categories on
+every JDK, and an unrecognized category is a hard `error: invalid flag` rather than a warning — so it
+cannot be suppressed, and a blocking config would break the *oldest* JDK in the matrix rather than
+the newest. `restricted` requires JDK 22+, `this-escape` requires 21+, and the cfarm Solaris SPARC
+job builds on 17. Run it by hand instead, forking the compiler so javac reads the environment
+variable:
+
+```sh
+JDK_JAVAC_OPTIONS="-Xlint:all -Xmaxwarns 100000" \
+    ./mvnw clean install -DskipTests -Dmaven.compiler.fork=true > /tmp/lint.log 2>&1
+grep '^\[WARNING\]' /tmp/lint.log | sed -E 's/.*\[([a-z-]+)\].*/\1/' | sort | uniq -c | sort -rn
+```
+
+* **`-Xmaxwarns` is not optional.** javac stops after 100 warnings *per compilation* by default and
+  says nothing about it, which hid 48% of the findings (237 reported of 457 real) the first time this
+  was surveyed — including both of the only two genuine bugs it found. A per-module count of exactly
+  100 is truncation, not a result.
+* **`clean` is not optional either**, or incremental compilation recompiles nothing and cheerfully
+  reports zero warnings.
+* Use a JDK 25+ toolchain, or `oshi-core-ffm`, `oshi-benchmark`, and `oshi-dist` are silently skipped.
+  Findings are *not* OS-dependent — javac compiles every platform's sources on every host — so a
+  single sweep on any one machine covers all supported platforms.
+* **The value is the delta, not the total.** As of 7.5.0 the expected result is 455 findings in
+  exactly three categories, all structural and all deliberate:
+
+  | Category | Count | Why it is expected |
+  |---|---|---|
+  | `restricted` | 285 | FFM downcall and `reinterpret` calls, which are the entire point of `oshi-core-ffm`; the runtime side is declared by the native-access flag |
+  | `this-escape` | 149 | Memoized `this::method` suppliers, invoked only after construction, plus abstract accessors whose implementations return stateless singletons |
+  | `exports` | 21 | Public `oshi.ffm` methods returning types from non-exported packages, which [AGENTS.md](AGENTS.md) already declares off-limits to dependents |
+
+  Anything in a fourth category is new and worth reading. The 7.5.0 sweep surfaced two real defects
+  this way — a missing `serialVersionUID` and a raw `List` array — both of which had been hidden
+  under the 100-warning cap through several earlier passes.
 
 ### Release
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Win32Exception.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/Win32Exception.java
@@ -8,6 +8,8 @@ import java.util.Locale;
 
 public class Win32Exception extends RuntimeException {
 
+    private static final long serialVersionUID = 1L;
+
     private final int errorCode;
 
     public Win32Exception(int errorCode) {

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfDataUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfDataUtilFFM.java
@@ -309,7 +309,8 @@ public final class PerfDataUtilFFM {
                 // counterHandles[propIndex - 1][instanceIndex]
                 // Detect _Base suffix: strip it from the counter path and read SecondValue instead
                 boolean[] isBase = new boolean[props.length - 1];
-                @SuppressWarnings("unchecked")
+                // Generic array creation is illegal, so the array is allocated raw and cast
+                @SuppressWarnings({ "unchecked", "rawtypes" })
                 List<MemorySegment>[] counterHandles = new List[props.length - 1];
                 for (int p = 1; p < props.length; p++) {
                     String counterName = props[p].getCounter();


### PR DESCRIPTION
A full-reactor `-Xlint:all` sweep with the warning cap raised turns up 455 findings, all but two of them structural. This fixes the two that are not, and documents the sweep as a pre-release step rather than enabling it in the build.

### The two fixes

- **`Win32Exception`** extends `RuntimeException` and carries an `int errorCode` field but declared no `serialVersionUID`, so its serialized form was pinned to the compiler-generated default. Its sibling `FfmComException` already declared one.
- **`PerfDataUtilFFM`** allocates a raw `List[]` for the per-property counter handles — the same generic-array idiom #3607 fixed in `FileStorePanel`. It suppressed `unchecked` but not `rawtypes`.

Both had been hidden behind javac's default `-Xmaxwarns 100`, which truncates *per compilation* and reports nothing about having done so: the capped survey showed 237 findings where there are 457, and both of these sat in the tail. That is also why #3607 fixed the `oshi-demo` copy of the raw-array idiom and missed this one.

### Why not enable `-Xlint:all -Werror` in the build

`-Xlint:all` expands to a different set of categories on every JDK, and an unrecognized category is a hard `error: invalid flag` — not a warning, so it cannot be suppressed. `restricted` requires JDK 22+ and `this-escape` requires 21+, so a config excluding them compiles fine on a modern JDK and breaks the *oldest* one in the matrix, including the cfarm Solaris SPARC job that builds on 17. Verified by hand: JDK 21 rejects `-restricted`, JDK 17 rejects both.

The remaining 455 findings are all deliberate anyway — `restricted` (285) is FFM downcalls, which are the point of `oshi-core-ffm`; `this-escape` (149) is memoized `this::method` suppliers invoked only after construction, plus abstract accessors whose implementations return stateless singletons; `exports` (21) is public `oshi.ffm` methods returning types from non-exported packages, which AGENTS.md already declares off-limits to dependents.

So RELEASING.md gets a **Pre-release bug hunt** section instead: a copy-pasteable sweep that needs no pom changes, the expected per-category baseline so that a *fourth* category stands out as new, and the two traps that make a sweep silently under-report (`-Xmaxwarns`, and `clean` — without it incremental compilation recompiles nothing and reports zero). Error Prone, SonarCloud, Coverity, and the `oshi.comparison` twin tests already run on every PR, so `-Xlint` is the only bug-hunting signal not continuously enforced.

### Verification

Full gate green on macOS / JDK 26 — `clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`, 1560 tests successful, 0 failed. Neither fix changes runtime behavior, and both are in Windows-only FFM code I cannot execute here; CI's Windows job covers the compile. No CHANGELOG entry — nothing user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning handling during compilation for cleaner pre-release validation.
  * Added serialization metadata to improve compatibility for Windows-related exceptions.
  * Reduced compiler warnings when reading Windows performance data.

* **Documentation**
  * Added pre-release guidance covering lint checks, JDK compatibility, clean builds, and expected warning categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->