### PR TITLE
Make the driver package's nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lscfg.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lscfg.java
@@ -6,6 +6,8 @@ package oshi.driver.common.unix.aix;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -36,7 +38,8 @@ public final class Lscfg {
      * @param lscfg The output of a previous call to {@code lscfg -vp}
      * @return A triplet with backplane model, serial number, and version
      */
-    public static Triplet<String, String, String> queryBackplaneModelSerialVersion(List<String> lscfg) {
+    public static Triplet<@Nullable String, @Nullable String, @Nullable String> queryBackplaneModelSerialVersion(
+            List<String> lscfg) {
         final String planeMarker = "WAY BACKPLANE";
         final String modelMarker = "Part Number";
         final String serialMarker = "Serial Number";
@@ -81,7 +84,7 @@ public final class Lscfg {
      * @param device The disk to get the model and serial from
      * @return A pair containing the model and serial number for the device, or null if not found
      */
-    public static Pair<String, String> queryModelSerial(String device) {
+    public static Pair<@Nullable String, @Nullable String> queryModelSerial(String device) {
         return parseModelSerial(ExecutingCommand.runNative("lscfg -vl " + device), device);
     }
 
@@ -92,7 +95,7 @@ public final class Lscfg {
      * @param device The disk the output describes
      * @return A pair containing the model and serial number for the device, either of which may be null if not found
      */
-    public static Pair<String, String> parseModelSerial(List<String> lscfg, String device) {
+    public static Pair<@Nullable String, @Nullable String> parseModelSerial(List<String> lscfg, String device) {
         String modelMarker = "Machine Type and Model";
         String serialMarker = "Serial Number";
         String model = null;

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lspv.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/Lspv.java
@@ -153,7 +153,12 @@ public final class Lspv {
             // All maps should have same keys
             String name = entry.getKey();
             String type = typeMap.get(name);
-            long size = ppSize * ppMap.get(name);
+            Integer physicalPartitions = ppMap.get(name);
+            if (type == null || physicalPartitions == null) {
+                // The maps are filled together from one lspv run; a gap means its output was inconsistent
+                continue;
+            }
+            long size = ppSize * physicalPartitions;
             Pair<Integer, Integer> majMin = majMinMap.get(name);
             int major = majMin == null ? ParseUtil.getFirstIntValue(name) : majMin.getA();
             int minor = majMin == null ? ParseUtil.getFirstIntValue(name) : majMin.getB();

--- a/oshi-common/src/main/java/oshi/driver/common/unix/aix/PsInfo.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/aix/PsInfo.java
@@ -6,6 +6,7 @@ package oshi.driver.common.unix.aix;
 
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +58,7 @@ public final class PsInfo {
      * @param psinfo a populated {@link AixPsInfo} containing the offset pointers
      * @return a triplet of {@code (argc, argv, envp)}, or {@code null} if the psinfo is unusable
      */
-    public static Triplet<Integer, Long, Long> queryArgsEnvAddrs(int pid, AixPsInfo psinfo) {
+    public static @Nullable Triplet<Integer, Long, Long> queryArgsEnvAddrs(int pid, AixPsInfo psinfo) {
         if (psinfo != null) {
             int argc = psinfo.pr_argc;
             // Must have at least one argc (the command itself) so failure here means exit

--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/PsInfo.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/PsInfo.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public final class PsInfo {
      * @param pid the process ID
      * @return populated {@link SolarisPsInfo}, or {@code null} if the file isn't readable
      */
-    public static SolarisPsInfo queryPsInfo(int pid) {
+    public static @Nullable SolarisPsInfo queryPsInfo(int pid) {
         String path = String.format(Locale.ROOT, "/proc/%d/psinfo", pid);
         ByteBuffer buff = FileUtil.readAllBytesAsBuffer(path);
         if (buff == null || buff.remaining() == 0) {
@@ -62,7 +63,7 @@ public final class PsInfo {
      * @param tid the thread ID (lwpid)
      * @return populated {@link SolarisLwpsInfo}, or {@code null} if not readable
      */
-    public static SolarisLwpsInfo queryLwpsInfo(int pid, int tid) {
+    public static @Nullable SolarisLwpsInfo queryLwpsInfo(int pid, int tid) {
         ByteBuffer buff = FileUtil
                 .readAllBytesAsBuffer(String.format(Locale.ROOT, "/proc/%d/lwp/%d/lwpsinfo", pid, tid));
         if (buff == null || buff.remaining() == 0) {
@@ -82,7 +83,7 @@ public final class PsInfo {
      * @param pid the process ID
      * @return populated {@link SolarisPrUsage}, or {@code null} if not readable
      */
-    public static SolarisPrUsage queryPrUsage(int pid) {
+    public static @Nullable SolarisPrUsage queryPrUsage(int pid) {
         ByteBuffer buff = FileUtil.readAllBytesAsBuffer(String.format(Locale.ROOT, "/proc/%d/usage", pid));
         if (buff == null || buff.remaining() == 0) {
             return null;
@@ -102,7 +103,7 @@ public final class PsInfo {
      * @param tid the thread ID
      * @return populated {@link SolarisPrUsage}, or {@code null} if not readable
      */
-    public static SolarisPrUsage queryPrUsage(int pid, int tid) {
+    public static @Nullable SolarisPrUsage queryPrUsage(int pid, int tid) {
         ByteBuffer buff = FileUtil.readAllBytesAsBuffer(String.format(Locale.ROOT, "/proc/%d/lwp/%d/usage", pid, tid));
         if (buff == null || buff.remaining() == 0) {
             return null;

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/LoadAverage.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/LoadAverage.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.IdleProcessorTimeProperty;
 import oshi.driver.common.windows.perfmon.SystemInformation.ProcessorQueueLengthProperty;
@@ -27,7 +29,7 @@ public abstract class LoadAverage {
     }
 
     // Daemon thread for Load Average
-    private Thread loadAvgThread = null;
+    private @Nullable Thread loadAvgThread = null;
 
     private final double[] loadAverages = new double[] { -1d, -1d, -1d };
     private static final double[] EXP_WEIGHT = new double[] {

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/MemoryInformation.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/MemoryInformation.java
@@ -10,6 +10,8 @@ import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW
 import java.util.Collections;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -27,16 +29,16 @@ public final class MemoryInformation {
         /** Pages written to disk per second. */
         PAGESOUTPUTPERSEC(null, "Pages Output/sec");
 
-        private final String instance;
+        private final @Nullable String instance;
         private final String counter;
 
-        PageSwapProperty(String instance, String counter) {
+        PageSwapProperty(@Nullable String instance, String counter) {
             this.instance = instance;
             this.counter = counter;
         }
 
         @Override
-        public String getInstance() {
+        public @Nullable String getInstance() {
             return instance;
         }
 

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PdhCounterProperty.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PdhCounterProperty.java
@@ -4,6 +4,8 @@
  */
 package oshi.driver.common.windows.perfmon;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Contract for Counter Property Enums. Enums implementing this interface define a specific PDH counter instance and
  * counter name pair.
@@ -12,8 +14,9 @@ public interface PdhCounterProperty {
     /**
      * Gets the PDH counter instance name.
      *
-     * @return Returns the instance.
+     * @return Returns the instance, or {@code null} for a counter with no instance filter.
      */
+    @Nullable
     String getInstance();
 
     /**

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PerfCounter.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/PerfCounter.java
@@ -6,6 +6,8 @@ package oshi.driver.common.windows.perfmon;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 
 /**
@@ -16,7 +18,7 @@ import oshi.annotation.concurrent.Immutable;
 public final class PerfCounter {
 
     private final String object;
-    private final String instance;
+    private final @Nullable String instance;
     private final String counter;
     private final boolean baseCounter;
 
@@ -30,10 +32,10 @@ public final class PerfCounter {
      * Creates a PerfCounter.
      *
      * @param objectName   the PDH object name
-     * @param instanceName the instance name
+     * @param instanceName the instance name, or {@code null} for a counter with no instance filter
      * @param counterName  the counter name (may end with _Base for SecondValue)
      */
-    public PerfCounter(String objectName, String instanceName, String counterName) {
+    public PerfCounter(String objectName, @Nullable String instanceName, String counterName) {
         this.object = objectName;
         this.instance = instanceName;
         this.baseCounter = counterName.endsWith(BASE_SUFFIX);
@@ -55,7 +57,7 @@ public final class PerfCounter {
      *
      * @return Returns the instance.
      */
-    public String getInstance() {
+    public @Nullable String getInstance() {
         return instance;
     }
 

--- a/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/SystemInformation.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/perfmon/SystemInformation.java
@@ -10,6 +10,8 @@ import static oshi.driver.common.windows.perfmon.PerfmonConstants.WIN32_PERF_RAW
 import java.util.Collections;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -25,16 +27,16 @@ public final class SystemInformation {
         /** Context switches per second. */
         CONTEXTSWITCHESPERSEC(null, "Context Switches/sec");
 
-        private final String instance;
+        private final @Nullable String instance;
         private final String counter;
 
-        ContextSwitchProperty(String instance, String counter) {
+        ContextSwitchProperty(@Nullable String instance, String counter) {
             this.instance = instance;
             this.counter = counter;
         }
 
         @Override
-        public String getInstance() {
+        public @Nullable String getInstance() {
             return instance;
         }
 
@@ -51,16 +53,16 @@ public final class SystemInformation {
         /** Processor queue length. */
         PROCESSORQUEUELENGTH(null, "Processor Queue Length");
 
-        private final String instance;
+        private final @Nullable String instance;
         private final String counter;
 
-        ProcessorQueueLengthProperty(String instance, String counter) {
+        ProcessorQueueLengthProperty(@Nullable String instance, String counter) {
             this.instance = instance;
             this.counter = counter;
         }
 
         @Override
-        public String getInstance() {
+        public @Nullable String getInstance() {
             return instance;
         }
 

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/HkeyPerformanceDataUtil.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/HkeyPerformanceDataUtil.java
@@ -9,6 +9,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +80,7 @@ public abstract class HkeyPerformanceDataUtil {
      *         mapping counter enum values to their index as the second element, if the lookup is successful; null
      *         otherwise.
      */
-    protected static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<Integer, EnumMap<T, Integer>> getCounterIndices(
+    protected static <T extends Enum<T> & PdhCounterWildcardProperty> @Nullable Pair<Integer, EnumMap<T, Integer>> getCounterIndices(
             String objectName, Class<T> counterEnum, Map<String, Integer> counterIndexMap) {
         Integer counterIndex = counterIndexMap.get(objectName);
         if (counterIndex == null) {

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/PerfCounterValues.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/PerfCounterValues.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.registry;
+
+import java.util.List;
+import java.util.Map;
+
+import oshi.annotation.concurrent.ThreadSafe;
+
+/**
+ * Typed lookups into the property maps produced for a performance counter object.
+ * <p>
+ * Every property of the counter enum is present or none of them are: {@link HkeyPerformanceDataUtil#getCounterIndices}
+ * returns {@code null} unless it resolved an index for each one, and the perf-counter path fills its value map from the
+ * same all-or-nothing query. A missing key therefore means the data was assembled inconsistently rather than that a
+ * counter is optional, so these throw rather than substitute a value, naming the property instead of failing later with
+ * a bare {@code NullPointerException}.
+ */
+@ThreadSafe
+final class PerfCounterValues {
+
+    private PerfCounterValues() {
+    }
+
+    private static <T extends Enum<T>> Object require(Map<T, ?> map, T key) {
+        Object value = map.get(key);
+        if (value == null) {
+            throw new IllegalStateException("Missing performance counter value for " + key.name());
+        }
+        return value;
+    }
+
+    /**
+     * Fetches a property whose value is stored as an {@code Integer}.
+     *
+     * @param <T> the counter property enum type
+     * @param map the property map for one instance
+     * @param key the property to fetch
+     * @return the value as an {@code int}
+     */
+    static <T extends Enum<T>> int intValue(Map<T, Object> map, T key) {
+        return ((Integer) require(map, key)).intValue();
+    }
+
+    /**
+     * Fetches a property whose value is stored as a {@code Long}.
+     *
+     * @param <T> the counter property enum type
+     * @param map the property map for one instance
+     * @param key the property to fetch
+     * @return the value as a {@code long}
+     */
+    static <T extends Enum<T>> long longValue(Map<T, Object> map, T key) {
+        return ((Long) require(map, key)).longValue();
+    }
+
+    /**
+     * Fetches a property whose value is stored as a {@code String}.
+     *
+     * @param <T> the counter property enum type
+     * @param map the property map for one instance
+     * @param key the property to fetch
+     * @return the value as a {@code String}
+     */
+    static <T extends Enum<T>> String stringValue(Map<T, Object> map, T key) {
+        return (String) require(map, key);
+    }
+
+    /**
+     * Fetches a pointer-sized property, which the registry reports as an {@code Integer} on a 32-bit system and a
+     * {@code Long} on a 64-bit one.
+     *
+     * @param <T> the counter property enum type
+     * @param map the property map for one instance
+     * @param key the property to fetch
+     * @return the value widened to a {@code long}, without sign extension
+     */
+    static <T extends Enum<T>> long pointerValue(Map<T, Object> map, T key) {
+        Object value = require(map, key);
+        return value instanceof Long ? (Long) value : Integer.toUnsignedLong((Integer) value);
+    }
+
+    /**
+     * Fetches the per-instance values of one counter from a performance counter query result.
+     *
+     * @param <T>      the counter property enum type
+     * @param valueMap the query's value map
+     * @param key      the property to fetch
+     * @return the list of values, one per instance
+     */
+    static <T extends Enum<T>> List<Long> counterList(Map<T, List<Long>> valueMap, T key) {
+        @SuppressWarnings("unchecked")
+        List<Long> values = (List<Long>) require(valueMap, key);
+        return values;
+    }
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/ProcessPerformanceData.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/ProcessPerformanceData.java
@@ -4,10 +4,17 @@
  */
 package oshi.driver.common.windows.registry;
 
+import static oshi.driver.common.windows.registry.PerfCounterValues.counterList;
+import static oshi.driver.common.windows.registry.PerfCounterValues.intValue;
+import static oshi.driver.common.windows.registry.PerfCounterValues.longValue;
+import static oshi.driver.common.windows.registry.PerfCounterValues.stringValue;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.ProcessPerformanceProperty;
@@ -38,8 +45,9 @@ public final class ProcessPerformanceData {
      * @return A map with Process ID as the key and a {@link ProcessPerfCounterBlock} object populated with performance
      *         counter information, or null if processData is null.
      */
-    public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids,
-            Triplet<List<Map<ProcessPerformanceProperty, Object>>, Long, Long> processData) {
+    public static @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(
+            @Nullable Collection<Integer> pids,
+            @Nullable Triplet<List<Map<ProcessPerformanceProperty, Object>>, Long, Long> processData) {
         if (processData == null) {
             return null;
         }
@@ -48,10 +56,10 @@ public final class ProcessPerformanceData {
 
         Map<Integer, ProcessPerfCounterBlock> processMap = new HashMap<>();
         for (Map<ProcessPerformanceProperty, Object> processInstanceMap : processInstanceMaps) {
-            int pid = ((Integer) processInstanceMap.get(ProcessPerformanceProperty.IDPROCESS)).intValue();
-            String name = (String) processInstanceMap.get(ProcessPerformanceProperty.NAME);
+            int pid = intValue(processInstanceMap, ProcessPerformanceProperty.IDPROCESS);
+            String name = stringValue(processInstanceMap, ProcessPerformanceProperty.NAME);
             if ((pids == null || pids.contains(pid)) && !"_Total".equals(name)) {
-                long ctime = (Long) processInstanceMap.get(ProcessPerformanceProperty.ELAPSEDTIME);
+                long ctime = longValue(processInstanceMap, ProcessPerformanceProperty.ELAPSEDTIME);
                 if (ctime > now) {
                     ctime = ParseUtil.filetimeToUtcMs(ctime, false);
                 }
@@ -59,15 +67,16 @@ public final class ProcessPerformanceData {
                 if (upTime < 1L) {
                     upTime = 1L;
                 }
-                processMap.put(pid, new ProcessPerfCounterBlock(name,
-                        (Integer) processInstanceMap.get(ProcessPerformanceProperty.CREATINGPROCESSID),
-                        (Integer) processInstanceMap.get(ProcessPerformanceProperty.PRIORITYBASE),
-                        (Long) processInstanceMap.get(ProcessPerformanceProperty.WORKINGSETPRIVATE),
-                        (Long) processInstanceMap.get(ProcessPerformanceProperty.WORKINGSET), ctime, upTime,
-                        (Long) processInstanceMap.get(ProcessPerformanceProperty.IOREADBYTESPERSEC),
-                        (Long) processInstanceMap.get(ProcessPerformanceProperty.IOWRITEBYTESPERSEC),
-                        Integer.toUnsignedLong(
-                                (Integer) processInstanceMap.get(ProcessPerformanceProperty.PAGEFAULTSPERSEC))));
+                processMap.put(pid,
+                        new ProcessPerfCounterBlock(name,
+                                intValue(processInstanceMap, ProcessPerformanceProperty.CREATINGPROCESSID),
+                                intValue(processInstanceMap, ProcessPerformanceProperty.PRIORITYBASE),
+                                longValue(processInstanceMap, ProcessPerformanceProperty.WORKINGSETPRIVATE),
+                                longValue(processInstanceMap, ProcessPerformanceProperty.WORKINGSET), ctime, upTime,
+                                longValue(processInstanceMap, ProcessPerformanceProperty.IOREADBYTESPERSEC),
+                                longValue(processInstanceMap, ProcessPerformanceProperty.IOWRITEBYTESPERSEC),
+                                Integer.toUnsignedLong(
+                                        intValue(processInstanceMap, ProcessPerformanceProperty.PAGEFAULTSPERSEC))));
             }
         }
         return processMap;
@@ -81,8 +90,9 @@ public final class ProcessPerformanceData {
      * @return A map with Process ID as the key and a {@link ProcessPerfCounterBlock} object populated with performance
      *         counter information, or null if instanceValues is null.
      */
-    public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids,
-            Pair<List<String>, Map<ProcessPerformanceProperty, List<Long>>> instanceValues) {
+    public static @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
+            @Nullable Collection<Integer> pids,
+            @Nullable Pair<List<String>, Map<ProcessPerformanceProperty, List<Long>>> instanceValues) {
         if (instanceValues == null) {
             return null;
         }
@@ -90,15 +100,15 @@ public final class ProcessPerformanceData {
         long now = System.currentTimeMillis(); // 1970 epoch
         List<String> instances = instanceValues.getA();
         Map<ProcessPerformanceProperty, List<Long>> valueMap = instanceValues.getB();
-        List<Long> pidList = valueMap.get(ProcessPerformanceProperty.IDPROCESS);
-        List<Long> ppidList = valueMap.get(ProcessPerformanceProperty.CREATINGPROCESSID);
-        List<Long> priorityList = valueMap.get(ProcessPerformanceProperty.PRIORITYBASE);
-        List<Long> ioReadList = valueMap.get(ProcessPerformanceProperty.IOREADBYTESPERSEC);
-        List<Long> ioWriteList = valueMap.get(ProcessPerformanceProperty.IOWRITEBYTESPERSEC);
-        List<Long> privateWorkingSetList = valueMap.get(ProcessPerformanceProperty.WORKINGSETPRIVATE);
-        List<Long> workingSetList = valueMap.get(ProcessPerformanceProperty.WORKINGSET);
-        List<Long> elapsedTimeList = valueMap.get(ProcessPerformanceProperty.ELAPSEDTIME);
-        List<Long> pageFaultsList = valueMap.get(ProcessPerformanceProperty.PAGEFAULTSPERSEC);
+        List<Long> pidList = counterList(valueMap, ProcessPerformanceProperty.IDPROCESS);
+        List<Long> ppidList = counterList(valueMap, ProcessPerformanceProperty.CREATINGPROCESSID);
+        List<Long> priorityList = counterList(valueMap, ProcessPerformanceProperty.PRIORITYBASE);
+        List<Long> ioReadList = counterList(valueMap, ProcessPerformanceProperty.IOREADBYTESPERSEC);
+        List<Long> ioWriteList = counterList(valueMap, ProcessPerformanceProperty.IOWRITEBYTESPERSEC);
+        List<Long> privateWorkingSetList = counterList(valueMap, ProcessPerformanceProperty.WORKINGSETPRIVATE);
+        List<Long> workingSetList = counterList(valueMap, ProcessPerformanceProperty.WORKINGSET);
+        List<Long> elapsedTimeList = counterList(valueMap, ProcessPerformanceProperty.ELAPSEDTIME);
+        List<Long> pageFaultsList = counterList(valueMap, ProcessPerformanceProperty.PAGEFAULTSPERSEC);
 
         for (int inst = 0; inst < instances.size(); inst++) {
             int pid = pidList.get(inst).intValue();

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/RegistryValueUtil.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/RegistryValueUtil.java
@@ -4,6 +4,8 @@
  */
 package oshi.driver.common.windows.registry;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ParseUtil;
 
@@ -27,7 +29,7 @@ public final class RegistryValueUtil {
      * @param val the raw registry value, or {@code null}
      * @return the value as a String, or {@code null} if the value is {@code null} or an unsupported type
      */
-    public static String registryValueToString(Object val) {
+    public static @Nullable String registryValueToString(@Nullable Object val) {
         // REG_SZ / REG_EXPAND_SZ
         if (val instanceof String) {
             return ((String) val).trim();
@@ -51,7 +53,7 @@ public final class RegistryValueUtil {
      * @param val the raw registry value, or {@code null}
      * @return the value as a long, or {@code 0} if the value is {@code null} or an unsupported type
      */
-    public static long registryValueToLong(Object val) {
+    public static long registryValueToLong(@Nullable Object val) {
         if (val == null) {
             return 0L;
         }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/registry/ThreadPerformanceData.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/registry/ThreadPerformanceData.java
@@ -4,10 +4,18 @@
  */
 package oshi.driver.common.windows.registry;
 
+import static oshi.driver.common.windows.registry.PerfCounterValues.counterList;
+import static oshi.driver.common.windows.registry.PerfCounterValues.intValue;
+import static oshi.driver.common.windows.registry.PerfCounterValues.longValue;
+import static oshi.driver.common.windows.registry.PerfCounterValues.pointerValue;
+import static oshi.driver.common.windows.registry.PerfCounterValues.stringValue;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ThreadInformation.ThreadPerformanceProperty;
@@ -38,8 +46,9 @@ public final class ThreadPerformanceData {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information, or null if threadData is null.
      */
-    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids,
-            Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(
+            @Nullable Collection<Integer> pids,
+            @Nullable Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData) {
         if (threadData == null) {
             return null;
         }
@@ -49,33 +58,28 @@ public final class ThreadPerformanceData {
 
         Map<Integer, ThreadPerfCounterBlock> threadMap = new HashMap<>();
         for (Map<ThreadPerformanceProperty, Object> threadInstanceMap : threadInstanceMaps) {
-            Integer pid = (Integer) threadInstanceMap.get(ThreadPerformanceProperty.IDPROCESS);
-            int tid = ((Integer) threadInstanceMap.get(ThreadPerformanceProperty.IDTHREAD)).intValue();
+            int pid = intValue(threadInstanceMap, ThreadPerformanceProperty.IDPROCESS);
+            int tid = intValue(threadInstanceMap, ThreadPerformanceProperty.IDTHREAD);
             // TID 0 is never a real thread -- thread IDs come from the same pool as PIDs -- so never key the map
             // on it; 0 is the "ID Thread" sentinel the perf-counter path can report for the _Total aggregate or
             // an exiting thread.
             if (tid != 0 && (pids == null || pids.contains(pid)) && pid > 0) {
-                String name = (String) threadInstanceMap.get(ThreadPerformanceProperty.NAME);
-                long upTime = (perfTime100nSec - (Long) threadInstanceMap.get(ThreadPerformanceProperty.ELAPSEDTIME))
+                String name = stringValue(threadInstanceMap, ThreadPerformanceProperty.NAME);
+                long upTime = (perfTime100nSec - longValue(threadInstanceMap, ThreadPerformanceProperty.ELAPSEDTIME))
                         / 10_000L;
                 if (upTime < 1) {
                     upTime = 1;
                 }
-                long user = ((Long) threadInstanceMap.get(ThreadPerformanceProperty.PERCENTUSERTIME)).longValue()
-                        / 10_000L;
-                long kernel = ((Long) threadInstanceMap.get(ThreadPerformanceProperty.PERCENTPRIVILEGEDTIME))
-                        .longValue() / 10_000L;
-                int priority = ((Integer) threadInstanceMap.get(ThreadPerformanceProperty.PRIORITYCURRENT)).intValue();
-                int threadState = ((Integer) threadInstanceMap.get(ThreadPerformanceProperty.THREADSTATE)).intValue();
-                int threadWaitReason = ((Integer) threadInstanceMap.get(ThreadPerformanceProperty.THREADWAITREASON))
-                        .intValue();
+                long user = longValue(threadInstanceMap, ThreadPerformanceProperty.PERCENTUSERTIME) / 10_000L;
+                long kernel = longValue(threadInstanceMap, ThreadPerformanceProperty.PERCENTPRIVILEGEDTIME) / 10_000L;
+                int priority = intValue(threadInstanceMap, ThreadPerformanceProperty.PRIORITYCURRENT);
+                int threadState = intValue(threadInstanceMap, ThreadPerformanceProperty.THREADSTATE);
+                int threadWaitReason = intValue(threadInstanceMap, ThreadPerformanceProperty.THREADWAITREASON);
                 // Start address is pointer sized when fetched from registry, so this could be
                 // either Integer (uint32) or Long depending on OS bitness
-                Object addr = threadInstanceMap.get(ThreadPerformanceProperty.STARTADDRESS);
-                long startAddr = addr.getClass().equals(Long.class) ? (Long) addr
-                        : Integer.toUnsignedLong((Integer) addr);
-                long contextSwitches = Integer.toUnsignedLong(
-                        ((Integer) threadInstanceMap.get(ThreadPerformanceProperty.CONTEXTSWITCHESPERSEC)));
+                long startAddr = pointerValue(threadInstanceMap, ThreadPerformanceProperty.STARTADDRESS);
+                long contextSwitches = Integer
+                        .toUnsignedLong(intValue(threadInstanceMap, ThreadPerformanceProperty.CONTEXTSWITCHESPERSEC));
                 threadMap.put(tid, new ThreadPerfCounterBlock(name, tid, pid, now - upTime, user, kernel, priority,
                         threadState, threadWaitReason, startAddr, contextSwitches));
             }
@@ -91,8 +95,9 @@ public final class ThreadPerformanceData {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information, or null if instanceValues is null.
      */
-    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids,
-            Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> instanceValues) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
+            @Nullable Collection<Integer> pids,
+            @Nullable Pair<List<String>, Map<ThreadPerformanceProperty, List<Long>>> instanceValues) {
         if (instanceValues == null) {
             return null;
         }
@@ -100,16 +105,16 @@ public final class ThreadPerformanceData {
         long now = System.currentTimeMillis(); // 1970 epoch
         List<String> instances = instanceValues.getA();
         Map<ThreadPerformanceProperty, List<Long>> valueMap = instanceValues.getB();
-        List<Long> tidList = valueMap.get(ThreadPerformanceProperty.IDTHREAD);
-        List<Long> pidList = valueMap.get(ThreadPerformanceProperty.IDPROCESS);
-        List<Long> userList = valueMap.get(ThreadPerformanceProperty.PERCENTUSERTIME); // 100-nsec
-        List<Long> kernelList = valueMap.get(ThreadPerformanceProperty.PERCENTPRIVILEGEDTIME); // 100-nsec
-        List<Long> startTimeList = valueMap.get(ThreadPerformanceProperty.ELAPSEDTIME); // filetime
-        List<Long> priorityList = valueMap.get(ThreadPerformanceProperty.PRIORITYCURRENT);
-        List<Long> stateList = valueMap.get(ThreadPerformanceProperty.THREADSTATE);
-        List<Long> waitReasonList = valueMap.get(ThreadPerformanceProperty.THREADWAITREASON);
-        List<Long> startAddrList = valueMap.get(ThreadPerformanceProperty.STARTADDRESS);
-        List<Long> contextSwitchesList = valueMap.get(ThreadPerformanceProperty.CONTEXTSWITCHESPERSEC);
+        List<Long> tidList = counterList(valueMap, ThreadPerformanceProperty.IDTHREAD);
+        List<Long> pidList = counterList(valueMap, ThreadPerformanceProperty.IDPROCESS);
+        List<Long> userList = counterList(valueMap, ThreadPerformanceProperty.PERCENTUSERTIME); // 100-nsec
+        List<Long> kernelList = counterList(valueMap, ThreadPerformanceProperty.PERCENTPRIVILEGEDTIME); // 100-nsec
+        List<Long> startTimeList = counterList(valueMap, ThreadPerformanceProperty.ELAPSEDTIME); // filetime
+        List<Long> priorityList = counterList(valueMap, ThreadPerformanceProperty.PRIORITYCURRENT);
+        List<Long> stateList = counterList(valueMap, ThreadPerformanceProperty.THREADSTATE);
+        List<Long> waitReasonList = counterList(valueMap, ThreadPerformanceProperty.THREADWAITREASON);
+        List<Long> startAddrList = counterList(valueMap, ThreadPerformanceProperty.STARTADDRESS);
+        List<Long> contextSwitchesList = counterList(valueMap, ThreadPerformanceProperty.CONTEXTSWITCHESPERSEC);
 
         int nameIndex = 0;
         for (int inst = 0; inst < instances.size(); inst++) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixBaseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixBaseboard.java
@@ -7,6 +7,8 @@ package oshi.hardware.common.platform.unix.aix;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.driver.common.unix.aix.Lscfg;
 import oshi.hardware.common.AbstractBaseboard;
@@ -25,7 +27,8 @@ public final class AixBaseboard extends AbstractBaseboard {
     private final String version;
 
     AixBaseboard(Supplier<List<String>> lscfg) {
-        Triplet<String, String, String> msv = Lscfg.queryBackplaneModelSerialVersion(lscfg.get());
+        Triplet<@Nullable String, @Nullable String, @Nullable String> msv = Lscfg
+                .queryBackplaneModelSerialVersion(lscfg.get());
         this.model = ParseUtil.getStringValueOrUnknown(msv.getA());
         this.serialNumber = ParseUtil.getStringValueOrUnknown(msv.getB());
         this.version = ParseUtil.getStringValueOrUnknown(msv.getC());

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.driver.common.unix.solaris.PsInfo;
 import oshi.driver.common.unix.solaris.SolarisPrUsage;
 import oshi.driver.common.unix.solaris.SolarisPsInfo;
@@ -53,11 +55,11 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
         super(pid);
     }
 
-    private SolarisPsInfo queryPsInfo() {
+    private @Nullable SolarisPsInfo queryPsInfo() {
         return PsInfo.queryPsInfo(this.getProcessID());
     }
 
-    private SolarisPrUsage queryPrUsage() {
+    private @Nullable SolarisPrUsage queryPrUsage() {
         return PsInfo.queryPrUsage(this.getProcessID());
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
@@ -38,8 +38,8 @@ import oshi.util.tuples.Pair;
  */
 public abstract class SolarisOSProcess extends AbstractProcOSProcess {
 
-    private final Supplier<SolarisPsInfo> psinfo = memoize(this::queryPsInfo, defaultExpiration());
-    private final Supplier<SolarisPrUsage> prusage = memoize(this::queryPrUsage, defaultExpiration());
+    private final Supplier<@Nullable SolarisPsInfo> psinfo = memoize(this::queryPsInfo, defaultExpiration());
+    private final Supplier<@Nullable SolarisPrUsage> prusage = memoize(this::queryPrUsage, defaultExpiration());
 
     private volatile long minorFaults;
     private volatile long majorFaults;
@@ -68,7 +68,7 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
      *
      * @return the parsed {@link SolarisPsInfo}, or {@code null} if it could not be read
      */
-    protected SolarisPsInfo getPsInfo() {
+    protected @Nullable SolarisPsInfo getPsInfo() {
         return psinfo.get();
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSThread.java
@@ -10,6 +10,8 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.driver.common.unix.solaris.PsInfo;
 import oshi.driver.common.unix.solaris.SolarisLwpsInfo;
 import oshi.driver.common.unix.solaris.SolarisPrUsage;
@@ -37,11 +39,11 @@ public abstract class SolarisOSThread extends AbstractOSThread {
         updateAttributes();
     }
 
-    private SolarisLwpsInfo queryLwpsInfo() {
+    private @Nullable SolarisLwpsInfo queryLwpsInfo() {
         return PsInfo.queryLwpsInfo(this.getOwningProcessId(), this.getThreadId());
     }
 
-    private SolarisPrUsage queryPrUsage() {
+    private @Nullable SolarisPrUsage queryPrUsage() {
         return PsInfo.queryPrUsage(this.getOwningProcessId(), this.getThreadId());
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSThread.java
@@ -24,8 +24,8 @@ import oshi.util.Util;
  */
 public abstract class SolarisOSThread extends AbstractOSThread {
 
-    private final Supplier<SolarisLwpsInfo> lwpsinfo = memoize(this::queryLwpsInfo, defaultExpiration());
-    private final Supplier<SolarisPrUsage> prusage = memoize(this::queryPrUsage, defaultExpiration());
+    private final Supplier<@Nullable SolarisLwpsInfo> lwpsinfo = memoize(this::queryLwpsInfo, defaultExpiration());
+    private final Supplier<@Nullable SolarisPrUsage> prusage = memoize(this::queryPrUsage, defaultExpiration());
 
     /**
      * Constructs a new {@code SolarisOSThread}.

--- a/oshi-common/src/main/java/oshi/util/Memoizer.java
+++ b/oshi-common/src/main/java/oshi/util/Memoizer.java
@@ -7,6 +7,8 @@ package oshi.util;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -62,7 +64,7 @@ public final class Memoizer {
      * @param ttlNanos Time in nanoseconds to retain calculation. If negative, retain indefinitely.
      * @return A memoized version of the supplier
      */
-    public static <T> Supplier<T> memoize(Supplier<T> original, long ttlNanos) {
+    public static <T extends @Nullable Object> Supplier<T> memoize(Supplier<T> original, long ttlNanos) {
         // Adapted from Guava's ExpiringMemoizingSupplier
         return new Supplier<T>() {
             private final Supplier<T> delegate = original;
@@ -98,7 +100,7 @@ public final class Memoizer {
      * @param original The {@link Supplier} to memoize
      * @return A memoized version of the supplier
      */
-    public static <T> Supplier<T> memoize(Supplier<T> original) {
+    public static <T extends @Nullable Object> Supplier<T> memoize(Supplier<T> original) {
         return memoize(original, -1L);
     }
 }

--- a/oshi-common/src/main/java/oshi/util/tuples/Pair.java
+++ b/oshi-common/src/main/java/oshi/util/tuples/Pair.java
@@ -4,6 +4,8 @@
  */
 package oshi.util.tuples;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -13,7 +15,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  * @param <B> Type of the second element
  */
 @ThreadSafe
-public class Pair<A, B> {
+public class Pair<A extends @Nullable Object, B extends @Nullable Object> {
 
     private final A a;
     private final B b;

--- a/oshi-common/src/main/java/oshi/util/tuples/Quartet.java
+++ b/oshi-common/src/main/java/oshi/util/tuples/Quartet.java
@@ -4,6 +4,8 @@
  */
 package oshi.util.tuples;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -15,7 +17,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  * @param <D> Type of the fourth element
  */
 @ThreadSafe
-public class Quartet<A, B, C, D> {
+public class Quartet<A extends @Nullable Object, B extends @Nullable Object, C extends @Nullable Object, D extends @Nullable Object> {
 
     private final A a;
     private final B b;

--- a/oshi-common/src/main/java/oshi/util/tuples/Quintet.java
+++ b/oshi-common/src/main/java/oshi/util/tuples/Quintet.java
@@ -4,6 +4,8 @@
  */
 package oshi.util.tuples;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -16,7 +18,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  * @param <E> Type of the fifth element
  */
 @ThreadSafe
-public class Quintet<A, B, C, D, E> {
+public class Quintet<A extends @Nullable Object, B extends @Nullable Object, C extends @Nullable Object, D extends @Nullable Object, E extends @Nullable Object> {
 
     private final A a;
     private final B b;

--- a/oshi-common/src/main/java/oshi/util/tuples/Triplet.java
+++ b/oshi-common/src/main/java/oshi/util/tuples/Triplet.java
@@ -4,6 +4,8 @@
  */
 package oshi.util.tuples;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -14,7 +16,7 @@ import oshi.annotation.concurrent.ThreadSafe;
  * @param <C> Type of the third element
  */
 @ThreadSafe
-public class Triplet<A, B, C> {
+public class Triplet<A extends @Nullable Object, B extends @Nullable Object, C extends @Nullable Object> {
 
     private final A a;
     private final B b;

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataFFM.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.ProcessPerformanceProperty;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
@@ -36,7 +38,8 @@ public final class ProcessPerformanceDataFFM {
      * @return A map with Process ID as the key and a {@link ProcessPerfCounterBlock} object populated with performance
      *         counter information if successful, or null otherwise.
      */
-    public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(
+            Collection<Integer> pids) {
         Triplet<List<Map<ProcessPerformanceProperty, Object>>, Long, Long> processData = null;
         if (PERFDATA) {
             processData = HkeyPerformanceDataUtilFFM.readPerfDataFromRegistry(ProcessPerformanceData.PROCESS,
@@ -52,7 +55,8 @@ public final class ProcessPerformanceDataFFM {
      * @return A map with Process ID as the key and a {@link ProcessPerfCounterBlock} object populated with performance
      *         counter information.
      */
-    public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
+            Collection<Integer> pids) {
         if (PerfmonDisabledFFM.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataFFM.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ThreadInformation.ThreadPerformanceProperty;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
@@ -36,7 +38,7 @@ public final class ThreadPerformanceDataFFM {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information if successful, or null otherwise.
      */
-    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
         Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtilFFM
                 .readPerfDataFromRegistry(ThreadPerformanceData.THREAD, ThreadPerformanceProperty.class);
         return ThreadPerformanceData.buildThreadMapFromRegistry(pids, threadData);
@@ -49,7 +51,8 @@ public final class ThreadPerformanceDataFFM {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information.
      */
-    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
+            Collection<Integer> pids) {
         return buildThreadMapFromPerfCounters(pids, null, -1);
     }
 
@@ -62,8 +65,8 @@ public final class ThreadPerformanceDataFFM {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information.
      */
-    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids,
-            String procName, int threadNum) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
+            Collection<Integer> pids, String procName, int threadNum) {
         if (PerfmonDisabledFFM.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/aix/AixHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/aix/AixHWDiskStoreFFM.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.aix.Ls;
 import oshi.driver.common.unix.aix.Lscfg;
@@ -64,7 +66,7 @@ public final class AixHWDiskStoreFFM extends AixHWDiskStore {
         List<AixHWDiskStoreFFM> storeList = new ArrayList<>();
         for (PerfstatDiskFFM.Disk disk : diskStats.get()) {
             String storeName = disk.name;
-            Pair<String, String> ms = Lscfg.queryModelSerial(storeName);
+            Pair<@Nullable String, @Nullable String> ms = Lscfg.queryModelSerial(storeName);
             String model = ms.getA() == null ? disk.description : ms.getA();
             String serial = ParseUtil.getStringValueOrUnknown(ms.getB());
             storeList.add(createStore(storeName, model, serial, disk.size << 20, diskStats, majMinMap));

--- a/oshi-core/src/main/java/oshi/driver/unix/solaris/PsInfoJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/solaris/PsInfoJNA.java
@@ -46,7 +46,8 @@ public final class PsInfoJNA {
      * {@link SolarisPsInfo}.
      *
      * @param pid    The process ID
-     * @param psinfo A populated {@link SolarisPsInfo} containing the offset pointers for these fields
+     * @param psinfo A populated {@link SolarisPsInfo} containing the offset pointers for these fields, or {@code null}
+     *               if it could not be read
      * @return A quartet containing the argc, argv, envp and dmodel values, or null if unable to read
      */
     public static @Nullable Quartet<Integer, Long, Long, Byte> queryArgsEnvAddrs(int pid,
@@ -77,8 +78,10 @@ public final class PsInfoJNA {
      * Read the argument and environment strings from process address space
      *
      * @param pid    the process id
-     * @param psinfo A populated {@link SolarisPsInfo} containing the offset pointers for these fields
-     * @return A pair containing a list of the arguments and a map of environment variables
+     * @param psinfo A populated {@link SolarisPsInfo} containing the offset pointers for these fields, or {@code null}
+     *               if it could not be read
+     * @return A pair containing a list of the arguments and a map of environment variables, both empty if the process
+     *         information was unavailable
      */
     public static Pair<List<String>, Map<String, String>> queryArgsEnv(int pid, @Nullable SolarisPsInfo psinfo) {
         List<String> args = new ArrayList<>();

--- a/oshi-core/src/main/java/oshi/driver/unix/solaris/PsInfoJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/unix/solaris/PsInfoJNA.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +49,8 @@ public final class PsInfoJNA {
      * @param psinfo A populated {@link SolarisPsInfo} containing the offset pointers for these fields
      * @return A quartet containing the argc, argv, envp and dmodel values, or null if unable to read
      */
-    public static Quartet<Integer, Long, Long, Byte> queryArgsEnvAddrs(int pid, SolarisPsInfo psinfo) {
+    public static @Nullable Quartet<Integer, Long, Long, Byte> queryArgsEnvAddrs(int pid,
+            @Nullable SolarisPsInfo psinfo) {
         if (psinfo != null) {
             int argc = psinfo.pr_argc;
             // Must have at least one argc (the command itself) so failure here means exit
@@ -78,7 +80,7 @@ public final class PsInfoJNA {
      * @param psinfo A populated {@link SolarisPsInfo} containing the offset pointers for these fields
      * @return A pair containing a list of the arguments and a map of environment variables
      */
-    public static Pair<List<String>, Map<String, String>> queryArgsEnv(int pid, SolarisPsInfo psinfo) {
+    public static Pair<List<String>, Map<String, String>> queryArgsEnv(int pid, @Nullable SolarisPsInfo psinfo) {
         List<String> args = new ArrayList<>();
         Map<String, String> env = new LinkedHashMap<>();
 

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataJNA.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.ProcessPerformanceProperty;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
@@ -36,7 +38,8 @@ public final class ProcessPerformanceDataJNA {
      * @return A map with Process ID as the key and a {@link ProcessPerfCounterBlock} object populated with performance
      *         counter information if successful, or null otherwise.
      */
-    public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(
+            Collection<Integer> pids) {
         Triplet<List<Map<ProcessPerformanceProperty, Object>>, Long, Long> processData = null;
         if (PERFDATA) {
             processData = HkeyPerformanceDataUtilJNA.readPerfDataFromRegistry(ProcessPerformanceData.PROCESS,
@@ -52,7 +55,8 @@ public final class ProcessPerformanceDataJNA {
      * @return A map with Process ID as the key and a {@link ProcessPerfCounterBlock} object populated with performance
      *         counter information.
      */
-    public static Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
+            Collection<Integer> pids) {
         if (PerfmonDisabled.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataJNA.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ThreadInformation.ThreadPerformanceProperty;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
@@ -35,7 +37,7 @@ public final class ThreadPerformanceDataJNA {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information if successful, or null otherwise.
      */
-    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
         Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtilJNA
                 .readPerfDataFromRegistry(ThreadPerformanceData.THREAD, ThreadPerformanceProperty.class);
         return ThreadPerformanceData.buildThreadMapFromRegistry(pids, threadData);
@@ -48,7 +50,8 @@ public final class ThreadPerformanceDataJNA {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information.
      */
-    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
+            Collection<Integer> pids) {
         return buildThreadMapFromPerfCounters(pids, null, -1);
     }
 
@@ -61,8 +64,8 @@ public final class ThreadPerformanceDataJNA {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information.
      */
-    public static Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids,
-            String procName, int threadNum) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
+            Collection<Integer> pids, String procName, int threadNum) {
         if (PerfmonDisabled.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/aix/AixHWDiskStoreJNA.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.Native;
 import com.sun.jna.platform.unix.aix.Perfstat.perfstat_disk_t;
 
@@ -66,7 +68,7 @@ public final class AixHWDiskStoreJNA extends AixHWDiskStore {
         List<AixHWDiskStoreJNA> storeList = new ArrayList<>();
         for (perfstat_disk_t disk : diskStats.get()) {
             String storeName = Native.toString(disk.name);
-            Pair<String, String> ms = Lscfg.queryModelSerial(storeName);
+            Pair<@Nullable String, @Nullable String> ms = Lscfg.queryModelSerial(storeName);
             String model = ms.getA() == null ? Native.toString(disk.description) : ms.getA();
             String serial = ParseUtil.getStringValueOrUnknown(ms.getB());
             storeList.add(createStore(storeName, model, serial, disk.size << 20, diskStats, majMinMap));

--- a/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
@@ -6,6 +6,7 @@ package oshi.util.platform.windows;
 
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +84,7 @@ public final class RegistryUtil {
      * @param accessFlag the access flag
      * @return the registry value as a string
      */
-    public static String getStringValue(WinReg.HKEY root, String path, String key, int accessFlag) {
+    public static @Nullable String getStringValue(WinReg.HKEY root, String path, String key, int accessFlag) {
         Object val = getRegistryValueOrNull(root, path, key, accessFlag);
         return RegistryValueUtil.registryValueToString(val);
     }


### PR DESCRIPTION
First group of the backlog #3618 left at WARN. Clears `oshi.driver.common`, taking `oshi-common` from **306 warnings to 229**. One finding remains in `DxgiUtil`, which belongs with the GPU group rather than here.

### Three contracts were wrong, not merely unstated

**`PdhCounterProperty.getInstance()` returns the PDH instance filter, and the counters that have no filter set it to `null` literally** — `PAGESINPUTPERSEC(null, "Pages Input/sec")`. The interface promised non-null while its own enum constants passed null. `PerfCounter`, which stores and returns the same value, had it too.

**`Lscfg` documents that the model, serial and version it reads "may be null if not found"** and returns them in a tuple whose elements were declared non-null.

**The `psinfo` readers on Solaris and AIX return `null` when the process has exited** between listing and reading — the normal case for a short-lived process — through signatures that promised otherwise.

### The tuple type parameters

`Pair`, `Triplet`, `Quartet` and `Quintet` now declare their type parameters as `<A extends @Nullable Object, ...>`. This **permits** a nullable element without requiring one; `Pair<String, String>` still means both are non-null.

It is forced by the third contract above. `oshi.util.tuples` is marked, so its type variables otherwise default to non-null, which no caller storing an absent value can satisfy. The alternative — leaving the tuples unmarked — would have made every tuple in the API silent about nullability, which is the opposite of the point.

### The performance-data classes

`ProcessPerformanceData` and `ThreadPerformanceData` account for 50 of the 54 findings in the registry package, in two shapes: casting and unboxing a possibly-absent property, and dereferencing nine or ten per-counter lists.

Neither was a latent `NullPointerException`. `HkeyPerformanceDataUtil.getCounterIndices` returns `null` unless it resolved an index for **every** constant of the counter enum, so the property maps are all-or-nothing and a missing key means the data was assembled inconsistently rather than that a counter is optional. Defaulting to `0` or skipping the instance would have changed behavior for a case that cannot happen.

Instead a new package-private `PerfCounterValues` provides typed lookups — `intValue`, `longValue`, `stringValue`, `pointerValue` for the registry values that are `Integer` on a 32-bit system and `Long` on a 64-bit one, and `counterList`. Each throws naming the property, so the impossible case fails clearly rather than as a bare NPE, and the call sites lose their casts:

```java
- int priority = ((Integer) threadInstanceMap.get(ThreadPerformanceProperty.PRIORITYCURRENT)).intValue();
+ int priority = intValue(threadInstanceMap, ThreadPerformanceProperty.PRIORITYCURRENT);
```

`Lspv` reads three maps it fills together, and its own comment notes they share keys; that is now expressed rather than assumed, by skipping an entry if the maps disagree.

`AixBaseboard` and the Solaris process and thread classes follow the drivers they call, as do the JNA and FFM forwarding twins of the performance-data classes.

### What is deliberately left

Making these contracts honest surfaces **25 warnings in `oshi-core` and `oshi-core-ffm`**, in the Windows registry and operating system stack — `RegistryUtil.getStringValue`'s callers, `WindowsOperatingSystem`, `WindowsOSProcess`, `WindowsGraphicsCard`, `InstalledAppsData`, `PerfDataUtilFFM`.

Resolving them here would mean nine more files and changing the abstract `buildXxxMap` declarations in `WindowsOperatingSystem`, which starts another round of the same propagation. They are left for the group that covers those modules. Nothing is lost by deferring: the warning count tracks them, and this is what the WARN period is for.

Across the reactor the count goes 682 to 622 — 85 resolved, 25 surfaced. That direction is expected whenever a shared contract stops lying.

### Verification

Full gate green locally on macOS/JDK 25: `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`, 1561 tests passing, plus `./mvnw -Perror-prone clean install -DskipTests` building successfully across the reactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when AIX partition data is incomplete by safely skipping invalid entries.
  * Added safer handling for missing Windows performance-counter and registry values.

* **Improvements**
  * Clarified when hardware, process, thread, registry, and monitoring results may be unavailable.
  * Added support for nullable tuple values and typed performance-counter lookups.

* **Compatibility**
  * Existing behavior is preserved while incomplete platform data is handled more safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->