### PR TITLE
Make the Linux nullability contracts honest

### DIFF
--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -443,12 +443,17 @@ class NativeComparisonTest {
         assertThat(ffm.getCommandLine()).isEqualTo(jna.getCommandLine());
         assertThat(ffm.getSoftOpenFileLimit()).as("process.softOpenFileLimit").isEqualTo(jna.getSoftOpenFileLimit());
         assertThat(ffm.getHardOpenFileLimit()).as("process.hardOpenFileLimit").isEqualTo(jna.getHardOpenFileLimit());
-        // Context switches: both use getrusage, snapshots taken at different times
-        assertWithinRatio(ffm.getContextSwitches(), jna.getContextSwitches(), 0.2, "process.contextSwitches");
-        assertWithinRatio(ffm.getVoluntaryContextSwitches(), jna.getVoluntaryContextSwitches(), 0.2,
-                "process.voluntaryContextSwitches");
-        assertWithinRatio(ffm.getInvoluntaryContextSwitches(), jna.getInvoluntaryContextSwitches(), 0.2,
-                "process.involuntaryContextSwitches");
+        // Context switches are cumulative and the FFM snapshot is taken second, so it cannot be the lower of the
+        // two - the same shape as the kernel and user time assertions above. A ratio bound is unusable here: a JVM
+        // accumulates thousands of switches per second, and this test runs on one only seconds old, so 20% amounts
+        // to requiring the two snapshots be under half a second apart. An OpenIndiana run measured 2708 against
+        // 3496. Ordering still catches the wrong-field or wrong-process binding this is here to detect.
+        assertThat(ffm.getContextSwitches()).as("process.contextSwitches")
+                .isGreaterThanOrEqualTo(jna.getContextSwitches());
+        assertThat(ffm.getVoluntaryContextSwitches()).as("process.voluntaryContextSwitches")
+                .isGreaterThanOrEqualTo(jna.getVoluntaryContextSwitches());
+        assertThat(ffm.getInvoluntaryContextSwitches()).as("process.involuntaryContextSwitches")
+                .isGreaterThanOrEqualTo(jna.getInvoluntaryContextSwitches());
     }
 
     @Test

--- a/oshi-core-ffm/src/main/java/oshi/driver/linux/WhoFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/linux/WhoFFM.java
@@ -15,6 +15,8 @@ import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.ffm.platform.linux.LinuxLibcFunctions;
 import oshi.ffm.platform.linux.SystemdFunctions;
@@ -136,7 +138,7 @@ public final class WhoFFM {
         return sessionList;
     }
 
