### PR TITLE
Make the Windows hardware layer's nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/gpu/DxgiUtil.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/gpu/DxgiUtil.java
@@ -38,7 +38,7 @@ public final class DxgiUtil {
      * @return best-matching adapter, or {@code null}
      */
     public static @Nullable DxgiAdapterInfo findMatch(List<DxgiAdapterInfo> adapters, int vendorId, int deviceId,
-            String adapterName) {
+            @Nullable String adapterName) {
         if (vendorId != 0 && deviceId != 0) {
             for (DxgiAdapterInfo a : adapters) {
                 if (a.getVendorId() == vendorId && a.getDeviceId() == deviceId) {
@@ -117,7 +117,7 @@ public final class DxgiUtil {
      * @param locationInfo the LocationInformation registry value
      * @return PCI bus number, or -1 if not parseable
      */
-    public static int parsePciBusNumber(String locationInfo) {
+    public static int parsePciBusNumber(@Nullable String locationInfo) {
         if (locationInfo == null || locationInfo.isEmpty()) {
             return -1;
         }
@@ -138,7 +138,7 @@ public final class DxgiUtil {
      * @param locationInfo the LocationInformation registry value
      * @return PCI device number, or -1 if not parseable
      */
-    public static int parsePciDevice(String locationInfo) {
+    public static int parsePciDevice(@Nullable String locationInfo) {
         if (locationInfo == null || locationInfo.isEmpty()) {
             return -1;
         }
@@ -159,7 +159,7 @@ public final class DxgiUtil {
      * @param locationInfo the LocationInformation registry value
      * @return PCI function number, or -1 if not parseable
      */
-    public static int parsePciFunction(String locationInfo) {
+    public static int parsePciFunction(@Nullable String locationInfo) {
         if (locationInfo == null || locationInfo.isEmpty()) {
             return -1;
         }
@@ -181,7 +181,7 @@ public final class DxgiUtil {
      * @param locationInfo the LocationInformation registry value
      * @return PCI bus ID string, or empty string if not parseable
      */
-    public static String buildPciBusId(String locationInfo) {
+    public static String buildPciBusId(@Nullable String locationInfo) {
         int bus = parsePciBusNumber(locationInfo);
         int device = parsePciDevice(locationInfo);
         int function = parsePciFunction(locationInfo);

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractPowerSource.java
@@ -62,7 +62,7 @@ public abstract class AbstractPowerSource implements PowerSource {
      * @param designCapacity           design capacity
      * @param cycleCount               charge cycle count
      * @param chemistry                battery chemistry
-     * @param manufactureDate          manufacture date
+     * @param manufactureDate          manufacture date, or {@code null} if the platform did not report one
      * @param manufacturer             manufacturer name
      * @param serialNumber             serial number
      * @param temperature              temperature in degrees Celsius

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsHWDiskStore.java
@@ -14,6 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,7 +118,7 @@ public abstract class WindowsHWDiskStore extends AbstractHWDiskStore {
      * @param instanceValuePair The raw PDH counter data
      * @return A populated DiskStats object
      */
-    protected static DiskStats populateDiskStats(String index,
+    protected static DiskStats populateDiskStats(@Nullable String index,
             Pair<List<String>, Map<PhysicalDiskProperty, List<Long>>> instanceValuePair) {
         DiskStats stats = new DiskStats();
         List<String> instances = instanceValuePair.getA();

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsNetworkIF.java
@@ -6,6 +6,8 @@ package oshi.hardware.common.platform.windows;
 
 import java.net.NetworkInterface;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.AbstractNetworkIF;
 
@@ -109,5 +111,5 @@ public abstract class WindowsNetworkIF extends AbstractNetworkIF {
      *
      * @return the stats, or {@code null} if the query failed
      */
-    protected abstract IfStats queryStats();
+    protected abstract @Nullable IfStats queryStats();
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsSensors.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.BiPredicate;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -313,7 +314,7 @@ public abstract class WindowsSensors extends AbstractSensors {
      * @param searchCpu   whether to search for a {@code cpu} identifier (vs. using the first)
      * @return the sensor values, or {@code null} if unavailable
      */
-    protected abstract WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName,
+    protected abstract @Nullable WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName,
             String sensorType, boolean searchCpu);
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorFFM.java
@@ -160,7 +160,7 @@ class WindowsCentralProcessorFFM extends WindowsCentralProcessor {
 
     @Override
     protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
-        Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> lpi = LogicalProcessorInformationFFM
+        Triplet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>> lpi = LogicalProcessorInformationFFM
                 .getLogicalProcessorInformationEx();
         buildNumaNodeProcMap(lpi.getA());
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
@@ -4,8 +4,6 @@
  */
 package oshi.hardware.platform.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static oshi.util.ExceptionUtil.getOrDefault;
@@ -16,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.platform.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static oshi.util.ExceptionUtil.getOrDefault;
@@ -88,7 +90,7 @@ final class WindowsDisplayFFM extends AbstractDisplay {
         return displays;
     }
 
-    private static byte[] queryEdidFromKey(MemorySegment key, MemorySegment edidName, Arena arena) {
+    private static byte @Nullable [] queryEdidFromKey(MemorySegment key, MemorySegment edidName, Arena arena) {
         return getOrDefault(() -> {
             MemorySegment pType = arena.allocate(JAVA_INT);
             MemorySegment lpcbData = arena.allocate(JAVA_INT);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.platform.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.util.LogLevel.ERROR;
 
@@ -44,7 +46,7 @@ public final class WindowsNetworkIfFFM extends WindowsNetworkIF {
     }
 
     @Override
-    protected IfStats queryStats() {
+    protected @Nullable IfStats queryStats() {
         // FFM targets JDK 25+ which requires Vista+; use GetIfEntry2 directly
         return callInArenaOrDefault(arena -> {
             MemorySegment ifRow = arena.allocate(IPHlpAPIFFM.MIB_IF_ROW2_SIZE);

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfFFM.java
@@ -4,8 +4,6 @@
  */
 package oshi.hardware.platform.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import static oshi.ffm.ForeignFunctions.callInArenaOrDefault;
 import static oshi.util.LogLevel.ERROR;
 
@@ -15,6 +13,7 @@ import java.net.NetworkInterface;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.platform.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
@@ -71,7 +73,7 @@ public final class WindowsPowerSourceFFM extends WindowsPowerSource {
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
             CapacityUnits psCapacityUnits, int psCurrentCapacity, int psMaxCapacity, int psDesignCapacity,
-            int psCycleCount, String psChemistry, LocalDate psManufactureDate, String psManufacturer,
+            int psCycleCount, String psChemistry, @Nullable LocalDate psManufactureDate, String psManufacturer,
             String psSerialNumber, double psTemperature) {
         super(psName, psDeviceName, psRemainingCapacityPercent, psTimeRemainingEstimated, psTimeRemainingInstant,
                 psPowerUsageRate, psVoltage, psAmperage, psPowerOnLine, psCharging, psDischarging, psCapacityUnits,

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
@@ -4,8 +4,6 @@
  */
 package oshi.hardware.platform.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
@@ -48,6 +46,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsSensorsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsSensorsFFM.java
@@ -4,11 +4,10 @@
  */
 package oshi.hardware.platform.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +37,7 @@ final class WindowsSensorsFFM extends WindowsSensors {
 
     @Override
     protected @Nullable WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName,
-            String sensorType,
-            boolean searchCpu) {
+            String sensorType, boolean searchCpu) {
         return getOhmSensors(typeToQuery, typeName, sensorType, (h, ohmHardware) -> {
             String cpuIdentifier = selectOhmCpuIdentifier(ohmHardware, searchCpu);
             if (!cpuIdentifier.isEmpty()) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsSensorsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsSensorsFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.platform.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 import java.util.function.BiFunction;
 
@@ -35,7 +37,8 @@ final class WindowsSensorsFFM extends WindowsSensors {
     private static final Logger LOG = LoggerFactory.getLogger(WindowsSensorsFFM.class);
 
     @Override
-    protected WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName, String sensorType,
+    protected @Nullable WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName,
+            String sensorType,
             boolean searchCpu) {
         return getOhmSensors(typeToQuery, typeName, sensorType, (h, ohmHardware) -> {
             String cpuIdentifier = selectOhmCpuIdentifier(ohmHardware, searchCpu);
@@ -46,7 +49,8 @@ final class WindowsSensorsFFM extends WindowsSensors {
         });
     }
 
-    private static WmiResult<ValueProperty> getOhmSensors(String typeToQuery, String typeName, String sensorType,
+    private static @Nullable WmiResult<ValueProperty> getOhmSensors(String typeToQuery, String typeName,
+            String sensorType,
             BiFunction<WmiQueryHandlerFFM, WmiResult<IdentifierProperty>, WmiResult<ValueProperty>> querySensorFunction) {
         WmiQueryHandlerFFM h = Objects.requireNonNull(WmiQueryHandlerFFM.createInstance());
         boolean comInit = false;

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsCentralProcessorJNA.java
@@ -122,7 +122,7 @@ class WindowsCentralProcessorJNA extends WindowsCentralProcessor {
 
     @Override
     protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
-        Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> lpi;
+        Triplet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>> lpi;
         if (VersionHelpers.IsWindows7OrGreater()) {
             lpi = LogicalProcessorInformation.getLogicalProcessorInformationEx();
             buildNumaNodeProcMap(lpi.getA());

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardJNA.java
@@ -290,7 +290,7 @@ final class WindowsGraphicsCardJNA extends WindowsGraphicsCard {
      * @param locationInfo the LocationInformation registry value
      * @return PCI bus number, or -1 if not parseable
      */
-    static int parsePciBusNumber(String locationInfo) {
+    static int parsePciBusNumber(@Nullable String locationInfo) {
         return DxgiUtil.parsePciBusNumber(locationInfo);
     }
 
@@ -321,7 +321,7 @@ final class WindowsGraphicsCardJNA extends WindowsGraphicsCard {
      * @param locationInfo the LocationInformation registry value
      * @return PCI bus ID string, or empty string if not parseable
      */
-    static String buildPciBusId(String locationInfo) {
+    static String buildPciBusId(@Nullable String locationInfo) {
         return DxgiUtil.buildPciBusId(locationInfo);
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
@@ -4,11 +4,10 @@
  */
 package oshi.hardware.platform.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import java.net.NetworkInterface;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsNetworkIfJNA.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.platform.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import java.net.NetworkInterface;
 import java.util.List;
 
@@ -59,11 +61,11 @@ public class WindowsNetworkIfJNA extends WindowsNetworkIF {
     }
 
     @Override
-    protected IfStats queryStats() {
+    protected @Nullable IfStats queryStats() {
         return isVistaOrGreater() ? queryStatsVista() : queryStatsLegacy();
     }
 
-    private IfStats queryStatsVista() {
+    private @Nullable IfStats queryStatsVista() {
         // MIB_IFROW2 requires Vista (6.0) or later.
         try (CloseableMibIfRow2 ifRow = new CloseableMibIfRow2()) {
             ifRow.InterfaceIndex = queryNetworkInterface().getIndex();
@@ -91,7 +93,7 @@ public class WindowsNetworkIfJNA extends WindowsNetworkIF {
         }
     }
 
-    private IfStats queryStatsLegacy() {
+    private @Nullable IfStats queryStatsLegacy() {
         // Pre-Vista MIB_IFROW: a narrower field set with unsigned 32-bit counters widened to long. Physical medium
         // type, connector-present, alias, and oper-status are not available and keep their IfStats defaults.
         try (CloseableMibIfRow ifRow = new CloseableMibIfRow()) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.platform.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import java.nio.charset.StandardCharsets;
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -50,7 +52,7 @@ public final class WindowsPowerSourceJNA extends WindowsPowerSource {
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
             CapacityUnits psCapacityUnits, int psCurrentCapacity, int psMaxCapacity, int psDesignCapacity,
-            int psCycleCount, String psChemistry, LocalDate psManufactureDate, String psManufacturer,
+            int psCycleCount, String psChemistry, @Nullable LocalDate psManufactureDate, String psManufacturer,
             String psSerialNumber, double psTemperature) {
         super(psName, psDeviceName, psRemainingCapacityPercent, psTimeRemainingEstimated, psTimeRemainingInstant,
                 psPowerUsageRate, psVoltage, psAmperage, psPowerOnLine, psCharging, psDischarging, psCapacityUnits,

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceJNA.java
@@ -4,13 +4,13 @@
  */
 package oshi.hardware.platform.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import java.nio.charset.StandardCharsets;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
+
+import org.jspecify.annotations.Nullable;
 
 import com.sun.jna.Memory;
 import com.sun.jna.Native;

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensorsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensorsJNA.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.platform.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 import java.util.function.BiFunction;
 
@@ -36,7 +38,8 @@ final class WindowsSensorsJNA extends WindowsSensors {
     private static final Logger LOG = LoggerFactory.getLogger(WindowsSensorsJNA.class);
 
     @Override
-    protected WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName, String sensorType,
+    protected @Nullable WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName,
+            String sensorType,
             boolean searchCpu) {
         return getOhmSensors(typeToQuery, typeName, sensorType, (h, ohmHardware) -> {
             String cpuIdentifier = selectOhmCpuIdentifier(ohmHardware, searchCpu);
@@ -47,7 +50,8 @@ final class WindowsSensorsJNA extends WindowsSensors {
         });
     }
 
-    private static WmiResult<ValueProperty> getOhmSensors(String typeToQuery, String typeName, String sensorType,
+    private static @Nullable WmiResult<ValueProperty> getOhmSensors(String typeToQuery, String typeName,
+            String sensorType,
             BiFunction<WmiQueryHandler, WmiResult<IdentifierProperty>, WmiResult<ValueProperty>> querySensorFunction) {
         WmiQueryHandler h = Objects.requireNonNull(WmiQueryHandler.createInstance());
         boolean comInit = false;

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensorsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensorsJNA.java
@@ -4,11 +4,10 @@
  */
 package oshi.hardware.platform.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,8 +38,7 @@ final class WindowsSensorsJNA extends WindowsSensors {
 
     @Override
     protected @Nullable WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName,
-            String sensorType,
-            boolean searchCpu) {
+            String sensorType, boolean searchCpu) {
         return getOhmSensors(typeToQuery, typeName, sensorType, (h, ohmHardware) -> {
             String cpuIdentifier = selectOhmCpuIdentifier(ohmHardware, searchCpu);
             if (!cpuIdentifier.isEmpty()) {

--- a/oshi-core/src/main/java/oshi/util/gpu/DxgiUtilJNA.java
+++ b/oshi-core/src/main/java/oshi/util/gpu/DxgiUtilJNA.java
@@ -41,7 +41,7 @@ public final class DxgiUtilJNA {
      * @return best-matching adapter, or {@code null}
      */
     public static @Nullable DxgiAdapterInfo findMatch(List<DxgiAdapterInfo> adapters, int vendorId, int deviceId,
-            String adapterName) {
+            @Nullable String adapterName) {
         return DxgiUtil.findMatch(adapters, vendorId, deviceId, adapterName);
     }
 


### PR DESCRIPTION
Fourth step of draining `oshi-core` and `oshi-core-ffm`. Covers the Windows hardware components in
both implementations. **Reactor findings 253 → 233.**

The operating-system layer is the other half of this work and follows in a separate PR — the two
together were 36 files, past the size worth reviewing in one go. They touch disjoint files and each
builds and passes the gate on its own, so they can land in either order.

### Queries that report an unreadable device with null now say so

The network interface statistics on both the Vista-or-later and legacy paths, the Open Hardware
Monitor sensor lookups, and the FFM EDID registry read. Each caller already tested the result —
`WindowsNetworkIf.updateAttributes` returns `false` on a null, which is why the missing contract was
invisible to the analyzer rather than to the code.

### Optional arguments the callee already handles

The disk index filter that means "every disk", the adapter name that `DxgiUtil` matches loosely, and
the PCI location string that the bus-number and bus-id parsers already answer with `-1` and `""`.
The Windows power source takes a `@Nullable` manufacture date, which is what `PowerSource` has
declared since #3625.

### One generic type argument

`WindowsCentralProcessor`'s local `Triplet` in both twins now carries the nullable component types
that `LogicalProcessorInformation`'s return declared in #3628. The legacy path has always returned
null for the physical-processor and cache lists.

### No behavior change

No CHANGELOG entry. Verified by diffing against master and cancelling every line whose only
difference is an annotation: thirteen of the fifteen files have no residue at all, and the residue
in the other two is a long signature rewrapped across lines.

Verified with the full gate on macOS: `spotless:apply sortpom:sort checkstyle:check install
forbiddenapis:check javadoc:javadoc` plus `-Perror-prone clean install`, with the operating-system
half stashed so this commit is measured on its own. All modules green, 1561 tests, 0 failures. This
is Windows code, so nothing here is verified beyond compilation and CI.

Part of #3593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved nullability documentation across Windows hardware, graphics, networking, sensor, power, and processor APIs.
  * Clarified which inputs may be absent and which queries may return no results.

* **Bug Fixes**
  * Improved consistency when Windows APIs provide missing hardware information.
  * Preserved existing behavior while ensuring absent values are reported consistently across native Windows implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->