### PR TITLE
Resolve the nullness conditions Sonar reported after the jSpecify sweep

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/unix/solaris/PsInfo.java
+++ b/oshi-common/src/main/java/oshi/driver/common/unix/solaris/PsInfo.java
@@ -41,7 +41,7 @@ public final class PsInfo {
     public static @Nullable SolarisPsInfo queryPsInfo(int pid) {
         String path = String.format(Locale.ROOT, "/proc/%d/psinfo", pid);
         ByteBuffer buff = FileUtil.readAllBytesAsBuffer(path);
-        if (buff == null || buff.remaining() == 0) {
+        if (buff.remaining() == 0) {
             // Short-lived processes (e.g. test forks) commonly disappear from /proc
             // between enumeration and read. Logging at debug avoids CI noise.
             LOG.debug("psinfo file empty or unreadable for pid {} ({})", pid, path);
@@ -66,7 +66,7 @@ public final class PsInfo {
     public static @Nullable SolarisLwpsInfo queryLwpsInfo(int pid, int tid) {
         ByteBuffer buff = FileUtil
                 .readAllBytesAsBuffer(String.format(Locale.ROOT, "/proc/%d/lwp/%d/lwpsinfo", pid, tid));
-        if (buff == null || buff.remaining() == 0) {
+        if (buff.remaining() == 0) {
             return null;
         }
         try {
@@ -85,7 +85,7 @@ public final class PsInfo {
      */
     public static @Nullable SolarisPrUsage queryPrUsage(int pid) {
         ByteBuffer buff = FileUtil.readAllBytesAsBuffer(String.format(Locale.ROOT, "/proc/%d/usage", pid));
-        if (buff == null || buff.remaining() == 0) {
+        if (buff.remaining() == 0) {
             return null;
         }
         try {
@@ -105,7 +105,7 @@ public final class PsInfo {
      */
     public static @Nullable SolarisPrUsage queryPrUsage(int pid, int tid) {
         ByteBuffer buff = FileUtil.readAllBytesAsBuffer(String.format(Locale.ROOT, "/proc/%d/lwp/%d/usage", pid, tid));
-        if (buff == null || buff.remaining() == 0) {
+        if (buff.remaining() == 0) {
             return null;
         }
         try {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -61,8 +61,7 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
             }
         }
         String machine = BsdSysctlUtil.sysctl("hw.machine", "");
-        boolean cpu64bit = (machine != null && machine.contains("64"))
-                || ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
+        boolean cpu64bit = machine.contains("64") || ExecutingCommand.getFirstAnswer("uname -m").trim().contains("64");
 
         return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,
                 cpuFreq);

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/netbsd/NetBsdOSProcess.java
@@ -91,7 +91,7 @@ public class NetBsdOSProcess extends BsdOSProcess {
     protected List<String> queryArguments() {
         // NetBSD provides command line via /proc filesystem
         byte[] cmdBytes = FileUtil.readAllBytes("/proc/" + getProcessID() + "/cmdline", false);
-        if (cmdBytes != null && cmdBytes.length > 0) {
+        if (cmdBytes.length > 0) {
             return Collections.unmodifiableList(ParseUtil.parseByteArrayToStrings(cmdBytes));
         }
         return Collections.emptyList();

--- a/oshi-common/src/main/java/oshi/util/FileUtil.java
+++ b/oshi-common/src/main/java/oshi/util/FileUtil.java
@@ -193,7 +193,7 @@ public final class FileUtil {
      *
      *
      * @param filename The file to read
-     * @return A bytebuffer representing the file if read was successful; null otherwise
+     * @return A bytebuffer over the file's content, empty if it could not be read
      */
     public static ByteBuffer readAllBytesAsBuffer(String filename) {
         byte[] bytes = readAllBytes(filename, false);
@@ -395,7 +395,7 @@ public final class FileUtil {
     }
 
     private static boolean readPropertiesFromClassLoader(String propsFilename, Properties archProps,
-            ClassLoader loader) {
+            @Nullable ClassLoader loader) {
         if (loader == null) {
             return false;
         }

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -1299,7 +1299,7 @@ public final class ParseUtil {
      * @param defaultValue default value to return if parse fails
      * @return The corresponding int value
      */
-    public static int hexStringToInt(String hexString, int defaultValue) {
+    public static int hexStringToInt(@Nullable String hexString, int defaultValue) {
         if (hexString != null) {
             try {
                 if (hexString.startsWith("0x")) {
@@ -1322,7 +1322,7 @@ public final class ParseUtil {
      * @param defaultValue default value to return if parse fails
      * @return The corresponding long value
      */
-    public static long hexStringToLong(String hexString, long defaultValue) {
+    public static long hexStringToLong(@Nullable String hexString, long defaultValue) {
         if (hexString != null) {
             try {
                 if (hexString.startsWith("0x")) {

--- a/oshi-common/src/main/java/oshi/util/SystemInfoHelper.java
+++ b/oshi-common/src/main/java/oshi/util/SystemInfoHelper.java
@@ -396,8 +396,7 @@ public final class SystemInfoHelper {
             long usable = fs.getUsableSpace();
             long total = fs.getTotalSpace();
             String fmt = " %s (%s) [%s] %s of %s free (%.1f%%), %s of %s files free (%.1f%%) is %s "
-                    + (fs.getLogicalVolume() != null && !fs.getLogicalVolume().isEmpty() ? "[%s]" : "%s")
-                    + " and is mounted at %s";
+                    + (fs.getLogicalVolume().isEmpty() ? "%s" : "[%s]") + " and is mounted at %s";
             lines.add(String.format(Locale.ROOT, fmt, fs.getName(),
                     fs.getDescription().isEmpty() ? "file system" : fs.getDescription(), fs.getType(),
                     FormatUtil.formatBytes(usable), FormatUtil.formatBytes(fs.getTotalSpace()), 100d * usable / total,

--- a/oshi-common/src/main/java/oshi/util/common/platform/unix/bsd/BsdSysctlUtil.java
+++ b/oshi-common/src/main/java/oshi/util/common/platform/unix/bsd/BsdSysctlUtil.java
@@ -52,7 +52,7 @@ public final class BsdSysctlUtil {
      */
     public static String sysctl(String name, String def) {
         String v = ExecutingCommand.getFirstAnswer(SYSCTL_N + name);
-        if (null == v || v.isEmpty()) {
+        if (v.isEmpty()) {
             return def;
         }
         return v;

--- a/oshi-common/src/main/java/oshi/util/driver/linux/DrmEdid.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/DrmEdid.java
@@ -59,7 +59,7 @@ public final class DrmEdid {
             File edidFile = new File(connector, "edid");
             if (edidFile.exists() && edidFile.length() >= 128) {
                 byte[] edid = FileUtil.readAllBytes(edidFile.getPath(), false);
-                if (edid != null && edid.length >= 128) {
+                if (edid.length >= 128) {
                     displays.add(edid);
                 }
             }

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Lpstat.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Lpstat.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.Printer.PrinterStatus;
 import oshi.util.ExecutingCommand;
@@ -151,7 +153,7 @@ public final class Lpstat {
      * @param line a single line from {@code lpstat -p}
      * @return the parsed status
      */
-    public static PrinterStatus parseStatus(String line) {
+    public static PrinterStatus parseStatus(@Nullable String line) {
         if (line == null) {
             return PrinterStatus.UNKNOWN;
         }
@@ -174,7 +176,7 @@ public final class Lpstat {
      * @param line a single line from {@code lpstat -p}
      * @return the reason string, or empty string if none
      */
-    public static String parseStatusReason(String line) {
+    public static String parseStatusReason(@Nullable String line) {
         if (line == null) {
             return "";
         }
@@ -188,7 +190,7 @@ public final class Lpstat {
      * @param uri the device URI
      * @return true if the URI indicates a local printer
      */
-    public static boolean isLocalUri(String uri) {
+    public static boolean isLocalUri(@Nullable String uri) {
         if (uri == null) {
             return false;
         }

--- a/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/ForeignFunctions.java
@@ -584,11 +584,11 @@ public abstract class ForeignFunctions {
      *
      * @param lib        the symbol lookup
      * @param symbol     the symbol name
-     * @param resLayout  the return layout
+     * @param resLayout  the return layout, or {@code null} for a void function
      * @param argLayouts the argument layouts
      * @return the method handle
      */
-    public static MethodHandle downcall(SymbolLookup lib, String symbol, MemoryLayout resLayout,
+    public static MethodHandle downcall(SymbolLookup lib, String symbol, @Nullable MemoryLayout resLayout,
             MemoryLayout... argLayouts) {
         MemorySegment sym = lib.findOrThrow(symbol);
         FunctionDescriptor fd = (resLayout == null) ? FunctionDescriptor.ofVoid(argLayouts)

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxPowerSourceFFM.java
@@ -15,6 +15,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +52,7 @@ public final class LinuxPowerSourceFFM extends LinuxPowerSource {
         if (!HAS_UDEV) {
             return LinuxPowerSource.getPowerSources();
         }
+        @Nullable
         List<PowerSource> psList = callInArenaOrDefault(arena -> {
             List<PowerSource> result = new ArrayList<>();
             MemorySegment udev = UdevFunctions.udev_new();

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
@@ -78,7 +78,7 @@ final class WindowsDisplayFFM extends AbstractDisplay {
                     }
                     // wrapped only to release the native handle on close
                     try (var _ = NativeHandle.of(key, Advapi32FFM::RegCloseKey)) {
-                        byte[] edid = queryEdidFromKey(key, edidName, arena);
+                        byte @Nullable [] edid = queryEdidFromKey(key, edidName, arena);
                         if (edid != null) {
                             displays.add(new WindowsDisplayFFM(edid));
                         }

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
@@ -12,6 +12,7 @@ import java.lang.foreign.ValueLayout;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +31,7 @@ final class LinuxNetworkParamsFFM extends LinuxNetworkParams {
 
     @Override
     public String getHostName() {
+        @Nullable
         String hostname = callInArenaOrDefault(arena -> {
             MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
             if (0 == PosixLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
@@ -49,6 +51,7 @@ final class LinuxNetworkParamsFFM extends LinuxNetworkParams {
             LOG.warn("Unknown host exception when getting address of local host", e);
             return "";
         }
+        @Nullable
         String domainName = callInArenaOrDefault(arena -> {
             // Build hints: ai_flags = AI_CANONNAME, rest zero
             MemorySegment hints = arena.allocate(LinuxLibcFunctions.ADDRINFO_LAYOUT);

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacNetworkParamsFFM.java
@@ -21,6 +21,7 @@ import java.lang.foreign.MemorySegment;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,6 +83,7 @@ final class MacNetworkParamsFFM extends MacNetworkParams {
 
     @Override
     public String getHostName() {
+        @Nullable
         String hostname = callInArenaOrDefault(arena -> {
             MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
             if (gethostname(buf, HOST_NAME_MAX + 1L) == 0) {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessFFM.java
@@ -49,7 +49,7 @@ public class DragonFlyBsdOSProcessFFM extends DragonFlyBsdOSProcess {
     protected List<String> queryArguments() {
         // DragonFlyBSD provides command line via /proc filesystem
         byte[] cmdBytes = FileUtil.readAllBytes("/proc/" + getProcessID() + "/cmdline", false);
-        if (cmdBytes != null && cmdBytes.length > 0) {
+        if (cmdBytes.length > 0) {
             return Collections.unmodifiableList(ParseUtil.parseByteArrayToStrings(cmdBytes));
         }
         return Collections.emptyList();

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOperatingSystemFFM.java
@@ -257,9 +257,6 @@ public class WindowsOperatingSystemFFM extends WindowsOperatingSystem {
     public OSThread getCurrentThread() {
         final int tid = getThreadId();
         OSProcess proc = getCurrentProcess();
-        if (proc == null) {
-            return new WindowsOSThreadFFM(0, tid, null, null);
-        }
         return proc.getThreadDetails().stream().filter(t -> t.getThreadId() == tid).findFirst()
                 .orElseGet(() -> new WindowsOSThreadFFM(proc.getProcessID(), tid, null, null));
     }

--- a/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/dragonflybsd/DragonFlyBsdOSProcessJNA.java
@@ -40,7 +40,7 @@ public class DragonFlyBsdOSProcessJNA extends DragonFlyBsdOSProcess {
     protected List<String> queryArguments() {
         // DragonFlyBSD provides command line via /proc filesystem
         byte[] cmdBytes = FileUtil.readAllBytes("/proc/" + getProcessID() + "/cmdline", false);
-        if (cmdBytes != null && cmdBytes.length > 0) {
+        if (cmdBytes.length > 0) {
             return Collections.unmodifiableList(ParseUtil.parseByteArrayToStrings(cmdBytes));
         }
         return Collections.emptyList();

--- a/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
@@ -4,6 +4,7 @@
  */
 package oshi.metrics;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -60,7 +61,7 @@ public class FileSystemMetrics implements MeterBinder {
             String mount = fs.getMount();
             String type = fs.getType();
             String opts = fs.getOptions();
-            String mode = opts != null && java.util.Arrays.asList(opts.split(",")).contains("rw") ? "rw" : "ro";
+            String mode = Arrays.asList(opts.split(",")).contains("rw") ? "rw" : "ro";
 
             // system.filesystem.usage — UpDownCounter (Gauge), unit "By", attr: state, device, mount, type, mode
             Gauge.builder(FS_USAGE, fs, f -> {


### PR DESCRIPTION
Sonar's `java:S2589` and `java:S2583` flagged **25 conditions** whose result the declared nullability
makes constant — the fallout of the jSpecify arc finally giving Sonar contracts to reason about. They
are not one category: half are dead tests, half are declarations that were wrong. The remedy differs,
so each was checked individually.

### The value really can be null — the test was right, the declaration wrong

- **`ForeignFunctions.downcall`** treats a null `resLayout` as "void return", and `Kernel32FFM`,
  `Wtsapi32FFM`, `BStrFFM` and `Ole32FFM` all pass one. **NullAway never saw this**: those callers
  live in the native mapping packages, which we deliberately marked `@NullUnmarked`, so the literal
  `null` was never checked against the declaration. Sonar reads the declaration itself and caught
  what our own configuration had blinded us to. That single finding justifies the sweep.
- **Passing `null` as `callInArenaOrDefault`'s default makes the result nullable**, but the type
  argument was inferred from the lambda's non-null return, so the declared type of each local said
  otherwise. The locals now say `@Nullable` and inference follows. Same for the local receiving
  `WindowsDisplayFFM`'s `byte @Nullable []` EDID read. This is also the root of the `S4449` batch,
  which reported the same mismatch from the argument side.
- `readPropertiesFromClassLoader` can be handed the context class loader, which may be null.
- `ParseUtil`'s hex parsers and `Lpstat`'s line parsers are documented to fail soft on the malformed
  input real system output produces, so their arguments are annotated rather than their guards
  deleted — removing the guards would have been a behavior change.

### The value cannot be null — the test was dead

- **`FileUtil.readAllBytes` returns an empty array, never null**, which `readAllBytesAsBuffer`
  inherited while its javadoc still promised null. That one stale contract explains **eight** of the
  findings — `PsInfo` ×4, `NetBsdOSProcess`, both DragonFly `OSProcess` twins, and `DrmEdid`.
- `ExecutingCommand.getFirstAnswer` returns an empty string, so the BSD sysctl overload that supplies
  a default cannot yield null.
- `OSFileStore.getLogicalVolume` and `getOptions` are non-null API.
- `OperatingSystem.getCurrentProcess` is documented never to return null and substitutes a stub, so
  `WindowsOperatingSystemFFM`'s guard was unreachable. Removing it also **matches the JNA twin**,
  which never had one.

### No behavior change, and no CHANGELOG entry

Every deleted test was unreachable and every added annotation widens a contract. Verified by
cancelling the annotation-only lines from the diff against master: the remainder is exactly those
deletions, nothing else.

Full gate on macOS: `spotless:apply sortpom:sort spotless:check checkstyle:check install
forbiddenapis:check javadoc:javadoc` plus `-Perror-prone clean install` — all modules green, 1565
tests, 0 failures, and NullAway still reports zero findings now that it runs at `ERROR`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty or unavailable system data across Solaris, NetBSD, BSD, Linux, Windows, and DragonFly BSD platforms.
  - Prevented null-related parsing failures when processing hexadecimal values, printer information, hostnames, display data, and process arguments.
  - Improved filesystem, power-source, network, and native system-call fallback behavior.
  - Corrected Windows current-thread handling when process information is unavailable.

- **Documentation**
  - Clarified behavior when files cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->