### PR TITLE
Make the GPU vendor utilities' nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/gpu/DxgiUtil.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/gpu/DxgiUtil.java
@@ -61,10 +61,10 @@ public final class DxgiUtil {
      * Converts a registry value (REG_QWORD as Long, REG_DWORD as Integer, or REG_BINARY as byte[]) to a VRAM size in
      * bytes. REG_BINARY is interpreted as little-endian.
      *
-     * @param value the registry value object
+     * @param value the registry value object, may be {@code null}
      * @return the VRAM size in bytes, or 0 if the value type is unrecognised
      */
-    public static long registryValueToVram(Object value) {
+    public static long registryValueToVram(@Nullable Object value) {
         if (value instanceof Long) {
             return (long) value;
         } else if (value instanceof Integer) {
@@ -87,7 +87,7 @@ public final class DxgiUtil {
      * @param name the raw adapter name, may be {@code null}
      * @return normalized name, never {@code null}
      */
-    public static String normalizeName(String name) {
+    public static String normalizeName(@Nullable String name) {
         if (name == null) {
             return "";
         }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGpuStats.java
@@ -100,7 +100,7 @@ public abstract class WindowsGpuStats implements GpuStats {
      * @param pciBusId the PCI bus ID
      * @return the device handle string, or null
      */
-    protected abstract String nvmlFindDevice(String pciBusId);
+    protected abstract @Nullable String nvmlFindDevice(String pciBusId);
 
     /**
      * Finds an NVML device by name.
@@ -108,7 +108,7 @@ public abstract class WindowsGpuStats implements GpuStats {
      * @param gpuName the GPU name
      * @return the device handle string, or null
      */
-    protected abstract String nvmlFindDeviceByName(String gpuName);
+    protected abstract @Nullable String nvmlFindDeviceByName(String gpuName);
 
     /**
      * Gets the GPU temperature via NVML.

--- a/oshi-common/src/main/java/oshi/util/common/gpu/NvmlQuery.java
+++ b/oshi-common/src/main/java/oshi/util/common/gpu/NvmlQuery.java
@@ -75,7 +75,7 @@ public final class NvmlQuery {
      * @param sentinel the value denoting an unavailable metric
      * @return the metric, or {@code sentinel}
      */
-    public static <H, R> R query(String deviceId, NvmlScope<H> scope, Function<H, R> reader, R sentinel) {
+    public static <H, R> R query(@Nullable String deviceId, NvmlScope<H> scope, Function<H, R> reader, R sentinel) {
         if (deviceId == null || deviceId.isEmpty()) {
             return sentinel;
         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/AdlUtilFFM.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,19 +72,19 @@ public final class AdlUtilFFM {
     private static final long FAN_CURRENT_SPEED_OFFSET = 12;
 
     private static final boolean AVAILABLE;
-    private static final MethodHandle ADL2_MAIN_CONTROL_CREATE;
-    private static final MethodHandle ADL2_MAIN_CONTROL_DESTROY;
-    private static final MethodHandle ADL2_ADAPTER_NUMBER_OF_ADAPTERS_GET;
-    private static final MethodHandle ADL2_ADAPTER_ADAPTER_INFO_GET;
-    private static final MethodHandle ADL2_OVERDRIVE_CAPS;
-    private static final MethodHandle ADL2_OVERDRIVEN_TEMPERATURE_GET;
-    private static final MethodHandle ADL2_OVERDRIVEN_PERFORMANCE_STATUS_GET;
-    private static final MethodHandle ADL2_OVERDRIVEN_FAN_CONTROL_GET;
-    private static final MethodHandle ADL2_OVERDRIVE6_CURRENT_POWER_GET;
+    private static final @Nullable MethodHandle ADL2_MAIN_CONTROL_CREATE;
+    private static final @Nullable MethodHandle ADL2_MAIN_CONTROL_DESTROY;
+    private static final @Nullable MethodHandle ADL2_ADAPTER_NUMBER_OF_ADAPTERS_GET;
+    private static final @Nullable MethodHandle ADL2_ADAPTER_ADAPTER_INFO_GET;
+    private static final @Nullable MethodHandle ADL2_OVERDRIVE_CAPS;
+    private static final @Nullable MethodHandle ADL2_OVERDRIVEN_TEMPERATURE_GET;
+    private static final @Nullable MethodHandle ADL2_OVERDRIVEN_PERFORMANCE_STATUS_GET;
+    private static final @Nullable MethodHandle ADL2_OVERDRIVEN_FAN_CONTROL_GET;
+    private static final @Nullable MethodHandle ADL2_OVERDRIVE6_CURRENT_POWER_GET;
     // Upcall stub for malloc callback
-    private static final MemorySegment MALLOC_STUB;
+    private static final @Nullable MemorySegment MALLOC_STUB;
     // Native C malloc, so memory handed to ADL can be released by ADL's free()
-    private static final MethodHandle MALLOC;
+    private static final @Nullable MethodHandle MALLOC;
 
     static {
         boolean available = false;
@@ -171,24 +172,27 @@ public final class AdlUtilFFM {
      */
     @SuppressWarnings("unused")
     private static MemorySegment adlMalloc(int size) {
-        if (size <= 0 || MALLOC == null) {
+        MethodHandle malloc = MALLOC;
+        if (size <= 0 || malloc == null) {
             return MemorySegment.NULL;
         }
         try {
             // Allocate from the C heap (not a JVM Arena) so the pointer ADL later passes to free() is valid.
-            return (MemorySegment) MALLOC.invokeExact((long) size);
+            return (MemorySegment) malloc.invokeExact((long) size);
         } catch (Throwable _) {
             return MemorySegment.NULL;
         }
     }
 
-    private static MemorySegment adlInit(Arena arena) {
-        if (!AVAILABLE) {
+    private static @Nullable MemorySegment adlInit(Arena arena) {
+        MethodHandle create = ADL2_MAIN_CONTROL_CREATE;
+        MemorySegment mallocStub = MALLOC_STUB;
+        if (!AVAILABLE || create == null || mallocStub == null) {
             return null;
         }
         return getOrDefault(() -> {
             MemorySegment ctxRef = arena.allocate(ADDRESS);
-            int ret = (int) ADL2_MAIN_CONTROL_CREATE.invokeExact(MALLOC_STUB, 1, ctxRef);
+            int ret = (int) create.invokeExact(mallocStub, 1, ctxRef);
             if (ret == ADL_OK) {
                 return ctxRef.get(ADDRESS, 0);
             }
@@ -198,11 +202,15 @@ public final class AdlUtilFFM {
     }
 
     private static void adlUninit(MemorySegment context) {
+        MethodHandle destroy = ADL2_MAIN_CONTROL_DESTROY;
+        if (destroy == null) {
+            return;
+        }
         // Block lambda (not an expression lambda) so invokeExact() on this void handle is in a statement context and
         // its return type is inferred as void; an expression lambda infers Object -> WrongMethodTypeException (#3422).
         // The suppression on the next line stops S1602 collapsing the block back to the buggy expression form.
         runOrLog(() -> { // NOSONAR java:S1602 - block form required; expression lambda miscompiles void invokeExact
-            ADL2_MAIN_CONTROL_DESTROY.invokeExact(context);
+            destroy.invokeExact(context);
         }, LOG, "ADL uninit failed");
     }
 
@@ -224,10 +232,15 @@ public final class AdlUtilFFM {
         }
     }
 
-    private static Map<Integer, Integer> enumerateAdapters(MemorySegment ctx, Arena arena) {
+    private static @Nullable Map<Integer, Integer> enumerateAdapters(MemorySegment ctx, Arena arena) {
+        MethodHandle numAdaptersGet = ADL2_ADAPTER_NUMBER_OF_ADAPTERS_GET;
+        MethodHandle adapterInfoGet = ADL2_ADAPTER_ADAPTER_INFO_GET;
+        if (numAdaptersGet == null || adapterInfoGet == null) {
+            return null;
+        }
         return getOrDefault(() -> {
             MemorySegment numRef = arena.allocate(JAVA_INT);
-            if ((int) ADL2_ADAPTER_NUMBER_OF_ADAPTERS_GET.invokeExact(ctx, numRef) != ADL_OK) {
+            if ((int) numAdaptersGet.invokeExact(ctx, numRef) != ADL_OK) {
                 return null;
             }
             int num = numRef.get(JAVA_INT, 0);
@@ -246,7 +259,7 @@ public final class AdlUtilFFM {
             for (int i = 0; i < num; i++) {
                 infos.set(JAVA_INT, (long) i * ADAPTER_INFO_SIZE, ADAPTER_INFO_SIZE);
             }
-            if ((int) ADL2_ADAPTER_ADAPTER_INFO_GET.invokeExact(ctx, infos, (int) totalInfoSize) != ADL_OK) {
+            if ((int) adapterInfoGet.invokeExact(ctx, infos, (int) totalInfoSize) != ADL_OK) {
                 return null;
             }
             Map<Integer, Integer> map = new HashMap<>();
@@ -273,11 +286,15 @@ public final class AdlUtilFFM {
 
     private static boolean supportsOverdriveVersion(MemorySegment context, int adapterIndex, Arena arena,
             int minVersion) {
+        MethodHandle capsGet = ADL2_OVERDRIVE_CAPS;
+        if (capsGet == null) {
+            return false;
+        }
         return getBooleanOrDefault(() -> {
             MemorySegment supported = arena.allocate(JAVA_INT);
             MemorySegment enabled = arena.allocate(JAVA_INT);
             MemorySegment version = arena.allocate(JAVA_INT);
-            if ((int) ADL2_OVERDRIVE_CAPS.invokeExact(context, adapterIndex, supported, enabled, version) == ADL_OK) {
+            if ((int) capsGet.invokeExact(context, adapterIndex, supported, enabled, version) == ADL_OK) {
                 return supported.get(JAVA_INT, 0) != 0 && version.get(JAVA_INT, 0) >= minVersion;
             }
             return false;
@@ -328,7 +345,8 @@ public final class AdlUtilFFM {
      * @return the temperature, or -1 on failure
      */
     public static double getTemperature(int adapterIndex) {
-        if (adapterIndex < 0) {
+        MethodHandle tempGet = ADL2_OVERDRIVEN_TEMPERATURE_GET;
+        if (adapterIndex < 0 || tempGet == null) {
             return -1d;
         }
         return callInArenaDoubleOrDefault(arena -> {
@@ -341,8 +359,7 @@ public final class AdlUtilFFM {
                     return -1d;
                 }
                 MemorySegment temp = arena.allocate(JAVA_INT);
-                if ((int) ADL2_OVERDRIVEN_TEMPERATURE_GET.invokeExact(ctx, adapterIndex, ADL_OVERDRIVE_TEMPERATURE_EDGE,
-                        temp) == ADL_OK) {
+                if ((int) tempGet.invokeExact(ctx, adapterIndex, ADL_OVERDRIVE_TEMPERATURE_EDGE, temp) == ADL_OK) {
                     return temp.get(JAVA_INT, 0) / 1000.0;
                 }
             } finally {
@@ -361,7 +378,8 @@ public final class AdlUtilFFM {
      * @return the clock in MHz, or -1 if unavailable
      */
     private static long performanceClockMhz(int adapterIndex, long clockOffset, String what) {
-        if (adapterIndex < 0) {
+        MethodHandle perfGet = ADL2_OVERDRIVEN_PERFORMANCE_STATUS_GET;
+        if (adapterIndex < 0 || perfGet == null) {
             return -1L;
         }
         return callInArenaLongOrDefault(arena -> {
@@ -374,7 +392,7 @@ public final class AdlUtilFFM {
                     return -1L;
                 }
                 MemorySegment perf = arena.allocate(PERF_STATUS_SIZE);
-                if ((int) ADL2_OVERDRIVEN_PERFORMANCE_STATUS_GET.invokeExact(ctx, adapterIndex, perf) == ADL_OK) {
+                if ((int) perfGet.invokeExact(ctx, adapterIndex, perf) == ADL_OK) {
                     return perf.get(JAVA_INT, clockOffset) / ADL_ODN_CLOCK_UNITS_PER_MHZ;
                 }
             } finally {
@@ -411,7 +429,8 @@ public final class AdlUtilFFM {
      * @return the power draw in watts, or -1 on failure
      */
     public static double getPowerDraw(int adapterIndex) {
-        if (adapterIndex < 0) {
+        MethodHandle powerGet = ADL2_OVERDRIVE6_CURRENT_POWER_GET;
+        if (adapterIndex < 0 || powerGet == null) {
             return -1d;
         }
         return callInArenaDoubleOrDefault(arena -> {
@@ -426,7 +445,7 @@ public final class AdlUtilFFM {
                     return -1d;
                 }
                 MemorySegment power = arena.allocate(JAVA_INT);
-                if ((int) ADL2_OVERDRIVE6_CURRENT_POWER_GET.invokeExact(ctx, adapterIndex, 0, power) == ADL_OK) {
+                if ((int) powerGet.invokeExact(ctx, adapterIndex, 0, power) == ADL_OK) {
                     return power.get(JAVA_INT, 0) / 256.0;
                 }
             } finally {
@@ -443,7 +462,8 @@ public final class AdlUtilFFM {
      * @return the fan speed percentage, or -1 on failure
      */
     public static double getFanSpeedPercent(int adapterIndex) {
-        if (adapterIndex < 0) {
+        MethodHandle fanGet = ADL2_OVERDRIVEN_FAN_CONTROL_GET;
+        if (adapterIndex < 0 || fanGet == null) {
             return -1d;
         }
         return callInArenaDoubleOrDefault(arena -> {
@@ -456,7 +476,7 @@ public final class AdlUtilFFM {
                     return -1d;
                 }
                 MemorySegment fan = arena.allocate(FAN_CONTROL_SIZE);
-                if ((int) ADL2_OVERDRIVEN_FAN_CONTROL_GET.invokeExact(ctx, adapterIndex, fan) == ADL_OK) {
+                if ((int) fanGet.invokeExact(ctx, adapterIndex, fan) == ADL_OK) {
                     int mode = fan.get(JAVA_INT, FAN_CONTROL_MODE_OFFSET);
                     if (mode == ADL_FAN_SPEED_MODE_PERCENT) {
                         return fan.get(JAVA_INT, FAN_CURRENT_SPEED_OFFSET);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/NvmlUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/gpu/NvmlUtilFFM.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +145,7 @@ public final class NvmlUtilFFM {
      * @param arena  allocates the PCI info struct
      * @return the modern and legacy bus IDs, or {@code null} if the PCI info could not be read
      */
-    private static Pair<String, String> readBusIds(MemorySegment handle, Arena arena) {
+    private static @Nullable Pair<String, String> readBusIds(MemorySegment handle, Arena arena) {
         MemorySegment pciSeg = arena.allocate(NvmlFunctions.PCI_INFO_LAYOUT);
         if (NvmlFunctions.deviceGetPciInfo(handle, pciSeg) != NvmlFunctions.NVML_SUCCESS) {
             return null;
@@ -160,7 +161,7 @@ public final class NvmlUtilFFM {
      * @param arena  allocates the name buffer
      * @return the name, or {@code null} if it could not be read
      */
-    private static String readName(MemorySegment handle, Arena arena) {
+    private static @Nullable String readName(MemorySegment handle, Arena arena) {
         MemorySegment nameSeg = arena.allocate(NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE);
         if (NvmlFunctions.deviceGetName(handle, nameSeg,
                 NvmlFunctions.NVML_DEVICE_NAME_BUFFER_SIZE) != NvmlFunctions.NVML_SUCCESS) {
@@ -175,7 +176,7 @@ public final class NvmlUtilFFM {
      *
      * @return set of PCI bus ID strings, or {@code null} on NVML error
      */
-    private static Set<String> enumerateDeviceBusIds() {
+    private static @Nullable Set<String> enumerateDeviceBusIds() {
         try (Arena arena = Arena.ofConfined()) {
             Set<String> ids = new HashSet<>();
             boolean enumerated = forEachDevice(arena, handle -> {
@@ -196,7 +197,7 @@ public final class NvmlUtilFFM {
         }
     }
 
-    private static MemorySegment acquireHandleByBusId(String pciBusId, Arena arena) {
+    private static @Nullable MemorySegment acquireHandleByBusId(String pciBusId, Arena arena) {
         String needle = pciBusId.toLowerCase(Locale.ROOT);
         MemorySegment[] found = new MemorySegment[1];
         forEachDevice(arena, handle -> {
@@ -211,7 +212,7 @@ public final class NvmlUtilFFM {
         return found[0];
     }
 
-    private static MemorySegment acquireHandleByName(String gpuName, Arena arena) {
+    private static @Nullable MemorySegment acquireHandleByName(String gpuName, Arena arena) {
         String needle = gpuName.toLowerCase(Locale.ROOT);
         MemorySegment[] found = new MemorySegment[1];
         forEachDevice(arena, handle -> {
@@ -327,7 +328,7 @@ public final class NvmlUtilFFM {
      * @param pciBusId PCI bus ID fragment
      * @return matched PCI bus ID string, or {@code null} if not found
      */
-    public static String findDevice(String pciBusId) {
+    public static @Nullable String findDevice(@Nullable String pciBusId) {
         if (!NvmlFunctions.isAvailable() || pciBusId == null || pciBusId.isEmpty()) {
             return null;
         }
@@ -347,7 +348,7 @@ public final class NvmlUtilFFM {
      * @param gpuName GPU name string
      * @return PCI bus ID string, or {@code null} if not found
      */
-    public static String findDeviceByName(String gpuName) {
+    public static @Nullable String findDeviceByName(@Nullable String gpuName) {
         if (!NvmlFunctions.isAvailable() || gpuName == null || gpuName.isEmpty()) {
             return null;
         }
@@ -379,7 +380,7 @@ public final class NvmlUtilFFM {
         }
     }
 
-    private static String emptyToNull(String value) {
+    private static @Nullable String emptyToNull(String value) {
         return value.isEmpty() ? null : value;
     }
 
@@ -389,17 +390,18 @@ public final class NvmlUtilFFM {
      * @param deviceId stable device identifier
      * @return utilization percentage or -1
      */
-    public static double getGpuUtilization(String deviceId) {
+    public static double getGpuUtilization(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readUtilization, -1d);
     }
 
     /**
      * Returns total VRAM in bytes, or -1 if unavailable.
      *
-     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}
+     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}, or
+     *                 {@code null} if neither matched a device
      * @return total bytes or -1
      */
-    public static long getVramTotal(String deviceId) {
+    public static long getVramTotal(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readVramTotal, -1L);
     }
 
@@ -409,7 +411,7 @@ public final class NvmlUtilFFM {
      * @param deviceId stable device identifier
      * @return bytes used or -1
      */
-    public static long getVramUsed(String deviceId) {
+    public static long getVramUsed(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readVramUsed, -1L);
     }
 
@@ -419,7 +421,7 @@ public final class NvmlUtilFFM {
      * @param deviceId stable device identifier
      * @return temperature in °C or -1
      */
-    public static double getTemperature(String deviceId) {
+    public static double getTemperature(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readTemperature, -1d);
     }
 
@@ -429,7 +431,7 @@ public final class NvmlUtilFFM {
      * @param deviceId stable device identifier
      * @return power in watts or -1
      */
-    public static double getPowerDraw(String deviceId) {
+    public static double getPowerDraw(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readPowerDraw, -1d);
     }
 
@@ -439,7 +441,7 @@ public final class NvmlUtilFFM {
      * @param deviceId stable device identifier
      * @return core clock in MHz or -1
      */
-    public static long getCoreClockMhz(String deviceId) {
+    public static long getCoreClockMhz(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, device -> readClock(device, NvmlFunctions.NVML_CLOCK_GRAPHICS), -1L);
     }
 
@@ -449,7 +451,7 @@ public final class NvmlUtilFFM {
      * @param deviceId stable device identifier
      * @return memory clock in MHz or -1
      */
-    public static long getMemoryClockMhz(String deviceId) {
+    public static long getMemoryClockMhz(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, device -> readClock(device, NvmlFunctions.NVML_CLOCK_MEM), -1L);
     }
 
@@ -459,7 +461,7 @@ public final class NvmlUtilFFM {
      * @param deviceId stable device identifier
      * @return fan speed percentage or -1
      */
-    public static double getFanSpeedPercent(String deviceId) {
+    public static double getFanSpeedPercent(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilFFM::readFanSpeed, -1d);
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxGpuStatsFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.platform.linux;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.util.gpu.NvmlUtilFFM;
 import oshi.hardware.common.platform.linux.LinuxGpuStats;
@@ -24,12 +26,12 @@ final class LinuxGpuStatsFFM extends LinuxGpuStats {
     }
 
     @Override
-    protected String nvmlFindDevice(String busId) {
+    protected @Nullable String nvmlFindDevice(String busId) {
         return NvmlUtilFFM.findDevice(busId);
     }
 
     @Override
-    protected String nvmlFindDeviceByName(String name) {
+    protected @Nullable String nvmlFindDeviceByName(String name) {
         return NvmlUtilFFM.findDeviceByName(name);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsGpuStatsFFM.java
@@ -7,6 +7,8 @@ package oshi.hardware.platform.windows;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.GpuInformation.GpuAdapterMemoryProperty;
 import oshi.driver.common.windows.perfmon.GpuInformation.GpuEngineProperty;
@@ -50,12 +52,12 @@ final class WindowsGpuStatsFFM extends WindowsGpuStats {
     }
 
     @Override
-    protected String nvmlFindDevice(String pciBusId) {
+    protected @Nullable String nvmlFindDevice(String pciBusId) {
         return NvmlUtilFFM.findDevice(pciBusId);
     }
 
     @Override
-    protected String nvmlFindDeviceByName(String gpuName) {
+    protected @Nullable String nvmlFindDeviceByName(String gpuName) {
         return NvmlUtilFFM.findDeviceByName(gpuName);
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxGpuStatsJNA.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.platform.linux;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.platform.linux.LinuxGpuStats;
 import oshi.util.gpu.NvmlUtilJNA;
@@ -24,12 +26,12 @@ final class LinuxGpuStatsJNA extends LinuxGpuStats {
     }
 
     @Override
-    protected String nvmlFindDevice(String busId) {
+    protected @Nullable String nvmlFindDevice(String busId) {
         return NvmlUtilJNA.findDevice(busId);
     }
 
     @Override
-    protected String nvmlFindDeviceByName(String name) {
+    protected @Nullable String nvmlFindDeviceByName(String name) {
         return NvmlUtilJNA.findDeviceByName(name);
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGpuStatsJNA.java
@@ -7,6 +7,8 @@ package oshi.hardware.platform.windows;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.GpuInformation.GpuAdapterMemoryProperty;
 import oshi.driver.common.windows.perfmon.GpuInformation.GpuEngineProperty;
@@ -50,12 +52,12 @@ final class WindowsGpuStatsJNA extends WindowsGpuStats {
     }
 
     @Override
-    protected String nvmlFindDevice(String pciBusId) {
+    protected @Nullable String nvmlFindDevice(String pciBusId) {
         return NvmlUtilJNA.findDevice(pciBusId);
     }
 
     @Override
-    protected String nvmlFindDeviceByName(String gpuName) {
+    protected @Nullable String nvmlFindDeviceByName(String gpuName) {
         return NvmlUtilJNA.findDeviceByName(gpuName);
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardJNA.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -237,7 +238,7 @@ final class WindowsGraphicsCardJNA extends WindowsGraphicsCard {
      * @param value the registry value object
      * @return the VRAM size in bytes, or 0 if the value type is unrecognised
      */
-    static long registryValueToVram(Object value) {
+    static long registryValueToVram(@Nullable Object value) {
         return DxgiUtil.registryValueToVram(value);
     }
 

--- a/oshi-core/src/main/java/oshi/util/gpu/AdlUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/AdlUtilJNA.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.ToIntFunction;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,13 +52,13 @@ public final class AdlUtilJNA {
     // -------------------------------------------------------------------------
 
     private static final class Holder {
-        static final AdlLibrary LIB;
+        static final @Nullable AdlLibrary LIB;
         static final boolean LIBRARY_LOADED;
         // Strong reference prevents GC of the callback while ADL holds a native function pointer to it.
         // Uses raw Pointer (not Memory) because ADL frees the native allocation directly via C free().
         // Memory's destructor would double-free the same address.
         @SuppressWarnings("unused")
-        static final AdlMallocCallback MALLOC_CB;
+        static final @Nullable AdlMallocCallback MALLOC_CB;
 
         static {
             AdlLibrary lib = null;
@@ -108,12 +109,13 @@ public final class AdlUtilJNA {
      *
      * @return the ADL context pointer if initialization succeeded, or {@code null} if it failed
      */
-    private static Pointer adlInit() {
-        if (!Holder.LIBRARY_LOADED) {
+    private static @Nullable Pointer adlInit() {
+        AdlLibrary lib = Holder.LIB;
+        if (!Holder.LIBRARY_LOADED || lib == null) {
             return null;
         }
         PointerByReference ctxRef = new PointerByReference();
-        int ret = Holder.LIB.ADL2_Main_Control_Create(Holder.MALLOC_CB, 1, ctxRef);
+        int ret = lib.ADL2_Main_Control_Create(Holder.MALLOC_CB, 1, ctxRef);
         if (ret == Adl.ADL_OK) {
             return ctxRef.getValue();
         }
@@ -128,7 +130,10 @@ public final class AdlUtilJNA {
      * @param context the ADL context pointer returned by {@link #adlInit()}
      */
     private static void adlUninit(Pointer context) {
-        Holder.LIB.ADL2_Main_Control_Destroy(context);
+        AdlLibrary lib = Holder.LIB;
+        if (lib != null) {
+            lib.ADL2_Main_Control_Destroy(context);
+        }
     }
 
     /**
@@ -157,9 +162,13 @@ public final class AdlUtilJNA {
         }
     }
 
-    private static Map<Integer, Integer> enumerateAdapters(Pointer ctx) {
+    private static @Nullable Map<Integer, Integer> enumerateAdapters(Pointer ctx) {
+        AdlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return null;
+        }
         IntByReference numRef = new IntByReference();
-        if (Holder.LIB.ADL2_Adapter_NumberOfAdapters_Get(ctx, numRef) != Adl.ADL_OK) {
+        if (lib.ADL2_Adapter_NumberOfAdapters_Get(ctx, numRef) != Adl.ADL_OK) {
             return null;
         }
         int num = numRef.getValue();
@@ -170,7 +179,7 @@ public final class AdlUtilJNA {
         for (AdapterInfo info : infos) {
             info.iSize = info.size();
         }
-        if (Holder.LIB.ADL2_Adapter_AdapterInfo_Get(ctx, infos, infos[0].size() * num) != Adl.ADL_OK) {
+        if (lib.ADL2_Adapter_AdapterInfo_Get(ctx, infos, infos[0].size() * num) != Adl.ADL_OK) {
             return null;
         }
         Map<Integer, Integer> map = new HashMap<>();
@@ -191,10 +200,14 @@ public final class AdlUtilJNA {
     }
 
     private static boolean supportsOverdriveVersion(Pointer context, int adapterIndex, int minVersion) {
+        AdlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return false;
+        }
         IntByReference supported = new IntByReference();
         IntByReference enabled = new IntByReference();
         IntByReference version = new IntByReference();
-        if (Holder.LIB.ADL2_Overdrive_Caps(context, adapterIndex, supported, enabled, version) == Adl.ADL_OK) {
+        if (lib.ADL2_Overdrive_Caps(context, adapterIndex, supported, enabled, version) == Adl.ADL_OK) {
             return supported.getValue() != 0 && version.getValue() >= minVersion;
         }
         return false;
@@ -246,8 +259,9 @@ public final class AdlUtilJNA {
         if (adapterIndex < 0) {
             return -1d;
         }
+        AdlLibrary lib = Holder.LIB;
         Pointer ctx = adlInit();
-        if (ctx == null) {
+        if (ctx == null || lib == null) {
             return -1d;
         }
         try {
@@ -255,7 +269,7 @@ public final class AdlUtilJNA {
                 return -1d;
             }
             IntByReference temp = new IntByReference();
-            if (Holder.LIB.ADL2_OverdriveN_Temperature_Get(ctx, adapterIndex, Adl.ADL_OVERDRIVE_TEMPERATURE_EDGE,
+            if (lib.ADL2_OverdriveN_Temperature_Get(ctx, adapterIndex, Adl.ADL_OVERDRIVE_TEMPERATURE_EDGE,
                     temp) == Adl.ADL_OK) {
                 return temp.getValue() / 1000.0;
             }
@@ -276,8 +290,9 @@ public final class AdlUtilJNA {
         if (adapterIndex < 0) {
             return -1L;
         }
+        AdlLibrary lib = Holder.LIB;
         Pointer ctx = adlInit();
-        if (ctx == null) {
+        if (ctx == null || lib == null) {
             return -1L;
         }
         try {
@@ -285,7 +300,7 @@ public final class AdlUtilJNA {
                 return -1L;
             }
             ADLODNPerformanceStatus perf = new ADLODNPerformanceStatus();
-            if (Holder.LIB.ADL2_OverdriveN_PerformanceStatus_Get(ctx, adapterIndex, perf) == Adl.ADL_OK) {
+            if (lib.ADL2_OverdriveN_PerformanceStatus_Get(ctx, adapterIndex, perf) == Adl.ADL_OK) {
                 perf.read();
                 return clock.applyAsInt(perf) / 100L;
             }
@@ -326,8 +341,9 @@ public final class AdlUtilJNA {
         if (adapterIndex < 0) {
             return -1d;
         }
+        AdlLibrary lib = Holder.LIB;
         Pointer ctx = adlInit();
-        if (ctx == null) {
+        if (ctx == null || lib == null) {
             return -1d;
         }
         try {
@@ -337,7 +353,7 @@ public final class AdlUtilJNA {
                 return -1d;
             }
             IntByReference power = new IntByReference();
-            if (Holder.LIB.ADL2_Overdrive6_CurrentPower_Get(ctx, adapterIndex, 0, power) == Adl.ADL_OK) {
+            if (lib.ADL2_Overdrive6_CurrentPower_Get(ctx, adapterIndex, 0, power) == Adl.ADL_OK) {
                 return power.getValue() / 256.0;
             }
             return -1d;
@@ -356,8 +372,9 @@ public final class AdlUtilJNA {
         if (adapterIndex < 0) {
             return -1d;
         }
+        AdlLibrary lib = Holder.LIB;
         Pointer ctx = adlInit();
-        if (ctx == null) {
+        if (ctx == null || lib == null) {
             return -1d;
         }
         try {
@@ -365,7 +382,7 @@ public final class AdlUtilJNA {
                 return -1d;
             }
             ADLODNFanControl fan = new ADLODNFanControl();
-            if (Holder.LIB.ADL2_OverdriveN_FanControl_Get(ctx, adapterIndex, fan) == Adl.ADL_OK) {
+            if (lib.ADL2_OverdriveN_FanControl_Get(ctx, adapterIndex, fan) == Adl.ADL_OK) {
                 fan.read();
                 if (fan.iFanControlMode == Adl.ADL_FAN_SPEED_MODE_PERCENT) {
                     return fan.iCurrentFanSpeed;

--- a/oshi-core/src/main/java/oshi/util/gpu/DxgiUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/DxgiUtilJNA.java
@@ -51,7 +51,7 @@ public final class DxgiUtilJNA {
      * @param value the registry value object
      * @return the VRAM size in bytes, or 0 if the value type is unrecognised
      */
-    public static long registryValueToVram(Object value) {
+    public static long registryValueToVram(@Nullable Object value) {
         return DxgiUtil.registryValueToVram(value);
     }
 
@@ -61,7 +61,7 @@ public final class DxgiUtilJNA {
      * @param name the raw adapter name, may be {@code null}
      * @return normalized name, never {@code null}
      */
-    public static String normalizeName(String name) {
+    public static String normalizeName(@Nullable String name) {
         return DxgiUtil.normalizeName(name);
     }
 }

--- a/oshi-core/src/main/java/oshi/util/gpu/NvmlUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/NvmlUtilJNA.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +55,7 @@ public final class NvmlUtilJNA {
     // -------------------------------------------------------------------------
 
     private static final class Holder {
-        static final NvmlLibrary LIB;
+        static final @Nullable NvmlLibrary LIB;
         static final boolean LIBRARY_LOADED;
 
         static {
@@ -109,10 +110,11 @@ public final class NvmlUtilJNA {
      * @return true if this call successfully initialized NVML and must be paired with {@link #nvmlUninit()}
      */
     private static boolean nvmlInit() {
-        if (!Holder.LIBRARY_LOADED) {
+        NvmlLibrary lib = Holder.LIB;
+        if (!Holder.LIBRARY_LOADED || lib == null) {
             return false;
         }
-        int ret = Holder.LIB.nvmlInit_v2();
+        int ret = lib.nvmlInit_v2();
         if (ret == Nvml.NVML_SUCCESS) {
             return true;
         }
@@ -125,7 +127,10 @@ public final class NvmlUtilJNA {
      * Must be called exactly once for each successful call to {@link #nvmlInit()}.
      */
     private static void nvmlUninit() {
-        Holder.LIB.nvmlShutdown();
+        NvmlLibrary lib = Holder.LIB;
+        if (lib != null) {
+            lib.nvmlShutdown();
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -141,14 +146,18 @@ public final class NvmlUtilJNA {
      *         with no devices
      */
     private static boolean forEachDevice(Predicate<Pointer> visitor) {
+        NvmlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return false;
+        }
         IntByReference countRef = new IntByReference();
-        if (Holder.LIB.nvmlDeviceGetCount_v2(countRef) != Nvml.NVML_SUCCESS) {
+        if (lib.nvmlDeviceGetCount_v2(countRef) != Nvml.NVML_SUCCESS) {
             return false;
         }
         int count = countRef.getValue();
         for (int i = 0; i < count; i++) {
             PointerByReference handleRef = new PointerByReference();
-            if (Holder.LIB.nvmlDeviceGetHandleByIndex_v2(i, handleRef) != Nvml.NVML_SUCCESS) {
+            if (lib.nvmlDeviceGetHandleByIndex_v2(i, handleRef) != Nvml.NVML_SUCCESS) {
                 continue;
             }
             if (visitor.test(handleRef.getValue())) {
@@ -164,9 +173,13 @@ public final class NvmlUtilJNA {
      * @param handle the device handle
      * @return the modern and legacy bus IDs, or {@code null} if the PCI info could not be read
      */
-    private static Pair<String, String> readBusIds(Pointer handle) {
+    private static @Nullable Pair<String, String> readBusIds(Pointer handle) {
+        NvmlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return null;
+        }
         NvmlPciInfo pci = new NvmlPciInfo();
-        if (Holder.LIB.nvmlDeviceGetPciInfo_v3(handle, pci) != Nvml.NVML_SUCCESS) {
+        if (lib.nvmlDeviceGetPciInfo_v3(handle, pci) != Nvml.NVML_SUCCESS) {
             return null;
         }
         pci.read();
@@ -180,9 +193,13 @@ public final class NvmlUtilJNA {
      * @param handle the device handle
      * @return the name, or {@code null} if it could not be read
      */
-    private static String readName(Pointer handle) {
+    private static @Nullable String readName(Pointer handle) {
+        NvmlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return null;
+        }
         byte[] nameBuf = new byte[Nvml.NVML_DEVICE_NAME_BUFFER_SIZE];
-        if (Holder.LIB.nvmlDeviceGetName(handle, nameBuf, nameBuf.length) != Nvml.NVML_SUCCESS) {
+        if (lib.nvmlDeviceGetName(handle, nameBuf, nameBuf.length) != Nvml.NVML_SUCCESS) {
             return null;
         }
         return Native.toString(nameBuf).toLowerCase(Locale.ROOT);
@@ -194,7 +211,7 @@ public final class NvmlUtilJNA {
      *
      * @return set of PCI bus ID strings, or {@code null} on NVML error
      */
-    private static Set<String> enumerateDeviceBusIds() {
+    private static @Nullable Set<String> enumerateDeviceBusIds() {
         Set<String> ids = new HashSet<>();
         boolean enumerated = forEachDevice(handle -> {
             Pair<String, String> busIds = readBusIds(handle);
@@ -220,7 +237,7 @@ public final class NvmlUtilJNA {
      * @param pciBusId PCI bus ID fragment to match
      * @return device handle Pointer, or {@code null} if not found
      */
-    private static Pointer acquireHandleByBusId(String pciBusId) {
+    private static @Nullable Pointer acquireHandleByBusId(String pciBusId) {
         String needle = pciBusId.toLowerCase(Locale.ROOT);
         Pointer[] found = new Pointer[1];
         forEachDevice(handle -> {
@@ -242,7 +259,7 @@ public final class NvmlUtilJNA {
      * @param gpuName GPU name to match (case-insensitive substring)
      * @return device handle Pointer, or {@code null} if not found
      */
-    private static Pointer acquireHandleByName(String gpuName) {
+    private static @Nullable Pointer acquireHandleByName(String gpuName) {
         String needle = gpuName.toLowerCase(Locale.ROOT);
         Pointer[] found = new Pointer[1];
         forEachDevice(handle -> {
@@ -280,8 +297,12 @@ public final class NvmlUtilJNA {
     // -------------------------------------------------------------------------
 
     private static double readUtilization(Pointer device) {
+        NvmlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return -1d;
+        }
         NvmlUtilization util = new NvmlUtilization();
-        if (Holder.LIB.nvmlDeviceGetUtilizationRates(device, util) == Nvml.NVML_SUCCESS) {
+        if (lib.nvmlDeviceGetUtilizationRates(device, util) == Nvml.NVML_SUCCESS) {
             util.read();
             return util.gpu;
         }
@@ -289,8 +310,12 @@ public final class NvmlUtilJNA {
     }
 
     private static long readVramTotal(Pointer device) {
+        NvmlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return -1L;
+        }
         NvmlMemory mem = new NvmlMemory();
-        if (Holder.LIB.nvmlDeviceGetMemoryInfo(device, mem) == Nvml.NVML_SUCCESS) {
+        if (lib.nvmlDeviceGetMemoryInfo(device, mem) == Nvml.NVML_SUCCESS) {
             mem.read();
             return mem.total;
         }
@@ -298,8 +323,12 @@ public final class NvmlUtilJNA {
     }
 
     private static long readVramUsed(Pointer device) {
+        NvmlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return -1L;
+        }
         NvmlMemory mem = new NvmlMemory();
-        if (Holder.LIB.nvmlDeviceGetMemoryInfo(device, mem) == Nvml.NVML_SUCCESS) {
+        if (lib.nvmlDeviceGetMemoryInfo(device, mem) == Nvml.NVML_SUCCESS) {
             mem.read();
             return mem.used;
         }
@@ -307,32 +336,48 @@ public final class NvmlUtilJNA {
     }
 
     private static double readTemperature(Pointer device) {
+        NvmlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return -1d;
+        }
         IntByReference temp = new IntByReference();
-        if (Holder.LIB.nvmlDeviceGetTemperature(device, Nvml.NVML_TEMPERATURE_GPU, temp) == Nvml.NVML_SUCCESS) {
+        if (lib.nvmlDeviceGetTemperature(device, Nvml.NVML_TEMPERATURE_GPU, temp) == Nvml.NVML_SUCCESS) {
             return temp.getValue();
         }
         return -1d;
     }
 
     private static double readPowerDraw(Pointer device) {
+        NvmlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return -1d;
+        }
         IntByReference power = new IntByReference();
-        if (Holder.LIB.nvmlDeviceGetPowerUsage(device, power) == Nvml.NVML_SUCCESS) {
+        if (lib.nvmlDeviceGetPowerUsage(device, power) == Nvml.NVML_SUCCESS) {
             return power.getValue() / 1000.0;
         }
         return -1d;
     }
 
     private static long readClock(Pointer device, int clockType) {
+        NvmlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return -1L;
+        }
         IntByReference clock = new IntByReference();
-        if (Holder.LIB.nvmlDeviceGetClockInfo(device, clockType, clock) == Nvml.NVML_SUCCESS) {
+        if (lib.nvmlDeviceGetClockInfo(device, clockType, clock) == Nvml.NVML_SUCCESS) {
             return clock.getValue();
         }
         return -1L;
     }
 
     private static double readFanSpeed(Pointer device) {
+        NvmlLibrary lib = Holder.LIB;
+        if (lib == null) {
+            return -1d;
+        }
         IntByReference speed = new IntByReference();
-        if (Holder.LIB.nvmlDeviceGetFanSpeed(device, speed) == Nvml.NVML_SUCCESS) {
+        if (lib.nvmlDeviceGetFanSpeed(device, speed) == Nvml.NVML_SUCCESS) {
             return speed.getValue();
         }
         return -1d;
@@ -365,7 +410,7 @@ public final class NvmlUtilJNA {
      * @param pciBusId PCI bus ID fragment (e.g. {@code "0000:01:00.0"} or {@code "01:00.0"})
      * @return matched PCI bus ID string, or {@code null} if not found or NVML unavailable
      */
-    public static String findDevice(String pciBusId) {
+    public static @Nullable String findDevice(@Nullable String pciBusId) {
         if (!Holder.LIBRARY_LOADED || pciBusId == null || pciBusId.isEmpty()) {
             return null;
         }
@@ -390,7 +435,7 @@ public final class NvmlUtilJNA {
      * @param gpuName GPU name string (case-insensitive substring match)
      * @return PCI bus ID string of the matched device, or {@code null} if not found or NVML unavailable
      */
-    public static String findDeviceByName(String gpuName) {
+    public static @Nullable String findDeviceByName(@Nullable String gpuName) {
         if (!Holder.LIBRARY_LOADED || gpuName == null || gpuName.isEmpty()) {
             return null;
         }
@@ -425,87 +470,95 @@ public final class NvmlUtilJNA {
         }
     }
 
-    private static String emptyToNull(String value) {
+    private static @Nullable String emptyToNull(String value) {
         return value.isEmpty() ? null : value;
     }
 
     /**
      * Returns GPU core utilization percentage (0–100), or -1 if unavailable.
      *
-     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}
+     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}, or
+     *                 {@code null} if neither matched a device
      * @return utilization percentage or -1
      */
-    public static double getGpuUtilization(String deviceId) {
+    public static double getGpuUtilization(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readUtilization, -1d);
     }
 
     /**
      * Returns total VRAM in bytes, or -1 if unavailable.
      *
-     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}
+     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}, or
+     *                 {@code null} if neither matched a device
      * @return total bytes or -1
      */
-    public static long getVramTotal(String deviceId) {
+    public static long getVramTotal(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readVramTotal, -1L);
     }
 
     /**
      * Returns VRAM used in bytes, or -1 if unavailable.
      *
-     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}
+     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}, or
+     *                 {@code null} if neither matched a device
      * @return bytes used or -1
      */
-    public static long getVramUsed(String deviceId) {
+    public static long getVramUsed(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readVramUsed, -1L);
     }
 
     /**
      * Returns GPU temperature in degrees Celsius, or -1 if unavailable.
      *
-     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}
+     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}, or
+     *                 {@code null} if neither matched a device
      * @return temperature in °C or -1
      */
-    public static double getTemperature(String deviceId) {
+    public static double getTemperature(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readTemperature, -1d);
     }
 
     /**
      * Returns GPU power draw in watts, or -1 if unavailable.
      *
-     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}
+     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}, or
+     *                 {@code null} if neither matched a device
      * @return power in watts or -1
      */
-    public static double getPowerDraw(String deviceId) {
+    public static double getPowerDraw(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readPowerDraw, -1d);
     }
 
     /**
      * Returns GPU core clock speed in MHz, or -1 if unavailable.
      *
-     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}
+     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}, or
+     *                 {@code null} if neither matched a device
      * @return core clock in MHz or -1
      */
-    public static long getCoreClockMhz(String deviceId) {
+    public static long getCoreClockMhz(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, device -> readClock(device, Nvml.NVML_CLOCK_GRAPHICS), -1L);
     }
 
     /**
      * Returns GPU memory clock speed in MHz, or -1 if unavailable.
      *
-     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}
+     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}, or
+     *                 {@code null} if neither matched a device
      * @return memory clock in MHz or -1
      */
-    public static long getMemoryClockMhz(String deviceId) {
+    public static long getMemoryClockMhz(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, device -> readClock(device, Nvml.NVML_CLOCK_MEM), -1L);
     }
 
     /**
      * Returns GPU fan speed as a percentage (0–100), or -1 if unavailable.
      *
-     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}
+     * @param deviceId stable device identifier returned by {@link #findDevice} or {@link #findDeviceByName}, or
+     *                 {@code null} if neither matched a device
      * @return fan speed percentage or -1
      */
-    public static double getFanSpeedPercent(String deviceId) {
+    public static double getFanSpeedPercent(@Nullable String deviceId) {
         return NvmlQuery.query(deviceId, SCOPE, NvmlUtilJNA::readFanSpeed, -1d);
     }
 }


### PR DESCRIPTION
First step of draining `oshi-core` and `oshi-core-ffm`, now that `oshi-common` is at zero. Covers the
NVML and ADL vendor libraries and the DXGI helpers — the densest cluster left, 62 findings in 4 files.
**Reactor findings 406 → 341.**

### The library handles

The vendor library handles — `AdlLibrary`/`NvmlLibrary` in the JNA holders, and the ten ADL
`MethodHandle`s plus the malloc stub in the FFM twin — are null whenever the library failed to load,
which is the normal case on a machine without that vendor's GPU. Each is now declared `@Nullable` and
read into a local that is checked at its use site, so the guarantee the `AVAILABLE` / `LIBRARY_LOADED`
flag carries is one the analyzer can see.

**No reachable behavior change.** Every call site was already downstream of that flag, or of an
`adlInit()` / `nvmlInit()` that returns successfully only when the library loaded, so the new guards
cannot fire in practice. The alternative — `@SuppressWarnings("NullAway.Init")` — was considered and
rejected: it would leave a future dereference that forgets the guard unchecked, on exactly the path
where an NPE is nastiest.

### Contract marking

- The lookups that report "no such device" with null — `findDevice`, `findDeviceByName`, `readBusIds`,
  `readName`, `acquireHandleByBusId`/`ByName`, and the ADL adapter enumeration — now say so.
- The metric getters they feed take a `@Nullable` device identifier, which is what `NvmlQuery.query`
  has always accepted and answered with its sentinel. This is what closes the
  `getVramTotal(findDevice(...))` chain end to end.
- `DxgiUtil.normalizeName` and `registryValueToVram` take a `@Nullable` argument, as their javadoc and
  their own tests already assert.

### One twin inconsistency

`WindowsGpuStats` declared `nvmlFindDevice` and `nvmlFindDeviceByName` non-null while its
`LinuxGpuStats` twin declared both `@Nullable` — a miss from #3621. The two now agree; the Windows
caller already null-checked both results, so this is a declaration fix only.

### Scope boundary

`MacGpuStats` and `WindowsGraphicsCardJNA` still carry three findings each. They are IOKit/IOReport
and WMI code rather than vendor-library code, so they belong to the macOS and Windows PRs rather than
being decided twice here.

No CHANGELOG entry: no user-visible behavior changed. Verified by diffing against master and
cancelling every line whose only difference is an annotation — ten of the thirteen files have no
residue at all, and the residue in the other three is the field-to-local hoist and its guard.

Verified with the full gate on macOS: `spotless:apply sortpom:sort checkstyle:check install
forbiddenapis:check javadoc:javadoc` plus `-Perror-prone clean install`. All modules green, 1561
tests, 0 failures. Neither vendor library is present on this machine, so the ADL and NVML paths are
unverified beyond compilation.

Part of #3593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU monitoring reliability when optional vendor libraries or native handles are unavailable.
  * Prevented null-related failures during GPU discovery and metric collection.
  * Preserved existing fallback values when GPU information cannot be retrieved.

* **Refactor**
  * Clarified nullable GPU identifiers and lookup results across supported platforms, improving API safety and tooling guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->