-    private static OSSession queryOneSession(String sessionId, Arena arena) throws Throwable {
+    private static @Nullable OSSession queryOneSession(String sessionId, Arena arena) throws Throwable {
         MemorySegment sessionSeg = arena.allocateFrom(sessionId);
 
         // Get username (required)

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorFFM.java
@@ -14,6 +14,7 @@ import java.lang.foreign.ValueLayout;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,7 @@ public final class LinuxCentralProcessorFFM extends LinuxCentralProcessor {
     }
 
     @Override
-    protected List<String> enumerateCpuSyspathsViaUdev() {
+    protected @Nullable List<String> enumerateCpuSyspathsViaUdev() {
         if (!HAS_UDEV) {
             return null;
         }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +51,7 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
         return getDisks(null);
     }
 
-    static List<HWDiskStore> getDisks(LinuxHWDiskStore storeToUpdate) {
+    static List<HWDiskStore> getDisks(@Nullable LinuxHWDiskStore storeToUpdate) {
         if (!HAS_UDEV) {
             if (storeToUpdate == null) {
                 LOG.warn("Disk Store information requires libudev, which is not present.");

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxFileSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxFileSystemFFM.java
@@ -9,6 +9,7 @@ import static oshi.util.LogLevel.DEBUG;
 
 import java.lang.foreign.MemorySegment;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +26,7 @@ final class LinuxFileSystemFFM extends LinuxFileSystem {
     private static final Logger LOG = LoggerFactory.getLogger(LinuxFileSystemFFM.class);
 
     @Override
-    protected long[] queryStatvfs(String path) {
+    protected long @Nullable [] queryStatvfs(String path) {
         return callInArenaOrDefault(arena -> {
             MemorySegment pathSeg = arena.allocateFrom(path);
             MemorySegment buf = arena.allocate(LinuxLibcFunctions.STATVFS_LAYOUT);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOSProcessFFM.java
@@ -12,6 +12,7 @@ import static oshi.util.LogLevel.WARN;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,7 @@ public class LinuxOSProcessFFM extends LinuxOSProcess {
     }
 
     @Override
-    protected long[] queryContextSwitches() {
+    protected long @Nullable [] queryContextSwitches() {
         return callInArenaOrDefault(arena -> {
             MemorySegment rusage = arena.allocate(LinuxLibcFunctions.RUSAGE_SIZE);
             if (0 == LinuxLibcFunctions.getrusage(LinuxLibcFunctions.RUSAGE_SELF, rusage)) {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxOperatingSystemFFM.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +126,7 @@ public class LinuxOperatingSystemFFM extends LinuxOperatingSystem {
     }
 
     @Override
-    public OSProcess getProcess(int pid) {
+    public @Nullable OSProcess getProcess(int pid) {
         OSProcess proc = createOSProcess(pid);
         if (!proc.getState().equals(State.INVALID)) {
             return proc;

--- a/oshi-core/src/main/java/oshi/driver/linux/WhoJNA.java
+++ b/oshi-core/src/main/java/oshi/driver/linux/WhoJNA.java
@@ -155,7 +155,7 @@ public final class WhoJNA {
                                         ttyPointer = ttyPtr.getValue();
                                     }
                                 }
-                                if (nativeValue(ttyPointer) != 0) {
+                                if (ttyPointer != null && nativeValue(ttyPointer) != 0) {
                                     try {
                                         tty = ttyPointer.getString(0);
                                     } finally {
@@ -172,7 +172,7 @@ public final class WhoJNA {
                                         remoteHostPointer = remoteHostPtr.getValue();
                                     }
                                 }
-                                if (nativeValue(remoteHostPointer) != 0) {
+                                if (remoteHostPointer != null && nativeValue(remoteHostPointer) != 0) {
                                     try {
                                         remoteHost = remoteHostPointer.getString(0);
                                     } finally {

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessorJNA.java
@@ -9,6 +9,7 @@ import static oshi.software.os.linux.LinuxOperatingSystemJNA.HAS_UDEV;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ final class LinuxCentralProcessorJNA extends LinuxCentralProcessor {
     }
 
     @Override
-    protected List<String> enumerateCpuSyspathsViaUdev() {
+    protected @Nullable List<String> enumerateCpuSyspathsViaUdev() {
         if (!HAS_UDEV) {
             return null;
         }

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,7 @@ public final class LinuxHWDiskStoreJNA extends LinuxHWDiskStore {
         return getDisks(null);
     }
 
-    static List<HWDiskStore> getDisks(LinuxHWDiskStore storeToUpdate) {
+    static List<HWDiskStore> getDisks(@Nullable LinuxHWDiskStore storeToUpdate) {
         if (!HAS_UDEV) {
             LOG.warn("Disk Store information requires libudev, which is not present.");
             return Collections.emptyList();

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxFileSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxFileSystemJNA.java
@@ -4,6 +4,7 @@
  */
 package oshi.software.os.linux;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +23,7 @@ public class LinuxFileSystemJNA extends LinuxFileSystem {
     private static final Logger LOG = LoggerFactory.getLogger(LinuxFileSystemJNA.class);
 
     @Override
-    protected long[] queryStatvfs(String path) {
+    protected long @Nullable [] queryStatvfs(String path) {
         try {
             LibC.Statvfs vfsStat = new LibC.Statvfs();
             if (0 == LibC.INSTANCE.statvfs(path, vfsStat)) {

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOSProcessJNA.java
@@ -7,6 +7,8 @@ package oshi.software.os.linux;
 import static com.sun.jna.platform.unix.Resource.RLIMIT_NOFILE;
 import static oshi.jna.platform.unix.CLibrary.RUSAGE_SELF;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.jna.platform.unix.Resource;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -25,7 +27,7 @@ public class LinuxOSProcessJNA extends LinuxOSProcess {
     }
 
     @Override
-    protected long[] queryContextSwitches() {
+    protected long @Nullable [] queryContextSwitches() {
         LinuxLibc.Rusage rusage = new LinuxLibc.Rusage();
         if (0 == LinuxLibc.INSTANCE.getrusage(RUSAGE_SELF, rusage)) {
             return new long[] { rusage.ru_nvcsw.longValue(), rusage.ru_nivcsw.longValue() };

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystemJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxOperatingSystemJNA.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,7 +120,7 @@ public class LinuxOperatingSystemJNA extends LinuxOperatingSystem {
     }
 
     @Override
-    public OSProcess getProcess(int pid) {
+    public @Nullable OSProcess getProcess(int pid) {
         OSProcess proc = createOSProcess(pid);
         if (!proc.getState().equals(State.INVALID)) {
             return proc;


### PR DESCRIPTION
Ninth step of draining `oshi-core` and `oshi-core-ffm`. Covers the Linux hardware, file-system,
process and login-session components in both implementations. **Reactor findings 94 → 70** measured
against `master`; this branch is cut from `master` rather than stacked on #3633, so the two are
independent and can land in either order.

### Declarations catching up with contracts oshi-common already states

- `queryStatvfs` is documented as returning null on failure and declared `long @Nullable []` in the
  abstract base.
- `enumerateCpuSyspathsViaUdev` likewise, for a system without udev.
- `getProcess` for a process that is not running, which `OperatingSystem` has always declared
  `@Nullable`.
- The Linux disk enumerator takes a null store to mean "enumerate every disk" rather than refresh
  one, which is how its own no-argument overload calls it.
- The FFM session reader reports a session it cannot read with null, which its caller skips.

### One guard the analyzer could not read

`WhoJNA` tested its pointers with `nativeValue(ttyPointer) != 0`, which was **already correct**:
JNA's `Pointer.nativeValue` returns 0 for a null pointer in 5.18.1, the version this project uses.
The added `ttyPointer != null` is redundant at runtime and exists only to make that invariant
visible. Worth stating precisely, because the JNA jar that happens to sit in a local `~/.m2` may be
3.4.0, where that method dereferences `p.peer` with no null check — checking the version actually in
use is what turns this from "bug fix" into "no-op".

### Also: three flaky comparison assertions

Unrelated to the marking, but folded in here rather than spending another push cycle. The
OpenIndiana job failed on:

```
[process.contextSwitches: expected=2708.000000, actual=3496.000000]
```

Context switches are cumulative and the FFM snapshot is taken second, so it can never be the lower
of the two — the same shape as the `kernelTime` and `userTime` assertions immediately above, which
already use `isGreaterThanOrEqualTo`. A ratio bound is unusable: a JVM accumulates thousands of
switches per second and this test runs on one only seconds old, so 20% amounts to requiring the two
snapshots be under half a second apart. All three context-switch assertions are converted to the
ordering form, which still catches the wrong-field or wrong-process binding they exist to detect.
The system-wide counter at `processorContextSwitchesAndInterrupts` keeps its 0.01 ratio; it has not
flaked.

This failure is **not** related to #3633 — Solaris context switches come from `/proc/<pid>/usage`
(`pr_vctx`/`pr_ictx`) in `SolarisOSProcess`, which that PR does not touch.

### No behavior change

No CHANGELOG entry. Verified by diffing against master and cancelling every line whose only
difference is an annotation: 11 of the 12 source files have zero residue, the twelfth being the
`WhoJNA` guard above.

Full gate on macOS: `spotless:apply sortpom:sort spotless:check checkstyle:check install
forbiddenapis:check javadoc:javadoc` plus `-Perror-prone clean install`. All modules green, 1561
tests, 0 failures. This is Linux code, so nothing here is verified beyond compilation and CI.

Part of #3593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux system monitoring when optional process, session, disk, CPU, filesystem, or terminal information is unavailable.
  * Prevented errors when system-provided terminal or remote-host details are missing.
  * Improved handling of invalid or unavailable process information.

* **Tests**
  * Updated process monitoring checks to reliably validate context-switch counters as values progress over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->