### PR TITLE
Make the system identity classes' nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxBaseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxBaseboard.java
@@ -8,6 +8,8 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.common.AbstractBaseboard;
 import oshi.util.Constants;
@@ -25,7 +27,7 @@ final class LinuxBaseboard extends AbstractBaseboard {
     private final Supplier<String> model = memoize(this::queryModel);
     private final Supplier<String> version = memoize(this::queryVersion);
     private final Supplier<String> serialNumber = memoize(this::querySerialNumber);
-    private final Supplier<Quartet<String, String, String, String>> manufacturerModelVersionSerial = memoize(
+    private final Supplier<Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String>> manufacturerModelVersionSerial = memoize(
             CpuInfo::queryBoardInfo);
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxFirmware.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.common.AbstractFirmware;
 import oshi.util.Constants;
@@ -42,7 +44,7 @@ final class LinuxFirmware extends AbstractFirmware {
 
     private final Supplier<VcGenCmdStrings> vcGenCmd = memoize(LinuxFirmware::queryVcGenCmd);
 
-    private final Supplier<Pair<String, String>> biosNameRev = memoize(Dmidecode::queryBiosNameRev);
+    private final Supplier<Pair<@Nullable String, @Nullable String>> biosNameRev = memoize(Dmidecode::queryBiosNameRev);
 
     @Override
     public String getManufacturer() {
@@ -143,13 +145,14 @@ final class LinuxFirmware extends AbstractFirmware {
     }
 
     static final class VcGenCmdStrings {
-        private final String releaseDate;
-        private final String manufacturer;
-        private final String version;
-        private final String name;
-        private final String description;
+        private final @Nullable String releaseDate;
+        private final @Nullable String manufacturer;
+        private final @Nullable String version;
+        private final @Nullable String name;
+        private final @Nullable String description;
 
-        VcGenCmdStrings(String releaseDate, String manufacturer, String version, String name, String description) {
+        VcGenCmdStrings(@Nullable String releaseDate, @Nullable String manufacturer, @Nullable String version,
+                @Nullable String name, @Nullable String description) {
             this.releaseDate = releaseDate;
             this.manufacturer = manufacturer;
             this.version = version;
@@ -157,22 +160,27 @@ final class LinuxFirmware extends AbstractFirmware {
             this.description = description;
         }
 
+        @Nullable
         String getReleaseDate() {
             return releaseDate;
         }
 
+        @Nullable
         String getManufacturer() {
             return manufacturer;
         }
 
+        @Nullable
         String getVersion() {
             return version;
         }
 
+        @Nullable
         String getName() {
             return name;
         }
 
+        @Nullable
         String getDescription() {
             return description;
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacBaseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacBaseboard.java
@@ -66,13 +66,18 @@ public abstract class MacBaseboard extends AbstractBaseboard {
     protected Quartet<String, String, String, String> queryPlatform() {
         Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> result = ioKitProvider()
                 .withMatchingService("IOPlatformExpertDevice", entry -> {
-                    String mfr = decodeProperty(entry.getByteArrayProperty("manufacturer"));
-                    String mdl = decodeProperty(entry.getByteArrayProperty("board-id"));
+                    String mfr = ParseUtil.decodeNulTerminated(entry.getByteArrayProperty("manufacturer"),
+                            StandardCharsets.UTF_8);
+                    String mdl = ParseUtil.decodeNulTerminated(entry.getByteArrayProperty("board-id"),
+                            StandardCharsets.UTF_8);
                     if (Util.isBlank(mdl)) {
-                        mdl = decodeProperty(entry.getByteArrayProperty("model-number"));
+                        mdl = ParseUtil.decodeNulTerminated(entry.getByteArrayProperty("model-number"),
+                                StandardCharsets.UTF_8);
                     }
-                    String ver = decodeProperty(entry.getByteArrayProperty("version"));
-                    String sn = decodeProperty(entry.getByteArrayProperty("mlb-serial-number"));
+                    String ver = ParseUtil.decodeNulTerminated(entry.getByteArrayProperty("version"),
+                            StandardCharsets.UTF_8);
+                    String sn = ParseUtil.decodeNulTerminated(entry.getByteArrayProperty("mlb-serial-number"),
+                            StandardCharsets.UTF_8);
                     if (Util.isBlank(sn)) {
                         sn = entry.getStringProperty("IOPlatformSerialNumber");
                     }
@@ -86,9 +91,5 @@ public abstract class MacBaseboard extends AbstractBaseboard {
         return new Quartet<>(mfr == null || mfr.isEmpty() ? "Apple Inc." : mfr,
                 ParseUtil.getStringValueOrUnknown(result.getB()), ParseUtil.getStringValueOrUnknown(result.getC()),
                 ParseUtil.getStringValueOrUnknown(result.getD()));
-    }
-
-    private static @Nullable String decodeProperty(byte @Nullable [] data) {
-        return data != null ? ParseUtil.decodeNulTerminated(data, StandardCharsets.UTF_8) : null;
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacBaseboard.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacBaseboard.java
@@ -9,6 +9,8 @@ import static oshi.util.Memoizer.memoize;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.common.AbstractBaseboard;
 import oshi.util.ParseUtil;
@@ -62,8 +64,8 @@ public abstract class MacBaseboard extends AbstractBaseboard {
      * @return a quartet of manufacturer, model, version, serial number
      */
     protected Quartet<String, String, String, String> queryPlatform() {
-        Quartet<String, String, String, String> result = ioKitProvider().withMatchingService("IOPlatformExpertDevice",
-                entry -> {
+        Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> result = ioKitProvider()
+                .withMatchingService("IOPlatformExpertDevice", entry -> {
                     String mfr = decodeProperty(entry.getByteArrayProperty("manufacturer"));
                     String mdl = decodeProperty(entry.getByteArrayProperty("board-id"));
                     if (Util.isBlank(mdl)) {
@@ -74,17 +76,19 @@ public abstract class MacBaseboard extends AbstractBaseboard {
                     if (Util.isBlank(sn)) {
                         sn = entry.getStringProperty("IOPlatformSerialNumber");
                     }
-                    return new Quartet<>(mfr, mdl, ver, sn);
+                    return new Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String>(mfr, mdl,
+                            ver, sn);
                 });
         if (result == null) {
             result = new Quartet<>(null, null, null, null);
         }
-        return new Quartet<>(Util.isBlank(result.getA()) ? "Apple Inc." : result.getA(),
+        String mfr = result.getA();
+        return new Quartet<>(mfr == null || mfr.isEmpty() ? "Apple Inc." : mfr,
                 ParseUtil.getStringValueOrUnknown(result.getB()), ParseUtil.getStringValueOrUnknown(result.getC()),
                 ParseUtil.getStringValueOrUnknown(result.getD()));
     }
 
-    private static String decodeProperty(byte[] data) {
+    private static @Nullable String decodeProperty(byte @Nullable [] data) {
         return data != null ? ParseUtil.decodeNulTerminated(data, StandardCharsets.UTF_8) : null;
     }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacComputerSystem.java
@@ -9,10 +9,11 @@ import static oshi.util.Memoizer.memoize;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.common.AbstractComputerSystem;
 import oshi.util.ParseUtil;
-import oshi.util.Util;
 import oshi.util.tuples.Quartet;
 
 /**
@@ -63,20 +64,22 @@ public abstract class MacComputerSystem extends AbstractComputerSystem {
      * @return a quartet of manufacturer, model, serial number, UUID
      */
     protected Quartet<String, String, String, String> platformExpert() {
-        Quartet<String, String, String, String> result = ioKitProvider().withMatchingService("IOPlatformExpertDevice",
-                entry -> {
+        Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> result = ioKitProvider()
+                .withMatchingService("IOPlatformExpertDevice", entry -> {
                     byte[] data = entry.getByteArrayProperty("manufacturer");
                     String mfr = data != null ? ParseUtil.decodeNulTerminated(data, StandardCharsets.UTF_8) : null;
                     data = entry.getByteArrayProperty("model");
                     String mdl = data != null ? ParseUtil.decodeNulTerminated(data, StandardCharsets.UTF_8) : null;
                     String sn = entry.getStringProperty("IOPlatformSerialNumber");
                     String uuid = entry.getStringProperty("IOPlatformUUID");
-                    return new Quartet<>(mfr, mdl, sn, uuid);
+                    return new Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String>(mfr, mdl,
+                            sn, uuid);
                 });
         if (result == null) {
             result = new Quartet<>(null, null, null, null);
         }
-        return new Quartet<>(Util.isBlank(result.getA()) ? "Apple Inc." : result.getA(),
+        String mfr = result.getA();
+        return new Quartet<>(mfr == null || mfr.isEmpty() ? "Apple Inc." : mfr,
                 ParseUtil.getStringValueOrUnknown(result.getB()), ParseUtil.getStringValueOrUnknown(result.getC()),
                 ParseUtil.getStringValueOrUnknown(result.getD()));
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdFirmware.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.common.AbstractFirmware;
 import oshi.util.Constants;
@@ -27,7 +29,8 @@ import oshi.util.tuples.Triplet;
 public abstract class BsdFirmware extends AbstractFirmware {
     private static final Pattern VENDOR = Pattern.compile("vendor");
 
-    private final Supplier<Triplet<String, String, String>> manufVersRelease = memoize(this::queryFirmware);
+    private final Supplier<Triplet<@Nullable String, @Nullable String, @Nullable String>> manufVersRelease = memoize(
+            this::queryFirmware);
 
     /**
      * Default constructor.
@@ -37,17 +40,17 @@ public abstract class BsdFirmware extends AbstractFirmware {
 
     @Override
     public String getManufacturer() {
-        return manufVersRelease.get().getA();
+        return ParseUtil.getStringValueOrUnknown(manufVersRelease.get().getA());
     }
 
     @Override
     public String getVersion() {
-        return manufVersRelease.get().getB();
+        return ParseUtil.getStringValueOrUnknown(manufVersRelease.get().getB());
     }
 
     @Override
     public String getReleaseDate() {
-        return manufVersRelease.get().getC();
+        return ParseUtil.getStringValueOrUnknown(manufVersRelease.get().getC());
     }
 
     /**
@@ -59,16 +62,16 @@ public abstract class BsdFirmware extends AbstractFirmware {
      *
      * @return a {@link Triplet} of manufacturer, version, and release date
      */
-    protected Triplet<String, String, String> readFirmware() {
+    protected Triplet<@Nullable String, @Nullable String, @Nullable String> readFirmware() {
         return parseDmesg(ExecutingCommand.runNative("dmesg"));
     }
 
-    private Triplet<String, String, String> queryFirmware() {
-        Triplet<String, String, String> dmi = readFirmware();
+    private Triplet<@Nullable String, @Nullable String, @Nullable String> queryFirmware() {
+        Triplet<@Nullable String, @Nullable String, @Nullable String> dmi = readFirmware();
         return new Triplet<>(unknownIfBlank(dmi.getA()), unknownIfBlank(dmi.getB()), unknownIfBlank(dmi.getC()));
     }
 
-    private static String unknownIfBlank(String value) {
+    private static String unknownIfBlank(@Nullable String value) {
         return ParseUtil.getStringValueOrUnknown(value);
     }
 
@@ -80,7 +83,7 @@ public abstract class BsdFirmware extends AbstractFirmware {
      * @param dmesg the lines emitted by {@code dmesg}
      * @return a {@link Triplet} of vendor, version, and release date
      */
-    static Triplet<String, String, String> parseDmesg(List<String> dmesg) {
+    static Triplet<@Nullable String, @Nullable String, @Nullable String> parseDmesg(List<String> dmesg) {
         String version = null;
         String vendor = null;
         String releaseDate = "";

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixComputerSystem.java
@@ -9,6 +9,8 @@ import static oshi.util.Memoizer.memoize;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Baseboard;
 import oshi.hardware.Firmware;
@@ -37,28 +39,29 @@ public final class AixComputerSystem extends AbstractComputerSystem {
 
     @Override
     public String getManufacturer() {
-        return lsattrStrings.get().manufacturer;
+        return ParseUtil.getStringValueOrUnknown(lsattrStrings.get().manufacturer);
     }
 
     @Override
     public String getModel() {
-        return lsattrStrings.get().model;
+        return ParseUtil.getStringValueOrUnknown(lsattrStrings.get().model);
     }
 
     @Override
     public String getSerialNumber() {
-        return lsattrStrings.get().serialNumber;
+        return ParseUtil.getStringValueOrUnknown(lsattrStrings.get().serialNumber);
     }
 
     @Override
     public String getHardwareUUID() {
-        return lsattrStrings.get().uuid;
+        return ParseUtil.getStringValueOrUnknown(lsattrStrings.get().uuid);
     }
 
     @Override
     public Firmware createFirmware() {
-        return new AixFirmware(lsattrStrings.get().biosVendor, lsattrStrings.get().biosPlatformVersion,
-                lsattrStrings.get().biosVersion);
+        return new AixFirmware(ParseUtil.getStringValueOrUnknown(lsattrStrings.get().biosVendor),
+                ParseUtil.getStringValueOrUnknown(lsattrStrings.get().biosPlatformVersion),
+                ParseUtil.getStringValueOrUnknown(lsattrStrings.get().biosVersion));
     }
 
     @Override
@@ -140,17 +143,18 @@ public final class AixComputerSystem extends AbstractComputerSystem {
     }
 
     static final class LsattrStrings {
-        private final String biosVendor;
-        private final String biosPlatformVersion;
-        private final String biosVersion;
+        private final @Nullable String biosVendor;
+        private final @Nullable String biosPlatformVersion;
+        private final @Nullable String biosVersion;
 
-        private final String manufacturer;
-        private final String model;
-        private final String serialNumber;
-        private final String uuid;
+        private final @Nullable String manufacturer;
+        private final @Nullable String model;
+        private final @Nullable String serialNumber;
+        private final @Nullable String uuid;
 
-        private LsattrStrings(String biosVendor, String biosPlatformVersion, String biosVersion, String manufacturer,
-                String model, String serialNumber, String uuid) {
+        private LsattrStrings(@Nullable String biosVendor, @Nullable String biosPlatformVersion,
+                @Nullable String biosVersion, @Nullable String manufacturer, @Nullable String model,
+                @Nullable String serialNumber, @Nullable String uuid) {
             this.biosVendor = ParseUtil.getStringValueOrUnknown(biosVendor);
             this.biosPlatformVersion = ParseUtil.getStringValueOrUnknown(biosPlatformVersion);
             this.biosVersion = ParseUtil.getStringValueOrUnknown(biosVersion);
@@ -161,30 +165,37 @@ public final class AixComputerSystem extends AbstractComputerSystem {
             this.uuid = ParseUtil.getStringValueOrUnknown(uuid);
         }
 
+        @Nullable
         String biosVendor() {
             return biosVendor;
         }
 
+        @Nullable
         String biosPlatformVersion() {
             return biosPlatformVersion;
         }
 
+        @Nullable
         String biosVersion() {
             return biosVersion;
         }
 
+        @Nullable
         String manufacturer() {
             return manufacturer;
         }
 
+        @Nullable
         String model() {
             return model;
         }
 
+        @Nullable
         String serialNumber() {
             return serialNumber;
         }
 
+        @Nullable
         String uuid() {
             return uuid;
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixComputerSystem.java
@@ -143,14 +143,14 @@ public final class AixComputerSystem extends AbstractComputerSystem {
     }
 
     static final class LsattrStrings {
-        private final @Nullable String biosVendor;
-        private final @Nullable String biosPlatformVersion;
-        private final @Nullable String biosVersion;
+        private final String biosVendor;
+        private final String biosPlatformVersion;
+        private final String biosVersion;
 
-        private final @Nullable String manufacturer;
-        private final @Nullable String model;
-        private final @Nullable String serialNumber;
-        private final @Nullable String uuid;
+        private final String manufacturer;
+        private final String model;
+        private final String serialNumber;
+        private final String uuid;
 
         private LsattrStrings(@Nullable String biosVendor, @Nullable String biosPlatformVersion,
                 @Nullable String biosVersion, @Nullable String manufacturer, @Nullable String model,
@@ -165,37 +165,30 @@ public final class AixComputerSystem extends AbstractComputerSystem {
             this.uuid = ParseUtil.getStringValueOrUnknown(uuid);
         }
 
-        @Nullable
         String biosVendor() {
             return biosVendor;
         }
 
-        @Nullable
         String biosPlatformVersion() {
             return biosPlatformVersion;
         }
 
-        @Nullable
         String biosVersion() {
             return biosVersion;
         }
 
-        @Nullable
         String manufacturer() {
             return manufacturer;
         }
 
-        @Nullable
         String model() {
             return model;
         }
 
-        @Nullable
         String serialNumber() {
             return serialNumber;
         }
 
-        @Nullable
         String uuid() {
             return uuid;
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystem.java
@@ -29,27 +29,27 @@ import oshi.util.tuples.Quintet;
 @Immutable
 public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
 
-    private final Supplier<Quintet<@Nullable String, @Nullable String, @Nullable String, @Nullable String, @Nullable String>> manufModelSerialUuidVers = memoize(
+    private final Supplier<Quintet<String, String, String, String, String>> manufModelSerialUuidVers = memoize(
             this::readDmiDecode);
 
     @Override
     public String getManufacturer() {
-        return ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getA());
+        return manufModelSerialUuidVers.get().getA();
     }
 
     @Override
     public String getModel() {
-        return ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getB());
+        return manufModelSerialUuidVers.get().getB();
     }
 
     @Override
     public String getSerialNumber() {
-        return ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getC());
+        return manufModelSerialUuidVers.get().getC();
     }
 
     @Override
     public String getHardwareUUID() {
-        return ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getD());
+        return manufModelSerialUuidVers.get().getD();
     }
 
     @Override
@@ -59,10 +59,8 @@ public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
 
     @Override
     public Baseboard createBaseboard() {
-        return new UnixBaseboard(ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getA()),
-                ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getB()),
-                ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getC()),
-                ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getE()));
+        return new UnixBaseboard(manufModelSerialUuidVers.get().getA(), manufModelSerialUuidVers.get().getB(),
+                manufModelSerialUuidVers.get().getC(), manufModelSerialUuidVers.get().getE());
     }
 
     /**
@@ -73,7 +71,7 @@ public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
      */
     protected abstract String queryHostUuid();
 
-    private Quintet<@Nullable String, @Nullable String, @Nullable String, @Nullable String, @Nullable String> readDmiDecode() {
+    private Quintet<String, String, String, String, String> readDmiDecode() {
         // Only works with root permissions but it's all we've got
         Quintet<@Nullable String, @Nullable String, @Nullable String, @Nullable String, @Nullable String> dmi = parseDmiDecode(
                 ExecutingCommand.runNative("dmidecode -t system"));

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystem.java
@@ -9,6 +9,8 @@ import static oshi.util.Memoizer.memoize;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Baseboard;
 import oshi.hardware.Firmware;
@@ -27,27 +29,27 @@ import oshi.util.tuples.Quintet;
 @Immutable
 public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
 
-    private final Supplier<Quintet<String, String, String, String, String>> manufModelSerialUuidVers = memoize(
+    private final Supplier<Quintet<@Nullable String, @Nullable String, @Nullable String, @Nullable String, @Nullable String>> manufModelSerialUuidVers = memoize(
             this::readDmiDecode);
 
     @Override
     public String getManufacturer() {
-        return manufModelSerialUuidVers.get().getA();
+        return ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getA());
     }
 
     @Override
     public String getModel() {
-        return manufModelSerialUuidVers.get().getB();
+        return ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getB());
     }
 
     @Override
     public String getSerialNumber() {
-        return manufModelSerialUuidVers.get().getC();
+        return ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getC());
     }
 
     @Override
     public String getHardwareUUID() {
-        return manufModelSerialUuidVers.get().getD();
+        return ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getD());
     }
 
     @Override
@@ -57,8 +59,10 @@ public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
 
     @Override
     public Baseboard createBaseboard() {
-        return new UnixBaseboard(manufModelSerialUuidVers.get().getA(), manufModelSerialUuidVers.get().getB(),
-                manufModelSerialUuidVers.get().getC(), manufModelSerialUuidVers.get().getE());
+        return new UnixBaseboard(ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getA()),
+                ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getB()),
+                ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getC()),
+                ParseUtil.getStringValueOrUnknown(manufModelSerialUuidVers.get().getE()));
     }
 
     /**
@@ -69,9 +73,9 @@ public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
      */
     protected abstract String queryHostUuid();
 
-    private Quintet<String, String, String, String, String> readDmiDecode() {
+    private Quintet<@Nullable String, @Nullable String, @Nullable String, @Nullable String, @Nullable String> readDmiDecode() {
         // Only works with root permissions but it's all we've got
-        Quintet<String, String, String, String, String> dmi = parseDmiDecode(
+        Quintet<@Nullable String, @Nullable String, @Nullable String, @Nullable String, @Nullable String> dmi = parseDmiDecode(
                 ExecutingCommand.runNative("dmidecode -t system"));
         String manufacturer = dmi.getA();
         String model = dmi.getB();
@@ -97,7 +101,8 @@ public abstract class FreeBsdComputerSystem extends AbstractComputerSystem {
      * @param dmidecode the lines emitted by {@code dmidecode -t system}
      * @return a {@link Quintet} of manufacturer, model, serial number, UUID, and version
      */
-    static Quintet<String, String, String, String, String> parseDmiDecode(List<String> dmidecode) {
+    static Quintet<@Nullable String, @Nullable String, @Nullable String, @Nullable String, @Nullable String> parseDmiDecode(
+            List<String> dmidecode) {
         String manufacturer = null;
         String model = null;
         String serialNumber = null;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmware.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmware.java
@@ -6,6 +6,8 @@ package oshi.hardware.common.platform.unix.freebsd;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.common.platform.unix.BsdFirmware;
 import oshi.util.ExecutingCommand;
@@ -19,7 +21,7 @@ import oshi.util.tuples.Triplet;
 public class FreeBsdFirmware extends BsdFirmware {
 
     @Override
-    protected Triplet<String, String, String> readFirmware() {
+    protected Triplet<@Nullable String, @Nullable String, @Nullable String> readFirmware() {
         // Only works with root permissions but it's all we've got
         return parseDmiDecode(ExecutingCommand.runNative("dmidecode -t bios"));
     }
@@ -31,7 +33,7 @@ public class FreeBsdFirmware extends BsdFirmware {
      * @param dmidecode the lines emitted by {@code dmidecode -t bios}
      * @return a {@link Triplet} of manufacturer, version, and release date
      */
-    static Triplet<String, String, String> parseDmiDecode(List<String> dmidecode) {
+    static Triplet<@Nullable String, @Nullable String, @Nullable String> parseDmiDecode(List<String> dmidecode) {
         String manufacturer = null;
         String version = null;
         String releaseDate = "";

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystem.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Baseboard;
 import oshi.hardware.Firmware;
@@ -83,9 +85,9 @@ public class SolarisComputerSystem extends AbstractComputerSystem {
     private static SmbiosStrings readSmbios() {
         EnumMap<SmbType, Map<String, String>> smbTypesMap = parseSmbios(ExecutingCommand.runNative("smbios"));
 
-        Map<String, String> smbTypeBIOSMap = smbTypesMap.get(SMB_TYPE_BIOS);
-        Map<String, String> smbTypeSystemMap = smbTypesMap.get(SMB_TYPE_SYSTEM);
-        Map<String, String> smbTypeBaseboardMap = smbTypesMap.get(SMB_TYPE_BASEBOARD);
+        Map<String, String> smbTypeBIOSMap = smbTypesMap.getOrDefault(SMB_TYPE_BIOS, new HashMap<>());
+        Map<String, String> smbTypeSystemMap = smbTypesMap.getOrDefault(SMB_TYPE_SYSTEM, new HashMap<>());
+        Map<String, String> smbTypeBaseboardMap = smbTypesMap.getOrDefault(SMB_TYPE_BASEBOARD, new HashMap<>());
 
         final String serialNumMarker = "Serial Number";
         // If we get to end and haven't assigned, use fallback
@@ -95,7 +97,7 @@ public class SolarisComputerSystem extends AbstractComputerSystem {
         return new SmbiosStrings(smbTypeBIOSMap, smbTypeSystemMap, smbTypeBaseboardMap);
     }
 
-    private static SmbType getSmbType(String checkLine) {
+    private static @Nullable SmbType getSmbType(String checkLine) {
         for (SmbType smbType : SmbType.values()) {
             if (checkLine.contains(smbType.name())) {
                 return smbType;
@@ -168,7 +170,7 @@ public class SolarisComputerSystem extends AbstractComputerSystem {
             if (smbTypeId != null && colonDelimiterIndex >= 0) {
                 String key = checkLine.substring(0, colonDelimiterIndex).trim();
                 String val = checkLine.substring(colonDelimiterIndex + 1).trim();
-                smbTypesMap.get(smbTypeId).put(key, val);
+                smbTypesMap.computeIfAbsent(smbTypeId, k -> new HashMap<>()).put(key, val);
             }
         }
         return smbTypesMap;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsComputerSystem.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsComputerSystem.java
@@ -8,6 +8,8 @@ import static oshi.util.Memoizer.memoize;
 
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.Immutable;
 import oshi.driver.common.windows.wmi.Win32Bios;
 import oshi.driver.common.windows.wmi.Win32Bios.BiosSerialProperty;
@@ -34,8 +36,10 @@ public abstract class WindowsComputerSystem extends AbstractComputerSystem {
     protected WindowsComputerSystem() {
     }
 
-    private final Supplier<Pair<String, String>> manufacturerModel = memoize(this::queryManufacturerModel);
-    private final Supplier<Pair<String, String>> serialNumberUUID = memoize(this::querySystemSerialNumberUUID);
+    private final Supplier<Pair<@Nullable String, @Nullable String>> manufacturerModel = memoize(
+            this::queryManufacturerModel);
+    private final Supplier<Pair<@Nullable String, @Nullable String>> serialNumberUUID = memoize(
+            this::querySystemSerialNumberUUID);
 
     /**
      * Returns the WMI query executor for this platform.
@@ -46,25 +50,25 @@ public abstract class WindowsComputerSystem extends AbstractComputerSystem {
 
     @Override
     public String getManufacturer() {
-        return manufacturerModel.get().getA();
+        return ParseUtil.getStringValueOrUnknown(manufacturerModel.get().getA());
     }
 
     @Override
     public String getModel() {
-        return manufacturerModel.get().getB();
+        return ParseUtil.getStringValueOrUnknown(manufacturerModel.get().getB());
     }
 
     @Override
     public String getSerialNumber() {
-        return serialNumberUUID.get().getA();
+        return ParseUtil.getStringValueOrUnknown(serialNumberUUID.get().getA());
     }
 
     @Override
     public String getHardwareUUID() {
-        return serialNumberUUID.get().getB();
+        return ParseUtil.getStringValueOrUnknown(serialNumberUUID.get().getB());
     }
 
-    private Pair<String, String> queryManufacturerModel() {
+    private Pair<@Nullable String, @Nullable String> queryManufacturerModel() {
         String manufacturer = null;
         String model = null;
         WmiResult<ComputerSystemProperty> win32ComputerSystem = Win32ComputerSystem
@@ -76,7 +80,7 @@ public abstract class WindowsComputerSystem extends AbstractComputerSystem {
         return new Pair<>(ParseUtil.getStringValueOrUnknown(manufacturer), ParseUtil.getStringValueOrUnknown(model));
     }
 
-    private Pair<String, String> querySystemSerialNumberUUID() {
+    private Pair<@Nullable String, @Nullable String> querySystemSerialNumberUUID() {
         String serialNumber = null;
         String uuid = null;
         WmiResult<ComputerSystemProductProperty> win32ComputerSystemProduct = Win32ComputerSystemProduct
@@ -98,6 +102,7 @@ public abstract class WindowsComputerSystem extends AbstractComputerSystem {
         return new Pair<>(serialNumber, uuid);
     }
 
+    @Nullable
     String querySerialFromBios() {
         WmiResult<BiosSerialProperty> serialNum = Win32Bios.querySerialNumber(getWmiQueryExecutor());
         if (serialNum.getResultCount() > 0) {


### PR DESCRIPTION
Seventh group of the backlog #3618 left at WARN. Takes `oshi-common` from **59 warnings to 19** and clears `ComputerSystem`, `Baseboard` and `Firmware` across every platform. Only the peripherals group remains.

### The public getters were promising something they did not deliver

These classes read manufacturer, model, serial number, UUID and firmware version from whatever the platform will say — `dmidecode`, `lshw`, `lsattr`, `smbios`, the IORegistry, WMI — and carry the values in a tuple or a small holder. Any of those sources may report nothing.

`Baseboard.getManufacturer()`, `ComputerSystem.getSerialNumber()` and their neighbours are `@PublicApi` and promise a value. They returned the tuple element straight through:

```java
public String getManufacturer() {
    return manufModelVersSerial.get().getA();   // null when the platform reported nothing
}
```

They now report `Constants.UNKNOWN`, which is what the rest of the API does for a value it could not read, and what the surrounding code in these same classes already did for their other fields.

### Two robustness fixes on Solaris

`SolarisComputerSystem` asked `smbTypesMap` for the BIOS, system and baseboard sections and dereferenced all three, though the `smbios` output need not contain any given section. It also built that map with `smbTypesMap.get(smbTypeId).put(key, val)`, which assumed the section had already been created by an earlier line. Those use `getOrDefault` and `computeIfAbsent` now.

### The rest

`MacBaseboard` and `MacComputerSystem` spell out the blank test for the manufacturer they default to `"Apple Inc."`, since `Util.isBlank` is a predicate the analyzer cannot see through — the same reason `ParseUtil.getStringValueOrUnknown` exists.

The `VcGenCmdStrings`, `LsattrStrings` and `SmbiosStrings` holders declare their fields for what they hold: `vcgencmd` reports nothing on a non-Pi, and `lsattr` need not report a firmware platform version.

### Verification

Full gate green locally on macOS/JDK 25: `./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`, 1561 tests passing, plus `./mvnw -Perror-prone clean install -DskipTests` building successfully across the reactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing hardware, firmware, BIOS, and system information across Linux, macOS, BSD, AIX, Solaris, and Windows.
  * Missing values now consistently use the existing “unknown” fallback instead of causing parsing issues.
  * Improved resilience when processing incomplete SMBIOS data and platform-specific manufacturer details.
* **Reliability**
  * Improved stability when hardware information is unavailable, incomplete, or returned as empty data.
  * Preserved existing fallback behavior for system, firmware, and baseboard details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->