### PR TITLE
Make CentralProcessor's nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractCentralProcessor.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +63,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      * Create a Processor
      */
     protected AbstractCentralProcessor() {
-        Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> processorLists = initProcessorCounts();
+        Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> processorLists = initProcessorCounts();
         // Populate logical processor lists.
         this.logicalProcessors = Collections.unmodifiableList(processorLists.getA());
         if (processorLists.getB() == null) {
@@ -94,7 +95,7 @@ public abstract class AbstractCentralProcessor implements CentralProcessor {
      *
      * @return Lists of initialized Logical Processors, Physical Processors, Processor Caches, and Feature Flags.
      */
-    protected abstract Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts();
+    protected abstract Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts();
 
     /**
      * Updates logical and physical processor counts and arrays

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxCentralProcessor.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -260,7 +261,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
         // Attempt to read from sysfs
         Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> topology = readTopologyWithUdev();
         // This sometimes fails so fall back to CPUID
@@ -306,7 +307,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
      *
      * @return the CPU syspaths from udev, or {@code null} if udev is unavailable
      */
-    protected abstract List<String> enumerateCpuSyspathsViaUdev();
+    protected abstract @Nullable List<String> enumerateCpuSyspathsViaUdev();
 
     /**
      * Enumerates the sysfs paths of all CPUs, preferring udev and falling back to a sysfs directory scan.
@@ -374,7 +375,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
      * @return a LogicalProcessor for the given syspath
      */
     protected static LogicalProcessor getLogicalProcessorFromSyspath(String syspath, Set<ProcessorCache> caches,
-            String modAlias, Map<Integer, Integer> coreEfficiencyMap, Map<Integer, String> modAliasMap) {
+            @Nullable String modAlias, Map<Integer, Integer> coreEfficiencyMap, Map<Integer, String> modAliasMap) {
         int processor = ParseUtil.getFirstIntValue(syspath);
         int coreId = FileUtil.getIntFromFile(syspath + "/topology/core_id");
         int pkgId = FileUtil.getIntFromFile(syspath + "/topology/physical_package_id");
@@ -774,7 +775,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
      * @param cpuidLines the output lines from {@code cpuid -1r}
      * @return the processor ID string (edx + eax), or {@code null} if not found
      */
-    static String parseCpuidOutput(List<String> cpuidLines) {
+    static @Nullable String parseCpuidOutput(List<String> cpuidLines) {
         for (String checkLine : cpuidLines) {
             if (checkLine.contains("eax=") && checkLine.trim().startsWith("0x00000001")) {
                 String eax = "";
@@ -786,7 +787,7 @@ public abstract class LinuxCentralProcessor extends AbstractCentralProcessor {
                         edx = ParseUtil.removeMatchingString(register, "edx=0x");
                     }
                 }
-                if (!eax.isEmpty() && !edx.isEmpty()) {
+                if (eax != null && edx != null && !eax.isEmpty() && !edx.isEmpty()) {
                     return edx + eax;
                 }
             }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxCentralProcessorNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxCentralProcessorNF.java
@@ -6,6 +6,8 @@ package oshi.hardware.common.platform.linux.nativefree;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.platform.linux.LinuxCentralProcessor;
 import oshi.util.ExecutingCommand;
@@ -34,7 +36,7 @@ public final class LinuxCentralProcessorNF extends LinuxCentralProcessor {
     }
 
     @Override
-    protected List<String> enumerateCpuSyspathsViaUdev() {
+    protected @Nullable List<String> enumerateCpuSyspathsViaUdev() {
         // No udev; the base falls back to a sysfs directory scan
         return null;
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOKitProvider.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOKitProvider.java
@@ -8,6 +8,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Abstracts IOKit registry operations so that iteration logic can be shared between JNA and FFM implementations.
  */
@@ -21,7 +23,7 @@ public interface IOKitProvider {
      * @param extractor   function applied to the matched entry; receives a non-null {@link RegistryEntry}
      * @return the extracted value, or {@code null} if the service was not found
      */
-    <T> T withMatchingService(String serviceName, Function<RegistryEntry, T> extractor);
+    <T extends @Nullable Object> T withMatchingService(String serviceName, Function<RegistryEntry, T> extractor);
 
     /**
      * Iterates all IORegistry services matching a class name, invoking a consumer for each entry. Entries and the

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,7 +152,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      *
      * @return the vendor string
      */
-    protected String platformExpert() {
+    protected @Nullable String platformExpert() {
         String manufacturer = ioKitProvider().withMatchingService("IOPlatformExpertDevice", entry -> {
             byte[] data = entry.getByteArrayProperty("manufacturer");
             return data != null ? ParseUtil.decodeNulTerminated(data, StandardCharsets.UTF_8) : null;
@@ -168,8 +169,8 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @return a map of physical processor numbers to a pair of ({@code compatible}, {@code cluster-type}). Either
      *         element may be {@code null} if that property is absent from the node.
      */
-    protected Map<Integer, Pair<String, String>> queryCoreProperties() {
-        Map<Integer, Pair<String, String>> coreProperties = new HashMap<>();
+    protected Map<Integer, Pair<@Nullable String, @Nullable String>> queryCoreProperties() {
+        Map<Integer, Pair<@Nullable String, @Nullable String>> coreProperties = new HashMap<>();
         ioKitProvider().forEachMatchingService("IOPlatformDevice", entry -> {
             String name = entry.getName();
             if (name != null) {
@@ -191,7 +192,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @param data the raw property value, possibly null
      * @return the decoded string, or null if {@code data} was null
      */
-    private static String ioRegString(byte[] data) {
+    private static @Nullable String ioRegString(byte @Nullable [] data) {
         return data == null ? null : new String(data, StandardCharsets.UTF_8).replace('\0', ' ').trim();
     }
 
@@ -225,7 +226,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @return a map from core key to efficiency class, containing every key in {@code coreKeys}
      */
     static Map<Integer, Integer> deriveEfficiencyClasses(List<Integer> coreKeys,
-            Map<Integer, Pair<String, String>> coreProperties, int topPerfLevelCores) {
+            Map<Integer, Pair<@Nullable String, @Nullable String>> coreProperties, int topPerfLevelCores) {
         Map<Integer, Integer> efficiencyMap = new HashMap<>();
         // Strategy 1 and 2: cluster-type, directly and then propagated to cores sharing a codename
         Map<String, Integer> classByCodename = new HashMap<>();
@@ -304,7 +305,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @param properties the core's properties, possibly null
      * @return 1 for a performance cluster, 0 for an efficiency cluster, or null if not recognized
      */
-    private static Integer clusterTypeClass(Pair<String, String> properties) {
+    private static @Nullable Integer clusterTypeClass(@Nullable Pair<@Nullable String, @Nullable String> properties) {
         String clusterType = properties == null ? null : properties.getB();
         if (clusterType == null || clusterType.isEmpty()) {
             return null;
@@ -322,7 +323,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @param properties the core's properties, possibly null
      * @return the codename, e.g. {@code avalanche}, or null if absent
      */
-    private static String codename(Pair<String, String> properties) {
+    private static @Nullable String codename(@Nullable Pair<@Nullable String, @Nullable String> properties) {
         String compatible = properties == null ? null : properties.getA();
         if (compatible == null) {
             return null;
@@ -339,7 +340,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @param physicalProcessors the physical processors, whose ID strings hold the IORegistry {@code compatible} value
      * @return the description, or null if no Apple core codename was found
      */
-    static String deriveMicroarchitecture(List<PhysicalProcessor> physicalProcessors) {
+    static @Nullable String deriveMicroarchitecture(List<PhysicalProcessor> physicalProcessors) {
         // Sorting keys, ordering distinct codenames by descending efficiency class and then by core number
         Map<String, Pair<Integer, Integer>> codenames = new LinkedHashMap<>();
         for (PhysicalProcessor processor : physicalProcessors) {
@@ -480,7 +481,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
         int logicalProcessorCount = sysctlInt("hw.logicalcpu", 1);
         int physicalProcessorCount = sysctlInt("hw.physicalcpu", 1);
         int physicalPackageCount = sysctlInt("hw.packages", 1);
@@ -492,14 +493,14 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
             logProcs.add(new LogicalProcessor(i, coreId, pkgId));
             pkgCoreKeys.add((pkgId << 16) + coreId);
         }
-        Map<Integer, Pair<String, String>> coreProps = queryCoreProperties();
+        Map<Integer, Pair<@Nullable String, @Nullable String>> coreProps = queryCoreProperties();
         int perflevels = sysctlIntNoWarn("hw.nperflevels", 1);
         int topPerfLevelCores = sysctlIntNoWarn("hw.perflevel0.physicalcpu", 0);
         List<Integer> coreKeys = pkgCoreKeys.stream().sorted().collect(Collectors.toList());
         Map<Integer, Integer> efficiencyMap = deriveEfficiencyClasses(coreKeys, coreProps, topPerfLevelCores);
         List<PhysicalProcessor> physProcs = new ArrayList<>(coreKeys.size());
         for (Integer k : coreKeys) {
-            Pair<String, String> props = coreProps.get(k);
+            Pair<@Nullable String, @Nullable String> props = coreProps.get(k);
             String compat = props == null || props.getA() == null ? "" : props.getA().toLowerCase(Locale.ROOT);
             physProcs.add(new PhysicalProcessor(k >> 16, k & 0xffff, efficiencyMap.getOrDefault(k, 0), compat));
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdCentralProcessor.java
@@ -18,6 +18,8 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
@@ -54,7 +56,7 @@ public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
     protected abstract Pair<Long, Long> queryVmStats();
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
         List<String> dmesg = ExecutingCommand.runNative("dmesg");
         Pair<Map<Integer, Integer>, Map<Integer, Integer>> topology = parseTopology(dmesg);
         Map<Integer, Integer> coreMap = topology.getA();
@@ -163,7 +165,7 @@ public abstract class BsdCentralProcessor extends AbstractCentralProcessor {
         }
     }
 
-    static ProcessorCache parseCacheStr(String cacheStr) {
+    static @Nullable ProcessorCache parseCacheStr(String cacheStr) {
         String[] split = ParseUtil.whitespaces.split(cacheStr.trim(), -1);
         if (split.length > 3) {
             switch (split[split.length - 1]) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessor.java
@@ -10,6 +10,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.aix.Lssrad;
 import oshi.hardware.common.AbstractCentralProcessor;
@@ -123,7 +125,7 @@ public abstract class AixCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
         PartitionInfo info = queryPartitionInfo();
         int physProcs = (int) info.vcpusMax;
         if (physProcs < 1) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessor.java
@@ -15,6 +15,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.ExecutingCommand;
 import oshi.util.FileUtil;
@@ -254,7 +256,7 @@ public abstract class FreeBsdCentralProcessor extends AbstractCentralProcessor {
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
         List<LogicalProcessor> logProcs = parseTopology();
         // Force at least one processor
         if (logProcs.isEmpty()) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessor.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.AbstractCentralProcessor;
 import oshi.util.ExecutingCommand;
@@ -28,7 +30,7 @@ import oshi.util.tuples.Quartet;
 public abstract class SolarisCentralProcessor extends AbstractCentralProcessor {
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
         // Defensive copy: the base appends a fallback entry, so don't assume the subclass returned a mutable list
         List<LogicalProcessor> logProcs = new ArrayList<>(queryLogicalProcessors());
         if (logProcs.isEmpty()) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -7,6 +7,7 @@ package oshi.hardware.common.platform.windows;
 import static oshi.util.Memoizer.memoize;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -14,6 +15,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessorInformation.ProcessorFrequencyProperty;
@@ -34,7 +37,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     /** Default constructor. */
     protected WindowsCentralProcessor() {
         // Store the initial query and start the memoizer expiration
-        if (USE_CPU_UTILITY) {
+        if (USE_CPU_UTILITY && processorUtilityCounters != null) {
             setInitialUtilityCounters(processorUtilityCounters.get().getB());
         }
     }
@@ -42,7 +45,8 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     // Populated by initProcessorCounts, which the parent constructor calls before this class's field initializers
     // run; that ordering rules out an AtomicReference holder (its initializer would not have run yet), so this stays
     // a volatile reference to a swap-published immutable snapshot, for which volatile publication is sufficient.
-    private volatile Map<String, Integer> numaNodeProcToLogicalProcMap; // NOSONAR java:S3077
+    // Populated by initProcessorCounts; empty until then, as AbstractOSProcess does for its attributes
+    private volatile Map<String, Integer> numaNodeProcToLogicalProcMap = Collections.emptyMap(); // NOSONAR java:S3077
 
     /** Whether to use legacy Processor counters rather than Processor Information counters. */
     protected static final boolean USE_LEGACY_SYSTEM_COUNTERS = GlobalConfig
@@ -58,10 +62,10 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     // Previous sample for utility base multiplier calculation
     private final AtomicReference<Map<ProcessorUtilityTickCountProperty, List<Long>>> initialUtilityCounters = new AtomicReference<>();
     // Lazily initialized
-    private Long utilityBaseMultiplier;
+    private @Nullable Long utilityBaseMultiplier;
 
     // This tick query is memoized to enforce a minimum elapsed time for determining the capacity base multiplier
-    private final Supplier<Pair<List<String>, Map<ProcessorUtilityTickCountProperty, List<Long>>>> processorUtilityCounters = USE_CPU_UTILITY
+    private final @Nullable Supplier<Pair<List<String>, Map<ProcessorUtilityTickCountProperty, List<Long>>>> processorUtilityCounters = USE_CPU_UTILITY
             ? memoize(this::queryProcessorCapacityCounters, TimeUnit.MILLISECONDS.toNanos(300L))
             : null;
 
@@ -280,7 +284,8 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
         return queryNTPower(2); // Current is field index 2
     }
 
-    private long[] mapPercentToFreqs(List<String> instances, List<Long> percentList, long maxFreq) {
+    private long @Nullable [] mapPercentToFreqs(List<String> instances, @Nullable List<Long> percentList,
+            long maxFreq) {
         if (instances.isEmpty() || percentList == null) {
             return null;
         }
@@ -336,7 +341,7 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
         List<Long> initSystemUtility = null;
         List<Long> initProcessorUtility = null;
         List<Long> initProcessorUtilityBase = null;
-        if (USE_CPU_UTILITY) {
+        if (USE_CPU_UTILITY && processorUtilityCounters != null) {
             Pair<List<String>, Map<ProcessorUtilityTickCountProperty, List<Long>>> instanceValuePair = processorUtilityCounters
                     .get();
             instances = instanceValuePair.getA();
@@ -401,20 +406,18 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @param initProcessorUtilityBase initial processor utility base, may be null
      * @return the processed tick array
      */
-    protected long[][] processTickData(List<String> instances, List<Long> systemList, List<Long> userList,
-            List<Long> irqList, List<Long> softIrqList, List<Long> idleList, List<Long> baseList,
-            List<Long> systemUtility, List<Long> processorUtility, List<Long> processorUtilityBase,
-            List<Long> initSystemList, List<Long> initUserList, List<Long> initBase, List<Long> initSystemUtility,
-            List<Long> initProcessorUtility, List<Long> initProcessorUtilityBase) {
+    protected long[][] processTickData(List<String> instances, @Nullable List<Long> systemList,
+            @Nullable List<Long> userList, @Nullable List<Long> irqList, @Nullable List<Long> softIrqList,
+            @Nullable List<Long> idleList, @Nullable List<Long> baseList, @Nullable List<Long> systemUtility,
+            @Nullable List<Long> processorUtility, @Nullable List<Long> processorUtilityBase,
+            @Nullable List<Long> initSystemList, @Nullable List<Long> initUserList, @Nullable List<Long> initBase,
+            @Nullable List<Long> initSystemUtility, @Nullable List<Long> initProcessorUtility,
+            @Nullable List<Long> initProcessorUtilityBase) {
 
         int ncpu = getLogicalProcessorCount();
         long[][] ticks = new long[ncpu][TickType.values().length];
         if (instances.isEmpty() || systemList == null || userList == null || irqList == null || softIrqList == null
-                || idleList == null
-                || (USE_CPU_UTILITY && (baseList == null || systemUtility == null || processorUtility == null
-                        || processorUtilityBase == null || initSystemList == null || initUserList == null
-                        || initBase == null || initSystemUtility == null || initProcessorUtility == null
-                        || initProcessorUtilityBase == null))) {
+                || idleList == null) {
             return ticks;
         }
         int size = instances.size();
@@ -422,12 +425,11 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
                 || idleList.size() < size) {
             return ticks;
         }
-        if (USE_CPU_UTILITY && (baseList.size() < size || systemUtility.size() < size || processorUtility.size() < size
-                || processorUtilityBase.size() < size || initSystemList.size() < size || initUserList.size() < size
-                || initBase.size() < size || initSystemUtility.size() < size || initProcessorUtility.size() < size
-                || initProcessorUtilityBase.size() < size)) {
-            return ticks;
-        }
+        // The utility counters only refine the ticks read above. If any of them is missing or short, report the
+        // raw ticks rather than nothing; previously an absent utility counter discarded the whole sample.
+        boolean utilityAvailable = USE_CPU_UTILITY
+                && hasAll(size, baseList, systemUtility, processorUtility, processorUtilityBase, initSystemList,
+                        initUserList, initBase, initSystemUtility, initProcessorUtility, initProcessorUtilityBase);
         for (int i = 0; i < instances.size(); i++) {
             String instance = instances.get(i);
             int cpu;
@@ -448,7 +450,10 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
             ticks[cpu][TickType.SOFTIRQ.getIndex()] = softIrqList.get(i);
             ticks[cpu][TickType.IDLE.getIndex()] = idleList.get(i);
 
-            if (USE_CPU_UTILITY) {
+            if (utilityAvailable && baseList != null && initBase != null && processorUtilityBase != null
+                    && initProcessorUtilityBase != null && processorUtility != null && initProcessorUtility != null
+                    && systemUtility != null && initSystemUtility != null && initUserList != null
+                    && initSystemList != null) {
                 long deltaT = baseList.get(i) - initBase.get(i);
                 if (deltaT > 0) {
                     long deltaBase = processorUtilityBase.get(i) - initProcessorUtilityBase.get(i);
@@ -480,5 +485,21 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
             ticks[cpu][TickType.IDLE.getIndex()] /= 10_000L;
         }
         return ticks;
+    }
+
+    /**
+     * Reports whether every one of the given counter lists was read and holds at least {@code size} values.
+     *
+     * @param size  the number of processor instances to be indexed
+     * @param lists the counter lists to check
+     * @return true if all are present and long enough
+     */
+    private static boolean hasAll(int size, @Nullable List<Long>... lists) {
+        for (List<Long> list : lists) {
+            if (list == null || list.size() < size) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsCentralProcessor.java
@@ -45,8 +45,9 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
     // Populated by initProcessorCounts, which the parent constructor calls before this class's field initializers
     // run; that ordering rules out an AtomicReference holder (its initializer would not have run yet), so this stays
     // a volatile reference to a swap-published immutable snapshot, for which volatile publication is sufficient.
-    // Populated by initProcessorCounts; empty until then, as AbstractOSProcess does for its attributes
-    private volatile Map<String, Integer> numaNodeProcToLogicalProcMap = Collections.emptyMap(); // NOSONAR java:S3077
+    // Assigned by buildNumaNodeProcMap during initProcessorCounts, which the superclass constructor calls before
+    // this class's field initializers would run, so it must not be given one. Read through the getter.
+    private volatile @Nullable Map<String, Integer> numaNodeProcToLogicalProcMap; // NOSONAR java:S3077
 
     /** Whether to use legacy Processor counters rather than Processor Information counters. */
     protected static final boolean USE_LEGACY_SYSTEM_COUNTERS = GlobalConfig
@@ -113,7 +114,8 @@ public abstract class WindowsCentralProcessor extends AbstractCentralProcessor {
      * @return the map
      */
     protected Map<String, Integer> getNumaNodeProcToLogicalProcMap() {
-        return this.numaNodeProcToLogicalProcMap;
+        Map<String, Integer> map = this.numaNodeProcToLogicalProcMap;
+        return map == null ? Collections.emptyMap() : map;
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,7 +159,7 @@ class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
         Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> lpi = LogicalProcessorInformationFFM
                 .getLogicalProcessorInformationEx();
         buildNumaNodeProcMap(lpi.getA());

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorJNA.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,7 +121,7 @@ class WindowsCentralProcessorJNA extends WindowsCentralProcessor {
     }
 
     @Override
-    protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+    protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
         Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> lpi;
         if (VersionHelpers.IsWindows7OrGreater()) {
             lpi = LogicalProcessorInformation.getLogicalProcessorInformationEx();


### PR DESCRIPTION
Sixth group of the backlog #3618 left at WARN. Takes `oshi-common` from **103 warnings to 59** and clears `CentralProcessor` across all eight platform implementations.

Grouping by component rather than by operating system pays off here: the same contract is decided once with all eight implementations in view, instead of twice in separate reviews.

### A behavior fix worth reviewing

`processTickData` receives sixteen counter lists and null-checks every one of them. The check for the ten *utility* counters sits inside the `USE_CPU_UTILITY &&` branch:

```java
if (instances.isEmpty() || systemList == null || ... || idleList == null
        || (USE_CPU_UTILITY && (baseList == null || ... || initProcessorUtilityBase == null))) {
    return ticks;   // all zeros
}
```

So with `oshi.os.windows.cpu.utility=true` and any single utility counter unavailable, this returns **all-zero ticks**, discarding the five raw counters that were read successfully. The utility counters only ever refine those raw values, so the correct fallback is to report them unrefined.

They are now checked where they are used, and skipped when absent. The property is opt-in and defaults to false, so this only affects users who turned it on — but for them it is the difference between plausible CPU ticks and none.

### Contracts contradicted in their own file

`initProcessorCounts` returns `Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>>`, and its implementations pass `null` for the middle two outright:

```java
// SolarisCentralProcessor
return new Quartet<>(logProcs, null, null, Collections.emptyList());
// AixCentralProcessor
return new Quartet<>(logProcs, null, getCachesForModel(physProcs), Collections.emptyList());
```

Physical processors and caches are not discoverable on every platform, and the signature now says so.

### Lazily initialized Windows state

The NUMA node map now starts empty rather than null, following `AbstractOSThread` and the process attributes in #3622. The utility multiplier is annotated, and the capacity tick supplier — which only exists when the utility counters are in use — is checked where it is read rather than relying on the analyzer to correlate a static flag with a field.

### The rest were documented but unstated

The cpuid and IORegistry readers, the BSD cache string parser, the udev enumeration that returns null when udev is unavailable, and the per-core property pairs on Apple Silicon, whose `compatible` and `cluster-type` values are read separately and may each be absent.

### Verification

Full gate green locally on macOS/JDK 25: `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`, 1561 tests passing, plus `./mvnw -Perror-prone clean install -DskipTests` building successfully across the reactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows processor statistics when utility-counter data is unavailable or incomplete.
  - Processor metrics now preserve and use available raw counter data instead of discarding samples.
  - Improved CPU topology, cache, and processor metadata handling across Linux, macOS, BSD, AIX, Solaris, and Windows systems.

- **Refactor**
  - Clarified handling of optional hardware and platform information for more consistent detection and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->