### PR TITLE
Make the Solaris nullability contracts honest

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisHWDiskStore.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.driver.common.unix.solaris.disk.Iostat;
 import oshi.driver.common.unix.solaris.disk.Lshal;
@@ -128,5 +130,5 @@ public abstract class SolarisHWDiskStore extends AbstractHWDiskStore {
      *
      * @return stats POJO, or {@code null} if no entry was found for this disk name
      */
-    protected abstract DiskStats queryStats();
+    protected abstract @Nullable DiskStats queryStats();
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisNetworkIF.java
@@ -6,6 +6,8 @@ package oshi.hardware.common.platform.unix.solaris;
 
 import java.net.NetworkInterface;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.common.AbstractNetworkIF;
 
@@ -66,5 +68,5 @@ public abstract class SolarisNetworkIF extends AbstractNetworkIF {
      *
      * @return stats POJO, or {@code null} if no entry was found for this interface name
      */
-    protected abstract IfStats queryStats();
+    protected abstract @Nullable IfStats queryStats();
 }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -181,7 +181,7 @@ public abstract class ForeignFunctions {
      * @return the operation result, or {@code defaultValue} if the operation throws
      */
     public static <T extends @Nullable Object> T callInArenaOrDefault(ArenaCallable<T> callable, T defaultValue,
-            Logger logger, LogLevel level, String message, Object... args) {
+            Logger logger, LogLevel level, String message, @Nullable Object... args) {
         Objects.requireNonNull(callable, "callable");
         try (Arena arena = Arena.ofConfined()) {
             return callable.call(arena);
@@ -229,7 +229,7 @@ public abstract class ForeignFunctions {
      * @return the operation result, or {@code defaultValue} if the operation throws
      */
     public static int callInArenaIntOrDefault(ArenaIntCallable callable, int defaultValue, Logger logger,
-            LogLevel level, String message, Object... args) {
+            LogLevel level, String message, @Nullable Object... args) {
         Objects.requireNonNull(callable, "callable");
         try (Arena arena = Arena.ofConfined()) {
             return callable.call(arena);
@@ -277,7 +277,7 @@ public abstract class ForeignFunctions {
      * @return the operation result, or {@code defaultValue} if the operation throws
      */
     public static long callInArenaLongOrDefault(ArenaLongCallable callable, long defaultValue, Logger logger,
-            LogLevel level, String message, Object... args) {
+            LogLevel level, String message, @Nullable Object... args) {
         Objects.requireNonNull(callable, "callable");
         try (Arena arena = Arena.ofConfined()) {
             return callable.call(arena);
@@ -325,7 +325,7 @@ public abstract class ForeignFunctions {
      * @return the operation result, or {@code defaultValue} if the operation throws
      */
     public static double callInArenaDoubleOrDefault(ArenaDoubleCallable callable, double defaultValue, Logger logger,
-            LogLevel level, String message, Object... args) {
+            LogLevel level, String message, @Nullable Object... args) {
         Objects.requireNonNull(callable, "callable");
         try (Arena arena = Arena.ofConfined()) {
             return callable.call(arena);
@@ -373,7 +373,7 @@ public abstract class ForeignFunctions {
      * @return the operation result, or {@code defaultValue} if the operation throws
      */
     public static boolean callInArenaBooleanOrDefault(ArenaBooleanCallable callable, boolean defaultValue,
-            Logger logger, LogLevel level, String message, Object... args) {
+            Logger logger, LogLevel level, String message, @Nullable Object... args) {
         Objects.requireNonNull(callable, "callable");
         try (Arena arena = Arena.ofConfined()) {
             return callable.call(arena);

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/unix/solaris/KstatUtilFFM.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,7 +117,7 @@ public final class KstatUtilFFM {
          *         {@link MemorySegment#NULL}
          */
         @GuardedBy("CHAIN")
-        public MemorySegment lookup(String module, int instance, String name) {
+        public MemorySegment lookup(@Nullable String module, int instance, @Nullable String name) {
             return callInArenaOrDefault(arena -> {
                 MemorySegment modSeg = module == null ? MemorySegment.NULL : arena.allocateFrom(module);
                 MemorySegment nameSeg = name == null ? MemorySegment.NULL : arena.allocateFrom(name);
@@ -138,7 +139,7 @@ public final class KstatUtilFFM {
          * @return all matching kstats (each reinterpreted to {@link LibKstatFunctions#KSTAT_LAYOUT})
          */
         @GuardedBy("CHAIN")
-        public List<MemorySegment> lookupAll(String module, int instance, String name) {
+        public List<MemorySegment> lookupAll(@Nullable String module, int instance, @Nullable String name) {
             List<MemorySegment> matches = new ArrayList<>();
             MemorySegment ksp = lookup(module, instance, name);
             while (ksp.address() != 0L) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHWDiskStoreFFM.java
@@ -7,6 +7,8 @@ package oshi.hardware.platform.unix.solaris;
 import java.lang.foreign.MemorySegment;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.solaris.LibKstatFunctions;
 import oshi.ffm.util.platform.unix.solaris.KstatUtilFFM;
@@ -35,7 +37,7 @@ public final class SolarisHWDiskStoreFFM extends SolarisHWDiskStore {
     }
 
     @Override
-    protected DiskStats queryStats() {
+    protected @Nullable DiskStats queryStats() {
         try (KstatChain kc = KstatUtilFFM.openChain()) {
             MemorySegment ksp = kc.lookup(null, 0, getName());
             if (ksp.address() != 0L && kc.read(ksp)) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisNetworkIFFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisNetworkIFFFM.java
@@ -8,6 +8,8 @@ import java.lang.foreign.MemorySegment;
 import java.net.NetworkInterface;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.unix.solaris.LibKstatFunctions;
 import oshi.ffm.util.platform.unix.solaris.KstatUtilFFM;
@@ -38,7 +40,7 @@ public final class SolarisNetworkIFFFM extends SolarisNetworkIF {
     }
 
     @Override
-    protected IfStats queryStats() {
+    protected @Nullable IfStats queryStats() {
         try (KstatChain kc = KstatUtilFFM.openChain()) {
             MemorySegment ksp = kc.lookup("link", -1, getName());
             if (ksp.address() == 0L) {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/solaris/SolarisPowerSourceFFM.java
@@ -8,6 +8,8 @@ import java.lang.foreign.MemorySegment;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.util.platform.unix.solaris.KstatUtilFFM;
 import oshi.ffm.util.platform.unix.solaris.KstatUtilFFM.KstatChain;
@@ -40,7 +42,7 @@ public final class SolarisPowerSourceFFM extends SolarisPowerSource {
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
             CapacityUnits psCapacityUnits, int psCurrentCapacity, int psMaxCapacity, int psDesignCapacity,
-            int psCycleCount, String psChemistry, LocalDate psManufactureDate, String psManufacturer,
+            int psCycleCount, String psChemistry, @Nullable LocalDate psManufactureDate, String psManufacturer,
             String psSerialNumber, double psTemperature) {
         super(psName, psDeviceName, psRemainingCapacityPercent, psTimeRemainingEstimated, psTimeRemainingInstant,
                 psPowerUsageRate, psVoltage, psAmperage, psPowerOnLine, psCharging, psDischarging, psCapacityUnits,

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisHWDiskStoreJNA.java
@@ -8,6 +8,8 @@ import static oshi.software.os.unix.solaris.SolarisOperatingSystemJNA.HAS_KSTAT2
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.platform.unix.solaris.LibKstat.Kstat;
 import com.sun.jna.platform.unix.solaris.LibKstat.KstatIO;
 
@@ -37,7 +39,7 @@ public final class SolarisHWDiskStoreJNA extends SolarisHWDiskStore {
     }
 
     @Override
-    protected DiskStats queryStats() {
+    protected @Nullable DiskStats queryStats() {
         if (HAS_KSTAT2) {
             return queryStats2();
         }
@@ -59,7 +61,7 @@ public final class SolarisHWDiskStoreJNA extends SolarisHWDiskStore {
         return null;
     }
 
-    private DiskStats queryStats2() {
+    private @Nullable DiskStats queryStats2() {
         String fullName = getName();
         String alpha = fullName;
         String numeric = "";

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisNetworkIFJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisNetworkIFJNA.java
@@ -9,6 +9,8 @@ import static oshi.software.os.unix.solaris.SolarisOperatingSystemJNA.HAS_KSTAT2
 import java.net.NetworkInterface;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.platform.unix.solaris.LibKstat.Kstat;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -39,7 +41,7 @@ public final class SolarisNetworkIFJNA extends SolarisNetworkIF {
     }
 
     @Override
-    protected IfStats queryStats() {
+    protected @Nullable IfStats queryStats() {
         if (HAS_KSTAT2) {
             return queryStats2();
         }
@@ -67,7 +69,7 @@ public final class SolarisNetworkIFJNA extends SolarisNetworkIF {
         return null;
     }
 
-    private IfStats queryStats2() {
+    private @Nullable IfStats queryStats2() {
         Object[] results = KstatUtil.queryKstat2("kstat:/net/link/" + getName() + "/0", "obytes64", "rbytes64",
                 "opackets64", "ipackets64", "oerrors", "ierrors", "collisions", "dl_idrops", "ifspeed", "snaptime");
         if (results[results.length - 1] == null) {

--- a/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisPowerSourceJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/unix/solaris/SolarisPowerSourceJNA.java
@@ -7,6 +7,8 @@ package oshi.hardware.platform.unix.solaris;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.platform.unix.solaris.LibKstat.Kstat;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -42,7 +44,7 @@ public final class SolarisPowerSourceJNA extends SolarisPowerSource {
             double psTimeRemainingEstimated, double psTimeRemainingInstant, double psPowerUsageRate, double psVoltage,
             double psAmperage, boolean psPowerOnLine, boolean psCharging, boolean psDischarging,
             CapacityUnits psCapacityUnits, int psCurrentCapacity, int psMaxCapacity, int psDesignCapacity,
-            int psCycleCount, String psChemistry, LocalDate psManufactureDate, String psManufacturer,
+            int psCycleCount, String psChemistry, @Nullable LocalDate psManufactureDate, String psManufacturer,
             String psSerialNumber, double psTemperature) {
         super(psName, psDeviceName, psRemainingCapacityPercent, psTimeRemainingEstimated, psTimeRemainingInstant,
                 psPowerUsageRate, psVoltage, psAmperage, psPowerOnLine, psCharging, psDischarging, psCapacityUnits,

--- a/oshi-core/src/main/java/oshi/util/platform/unix/solaris/KstatUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/unix/solaris/KstatUtil.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,7 @@ public final class KstatUtil {
     // Only one thread may access the chain at any time, so we wrap this object in
     // the KstatChain class locked until the lock is released on auto-close.
     @GuardedBy("CHAIN")
-    private static KstatCtl kstatCtl = null;
+    private static @Nullable KstatCtl kstatCtl = null;
 
     private KstatUtil() {
     }
@@ -106,7 +107,7 @@ public final class KstatUtil {
          * @return The first match of the requested Kstat structure if found, or {@code null}
          */
         @GuardedBy("CHAIN")
-        public Kstat lookup(String module, int instance, String name) {
+        public @Nullable Kstat lookup(@Nullable String module, int instance, @Nullable String name) {
             return LibKstat.INSTANCE.kstat_lookup(localCtlRef, module, instance, name);
         }
 
@@ -122,7 +123,7 @@ public final class KstatUtil {
          * @return All matches of the requested Kstat structure if found, or an empty list otherwise
          */
         @GuardedBy("CHAIN")
-        public List<Kstat> lookupAll(String module, int instance, String name) {
+        public List<Kstat> lookupAll(@Nullable String module, int instance, @Nullable String name) {
             List<Kstat> kstats = new ArrayList<>();
             for (Kstat ksp = LibKstat.INSTANCE.kstat_lookup(localCtlRef, module, instance, name); ksp != null; ksp = ksp
                     .next()) {


### PR DESCRIPTION
Eighth step of draining `oshi-core` and `oshi-core-ffm`. Covers the kstat utilities and the Solaris
hardware and file-system components in both implementations. **Reactor findings 94 → 67.**

### One contract does most of the work

`kstat_lookup` treats a null module or name as a wildcard. `KstatChain.lookup` and `lookupAll`
document each argument as *"or null to ignore"* and both bodies test for it — but the parameters were
declared non-null, so every caller passing a wildcard reported a violation. Annotating those two
methods in each twin resolved the bulk of the 32 findings.

The stats queries report "no kstat entry for this disk or interface" with null, which their abstract
declarations in `oshi-common` already document, as does the Solaris power source's manufacture date.

### Two deliberate twin differences, recorded rather than papered over

- **The FFM `lookup` keeps `MemorySegment.NULL`** as its miss sentinel rather than adopting the JNA
  twin's Java null. That is what its javadoc promises and what all six of its callers test with
  `address() != 0L`. I annotated the return `@Nullable` first and backed it out: unlike
  `IOKitUtilFFM.getBSDNameMatchingDict` in #3631 — where the javadoc promised null and the JNA twin
  delivered it — this FFM contract is internally consistent. A `MemorySegment` has a natural null
  object; a JNA `Structure` does not, which is why the two representations differ.
- **`ForeignFunctions`' logging helpers take `@Nullable Object... args`.** A null log argument formats
  as `"null"`, which is exactly what these call sites want when reporting which wildcard lookup
  failed. This one reaches beyond Solaris.

### No behavior change

No CHANGELOG entry. Verified by diffing against master and cancelling every line whose only
difference is an annotation: **all eleven files have zero residue.**

Full gate on macOS: `spotless:apply sortpom:sort spotless:check checkstyle:check install
forbiddenapis:check javadoc:javadoc` plus `-Perror-prone clean install`. All modules green, 1561
tests, 0 failures. This is Solaris code, so nothing here is verified beyond compilation and the
OpenIndiana CI job.

Part of #3593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Solaris hardware, network, power, and system-statistics APIs with clearer handling of values that may be unavailable.
  * Enhanced parameter documentation for Solaris system-statistics lookups and foreign-function calls.
  * Clarified that missing disk statistics, network statistics, power-source dates, and lookup results are valid scenarios.
  * No runtime behavior changes are expected; these updates improve static analysis, tooling guidance, and API reliability for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->