### PR TITLE
Make the Windows operating-system layer's nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32LogicalDisk.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32LogicalDisk.java
@@ -4,6 +4,8 @@
  */
 package oshi.driver.common.windows.wmi;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
@@ -76,7 +78,7 @@ public class Win32LogicalDisk {
      * @param localOnly   Whether to only search local drives
      * @return Logical Disk Information
      */
-    public static WmiResult<LogicalDiskProperty> queryLogicalDisk(WmiQueryExecutor h, String nameToMatch,
+    public static WmiResult<LogicalDiskProperty> queryLogicalDisk(WmiQueryExecutor h, @Nullable String nameToMatch,
             boolean localOnly) {
         WmiQuery<LogicalDiskProperty> logicalDiskQuery = new WmiQuery<>(
                 buildWmiClassNameWithWhere(nameToMatch, localOnly), LogicalDiskProperty.class);

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32LogicalDisk.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/Win32LogicalDisk.java
@@ -56,7 +56,7 @@ public class Win32LogicalDisk {
      * @param localOnly   whether to only search local drives
      * @return the WMI class name with WHERE clause appended
      */
-    public static String buildWmiClassNameWithWhere(String nameToMatch, boolean localOnly) {
+    public static String buildWmiClassNameWithWhere(@Nullable String nameToMatch, boolean localOnly) {
         StringBuilder wmiClassName = new StringBuilder(WIN32_LOGICAL_DISK);
         boolean where = false;
         if (localOnly) {

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
@@ -65,7 +65,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     private final Supplier<List<String>> args = memoize(this::queryArguments);
     private final Supplier<Triplet<String, String, Map<String, String>>> cwdCmdEnv = memoize(
             this::queryCwdCommandlineEnvironment);
-    private final AtomicReference<Map<Integer, ThreadPerfCounterBlock>> tcb = new AtomicReference<>();
+    private final AtomicReference<@Nullable Map<Integer, ThreadPerfCounterBlock>> tcb = new AtomicReference<>();
 
     private volatile long workingSetSize;
     private volatile long privateWorkingSetSize;
@@ -80,7 +80,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
      * @param os            the os
      * @param processMap    the processMap
      * @param processWtsMap the processWtsMap
-     * @param threadMap     the threadMap
+     * @param threadMap     the threadMap, or {@code null} if the thread details have not been queried
      */
     protected WindowsOSProcess(int pid, OperatingSystem os, Map<Integer, ProcessPerfCounterBlock> processMap,
             Map<Integer, WtsInfo> processWtsMap, @Nullable Map<Integer, ThreadPerfCounterBlock> threadMap) {

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
@@ -83,7 +83,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
      * @param threadMap     the threadMap
      */
     protected WindowsOSProcess(int pid, OperatingSystem os, Map<Integer, ProcessPerfCounterBlock> processMap,
-            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
+            Map<Integer, WtsInfo> processWtsMap, @Nullable Map<Integer, ThreadPerfCounterBlock> threadMap) {
         super(pid);
         this.os = os;
         this.bitness = os.getBitness();
@@ -302,7 +302,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
      *
      * @param tcb the thread performance counter block map
      */
-    protected void setTcb(Map<Integer, ThreadPerfCounterBlock> tcb) {
+    protected void setTcb(@Nullable Map<Integer, ThreadPerfCounterBlock> tcb) {
         this.tcb.set(tcb);
     }
 
@@ -312,7 +312,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
      * @param pids the set of process IDs to match
      * @return a map of thread ID to thread performance counter block
      */
-    protected abstract Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids);
+    protected abstract @Nullable Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids);
 
     /**
      * Queries the command line for this process.

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSThread.java
@@ -13,6 +13,8 @@ import static oshi.software.os.OSProcess.State.STOPPED;
 import static oshi.software.os.OSProcess.State.SUSPENDED;
 import static oshi.software.os.OSProcess.State.WAITING;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;
 import oshi.software.common.AbstractOSThread;
@@ -31,7 +33,7 @@ public abstract class WindowsOSThread extends AbstractOSThread {
      * @param procName the procName
      * @param pcb      the pcb
      */
-    protected WindowsOSThread(int pid, int tid, String procName, ThreadPerfCounterBlock pcb) {
+    protected WindowsOSThread(int pid, int tid, @Nullable String procName, @Nullable ThreadPerfCounterBlock pcb) {
         super(pid);
         this.threadId = tid;
         updateAttributes(procName, pcb);
@@ -53,7 +55,7 @@ public abstract class WindowsOSThread extends AbstractOSThread {
      * @param pcb      the thread performance counter block, or null if unavailable
      * @return true if the thread is valid after the update
      */
-    protected boolean updateAttributes(String procName, ThreadPerfCounterBlock pcb) {
+    protected boolean updateAttributes(@Nullable String procName, @Nullable ThreadPerfCounterBlock pcb) {
         if (pcb == null) {
             this.state = INVALID;
             return false;

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOperatingSystem.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOperatingSystem.java
@@ -52,16 +52,16 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
     /*
      * Cache full process stats queries. The second query only populates if the first one returns nothing.
      */
-    private final Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromRegistry = memoize(
+    private final Supplier<@Nullable Map<Integer, ProcessPerfCounterBlock>> processMapFromRegistry = memoize(
             () -> buildProcessMapFromRegistry(null), defaultExpiration());
-    private final Supplier<Map<Integer, ProcessPerfCounterBlock>> processMapFromPerfCounters = memoize(
+    private final Supplier<@Nullable Map<Integer, ProcessPerfCounterBlock>> processMapFromPerfCounters = memoize(
             () -> buildProcessMapFromPerfCounters(null), defaultExpiration());
     /*
      * Cache full thread stats queries. Only used if USE_PROCSTATE_SUSPENDED is set true.
      */
-    private final Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromRegistry = memoize(
+    private final Supplier<@Nullable Map<Integer, ThreadPerfCounterBlock>> threadMapFromRegistry = memoize(
             () -> buildThreadMapFromRegistry(null), defaultExpiration());
-    private final Supplier<Map<Integer, ThreadPerfCounterBlock>> threadMapFromPerfCounters = memoize(
+    private final Supplier<@Nullable Map<Integer, ThreadPerfCounterBlock>> threadMapFromPerfCounters = memoize(
             () -> buildThreadMapFromPerfCounters(null), defaultExpiration());
 
     /**
@@ -70,7 +70,7 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
      * @return A map of process ID to performance counter block, or {@code null} if the registry data is unavailable
      */
-    protected abstract Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(
+    protected abstract @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(
             @Nullable Collection<Integer> pids);
 
     /**
@@ -79,7 +79,7 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
      * @return A map of process ID to performance counter block
      */
-    protected abstract Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
+    protected abstract @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
             @Nullable Collection<Integer> pids);
 
     /**
@@ -88,7 +88,7 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
      * @return A map of thread ID to performance counter block, or {@code null} if the registry data is unavailable
      */
-    protected abstract Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(
+    protected abstract @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(
             @Nullable Collection<Integer> pids);
 
     /**
@@ -97,7 +97,7 @@ public abstract class WindowsOperatingSystem extends AbstractOperatingSystem {
      * @param pids An optional collection of process IDs to filter the results to, or {@code null} for all processes
      * @return A map of thread ID to performance counter block
      */
-    protected abstract Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
+    protected abstract @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
             @Nullable Collection<Integer> pids);
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataFFM.java
@@ -39,7 +39,7 @@ public final class ProcessPerformanceDataFFM {
      *         counter information if successful, or null otherwise.
      */
     public static @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(
-            Collection<Integer> pids) {
+            @Nullable Collection<Integer> pids) {
         Triplet<List<Map<ProcessPerformanceProperty, Object>>, Long, Long> processData = null;
         if (PERFDATA) {
             processData = HkeyPerformanceDataUtilFFM.readPerfDataFromRegistry(ProcessPerformanceData.PROCESS,
@@ -56,7 +56,7 @@ public final class ProcessPerformanceDataFFM {
      *         counter information.
      */
     public static @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
-            Collection<Integer> pids) {
+            @Nullable Collection<Integer> pids) {
         if (PerfmonDisabledFFM.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessWtsDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessWtsDataFFM.java
@@ -4,8 +4,6 @@
  */
 package oshi.driver.windows.registry;
 
-import org.jspecify.annotations.Nullable;
-
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
@@ -32,6 +30,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessWtsDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ProcessWtsDataFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.driver.windows.registry;
 
+import org.jspecify.annotations.Nullable;
+
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
@@ -62,14 +64,14 @@ public final class ProcessWtsDataFFM {
      * @param pids An optional collection of process IDs to filter the list to. May be null for no filtering.
      * @return A map with Process ID as the key and a {@link WtsInfo} object populated with data.
      */
-    public static Map<Integer, WtsInfo> queryProcessWtsMap(Collection<Integer> pids) {
+    public static Map<Integer, WtsInfo> queryProcessWtsMap(@Nullable Collection<Integer> pids) {
         if (IS_WINDOWS7_OR_GREATER) {
             return queryProcessWtsMapFromWTS(pids);
         }
         return queryProcessWtsMapFromWMI(pids);
     }
 
-    private static Map<Integer, WtsInfo> queryProcessWtsMapFromWTS(Collection<Integer> pids) {
+    private static Map<Integer, WtsInfo> queryProcessWtsMapFromWTS(@Nullable Collection<Integer> pids) {
         Set<Integer> pidSet = pids != null ? new HashSet<>(pids) : null;
         Map<Integer, WtsInfo> wtsMap = new HashMap<>();
         return callInArenaOrDefault(arena -> {
@@ -113,7 +115,7 @@ public final class ProcessWtsDataFFM {
         }, LOG, ERROR, "Failed to enumerate Processes via WTS", wtsMap);
     }
 
-    static Map<Integer, WtsInfo> queryProcessWtsMapFromWMI(Collection<Integer> pids) {
+    static Map<Integer, WtsInfo> queryProcessWtsMapFromWMI(@Nullable Collection<Integer> pids) {
         Map<Integer, WtsInfo> wtsMap = new HashMap<>();
         WmiResult<ProcessXPProperty> processWmiResult = Win32ProcessFFM.queryProcesses(pids);
         for (int i = 0; i < processWmiResult.getResultCount(); i++) {

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataFFM.java
@@ -37,7 +37,8 @@ public final class ThreadPerformanceDataFFM {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information if successful, or null otherwise.
      */
-    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(
+            @Nullable Collection<Integer> pids) {
         Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtilFFM
                 .readPerfDataFromRegistry(ThreadPerformanceData.THREAD, ThreadPerformanceProperty.class);
         return ThreadPerformanceData.buildThreadMapFromRegistry(pids, threadData);

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataFFM.java
@@ -37,7 +37,7 @@ public final class ThreadPerformanceDataFFM {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information if successful, or null otherwise.
      */
-    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
         Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtilFFM
                 .readPerfDataFromRegistry(ThreadPerformanceData.THREAD, ThreadPerformanceProperty.class);
         return ThreadPerformanceData.buildThreadMapFromRegistry(pids, threadData);
@@ -51,7 +51,7 @@ public final class ThreadPerformanceDataFFM {
      *         counter information.
      */
     public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
-            Collection<Integer> pids) {
+            @Nullable Collection<Integer> pids) {
         return buildThreadMapFromPerfCounters(pids, null, -1);
     }
 
@@ -65,7 +65,7 @@ public final class ThreadPerformanceDataFFM {
      *         counter information.
      */
     public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
-            Collection<Integer> pids, @Nullable String procName, int threadNum) {
+            @Nullable Collection<Integer> pids, @Nullable String procName, int threadNum) {
         if (PerfmonDisabledFFM.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/wmi/Win32LogicalDiskFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/wmi/Win32LogicalDiskFFM.java
@@ -4,9 +4,9 @@
  */
 package oshi.driver.windows.wmi;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.wmi.Win32LogicalDisk;

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/wmi/Win32LogicalDiskFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/wmi/Win32LogicalDiskFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.driver.windows.wmi;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -17,7 +19,7 @@ public final class Win32LogicalDiskFFM extends Win32LogicalDisk {
     private Win32LogicalDiskFFM() {
     }
 
-    public static WmiResult<LogicalDiskProperty> queryLogicalDisk(String nameToMatch, boolean localOnly) {
+    public static WmiResult<LogicalDiskProperty> queryLogicalDisk(@Nullable String nameToMatch, boolean localOnly) {
         return Win32LogicalDisk.queryLogicalDisk(Objects.requireNonNull(WmiQueryExecutorFFM.createInstance()),
                 nameToMatch, localOnly);
     }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -4,8 +4,6 @@
  */
 package oshi.software.os.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
@@ -23,6 +21,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.perfmon.ProcessInformation.HandleCountProperty;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsFileSystemFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.software.os.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import static java.lang.foreign.MemorySegment.NULL;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
@@ -141,7 +143,7 @@ public class WindowsFileSystemFFM extends WindowsFileSystem {
      * @param volumeToMatch an optional string to filter match, null otherwise
      * @return A list of {@link OSFileStore} objects representing all local mounted volumes
      */
-    static List<OSFileStore> getLocalVolumes(String volumeToMatch) {
+    static List<OSFileStore> getLocalVolumes(@Nullable String volumeToMatch) {
         List<OSFileStore> fs = new ArrayList<>();
 
         try (Arena arena = Arena.ofConfined()) {
@@ -260,7 +262,7 @@ public class WindowsFileSystemFFM extends WindowsFileSystem {
      * @param localOnly   whether to only search local drives
      * @return A list of {@link OSFileStore} objects representing all WMI volumes
      */
-    static List<OSFileStore> getWmiVolumes(String nameToMatch, boolean localOnly) {
+    static List<OSFileStore> getWmiVolumes(@Nullable String nameToMatch, boolean localOnly) {
         List<OSFileStore> fs = new ArrayList<>();
         var drives = Win32LogicalDiskFFM.queryLogicalDisk(nameToMatch, localOnly);
 

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -79,7 +79,7 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
     private static final boolean IS_WINDOWS7_OR_GREATER = VersionHelpersFFM.IsWindows7OrGreater();
 
     public WindowsOSProcessFFM(int pid, WindowsOperatingSystemFFM os, Map<Integer, ProcessPerfCounterBlock> processMap,
-            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
+            Map<Integer, WtsInfo> processWtsMap, @Nullable Map<Integer, ThreadPerfCounterBlock> threadMap) {
         super(pid, os, processMap, processWtsMap, threadMap);
     }
 
@@ -156,7 +156,7 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
     }
 
     @Override
-    protected Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
         Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataFFM.buildThreadMapFromRegistry(pids);
         if (threads == null || threads.isEmpty()) {
             threads = ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
@@ -230,7 +230,7 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
         return pair != null ? pair : defaultPair();
     }
 
-    private Pair<String, String> getTokenAccountInfo(MemorySegment hToken, int tokenInfoClass, Arena arena)
+    private @Nullable Pair<String, String> getTokenAccountInfo(MemorySegment hToken, int tokenInfoClass, Arena arena)
             throws Throwable {
         MemorySegment returnLength = arena.allocate(JAVA_INT);
         Advapi32FFM.GetTokenInformation(hToken, tokenInfoClass, MemorySegment.NULL, 0, returnLength);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSThreadFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSThreadFFM.java
@@ -4,11 +4,11 @@
  */
 package oshi.software.os.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSThreadFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSThreadFFM.java
@@ -4,6 +4,8 @@
  */
 package oshi.software.os.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -18,7 +20,7 @@ import oshi.driver.windows.registry.ThreadPerformanceDataFFM;
 @ThreadSafe
 public class WindowsOSThreadFFM extends oshi.software.common.os.windows.WindowsOSThread {
 
-    public WindowsOSThreadFFM(int pid, int tid, String procName, ThreadPerfCounterBlock pcb) {
+    public WindowsOSThreadFFM(int pid, int tid, @Nullable String procName, @Nullable ThreadPerfCounterBlock pcb) {
         super(pid, tid, procName, pcb);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -265,7 +265,8 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     }
 
     @Override
-    protected @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(
+            @Nullable Collection<Integer> pids) {
         return ProcessPerformanceDataFFM.buildProcessMapFromRegistry(pids);
     }
 
@@ -276,12 +277,14 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     }
 
     @Override
-    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(
+            @Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataFFM.buildThreadMapFromRegistry(pids);
     }
 
     @Override
-    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
+            @Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -265,23 +265,23 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     }
 
     @Override
-    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(@Nullable Collection<Integer> pids) {
         return ProcessPerformanceDataFFM.buildProcessMapFromRegistry(pids);
     }
 
     @Override
-    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
+    protected @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
             @Nullable Collection<Integer> pids) {
         return ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(pids);
     }
 
     @Override
-    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataFFM.buildThreadMapFromRegistry(pids);
     }
 
     @Override
-    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(@Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids);
     }
 

--- a/oshi-core-ffm/src/test/java/oshi/software/os/windows/WindowsOperatingSystemFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/software/os/windows/WindowsOperatingSystemFFMTest.java
@@ -4,8 +4,6 @@
  */
 package oshi.software.os.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -15,6 +13,7 @@ import static org.hamcrest.Matchers.oneOf;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.EnabledOnOs;

--- a/oshi-core-ffm/src/test/java/oshi/software/os/windows/WindowsOperatingSystemFFMTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/software/os/windows/WindowsOperatingSystemFFMTest.java
@@ -4,6 +4,8 @@
  */
 package oshi.software.os.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -84,11 +86,11 @@ class WindowsOperatingSystemFFMTest {
             return queryDescendantProcesses(parentPid);
         }
 
-        private Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCountersForTest() {
+        private @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCountersForTest() {
             return buildProcessMapFromPerfCounters(null);
         }
 
-        private Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCountersForTest() {
+        private @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCountersForTest() {
             return buildThreadMapFromPerfCounters(null);
         }
 

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessPerformanceDataJNA.java
@@ -39,7 +39,7 @@ public final class ProcessPerformanceDataJNA {
      *         counter information if successful, or null otherwise.
      */
     public static @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(
-            Collection<Integer> pids) {
+            @Nullable Collection<Integer> pids) {
         Triplet<List<Map<ProcessPerformanceProperty, Object>>, Long, Long> processData = null;
         if (PERFDATA) {
             processData = HkeyPerformanceDataUtilJNA.readPerfDataFromRegistry(ProcessPerformanceData.PROCESS,
@@ -56,7 +56,7 @@ public final class ProcessPerformanceDataJNA {
      *         counter information.
      */
     public static @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
-            Collection<Integer> pids) {
+            @Nullable Collection<Integer> pids) {
         if (PerfmonDisabled.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessWtsData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessWtsData.java
@@ -4,6 +4,8 @@
  */
 package oshi.driver.windows.registry;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +49,7 @@ public final class ProcessWtsData {
      * @param pids An optional collection of process IDs to filter the list to. May be null for no filtering.
      * @return A map with Process ID as the key and a {@link WtsInfo} object populated with data.
      */
-    public static Map<Integer, WtsInfo> queryProcessWtsMap(Collection<Integer> pids) {
+    public static Map<Integer, WtsInfo> queryProcessWtsMap(@Nullable Collection<Integer> pids) {
         if (IS_WINDOWS7_OR_GREATER) {
             // Get processes from WTS
             return queryProcessWtsMapFromWTS(pids);
@@ -57,7 +59,7 @@ public final class ProcessWtsData {
         return queryProcessWtsMapFromPerfMon(pids);
     }
 
-    private static Map<Integer, WtsInfo> queryProcessWtsMapFromWTS(Collection<Integer> pids) {
+    private static Map<Integer, WtsInfo> queryProcessWtsMapFromWTS(@Nullable Collection<Integer> pids) {
         Map<Integer, WtsInfo> wtsMap = new HashMap<>();
         try (CloseableIntByReference pCount = new CloseableIntByReference(0);
                 CloseablePointerByReference ppProcessInfo = new CloseablePointerByReference();
@@ -91,7 +93,7 @@ public final class ProcessWtsData {
         return wtsMap;
     }
 
-    static Map<Integer, WtsInfo> queryProcessWtsMapFromPerfMon(Collection<Integer> pids) {
+    static Map<Integer, WtsInfo> queryProcessWtsMapFromPerfMon(@Nullable Collection<Integer> pids) {
         Map<Integer, WtsInfo> wtsMap = new HashMap<>();
         WmiResult<ProcessXPProperty> processWmiResult = Win32Process
                 .queryProcesses(Objects.requireNonNull(WmiQueryExecutorJNA.createInstance()), pids);

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessWtsData.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ProcessWtsData.java
@@ -4,13 +4,12 @@
  */
 package oshi.driver.windows.registry;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataJNA.java
@@ -36,7 +36,8 @@ public final class ThreadPerformanceDataJNA {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information if successful, or null otherwise.
      */
-    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(
+            @Nullable Collection<Integer> pids) {
         Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtilJNA
                 .readPerfDataFromRegistry(ThreadPerformanceData.THREAD, ThreadPerformanceProperty.class);
         return ThreadPerformanceData.buildThreadMapFromRegistry(pids, threadData);

--- a/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/registry/ThreadPerformanceDataJNA.java
@@ -36,7 +36,7 @@ public final class ThreadPerformanceDataJNA {
      * @return A map with Thread ID as the key and a {@link ThreadPerfCounterBlock} object populated with performance
      *         counter information if successful, or null otherwise.
      */
-    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(Collection<Integer> pids) {
+    public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
         Triplet<List<Map<ThreadPerformanceProperty, Object>>, Long, Long> threadData = HkeyPerformanceDataUtilJNA
                 .readPerfDataFromRegistry(ThreadPerformanceData.THREAD, ThreadPerformanceProperty.class);
         return ThreadPerformanceData.buildThreadMapFromRegistry(pids, threadData);
@@ -50,7 +50,7 @@ public final class ThreadPerformanceDataJNA {
      *         counter information.
      */
     public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
-            Collection<Integer> pids) {
+            @Nullable Collection<Integer> pids) {
         return buildThreadMapFromPerfCounters(pids, null, -1);
     }
 
@@ -64,7 +64,7 @@ public final class ThreadPerformanceDataJNA {
      *         counter information.
      */
     public static @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
-            Collection<Integer> pids, @Nullable String procName, int threadNum) {
+            @Nullable Collection<Integer> pids, @Nullable String procName, int threadNum) {
         if (PerfmonDisabled.PERF_PROC_DISABLED) {
             return Collections.emptyMap();
         }

--- a/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32LogicalDiskJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32LogicalDiskJNA.java
@@ -4,9 +4,9 @@
  */
 package oshi.driver.windows.wmi;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.wmi.Win32LogicalDisk;

--- a/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32LogicalDiskJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/windows/wmi/Win32LogicalDiskJNA.java
@@ -4,6 +4,8 @@
  */
 package oshi.driver.windows.wmi;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -17,7 +19,7 @@ public final class Win32LogicalDiskJNA extends Win32LogicalDisk {
     private Win32LogicalDiskJNA() {
     }
 
-    public static WmiResult<LogicalDiskProperty> queryLogicalDisk(String nameToMatch, boolean localOnly) {
+    public static WmiResult<LogicalDiskProperty> queryLogicalDisk(@Nullable String nameToMatch, boolean localOnly) {
         return Win32LogicalDisk.queryLogicalDisk(Objects.requireNonNull(WmiQueryExecutorJNA.createInstance()),
                 nameToMatch, localOnly);
     }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
@@ -4,6 +4,8 @@
  */
 package oshi.software.os.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -129,7 +131,7 @@ public class WindowsFileSystemJNA extends WindowsFileSystem {
      * @param volumeToMatch an optional string to filter match, null otherwise
      * @return A list of {@link OSFileStore} objects representing all local mounted volumes
      */
-    static List<OSFileStore> getLocalVolumes(String volumeToMatch) {
+    static List<OSFileStore> getLocalVolumes(@Nullable String volumeToMatch) {
         List<OSFileStore> fs;
         String volume;
         String strFsType;
@@ -216,7 +218,7 @@ public class WindowsFileSystemJNA extends WindowsFileSystem {
      * @param localOnly   Whether to only search local drives
      * @return A list of {@link OSFileStore} objects representing all network mounted volumes
      */
-    static List<OSFileStore> getWmiVolumes(String nameToMatch, boolean localOnly) {
+    static List<OSFileStore> getWmiVolumes(@Nullable String nameToMatch, boolean localOnly) {
         long free;
         long total;
         List<OSFileStore> fs = new ArrayList<>();

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsFileSystemJNA.java
@@ -4,14 +4,14 @@
  */
 package oshi.software.os.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
 
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.Kernel32;

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
@@ -64,7 +64,7 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
     private static final boolean IS_WINDOWS7_OR_GREATER = VersionHelpers.IsWindows7OrGreater();
 
     public WindowsOSProcessJNA(int pid, WindowsOperatingSystemJNA os, Map<Integer, ProcessPerfCounterBlock> processMap,
-            Map<Integer, WtsInfo> processWtsMap, Map<Integer, ThreadPerfCounterBlock> threadMap) {
+            Map<Integer, WtsInfo> processWtsMap, @Nullable Map<Integer, ThreadPerfCounterBlock> threadMap) {
         super(pid, os, processMap, processWtsMap, threadMap);
     }
 
@@ -143,7 +143,7 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
     }
 
     @Override
-    protected Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
         Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataJNA.buildThreadMapFromRegistry(pids);
         if (threads == null || threads.isEmpty()) {
             threads = ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids, this.getName(), -1);

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThreadJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThreadJNA.java
@@ -4,11 +4,11 @@
  */
 package oshi.software.os.windows;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.windows.registry.ThreadPerfCounterBlock;

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThreadJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSThreadJNA.java
@@ -4,6 +4,8 @@
  */
 package oshi.software.os.windows;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -18,7 +20,7 @@ import oshi.driver.windows.registry.ThreadPerformanceDataJNA;
 @ThreadSafe
 public class WindowsOSThreadJNA extends oshi.software.common.os.windows.WindowsOSThread {
 
-    public WindowsOSThreadJNA(int pid, int tid, String procName, ThreadPerfCounterBlock pcb) {
+    public WindowsOSThreadJNA(int pid, int tid, @Nullable String procName, @Nullable ThreadPerfCounterBlock pcb) {
         super(pid, tid, procName, pcb);
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
@@ -91,7 +91,7 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
     /*
      * Windows event log name
      */
-    private static final Supplier<String> SYSTEM_LOG = memoize(WindowsOperatingSystemJNA::querySystemLog,
+    private static final Supplier<@Nullable String> SYSTEM_LOG = memoize(WindowsOperatingSystemJNA::querySystemLog,
             TimeUnit.HOURS.toNanos(1));
 
     private static final long BOOTTIME = querySystemBootTime();

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
@@ -110,7 +110,8 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
             .memoize(WindowsInstalledAppsJNA::queryInstalledApps, installedAppsExpiration());
 
     @Override
-    protected @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(
+            @Nullable Collection<Integer> pids) {
         return ProcessPerformanceDataJNA.buildProcessMapFromRegistry(pids);
     }
 
@@ -121,12 +122,14 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
     }
 
     @Override
-    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(
+            @Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataJNA.buildThreadMapFromRegistry(pids);
     }
 
     @Override
-    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(
+            @Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids);
     }
 

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOperatingSystemJNA.java
@@ -110,23 +110,23 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
             .memoize(WindowsInstalledAppsJNA::queryInstalledApps, installedAppsExpiration());
 
     @Override
-    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromRegistry(@Nullable Collection<Integer> pids) {
         return ProcessPerformanceDataJNA.buildProcessMapFromRegistry(pids);
     }
 
     @Override
-    protected Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
+    protected @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCounters(
             @Nullable Collection<Integer> pids) {
         return ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(pids);
     }
 
     @Override
-    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromRegistry(@Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataJNA.buildThreadMapFromRegistry(pids);
     }
 
     @Override
-    protected Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(@Nullable Collection<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCounters(@Nullable Collection<Integer> pids) {
         return ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids);
     }
 
@@ -377,7 +377,7 @@ public class WindowsOperatingSystemJNA extends WindowsOperatingSystem {
         }
     }
 
-    private static String querySystemLog() {
+    private static @Nullable String querySystemLog() {
         String systemLog = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_EVENTLOG, "System");
         if (systemLog.isEmpty()) {
             // Use faster boot time approximation


### PR DESCRIPTION
Fifth step of draining `oshi-core` and `oshi-core-ffm`, and the last of the Windows groups. Covers
the operating-system layer and the drivers it reads through. **Reactor findings 253 → 216.**

The other half of this work is #3629, the Windows hardware layer. They were 36 files measured
together, past the size worth reviewing in one go. They touch disjoint files, and this branch is cut
directly from `master` rather than stacked on #3629 — each was built and gated on its own, so they
can land in either order. Applied together they take the reactor to 197 and Windows to zero.

### The four performance-map methods

`WindowsOperatingSystem`'s process and thread map builders are documented as returning `null` when
the registry data is unavailable — that null is exactly what drives the fallback to performance
counters — but were declared non-null. The abstract declarations, the eight implementations behind
them, and the memoized suppliers holding their results now agree with the javadoc and with the
caller, which has always tested for both null and empty:

```java
if (processMap == null || processMap.isEmpty()) {
    processMap = ... buildProcessMapFromPerfCounters(pids);
}
```

### The same, one level down

The process and thread map builders, the WTS map query, and the logical-disk query each take an
optional filter whose null means "everything", and each already branches on it. `WindowsOSProcess`
takes a thread map that is absent until the thread details are queried, and `WindowsOSThread` a
process name and counter block that are absent for a thread constructed before its first update —
both are passed null by existing callers.

`querySystemLog` returns null when the configured event log cannot be opened, and the FFM
token-account helper when the token holds no SID; both callers fall back on it.

### No behavior change

No CHANGELOG entry. Verified by diffing against master and cancelling every line whose only
difference is an annotation: **all twenty-one files have zero residue** — this half is annotations
and nothing else.

Verified with the full gate on macOS: `spotless:apply sortpom:sort checkstyle:check install
forbiddenapis:check javadoc:javadoc` plus `-Perror-prone clean install`, on this branch cut from
master so the commit is measured on its own. All modules green, 1561 tests, 0 failures. This is
Windows code, so nothing here is verified beyond compilation and CI.

Part of #3593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded nullability annotations across Windows process, thread, disk, filesystem, and performance-data APIs.
  * Clarified which optional filters, inputs, parameters, and results may be absent across supported Windows integrations.
* **Bug Fixes**
  * Improved static analysis and API safety when handling missing Windows performance data and optional values.
  * Behavior remains unchanged; annotations better reflect existing runtime handling across native-access implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->