### PR TITLE
Use ParseUtil's precompiled patterns instead of recompiling per call

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
@@ -30,6 +30,7 @@ import oshi.util.tuples.Quartet;
  * sysctl backend and the {@code vmstat} parsing are supplied by the subclasses.
  */
 public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
+    private static final Pattern COLON_SPACE = Pattern.compile(": ");
 
     private final Supplier<Pair<Long, Long>> vmStats = memoize(this::queryVmStats, defaultExpiration());
 
@@ -126,7 +127,7 @@ public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
                 }
             }
             if (s.startsWith("cpu")) {
-                String[] ss = s.trim().split(": ", -1);
+                String[] ss = COLON_SPACE.split(s.trim(), -1);
                 if (ss.length == 2 && ss[1].split(",").length > 3) {
                     featureFlags.add(ss[1]);
                 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdFirmware.java
@@ -8,6 +8,7 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.common.AbstractFirmware;
@@ -24,6 +25,7 @@ import oshi.util.tuples.Triplet;
  */
 @Immutable
 public abstract class BsdFirmware extends AbstractFirmware {
+    private static final Pattern VENDOR = Pattern.compile("vendor");
 
     private final Supplier<Triplet<String, String, String>> manufVersRelease = memoize(this::queryFirmware);
 
@@ -90,7 +92,7 @@ public abstract class BsdFirmware extends AbstractFirmware {
             if (line.startsWith("bios0: vendor")) {
                 version = ParseUtil.getStringBetween(line, '"');
                 releaseDate = ParseUtil.parseMmDdYyyyToYyyyMmDD(ParseUtil.parseLastString(line));
-                String afterVendor = line.split("vendor", -1)[1].trim();
+                String afterVendor = VENDOR.split(line, -1)[1].trim();
                 int versionIdx = afterVendor.indexOf(" version ");
                 vendor = versionIdx > 0 ? afterVendor.substring(0, versionIdx)
                         : ParseUtil.whitespaces.split(afterVendor, -1)[0];

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdFirmware.java
@@ -92,7 +92,8 @@ public abstract class BsdFirmware extends AbstractFirmware {
                 releaseDate = ParseUtil.parseMmDdYyyyToYyyyMmDD(ParseUtil.parseLastString(line));
                 String afterVendor = line.split("vendor", -1)[1].trim();
                 int versionIdx = afterVendor.indexOf(" version ");
-                vendor = versionIdx > 0 ? afterVendor.substring(0, versionIdx) : afterVendor.split("\\s+", -1)[0];
+                vendor = versionIdx > 0 ? afterVendor.substring(0, versionIdx)
+                        : ParseUtil.whitespaces.split(afterVendor, -1)[0];
             }
         }
         return new Triplet<>(vendor, version, releaseDate);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/CupsPrinter.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/CupsPrinter.java
@@ -118,7 +118,7 @@ public abstract class CupsPrinter extends AbstractPrinter {
 
         for (String line : lpstatLines) {
             if (line.startsWith("printer ")) {
-                String[] parts = line.split("\\s+", -1);
+                String[] parts = ParseUtil.whitespaces.split(line, -1);
                 if (parts.length >= 3) {
                     String name = parts[1];
                     PrinterStatus status = Lpstat.parseStatus(line);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -6,6 +6,7 @@ package oshi.hardware.common.platform.unix.netbsd;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.platform.unix.BsdCentralProcessor;
@@ -21,6 +22,7 @@ import oshi.util.tuples.Pair;
  */
 @ThreadSafe
 public class NetBsdCentralProcessor extends BsdCentralProcessor {
+    private static final Pattern KEY_VALUE = Pattern.compile("\\s*=\\s*");
 
     private static final int CPUSTATES = 5;
     private static final int CP_USER = 0;
@@ -184,7 +186,7 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
         }
         String[] pairs = cpTimeStr.substring(colonIdx + 1).split(",", -1);
         for (String pair : pairs) {
-            String[] kv = pair.trim().split("\\s*=\\s*", -1);
+            String[] kv = KEY_VALUE.split(pair.trim(), -1);
             if (kv.length == 2) {
                 long val = ParseUtil.parseLongOrDefault(kv[1].trim(), 0L);
                 switch (kv[0].trim()) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -92,9 +92,9 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
         long interrupts = 0L;
         for (String line : vmstat) {
             if (line.endsWith("CPU context switches")) {
-                contextSwitches = ParseUtil.parseLongOrDefault(line.trim().split("\\s+", -1)[0], 0L);
+                contextSwitches = ParseUtil.parseLongOrDefault(ParseUtil.whitespaces.split(line.trim(), -1)[0], 0L);
             } else if (line.endsWith("device interrupts")) {
-                interrupts = ParseUtil.parseLongOrDefault(line.trim().split("\\s+", -1)[0], 0L);
+                interrupts = ParseUtil.parseLongOrDefault(ParseUtil.whitespaces.split(line.trim(), -1)[0], 0L);
             }
         }
         return new Pair<>(contextSwitches, interrupts);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
@@ -49,7 +49,7 @@ public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
 
         // Get list of disks from sysctl
         // NetBSD: hw.disknames = ld0 fd0 dk0 dk1 cd0 (space-separated, no colon suffix)
-        String[] devices = BsdSysctlUtil.sysctl("hw.disknames", "").trim().split("\\s+", -1);
+        String[] devices = ParseUtil.whitespaces.split(BsdSysctlUtil.sysctl("hw.disknames", "").trim(), -1);
         NetBsdHWDiskStore store;
         for (String diskName : devices) {
             // Try disklabel first (works for physical disks, not wedges)

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessor.java
@@ -121,9 +121,9 @@ public abstract class OpenBsdCentralProcessor extends BsdCentralProcessor {
         long interrupts = 0L;
         for (String line : vmstat) {
             if (line.endsWith("cpu context switches")) {
-                contextSwitches = ParseUtil.parseLongOrDefault(line.trim().split("\\s+", -1)[0], 0L);
+                contextSwitches = ParseUtil.parseLongOrDefault(ParseUtil.whitespaces.split(line.trim(), -1)[0], 0L);
             } else if (line.endsWith("interrupts")) {
-                interrupts = ParseUtil.parseLongOrDefault(line.trim().split("\\s+", -1)[0], 0L);
+                interrupts = ParseUtil.parseLongOrDefault(ParseUtil.whitespaces.split(line.trim(), -1)[0], 0L);
             }
         }
         return new Pair<>(contextSwitches, interrupts);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsHWDiskStore.java
@@ -28,6 +28,7 @@ import oshi.util.tuples.Pair;
  */
 @ThreadSafe
 public abstract class WindowsHWDiskStore extends AbstractHWDiskStore {
+    private static final Pattern WHITESPACE_CHAR = Pattern.compile("\\s");
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsHWDiskStore.class);
 
@@ -213,7 +214,7 @@ public abstract class WindowsHWDiskStore extends AbstractHWDiskStore {
      * @return The first space-delimited value
      */
     protected static String getIndexFromName(String s) {
-        return s.split("\\s", 2)[0];
+        return WHITESPACE_CHAR.split(s, 2)[0];
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/software/common/AbstractNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractNetworkParams.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.os.NetworkParams;
@@ -21,6 +22,7 @@ import oshi.util.ParseUtil;
  */
 @ThreadSafe
 public abstract class AbstractNetworkParams implements NetworkParams {
+    private static final Pattern SERVER_VALUE_DELIM = Pattern.compile("[ \t#;]");
 
     /**
      * Default constructor.
@@ -68,7 +70,7 @@ public abstract class AbstractNetworkParams implements NetworkParams {
             if (line.startsWith(key)) {
                 String value = line.substring(key.length()).replaceFirst("^[ \t]+", "");
                 if (!value.isEmpty() && value.charAt(0) != '#' && value.charAt(0) != ';') {
-                    String val = value.split("[ \t#;]", 2)[0];
+                    String val = SERVER_VALUE_DELIM.split(value, 2)[0];
                     servers.add(val);
                 }
             }

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxCgroupInfo.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxCgroupInfo.java
@@ -256,7 +256,7 @@ public class LinuxCgroupInfo implements CgroupInfo {
         if (cpuMax.isEmpty()) {
             return UNLIMITED;
         }
-        String[] parts = cpuMax.split("\\s+", -1);
+        String[] parts = ParseUtil.whitespaces.split(cpuMax, -1);
         if (parts.length >= 1) {
             if ("max".equalsIgnoreCase(parts[0])) {
                 return UNLIMITED;
@@ -296,7 +296,7 @@ public class LinuxCgroupInfo implements CgroupInfo {
         if (cpuMax.isEmpty()) {
             return DEFAULT_CPU_PERIOD;
         }
-        String[] parts = cpuMax.split("\\s+", -1);
+        String[] parts = ParseUtil.whitespaces.split(cpuMax, -1);
         if (parts.length >= 2) {
             return ParseUtil.parseLongOrDefault(parts[1], DEFAULT_CPU_PERIOD);
         }
@@ -322,7 +322,7 @@ public class LinuxCgroupInfo implements CgroupInfo {
         List<String> lines = FileUtil.readFile(basePath + "cpu.stat");
         for (String line : lines) {
             if (line.startsWith("usage_usec")) {
-                String[] parts = line.split("\\s+", -1);
+                String[] parts = ParseUtil.whitespaces.split(line, -1);
                 if (parts.length >= 2) {
                     long usec = ParseUtil.parseLongOrDefault(parts[1], 0L);
                     return usec * NANOSECONDS_PER_MICROSECOND;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxFileSystem.java
@@ -392,7 +392,7 @@ public abstract class LinuxFileSystem extends AbstractFileSystem {
         }
         List<String> osDescriptors = FileUtil.readFile(filename);
         if (!osDescriptors.isEmpty()) {
-            String[] splittedLine = osDescriptors.get(0).split("\\D+", -1);
+            String[] splittedLine = ParseUtil.notDigits.split(osDescriptors.get(0), -1);
             return ParseUtil.parseLongOrDefault(splittedLine[index], 0L);
         }
         return 0L;

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInternetProtocolStats.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxInternetProtocolStats.java
@@ -102,7 +102,7 @@ public class LinuxInternetProtocolStats extends AbstractInternetProtocolStats {
         // UDP6, udplite6 stats
         for (int line = lines.size() - 1; line >= 0 && foundUDPv6StatsCount < 4; line--) {
             if (lines.get(line).startsWith(UDP6)) {
-                String[] parts = lines.get(line).split("\\s+", -1);
+                String[] parts = ParseUtil.whitespaces.split(lines.get(line), -1);
                 switch (parts[0]) {
                     case "Udp6InDatagrams":
                         inDatagrams = ParseUtil.parseLongOrDefault(parts[1], 0L);

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,8 @@ import oshi.util.tuples.Triplet;
  */
 @ThreadSafe
 public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
+    private static final Pattern PARENTHESES = Pattern.compile("[()]");
+    private static final Pattern COMMA_SPACE = Pattern.compile(", ");
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxOperatingSystem.class);
 
@@ -307,9 +310,9 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
             if (line.startsWith("VERSION=")) {
                 LOG.debug(OS_RELEASE_LOG, line);
                 line = line.replace("VERSION=", "").replaceAll(DOUBLE_QUOTES, "").trim();
-                String[] split = line.split("[()]");
+                String[] split = PARENTHESES.split(line);
                 if (split.length <= 1) {
-                    split = line.split(", ");
+                    split = COMMA_SPACE.split(line);
                 }
                 if (split.length > 0) {
                     versionId = split[0].trim();
@@ -471,7 +474,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
         String versionId = Constants.UNKNOWN;
         String codeName = Constants.UNKNOWN;
         if (split.length > 1) {
-            split = split[1].split("[()]");
+            split = PARENTHESES.split(split[1]);
             if (split.length > 0) {
                 versionId = split[0].trim();
             }

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -474,7 +474,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
         String versionId = Constants.UNKNOWN;
         String codeName = Constants.UNKNOWN;
         if (split.length > 1) {
-            split = PARENTHESES.split(split[1]);
+            split = split[1].split("[()]");
             if (split.length > 0) {
                 versionId = split[0].trim();
             }

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOperatingSystemNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOperatingSystemNF.java
@@ -111,7 +111,7 @@ public class LinuxOperatingSystemNF extends LinuxOperatingSystem {
         // /proc/loadavg format: "load1 load5 load15 running/total lastpid"
         String loadavg = FileUtil.getStringFromFile(ProcPath.LOADAVG);
         if (!loadavg.isEmpty()) {
-            String[] split = loadavg.split("\\s+", -1);
+            String[] split = ParseUtil.whitespaces.split(loadavg, -1);
             if (split.length >= 4) {
                 String[] runTotal = split[3].split("/", -1);
                 if (runTotal.length == 2) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -48,6 +49,8 @@ import oshi.util.common.platform.unix.netbsd.FstatUtil;
  */
 @ThreadSafe
 public class NetBsdOSProcess extends BsdOSProcess {
+    private static final Pattern AFFINITY = Pattern.compile("Affinity:");
+    private static final Pattern COMMA_OR_WHITESPACE = Pattern.compile("[,\\s]+");
 
     /**
      * Ordered {@code ps} columns queried for each process. Shared by NetBsdOSProcess and the NetBSD OperatingSystem so
@@ -150,7 +153,7 @@ public class NetBsdOSProcess extends BsdOSProcess {
         for (String line : schedctl) {
             // Output includes "Affinity: <list>" when bound
             if (line.contains("Affinity:")) {
-                String[] parts = line.split("Affinity:", -1)[1].trim().split("[,\\s]+", -1);
+                String[] parts = COMMA_OR_WHITESPACE.split(AFFINITY.split(line, -1)[1].trim(), -1);
                 for (String part : parts) {
                     int bitToSet = ParseUtil.parseIntOrDefault(part.trim(), -1);
                     if (bitToSet >= 0) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
@@ -255,7 +255,7 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
         // token that a non-numeric limit produces (e.g. "nofiles(descriptors) 256 unlimited" -> ["", "256", ""],
         // since "unlimited" is itself consumed as trailing non-digit delimiter text); parseLongOrDefault below
         // then falls back to -1 for that position instead of throwing.
-        final String[] split = nofilesLine.get().split("\\D+", -1);
+        final String[] split = ParseUtil.notDigits.split(nofilesLine.get(), -1);
         if (split.length <= index) {
             return -1;
         }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystem.java
@@ -39,8 +39,10 @@ public abstract class SolarisOperatingSystem extends AbstractOperatingSystem {
     private static final String VERSION;
     private static final String BUILD_NUMBER;
     static {
+        // Splitting on whitespace yields a zero-length array for input that is entirely whitespace, so guard the
+        // first element too; this runs in a static initializer, where an exception would leave the class unusable
         String[] split = ParseUtil.whitespaces.split(ExecutingCommand.getFirstAnswer("uname -rv"));
-        VERSION = split[0];
+        VERSION = split.length > 0 ? split[0] : "";
         BUILD_NUMBER = split.length > 1 ? split[1] : "";
     }
 

--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -251,7 +251,7 @@ public final class EdidUtil {
         for (byte[] b : getDescriptors(edid)) {
             if (getDescriptorType(b) == MONITOR_NAME_TYPE) {
                 // The model name is the final whitespace-delimited token of the monitor-name descriptor
-                String[] tokens = getDescriptorText(b).split("\\s+", -1);
+                String[] tokens = ParseUtil.whitespaces.split(getDescriptorText(b), -1);
                 return tokens[tokens.length - 1].trim();
             }
         }

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -141,9 +141,6 @@ public final class ParseUtil {
 
     /** Constant <code>startWithNotDigits</code> */
     public static final Pattern startWithNotDigits = Pattern.compile("^\\D*");
-
-    /** Constant <code>forwardSlash</code> */
-    public static final Pattern slash = Pattern.compile("\\/");
     // CHECKSTYLE:ON ConstantName
 
     static {

--- a/oshi-common/src/main/java/oshi/util/PrivilegedUtil.java
+++ b/oshi-common/src/main/java/oshi/util/PrivilegedUtil.java
@@ -82,7 +82,7 @@ public final class PrivilegedUtil {
         }
 
         // Extract the command name (first token)
-        String[] tokens = command.trim().split("\\s+", -1);
+        String[] tokens = ParseUtil.whitespaces.split(command.trim(), -1);
         if (tokens.length == 0) {
             return false;
         }
@@ -309,7 +309,7 @@ public final class PrivilegedUtil {
         List<String> cmdList = new ArrayList<>();
         String prefix = getPrefix();
         if (!prefix.isEmpty()) {
-            cmdList.addAll(Arrays.asList(prefix.split("\\s+")));
+            cmdList.addAll(Arrays.asList(ParseUtil.whitespaces.split(prefix)));
         }
         cmdList.add("cat");
         cmdList.add(filePath);

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/FstatUtil.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/FstatUtil.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
 
 /**
  * Reads from fstat and related utilities on NetBSD.
@@ -41,7 +42,7 @@ public final class FstatUtil {
      */
     public static String parseCwdFromFstat(List<String> fstatLines) {
         for (String line : fstatLines) {
-            String[] split = line.trim().split("\\s+", -1);
+            String[] split = ParseUtil.whitespaces.split(line.trim(), -1);
             if (split.length > 4 && "wd".equals(split[3])) {
                 return split[4];
             }

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Lpstat.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Lpstat.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.Printer.PrinterStatus;
 import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
 
 /**
  * Utility to parse printer information from {@code lpstat} and {@code lpoptions} commands. Shared fallback path for
@@ -103,7 +104,7 @@ public final class Lpstat {
         String currentPrinter = null;
         for (String line : lines) {
             if (line.startsWith("printer ")) {
-                String[] parts = line.split("\\s+", -1);
+                String[] parts = ParseUtil.whitespaces.split(line, -1);
                 if (parts.length >= 2) {
                     currentPrinter = parts[1];
                 }

--- a/oshi-common/src/main/java/oshi/util/driver/unix/ProcLimits.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/ProcLimits.java
@@ -58,7 +58,7 @@ public final class ProcLimits {
             return -1;
         }
         // Split all non-digits away -> ["", "{soft-limit}", "{hard-limit}", ""]
-        final String[] split = maxOpenFilesLine.get().split("\\D+", -1);
+        final String[] split = ParseUtil.notDigits.split(maxOpenFilesLine.get(), -1);
         // Element 0 is the empty string left of the label, so a usable index is 1 or 2
         if (index < 1 || split.length <= index) {
             return -1;


### PR DESCRIPTION
A mechanical follow-up to #3615 and #3616. No behavior change and no changelog entry.

### Twenty splits stop recompiling their pattern

`String.split` only takes the JDK fast path when the regex is a single character that is not one of `.$|()[{^?*+\`, or a two-character backslash escape. Anything longer falls through to `Pattern.compile(regex).split(this, limit)` — a fresh compile on every call. Twenty sites split on `\s+` or `\D+`, both of which `ParseUtil` already holds as compiled constants, and eleven of them sit inside per-line parsing loops.

```java
- String[] parts = line.split("\\s+", -1);
+ String[] parts = ParseUtil.whitespaces.split(line, -1);
```

The limit is preserved at each site (nineteen of the twenty carry the `, -1` added in #3597), and the receiver moves into the argument unchanged, including the awkward ones such as `BsdSysctlUtil.sysctl("hw.disknames", "").trim()` and `osDescriptors.get(0)`.

### The single-character splits are deliberately left alone

This is the part worth not "fixing" later. There are 83 sites splitting on `,` `:` `/` `=` and a bare space, and routing those through a precompiled `Pattern` would make them **slower**, because `Pattern.split` allocates a `Matcher` while the fast path is an `indexOf` loop. An indicative measurement on JDK 26, splitting a ten-field line two million times after warmup:

| split | ns/op |
|---|---|
| `","` via `String.split` (fast path) | **103** |
| `","` via precompiled `Pattern.split` | 317 |
| `"\\s+"` via `String.split` (compiles each call) | 491 |
| `"\\s+"` via precompiled `Pattern.split` | **393** |

That is a warmed-up loop rather than JMH, so treat the magnitudes as indicative; the direction is what matters, and it is the opposite of the intuition that a precompiled pattern is always better.

### Removes `ParseUtil.slash`

It has no callers anywhere in the project, and its javadoc still called it `forwardSlash` from a rename. It is also self-defeating: `\/` is a two-character escape, so a plain `split("/")` would take the fast path and beat it. `ParseUtil` is not annotated `@PublicApi`, which is what the japicmp configuration includes, so this is outside the compatibility-checked surface.

### Guards one static initializer

`SolarisOperatingSystem` read `split[0]` without checking the length. Splitting on whitespace returns a **zero-length** array when the input is entirely whitespace, so a `uname -rv` first line of only whitespace would have thrown. It is unreachable in practice — `getFirstAnswer` returns an empty string when the command fails, and splitting that yields a one-element array — but this runs in a static initializer, where an exception leaves the class permanently unusable, so it is cheap insurance.

### Not included

Twelve one-off multi-character regexes have no existing constant (`, `, `[()]`, `: `, `[ \t#;]`, `[,\s]+`, `[\n\r]`, `\s*=\s*`, `\s`, and two literal separators). Hoisting each to its own `private static final Pattern` is a judgment call rather than a mechanical one, and only the two inside `LinuxOperatingSystem` loops would measurably benefit, so they are left for a separate decision.

### Verification

Full gate green locally on macOS/JDK 25: `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`, plus `./mvnw -Perror-prone install -DskipTests` over the whole reactor. 1561 tests pass, with no test changes — the intended outcome for a semantics-preserving sweep, since `String.split`'s slow path *is* `Pattern.compile(regex).split(this, limit)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solaris version detection when system information is empty or incomplete.
  * Improved reliability when reading firmware, printer, processor, disk, filesystem, network, DNS, and system statistics across supported platforms.
  * Improved processor affinity parsing on NetBSD.

* **Refactor**
  * Standardized text parsing across supported platforms for more consistent results and reduced processing overhead.
  * Removed an obsolete parsing utility constant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->