### PR TITLE
Finish the two findings the previous round did not clear

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessor.java
@@ -6,7 +6,6 @@ package oshi.hardware.common.platform.unix.netbsd;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.jspecify.annotations.Nullable;
 
@@ -24,10 +23,6 @@ import oshi.util.tuples.Pair;
  */
 @ThreadSafe
 public class NetBsdCentralProcessor extends BsdCentralProcessor {
-    // Possessive quantifiers: whitespace can never match the "=" that follows it, so the engine never needs to
-    // give characters back. Behaviorally identical, with no backtracking to do.
-    private static final Pattern KEY_VALUE = Pattern.compile("\\s*+=\\s*+");
-
     private static final int CPUSTATES = 5;
     private static final int CP_USER = 0;
     private static final int CP_NICE = 1;
@@ -189,7 +184,8 @@ public class NetBsdCentralProcessor extends BsdCentralProcessor {
         }
         String[] pairs = cpTimeStr.substring(colonIdx + 1).split(",", -1);
         for (String pair : pairs) {
-            String[] kv = KEY_VALUE.split(pair.trim(), -1);
+            // Both halves are trimmed below, so a plain "=" split is equivalent to matching the spaces here
+            String[] kv = pair.split("=", -1);
             if (kv.length == 2) {
                 long val = ParseUtil.parseLongOrDefault(kv[1].trim(), 0L);
                 switch (kv[0].trim()) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsGpuStats.java
@@ -42,8 +42,8 @@ public abstract class WindowsGpuStats implements GpuStats {
     private boolean closed;
 
     private volatile @Nullable String cachedNvmlDevice;
-    private int cachedAdlIndex = Integer.MIN_VALUE;
-    private @Nullable GpuTicks prevUtilTicks;
+    private volatile int cachedAdlIndex = Integer.MIN_VALUE;
+    private volatile @Nullable GpuTicks prevUtilTicks;
 
     /**
      * Constructor.
@@ -274,9 +274,10 @@ public abstract class WindowsGpuStats implements GpuStats {
             }
         }
         GpuTicks curr = getGpuTicks();
-        if (prevUtilTicks != null) {
-            long dActive = curr.getActiveTicks() - prevUtilTicks.getActiveTicks();
-            long dIdle = curr.getIdleTicks() - prevUtilTicks.getIdleTicks();
+        GpuTicks prev = this.prevUtilTicks;
+        if (prev != null) {
+            long dActive = curr.getActiveTicks() - prev.getActiveTicks();
+            long dIdle = curr.getIdleTicks() - prev.getIdleTicks();
             if (dActive < 0 || dIdle < 0) {
                 prevUtilTicks = curr;
                 return -1d;


### PR DESCRIPTION
Both of these survived #3638. Re-reading them once the Sonar and Code Quality scans refreshed on
current master showed why — and in one case the reason was my own mistake.

### `WindowsGpuStats` — I fixed the wrong field

The `java/safe-publication` finding was on **`cachedAdlIndex`**, not the adjacent `cachedNvmlDevice` I
made volatile in #3638. I inferred which field the reported line number held rather than counting it,
so the finding just moved down one line with my change.

`cachedAdlIndex` and `prevUtilTicks` are both written after construction on a `@ThreadSafe` class, and
are volatile now. `closed` is not, and does not need to be — its only accessors are `synchronized`,
which is why CodeQL never flagged it.

Making `prevUtilTicks` volatile also required fixing how it is read. The old code tested it for null
and then dereferenced it — two reads of a field another thread can write in between:

```java
if (prevUtilTicks != null) {
    long dActive = curr.getActiveTicks() - prevUtilTicks.getActiveTicks();   // second read
```

It now reads once into a local, which removes the race as well as the visibility gap.

### `NetBsdCentralProcessor` — the regex was unnecessary, not just unlucky

The possessive quantifiers from #3638 did **not** satisfy `java:S8786`; Sonar still reported
backtracking on a pattern that by definition does none. Rather than argue with the rule, I looked at
the call site again:

```java
String[] kv = KEY_VALUE.split(pair.trim(), -1);
if (kv.length == 2) {
    long val = ParseUtil.parseLongOrDefault(kv[1].trim(), 0L);
    switch (kv[0].trim()) {
```

Both halves are trimmed immediately afterwards, so matching the surrounding whitespace in the pattern
achieved nothing the trim did not. Splitting on a plain `"="` is equivalent, takes the JDK's
single-character fast path rather than the regex engine, and leaves nothing for the rule to report.
The `Pattern` constant and its import are gone.

`parseCpTime`'s tests cover real `sysctl` output — `user = 2930, nice = 42, sys = 1334, ...` with
asserted tick values — and are unchanged.

### After this

Sonar should hold at the 5 known false positives; Code Quality at the 2 informational findings you
have been dismissing (`ParseUtil`'s overload pair and the deliberately unread `Udev` probe).

Full gate on macOS: `spotless:apply spotless:check checkstyle:check install forbiddenapis:check
javadoc:javadoc` plus `-Perror-prone clean install` — all modules green, 1326 oshi-common tests, 0
failures, NullAway zero at `ERROR`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading CPU timing information on NetBSD systems.
  * Improved consistency of GPU utilization reporting on Windows, especially during concurrent updates or invalid measurement intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->