### PR TITLE
Make the operating system layer's nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/AbstractOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOSProcess.java
@@ -9,6 +9,8 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.os.OSProcess;
 
@@ -27,7 +29,7 @@ public abstract class AbstractOSProcess implements OSProcess {
     // Common attributes populated by each platform's updateAttributes(). Declared protected (rather than private with
     // setters) so the platform subclasses can assign them directly in their native refresh methods; see the
     // VisibilityModifier suppression for this file.
-    protected volatile String name;
+    protected volatile String name = "";
     protected volatile String path = "";
     protected volatile State state = State.INVALID;
     protected volatile int parentProcessID;
@@ -130,7 +132,7 @@ public abstract class AbstractOSProcess implements OSProcess {
     }
 
     @Override
-    public double getProcessCpuLoadBetweenTicks(OSProcess priorSnapshot) {
+    public double getProcessCpuLoadBetweenTicks(@Nullable OSProcess priorSnapshot) {
         if (priorSnapshot != null && this.processID == priorSnapshot.getProcessID()
                 && getUpTime() > priorSnapshot.getUpTime()) {
             return (getUserTime() - priorSnapshot.getUserTime() + getKernelTime() - priorSnapshot.getKernelTime())

--- a/oshi-common/src/main/java/oshi/software/common/AbstractOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOSThread.java
@@ -10,6 +10,8 @@ import static oshi.util.Memoizer.memoize;
 import java.util.Locale;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSThread;
@@ -133,7 +135,7 @@ public abstract class AbstractOSThread implements OSThread {
     }
 
     @Override
-    public double getThreadCpuLoadBetweenTicks(OSThread priorSnapshot) {
+    public double getThreadCpuLoadBetweenTicks(@Nullable OSThread priorSnapshot) {
         if (priorSnapshot != null && owningProcessId == priorSnapshot.getOwningProcessId()
                 && getThreadId() == priorSnapshot.getThreadId() && getUpTime() > priorSnapshot.getUpTime()) {
             return (getUserTime() - priorSnapshot.getUserTime() + getKernelTime() - priorSnapshot.getKernelTime())

--- a/oshi-common/src/main/java/oshi/software/common/AbstractOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOperatingSystem.java
@@ -21,6 +21,8 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.software.os.OSDesktopWindow;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OSSession;
@@ -103,7 +105,8 @@ public abstract class AbstractOperatingSystem implements OperatingSystem {
     protected abstract int queryBitness(int jvmBitness);
 
     @Override
-    public List<OSProcess> getProcesses(Predicate<OSProcess> filter, Comparator<OSProcess> sort, int limit) {
+    public List<OSProcess> getProcesses(@Nullable Predicate<OSProcess> filter, @Nullable Comparator<OSProcess> sort,
+            int limit) {
         return queryAllProcesses().stream().filter(filter == null ? ALL_PROCESSES : filter)
                 .sorted(sort == null ? NO_SORTING : sort).limit(limit > 0 ? limit : Long.MAX_VALUE)
                 .collect(Collectors.toList());
@@ -117,8 +120,8 @@ public abstract class AbstractOperatingSystem implements OperatingSystem {
     protected abstract List<OSProcess> queryAllProcesses();
 
     @Override
-    public List<OSProcess> getChildProcesses(int parentPid, Predicate<OSProcess> filter, Comparator<OSProcess> sort,
-            int limit) {
+    public List<OSProcess> getChildProcesses(int parentPid, @Nullable Predicate<OSProcess> filter,
+            @Nullable Comparator<OSProcess> sort, int limit) {
         // Get this pid and its children
         List<OSProcess> childProcs = queryChildProcesses(parentPid);
         // Extract the parent from the list
@@ -141,8 +144,8 @@ public abstract class AbstractOperatingSystem implements OperatingSystem {
     protected abstract List<OSProcess> queryChildProcesses(int parentPid);
 
     @Override
-    public List<OSProcess> getDescendantProcesses(int parentPid, Predicate<OSProcess> filter,
-            Comparator<OSProcess> sort, int limit) {
+    public List<OSProcess> getDescendantProcesses(int parentPid, @Nullable Predicate<OSProcess> filter,
+            @Nullable Comparator<OSProcess> sort, int limit) {
         // Get this pid and its descendants
         List<OSProcess> descendantProcs = queryDescendantProcesses(parentPid);
         // Extract the parent from the list

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxFileSystem.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,7 +98,7 @@ public abstract class LinuxFileSystem extends AbstractFileSystem {
      * @param path the mount path to query
      * @return array of [totalInodes, freeInodes, totalSpace, usableSpace, freeSpace], or {@code null} on failure
      */
-    protected abstract long[] queryStatvfs(String path);
+    protected abstract long @Nullable [] queryStatvfs(String path);
 
     @Override
     public List<OSFileStore> getFileStores(boolean localOnly) {
@@ -144,7 +145,8 @@ public abstract class LinuxFileSystem extends AbstractFileSystem {
         return uuidMap;
     }
 
-    List<OSFileStore> getFileStoreMatching(String nameToMatch, Map<String, String> uuidMap, boolean localOnly) {
+    List<OSFileStore> getFileStoreMatching(@Nullable String nameToMatch, Map<String, String> uuidMap,
+            boolean localOnly) {
         List<OSFileStore> fsList = new ArrayList<>();
 
         Map<String, String> labelMap = queryLabelMap();
@@ -283,7 +285,7 @@ public abstract class LinuxFileSystem extends AbstractFileSystem {
      * @return the server address from the {@code addr=} or {@code mountaddr=} field, or {@code null} if neither is
      *         present
      */
-    static String parseNfsAddr(String options) {
+    static @Nullable String parseNfsAddr(String options) {
         Matcher m = NFS_ADDR_PATTERN.matcher(options);
         return m.find() ? m.group(1) : null;
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,8 +88,8 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
     private final Supplier<String> user = memoize(this::queryUser);
     private final Supplier<String> group = memoize(this::queryGroup);
 
-    private volatile String userID;
-    private volatile String groupID;
+    private volatile String userID = "";
+    private volatile String groupID = "";
     private volatile long residentSetSize;
     private volatile long privateResidentMemory;
     private volatile long minorFaults;
@@ -325,7 +326,7 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
      *
      * @return a two-element array {@code {voluntary, involuntary}}, or {@code null} if unavailable
      */
-    protected long[] queryContextSwitches() {
+    protected long @Nullable [] queryContextSwitches() {
         return null;
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOperatingSystem.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -291,7 +292,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @return a triplet with the parsed family, versionID and codeName if file successfully read and NAME= found, null
      *         otherwise
      */
-    private static Triplet<String, String, String> readOsRelease() {
+    private static @Nullable Triplet<String, String, String> readOsRelease() {
         return readOsRelease(FileUtil.readFile("/etc/os-release"));
     }
 
@@ -301,7 +302,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @param osRelease lines from /etc/os-release
      * @return a triplet with the parsed family, versionID and codeName if NAME= found, null otherwise
      */
-    static Triplet<String, String, String> readOsRelease(List<String> osRelease) {
+    static @Nullable Triplet<String, String, String> readOsRelease(List<String> osRelease) {
         String family = null;
         String versionId = Constants.UNKNOWN;
         String codeName = Constants.UNKNOWN;
@@ -337,7 +338,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @return a triplet with the parsed family, versionID and codeName if the command successfully executed and
      *         Distributor ID: or Description: found, null otherwise
      */
-    private static Triplet<String, String, String> execLsbRelease() {
+    private static @Nullable Triplet<String, String, String> execLsbRelease() {
         return execLsbRelease(ExecutingCommand.runNative("lsb_release -a"));
     }
 
@@ -348,7 +349,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @return a triplet with the parsed family, versionID and codeName if Distributor ID: or Description: found, null
      *         otherwise
      */
-    static Triplet<String, String, String> execLsbRelease(List<String> lines) {
+    static @Nullable Triplet<String, String, String> execLsbRelease(List<String> lines) {
         String family = null;
         String versionId = Constants.UNKNOWN;
         String codeName = Constants.UNKNOWN;
@@ -386,7 +387,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @return a triplet with the parsed family, versionID and codeName if file successfully read and and DISTRIB_ID or
      *         DISTRIB_DESCRIPTION, null otherwise
      */
-    private static Triplet<String, String, String> readLsbRelease() {
+    private static @Nullable Triplet<String, String, String> readLsbRelease() {
         return readLsbRelease(FileUtil.readFile("/etc/lsb-release"));
     }
 
@@ -397,7 +398,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @return a triplet with the parsed family, versionID and codeName if DISTRIB_ID or DISTRIB_DESCRIPTION found, null
      *         otherwise
      */
-    static Triplet<String, String, String> readLsbRelease(List<String> lines) {
+    static @Nullable Triplet<String, String, String> readLsbRelease(List<String> lines) {
         String family = null;
         String versionId = Constants.UNKNOWN;
         String codeName = Constants.UNKNOWN;
@@ -436,7 +437,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @return a triplet with the parsed family, versionID and codeName if file successfully read and " release " or "
      *         VERSION " found, null otherwise
      */
-    private static Triplet<String, String, String> readDistribRelease(String filename) {
+    private static @Nullable Triplet<String, String, String> readDistribRelease(String filename) {
         if (new File(filename).exists()) {
             return readDistribRelease(FileUtil.readFile(filename));
         }
@@ -450,7 +451,7 @@ public abstract class LinuxOperatingSystem extends AbstractOperatingSystem {
      * @return a triplet with the parsed family, versionID and codeName if " release " or " VERSION " found, null
      *         otherwise
      */
-    static Triplet<String, String, String> readDistribRelease(List<String> lines) {
+    static @Nullable Triplet<String, String, String> readDistribRelease(List<String> lines) {
         for (String line : lines) {
             if (line.contains(RELEASE_DELIM)) {
                 return parseRelease(line, RELEASE_DELIM);

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxFileSystemNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxFileSystemNF.java
@@ -4,6 +4,8 @@
  */
 package oshi.software.common.os.linux.nativefree;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.os.linux.LinuxFileSystem;
 
@@ -15,7 +17,7 @@ import oshi.software.common.os.linux.LinuxFileSystem;
 public class LinuxFileSystemNF extends LinuxFileSystem {
 
     @Override
-    protected long[] queryStatvfs(String path) {
+    protected long @Nullable [] queryStatvfs(String path) {
         return null;
     }
 }

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOperatingSystemNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxOperatingSystemNF.java
@@ -7,6 +7,8 @@ package oshi.software.common.os.linux.nativefree;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.os.linux.LinuxOperatingSystem;
 import oshi.software.os.FileSystem;
@@ -73,7 +75,7 @@ public class LinuxOperatingSystemNF extends LinuxOperatingSystem {
     }
 
     @Override
-    public OSProcess getProcess(int pid) {
+    public @Nullable OSProcess getProcess(int pid) {
         OSProcess proc = createOSProcess(pid);
         if (!proc.getState().equals(State.INVALID)) {
             return proc;

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,8 +98,8 @@ public final class MacInstalledApps {
                             version = Constants.UNKNOWN;
                         }
 
-                        appInfoSet.add(new ApplicationInfo(dictValues.get("_name"), version, vendor, lastModifiedEpoch,
-                                additionalInfo));
+                        appInfoSet.add(new ApplicationInfo(ParseUtil.getStringValueOrUnknown(dictValues.get("_name")),
+                                version, vendor, lastModifiedEpoch, additionalInfo));
                     } catch (Exception e) {
                         LOG.trace("Unable to parse dict values: {}", dictValues, e);
                     }
@@ -223,7 +224,7 @@ public final class MacInstalledApps {
         return map;
     }
 
-    static String parseStringArray(String arrayInner) {
+    static @Nullable String parseStringArray(String arrayInner) {
         int lt = arrayInner.indexOf('<');
         if (lt >= 0 && startsWith(arrayInner, lt, TAG_STRING_OPEN)) {
             String inner = extractSimpleInner(arrayInner, lt, TAG_STRING_OPEN, TAG_STRING_CLOSE);
@@ -249,7 +250,7 @@ public final class MacInstalledApps {
         return s.substring(start + openTag.length(), end);
     }
 
-    private static String extractBalancedInner(String s, int openPos, String openTag, String closeTag) {
+    private static @Nullable String extractBalancedInner(String s, int openPos, String openTag, String closeTag) {
         int pos = openPos;
         if (!startsWith(s, pos, openTag)) {
             return null;
@@ -300,7 +301,7 @@ public final class MacInstalledApps {
                 .replace("&apos;", "'");
     }
 
-    private static String readStringValue(String xml, String keyName) {
+    private static @Nullable String readStringValue(String xml, String keyName) {
         int i = xml.indexOf("<key>" + keyName + "</key>");
         if (i > 0) {
             i = xml.indexOf(TAG_STRING_OPEN, i);

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOSProcess.java
@@ -65,11 +65,11 @@ public abstract class MacOSProcess extends AbstractOSProcess {
     private final Supplier<Pair<List<String>, Map<String, String>>> argsEnviron = memoize(
             this::queryArgsAndEnvironment);
 
-    protected volatile String currentWorkingDirectory;
-    protected volatile String user;
-    protected volatile String userID;
-    protected volatile String group;
-    protected volatile String groupID;
+    protected volatile String currentWorkingDirectory = "";
+    protected volatile String user = "";
+    protected volatile String userID = "";
+    protected volatile String group = "";
+    protected volatile String groupID = "";
     protected volatile long residentSetSize;
     protected volatile long memoryFootprint;
     protected volatile long openFiles;

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacOperatingSystem.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,7 +107,7 @@ public abstract class MacOperatingSystem extends AbstractOperatingSystem {
      *
      * @return the code name
      */
-    protected String parseCodeName() {
+    protected @Nullable String parseCodeName() {
         Properties verProps = FileUtil.readPropertiesFromFilename(MACOS_VERSIONS_PROPERTIES);
         String codeName = null;
         if (this.major > 10) {

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/AbstractProcOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/AbstractProcOSProcess.java
@@ -49,11 +49,11 @@ public abstract class AbstractProcOSProcess extends AbstractOSProcess {
     private final Supplier<Pair<List<String>, Map<String, String>>> cmdEnv = memoize(this::queryCommandlineEnvironment);
 
     // Populated by the subclass updateAttributes()
-    protected volatile String commandLineBackup;
-    protected volatile String user;
-    protected volatile String userID;
-    protected volatile String group;
-    protected volatile String groupID;
+    protected volatile String commandLineBackup = "";
+    protected volatile String user = "";
+    protected volatile String userID = "";
+    protected volatile String group = "";
+    protected volatile String groupID = "";
     protected volatile long residentSetSize;
     protected volatile long privateResidentMemory;
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixFileSystem.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractFileSystem;
 import oshi.software.os.OSFileStore;
@@ -50,7 +52,7 @@ public class AixFileSystem extends AbstractFileSystem {
     }
 
     // Called by AixOSFileStore
-    static List<OSFileStore> getFileStoreMatching(String nameToMatch, boolean localOnly) {
+    static List<OSFileStore> getFileStoreMatching(@Nullable String nameToMatch, boolean localOnly) {
         List<OSFileStore> fsList = new ArrayList<>();
 
         // Get inode usage data

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOperatingSystem.java
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.aix.AixPerfstatProcess;
 import oshi.driver.common.unix.aix.Uptime;
@@ -115,7 +117,7 @@ public abstract class AixOperatingSystem extends AbstractOperatingSystem {
     }
 
     @Override
-    public OSProcess getProcess(int pid) {
+    public @Nullable OSProcess getProcess(int pid) {
         List<OSProcess> procs = getProcessListFromProcfs(pid);
         return procs.isEmpty() ? null : procs.get(0);
     }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSProcess.java
@@ -37,16 +37,16 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
     private final Supplier<List<String>> arguments = memoize(this::queryArguments);
     private final Supplier<Map<String, String>> environmentVariables = memoize(this::queryEnvironmentVariables);
 
-    protected volatile String user;
-    protected volatile String userID;
-    protected volatile String group;
-    protected volatile String groupID;
+    protected volatile String user = "";
+    protected volatile String userID = "";
+    protected volatile String group = "";
+    protected volatile String groupID = "";
     protected volatile long residentSetSize;
     protected volatile long minorFaults;
     protected volatile long majorFaults;
     protected volatile long voluntaryContextSwitches;
     protected volatile long involuntaryContextSwitches;
-    protected volatile String commandLineBackup;
+    protected volatile String commandLineBackup = "";
 
     /**
      * Constructs a new {@code BsdOSProcess}.
@@ -182,18 +182,20 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
      */
     protected synchronized boolean updateAttributes(Map<BsdPsKeyword, String> psMap) {
         long now = System.currentTimeMillis();
-        this.state = getStateFromOutput(psMap.get(BsdPsKeyword.STATE).charAt(0));
+        String stateValue = ParseUtil.getStringValueOrEmpty(psMap.get(BsdPsKeyword.STATE));
+        // An absent state column falls through to OTHER rather than failing the whole update
+        this.state = getStateFromOutput(stateValue.isEmpty() ? ' ' : stateValue.charAt(0));
         this.parentProcessID = ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PPID), 0);
-        this.user = psMap.get(BsdPsKeyword.USER);
-        this.userID = psMap.get(BsdPsKeyword.UID);
+        this.user = ParseUtil.getStringValueOrEmpty(psMap.get(BsdPsKeyword.USER));
+        this.userID = ParseUtil.getStringValueOrEmpty(psMap.get(BsdPsKeyword.UID));
         // Most platforms report a group name and gid. DragonFly's ps has no group column, so fall
         // back to the user name and the real group id.
         if (psMap.containsKey(BsdPsKeyword.GROUP)) {
-            this.group = psMap.get(BsdPsKeyword.GROUP);
-            this.groupID = psMap.get(BsdPsKeyword.GID);
+            this.group = ParseUtil.getStringValueOrEmpty(psMap.get(BsdPsKeyword.GROUP));
+            this.groupID = ParseUtil.getStringValueOrEmpty(psMap.get(BsdPsKeyword.GID));
         } else {
             this.group = this.user;
-            this.groupID = psMap.get(BsdPsKeyword.RGID);
+            this.groupID = ParseUtil.getStringValueOrEmpty(psMap.get(BsdPsKeyword.RGID));
         }
         this.priority = ParseUtil.parseIntOrDefault(psMap.get(BsdPsKeyword.PRI), 0);
         // These are in KB, multiply
@@ -234,15 +236,16 @@ public abstract class BsdOSProcess extends AbstractOSProcess {
             this.startTime = now - this.upTime;
         }
         // Path/name come from comm (ucomm on DragonFly)
-        this.path = psMap.get(psMap.containsKey(BsdPsKeyword.UCOMM) ? BsdPsKeyword.UCOMM : BsdPsKeyword.COMM);
+        this.path = ParseUtil.getStringValueOrEmpty(
+                psMap.get(psMap.containsKey(BsdPsKeyword.UCOMM) ? BsdPsKeyword.UCOMM : BsdPsKeyword.COMM));
         this.name = this.path.substring(this.path.lastIndexOf('/') + 1);
         this.minorFaults = ParseUtil.parseLongOrDefault(psMap.get(BsdPsKeyword.MINFLT), 0L);
         this.majorFaults = ParseUtil.parseLongOrDefault(psMap.get(BsdPsKeyword.MAJFLT), 0L);
         this.voluntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(BsdPsKeyword.NVCSW), 0L);
         this.involuntaryContextSwitches = ParseUtil.parseLongOrDefault(psMap.get(BsdPsKeyword.NIVCSW), 0L);
         // Command-line fallback: the full args column (named "command" on DragonFly)
-        this.commandLineBackup = psMap
-                .get(psMap.containsKey(BsdPsKeyword.COMMAND) ? BsdPsKeyword.COMMAND : BsdPsKeyword.ARGS);
+        this.commandLineBackup = ParseUtil.getStringValueOrEmpty(
+                psMap.get(psMap.containsKey(BsdPsKeyword.COMMAND) ? BsdPsKeyword.COMMAND : BsdPsKeyword.ARGS));
         return true;
     }
 

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOSThread.java
@@ -7,6 +7,8 @@ package oshi.software.common.os.unix.bsd;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOSThread;
 import oshi.software.os.OSProcess;
@@ -65,7 +67,9 @@ public abstract class BsdOSThread extends AbstractOSThread {
     protected synchronized boolean updateAttributes(Map<BsdPsThreadKeyword, String> threadMap) {
         // Thread id: lwp (FreeBSD), tid (OpenBSD/DragonFly), or lid (NetBSD)
         this.threadId = ParseUtil.parseIntOrDefault(threadIdValue(threadMap), 0);
-        this.state = BsdOSProcess.getStateFromOutput(threadMap.get(BsdPsThreadKeyword.STATE).charAt(0));
+        String stateValue = ParseUtil.getStringValueOrEmpty(threadMap.get(BsdPsThreadKeyword.STATE));
+        // An absent state column falls through to OTHER rather than failing the whole update
+        this.state = BsdOSProcess.getStateFromOutput(stateValue.isEmpty() ? ' ' : stateValue.charAt(0));
         // Name: tdname (FreeBSD), args (OpenBSD/NetBSD), or absent (DragonFly leaves the default empty string)
         if (threadMap.containsKey(BsdPsThreadKeyword.TDNAME)) {
             this.name = threadMap.get(BsdPsThreadKeyword.TDNAME);
@@ -111,7 +115,7 @@ public abstract class BsdOSThread extends AbstractOSThread {
         return true;
     }
 
-    private static String threadIdValue(Map<BsdPsThreadKeyword, String> threadMap) {
+    private static @Nullable String threadIdValue(Map<BsdPsThreadKeyword, String> threadMap) {
         if (threadMap.containsKey(BsdPsThreadKeyword.LWP)) {
             return threadMap.get(BsdPsThreadKeyword.LWP);
         }

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/bsd/BsdOperatingSystem.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +76,7 @@ public abstract class BsdOperatingSystem extends AbstractOperatingSystem {
     }
 
     @Override
-    public OSProcess getProcess(int pid) {
+    public @Nullable OSProcess getProcess(int pid) {
         if (pid < 0) {
             // A negative pid is the getProcessListFromPS "all processes" sentinel, not a real process
             return null;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystem.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractFileSystem;
 import oshi.software.os.OSFileStore;
@@ -47,7 +49,7 @@ public class NetBsdFileSystem extends AbstractFileSystem {
     }
 
     // Called by NetBsdOSFileStore
-    static List<OSFileStore> getFileStoreMatching(String nameToMatch, boolean localOnly) {
+    static List<OSFileStore> getFileStoreMatching(@Nullable String nameToMatch, boolean localOnly) {
         List<OSFileStore> fsList = new ArrayList<>();
 
         // Get inode usage data

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystem.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.software.common.AbstractFileSystem;
 import oshi.software.os.OSFileStore;
 import oshi.util.ExecutingCommand;
@@ -94,7 +96,7 @@ public abstract class OpenBsdFileSystem extends AbstractFileSystem {
      * @param localOnly   if true, only return local file systems
      * @return list of matching file stores
      */
-    public List<OSFileStore> getFileStoreMatching(String nameToMatch, boolean localOnly) {
+    public List<OSFileStore> getFileStoreMatching(@Nullable String nameToMatch, boolean localOnly) {
         List<OSFileStore> fsList = new ArrayList<>();
 
         // Get inode usage data

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisFileSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisFileSystem.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractFileSystem;
 import oshi.software.os.OSFileStore;
@@ -51,7 +53,7 @@ public abstract class SolarisFileSystem extends AbstractFileSystem {
     }
 
     // Called by SolarisOSFileStore
-    static List<OSFileStore> getFileStoreMatching(String nameToMatch, boolean localOnly) {
+    static List<OSFileStore> getFileStoreMatching(@Nullable String nameToMatch, boolean localOnly) {
         List<OSFileStore> fsList = new ArrayList<>();
 
         // Get inode usage data

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystem.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractOperatingSystem;
 import oshi.software.os.InternetProtocolStats;
@@ -70,7 +72,7 @@ public abstract class SolarisOperatingSystem extends AbstractOperatingSystem {
     }
 
     @Override
-    public OSProcess getProcess(int pid) {
+    public @Nullable OSProcess getProcess(int pid) {
         List<OSProcess> procs = getProcessListFromProcfs(pid);
         if (procs.isEmpty()) {
             return null;

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
@@ -18,6 +18,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
@@ -216,7 +218,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
      * @param wts WTS info for this process, or null if unavailable
      * @return true if the process is valid after the update
      */
-    protected boolean updateAttributes(ProcessPerfCounterBlock pcb, WtsInfo wts) {
+    protected boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
         if (pcb == null) {
             this.state = INVALID;
             return false;

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOperatingSystem.java
@@ -18,6 +18,8 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ProcessPerfCounterBlock;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
@@ -68,7 +70,8 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
      * @return A map of process ID to performance counter block, or {@code null} if the registry data is unavailable
      */
-    protected abstract Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids);
+    protected abstract Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(
+            @Nullable Collection<Integer> pids);
 
     /**
      * Reads process performance data from performance counters, with a WMI backup.
@@ -76,7 +79,8 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
      * @return A map of process ID to performance counter block
      */
-    protected abstract Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids);
+    protected abstract Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
+            @Nullable Collection<Integer> pids);
 
     /**
      * Reads thread performance data from {@code HKEY_PERFORMANCE_DATA}.
@@ -84,7 +88,8 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
      * @return A map of thread ID to performance counter block, or {@code null} if the registry data is unavailable
      */
-    protected abstract Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids);
+    protected abstract Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(
+            @Nullable Collection<Integer> pids);
 
     /**
      * Reads thread performance data from performance counters, with a WMI backup.
@@ -92,7 +97,8 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
      * @return A map of thread ID to performance counter block
      */
-    protected abstract Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids);
+    protected abstract Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
+            @Nullable Collection<Integer> pids);
 
     /**
      * Reads process information from the Windows Terminal Service, with a WMI backup.
@@ -100,7 +106,7 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
      * @return A map of process ID to terminal service information
      */
-    protected abstract Map<Integer, WtsInfo> queryProcessWtsMap(Collection<Integer> pids);
+    protected abstract Map<Integer, WtsInfo> queryProcessWtsMap(@Nullable Collection<Integer> pids);
 
     /**
      * Maps every process ID to the ID of its parent.
@@ -120,10 +126,10 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @return The process
      */
     protected abstract OSProcess createOSProcess(int pid, Map<Integer, ProcessPerfCounterBlock> processMap,
-            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap);
+            Map<Integer, WtsInfo> processWtsMap, @Nullable Map<Integer, ThreadPerfCounterBlock> threadMap);
 
     @Override
-    public List<OSProcess> getProcesses(Collection<Integer> pids) {
+    public List<OSProcess> getProcesses(@Nullable Collection<Integer> pids) {
         return processMapToList(pids);
     }
 
@@ -133,7 +139,7 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
     }
 
     @Override
-    public OSProcess getProcess(int pid) {
+    public @Nullable OSProcess getProcess(int pid) {
         List<OSProcess> procList = processMapToList(Collections.singletonList(pid));
         return procList.isEmpty() ? null : procList.get(0);
     }
@@ -158,7 +164,7 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
         return resolveProcessMap(null);
     }
 
-    private Map<Integer, ProcessPerfCounterBlock> resolveProcessMap(Collection<Integer> pids) {
+    private Map<Integer, ProcessPerfCounterBlock> resolveProcessMap(@Nullable Collection<Integer> pids) {
         // Get data from the registry if possible
         Map<Integer, ProcessPerfCounterBlock> processMap = processMapFromRegistry.get();
         // otherwise performance counters with WMI backup
@@ -168,7 +174,7 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
         return processMap == null ? Collections.emptyMap() : processMap;
     }
 
-    private List<OSProcess> processMapToList(Collection<Integer> pids) {
+    private List<OSProcess> processMapToList(@Nullable Collection<Integer> pids) {
         Map<Integer, ProcessPerfCounterBlock> processMap = resolveProcessMap(pids);
         Map<Integer, ThreadPerfCounterBlock> threadMap = null;
         if (USE_PROCSTATE_SUSPENDED) {

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -1582,7 +1582,7 @@ public final class ParseUtil {
      * @param datePattern The expected date format pattern (e.g., {@code "yyyyMMdd"}).
      * @return The epoch time in milliseconds since January 1, 1970, UTC. Returns {@code 0} if parsing fails.
      */
-    public static long parseDateToEpoch(String dateString, String datePattern) {
+    public static long parseDateToEpoch(@Nullable String dateString, String datePattern) {
         if (dateString == null || dateString.equals(Constants.UNKNOWN) || dateString.isEmpty()
                 || datePattern.isEmpty()) {
             return 0; // Default value if date is unknown or empty or null

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,7 +121,7 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
     }
 
     @Override
-    protected boolean updateAttributes(ProcessPerfCounterBlock pcb, WtsInfo wts) {
+    protected boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
         if (!super.updateAttributes(pcb, wts)) {
             return false;
         }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -264,33 +265,34 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     }
 
     @Override
-    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids) {
+    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(@Nullable Collection<Integer> pids) {
         return ProcessPerformanceDataFFM.buildProcessMapFromRegistry(pids);
     }
 
     @Override
-    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids) {
+    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
+            @Nullable Collection<Integer> pids) {
         return ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(pids);
     }
 
     @Override
-    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
+    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataFFM.buildThreadMapFromRegistry(pids);
     }
 
     @Override
-    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids) {
+    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(@Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids);
     }
 
     @Override
-    protected Map<Integer, WtsInfo> queryProcessWtsMap(Collection<Integer> pids) {
+    protected Map<Integer, WtsInfo> queryProcessWtsMap(@Nullable Collection<Integer> pids) {
         return ProcessWtsDataFFM.queryProcessWtsMap(pids);
     }
 
     @Override
     protected OSProcess createOSProcess(int pid, Map<Integer, ProcessPerfCounterBlock> processMap,
-            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
+            Map<Integer, WtsInfo> processWtsMap, @Nullable Map<Integer, ThreadPerfCounterBlock> threadMap) {
         return new WindowsOSProcessFFM(pid, this, processMap, processWtsMap, threadMap);
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,7 +106,7 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
     }
 
     @Override
-    protected boolean updateAttributes(ProcessPerfCounterBlock pcb, WtsInfo wts) {
+    protected boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
         if (!super.updateAttributes(pcb, wts)) {
             return false;
         }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,33 +110,34 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
             .memoize(WindowsInstalledAppsJNA::queryInstalledApps, installedAppsExpiration());
 
     @Override
-    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(Collection<Integer> pids) {
+    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(@Nullable Collection<Integer> pids) {
         return ProcessPerformanceDataJNA.buildProcessMapFromRegistry(pids);
     }
 
     @Override
-    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(Collection<Integer> pids) {
+    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
+            @Nullable Collection<Integer> pids) {
         return ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(pids);
     }
 
     @Override
-    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
+    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataJNA.buildThreadMapFromRegistry(pids);
     }
 
     @Override
-    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(Collection<Integer> pids) {
+    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(@Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids);
     }
 
     @Override
-    protected Map<Integer, WtsInfo> queryProcessWtsMap(Collection<Integer> pids) {
+    protected Map<Integer, WtsInfo> queryProcessWtsMap(@Nullable Collection<Integer> pids) {
         return ProcessWtsData.queryProcessWtsMap(pids);
     }
 
     @Override
     protected OSProcess createOSProcess(int pid, Map<Integer, ProcessPerfCounterBlock> processMap,
-            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
+            Map<Integer, WtsInfo> processWtsMap, @Nullable Map<Integer, ThreadPerfCounterBlock> threadMap) {
         return new WindowsOSProcessJNA(pid, this, processMap, processWtsMap, threadMap);
     }
 


### PR DESCRIPTION
Fifth group of the backlog #3618 left at WARN, following #3619, #3620 and #3621. Takes `oshi-common` from **158 warnings to 103** and clears `oshi.software.common`.

### Eighteen process attribute fields now start empty rather than null

`AbstractOSProcess.name`, and the user, group, id, working directory and command-line-backup fields on `MacOSProcess`, `AbstractProcOSProcess`, `BsdOSProcess` and `LinuxOSProcess`, are populated by `updateAttributes` rather than by a constructor.

Whether that leaves a window depends on the subclass: `LinuxOSProcess` and `MacOSProcess` call `updateAttributes` from their constructors, while the `AbstractProcOSProcess`, `BsdOSProcess` and `SolarisOSProcess` hierarchies do not. So the gap is real for some callers and merely unprovable for the rest, and either way a getter reaching a field early returned `null` through a signature promising otherwise.

`AbstractOSThread` already declared `protected volatile String name = "";`. The rest now match it, which is a defensive guard rather than a new convention.

### A real failure on the BSDs

`BsdOSProcess.updateAttributes` read the `ps` state column as `psMap.get(BsdPsKeyword.STATE).charAt(0)`, and `BsdOSThread` did the same. A `ps` variant that does not emit that column would throw partway through the update, leaving the process or thread object half-populated with no indication why. An absent state column now falls through to `OTHER` and the rest of the update completes.

### Five overrides repeat what their interface already says

An override cannot narrow a parameter, so these restate an annotation the API has carried since #3614: the `filter` and `sort` arguments of the three process listing methods, and the prior snapshot of `getProcessCpuLoadBetweenTicks` and `getThreadCpuLoadBetweenTicks`.

`getProcess(int)` is annotated in five implementations. `OperatingSystem.getProcess(int)` has documented returning `null` for a process that is not running since #3614, so those signatures had been contradicting the interface.

### The rest were documented but unstated

The release-file readers on Linux (`readOsRelease`, `readLsbRelease`, `execLsbRelease`, `readDistribRelease`), the plist readers on macOS, the `ps` output columns on the BSDs, and the `getFileStoreMatching` implementations whose name argument is `null` to mean "match everything".

`queryStatvfs` and `queryContextSwitches` return `long @Nullable []` — note the annotation goes after the type for an array, since `@Nullable long[]` would annotate the element type instead.

### Scope

The second commit matches the overrides in `WindowsOperatingSystem` and `WindowsOSProcess`'s JNA and FFM implementations, since the abstract signatures changed here. The forwarding calls and returns those same signatures surface in those files are left for the group that covers `oshi-core` and `oshi-core-ffm`; the reactor total drops 554 to 505.

### Verification

Full gate green locally on macOS/JDK 25: `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`, 1561 tests passing, plus `./mvnw -Perror-prone clean install -DskipTests` building successfully across the reactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Expanded nullability annotations across process, thread, operating-system, filesystem, and parsing APIs.
  - Clarified which optional inputs may be omitted and which lookups may return no result.
  - Added safer empty-string defaults for unavailable process metadata.
  - Improved resilience when system data is incomplete, including missing process states and application names.
  - Preserved existing behavior for date parsing, process discovery, filesystem queries, and CPU-load calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->