### PR TITLE
Make the GPU classes' nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/gpu/DxgiUtil.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/gpu/DxgiUtil.java
@@ -7,6 +7,8 @@ package oshi.driver.common.windows.gpu;
 import java.util.List;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ParseUtil;
 
@@ -35,7 +37,7 @@ public final class DxgiUtil {
      * @param adapterName adapter name from the registry {@code DriverDesc} value
      * @return best-matching adapter, or {@code null}
      */
-    public static DxgiAdapterInfo findMatch(List<DxgiAdapterInfo> adapters, int vendorId, int deviceId,
+    public static @Nullable DxgiAdapterInfo findMatch(List<DxgiAdapterInfo> adapters, int vendorId, int deviceId,
             String adapterName) {
         if (vendorId != 0 && deviceId != 0) {
             for (DxgiAdapterInfo a : adapters) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGpuStats.java
@@ -7,6 +7,8 @@ package oshi.hardware.common.platform.linux;
 import java.io.File;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.GpuStats;
 import oshi.hardware.GpuTicks;
@@ -90,7 +92,7 @@ public abstract class LinuxGpuStats implements GpuStats {
      * @param busId PCI bus ID
      * @return device identifier string, or {@code null}
      */
-    protected abstract String nvmlFindDevice(String busId);
+    protected abstract @Nullable String nvmlFindDevice(String busId);
 
     /**
      * Finds the NVML device by GPU name.
@@ -98,7 +100,7 @@ public abstract class LinuxGpuStats implements GpuStats {
      * @param name GPU name
      * @return device identifier string, or {@code null}
      */
-    protected abstract String nvmlFindDeviceByName(String name);
+    protected abstract @Nullable String nvmlFindDeviceByName(String name);
 
     /**
      * Returns VRAM used in bytes via NVML, or -1.
@@ -153,14 +155,14 @@ public abstract class LinuxGpuStats implements GpuStats {
     // -------------------------------------------------------------------------
 
     // Cached NVML device id; null means not yet resolved, empty string means unavailable
-    private String nvmlDeviceId;
+    private @Nullable String nvmlDeviceId;
 
     /**
      * Resolves the NVML device identifier, caching the result.
      *
      * @return device identifier, or {@code null} if unavailable
      */
-    protected String findNvmlDevice() {
+    protected @Nullable String findNvmlDevice() {
         if (nvmlDeviceId != null) {
             return nvmlDeviceId.isEmpty() ? null : nvmlDeviceId;
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxGraphicsCard.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.ToLongFunction;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.GraphicsCard;
 import oshi.hardware.common.AbstractGraphicsCard;
@@ -214,7 +216,7 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
      * @return list of graphics cards
      */
     static List<GraphicsCard> getGraphicsCardsFromLspci(List<String> lspci, Function<Attrs, GraphicsCard> factory,
-            ToLongFunction<String> vramLookup, Function<String, Triplet<String, String, String>> drmLookup) {
+            ToLongFunction<String> vramLookup, Function<@Nullable String, Triplet<String, String, String>> drmLookup) {
         List<GraphicsCard> cardList = new ArrayList<>();
         String name = Constants.UNKNOWN;
         String deviceId = Constants.UNKNOWN;
@@ -310,7 +312,7 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
      * @return list of graphics cards
      */
     static List<GraphicsCard> getGraphicsCardsFromLshw(List<String> lshw, Function<Attrs, GraphicsCard> factory,
-            Function<String, Triplet<String, String, String>> drmLookup) {
+            Function<@Nullable String, Triplet<String, String, String>> drmLookup) {
         List<GraphicsCard> cardList = new ArrayList<>();
         String name = Constants.UNKNOWN;
         String deviceId = Constants.UNKNOWN;
@@ -395,7 +397,7 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
      * @param pciSlot the PCI slot address from lspci (e.g. {@code "01:00.0"}), or {@code null} to use first-match
      * @return triplet of (drmDevicePath, driverName, pciBusId), all empty strings if not found
      */
-    private static Triplet<String, String, String> findDrmInfo(String pciSlot) {
+    private static Triplet<String, String, String> findDrmInfo(@Nullable String pciSlot) {
         return findDrmInfo(pciSlot, DRM_PATH);
     }
 
@@ -406,7 +408,7 @@ public abstract class LinuxGraphicsCard extends AbstractGraphicsCard {
      * @param drmPath the base DRM sysfs directory path
      * @return triplet of (drmDevicePath, driverName, pciBusId), all empty strings if not found
      */
-    static Triplet<String, String, String> findDrmInfo(String pciSlot, String drmPath) {
+    static Triplet<String, String, String> findDrmInfo(@Nullable String pciSlot, String drmPath) {
         File drmDir = new File(drmPath);
         File[] cards = drmDir.listFiles(f -> f.getName().matches("card\\d+"));
         if (cards == null) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxGraphicsCardNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxGraphicsCardNF.java
@@ -6,6 +6,8 @@ package oshi.hardware.common.platform.linux.nativefree;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.GpuStats;
 import oshi.hardware.GraphicsCard;
@@ -55,12 +57,12 @@ final class LinuxGraphicsCardNF extends LinuxGraphicsCard {
         }
 
         @Override
-        protected String nvmlFindDevice(String busId) {
+        protected @Nullable String nvmlFindDevice(String busId) {
             return null;
         }
 
         @Override
-        protected String nvmlFindDeviceByName(String name) {
+        protected @Nullable String nvmlFindDeviceByName(String name) {
             return null;
         }
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGpuStats.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,7 @@ public abstract class MacGpuStats implements GpuStats {
     private final Pattern cardNamePattern;
 
     /** Non-null only on Apple Silicon, where the IOReport GPU channels exist. */
-    private final IOReportSampler sampler;
+    private final @Nullable IOReportSampler sampler;
 
     private boolean closed;
 
@@ -78,7 +79,7 @@ public abstract class MacGpuStats implements GpuStats {
      *                       It is consulted only on Apple Silicon: the IOReport GPU channels do not exist on Intel, so
      *                       subscribing there would attempt a subscription that can never yield a sample.
      */
-    protected MacGpuStats(boolean isAppleSilicon, String cardName, Supplier<IOReportSampler> samplerFactory) {
+    protected MacGpuStats(boolean isAppleSilicon, String cardName, Supplier<@Nullable IOReportSampler> samplerFactory) {
         this.isAppleSilicon = isAppleSilicon;
         this.normCardName = normalize(cardName);
         this.cardNamePattern = Pattern.compile("\\b" + Pattern.quote(normCardName) + "\\b");

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGpuStats.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,9 +41,9 @@ public abstract class WindowsGpuStats implements GpuStats {
 
     private boolean closed;
 
-    private String cachedNvmlDevice;
+    private @Nullable String cachedNvmlDevice;
     private int cachedAdlIndex = Integer.MIN_VALUE;
-    private GpuTicks prevUtilTicks;
+    private @Nullable GpuTicks prevUtilTicks;
 
     /**
      * Constructor.
@@ -456,7 +457,7 @@ public abstract class WindowsGpuStats implements GpuStats {
         return -1L;
     }
 
-    private String findNvmlDevice() {
+    private @Nullable String findNvmlDevice() {
         if (cachedNvmlDevice != null) {
             return cachedNvmlDevice.isEmpty() ? null : cachedNvmlDevice;
         }

--- a/oshi-core/src/main/java/oshi/util/gpu/DxgiUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/DxgiUtilJNA.java
@@ -6,6 +6,8 @@ package oshi.util.gpu;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.gpu.DxgiAdapterInfo;
 import oshi.driver.common.windows.gpu.DxgiUtil;
@@ -38,7 +40,7 @@ public final class DxgiUtilJNA {
      * @param adapterName adapter name from the registry {@code DriverDesc} value
      * @return best-matching adapter, or {@code null}
      */
-    public static DxgiAdapterInfo findMatch(List<DxgiAdapterInfo> adapters, int vendorId, int deviceId,
+    public static @Nullable DxgiAdapterInfo findMatch(List<DxgiAdapterInfo> adapters, int vendorId, int deviceId,
             String adapterName) {
         return DxgiUtil.findMatch(adapters, vendorId, deviceId, adapterName);
     }

--- a/oshi-core/src/test/java/oshi/util/gpu/DxgiUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/gpu/DxgiUtilTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,6 +36,7 @@ class DxgiUtilTest {
         List<DxgiAdapterInfo> adapters = Arrays.asList(arc, igpu);
 
         DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0x8086, 0x56A0, "Intel Arc A770");
+        assertNotNull(match);
         assertThat("Should match Arc A770 by vendor+device ID", match, is(notNullValue()));
         assertThat(match.getDedicatedVideoMemory(), is(16L * 1024 * 1024 * 1024));
     }
@@ -62,6 +64,7 @@ class DxgiUtilTest {
         List<DxgiAdapterInfo> adapters = Collections.singletonList(adapter);
 
         DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0, 0, "Intel Arc A770 Graphics");
+        assertNotNull(match);
         assertThat("Should match by normalized name after stripping (R)/(TM)", match, is(notNullValue()));
         assertThat(match.getDedicatedVideoMemory(), is(16L * 1024 * 1024 * 1024));
     }


### PR DESCRIPTION
Fourth group of the backlog #3618 left at WARN, following #3619 and #3620. Takes `oshi-common` from **172 warnings to 158** and clears the GPU classes. The reactor drops 568 to 554 with nothing newly surfaced.

No behavior changes.

### Two of these describe themselves

**`LinuxGpuStats` caches the NVML device id in a field carrying this comment:**

```java
// Cached NVML device id; null means not yet resolved, empty string means unavailable
private String nvmlDeviceId;
```

Three states in a type that admitted two. `WindowsGpuStats` keeps the same cache, plus a previous-ticks snapshot that is null until the first sample.

**`findDrmInfo` documents `@param pciSlot the PCI slot address ... or null to use first-match`** on both overloads, and is handed to `getGraphicsCardsFrom*` as a `Function` whose input the callers may genuinely not know — `lspci` does not always report a slot.

The rest follow the same pattern: `MacGpuStats.sampler`, which is null when the IOReport subscription could not be created — the constructor already checks for that and logs it — and `DxgiUtil.findMatch` with its JNA forwarder, whose javadoc already said "or `null`".

### Scope note

`LinuxGraphicsCard` and `LinuxGraphicsCardNF` are in this group rather than with the peripherals later on. They share `findDrmInfo` and the DRM lookup `Function` with the GpuStats classes, so splitting them would mean deciding one contract in two separate reviews — the same fragmentation avoided by grouping these changes by subsystem rather than by operating system.

### Verification

Full gate green locally on macOS/JDK 25: `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`, 1561 tests passing, plus `./mvnw -Perror-prone clean install -DskipTests` building successfully across the reactor.

Two assertions were added in `DxgiUtilTest`, at the two places that dereference the now-nullable `findMatch` result. The tests that assert it *returns* null are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clarity around GPU hardware detection when information is unavailable across Windows, Linux, and macOS.
  * Preserved existing GPU matching and statistics behavior.

* **Tests**
  * Strengthened GPU matching tests to verify successful results before checking their details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->