### PR TITLE
Clear the remaining Sonar and GitHub Code Quality findings

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/DisplayInfoImpl.java
+++ b/oshi-common/src/main/java/oshi/hardware/DisplayInfoImpl.java
@@ -29,8 +29,7 @@ public class DisplayInfoImpl implements DisplayInfo {
 
     // For a real EDID this is set in the constructor and the field getters parse it on demand; for a synthetic instance
     // it starts null and is lazily populated by getEdid() from the field values below.
-    @SuppressWarnings("java:S3077") // the array reference is swapped wholesale, never mutated in place
-    private volatile byte @Nullable [] edid;
+    private volatile byte @Nullable [] edid; // NOSONAR java:S3077 - reference swapped wholesale, never mutated
 
     // Populated only for a synthetic instance; for a real instance the getters derive these from the EDID bytes, and
     // these hold the empty string rather than null so that no getter can return null for either flavor of instance.

--- a/oshi-common/src/main/java/oshi/hardware/DisplayInfoImpl.java
+++ b/oshi-common/src/main/java/oshi/hardware/DisplayInfoImpl.java
@@ -29,6 +29,7 @@ public class DisplayInfoImpl implements DisplayInfo {
 
     // For a real EDID this is set in the constructor and the field getters parse it on demand; for a synthetic instance
     // it starts null and is lazily populated by getEdid() from the field values below.
+    @SuppressWarnings("java:S3077") // the array reference is swapped wholesale, never mutated in place
     private volatile byte @Nullable [] edid;
 
     // Populated only for a synthetic instance; for a real instance the getters derive these from the EDID bytes, and

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractPowerSource.java
@@ -20,27 +20,27 @@ import oshi.util.Constants;
 @ThreadSafe
 public abstract class AbstractPowerSource implements PowerSource {
 
-    private String name;
-    private String deviceName;
-    private double remainingCapacityPercent;
-    private double timeRemainingEstimated;
-    private double timeRemainingInstant;
-    private double powerUsageRate;
-    private double voltage;
-    private double amperage;
-    private boolean powerOnLine;
-    private boolean charging;
-    private boolean discharging;
-    private CapacityUnits capacityUnits;
-    private int currentCapacity;
-    private int maxCapacity;
-    private int designCapacity;
-    private int cycleCount;
-    private String chemistry;
-    private @Nullable LocalDate manufactureDate;
-    private String manufacturer;
-    private String serialNumber;
-    private double temperature;
+    private volatile String name;
+    private volatile String deviceName;
+    private volatile double remainingCapacityPercent;
+    private volatile double timeRemainingEstimated;
+    private volatile double timeRemainingInstant;
+    private volatile double powerUsageRate;
+    private volatile double voltage;
+    private volatile double amperage;
+    private volatile boolean powerOnLine;
+    private volatile boolean charging;
+    private volatile boolean discharging;
+    private volatile CapacityUnits capacityUnits;
+    private volatile int currentCapacity;
+    private volatile int maxCapacity;
+    private volatile int designCapacity;
+    private volatile int cycleCount;
+    private volatile String chemistry;
+    private volatile @Nullable LocalDate manufactureDate;
+    private volatile String manufacturer;
+    private volatile String serialNumber;
+    private volatile double temperature;
 
     /**
      * Creates an AbstractPowerSource with the given parameters.

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -24,7 +24,9 @@ import oshi.util.tuples.Pair;
  */
 @ThreadSafe
 public class NetBsdCentralProcessor extends BsdCentralProcessor {
-    private static final Pattern KEY_VALUE = Pattern.compile("\\s*=\\s*");
+    // Possessive quantifiers: whitespace can never match the "=" that follows it, so the engine never needs to
+    // give characters back. Behaviorally identical, and linear rather than super-linear on a long run of spaces.
+    private static final Pattern KEY_VALUE = Pattern.compile("\\s*+=\\s*+");
 
     private static final int CPUSTATES = 5;
     private static final int CP_USER = 0;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -25,7 +25,7 @@ import oshi.util.tuples.Pair;
 @ThreadSafe
 public class NetBsdCentralProcessor extends BsdCentralProcessor {
     // Possessive quantifiers: whitespace can never match the "=" that follows it, so the engine never needs to
-    // give characters back. Behaviorally identical, and linear rather than super-linear on a long run of spaces.
+    // give characters back. Behaviorally identical, with no backtracking to do.
     private static final Pattern KEY_VALUE = Pattern.compile("\\s*+=\\s*+");
 
     private static final int CPUSTATES = 5;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGpuStats.java
@@ -41,7 +41,7 @@ public abstract class WindowsGpuStats implements GpuStats {
 
     private boolean closed;
 
-    private @Nullable String cachedNvmlDevice;
+    private volatile @Nullable String cachedNvmlDevice;
     private int cachedAdlIndex = Integer.MIN_VALUE;
     private @Nullable GpuTicks prevUtilTicks;
 

--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -14,7 +14,6 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import oshi.annotation.SuppressForbidden;
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.DisplayInfo;
 import oshi.hardware.DisplayInfoImpl;
@@ -56,15 +55,12 @@ public final class EdidUtil {
      * @param edid The EDID byte array
      * @return The manufacturer ID
      */
-    @SuppressForbidden(reason = "customized base 2 parsing not in Util class")
     public static String getManufacturerID(byte[] edid) {
-        // Bytes 8-9 are manufacturer ID in 3 5-bit characters.
-        String temp = String.format(Locale.ROOT, "%8s%8s", Integer.toBinaryString(edid[MANUFACTURER_ID_OFFSET] & 0xFF),
-                Integer.toBinaryString(edid[MANUFACTURER_ID_OFFSET + 1] & 0xFF)).replace(' ', '0');
-        LOG.debug("Manufacurer ID: {}", temp);
-        return String.format(Locale.ROOT, "%s%s%s", (char) (64 + Integer.parseInt(temp.substring(1, 6), 2)),
-                (char) (64 + Integer.parseInt(temp.substring(6, 11), 2)),
-                (char) (64 + Integer.parseInt(temp.substring(11, 16), 2))).replace("@", "");
+        // Bytes 8-9 are the manufacturer ID: bit 15 is reserved, then three 5-bit letters, 1 = 'A'.
+        int id = ((edid[MANUFACTURER_ID_OFFSET] & 0xFF) << 8) | (edid[MANUFACTURER_ID_OFFSET + 1] & 0xFF);
+        LOG.debug("Manufacturer ID: {}", id);
+        return String.format(Locale.ROOT, "%s%s%s", (char) (64 + ((id >> 10) & 0x1F)), (char) (64 + ((id >> 5) & 0x1F)),
+                (char) (64 + (id & 0x1F))).replace("@", "");
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -56,11 +56,33 @@ public final class EdidUtil {
      * @return The manufacturer ID
      */
     public static String getManufacturerID(byte[] edid) {
-        // Bytes 8-9 are the manufacturer ID: bit 15 is reserved, then three 5-bit letters, 1 = 'A'.
-        int id = ((edid[MANUFACTURER_ID_OFFSET] & 0xFF) << 8) | (edid[MANUFACTURER_ID_OFFSET + 1] & 0xFF);
-        LOG.debug("Manufacturer ID: {}", id);
-        return String.format(Locale.ROOT, "%s%s%s", (char) (64 + ((id >> 10) & 0x1F)), (char) (64 + ((id >> 5) & 0x1F)),
-                (char) (64 + (id & 0x1F))).replace("@", "");
+        int packedId = ((edid[MANUFACTURER_ID_OFFSET] & 0xFF) << 8) | (edid[MANUFACTURER_ID_OFFSET + 1] & 0xFF);
+        LOG.debug("Manufacturer ID bytes: {}", packedId);
+        return manufacturerLetters(packedId);
+    }
+
+    /**
+     * Decodes the letters packed into the manufacturer ID of a real EDID.
+     * <p>
+     * Bytes 8 and 9 hold, from the most significant bit down: one reserved bit, then three five-bit letter codes in
+     * which {@code 1} is {@code 'A'}. A code of zero is not a letter; a manufacturer with a two-letter ID leaves one
+     * empty, and it is dropped rather than rendered.
+     * <p>
+     * This is the lenient reader, for bytes that came from hardware. {@link #decodeManufacturerId(long)} is the strict
+     * one, which rejects the whole ID if any code is not a letter, and is used to validate a synthesized display.
+     *
+     * @param packedId the two manufacturer ID bytes, most significant first
+     * @return the manufacturer's letters, at most three of them
+     */
+    static String manufacturerLetters(int packedId) {
+        StringBuilder letters = new StringBuilder(3);
+        for (int shift = 10; shift >= 0; shift -= 5) {
+            int code = (packedId >> shift) & 0x1F;
+            if (code != 0) {
+                letters.append((char) ('A' - 1 + code));
+            }
+        }
+        return letters.toString();
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -64,14 +64,15 @@ public final class EdidUtil {
     /**
      * Decodes the letters packed into the manufacturer ID of a real EDID.
      * <p>
-     * Bytes 8 and 9 hold, from the most significant bit down: one reserved bit, then three five-bit letter codes in
-     * which {@code 1} is {@code 'A'}. A code of zero is not a letter; a manufacturer with a two-letter ID leaves one
-     * empty, and it is dropped rather than rendered.
+     * The three letters are three five-bit codes in the low 15 bits, most significant first, in which {@code 1} is
+     * {@code 'A'}. A code of zero is not a letter; a manufacturer with a two-letter ID leaves one empty, and it is
+     * dropped rather than rendered. Everything above bit 14 is ignored.
      * <p>
-     * This is the lenient reader, for bytes that came from hardware. {@link #decodeManufacturerId(long)} is the strict
+     * This is the lenient reader, for bits that came from hardware. {@link #decodeManufacturerId(long)} is the strict
      * one, which rejects the whole ID if any code is not a letter, and is used to validate a synthesized display.
      *
-     * @param packedId the two manufacturer ID bytes, most significant first
+     * @param packedId the manufacturer ID in its low 15 bits. Taken as an {@code int} so the caller composing it from
+     *                 EDID bytes 8 and 9 need not cast; the width beyond those 15 bits carries no meaning
      * @return the manufacturer's letters, at most three of them
      */
     static String manufacturerLetters(int packedId) {

--- a/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
@@ -429,4 +429,27 @@ class EdidUtilTest {
         assertThat(info.getSerialNo(), is("FD626D62"));
         assertThat(info.getProductSerialNumber(), is("ABC123"));
     }
+
+    /**
+     * The three letter codes are packed five bits each, most significant first, with {@code 1} meaning {@code 'A'}.
+     * "AUO" is the manufacturer in the fixture above: A=1, U=21, O=15.
+     */
+    @Test
+    void testManufacturerLetters() {
+        assertThat("AUO", EdidUtil.manufacturerLetters((1 << 10) | (21 << 5) | 15), is("AUO"));
+        assertThat("first and last letter", EdidUtil.manufacturerLetters((1 << 10) | (26 << 5) | 26), is("AZZ"));
+        assertThat("reserved high bit is ignored", EdidUtil.manufacturerLetters(0x8000 | (1 << 10) | (21 << 5) | 15),
+                is("AUO"));
+    }
+
+    /**
+     * A zero code is not a letter. A manufacturer with a shorter ID leaves one empty, and it is dropped rather than
+     * rendered as the character below 'A'.
+     */
+    @Test
+    void testManufacturerLettersDropsEmptyCodes() {
+        assertThat("trailing code empty", EdidUtil.manufacturerLetters((1 << 10) | (21 << 5)), is("AU"));
+        assertThat("leading code empty", EdidUtil.manufacturerLetters((21 << 5) | 15), is("UO"));
+        assertThat("all codes empty", EdidUtil.manufacturerLetters(0), is(""));
+    }
 }

--- a/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
@@ -438,8 +438,8 @@ class EdidUtilTest {
     void testManufacturerLetters() {
         assertThat("AUO", EdidUtil.manufacturerLetters((1 << 10) | (21 << 5) | 15), is("AUO"));
         assertThat("first and last letter", EdidUtil.manufacturerLetters((1 << 10) | (26 << 5) | 26), is("AZZ"));
-        assertThat("reserved high bit is ignored", EdidUtil.manufacturerLetters(0x8000 | (1 << 10) | (21 << 5) | 15),
-                is("AUO"));
+        assertThat("everything above bit 14 is ignored",
+                EdidUtil.manufacturerLetters(0xFFFF8000 | (1 << 10) | (21 << 5) | 15), is("AUO"));
     }
 
     /**

--- a/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/util/platform/windows/WmiQueryHandlerFFM.java
@@ -8,7 +8,6 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -51,10 +50,10 @@ public class WmiQueryHandlerFFM implements WmiQueryExecutor {
     private volatile int wmiTimeout = globalTimeout;
 
     // Cache failed wmi classes
-    private final Set<String> failedWmiClassNames = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<String> failedWmiClassNames = ConcurrentHashMap.newKeySet();
 
     // Preferred threading model
-    private int comThreading = Ole32FFM.COINIT_MULTITHREADED;
+    private volatile int comThreading = Ole32FFM.COINIT_MULTITHREADED;
 
     // Track initialization of Security
     private volatile boolean securityInitialized = false;

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/CupsPrinterFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/unix/CupsPrinterFFM.java
@@ -68,9 +68,6 @@ public final class CupsPrinterFFM extends CupsPrinter {
                     MemorySegment dest = destsArray.asSlice(offset, CupsFunctions.CUPS_DEST_T.byteSize());
 
                     MemorySegment namePtr = (MemorySegment) CupsFunctions.CUPS_DEST_NAME.get(dest, 0L);
-                    if (namePtr == null || namePtr.equals(MemorySegment.NULL)) {
-                        continue;
-                    }
                     String name = ForeignFunctions.getStringFromNativePointer(namePtr, arena);
                     if (name == null) {
                         continue;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdInternetProtocolStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/unix/freebsd/FreeBsdInternetProtocolStatsFFM.java
@@ -32,10 +32,10 @@ public class FreeBsdInternetProtocolStatsFFM extends FreeBsdInternetProtocolStat
     private static final int TCPSTAT_MIN_SIZE = 128;
     private static final int UDPSTAT_MIN_SIZE = 84;
 
-    private Supplier<Pair<Long, Long>> establishedv4v6 = memoize(NetStat::queryTcpnetstat, defaultExpiration());
-    private Supplier<@Nullable MemorySegment> tcpstat = memoize(FreeBsdInternetProtocolStatsFFM::queryTcpstat,
+    private final Supplier<Pair<Long, Long>> establishedv4v6 = memoize(NetStat::queryTcpnetstat, defaultExpiration());
+    private final Supplier<@Nullable MemorySegment> tcpstat = memoize(FreeBsdInternetProtocolStatsFFM::queryTcpstat,
             defaultExpiration());
-    private Supplier<@Nullable MemorySegment> udpstat = memoize(FreeBsdInternetProtocolStatsFFM::queryUdpstat,
+    private final Supplier<@Nullable MemorySegment> udpstat = memoize(FreeBsdInternetProtocolStatsFFM::queryUdpstat,
             defaultExpiration());
 
     @Override

--- a/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryHandler.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/WmiQueryHandler.java
@@ -5,7 +5,6 @@
 package oshi.util.platform.windows;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
@@ -46,10 +45,10 @@ public class WmiQueryHandler implements WmiQueryExecutor {
     private volatile int wmiTimeout = globalTimeout;
 
     // Cache failed wmi classes
-    private final Set<String> failedWmiClassNames = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<String> failedWmiClassNames = ConcurrentHashMap.newKeySet();
 
     // Preferred threading model
-    private int comThreading = Ole32.COINIT_MULTITHREADED;
+    private volatile int comThreading = Ole32.COINIT_MULTITHREADED;
 
     // Track initialization of Security
     private volatile boolean securityInitialized = false;


### PR DESCRIPTION
Two commits: the last three Sonar findings, then the 82 GitHub Code Quality findings.

## Sonar — three fixes, taking 8 open issues down to the 5 I believe are false positives

- **`java:S135` in `CupsPrinterFFM`** — the loop tested its name pointer for null and `MemorySegment.NULL`,
  then tested the decoded string for null. `getStringFromNativePointer` performs *exactly* the first
  test and answers null for it, so the guard was duplicated. Removing it leaves one `continue`, which
  is what the rule reported. I introduced that duplication in #3635.
- **`java:S3077` in `DisplayInfoImpl`** — the volatile EDID array is swapped wholesale and never mutated
  element-wise, so `AtomicReferenceArray` would be the wrong tool. Suppressed the way `Memoizer`'s
  holder field is: rule-scoped `@SuppressWarnings` on the declaration, per AGENTS.md.
- **`java:S8786` in `NetBsdCentralProcessor`** — possessive quantifiers on the key/value split.
  Whitespace can never match the `=` that follows it, so the engine never needs to give characters
  back. Verified identical against `a = b`, `a=b`, `  key   =   value  `, `no equals here`, `a==b`,
  ` = `, `a =` and `= b`.

The five left open each test a value a lambda genuinely returns as `null`; Sonar infers the enclosing
generic call's type argument from the lambda's non-null branch and concludes otherwise. Same gap as
the `java:S4449` batch already dismissed. My attempt in #3637 to fix these by declaring the locals
`@Nullable` did **not** move Sonar — the annotations are accurate, so I left them, but they were not
the remedy I claimed.

## Code Quality — 82 findings, 61 of them in one file

**`AbstractPowerSource` is annotated `@ThreadSafe` and has 21 mutable fields, none volatile**, all
written by `updateAttributes()` and read by the getters. A caller on another thread could read stale
values indefinitely — precisely what the annotation promises will not happen. It is also the only one
of its siblings never hardened this way:

| class | volatile fields |
|---|---|
| `AbstractOSProcess` | 13 |
| `AbstractOSThread` | 12 |
| `AbstractNetworkIF` | 10 |
| `AbstractHWDiskStore` | 8 |
| **`AbstractPowerSource`** | **0** |

Same `updateAttributes()` shape in every case. Making the 21 fields volatile closes both clusters
reported against the file.

The rest:

- `WmiQueryHandler` and its FFM twin declare `comThreading` mutable and non-volatile on a
  `@ThreadSafe` class; it is set through `setThreading()`.
- Their `failedWmiClassNames` set is already `final` and `ConcurrentHashMap`-backed, so those **ten
  findings are false positives**. Switching to `ConcurrentHashMap.newKeySet()` is the same set under
  a name the analyzer recognises, and is the idiomatic form regardless.
- `WindowsGpuStats`' lazily populated device cache is now volatile; the three memoized suppliers in
  `FreeBsdInternetProtocolStatsFFM` are `final`, which is what publishes them safely.
- **`EdidUtil`** built a 16-character binary string only to parse three 5-bit slices back out of it.
  Reading the bits directly removes three potential `NumberFormatException`s and the file's last use
  of `Integer.parseInt`, so its `@SuppressForbidden` goes too. `EdidUtilTest` asserts the decoded
  manufacturer (`"AUO"`) against a real EDID fixture and is unchanged.

**Two left open deliberately.** `ParseUtil`'s two `getValueOrUnknown` overloads are reported as
confusable, but they are behaviorally identical and the more specific one wins at every call site, so
removing a public utility method to satisfy a note-severity rule is not worth it.
`LinuxOperatingSystemJNA`'s unread `Udev` variable exists *precisely* to be unread — it forces the JNA
library load whose failure is the signal — and already says so with `@SuppressWarnings("unused")`.

Full gate on macOS: `spotless:apply spotless:check checkstyle:check install forbiddenapis:check
javadoc:javadoc` plus `-Perror-prone clean install` — all modules green, 1565 tests, 0 failures,
NullAway zero findings at `ERROR`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing reliability for NetBSD processor information and CUPS printer data.
  * Improved display manufacturer identification, including support for edge-case EDID values.
* **Improvements**
  * Improved reliability and consistency of hardware, battery, graphics, and operating system information in multi-threaded environments.
  * Improved efficiency of hardware monitoring without changing existing behavior.
* **Tests**
  * Expanded coverage for display identification data, including boundary and incomplete values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->