### PR TITLE
Make the macOS native utilities' nullability contracts honest

### DIFF
--- a/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/mac/IOReportClientFFM.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,8 +52,8 @@ public final class IOReportClientFFM implements IOReportSampler {
     private final MemorySegment subscription;
     private final MemorySegment subscribedChannels;
 
-    private MemorySegment prevSampleUtil;
-    private MemorySegment prevSamplePower;
+    private @Nullable MemorySegment prevSampleUtil;
+    private @Nullable MemorySegment prevSamplePower;
     private long prevSamplePowerNanos;
 
     private boolean closed;
@@ -67,7 +68,7 @@ public final class IOReportClientFFM implements IOReportSampler {
      *
      * @return a new client, or {@code null} if IOReport is unavailable or subscription fails
      */
-    public static IOReportClientFFM create() {
+    public static @Nullable IOReportClientFFM create() {
         if (!IOReportFunctions.isAvailable()) {
             return null;
         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/CFUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/CFUtilFFM.java
@@ -6,6 +6,8 @@ package oshi.ffm.util.platform.mac;
 
 import java.lang.foreign.MemorySegment;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.mac.CoreFoundation.CFDictionaryRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFNumberRef;
@@ -69,7 +71,7 @@ public final class CFUtilFFM {
      * @param key  the string key to look up
      * @return the value as a {@link CFDictionaryRef}, or {@code null} if the key is absent
      */
-    public static CFDictionaryRef getDictionary(CFDictionaryRef dict, String key) {
+    public static @Nullable CFDictionaryRef getDictionary(CFDictionaryRef dict, String key) {
         try (CFStringRef k = CFStringRef.createCFString(key)) {
             MemorySegment v = dict.getValue(k);
             return v == null || v.equals(MemorySegment.NULL) ? null : new CFDictionaryRef(v);
@@ -85,7 +87,7 @@ public final class CFUtilFFM {
      * @param key  the string key to look up
      * @return the value as a {@link String}, or {@code null} if the key is absent
      */
-    public static String getString(CFDictionaryRef dict, String key) {
+    public static @Nullable String getString(CFDictionaryRef dict, String key) {
         try (CFStringRef k = CFStringRef.createCFString(key)) {
             MemorySegment v = dict.getValue(k);
             return v == null || v.equals(MemorySegment.NULL) ? null : CFStringRef.stringValue(v);
@@ -102,7 +104,7 @@ public final class CFUtilFFM {
      * @param key  the string key to look up
      * @return the value as a {@link Long}, or {@code null} if the key is absent
      */
-    public static Long getLong(CFDictionaryRef dict, String key) {
+    public static @Nullable Long getLong(CFDictionaryRef dict, String key) {
         try (CFStringRef k = CFStringRef.createCFString(key)) {
             MemorySegment v = dict.getValue(k);
             return v == null || v.equals(MemorySegment.NULL) ? null : CFNumberRef.longValue(v);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/IOKitUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/IOKitUtilFFM.java
@@ -22,6 +22,7 @@ import static oshi.util.LogLevel.TRACE;
 
 import java.lang.foreign.MemorySegment;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +64,7 @@ public final class IOKitUtilFFM {
      *
      * @return a handle to the IORoot. Callers should release when finished.
      */
-    public static IORegistryEntry getRoot() {
+    public static @Nullable IORegistryEntry getRoot() {
         return getOrDefault(() -> {
             int masterPort = getMasterPort();
             MemorySegment root = IORegistryGetRootEntry(masterPort);
@@ -78,7 +79,7 @@ public final class IOKitUtilFFM {
      * @param serviceName The service name to match
      * @return a handle to an IOService if successful, {@code null} if failed. Callers should release when finished.
      */
-    public static IOService getMatchingService(String serviceName) {
+    public static @Nullable IOService getMatchingService(String serviceName) {
         return callInArenaOrDefault(arena -> {
             MemorySegment nameStr = arena.allocateFrom(serviceName);
             MemorySegment dict = IOServiceMatching(nameStr);
@@ -95,7 +96,7 @@ public final class IOKitUtilFFM {
      * @param matchingDictionary The dictionary to match. This method will consume a reference to the dictionary.
      * @return a handle to an IOService if successful, {@code null} if failed. Callers should release when finished.
      */
-    public static IOService getMatchingService(MemorySegment matchingDictionary) {
+    public static @Nullable IOService getMatchingService(MemorySegment matchingDictionary) {
         return getOrDefault(() -> {
             int masterPort = getMasterPort();
             MemorySegment service = IOServiceGetMatchingService(masterPort, matchingDictionary);
@@ -110,7 +111,7 @@ public final class IOKitUtilFFM {
      * @param serviceName The service name to match
      * @return a handle to an IOIterator if successful, {@code null} if failed. Callers should release when finished.
      */
-    public static IOIterator getMatchingServices(String serviceName) {
+    public static @Nullable IOIterator getMatchingServices(String serviceName) {
         return callInArenaOrDefault(arena -> {
             MemorySegment nameStr = arena.allocateFrom(serviceName);
             MemorySegment dict = IOServiceMatching(nameStr);
@@ -127,7 +128,7 @@ public final class IOKitUtilFFM {
      * @param matchingDictionary The dictionary to match. This method will consume a reference to the dictionary.
      * @return a handle to an IOIterator if successful, {@code null} if failed. Callers should release when finished.
      */
-    public static IOIterator getMatchingServices(MemorySegment matchingDictionary) {
+    public static @Nullable IOIterator getMatchingServices(MemorySegment matchingDictionary) {
         return callInArenaOrDefault(arena -> {
             int masterPort = getMasterPort();
             MemorySegment iteratorSeg = arena.allocate(ADDRESS);
@@ -151,7 +152,7 @@ public final class IOKitUtilFFM {
      * @param bsdName The bsd name of the registry entry
      * @return The dictionary ref if successful, {@code null} if failed. Callers should release when finished.
      */
-    public static MemorySegment getBSDNameMatchingDict(String bsdName) {
+    public static @Nullable MemorySegment getBSDNameMatchingDict(String bsdName) {
         return callInArenaOrDefault(arena -> {
             int masterPort = getMasterPort();
             MemorySegment bsdNameStr = arena.allocateFrom(bsdName);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/IOKitUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/IOKitUtilFFM.java
@@ -158,7 +158,7 @@ public final class IOKitUtilFFM {
             MemorySegment bsdNameStr = arena.allocateFrom(bsdName);
             MemorySegment result = IOBSDNameMatching(masterPort, 0, bsdNameStr);
             deallocatePort(masterPort);
-            return result;
+            return result.equals(MemorySegment.NULL) ? null : result;
         }, LOG, TRACE, "Failed to get BSD name matching dictionary", null);
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/mac/SmcUtilFFM.java
@@ -44,6 +44,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -282,7 +283,7 @@ public final class SmcUtilFFM {
      * @param index The index, from 0 to the value of {@link #SMC_KEY_COUNT}
      * @return The four-character key name, or null if it could not be read
      */
-    public static String smcReadKeyAtIndex(int conn, int index) {
+    public static @Nullable String smcReadKeyAtIndex(int conn, int index) {
         return callInArenaOrDefault(arena -> {
             MemorySegment input = arena.allocate(SMC_KEY_DATA);
             MemorySegment output = arena.allocate(SMC_KEY_DATA);
@@ -366,7 +367,7 @@ public final class SmcUtilFFM {
     /**
      * @return the keys to read, or null if neither the key index nor {@code FNum} could be read
      */
-    private static List<String> discoverFanSpeedKeys() {
+    private static @Nullable List<String> discoverFanSpeedKeys() {
         int conn = smcOpen();
         if (conn == 0) {
             return null; // NOSONAR java:S1168 - null means "could not read", which the caller must not cache
@@ -435,7 +436,7 @@ public final class SmcUtilFFM {
     /**
      * @return the discovered keys, or null if the SMC key index could not be read
      */
-    private static List<String> discoverGpuTemperatureKeys() {
+    private static @Nullable List<String> discoverGpuTemperatureKeys() {
         int conn = smcOpen();
         if (conn == 0) {
             return null; // NOSONAR java:S1168 - null means "could not read", which the caller must not cache

--- a/oshi-core/src/main/java/oshi/driver/mac/IOReportClient.java
+++ b/oshi-core/src/main/java/oshi/driver/mac/IOReportClient.java
@@ -8,6 +8,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.mac.CoreFoundation.CFArrayRef;
@@ -46,10 +48,10 @@ public final class IOReportClient implements IOReportSampler {
     private final CFDictionaryRef subscribedChannels;
 
     // Previous sample for utilization delta
-    private CFDictionaryRef prevSampleUtil;
+    private @Nullable CFDictionaryRef prevSampleUtil;
 
     // Previous sample and timestamp for power delta
-    private CFDictionaryRef prevSamplePower;
+    private @Nullable CFDictionaryRef prevSamplePower;
     private long prevSamplePowerNanos;
 
     private boolean closed;
@@ -66,7 +68,7 @@ public final class IOReportClient implements IOReportSampler {
      *
      * @return a new client, or {@code null} if IOReport is unavailable or subscription fails
      */
-    public static IOReportClient create() {
+    public static @Nullable IOReportClient create() {
         IOReport io;
         try {
             io = Native.load("IOReport", IOReport.class);

--- a/oshi-core/src/main/java/oshi/driver/mac/disk/Fsstat.java
+++ b/oshi-core/src/main/java/oshi/driver/mac/disk/Fsstat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The OSHI Project Contributors
+ * Copyright 2020-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.mac.disk;
@@ -7,6 +7,8 @@ package oshi.driver.mac.disk;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
 
 import com.sun.jna.Native;
 import com.sun.jna.platform.mac.SystemB;
@@ -48,7 +50,7 @@ public final class Fsstat {
         return mountPointMap;
     }
 
-    private static int queryFsstat(Statfs[] buf, int bufsize, int flags) {
+    private static int queryFsstat(Statfs @Nullable [] buf, int bufsize, int flags) {
         return SystemB.INSTANCE.getfsstat64(buf, bufsize, flags);
     }
 

--- a/oshi-core/src/main/java/oshi/util/platform/mac/CFUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/CFUtil.java
@@ -4,6 +4,8 @@
  */
 package oshi.util.platform.mac;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.mac.CoreFoundation;
 import com.sun.jna.platform.mac.CoreFoundation.CFDictionaryRef;
@@ -30,7 +32,7 @@ public final class CFUtil {
      * @param result Pointer to the CFString
      * @return a CFString or "unknown" if it has no value
      */
-    public static String cfPointerToString(Pointer result) {
+    public static String cfPointerToString(@Nullable Pointer result) {
         return cfPointerToString(result, true);
     }
 
@@ -41,7 +43,7 @@ public final class CFUtil {
      * @param returnUnknown Whether to return the "unknown" string
      * @return a CFString including a possible empty one if {@code returnUnknown} is false, or "unknown" if it is true
      */
-    public static String cfPointerToString(Pointer result, boolean returnUnknown) {
+    public static String cfPointerToString(@Nullable Pointer result, boolean returnUnknown) {
         String s = "";
         if (result != null) {
             CFStringRef cfs = new CFStringRef(result);
@@ -63,7 +65,7 @@ public final class CFUtil {
      * @param key  the string key to look up
      * @return the value as a {@link CFDictionaryRef}, or {@code null} if the key is absent
      */
-    public static CFDictionaryRef getDictionary(CFDictionaryRef dict, String key) {
+    public static @Nullable CFDictionaryRef getDictionary(CFDictionaryRef dict, String key) {
         CFStringRef k = CFStringRef.createCFString(key);
         try {
             Pointer v = CF.CFDictionaryGetValue(dict, k);
@@ -82,7 +84,7 @@ public final class CFUtil {
      * @param key  the string key to look up
      * @return the value as a {@link String}, or {@code null} if the key is absent
      */
-    public static String getString(CFDictionaryRef dict, String key) {
+    public static @Nullable String getString(CFDictionaryRef dict, String key) {
         CFStringRef k = CFStringRef.createCFString(key);
         try {
             Pointer v = CF.CFDictionaryGetValue(dict, k);
@@ -102,7 +104,7 @@ public final class CFUtil {
      * @param key  the string key to look up
      * @return the value as a {@link Long}, or {@code null} if the key is absent
      */
-    public static Long getLong(CFDictionaryRef dict, String key) {
+    public static @Nullable Long getLong(CFDictionaryRef dict, String key) {
         CFStringRef k = CFStringRef.createCFString(key);
         try {
             Pointer v = CF.CFDictionaryGetValue(dict, k);

--- a/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/mac/SmcUtil.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,7 +136,7 @@ public final class SmcUtil {
      *
      * @return The connection if successful, null if failure
      */
-    public static IOConnect smcOpen() {
+    public static @Nullable IOConnect smcOpen() {
         IOService smcService = IOKitUtil.getMatchingService("AppleSMC");
         if (smcService != null) {
             try (CloseablePointerByReference connPtr = new CloseablePointerByReference()) {
@@ -259,7 +260,7 @@ public final class SmcUtil {
      * @param index The index, from 0 to the value of {@link #SMC_KEY_COUNT}
      * @return The four-character key name, or null if it could not be read
      */
-    public static String smcReadKeyAtIndex(IOConnect conn, int index) {
+    public static @Nullable String smcReadKeyAtIndex(IOConnect conn, int index) {
         try (SMCKeyData input = new SMCKeyData(); SMCKeyData output = new SMCKeyData()) {
             input.data8 = SMC_CMD_READ_INDEX;
             input.data32 = index;
@@ -337,7 +338,7 @@ public final class SmcUtil {
     /**
      * @return the keys to read, or null if neither the key index nor {@code FNum} could be read
      */
-    private static List<String> discoverFanSpeedKeys() {
+    private static @Nullable List<String> discoverFanSpeedKeys() {
         IOConnect conn = smcOpen();
         if (conn == null) {
             return null; // NOSONAR java:S1168 - null means "could not read", which the caller must not cache
@@ -406,7 +407,7 @@ public final class SmcUtil {
     /**
      * @return the discovered keys, or null if the SMC key index could not be read
      */
-    private static List<String> discoverGpuTemperatureKeys() {
+    private static @Nullable List<String> discoverGpuTemperatureKeys() {
         IOConnect conn = smcOpen();
         if (conn == null) {
             return null; // NOSONAR java:S1168 - null means "could not read", which the caller must not cache


### PR DESCRIPTION
Sixth step of draining `oshi-core` and `oshi-core-ffm`, and the first macOS group. Covers the
CoreFoundation, IOKit, SMC and IOReport utilities and drivers in both implementations.
**Reactor findings 194 → 147.**

### Almost entirely documentation catching up with declarations

Every one of these is a lookup into a native registry or dictionary that reports "no such key", "no
such service" or "library unavailable" by returning null — and in nearly every case the javadoc
already said so:

- `CFUtil`'s dictionary readers: *"or `null` if the key is absent"*
- `IOKitUtilFFM`'s service and iterator lookups: *"`null` if failed"*
- `SmcUtil`'s key-index reader, and its fan-key and GPU-temperature-key discovery

The declarations now agree with the documentation. The two `IOReportClient` twins additionally hold
their previous power sample in a field that stays null until the first sample is taken — which is
exactly what the delta calculation tests for — and their factories return null when the IOReport
library cannot be loaded.

`CFUtil.cfPointerToString` takes a `@Nullable` pointer, which its own test already asserts: a null
pointer yields `Constants.UNKNOWN`, or an empty string when `returnUnknown` is false. `Fsstat`'s
buffer argument is null when `statfs` is being asked only for a count, which is how the first of its
two calls uses it.

### Verified at runtime, for once

Unlike every Windows PR in this series, this is code I can actually execute. Both backends were run
end to end on an M2 Max after the change and agree:

```
JNA: Sensors: CPU Temperature=51.644737243652344C, Fan Speeds=[1343, 1536], CPU Voltage=0.0
FFM: Sensors: CPU Temperature=51.59991455078125C,  Fan Speeds=[1361, 1516], CPU Voltage=0.0
```

Same sensors, same shape, values differing only as live readings do between two samples. The SMC key
discovery this PR annotates is what produces those fan speeds, so it is exercised rather than merely
compiled. `CPU Voltage=0.0` is the known Apple Silicon behaviour, unchanged.

### No behavior change

No CHANGELOG entry. Verified by diffing against master and cancelling every line whose only
difference is an annotation: **all eight files have zero residue.**

Full gate on macOS: `spotless:apply sortpom:sort spotless:check checkstyle:check install
forbiddenapis:check javadoc:javadoc` plus `-Perror-prone clean install`. All modules green, 1561
tests, 0 failures.

Part of #3593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety documentation for macOS hardware and system monitoring APIs.
  * Clarified when system reports, CoreFoundation values, I/O services, and SMC sensor data may be unavailable.
  * No runtime behavior changes; developers receive clearer guidance for safely handling missing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->