### PR TITLE
Make the macOS hardware and operating-system layers' nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOKitProvider.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/IOKitProvider.java
@@ -23,7 +23,7 @@ public interface IOKitProvider {
      * @param extractor   function applied to the matched entry; receives a non-null {@link RegistryEntry}
      * @return the extracted value, or {@code null} if the service was not found
      */
-    <T extends @Nullable Object> T withMatchingService(String serviceName, Function<RegistryEntry, T> extractor);
+    <T> @Nullable T withMatchingService(String serviceName, Function<RegistryEntry, @Nullable T> extractor);
 
     /**
      * Iterates all IORegistry services matching a class name, invoking a consumer for each entry. Entries and the

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
@@ -157,7 +157,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
             byte[] data = entry.getByteArrayProperty("manufacturer");
             return data != null ? ParseUtil.decodeNulTerminated(data, StandardCharsets.UTF_8) : null;
         });
-        return Util.isBlank(manufacturer) ? "Apple Inc." : manufacturer;
+        return manufacturer == null || manufacturer.isEmpty() ? "Apple Inc." : manufacturer;
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGpuStats.java
@@ -100,7 +100,7 @@ public abstract class MacGpuStats implements GpuStats {
      * @param keys the keys to read
      * @return the requested keys that were present, or {@code null} if this card's statistics could not be read
      */
-    protected abstract Map<String, Long> queryPerfStats(String... keys);
+    protected abstract @Nullable Map<String, Long> queryPerfStats(String... keys);
 
     /**
      * Reads the GPU temperature from the SMC. Called only on Apple Silicon.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacHWDiskStore.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware.common.platform.mac;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.AbstractHWDiskStore;
 
@@ -46,7 +48,7 @@ public abstract class MacHWDiskStore extends AbstractHWDiskStore {
      *                   {@code null} if the property is absent
      * @return {@code "SSD"}, {@code "HDD"}, or {@code "Unknown"} if the medium type is absent or unrecognized
      */
-    protected static String parseMediumType(String mediumType) {
+    protected static String parseMediumType(@Nullable String mediumType) {
         if (mediumType != null) {
             if (mediumType.contains("Solid State") || mediumType.contains("SSD")) {
                 return "SSD";

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacUsbDevice.java
@@ -68,12 +68,14 @@ public final class MacUsbDevice extends AbstractUsbDevice {
          * @param plane the registry plane to search
          * @return the parent entry in the given plane, or {@code null} if none
          */
+        @Nullable
         RegistryEntry getParentEntry(String plane);
 
         /**
          * @param plane the registry plane to iterate
          * @return an iterator over child entries in the given plane, or {@code null} if none
          */
+        @Nullable
         RegistryIterator getChildIterator(String plane);
 
         /**
@@ -82,6 +84,7 @@ public final class MacUsbDevice extends AbstractUsbDevice {
          *
          * @return a two-element array {@code {vendorId, productId}}; either element may be {@code null} if not found
          */
+        @Nullable
         String[] lookupControllerVidPid();
 
         /**
@@ -102,6 +105,7 @@ public final class MacUsbDevice extends AbstractUsbDevice {
         /**
          * @return the next entry, or {@code null} when the iterator is exhausted
          */
+        @Nullable
         RegistryEntry next();
 
         /**
@@ -121,7 +125,7 @@ public final class MacUsbDevice extends AbstractUsbDevice {
      * @param root the IO registry root as a backend-neutral view, or {@code null} if unavailable
      * @return a list of USB controllers, each with its connected-device tree
      */
-    public static List<UsbDevice> getUsbDevices(RegistryEntry root) {
+    public static List<UsbDevice> getUsbDevices(@Nullable RegistryEntry root) {
         if (root == null) {
             return emptyList();
         }
@@ -157,12 +161,15 @@ public final class MacUsbDevice extends AbstractUsbDevice {
                         }
                         // The only controller info in the registry is its locationID; use it to find the matching PCI
                         // device and pull vendor/product IDs.
+                        @Nullable
                         String[] vidPid = controller.lookupControllerVidPid();
-                        if (vidPid[0] != null) {
-                            vendorIdMap.put(id, vidPid[0]);
+                        String controllerVendorId = vidPid[0];
+                        if (controllerVendorId != null) {
+                            vendorIdMap.put(id, controllerVendorId);
                         }
-                        if (vidPid[1] != null) {
-                            productIdMap.put(id, vidPid[1]);
+                        String controllerProductId = vidPid[1];
+                        if (controllerProductId != null) {
+                            productIdMap.put(id, controllerProductId);
                         }
                     }
                     controller.release();

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/IOKitProviderFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/IOKitProviderFFM.java
@@ -8,6 +8,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.ffm.platform.mac.IOKit.IOIterator;
 import oshi.ffm.platform.mac.IOKit.IORegistryEntry;
 import oshi.ffm.util.platform.mac.IOKitUtilFFM;
@@ -24,7 +26,7 @@ final class IOKitProviderFFM implements IOKitProvider {
     }
 
     @Override
-    public <T> T withMatchingService(String serviceName, Function<RegistryEntry, T> extractor) {
+    public <T> @Nullable T withMatchingService(String serviceName, Function<RegistryEntry, @Nullable T> extractor) {
         IORegistryEntry entry = IOKitUtilFFM.getMatchingService(serviceName);
         if (entry != null) {
             try (entry) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
@@ -10,6 +10,7 @@ import java.lang.foreign.ValueLayout;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +61,8 @@ final class MacDisplayFFM extends AbstractDisplay {
         return displays;
     }
 
-    private static List<Display> getDisplaysFromService(String serviceName, String edidKeyName, String childEntryName) {
+    private static List<Display> getDisplaysFromService(String serviceName, String edidKeyName,
+            @Nullable String childEntryName) {
         List<Display> displays = new ArrayList<>();
         IOIterator serviceIterator = IOKitUtilFFM.getMatchingServices(serviceName);
         if (serviceIterator == null) {
@@ -159,7 +161,7 @@ final class MacDisplayFFM extends AbstractDisplay {
 
     // Maps an Apple Silicon DisplayAttributes dictionary onto a synthetic DisplayInfo via EdidUtil, enriched with
     // native resolution and device name from the framebuffer node and CoreGraphics.
-    private static DisplayInfo synthesize(IORegistryEntry fb, CFDictionaryRef attrs) {
+    private static @Nullable DisplayInfo synthesize(IORegistryEntry fb, CFDictionaryRef attrs) {
         CFDictionaryRef product = CFUtilFFM.getDictionary(attrs, "ProductAttributes");
         if (product == null) {
             return null;
@@ -232,7 +234,7 @@ final class MacDisplayFFM extends AbstractDisplay {
     }
 
     // Returns the NSScreen.localizedName for the given CGDirectDisplayID, or null.
-    private static String getLocalizedDisplayName(int targetDisplayId) {
+    private static @Nullable String getLocalizedDisplayName(int targetDisplayId) {
         return ExceptionUtil.getOrDefault(() -> {
             try (Arena arena = Arena.ofConfined()) {
                 // Autorelease pool is thread-local; concurrent callers each get their own pool
@@ -246,7 +248,7 @@ final class MacDisplayFFM extends AbstractDisplay {
         }, null, LOG, "Failed to get localized display name");
     }
 
-    private static String queryLocalizedDisplayName(Arena arena, int targetDisplayId) throws Throwable {
+    private static @Nullable String queryLocalizedDisplayName(Arena arena, int targetDisplayId) throws Throwable {
         MemorySegment nsScreenClass = ObjCFunctions.objc_getClass(arena.allocateFrom("NSScreen"));
         if (nsScreenClass.address() == 0) {
             return null;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacGpuStatsFFM.java
@@ -8,6 +8,7 @@ import java.lang.foreign.MemorySegment;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,7 @@ final class MacGpuStatsFFM extends MacGpuStats {
     }
 
     @Override
-    protected Map<String, Long> queryPerfStats(String... keys) {
+    protected @Nullable Map<String, Long> queryPerfStats(String... keys) {
         CFMutableDictionaryRef perfStats = openPerfStats();
         if (perfStats == null) {
             return null; // NOSONAR java:S1168 - null and empty are different answers; see the superclass javadoc
@@ -79,7 +80,7 @@ final class MacGpuStatsFFM extends MacGpuStats {
      * @return the retained dictionary, which the caller must close, or {@code null} if this card has no accelerator
      *         entry
      */
-    private CFMutableDictionaryRef openPerfStats() {
+    private @Nullable CFMutableDictionaryRef openPerfStats() {
         IOIterator iter = IOKitUtilFFM.getMatchingServices("IOAccelerator");
         if (iter == null) {
             return null;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -16,6 +16,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -400,7 +401,7 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
      * @param media the IOMedia registry entry
      * @return the {@code Medium Type} string, or {@code null} if any step of the traversal finds nothing
      */
-    private static String queryMediumType(IORegistryEntry media) {
+    private static @Nullable String queryMediumType(IORegistryEntry media) {
         // Traverse up: IOMedia -> IOBlockStorageDriver -> IOBlockStorageDevice
         IORegistryEntry driver = media.getParentEntry("IOService");
         if (driver == null) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacPowerSourceFFM.java
@@ -14,6 +14,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.mac.CoreFoundation.CFArrayRef;
 import oshi.ffm.platform.mac.CoreFoundation.CFBooleanRef;
@@ -35,7 +37,7 @@ public final class MacPowerSourceFFM extends MacPowerSource {
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
             CapacityUnits psCapacityUnits, int psCurrentCapacity, int psMaxCapacity, int psDesignCapacity,
-            int psCycleCount, String psChemistry, LocalDate psManufactureDate, String psManufacturer,
+            int psCycleCount, String psChemistry, @Nullable LocalDate psManufactureDate, String psManufacturer,
             String psSerialNumber, double psTemperature) {
         super(psName, psDeviceName, psRemainingCapacityPercent, psTimeRemainingEstimated, psTimeRemainingInstant,
                 psPowerUsageRate, psVoltage, psAmperage, psPowerOnLine, psCharging, psDischarging, psCapacityUnits,

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceFFM.java
@@ -10,6 +10,7 @@ import java.lang.foreign.MemorySegment;
 import java.util.List;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,19 +78,19 @@ public final class MacUsbDeviceFFM {
         }
 
         @Override
-        public MacUsbDevice.RegistryEntry getParentEntry(String plane) {
+        public MacUsbDevice.@Nullable RegistryEntry getParentEntry(String plane) {
             IORegistryEntry parent = entry.getParentEntry(plane);
             return parent == null ? null : new FfmRegistryEntry(parent);
         }
 
         @Override
-        public MacUsbDevice.RegistryIterator getChildIterator(String plane) {
+        public MacUsbDevice.@Nullable RegistryIterator getChildIterator(String plane) {
             IOIterator iter = entry.getChildIterator(plane);
             return iter == null ? null : new FfmRegistryIterator(iter);
         }
 
         @Override
-        public String[] lookupControllerVidPid() {
+        public @Nullable String[] lookupControllerVidPid() {
             String[] result = new String[2];
             CFStringRef locationIDKey = CFStringRef.createCFString("locationID");
             CFStringRef ioPropertyMatchKey = CFStringRef.createCFString("IOPropertyMatch");
@@ -125,7 +126,7 @@ public final class MacUsbDeviceFFM {
          * @param serviceIterator the iterator of matching services, or {@code null}
          * @param result          the two-element {@code {vendorId, productId}} array to populate
          */
-        private static void readVidPid(IOIterator serviceIterator, String[] result) {
+        private static void readVidPid(@Nullable IOIterator serviceIterator, @Nullable String[] result) {
             if (serviceIterator == null) {
                 return;
             }
@@ -171,7 +172,7 @@ public final class MacUsbDeviceFFM {
         }
 
         @Override
-        public MacUsbDevice.RegistryEntry next() {
+        public MacUsbDevice.@Nullable RegistryEntry next() {
             IORegistryEntry next = iter.next();
             return next == null ? null : new FfmRegistryEntry(next);
         }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacFileSystemFFM.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +65,7 @@ public class MacFileSystemFFM extends MacFileSystem {
     }
 
     // Called by MacOSFileStore
-    static List<OSFileStore> getFileStoreMatching(String nameToMatch, boolean localOnly) {
+    static List<OSFileStore> getFileStoreMatching(@Nullable String nameToMatch, boolean localOnly) {
         List<OSFileStore> fsList = new ArrayList<>();
         return callInArenaOrDefault(arena -> {
             // Use getfsstat to find fileSystems

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
@@ -50,6 +50,7 @@ import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,7 +125,7 @@ public class MacInternetProtocolStatsFFM extends MacInternetProtocolStats {
         }, fdList, LOG, TRACE, "Failed to query file descriptor list");
     }
 
-    private static IPConnection queryIPConnection(int pid, int fd, Arena arena) {
+    private static @Nullable IPConnection queryIPConnection(int pid, int fd, Arena arena) {
         return getOrDefault(() -> {
             MemorySegment socketInfo = arena.allocate(SOCKET_FD_INFO);
             int ret = proc_pidfdinfo(pid, fd, PROC_PIDFDSOCKETINFO, socketInfo, (int) SOCKET_FD_INFO.byteSize());

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOperatingSystemFFM.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,7 +118,7 @@ public class MacOperatingSystemFFM extends MacOperatingSystem {
     }
 
     @Override
-    public OSProcess getProcess(int pid) {
+    public @Nullable OSProcess getProcess(int pid) {
         OSProcess proc = new MacOSProcessFFM(pid, this.major, this.minor, this);
         return proc.getState().equals(State.INVALID) ? null : proc;
     }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/IOKitProviderJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/IOKitProviderJNA.java
@@ -8,6 +8,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.platform.mac.IOKit.IOIterator;
 import com.sun.jna.platform.mac.IOKit.IORegistryEntry;
 import com.sun.jna.platform.mac.IOKitUtil;
@@ -25,7 +27,7 @@ final class IOKitProviderJNA implements IOKitProvider {
     }
 
     @Override
-    public <T> T withMatchingService(String serviceName, Function<RegistryEntry, T> extractor) {
+    public <T> @Nullable T withMatchingService(String serviceName, Function<RegistryEntry, @Nullable T> extractor) {
         IORegistryEntry entry = IOKitUtil.getMatchingService(serviceName);
         if (entry != null) {
             try {

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
@@ -7,6 +7,7 @@ package oshi.hardware.platform.mac;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,7 +95,8 @@ final class MacDisplayJNA extends AbstractDisplay {
      * @param childEntryName The name of the child entry to search in, or null to search directly in the service
      * @return List of Display objects found using this service
      */
-    private static List<Display> getDisplaysFromService(String serviceName, String edidKeyName, String childEntryName) {
+    private static List<Display> getDisplaysFromService(String serviceName, String edidKeyName,
+            @Nullable String childEntryName) {
         List<Display> displays = new ArrayList<>();
 
         IOIterator serviceIterator = IOKitUtil.getMatchingServices(serviceName);
@@ -214,7 +216,7 @@ final class MacDisplayJNA extends AbstractDisplay {
 
     // Maps an Apple Silicon DisplayAttributes dictionary onto a synthetic DisplayInfo via EdidUtil, enriched with
     // native resolution and device name from the framebuffer node and CoreGraphics.
-    private static DisplayInfo synthesize(IORegistryEntry fb, CFDictionaryRef attrs) {
+    private static @Nullable DisplayInfo synthesize(IORegistryEntry fb, CFDictionaryRef attrs) {
         CFDictionaryRef product = CFUtil.getDictionary(attrs, "ProductAttributes");
         if (product == null) {
             return null;
@@ -280,7 +282,7 @@ final class MacDisplayJNA extends AbstractDisplay {
     }
 
     // Returns the NSScreen.localizedName for the given CGDirectDisplayID, or null.
-    private static String getLocalizedDisplayName(int targetDisplayId) {
+    private static @Nullable String getLocalizedDisplayName(int targetDisplayId) {
         return ExceptionUtil.getOrDefault(() -> {
             ObjCRuntime objc = ObjCRuntime.INSTANCE;
             // Autorelease pool is thread-local; concurrent callers each get their own pool
@@ -293,7 +295,7 @@ final class MacDisplayJNA extends AbstractDisplay {
         }, null, LOG, "Failed to get localized display name");
     }
 
-    private static String queryLocalizedDisplayName(ObjCRuntime objc, int targetDisplayId) {
+    private static @Nullable String queryLocalizedDisplayName(ObjCRuntime objc, int targetDisplayId) {
         Pointer nsScreenClass = objc.objc_getClass("NSScreen");
         if (nsScreenClass == null) {
             return null;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacGpuStatsJNA.java
@@ -7,6 +7,8 @@ package oshi.hardware.platform.mac;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.mac.CoreFoundation;
 import com.sun.jna.platform.mac.CoreFoundation.CFMutableDictionaryRef;
@@ -38,7 +40,7 @@ final class MacGpuStatsJNA extends MacGpuStats {
     }
 
     @Override
-    protected Map<String, Long> queryPerfStats(String... keys) {
+    protected @Nullable Map<String, Long> queryPerfStats(String... keys) {
         CFMutableDictionaryRef perfStats = openPerfStats();
         if (perfStats == null) {
             return null; // NOSONAR java:S1168 - null and empty are different answers; see the superclass javadoc
@@ -78,7 +80,7 @@ final class MacGpuStatsJNA extends MacGpuStats {
      * @return the retained dictionary, which the caller must release, or {@code null} if this card has no accelerator
      *         entry
      */
-    private CFMutableDictionaryRef openPerfStats() {
+    private @Nullable CFMutableDictionaryRef openPerfStats() {
         IOIterator iter = IOKitUtil.getMatchingServices("IOAccelerator");
         if (iter == null) {
             return null;

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -405,7 +406,7 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
      * @param media the IOMedia registry entry
      * @return the {@code Medium Type} string, or {@code null} if any step of the traversal finds nothing
      */
-    private static String queryMediumType(IORegistryEntry media) {
+    private static @Nullable String queryMediumType(IORegistryEntry media) {
         // Traverse up: IOMedia -> IOBlockStorageDriver -> IOBlockStorageDevice
         IORegistryEntry driver = media.getParentEntry("IOService");
         if (driver == null) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacPowerSourceJNA.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.mac.CoreFoundation;
 import com.sun.jna.platform.mac.CoreFoundation.CFArrayRef;
@@ -37,7 +39,7 @@ public final class MacPowerSourceJNA extends MacPowerSource {
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
             CapacityUnits psCapacityUnits, int psCurrentCapacity, int psMaxCapacity, int psDesignCapacity,
-            int psCycleCount, String psChemistry, LocalDate psManufactureDate, String psManufacturer,
+            int psCycleCount, String psChemistry, @Nullable LocalDate psManufactureDate, String psManufacturer,
             String psSerialNumber, double psTemperature) {
         super(psName, psDeviceName, psRemainingCapacityPercent, psTimeRemainingEstimated, psTimeRemainingInstant,
                 psPowerUsageRate, psVoltage, psAmperage, psPowerOnLine, psCharging, psDischarging, psCapacityUnits,

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacUsbDeviceJNA.java
@@ -7,6 +7,8 @@ package oshi.hardware.platform.mac;
 import java.util.List;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.platform.mac.CoreFoundation;
 import com.sun.jna.platform.mac.CoreFoundation.CFIndex;
 import com.sun.jna.platform.mac.CoreFoundation.CFMutableDictionaryRef;
@@ -73,19 +75,19 @@ public final class MacUsbDeviceJNA {
         }
 
         @Override
-        public MacUsbDevice.RegistryEntry getParentEntry(String plane) {
+        public MacUsbDevice.@Nullable RegistryEntry getParentEntry(String plane) {
             IORegistryEntry parent = entry.getParentEntry(plane);
             return parent == null ? null : new JnaRegistryEntry(parent);
         }
 
         @Override
-        public MacUsbDevice.RegistryIterator getChildIterator(String plane) {
+        public MacUsbDevice.@Nullable RegistryIterator getChildIterator(String plane) {
             IOIterator iter = entry.getChildIterator(plane);
             return iter == null ? null : new JnaRegistryIterator(iter);
         }
 
         @Override
-        public String[] lookupControllerVidPid() {
+        public @Nullable String[] lookupControllerVidPid() {
             String[] result = new String[2];
             CFStringRef locationIDKey = CFStringRef.createCFString("locationID");
             CFStringRef ioPropertyMatchKey = CFStringRef.createCFString("IOPropertyMatch");
@@ -168,7 +170,7 @@ public final class MacUsbDeviceJNA {
         }
 
         @Override
-        public MacUsbDevice.RegistryEntry next() {
+        public MacUsbDevice.@Nullable RegistryEntry next() {
             IORegistryEntry next = iter.next();
             return next == null ? null : new JnaRegistryEntry(next);
         }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacFileSystemJNA.java
@@ -12,6 +12,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +55,7 @@ public class MacFileSystemJNA extends MacFileSystem {
     }
 
     // Called by MacOSFileStoreJNA
-    static List<OSFileStore> getFileStoreMatching(String nameToMatch, boolean localOnly) {
+    static List<OSFileStore> getFileStoreMatching(@Nullable String nameToMatch, boolean localOnly) {
         List<OSFileStore> fsList = new ArrayList<>();
 
         // Use getfsstat to find fileSystems

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
@@ -18,6 +18,8 @@ import static oshi.software.os.InternetProtocolStats.TcpState.NONE;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.Memory;
 import com.sun.jna.platform.mac.SystemB.InSockInfo;
 import com.sun.jna.platform.mac.SystemB.ProcFdInfo;
@@ -78,7 +80,7 @@ public class MacInternetProtocolStatsJNA extends MacInternetProtocolStats {
         return fdList;
     }
 
-    private static IPConnection queryIPConnection(int pid, int fd) {
+    private static @Nullable IPConnection queryIPConnection(int pid, int fd) {
         try (CloseableSocketFdInfo si = new CloseableSocketFdInfo()) {
             int ret = SystemB.INSTANCE.proc_pidfdinfo(pid, fd, PROC_PIDFDSOCKETINFO, si, si.size());
             if (si.size() == ret && (si.psi.soi_family == AF_INET || si.psi.soi_family == AF_INET6)) {

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOperatingSystemJNA.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.platform.mac.SystemB;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -103,7 +105,7 @@ public class MacOperatingSystemJNA extends MacOperatingSystem {
     }
 
     @Override
-    public OSProcess getProcess(int pid) {
+    public @Nullable OSProcess getProcess(int pid) {
         OSProcess proc = new MacOSProcessJNA(pid, this.major, this.minor, this);
         return proc.getState().equals(OSProcess.State.INVALID) ? null : proc;
     }


### PR DESCRIPTION
Seventh step of draining `oshi-core` and `oshi-core-ffm`, and the last macOS group. Covers the
hardware components and the operating-system layer in both implementations, including the
`MacGpuStats` twins deferred from #3626. **Reactor findings 147 → 94.**

### Mostly declarations catching up with documentation

The IO registry views report an absent parent, an exhausted iterator, or a card with no accelerator
entry by returning null, and each already said so. `MacGpuStats.queryPerfStats` even carries a
paragraph explaining why null and an empty map are *different answers* there — `getTemperature`
latches a card as having no sensor only when the dictionary was present and the key was absent,
never when the dictionary itself was missing, which can be transient. The display synthesis, the
medium-type traversal and the localized display name report failure the same way, as does
`getProcess` for a process that is not running, which `OperatingSystem` has always declared
`@Nullable`.

### Two contracts the analyzer read differently from a reader

- **`IOKitProvider.withMatchingService`** returns null when no service matches, *whatever `T` is*,
  and its extractor may itself report an absent property with null. `<T extends @Nullable Object> T`
  said neither of those things; it is now `<T> @Nullable T` taking a
  `Function<RegistryEntry, @Nullable T>`.
- **`RegistryEntry.lookupControllerVidPid`** returns a two-element array whose *elements* may each be
  absent — `@Nullable String[]`, not `String @Nullable []`. The javadoc says "either element may be
  `null`"; the first annotation I wrote said the array itself could be null, and NullAway caught it.

`MacCentralProcessor.platformExpert` tested its result with `Util.isBlank`, which the analyzer cannot
see through; the explicit null-or-empty check is the same test that method performs.

### Verified at runtime on both backends

Run end to end on an M2 Max after the change:

| section | JNA vs FFM |
|---|---|
| Displays | identical |
| USB Devices | identical |
| Graphics Cards | identical but the object hashcode |
| Disks | identical but live read/write counters |

`Apple M2 Max, vendor=Apple (0x106b), vRam=68719476736` on both. The USB tree exercises
`lookupControllerVidPid` and the registry iterator, which are precisely what this PR re-declares, so
those paths are executed rather than merely compiled.

### No behavior change

No CHANGELOG entry. Verified by diffing against master and cancelling every line whose only
difference is an annotation: 19 of the 23 files have no residue, and the rest is the `isBlank`
rewrite above, two array elements read into locals because NullAway does not refine array elements,
and one signature rewrapped across lines.

Full gate on macOS: `spotless:apply sortpom:sort spotless:check checkstyle:check install
forbiddenapis:check javadoc:javadoc` plus `-Perror-prone clean install`. All modules green, 1561
tests, 0 failures.

Part of #3593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS processor manufacturer reporting: whitespace-only values are now preserved, while missing values still use the standard fallback.
  - Improved handling of unavailable macOS hardware, display, storage, USB, process, network, and power-source information.

- **Refactor**
  - Clarified nullable results throughout macOS hardware and operating-system integrations, improving API accuracy and reliability without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->