### PR TITLE
Mark the API and util packages, and the modules, for nullability

### DIFF
--- a/oshi-common/pom.xml
+++ b/oshi-common/pom.xml
@@ -128,4 +128,31 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!-- The main compile targets release 8, which predates JPMS and therefore excludes
+                 module-info.java. NullAway reads @NullMarked from the module declaration, so under this
+                 profile the whole module compiles at release 9 with module-info.java included; the
+                 released jar is unaffected, still built at release 8 by the default profile. -->
+            <id>error-prone</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <configuration>
+                                    <release>9</release>
+                                    <excludes combine.self="override" />
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/oshi-common/src/main/java/module-info.java
+++ b/oshi-common/src/main/java/module-info.java
@@ -1,3 +1,5 @@
+import org.jspecify.annotations.NullMarked;
+
 /**
  * Common OSHI API interfaces, abstract base classes, annotations, and utilities shared by all OSHI implementations.
  * <p>
@@ -17,7 +19,7 @@
  * {@code oshi.util.ProcUtil}), or other non-native techniques.</li>
  * </ol>
  */
-module com.github.oshi.common {
+@NullMarked module com.github.oshi.common {
     exports oshi.annotation;
     exports oshi.annotation.concurrent;
     exports oshi.driver.common.mac;

--- a/oshi-common/src/main/java/oshi/annotation/package-info.java
+++ b/oshi-common/src/main/java/oshi/annotation/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides useful annotation for oshi project.
  */
+@NullMarked
 package oshi.annotation;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiResult.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiResult.java
@@ -4,6 +4,8 @@
  */
 package oshi.driver.common.windows.wmi;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Common interface for WMI query results, abstracting JNA and FFM implementations.
  *
@@ -23,8 +25,9 @@ public interface WmiResult<T extends Enum<T>> {
      *
      * @param property the property enum constant
      * @param index    the row index
-     * @return the value
+     * @return the value, or {@code null} if the property was not set on this row
      */
+    @Nullable
     Object getValue(T property, int index);
 
     /**

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.platform.unix.BsdCentralProcessor;
 import oshi.util.ExecutingCommand;
@@ -174,7 +176,7 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
      * @param cpTimeStr the sysctl output string
      * @return array of [user, nice, sys, intr, idle] tick values
      */
-    static long[] parseCpTime(String cpTimeStr) {
+    static long[] parseCpTime(@Nullable String cpTimeStr) {
         long[] ticks = new long[CPUSTATES];
         if (cpTimeStr == null || cpTimeStr.isEmpty()) {
             return ticks;

--- a/oshi-common/src/main/java/oshi/spi/package-info.java
+++ b/oshi-common/src/main/java/oshi/spi/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Service Provider Interface for OSHI's SystemInfo entry points.
  */
+@NullMarked
 package oshi.spi;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/common/gpu/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/gpu/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides utilities shared across the GPU JNA and FFM implementations
  */
+@NullMarked
 package oshi.util.common.gpu;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides utilities shared across the macOS JNA and FFM implementations
  */
+@NullMarked
 package oshi.util.common.platform.mac;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/bsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/bsd/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides utilities shared across BSD-family operating systems
  */
+@NullMarked
 package oshi.util.common.platform.unix.bsd;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/dragonflybsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/dragonflybsd/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides utilities for DragonFly BSD
  */
+@NullMarked
 package oshi.util.common.platform.unix.dragonflybsd;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/freebsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/freebsd/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Shared, native-free FreeBSD utility classes (procstat parsing, etc.) used by both JNA and FFM implementations.
  */
+@NullMarked
 package oshi.util.common.platform.unix.freebsd;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/netbsd/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides utilities for NetBSD
  */
+@NullMarked
 package oshi.util.common.platform.unix.netbsd;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/openbsd/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/openbsd/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Provides pure-Java utility classes for OpenBSD, shared by the JNA and FFM modules.
  */
+@NullMarked
 package oshi.util.common.platform.unix.openbsd;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/driver/linux/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Provides non-native Linux driver utilities for querying system information.
  */
+@NullMarked
 package oshi.util.driver.linux;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Provides non-native Linux driver utilities for querying the {@code /proc} filesystem.
  */
+@NullMarked
 package oshi.util.driver.linux.proc;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/driver/unix/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides driver utilities common to unix systems that do not require native access
  */
+@NullMarked
 package oshi.util.driver.unix;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/linux/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/linux/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Provides constants for Linux filesystem paths ({@code /proc}, {@code /dev}, {@code /sys}).
  */
+@NullMarked
 package oshi.util.linux;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/main/java/oshi/util/tuples/package-info.java
+++ b/oshi-common/src/main/java/oshi/util/tuples/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides classes encapsulating multiple objects, intended as return types from methods
  */
+@NullMarked
 package oshi.util.tuples;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/GeomDiskListTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/GeomDiskListTest.java
@@ -7,6 +7,7 @@ package oshi.driver.common.unix.freebsd.disk;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,11 +34,13 @@ class GeomDiskListTest {
         assertThat(result.size(), is(2));
 
         Triplet<String, String, Long> ada0 = result.get("ada0");
+        assertNotNull(ada0, "ada0 missing");
         assertThat(ada0.getA(), is("Samsung SSD 860 EVO 500GB"));
         assertThat(ada0.getB(), is("S3Z2NB0K123456X"));
         assertThat(ada0.getC(), is(500107862016L));
 
         Triplet<String, String, Long> da0 = result.get("da0");
+        assertNotNull(da0, "da0 missing");
         assertThat(da0.getA(), is("USB Flash Drive"));
         assertThat(da0.getB(), is(""));
         assertThat(da0.getC(), is(8053063680L));
@@ -57,6 +60,7 @@ class GeomDiskListTest {
 
         assertThat(result.size(), is(1));
         Triplet<String, String, Long> vtbd0 = result.get("vtbd0");
+        assertNotNull(vtbd0, "vtbd0 missing");
         assertThat(vtbd0.getA(), is("VirtIO Block Device"));
         assertThat(vtbd0.getB(), is("serial123"));
         assertThat(vtbd0.getC(), is(0L));
@@ -70,6 +74,7 @@ class GeomDiskListTest {
 
         assertThat(result.size(), is(1));
         Triplet<String, String, Long> nvd0 = result.get("nvd0");
+        assertNotNull(nvd0, "nvd0 missing");
         assertThat(nvd0.getA(), is(Constants.UNKNOWN));
         assertThat(nvd0.getB(), is(Constants.UNKNOWN));
         assertThat(nvd0.getC(), is(1024000000000L));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/IostatTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/IostatTest.java
@@ -7,6 +7,7 @@ package oshi.driver.common.unix.solaris.disk;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,6 +77,7 @@ class IostatTest {
         assertThat(result.size(), is(2));
 
         Quintet<String, String, String, String, Long> cmdk0 = result.get("cmdk0");
+        assertNotNull(cmdk0, "cmdk0 missing");
         assertThat(cmdk0.getA(), is("VBOX HARDDISK"));
         assertThat(cmdk0.getB(), is(""));
         assertThat(cmdk0.getC(), is(""));
@@ -83,6 +85,7 @@ class IostatTest {
         assertThat(cmdk0.getE(), is(21474836480L));
 
         Quintet<String, String, String, String, Long> sd0 = result.get("sd0");
+        assertNotNull(sd0, "sd0 missing");
         assertThat(sd0.getA(), is(""));
         assertThat(sd0.getB(), is("ATA"));
         assertThat(sd0.getC(), is("Samsung SSD 860"));

--- a/oshi-common/src/test/java/oshi/driver/common/windows/wmi/WmiUtilTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/windows/wmi/WmiUtilTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 class WmiUtilTest {
@@ -77,6 +78,9 @@ class WmiUtilTest {
     }
 
     @Test
+    // The constructor's parameters are non-null and it enforces that with requireNonNull. This test exists to prove
+    // the enforcement, so it has to pass the nulls the type system otherwise rules out.
+    @SuppressWarnings("NullAway")
     void testWmiQueryNullValidation() {
         assertThrows(NullPointerException.class, () -> new WmiQuery<>(null, "Class", TestProp.class));
         assertThrows(NullPointerException.class, () -> new WmiQuery<>("NS", null, TestProp.class));
@@ -86,9 +90,9 @@ class WmiUtilTest {
     private static class MockWmiResult<T extends Enum<T>> implements WmiResult<T> {
         private final int cimType;
         private final int vtType;
-        private final Object value;
+        private final @Nullable Object value;
 
-        MockWmiResult(int cimType, int vtType, Object value) {
+        MockWmiResult(int cimType, int vtType, @Nullable Object value) {
             this.cimType = cimType;
             this.vtType = vtType;
             this.value = value;
@@ -100,7 +104,7 @@ class WmiUtilTest {
         }
 
         @Override
-        public Object getValue(T property, int index) {
+        public @Nullable Object getValue(T property, int index) {
             return value;
         }
 

--- a/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
+++ b/oshi-common/src/test/java/oshi/nativefree/SystemInfoTest.java
@@ -66,7 +66,7 @@ public class SystemInfoTest {
     @Test
     void testPlatformEnum() {
         assertThat("Unsupported OS", PlatformEnum.getCurrentPlatform(), is(not(PlatformEnum.UNKNOWN)));
-        main(null);
+        main(new String[0]);
     }
 
     public static void main(String[] args) {

--- a/oshi-core-ffm/pom.xml
+++ b/oshi-core-ffm/pom.xml
@@ -24,6 +24,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>${jspecify.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>oshi-common</artifactId>
             <version>${project.version}</version>

--- a/oshi-core-ffm/src/main/java/module-info.java
+++ b/oshi-core-ffm/src/main/java/module-info.java
@@ -1,3 +1,5 @@
+import org.jspecify.annotations.NullMarked;
+
 /**
  * FFM-based native implementation of the OSHI API for JDK 25+.
  * <p>
@@ -17,7 +19,7 @@
  *
  * @see oshi.ffm.SystemInfo
  */
-module com.github.oshi.ffm {
+@NullMarked module com.github.oshi.ffm {
     // API
     exports oshi.ffm;
     exports oshi.ffm.util;
@@ -32,6 +34,7 @@ module com.github.oshi.ffm {
     provides oshi.spi.SystemInfoProvider with oshi.ffm.SystemInfo;
 
     // dependencies
+    requires static org.jspecify;
     requires transitive com.github.oshi.common;
     requires transitive java.desktop;
     requires transitive org.slf4j;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/common/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/common/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides FFM bindings for cross-platform native libraries.
  */
+@NullUnmarked
 package oshi.ffm.common;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides FFM access to system libraries and cross-platform utilities
  */
+@NullMarked
 package oshi.ffm;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/linux/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/linux/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Provides FFM access to system libraries for Linux.
  */
+@NullUnmarked
 package oshi.ffm.platform.linux;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides FFM access to system libraries for macOS.
  */
+@NullUnmarked
 package oshi.ffm.platform.mac;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/aix/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/aix/package-info.java
@@ -5,4 +5,7 @@
 /**
  * FFM bindings for AIX-specific native libraries (libc thread/process IDs, {@code libperfstat}).
  */
+@NullUnmarked
 package oshi.ffm.platform.unix.aix;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/dragonflybsd/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/dragonflybsd/package-info.java
@@ -5,4 +5,7 @@
 /**
  * FFM bindings for DragonFly BSD-specific libc functions.
  */
+@NullUnmarked
 package oshi.ffm.platform.unix.dragonflybsd;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/freebsd/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/freebsd/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Provides FFM access to system libraries for FreeBSD.
  */
+@NullUnmarked
 package oshi.ffm.platform.unix.freebsd;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/openbsd/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/openbsd/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Provides FFM access to system libraries for OpenBSD.
  */
+@NullUnmarked
 package oshi.ffm.platform.unix.openbsd;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides FFM access to system libraries for Unix-like systems.
  */
+@NullUnmarked
 package oshi.ffm.platform.unix;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/solaris/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/unix/solaris/package-info.java
@@ -1,4 +1,7 @@
 /**
  * Provides FFM access to system libraries for Solaris/illumos.
  */
+@NullUnmarked
 package oshi.ffm.platform.unix.solaris;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/com/package-info.java
@@ -7,4 +7,7 @@
  * bindings for OLE32, WMI interfaces (IWbemLocator, IWbemServices, IEnumWbemClassObject, IWbemClassObject), and
  * supporting types (GUID, VARIANT, BSTR).
  */
+@NullUnmarked
 package oshi.ffm.platform.windows.com;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/package-info.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides Windows-specific Foreign Function and Memory (FFM) API implementations.
  */
+@NullUnmarked
 package oshi.ffm.platform.windows;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -36,6 +36,12 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>${jspecify.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>oshi-common</artifactId>
             <version>${project.version}</version>
@@ -169,4 +175,31 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <profiles>
+        <profile>
+            <!-- The main compile targets release 8, which predates JPMS and therefore excludes
+                 module-info.java. NullAway reads @NullMarked from the module declaration, so under this
+                 profile the whole module compiles at release 9 with module-info.java included; the
+                 released jar is unaffected, still built at release 8 by the default profile. -->
+            <id>error-prone</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <configuration>
+                                    <release>9</release>
+                                    <excludes combine.self="override" />
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/oshi-core/src/main/java/module-info.java
+++ b/oshi-core/src/main/java/module-info.java
@@ -1,3 +1,5 @@
+import org.jspecify.annotations.NullMarked;
+
 /**
  * JNA-based native implementation of the OSHI API for JDK 8+.
  * <p>
@@ -17,7 +19,7 @@
  *
  * @see oshi.SystemInfo
  */
-module com.github.oshi {
+@NullMarked module com.github.oshi {
     // API
     exports oshi;
     exports oshi.util.gpu;
@@ -39,6 +41,7 @@ module com.github.oshi {
     opens oshi.jna.platform.unix to com.sun.jna;
 
     // dependencies
+    requires static org.jspecify;
     requires transitive com.github.oshi.common;
     requires transitive com.sun.jna;
     requires transitive com.sun.jna.platform;

--- a/oshi-core/src/main/java/oshi/jna/common/package-info.java
+++ b/oshi-core/src/main/java/oshi/jna/common/package-info.java
@@ -6,4 +6,7 @@
  * Provides JNA library bindings that are not platform-specific. These classes should be considered non-API as they may
  * be removed if/when their code is incorporated into the JNA project.
  */
+@NullUnmarked
 package oshi.jna.common;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core/src/main/java/oshi/jna/package-info.java
+++ b/oshi-core/src/main/java/oshi/jna/package-info.java
@@ -6,4 +6,7 @@
  * Provides wrapper functions to proactively close native memory allocations. These classes should be considered
  * non-API.
  */
+@NullUnmarked
 package oshi.jna;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core/src/main/java/oshi/jna/platform/linux/package-info.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/linux/package-info.java
@@ -6,4 +6,7 @@
  * Provides extensions of JNA libraries for Linux. These classes should be considered non-API as they may be removed
  * if/when their code is incorporated into the JNA project.
  */
+@NullUnmarked
 package oshi.jna.platform.linux;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core/src/main/java/oshi/jna/platform/mac/package-info.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/mac/package-info.java
@@ -6,4 +6,7 @@
  * Provides extensions of JNA libraries for macOS. These classes should be considered non-API as they may be removed
  * if/when their code is incorporated into the JNA project.
  */
+@NullUnmarked
 package oshi.jna.platform.mac;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core/src/main/java/oshi/jna/platform/unix/package-info.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/unix/package-info.java
@@ -6,4 +6,7 @@
  * Provides extensions of JNA libraries for Unix. These classes should be considered non-API as they may be removed
  * if/when their code is incorporated into the JNA project.
  */
+@NullUnmarked
 package oshi.jna.platform.unix;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core/src/main/java/oshi/jna/platform/windows/package-info.java
+++ b/oshi-core/src/main/java/oshi/jna/platform/windows/package-info.java
@@ -6,4 +6,7 @@
  * Provides extensions of JNA libraries for Windows. These classes should be considered non-API as they may be removed
  * if/when their code is incorporated into the JNA project.
  */
+@NullUnmarked
 package oshi.jna.platform.windows;
+
+import org.jspecify.annotations.NullUnmarked;

--- a/oshi-core/src/main/java/oshi/package-info.java
+++ b/oshi-core/src/main/java/oshi/package-info.java
@@ -60,4 +60,7 @@
  * This approach trades some coverage (not all information is available without native access) for compatibility with
  * restricted JVM environments.
  */
+@NullMarked
 package oshi;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-core/src/main/java/oshi/util/gpu/package-info.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Utility classes for optional vendor GPU library integration (NVML, ADL).
  */
+@NullMarked
 package oshi.util.gpu;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-core/src/main/java/oshi/util/platform/mac/package-info.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides utilities for macOS.
  */
+@NullMarked
 package oshi.util.platform.mac;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-core/src/main/java/oshi/util/platform/unix/freebsd/package-info.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/freebsd/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides utilities for FreeBSD
  */
+@NullMarked
 package oshi.util.platform.unix.freebsd;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/package-info.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/netbsd/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides JNA-based native sysctl utilities for NetBSD.
  */
+@NullMarked
 package oshi.util.platform.unix.netbsd;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-core/src/main/java/oshi/util/platform/unix/openbsd/package-info.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/openbsd/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides utilities for OpenBSD
  */
+@NullMarked
 package oshi.util.platform.unix.openbsd;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-core/src/main/java/oshi/util/platform/unix/solaris/package-info.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/solaris/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides utilities for Solaris
  */
+@NullMarked
 package oshi.util.platform.unix.solaris;
+
+import org.jspecify.annotations.NullMarked;

--- a/oshi-core/src/main/java/oshi/util/platform/windows/package-info.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/package-info.java
@@ -5,4 +5,7 @@
 /**
  * Provides utilities for Windows.
  */
+@NullMarked
 package oshi.util.platform.windows;
+
+import org.jspecify.annotations.NullMarked;

--- a/pom.xml
+++ b/pom.xml
@@ -1237,8 +1237,12 @@
                                 <arg>-Xlint:-options</arg>
                                 <!-- javac's default -Xmaxwarns is 100 per module; Error Prone's findings are
                                 javac warnings, so without this a module with more findings than that silently
-                                drops the rest with no indication anything was truncated. -->
+                                drops the rest with no indication anything was truncated. -Xmaxerrs is the same
+                                cap for the checks raised to ERROR, NullAway among them, and truncates just as
+                                silently: a survey of oshi-common reported exactly 100 findings until it was set. -->
                                 <arg>-Xmaxwarns</arg>
+                                <arg>100000</arg>
+                                <arg>-Xmaxerrs</arg>
                                 <arg>100000</arg>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
@@ -1270,7 +1274,7 @@
                                 74-site backlog was drained; every log call now passes the throwable rather than
                                 its message, so it is back at the plugin's default ERROR. Note the severity token
                                 Error Prone accepts is WARN, not WARNING. -->
-                                <arg>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF -Xep:MissingSummary:OFF -Xep:StringSplitter:ERROR -Xep:EnumOrdinal:ERROR -Xep:OperatorPrecedence:ERROR -Xep:MixedMutabilityReturnType:ERROR -Xep:ReferenceEquality:ERROR -Xep:BoxingComparator:ERROR -Xep:NarrowCalculation:ERROR -Xep:LongDoubleConversion:ERROR -Xep:IntLiteralCast:ERROR -Xep:UnnecessaryLongToIntConversion:ERROR -Xep:IntLongMath:ERROR -Xep:BadImport:ERROR -Xep:ModifyCollectionInEnhancedForLoop:ERROR -Xep:EqualsGetClass:ERROR -Xep:DuplicateBranches:ERROR -Xep:InconsistentCapitalization:ERROR -Xep:NonApiType:ERROR -Xep:InvalidParam:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:UnnecessaryLambda:ERROR -Xep:UnnecessaryParentheses:ERROR -Xep:AssignmentExpression:ERROR -Xep:UnusedVariable:ERROR -Xep:PatternMatchingInstanceof:ERROR -Xep:EscapedEntity:ERROR -Xep:NotJavadoc:ERROR -Xep:AlmostJavadoc:ERROR -Xep:InvalidInlineTag:ERROR -Xep:InlineFormatString:ERROR -Xep:Slf4jLoggerShouldBeNonStatic:OFF -Xep:Slf4jSignOnlyFormat:OFF -Xep:Slf4jDoNotLogMessageOfExceptionExplicitly:ERROR -Xep:Slf4jPlaceholderMismatch:ERROR -Xep:Slf4jFormatShouldBeConst:ERROR -Xep:Slf4jLoggerShouldBePrivate:ERROR -Xep:Slf4jLoggerShouldBeFinal:ERROR -Xep:Slf4jIllegalPassedClass:ERROR -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:HandleTestAssertionLibraries=true</arg>
+                                <arg>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF -Xep:MissingSummary:OFF -Xep:StringSplitter:ERROR -Xep:EnumOrdinal:ERROR -Xep:OperatorPrecedence:ERROR -Xep:MixedMutabilityReturnType:ERROR -Xep:ReferenceEquality:ERROR -Xep:BoxingComparator:ERROR -Xep:NarrowCalculation:ERROR -Xep:LongDoubleConversion:ERROR -Xep:IntLiteralCast:ERROR -Xep:UnnecessaryLongToIntConversion:ERROR -Xep:IntLongMath:ERROR -Xep:BadImport:ERROR -Xep:ModifyCollectionInEnhancedForLoop:ERROR -Xep:EqualsGetClass:ERROR -Xep:DuplicateBranches:ERROR -Xep:InconsistentCapitalization:ERROR -Xep:NonApiType:ERROR -Xep:InvalidParam:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:UnnecessaryLambda:ERROR -Xep:UnnecessaryParentheses:ERROR -Xep:AssignmentExpression:ERROR -Xep:UnusedVariable:ERROR -Xep:PatternMatchingInstanceof:ERROR -Xep:EscapedEntity:ERROR -Xep:NotJavadoc:ERROR -Xep:AlmostJavadoc:ERROR -Xep:InvalidInlineTag:ERROR -Xep:InlineFormatString:ERROR -Xep:Slf4jLoggerShouldBeNonStatic:OFF -Xep:Slf4jSignOnlyFormat:OFF -Xep:Slf4jDoNotLogMessageOfExceptionExplicitly:ERROR -Xep:Slf4jPlaceholderMismatch:ERROR -Xep:Slf4jFormatShouldBeConst:ERROR -Xep:Slf4jLoggerShouldBePrivate:ERROR -Xep:Slf4jLoggerShouldBeFinal:ERROR -Xep:Slf4jIllegalPassedClass:ERROR -Xep:NullAway:WARN -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:HandleTestAssertionLibraries=true</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>


### PR DESCRIPTION
Establishes the end state for #3593 across `oshi-common`, `oshi-core` and `oshi-core-ffm`, then leaves NullAway at **WARN** while the backlog it reports is drained. It returns to ERROR once the count reaches zero — the same approach #3597 took with the SLF4J check, which spent a release cycle at WARN while its 74 sites were fixed.

Nothing here changes behavior. The two bug fixes described at the end were found by the marking.

### Two mechanisms, each aimed at what it can reach

A package annotation is the only one every consumer sees. A JDK 8 user has no module system at all, and a JDK 9+ user on the classpath does not resolve module annotations either — those are only observed when the jar is on the **module path**. So the split is by audience rather than by convenience:

| scope | mechanism |
|---|---|
| packages holding `@PublicApi` types — `oshi`, `oshi.hardware`, `oshi.software.os`, `oshi.util`, `oshi.spi`, `oshi.annotation`, `oshi.ffm` | `@NullMarked` on `package-info.java` |
| the whole `oshi.util` tree, which callers do sometimes reach for | `@NullMarked` on `package-info.java` |
| everything else — per-OS implementations, abstract bases, drivers | `@NullMarked` on `module-info.java` |

The second group is what the project already documents as not meant for outside use. Marking it at the module level exists so we can check our own code, and it needs no upkeep as packages are added — which is the one real weakness of per-package marking.

### The native mappings are opted out

`@NullUnmarked` on `oshi.jna`, `oshi.jna.common`, `oshi.jna.platform.*`, `oshi.ffm.common` and `oshi.ffm.platform.*`. Those describe someone else's memory layout rather than our contracts, and are already exempt from the javadoc rules for the same reason.

Their utility packages are **not** opted out: `oshi.jna.util` and `oshi.ffm.util.*` follow the rules like any other code, and `oshi.jna.util.SysctlUtilJNA` duly reports findings.

### Build changes this needs

**`oshi-common` and `oshi-core` compile at release 9 under `-Perror-prone` only.** Their sources target release 8, which predates JPMS and therefore excludes `module-info.java` from the compilation — so NullAway never sees the module annotation and marking the module does nothing. Under this profile the whole module compiles at release 9 with `module-info.java` included. The released jars are unchanged, still built at release 8 by the default profile, and every test job still compiles at release 8, so a Java 9+ API would still fail there.

**`oshi-core` and `oshi-core-ffm` gain the jspecify dependency and `requires static org.jspecify`**, since `oshi-common` declares it `optional` and it is therefore not transitive.

**`-Xmaxerrs` joins the `-Xmaxwarns` that #3597 set.** NullAway reports at ERROR once the backlog is drained, and javac caps errors at 100 by default just as silently as it caps warnings. This is not hypothetical: a survey of `oshi-common` reported *exactly* 100 findings until this was set, against a real 288.

### Two false contracts the marking exposed

**`WmiResult.getValue` declared a non-null return that every caller already distrusted.** All four call sites in `WmiUtil` do `Object o = result.getValue(...); if (o == null) {...}`. A WMI row that does not carry the requested property returns null through a signature promising otherwise, so the null check was load-bearing and the signature was wrong.

**`NetBsdCentralProcessor.parseCpTime` opens with `if (cpTimeStr == null || cpTimeStr.isEmpty())`** on a parameter it declared non-null.

Two tests also asserted on a map lookup without checking the key was present — a miss would have failed with a `NullPointerException` rather than naming the key — and one called `main(null)` where an empty array says the same thing.

### Where the backlog stands

682 warnings: `oshi-common` 306, `oshi-core-ffm` 219, `oshi-core` 157; 648 in main sources and 34 in tests. Largest clusters are `oshi.driver.common.windows.registry` 54, `oshi.ffm.util.gpu` 38, `oshi.hardware.common.platform.windows` 31, `oshi.hardware.common.platform.mac` 24, `oshi.util.gpu` 24. `oshi-demo` has no `module-info.java` and is left alone for now.

### Verification

Full gate green locally on macOS/JDK 25: `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`, 1561 tests passing, plus `./mvnw -Perror-prone clean install -DskipTests` over the whole reactor building successfully at WARN.

Note the `clean` on that last command. Without it Maven finds the classes up to date, skips recompilation, and Error Prone reports success having analysed nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive nullability annotations across core, common, native, and platform-specific APIs.
  * Clarified that certain WMI values may be absent.
* **Bug Fixes**
  * Improved handling and validation of potentially missing parsed data.
* **Tests**
  * Strengthened test assertions for absent or invalid values.
* **Chores**
  * Added validation support for nullability analysis while preserving Java 8 compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->