### PR TITLE
Make the oshi.util tree's nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/util/ExecutingCommand.java
+++ b/oshi-common/src/main/java/oshi/util/ExecutingCommand.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,7 @@ public final class ExecutingCommand {
      *                         process.
      * @return A list of Strings representing the result of the command, or empty string if the command failed
      */
-    public static List<String> runNative(String[] cmdToRunWithArgs, String[] envp) {
+    public static List<String> runNative(String[] cmdToRunWithArgs, String @Nullable [] envp) {
         Process p = null;
         try {
             p = Runtime.getRuntime().exec(cmdToRunWithArgs, envp);

--- a/oshi-common/src/main/java/oshi/util/common/gpu/NvmlQuery.java
+++ b/oshi-common/src/main/java/oshi/util/common/gpu/NvmlQuery.java
@@ -8,6 +8,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -119,7 +121,7 @@ public final class NvmlQuery {
      * @param fragment the fragment to match
      * @return the matching bus ID, or {@code null} if none matched or the fragment was blank
      */
-    public static String matchBusId(Set<String> busIds, String fragment) {
+    public static @Nullable String matchBusId(Set<String> busIds, @Nullable String fragment) {
         if (fragment == null || fragment.isEmpty()) {
             return null;
         }

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyCache.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyCache.java
@@ -7,6 +7,7 @@ package oshi.util.common.platform.mac;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public final class SmcKeyCache {
     private final Object lock = new Object();
 
     /** Only ever assigned an unmodifiable list, so the volatile write safely publishes an immutable value. */
-    private volatile List<String> keys; // NOSONAR java:S3077 - published value is immutable
+    private volatile @Nullable List<String> keys; // NOSONAR java:S3077 - published value is immutable
 
     /**
      * Creates a key cache.
@@ -58,7 +59,7 @@ public final class SmcKeyCache {
      *                  once per completed resolution.
      * @return the keys, never null
      */
-    public List<String> get(Supplier<List<String>> discovery) {
+    public List<String> get(Supplier<@Nullable List<String>> discovery) {
         List<String> resolved = keys;
         if (resolved != null) {
             return resolved;

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
@@ -96,7 +96,7 @@ public final class SmcKeyIndex {
      * @param mask       an additional test each candidate key must pass
      * @return the matching keys in index order, or {@code null} if the index could not be read
      */
-    public static @Nullable List<String> findKeys(int keyCount, IntFunction<String> keyAtIndex, String prefix,
+    public static @Nullable List<String> findKeys(int keyCount, IntFunction<@Nullable String> keyAtIndex, String prefix,
             Predicate<String> mask) {
         if (keyCount <= 0 || keyCount > MAX_KEY_COUNT) {
             LOG.debug("Implausible SMC key count {}; skipping key discovery.", keyCount);
@@ -106,7 +106,7 @@ public final class SmcKeyIndex {
         // substitutes a neighbour for an unreadable probe, which can move the landing point past the block entirely,
         // and the scan skips an unreadable index outright. Track failures through one wrapper so no path is missed.
         boolean[] readFailed = new boolean[1];
-        IntFunction<String> tracked = i -> {
+        IntFunction<@Nullable String> tracked = i -> {
             String key = keyAtIndex.apply(i);
             if (key == null) {
                 readFailed[0] = true;
@@ -156,7 +156,7 @@ public final class SmcKeyIndex {
      * @param prefix     the prefix to locate
      * @return that index, or {@code -1} if the index could not be read
      */
-    private static int lowerBound(int keyCount, IntFunction<String> keyAtIndex, String prefix) {
+    private static int lowerBound(int keyCount, IntFunction<@Nullable String> keyAtIndex, String prefix) {
         int lo = 0;
         int hi = keyCount;
         while (lo < hi) {
@@ -185,7 +185,7 @@ public final class SmcKeyIndex {
      * @param keyCount   the number of keys in the index, bounding the outward walk
      * @return a key name, or {@code null} if nothing nearby could be read
      */
-    private static @Nullable String probe(IntFunction<String> keyAtIndex, int index, int keyCount) {
+    private static @Nullable String probe(IntFunction<@Nullable String> keyAtIndex, int index, int keyCount) {
         String key = keyAtIndex.apply(index);
         if (key != null) {
             return key;

--- a/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/mac/SmcKeyIndex.java
@@ -16,6 +16,7 @@ import java.util.function.Predicate;
 import java.util.function.ToDoubleFunction;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +96,7 @@ public final class SmcKeyIndex {
      * @param mask       an additional test each candidate key must pass
      * @return the matching keys in index order, or {@code null} if the index could not be read
      */
-    public static List<String> findKeys(int keyCount, IntFunction<String> keyAtIndex, String prefix,
+    public static @Nullable List<String> findKeys(int keyCount, IntFunction<String> keyAtIndex, String prefix,
             Predicate<String> mask) {
         if (keyCount <= 0 || keyCount > MAX_KEY_COUNT) {
             LOG.debug("Implausible SMC key count {}; skipping key discovery.", keyCount);
@@ -184,7 +185,7 @@ public final class SmcKeyIndex {
      * @param keyCount   the number of keys in the index, bounding the outward walk
      * @return a key name, or {@code null} if nothing nearby could be read
      */
-    private static String probe(IntFunction<String> keyAtIndex, int index, int keyCount) {
+    private static @Nullable String probe(IntFunction<String> keyAtIndex, int index, int keyCount) {
         String key = keyAtIndex.apply(index);
         if (key != null) {
             return key;
@@ -212,7 +213,7 @@ public final class SmcKeyIndex {
      * @param key the four-character SMC key
      * @return true if the key matches the GPU temperature naming convention
      */
-    public static boolean isGpuTemperatureKey(String key) {
+    public static boolean isGpuTemperatureKey(@Nullable String key) {
         return key != null && GPU_TEMPERATURE_KEY.matcher(key).matches();
     }
 
@@ -222,7 +223,7 @@ public final class SmcKeyIndex {
      * @param key the four-character SMC key
      * @return true if the key matches the fan current-speed naming convention
      */
-    public static boolean isFanSpeedKey(String key) {
+    public static boolean isFanSpeedKey(@Nullable String key) {
         return key != null && FAN_SPEED_KEY.matcher(key).matches();
     }
 
@@ -260,7 +261,7 @@ public final class SmcKeyIndex {
      * @param fanCount   the count from {@code FNum}, or 0 if that read failed
      * @return the keys to read, or {@code null} if the answer is not yet known
      */
-    public static List<String> reconcileFanKeys(List<String> discovered, long fanCount) {
+    public static @Nullable List<String> reconcileFanKeys(@Nullable List<String> discovered, long fanCount) {
         if (discovered != null && !discovered.isEmpty()) {
             if (fanCount > 0 && discovered.size() != fanCount) {
                 LOG.debug("Found {} fan speed keys {} but FNum reports {} fans; using the discovered keys.",
@@ -286,7 +287,7 @@ public final class SmcKeyIndex {
      * @param csv the configured value, which may be null or empty
      * @return the keys, never null
      */
-    public static List<String> parseConfiguredKeys(String csv) {
+    public static List<String> parseConfiguredKeys(@Nullable String csv) {
         if (csv == null || csv.trim().isEmpty()) {
             return Collections.emptyList();
         }

--- a/oshi-common/src/main/java/oshi/util/driver/linux/Devicetree.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Devicetree.java
@@ -4,6 +4,8 @@
  */
 package oshi.util.driver.linux;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.FileUtil;
 import oshi.util.linux.SysPath;
@@ -22,7 +24,7 @@ public final class Devicetree {
      *
      * @return The model if available, null otherwise
      */
-    public static String queryModel() {
+    public static @Nullable String queryModel() {
         String modelStr = FileUtil.getStringFromFile(SysPath.MODEL);
         if (!modelStr.isEmpty()) {
             return modelStr.replace("Machine: ", "");

--- a/oshi-common/src/main/java/oshi/util/driver/linux/Dmidecode.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Dmidecode.java
@@ -7,6 +7,8 @@ package oshi.util.driver.linux;
 import java.util.List;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -63,7 +65,7 @@ public final class Dmidecode {
      *
      * @return The serial number if available, null otherwise
      */
-    public static String querySerialNumber() {
+    public static @Nullable String querySerialNumber() {
         return querySerialNumber(ExecutingCommand.runPrivilegedNative("dmidecode -t system"));
     }
 
@@ -73,7 +75,7 @@ public final class Dmidecode {
      * @param lines output of {@code dmidecode -t system}
      * @return The serial number if available, null otherwise
      */
-    static String querySerialNumber(List<String> lines) {
+    static @Nullable String querySerialNumber(List<String> lines) {
         String marker = "Serial Number:";
         for (String checkLine : lines) {
             if (checkLine.contains(marker)) {
@@ -88,7 +90,7 @@ public final class Dmidecode {
      *
      * @return The UUID if available, null otherwise
      */
-    public static String queryUUID() {
+    public static @Nullable String queryUUID() {
         return queryUUID(ExecutingCommand.runPrivilegedNative("dmidecode -t system"));
     }
 
@@ -98,7 +100,7 @@ public final class Dmidecode {
      * @param lines output of {@code dmidecode -t system}
      * @return The UUID if available, null otherwise
      */
-    static String queryUUID(List<String> lines) {
+    static @Nullable String queryUUID(List<String> lines) {
         String marker = "UUID:";
         for (String checkLine : lines) {
             if (checkLine.contains(marker)) {
@@ -113,7 +115,7 @@ public final class Dmidecode {
      *
      * @return The a pair containing the name and revision if available, null values in the pair otherwise
      */
-    public static Pair<String, String> queryBiosNameRev() {
+    public static Pair<@Nullable String, @Nullable String> queryBiosNameRev() {
         return queryBiosNameRev(ExecutingCommand.runPrivilegedNative("dmidecode -t bios"));
     }
 
@@ -123,7 +125,7 @@ public final class Dmidecode {
      * @param lines output of {@code dmidecode -t bios}
      * @return A pair containing the name and revision if available, null values in the pair otherwise
      */
-    static Pair<String, String> queryBiosNameRev(List<String> lines) {
+    static Pair<@Nullable String, @Nullable String> queryBiosNameRev(List<String> lines) {
         String biosName = null;
         String revision = null;
 

--- a/oshi-common/src/main/java/oshi/util/driver/linux/Lshal.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Lshal.java
@@ -6,6 +6,8 @@ package oshi.util.driver.linux;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -24,7 +26,7 @@ public final class Lshal {
      *
      * @return The serial number if available, null otherwise
      */
-    public static String querySerialNumber() {
+    public static @Nullable String querySerialNumber() {
         return querySerialNumber(ExecutingCommand.runNative("lshal"));
     }
 
@@ -34,7 +36,7 @@ public final class Lshal {
      * @param lines output of {@code lshal}
      * @return The serial number if available, null otherwise
      */
-    static String querySerialNumber(List<String> lines) {
+    static @Nullable String querySerialNumber(List<String> lines) {
         String marker = "system.hardware.serial =";
         for (String checkLine : lines) {
             if (checkLine.contains(marker)) {
@@ -49,7 +51,7 @@ public final class Lshal {
      *
      * @return The UUID if available, null otherwise
      */
-    public static String queryUUID() {
+    public static @Nullable String queryUUID() {
         return queryUUID(ExecutingCommand.runNative("lshal"));
     }
 
@@ -59,7 +61,7 @@ public final class Lshal {
      * @param lines output of {@code lshal}
      * @return The UUID if available, null otherwise
      */
-    static String queryUUID(List<String> lines) {
+    static @Nullable String queryUUID(List<String> lines) {
         String marker = "system.hardware.uuid =";
         for (String checkLine : lines) {
             if (checkLine.contains(marker)) {

--- a/oshi-common/src/main/java/oshi/util/driver/linux/Lshw.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Lshw.java
@@ -6,6 +6,8 @@ package oshi.util.driver.linux;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -20,11 +22,12 @@ public final class Lshw {
     private Lshw() {
     }
 
-    private static final String MODEL;
-    private static final String SERIAL;
-    private static final String UUID;
+    private static final @Nullable String MODEL;
+    private static final @Nullable String SERIAL;
+    private static final @Nullable String UUID;
     static {
-        Triplet<String, String, String> info = parseSystemInfo(ExecutingCommand.runPrivilegedNative("lshw -C system"));
+        Triplet<@Nullable String, @Nullable String, @Nullable String> info = parseSystemInfo(
+                ExecutingCommand.runPrivilegedNative("lshw -C system"));
         MODEL = info.getA();
         SERIAL = info.getB();
         UUID = info.getC();
@@ -36,7 +39,7 @@ public final class Lshw {
      * @param lines output of {@code lshw -C system}
      * @return triplet of (model, serial, uuid), with null for missing values
      */
-    static Triplet<String, String, String> parseSystemInfo(List<String> lines) {
+    static Triplet<@Nullable String, @Nullable String, @Nullable String> parseSystemInfo(List<String> lines) {
         String model = null;
         String serial = null;
         String uuid = null;
@@ -62,7 +65,7 @@ public final class Lshw {
      *
      * @return The model if available, null otherwise
      */
-    public static String queryModel() {
+    public static @Nullable String queryModel() {
         return MODEL;
     }
 
@@ -71,7 +74,7 @@ public final class Lshw {
      *
      * @return The serial number if available, null otherwise
      */
-    public static String querySerialNumber() {
+    public static @Nullable String querySerialNumber() {
         return SERIAL;
     }
 
@@ -80,7 +83,7 @@ public final class Lshw {
      *
      * @return The UUID if available, null otherwise
      */
-    public static String queryUUID() {
+    public static @Nullable String queryUUID() {
         return UUID;
     }
 

--- a/oshi-common/src/main/java/oshi/util/driver/linux/Sysfs.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/Sysfs.java
@@ -4,6 +4,8 @@
  */
 package oshi.util.driver.linux;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
@@ -25,7 +27,7 @@ public final class Sysfs {
      *
      * @return The vendor if available, null otherwise
      */
-    public static String querySystemVendor() {
+    public static @Nullable String querySystemVendor() {
         final String sysVendor = FileUtil.getStringFromFile(SysPath.DMI_ID + "sys_vendor").trim();
         if (!sysVendor.isEmpty()) {
             return sysVendor;
@@ -38,7 +40,7 @@ public final class Sysfs {
      *
      * @return The model if available, null otherwise
      */
-    public static String queryProductModel() {
+    public static @Nullable String queryProductModel() {
         final String productName = FileUtil.getStringFromFile(SysPath.DMI_ID + "product_name").trim();
         final String productVersion = FileUtil.getStringFromFile(SysPath.DMI_ID + "product_version").trim();
         if (productName.isEmpty()) {
@@ -59,7 +61,7 @@ public final class Sysfs {
      *
      * @return The serial number if available, null otherwise
      */
-    public static String queryProductSerial() {
+    public static @Nullable String queryProductSerial() {
         // These sysfs files accessible by root, or can be chmod'd at boot time
         // to enable access without root, or use privileged read fallback
         String serial = PrivilegedUtil.getStringFromFilePrivileged(SysPath.DMI_ID + "product_serial");
@@ -74,7 +76,7 @@ public final class Sysfs {
      *
      * @return The UUID if available, null otherwise
      */
-    public static String queryUUID() {
+    public static @Nullable String queryUUID() {
         // These sysfs files accessible by root, or can be chmod'd at boot time
         // to enable access without root, or use privileged read fallback
         String uuid = PrivilegedUtil.getStringFromFilePrivileged(SysPath.DMI_ID + "product_uuid");
@@ -89,7 +91,7 @@ public final class Sysfs {
      *
      * @return The board vendor if available, null otherwise
      */
-    public static String queryBoardVendor() {
+    public static @Nullable String queryBoardVendor() {
         final String boardVendor = FileUtil.getStringFromFile(SysPath.DMI_ID + "board_vendor").trim();
         if (!boardVendor.isEmpty()) {
             return boardVendor;
@@ -102,7 +104,7 @@ public final class Sysfs {
      *
      * @return The board model if available, null otherwise
      */
-    public static String queryBoardModel() {
+    public static @Nullable String queryBoardModel() {
         final String boardName = FileUtil.getStringFromFile(SysPath.DMI_ID + "board_name").trim();
         if (!boardName.isEmpty()) {
             return boardName;
@@ -115,7 +117,7 @@ public final class Sysfs {
      *
      * @return The board version if available, null otherwise
      */
-    public static String queryBoardVersion() {
+    public static @Nullable String queryBoardVersion() {
         final String boardVersion = FileUtil.getStringFromFile(SysPath.DMI_ID + "board_version").trim();
         if (!boardVersion.isEmpty()) {
             return boardVersion;
@@ -128,7 +130,7 @@ public final class Sysfs {
      *
      * @return The board serial number if available, null otherwise
      */
-    public static String queryBoardSerial() {
+    public static @Nullable String queryBoardSerial() {
         // Board serial is also root-only, use privileged read fallback
         final String boardSerial = PrivilegedUtil.getStringFromFilePrivileged(SysPath.DMI_ID + "board_serial").trim();
         if (!boardSerial.isEmpty()) {
@@ -142,7 +144,7 @@ public final class Sysfs {
      *
      * @return The bios vendor if available, null otherwise
      */
-    public static String queryBiosVendor() {
+    public static @Nullable String queryBiosVendor() {
         final String biosVendor = FileUtil.getStringFromFile(SysPath.DMI_ID + "bios_vendor").trim();
         if (biosVendor.isEmpty()) {
             return biosVendor;
@@ -155,7 +157,7 @@ public final class Sysfs {
      *
      * @return The bios description if available, null otherwise
      */
-    public static String queryBiosDescription() {
+    public static @Nullable String queryBiosDescription() {
         final String modalias = FileUtil.getStringFromFile(SysPath.DMI_ID + "modalias").trim();
         if (!modalias.isEmpty()) {
             return modalias;
@@ -169,7 +171,7 @@ public final class Sysfs {
      * @param biosRevision A revision string to append
      * @return The bios version if available, null otherwise
      */
-    public static String queryBiosVersion(String biosRevision) {
+    public static @Nullable String queryBiosVersion(@Nullable String biosRevision) {
         final String biosVersion = FileUtil.getStringFromFile(SysPath.DMI_ID + "bios_version").trim();
         if (!biosVersion.isEmpty()) {
             return biosVersion + (Util.isBlank(biosRevision) ? "" : " (revision " + biosRevision + ")");
@@ -182,7 +184,7 @@ public final class Sysfs {
      *
      * @return The bios release date if available, null otherwise
      */
-    public static String queryBiosReleaseDate() {
+    public static @Nullable String queryBiosReleaseDate() {
         final String biosDate = FileUtil.getStringFromFile(SysPath.DMI_ID + "bios_date").trim();
         if (!biosDate.isEmpty()) {
             return ParseUtil.parseMmDdYyyyToYyyyMmDD(biosDate);

--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/CpuInfo.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/CpuInfo.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.Constants;
 import oshi.util.FileUtil;
@@ -30,7 +32,7 @@ public final class CpuInfo {
      *
      * @return The manufacturer if known, null otherwise
      */
-    public static String queryCpuManufacturer() {
+    public static @Nullable String queryCpuManufacturer() {
         return queryCpuManufacturer(FileUtil.readFile(CPUINFO));
     }
 
@@ -40,7 +42,7 @@ public final class CpuInfo {
      * @param cpuInfo lines from /proc/cpuinfo
      * @return The manufacturer if known, null otherwise
      */
-    static String queryCpuManufacturer(List<String> cpuInfo) {
+    static @Nullable String queryCpuManufacturer(List<String> cpuInfo) {
         for (String line : cpuInfo) {
             if (line.startsWith("CPU implementer")) {
                 int part = ParseUtil.parseLastInt(line, 0);
@@ -81,7 +83,7 @@ public final class CpuInfo {
      * @return A quartet of strings for manufacturer, model, version, and serial number. Each one may be null if
      *         unknown.
      */
-    public static Quartet<String, String, String, String> queryBoardInfo() {
+    public static Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> queryBoardInfo() {
         return queryBoardInfo(FileUtil.readFile(CPUINFO));
     }
 
@@ -91,7 +93,8 @@ public final class CpuInfo {
      * @param cpuInfo lines from /proc/cpuinfo
      * @return A quartet of strings for manufacturer, model, version, and serial number
      */
-    static Quartet<String, String, String, String> queryBoardInfo(List<String> cpuInfo) {
+    static Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> queryBoardInfo(
+            List<String> cpuInfo) {
         String pcManufacturer = null;
         String pcModel = null;
         String pcVersion = null;

--- a/oshi-common/src/main/java/oshi/util/driver/linux/proc/ProcessStat.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/proc/ProcessStat.java
@@ -22,6 +22,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.os.OSProcess;
 import oshi.util.Constants;
@@ -364,7 +366,7 @@ public final class ProcessStat {
      *         <p>
      *         If the process doesn't exist, returns null.
      */
-    public static Triplet<String, Character, Map<PidStat, Long>> getPidStats(int pid) {
+    public static @Nullable Triplet<String, Character, Map<PidStat, Long>> getPidStats(int pid) {
         String stat = FileUtil.getStringFromFile(String.format(Locale.ROOT, ProcPath.PID_STAT, pid));
         if (stat.isEmpty()) {
             // If pid doesn't exist
@@ -394,7 +396,7 @@ public final class ProcessStat {
      *         <p>
      *         If the process doesn't exist, returns null.
      */
-    public static Map<PidStatM, Long> getPidStatM(int pid) {
+    public static @Nullable Map<PidStatM, Long> getPidStatM(int pid) {
         String statm = FileUtil.getStringFromFile(String.format(Locale.ROOT, ProcPath.PID_STATM, pid));
         if (statm.isEmpty()) {
             // If pid doesn't exist

--- a/oshi-common/src/test/java/oshi/util/common/gpu/NvmlQueryTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/gpu/NvmlQueryTest.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.util.common.gpu.NvmlQuery.NvmlScope;
@@ -27,12 +28,12 @@ class NvmlQueryTest {
 
     /** A scope that records its lifecycle calls and hands out a fixed handle. */
     private static final class FakeScope implements NvmlScope<String> {
-        private final String handle;
+        private final @Nullable String handle;
         private final boolean initSucceeds;
         private int inits;
         private int uninits;
 
-        FakeScope(String handle, boolean initSucceeds) {
+        FakeScope(@Nullable String handle, boolean initSucceeds) {
             this.handle = handle;
             this.initSucceeds = initSucceeds;
         }

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyCacheTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyCacheTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.util.GlobalConfig;
@@ -31,16 +32,16 @@ class SmcKeyCacheTest {
     private static final List<String> FALLBACK = Collections.unmodifiableList(Arrays.asList("Tg05", "Tg0D"));
 
     /** A discovery function that records how many times it ran. */
-    private static final class CountingDiscovery implements Supplier<List<String>> {
+    private static final class CountingDiscovery implements Supplier<@Nullable List<String>> {
         private final AtomicInteger calls = new AtomicInteger();
-        private final List<String> result;
+        private final @Nullable List<String> result;
 
-        private CountingDiscovery(List<String> result) {
+        private CountingDiscovery(@Nullable List<String> result) {
             this.result = result;
         }
 
         @Override
-        public List<String> get() {
+        public @Nullable List<String> get() {
             calls.incrementAndGet();
             return result;
         }

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
@@ -31,7 +31,7 @@ class SmcKeyIndexTest {
     private static final String[] SORTED = { "#KEY", "ALI0", "F0Ac", "TB0T", "TC0P", "TCMb", "TCMz", "Tf00", "Tf11",
             "Tg0W", "Tg0X", "Tg0e", "Tg0f", "Tg1g", "Tg1h", "Th00", "Tp01", "Tp09", "VP0C", "zSPc" };
 
-    private static IntFunction<String> lookup(String[] keys) {
+    private static IntFunction<@Nullable String> lookup(String[] keys) {
         return i -> i >= 0 && i < keys.length ? keys[i] : null;
     }
 
@@ -102,7 +102,7 @@ class SmcKeyIndexTest {
     void testTransientFailureIsRecovered() {
         // Fails the first read of one index, then succeeds: the retry must recover the full block.
         Set<Integer> failedOnce = new HashSet<>();
-        IntFunction<String> flaky = i -> i == 12 && failedOnce.add(i) ? null : SORTED[i];
+        IntFunction<@Nullable String> flaky = i -> i == 12 && failedOnce.add(i) ? null : SORTED[i];
         assertThat(SmcKeyIndex.findKeys(SORTED.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey),
                 contains("Tg0W", "Tg0X", "Tg0e", "Tg0f", "Tg1g", "Tg1h"));
     }
@@ -110,7 +110,7 @@ class SmcKeyIndexTest {
     @Test
     void testPermanentFailureMidScanSkipsOnlyThatKey() {
         // Index 12 is Tg0f. Skipping rather than stopping preserves Tg1g/Tg1h, which a break would have discarded.
-        IntFunction<String> flaky = i -> i == 12 ? null : SORTED[i];
+        IntFunction<@Nullable String> flaky = i -> i == 12 ? null : SORTED[i];
         assertThat(SmcKeyIndex.findKeys(SORTED.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey),
                 contains("Tg0W", "Tg0X", "Tg0e", "Tg1g", "Tg1h"));
     }
@@ -120,7 +120,7 @@ class SmcKeyIndexTest {
         // The only Tg key is unreadable and the next key ends the block. Reporting empty would be cached as "this
         // machine has no GPU sensors" and would disable the sensor for the JVM lifetime.
         String[] keys = { "TB0T", "Tg0f", "Th00", "Tp01" };
-        IntFunction<String> flaky = i -> i == 1 ? null : keys[i];
+        IntFunction<@Nullable String> flaky = i -> i == 1 ? null : keys[i];
         assertThat("An unreadable sole match must not be cached as a confirmed absence",
                 SmcKeyIndex.findKeys(keys.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
     }
@@ -133,7 +133,7 @@ class SmcKeyIndexTest {
         // have recovered Tg0f and returned a non-empty list. A permanently failing index cannot tell the two apart.
         String[] keys = { "TB0T", "TCMb", "Tg0f", "Th00" };
         Set<Integer> failedOnce = new HashSet<>();
-        IntFunction<String> flaky = i -> i == 2 && failedOnce.add(i) ? null : keys[i];
+        IntFunction<@Nullable String> flaky = i -> i == 2 && failedOnce.add(i) ? null : keys[i];
         assertThat("A search that skipped the block on a failed read must not report a confirmed absence",
                 SmcKeyIndex.findKeys(keys.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey), is(nullValue()));
     }
@@ -149,7 +149,7 @@ class SmcKeyIndexTest {
     @Test
     void testFailedProbeDuringSearchIsRetriedAtNeighbour() {
         // A permanently unreadable index during the binary search descends via a neighbour instead of aborting.
-        IntFunction<String> flaky = i -> i == SORTED.length / 2 ? null : SORTED[i];
+        IntFunction<@Nullable String> flaky = i -> i == SORTED.length / 2 ? null : SORTED[i];
         assertThat(SmcKeyIndex.findKeys(SORTED.length, flaky, "Tg", SmcKeyIndex::isGpuTemperatureKey),
                 is(notNullValue()));
     }

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.IntFunction;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,7 +35,7 @@ class SmcKeyIndexTest {
         return i -> i >= 0 && i < keys.length ? keys[i] : null;
     }
 
-    private static List<String> findTg(String[] keys) {
+    private static @Nullable List<String> findTg(String[] keys) {
         return SmcKeyIndex.findKeys(keys.length, lookup(keys), "Tg", SmcKeyIndex::isGpuTemperatureKey);
     }
 

--- a/oshi-common/src/test/java/oshi/util/driver/linux/DmidecodeTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/DmidecodeTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -60,14 +61,14 @@ class DmidecodeTest {
 
     @Test
     void testQueryBiosNameRev() {
-        Pair<String, String> result = Dmidecode.queryBiosNameRev(BIOS_OUTPUT);
+        Pair<@Nullable String, @Nullable String> result = Dmidecode.queryBiosNameRev(BIOS_OUTPUT);
         assertThat(result.getA(), is("SMBIOS 2.7"));
         assertThat(result.getB(), is("2.5"));
     }
 
     @Test
     void testQueryBiosNameRevEmpty() {
-        Pair<String, String> result = Dmidecode.queryBiosNameRev(Collections.emptyList());
+        Pair<@Nullable String, @Nullable String> result = Dmidecode.queryBiosNameRev(Collections.emptyList());
         assertThat(result.getA(), is(nullValue()));
         assertThat(result.getB(), is(nullValue()));
     }
@@ -75,7 +76,7 @@ class DmidecodeTest {
     @Test
     void testQueryBiosNameRevNoRevision() {
         List<String> noRev = Arrays.asList("SMBIOS 3.0 present.", "Handle 0x0000, DMI type 0, 24 bytes");
-        Pair<String, String> result = Dmidecode.queryBiosNameRev(noRev);
+        Pair<@Nullable String, @Nullable String> result = Dmidecode.queryBiosNameRev(noRev);
         assertThat(result.getA(), is("SMBIOS 3.0"));
         assertThat(result.getB(), is(nullValue()));
     }
@@ -83,7 +84,7 @@ class DmidecodeTest {
     @Test
     void testQueryBiosNameRevLowercaseVariant() {
         List<String> lowerCase = Arrays.asList("SMBIOS 3.1 present.", "\tbios revision: 1.2");
-        Pair<String, String> result = Dmidecode.queryBiosNameRev(lowerCase);
+        Pair<@Nullable String, @Nullable String> result = Dmidecode.queryBiosNameRev(lowerCase);
         assertThat(result.getA(), is("SMBIOS 3.1"));
         assertThat(result.getB(), is("1.2"));
     }
@@ -104,7 +105,7 @@ class DmidecodeTest {
 
         @Test
         void testQueryBiosNameRevReturnsPair() {
-            Pair<String, String> result = Dmidecode.queryBiosNameRev();
+            Pair<@Nullable String, @Nullable String> result = Dmidecode.queryBiosNameRev();
             assertThat(result, notNullValue());
         }
     }

--- a/oshi-common/src/test/java/oshi/util/driver/linux/LshwTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/LshwTest.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -39,7 +40,7 @@ class LshwTest {
 
     @Test
     void testParseSystemInfo() {
-        Triplet<String, String, String> result = Lshw.parseSystemInfo(SYSTEM_OUTPUT);
+        Triplet<@Nullable String, @Nullable String, @Nullable String> result = Lshw.parseSystemInfo(SYSTEM_OUTPUT);
         assertThat(result.getA(), is("PowerEdge R720"));
         assertThat(result.getB(), is("ABC1234"));
         assertThat(result.getC(), is("4C4C4544-0044-4810-8031-B4C04F333132"));
@@ -47,7 +48,8 @@ class LshwTest {
 
     @Test
     void testParseSystemInfoEmpty() {
-        Triplet<String, String, String> result = Lshw.parseSystemInfo(Collections.emptyList());
+        Triplet<@Nullable String, @Nullable String, @Nullable String> result = Lshw
+                .parseSystemInfo(Collections.emptyList());
         assertThat(result.getA(), is(nullValue()));
         assertThat(result.getB(), is(nullValue()));
         assertThat(result.getC(), is(nullValue()));
@@ -56,7 +58,7 @@ class LshwTest {
     @Test
     void testParseSystemInfoPartial() {
         List<String> partial = Arrays.asList("       product: MyServer");
-        Triplet<String, String, String> result = Lshw.parseSystemInfo(partial);
+        Triplet<@Nullable String, @Nullable String, @Nullable String> result = Lshw.parseSystemInfo(partial);
         assertThat(result.getA(), is("MyServer"));
         assertThat(result.getB(), is(nullValue()));
         assertThat(result.getC(), is(nullValue()));

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/CpuInfoTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/CpuInfoTest.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -69,7 +70,8 @@ class CpuInfoTest {
 
     @Test
     void testQueryBoardInfoRaspberryPi() {
-        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo(CPUINFO_ARM);
+        Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> info = CpuInfo
+                .queryBoardInfo(CPUINFO_ARM);
         assertThat(info.getA(), is("Sony UK")); // manufacturer from revision digit '0'
         assertThat(info.getB(), is("BCM2835")); // model from Hardware
         assertThat(info.getC(), is("a020d3")); // version from Revision
@@ -79,21 +81,24 @@ class CpuInfoTest {
     @Test
     void testQueryBoardInfoEgoman() {
         List<String> egoman = Arrays.asList("Revision\t: a120d3");
-        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo(egoman);
+        Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> info = CpuInfo
+                .queryBoardInfo(egoman);
         assertThat(info.getA(), is("Egoman"));
     }
 
     @Test
     void testQueryBoardInfoUnknownManufacturer() {
         List<String> unknown = Arrays.asList("Revision\t: a920d3");
-        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo(unknown);
+        Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> info = CpuInfo
+                .queryBoardInfo(unknown);
         assertThat(info.getA(), is(Constants.UNKNOWN));
     }
 
     @Test
     void testQueryBoardInfoX86() {
         // x86 doesn't have Hardware/Revision/Serial
-        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo(CPUINFO_X86);
+        Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> info = CpuInfo
+                .queryBoardInfo(CPUINFO_X86);
         assertThat(info.getA(), is(nullValue()));
         assertThat(info.getB(), is(nullValue()));
         assertThat(info.getC(), is(nullValue()));
@@ -102,7 +107,8 @@ class CpuInfoTest {
 
     @Test
     void testQueryBoardInfoEmpty() {
-        Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo(Collections.emptyList());
+        Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> info = CpuInfo
+                .queryBoardInfo(Collections.emptyList());
         assertThat(info.getA(), is(nullValue()));
     }
 
@@ -137,7 +143,8 @@ class CpuInfoTest {
 
         @Test
         void testQueryBoardInfoAccessors() {
-            Quartet<String, String, String, String> info = CpuInfo.queryBoardInfo();
+            Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> info = CpuInfo
+                    .queryBoardInfo();
             assertDoesNotThrow(info::getA);
             assertDoesNotThrow(info::getB);
             assertDoesNotThrow(info::getC);

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/DiskStatsTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/DiskStatsTest.java
@@ -33,6 +33,7 @@ class DiskStatsTest {
         Map<String, Map<IoStat, Long>> map = DiskStats.parseDiskStats(diskstats);
         assertThat(map.keySet(), containsInAnyOrder("sda", "sda1"));
         Map<IoStat, Long> sda = map.get("sda");
+        assertNotNull(sda);
         assertThat(sda.get(IoStat.MAJOR), is(8L));
         assertThat(sda.get(IoStat.READS), is(100L));
         assertThat(sda.get(IoStat.READS_SECTOR), is(2000L));
@@ -40,7 +41,9 @@ class DiskStatsTest {
         assertThat(sda.get(IoStat.WRITES_SECTOR), is(4000L));
         // NAME is used as the map key, not stored in the per-device map
         assertThat(sda.containsKey(IoStat.NAME), is(false));
-        assertThat(map.get("sda1").get(IoStat.READS), is(40L));
+        Map<IoStat, Long> sda1 = map.get("sda1");
+        assertNotNull(sda1);
+        assertThat(sda1.get(IoStat.READS), is(40L));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoParsingTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoParsingTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.Rectangle;
 import java.util.Arrays;
@@ -78,6 +79,7 @@ class XwininfoParsingTest {
 
         // Check rectangle for Terminal: 800x600 at +100+200
         Rectangle termRect = windows.get("0x1400003");
+        assertNotNull(termRect);
         assertThat(termRect.width, is(800));
         assertThat(termRect.height, is(600));
         assertThat(termRect.x, is(100));
@@ -85,6 +87,7 @@ class XwininfoParsingTest {
 
         // Check negative coordinate
         Rectangle noNameRect = windows.get("0x1800003");
+        assertNotNull(noNameRect);
         assertThat(noNameRect.y, is(-10));
     }
 

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.Rectangle;
 import java.util.Arrays;
@@ -70,12 +71,15 @@ class XwininfoTest {
 
         // Verify rectangle bounds (x, y, width, height)
         Rectangle terminal = windowMap.get("0x1400003");
+        assertNotNull(terminal);
         assertThat(terminal.x, is(100));
         assertThat(terminal.y, is(200));
         assertThat(terminal.width, is(800));
         assertThat(terminal.height, is(600));
 
         Rectangle firefox = windowMap.get("0x1600003");
+
+        assertNotNull(firefox);
         assertThat(firefox.x, is(50));
         assertThat(firefox.y, is(75));
         assertThat(firefox.width, is(1024));
@@ -83,6 +87,7 @@ class XwininfoTest {
 
         // Negative coordinates
         Rectangle anonymous = windowMap.get("0x1800003");
+        assertNotNull(anonymous);
         assertThat(anonymous.x, is(-10));
         assertThat(anonymous.y, is(30));
         assertThat(anonymous.width, is(640));
@@ -131,6 +136,7 @@ class XwininfoTest {
 
         assertThat(windowMap, aMapWithSize(1));
         Rectangle rect = windowMap.get("0x2000001");
+        assertNotNull(rect);
         assertThat(rect.x, is(0));
         assertThat(rect.y, is(0));
         assertThat(rect.width, is(320));


### PR DESCRIPTION
Third group of the backlog #3618 left at WARN, following #3619. Takes `oshi-common` from **229 warnings to 172** and clears the `oshi.util` tree entirely.

This is the group whose contracts consumers actually read. Those packages are annotated individually, so a caller on JDK 8 — which has no module system — or on the classpath, which does not resolve module annotations, sees them. The module-level marking that covers the rest of `oshi-common` reaches neither.

Nothing here changes behavior, and nothing propagates outward: the reactor total drops 619 to 568 with no new findings in `oshi-core` or `oshi-core-ffm`.

### Mostly documentation catching up with behavior

**Eleven `Sysfs` query methods return `null`** when the sysfs file is absent — the normal case on a machine that does not expose that DMI field — through signatures that promised otherwise. The readers in `Dmidecode`, `Lshal`, `Lshw`, `Devicetree`, `CpuInfo` and `ProcessStat` do the same, and the tuples they return carry values the parsers may simply not find.

**Five methods in `SmcKeyIndex` already said so, in the wrong place.** Each `return null` carries `// NOSONAR java:S1168 - null and empty are different answers; see the javadoc`, so the intent was recorded next to the statement, in the javadoc, and in a Sonar suppression — everywhere except the signature.

**`ExecutingCommand.runNative(cmd, envp)` treats a null environment as "inherit the parent's"**, which three callers in `Xwininfo` and `Xrandr` rely on by passing `null` literally.

**`SmcKeyCache` resolves its keys on first use.** The field is null until then and the code already checks it twice; its discovery supplier returns null when discovery cannot complete, which the caller distinguishes from an empty result in order not to cache a failure.

`Memoizer`'s type parameter, which #3619 made nullable-capable for the Solaris suppliers, is what lets that cache type itself honestly.

### Tests

The test changes mirror the contracts rather than working around them: type arguments where a test holds a tuple that may now carry an absent value, `assertNotNull` where a test dereferenced a map lookup directly — a miss would previously have failed with a `NullPointerException` rather than naming the key — and `@Nullable` on two test doubles, `CountingDiscovery` and `FakeScope`, that produce nulls deliberately to exercise the paths above.

No suppressions were added.

### Verification

Full gate green locally on macOS/JDK 25: `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`, 1561 tests passing, plus `./mvnw -Perror-prone clean install -DskipTests` building successfully across the reactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified which system-information values may be unavailable, improving API guidance for applications consuming hardware and operating-system data.
  * Documented nullable results across Linux, macOS, GPU, process, firmware, and device-information queries without changing runtime behavior.

* **Tests**
  * Strengthened coverage for absent hardware data, incomplete system information, and missing window or disk-stat entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->