### PR TITLE
Make the Windows native utility layer's nullability contracts honest

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -20,6 +20,7 @@ import java.lang.invoke.VarHandle;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import oshi.util.ExceptionUtil;
@@ -39,7 +40,7 @@ public abstract class ForeignFunctions {
      * @param <T> the return type
      */
     @FunctionalInterface
-    public interface ArenaCallable<T> {
+    public interface ArenaCallable<T extends @Nullable Object> {
         /**
          * Executes this operation with the provided arena.
          *
@@ -148,8 +149,8 @@ public abstract class ForeignFunctions {
      * @param defaultValue the value to return if the operation throws
      * @return the operation result, or {@code defaultValue} if the operation throws
      */
-    public static <T> T callInArenaOrDefault(ArenaCallable<T> callable, Logger logger, LogLevel level, String message,
-            T defaultValue) {
+    public static <T extends @Nullable Object> T callInArenaOrDefault(ArenaCallable<T> callable, Logger logger,
+            LogLevel level, String message, T defaultValue) {
         Objects.requireNonNull(callable, "callable");
         try (Arena arena = Arena.ofConfined()) {
             return callable.call(arena);
@@ -179,8 +180,8 @@ public abstract class ForeignFunctions {
      * @param args         the arguments filling the message placeholders
      * @return the operation result, or {@code defaultValue} if the operation throws
      */
-    public static <T> T callInArenaOrDefault(ArenaCallable<T> callable, T defaultValue, Logger logger, LogLevel level,
-            String message, Object... args) {
+    public static <T extends @Nullable Object> T callInArenaOrDefault(ArenaCallable<T> callable, T defaultValue,
+            Logger logger, LogLevel level, String message, Object... args) {
         Objects.requireNonNull(callable, "callable");
         try (Arena arena = Arena.ofConfined()) {
             return callable.call(arena);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/Advapi32UtilFFM.java
@@ -47,6 +47,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -279,7 +280,7 @@ public final class Advapi32UtilFFM {
      *         REG_SZ/REG_EXPAND_SZ), or null if unsupported
      * @throws Throwable if the native call fails
      */
-    public static Object registryGetValue(MemorySegment hKey, String valueName) throws Throwable {
+    public static @Nullable Object registryGetValue(MemorySegment hKey, String valueName) throws Throwable {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment lpType = arena.allocate(JAVA_INT);
             MemorySegment lpcbData = arena.allocate(JAVA_INT);
@@ -312,7 +313,7 @@ public final class Advapi32UtilFFM {
      * @return The value object (Integer for REG_DWORD, Long for REG_QWORD, byte[] for REG_BINARY, String for
      *         REG_SZ/REG_EXPAND_SZ), or null on failure
      */
-    public static Object registryGetValue(MemorySegment rootKey, String keyPath, String valueName) {
+    public static @Nullable Object registryGetValue(MemorySegment rootKey, String keyPath, String valueName) {
         return callInArenaOrDefault(arena -> {
             MemorySegment phkResult = arena.allocate(ADDRESS);
             int rc = RegOpenKeyEx(rootKey, toWideString(arena, keyPath), 0, KEY_READ, phkResult);
@@ -509,7 +510,7 @@ public final class Advapi32UtilFFM {
      *
      * @return the event log name, or null if unavailable
      */
-    public static String querySystemLog() {
+    public static @Nullable String querySystemLog() {
         String systemLog = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_EVENTLOG, "System");
         if (systemLog.isEmpty()) {
             return null;

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/IPHlpAPIUtilFFM.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,7 +125,7 @@ public final class IPHlpAPIUtilFFM {
      * @param family the address family (AF_INET or AF_INET6)
      * @return TCP statistics, or null on failure
      */
-    public static TcpStats getTcpStats(int family) {
+    public static @Nullable TcpStats getTcpStats(int family) {
         return callInArenaOrDefault(arena -> {
             MemorySegment stats = arena.allocate(MIB_TCPSTATS_LAYOUT);
 
@@ -163,7 +164,7 @@ public final class IPHlpAPIUtilFFM {
      * @param family the address family (AF_INET or AF_INET6)
      * @return UDP statistics, or null on failure
      */
-    public static UdpStats getUdpStats(int family) {
+    public static @Nullable UdpStats getUdpStats(int family) {
         return callInArenaOrDefault(arena -> {
             MemorySegment stats = arena.allocate(MIB_UDPSTATS_LAYOUT);
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfCounterWildcardQueryFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfCounterWildcardQueryFFM.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +70,7 @@ public final class PerfCounterWildcardQueryFFM {
      *         {@code propertyEnum} on success, or an empty list and empty map if both PDH and WMI queries failed.
      */
     public static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
-            Class<T> propertyEnum, String perfObject, String perfWmiClass, String customFilter) {
+            Class<T> propertyEnum, String perfObject, String perfWmiClass, @Nullable String customFilter) {
         if (!Util.isBlank(customFilter) || !FAILED_QUERY_CACHE.contains(perfObject)) {
             Pair<List<String>, Map<T, List<Long>>> result = queryInstancesAndValuesFromPDH(propertyEnum, perfObject,
                     customFilter);
@@ -113,7 +114,7 @@ public final class PerfCounterWildcardQueryFFM {
      *         {@code propertyEnum} on success, or an empty list and empty map if the PDH query failed.
      */
     public static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromPDH(
-            Class<T> propertyEnum, String perfObject, String customFilter) {
+            Class<T> propertyEnum, String perfObject, @Nullable String customFilter) {
         return PerfDataUtilFFM.queryWildcardCounters(propertyEnum, perfObject, customFilter);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfDataUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/PerfDataUtilFFM.java
@@ -39,6 +39,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,7 +115,8 @@ public final class PerfDataUtilFFM {
                 for (var entry : counterHandles.entrySet()) {
                     runOrLog(
                             () -> valueMap.put(entry.getKey(),
-                                    readRawCounterValue(arena, entry.getValue(), baseFlags.get(entry.getKey()))),
+                                    readRawCounterValue(arena, entry.getValue(),
+                                            baseFlags.getOrDefault(entry.getKey(), false))),
                             LOG, "Failed to read counter for {}", entry.getKey());
                 }
 
@@ -125,7 +127,7 @@ public final class PerfDataUtilFFM {
         }, new EnumMap<>(propertyEnum), LOG, DEBUG, "PDH queryCounters failed for {}", perfObject);
     }
 
-    private static String counterPath(String object, String instance, String counter) {
+    private static String counterPath(String object, @Nullable String instance, String counter) {
         StringBuilder path = new StringBuilder();
         path.append('\\').append(object);
         if (instance != null) {
@@ -281,15 +283,15 @@ public final class PerfDataUtilFFM {
      *         empty list and empty map on failure.
      */
     public static <T extends Enum<T> & PdhCounterWildcardProperty> Pair<List<String>, Map<T, List<Long>>> queryWildcardCounters(
-            Class<T> propertyEnum, String perfObject, String customFilter) {
+            Class<T> propertyEnum, String perfObject, @Nullable String customFilter) {
 
         T[] props = propertyEnum.getEnumConstants();
         if (props.length < 2) {
             throw new IllegalArgumentException("Enum " + propertyEnum.getName()
                     + " must have at least two elements, an instance filter and a counter.");
         }
-        String instanceFilter = Util.isBlank(customFilter) ? props[0].getCounter().toLowerCase(Locale.ROOT)
-                : customFilter.toLowerCase(Locale.ROOT);
+        String instanceFilter = (customFilter == null || customFilter.isEmpty() ? props[0].getCounter() : customFilter)
+                .toLowerCase(Locale.ROOT);
 
         List<String> instances = enumInstances(perfObject, instanceFilter);
         EnumMap<T, List<Long>> valuesMap = new EnumMap<>(propertyEnum);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WbemcliUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WbemcliUtilFFM.java
@@ -38,6 +38,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -132,7 +133,7 @@ public final class WbemcliUtilFFM {
      */
     public static class WmiResult<T extends Enum<T>> {
 
-        private final Map<T, List<Object>> propertyMap;
+        private final Map<T, List<@Nullable Object>> propertyMap;
         private final Map<T, Integer> vtTypeMap;
         private final Map<T, Integer> cimTypeMap;
         private int resultCount;
@@ -158,10 +159,11 @@ public final class WbemcliUtilFFM {
          *
          * @param property the property enum constant
          * @param index    the row index
-         * @return the value object
+         * @return the value object, or {@code null} if the property was not set on this row
          */
-        public Object getValue(T property, int index) {
-            return propertyMap.get(property).get(index);
+        public @Nullable Object getValue(T property, int index) {
+            List<@Nullable Object> values = propertyMap.get(property);
+            return values == null ? null : values.get(index);
         }
 
         /**
@@ -171,7 +173,7 @@ public final class WbemcliUtilFFM {
          * @return the VT type code
          */
         public int getVtType(T property) {
-            return vtTypeMap.get(property);
+            return vtTypeMap.getOrDefault(property, 0);
         }
 
         /**
@@ -181,7 +183,7 @@ public final class WbemcliUtilFFM {
          * @return the CIM type code
          */
         public int getCIMType(T property) {
-            return cimTypeMap.get(property);
+            return cimTypeMap.getOrDefault(property, WbemcliFFM.CIM_EMPTY);
         }
 
         /**
@@ -201,12 +203,13 @@ public final class WbemcliUtilFFM {
          * @param property the property enum constant
          * @param value    the value (may be null)
          */
-        public void add(int vtType, int cimType, T property, Object value) {
-            propertyMap.get(property).add(value);
-            if (vtType != VT_NULL && vtType != VT_EMPTY && vtTypeMap.get(property) == 0) {
+        public void add(int vtType, int cimType, T property, @Nullable Object value) {
+            propertyMap.computeIfAbsent(property, k -> new ArrayList<>()).add(value);
+            if (vtType != VT_NULL && vtType != VT_EMPTY && vtTypeMap.getOrDefault(property, 0) == 0) {
                 vtTypeMap.put(property, vtType);
             }
-            if (cimType != WbemcliFFM.CIM_EMPTY && cimTypeMap.get(property) == WbemcliFFM.CIM_EMPTY) {
+            if (cimType != WbemcliFFM.CIM_EMPTY
+                    && cimTypeMap.getOrDefault(property, WbemcliFFM.CIM_EMPTY) == WbemcliFFM.CIM_EMPTY) {
                 cimTypeMap.put(property, cimType);
             }
         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryExecutorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryExecutorFFM.java
@@ -6,6 +6,8 @@ package oshi.ffm.util.platform.windows;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.driver.common.windows.wmi.WmiQuery;
 import oshi.driver.common.windows.wmi.WmiQueryExecutor;
 import oshi.driver.common.windows.wmi.WmiResult;
@@ -31,7 +33,7 @@ public class WmiQueryExecutorFFM implements WmiQueryExecutor {
      *
      * @return a new executor, or {@code null} if handler creation fails
      */
-    public static WmiQueryExecutorFFM createInstance() {
+    public static @Nullable WmiQueryExecutorFFM createInstance() {
         WmiQueryHandlerFFM h = WmiQueryHandlerFFM.createInstance();
         return h == null ? null : new WmiQueryExecutorFFM(h);
     }
@@ -71,7 +73,7 @@ public class WmiQueryExecutorFFM implements WmiQueryExecutor {
         }
 
         @Override
-        public Object getValue(T property, int index) {
+        public @Nullable Object getValue(T property, int index) {
             return delegate.getValue(property, index);
         }
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,7 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
             + " Will not attempt to query it again. Error was {}";
 
     // Factory to create this or a subclass
-    private static Class<? extends WmiQueryHandlerFFM> customClass = null;
+    private static @Nullable Class<? extends WmiQueryHandlerFFM> customClass = null;
 
     /**
      * Creates a new WmiQueryHandlerFFM instance.
@@ -256,7 +257,7 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
             }
 
             @Override
-            public Object getValue(T property, int index) {
+            public @Nullable Object getValue(T property, int index) {
                 return ffmResult.getValue(property, index);
             }
 
@@ -282,7 +283,7 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
      * @param rowProcessor  processor to populate result object from WMI row
      * @return list of result objects, empty list if query fails
      */
-    public <T> List<T> queryWMI(String wmiClassName, String whereClause, Supplier<T> resultFactory,
+    public <T> List<T> queryWMI(String wmiClassName, @Nullable String whereClause, Supplier<T> resultFactory,
             TriConsumer<MemorySegment, Arena, T> rowProcessor) {
         return queryWMI(WbemcliFFM.DEFAULT_NAMESPACE, wmiClassName, whereClause, resultFactory, rowProcessor);
     }
@@ -298,8 +299,8 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
      * @param rowProcessor  processor to populate result object from WMI row
      * @return list of result objects, empty list if query fails
      */
-    public <T> List<T> queryWMI(String namespace, String wmiClassName, String whereClause, Supplier<T> resultFactory,
-            TriConsumer<MemorySegment, Arena, T> rowProcessor) {
+    public <T> List<T> queryWMI(String namespace, String wmiClassName, @Nullable String whereClause,
+            Supplier<T> resultFactory, TriConsumer<MemorySegment, Arena, T> rowProcessor) {
         if (failedWmiClassNames.contains(wmiClassName)) {
             return new ArrayList<>();
         }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQueryHandler.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterQueryHandler.java
@@ -7,6 +7,7 @@ package oshi.util.platform.windows;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ public final class PerfCounterQueryHandler implements AutoCloseable {
     // Map of counter handles
     private Map<PerfCounter, CloseableHANDLEByReference> counterHandleMap = new HashMap<>();
     // The query handle
-    private CloseableHANDLEByReference queryHandle = null;
+    private @Nullable CloseableHANDLEByReference queryHandle = null;
 
     /**
      * Begin monitoring a Performance Data counter.

--- a/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/PerfCounterWildcardQuery.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,7 @@ public final class PerfCounterWildcardQuery {
      *         {@code propertyEnum} on success, or an empty list and empty map if both PDH and WMI queries failed.
      */
     public static <T extends Enum<T>> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValues(
-            Class<T> propertyEnum, String perfObject, String perfWmiClass, String customFilter) {
+            Class<T> propertyEnum, String perfObject, String perfWmiClass, @Nullable String customFilter) {
         if (FAILED_QUERY_CACHE.isEmpty()
                 || (!PERF_DISABLE_ALL_ON_FAILURE && !FAILED_QUERY_CACHE.contains(perfObject))) {
             Pair<List<String>, Map<T, List<Long>>> instancesAndValuesMap = queryInstancesAndValuesFromPDH(propertyEnum,
@@ -130,7 +131,7 @@ public final class PerfCounterWildcardQuery {
      *         {@code propertyEnum} on success, or an empty list and empty map if the PDH query failed.
      */
     public static <T extends Enum<T>> Pair<List<String>, Map<T, List<Long>>> queryInstancesAndValuesFromPDH(
-            Class<T> propertyEnum, String perfObject, String customFilter) {
+            Class<T> propertyEnum, String perfObject, @Nullable String customFilter) {
         T[] props = propertyEnum.getEnumConstants();
         if (props.length < 2) {
             throw new IllegalArgumentException("Enum " + propertyEnum.getName()
@@ -138,9 +139,9 @@ public final class PerfCounterWildcardQuery {
         }
         // Lowercase the filter (matching the built-in default below) since instance names are compared
         // case-insensitively via toLowerCase at the wildcardMatch call.
-        String instanceFilter = (Util.isBlank(customFilter)
-                ? ((PdhCounterWildcardProperty) propertyEnum.getEnumConstants()[0]).getCounter()
-                : customFilter).toLowerCase(Locale.ROOT);
+        String defaultFilter = ((PdhCounterWildcardProperty) propertyEnum.getEnumConstants()[0]).getCounter();
+        String instanceFilter = (customFilter == null || customFilter.isEmpty() ? defaultFilter : customFilter)
+                .toLowerCase(Locale.ROOT);
         // Localize the perfObject using different variable for the EnumObjectItems
         // Will still use unlocalized perfObject for the query
         String perfObjectLocalized = PerfCounterQuery.localizeIfNeeded(perfObject, true);
@@ -183,7 +184,7 @@ public final class PerfCounterWildcardQuery {
                 for (int i = 1; i < props.length; i++) {
                     T prop = props[i];
                     List<Long> values = new ArrayList<>();
-                    for (PerfCounter counter : counterListMap.get(prop)) {
+                    for (PerfCounter counter : counterListMap.getOrDefault(prop, Collections.emptyList())) {
                         values.add(pdhQueryHandler.queryCounter(counter));
                     }
                     valuesMap.put(prop, values);

--- a/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/RegistryUtil.java
@@ -51,7 +51,8 @@ public final class RegistryUtil {
      * @param accessFlag the access flag
      * @return the registry value or null
      */
-    public static Object getRegistryValueOrNull(HKEY root, String path, String key, int accessFlag) {
+    public static @Nullable Object getRegistryValueOrNull(HKEY root, String path, @Nullable String key,
+            int accessFlag) {
         try {
             // registryGetValues opens the key with KEY_READ | accessFlag, so the WOW64 access flag (e.g.
             // KEY_WOW64_32KEY/KEY_WOW64_64KEY) is honored when reading the value. Reading the value separately via

--- a/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryExecutorJNA.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryExecutorJNA.java
@@ -6,6 +6,8 @@ package oshi.util.platform.windows;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.platform.win32.COM.WbemcliUtil;
 
 import oshi.driver.common.windows.wmi.WmiQuery;
@@ -33,7 +35,7 @@ public class WmiQueryExecutorJNA implements WmiQueryExecutor {
      *
      * @return a new executor, or {@code null} if handler creation fails
      */
-    public static WmiQueryExecutorJNA createInstance() {
+    public static @Nullable WmiQueryExecutorJNA createInstance() {
         WmiQueryHandler h = WmiQueryHandler.createInstance();
         return h == null ? null : new WmiQueryExecutorJNA(h);
     }

--- a/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryHandler.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryHandler.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +61,7 @@ public class WmiQueryHandler implements WmiQueryExecutor {
             + " Will not attempt to query it again. Error was {}";
 
     // Factory to create this or a subclass
-    private static Class<? extends WmiQueryHandler> customClass = null;
+    private static @Nullable Class<? extends WmiQueryHandler> customClass = null;
 
     /** Creates the WMI query handler. Subclasses may override via {@link #setInstanceClass(Class)}. */
     protected WmiQueryHandler() {
@@ -72,7 +73,7 @@ public class WmiQueryHandler implements WmiQueryExecutor {
      *
      * @return An instance of this class or a class defined by {@link #setInstanceClass(Class)}
      */
-    public static synchronized WmiQueryHandler createInstance() {
+    public static synchronized @Nullable WmiQueryHandler createInstance() {
         if (customClass == null) {
             return new WmiQueryHandler();
         }

--- a/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterQueryTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterQueryTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static oshi.driver.common.windows.wmi.WmiConstants.CIM_DATETIME;
 import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT16;
@@ -21,6 +22,7 @@ import static oshi.driver.common.windows.wmi.WmiConstants.VT_I4;
 import java.util.EnumMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -64,7 +66,7 @@ class PerfCounterQueryTest {
         }
 
         @Override
-        public Object getValue(Prop property, int index) {
+        public @Nullable Object getValue(Prop property, int index) {
             return values.get(property);
         }
 
@@ -139,7 +141,8 @@ class PerfCounterQueryTest {
         assertThat("OSType is a small enumeration value", values.get(OsProp.OSTYPE), is(greaterThan(0L)));
         assertThat("A running system has processes", values.get(OsProp.NUMBEROFPROCESSES), is(greaterThan(0L)));
         assertThat("Free memory is reported in kilobytes", values.get(OsProp.FREEPHYSICALMEMORY), is(greaterThan(0L)));
-        long boot = values.get(OsProp.LASTBOOTUPTIME);
+        Long boot = values.get(OsProp.LASTBOOTUPTIME);
+        assertNotNull(boot);
         assertThat("Boot time is a plausible epoch millisecond value in the past", boot,
                 is(both(greaterThan(946684800000L)).and(lessThanOrEqualTo(System.currentTimeMillis()))));
     }

--- a/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterWildcardQueryTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterWildcardQueryTest.java
@@ -22,6 +22,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.driver.common.windows.wmi.WmiResult;
@@ -61,7 +62,7 @@ class PerfCounterWildcardQueryTest {
         }
 
         @Override
-        public Object getValue(Prop property, int index) {
+        public @Nullable Object getValue(Prop property, int index) {
             List<Object> v = values.get(property);
             return v == null || index >= v.size() ? null : v.get(index);
         }


### PR DESCRIPTION
Second step of draining `oshi-core` and `oshi-core-ffm`, covering the WMI, PDH and registry utility
layers in both implementations. **Reactor findings 341 → 292.**

### One shared fix does most of the work

`ForeignFunctions.callInArenaOrDefault` and its `ArenaCallable` declared a bare `<T>`, which in a
marked package means non-null — so the many callers that pass `null` as the failure default were each
reporting a violation. The type parameter now admits null, matching `ExceptionUtil.getOrDefault`,
which was given the same bound in #3620. That alone resolved findings well beyond this package.

This is the same generic-absorbs-nullability trap that `Memoizer` and the tuple classes hit in the
first phase; the JDK and FFM helper families now agree.

### Contract marking

- The factories and lookups that report failure with `null` say so: `createInstance` in all four
  handler and executor classes, `Advapi32UtilFFM`'s registry readers and `querySystemLog`,
  `IPHlpAPIUtilFFM`'s TCP and UDP stats, and `RegistryUtil.getRegistryValueOrNull`, whose name
  already did.
- The optional arguments documented as "null for none" — the WMI where clause and the PDH custom
  instance filter — are annotated as such.
- `WbemcliUtilFFM.WmiResult` reports an unset property as `null` rather than dereferencing an absent
  list, and reads its type maps through the same defaults its constructor seeds them with. The
  constructor fills every enum constant, so those defaults are unreachable — the same all-or-nothing
  invariant `PerfCounterValues` documented in #3619.

### Two `Util.isBlank` rewrites

Two instance-filter expressions tested their argument with `Util.isBlank`, which the analyzer cannot
see through. `Util.isBlank` is `s == null || s.isEmpty()`, so the explicit check that replaces it is
the same test written where the analyzer can read it.

### No behavior change

No CHANGELOG entry. Verified by diffing against master and cancelling every line whose only
difference is an annotation: eight of the fifteen files have no residue at all, and the residue in
the rest is signatures, `get` → `getOrDefault` on maps that were already fully seeded, and the two
`isBlank` rewrites above.

Verified with the full gate on macOS: `spotless:apply sortpom:sort checkstyle:check install
forbiddenapis:check javadoc:javadoc` plus `-Perror-prone clean install`. All modules green, 1561
tests, 0 failures. This is all Windows code, so nothing here is verified beyond compilation and CI.

Part of #3593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows performance-counter and WMI handling when optional filters, properties, registry values, or system information are unavailable.
  - Prevented failures when counter metadata or result entries are missing.
  - Clarified behavior for empty versus whitespace-only filters.

- **Documentation**
  - Added nullability information across Windows monitoring APIs, making optional inputs and potentially absent results clearer to developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->