### PR TITLE
Hoist the printer boolean accessor into WmiUtil

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiConstants.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiConstants.java
@@ -19,6 +19,8 @@ public final class WmiConstants {
     public static final int CIM_REAL32 = 4;
     /** CIM type for string. */
     public static final int CIM_STRING = 8;
+    /** CIM type for boolean. */
+    public static final int CIM_BOOLEAN = 11;
     /** CIM type for unsigned 16-bit integer. */
     public static final int CIM_UINT16 = 18;
     /** CIM type for unsigned 32-bit integer. */
@@ -37,4 +39,6 @@ public final class WmiConstants {
     public static final int VT_R4 = 4;
     /** Variant type for BSTR (string). */
     public static final int VT_BSTR = 8;
+    /** Variant type for boolean. */
+    public static final int VT_BOOL = 11;
 }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiUtil.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiUtil.java
@@ -4,6 +4,7 @@
  */
 package oshi.driver.common.windows.wmi;
 
+import static oshi.driver.common.windows.wmi.WmiConstants.CIM_BOOLEAN;
 import static oshi.driver.common.windows.wmi.WmiConstants.CIM_DATETIME;
 import static oshi.driver.common.windows.wmi.WmiConstants.CIM_REAL32;
 import static oshi.driver.common.windows.wmi.WmiConstants.CIM_REFERENCE;
@@ -12,6 +13,7 @@ import static oshi.driver.common.windows.wmi.WmiConstants.CIM_STRING;
 import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT16;
 import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT32;
 import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT64;
+import static oshi.driver.common.windows.wmi.WmiConstants.VT_BOOL;
 import static oshi.driver.common.windows.wmi.WmiConstants.VT_BSTR;
 import static oshi.driver.common.windows.wmi.WmiConstants.VT_I4;
 import static oshi.driver.common.windows.wmi.WmiConstants.VT_R4;
@@ -236,6 +238,26 @@ public final class WmiUtil {
             return (int) o;
         }
         throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "32-bit integer",
+                result.getCIMType(property), result.getVtType(property)));
+    }
+
+    /**
+     * Gets a Boolean value from a WmiResult.
+     *
+     * @param <T>      the property enum type
+     * @param result   The WmiResult from which to fetch the value
+     * @param property The property (column) to fetch
+     * @param index    The index (row) to fetch
+     * @return The stored value if non-null, {@code false} otherwise
+     */
+    public static <T extends Enum<T>> boolean getBoolean(WmiResult<T> result, T property, int index) {
+        Object o = result.getValue(property, index);
+        if (o == null) {
+            return false;
+        } else if (result.getCIMType(property) == CIM_BOOLEAN && result.getVtType(property) == VT_BOOL) {
+            return (boolean) o;
+        }
+        throw new ClassCastException(String.format(Locale.ROOT, CLASS_CAST_MSG, property.name(), "Boolean",
                 result.getCIMType(property), result.getVtType(property)));
     }
 

--- a/oshi-common/src/test/java/oshi/driver/common/windows/wmi/WmiUtilTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/windows/wmi/WmiUtilTest.java
@@ -72,6 +72,24 @@ class WmiUtilTest {
     }
 
     @Test
+    void testGetBooleanValid() {
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_BOOLEAN, WmiConstants.VT_BOOL, true);
+        assertThat(WmiUtil.getBoolean(result, TestProp.ID, 0), is(true));
+    }
+
+    @Test
+    void testGetBooleanNull() {
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_BOOLEAN, WmiConstants.VT_BOOL, null);
+        assertThat(WmiUtil.getBoolean(result, TestProp.ID, 0), is(false));
+    }
+
+    @Test
+    void testGetBooleanWrongType() {
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_UINT32, WmiConstants.VT_I4, 42);
+        assertThrows(ClassCastException.class, () -> WmiUtil.getBoolean(result, TestProp.ID, 0));
+    }
+
+    @Test
     void testGetFloat() {
         WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_REAL32, WmiConstants.VT_R4, 3.14f);
         assertThat(WmiUtil.getFloat(result, TestProp.SIZE, 0), is(3.14f));

--- a/oshi-common/src/test/java/oshi/driver/common/windows/wmi/WmiUtilTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/windows/wmi/WmiUtilTest.java
@@ -84,8 +84,15 @@ class WmiUtilTest {
     }
 
     @Test
-    void testGetBooleanWrongType() {
-        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_UINT32, WmiConstants.VT_I4, 42);
+    void testGetBooleanWrongCimType() {
+        // Boolean payload, so only the CIM metadata is wrong and the throw cannot come from the cast
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_UINT32, WmiConstants.VT_BOOL, true);
+        assertThrows(ClassCastException.class, () -> WmiUtil.getBoolean(result, TestProp.ID, 0));
+    }
+
+    @Test
+    void testGetBooleanWrongVtType() {
+        WmiResult<TestProp> result = new MockWmiResult<>(WmiConstants.CIM_BOOLEAN, WmiConstants.VT_I4, true);
         assertThrows(ClassCastException.class, () -> WmiUtil.getBoolean(result, TestProp.ID, 0));
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPrinterFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPrinterFFM.java
@@ -41,21 +41,13 @@ final class WindowsPrinterFFM extends WindowsPrinter {
             String description = WmiUtil.getString(result, PrinterProperty.DESCRIPTION, i);
             int statusCode = WmiUtil.getUint16(result, PrinterProperty.PRINTERSTATUS, i);
             int errorState = WmiUtil.getUint16(result, PrinterProperty.DETECTEDERRORSTATE, i);
-            boolean isDefault = getBooleanValue(result, PrinterProperty.DEFAULT, i);
-            boolean isLocal = getBooleanValue(result, PrinterProperty.LOCAL, i);
+            boolean isDefault = WmiUtil.getBoolean(result, PrinterProperty.DEFAULT, i);
+            boolean isLocal = WmiUtil.getBoolean(result, PrinterProperty.LOCAL, i);
             String portName = WmiUtil.getString(result, PrinterProperty.PORTNAME, i);
 
             printers.add(new WindowsPrinterFFM(name, driverName, description, parseStatus(statusCode, errorState),
                     parseErrorState(errorState), isDefault, isLocal, portName));
         }
         return printers;
-    }
-
-    private static boolean getBooleanValue(WmiResult<PrinterProperty> result, PrinterProperty property, int index) {
-        Object o = result.getValue(property, index);
-        if (o instanceof Boolean bool) {
-            return bool;
-        }
-        return false;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPrinterJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsPrinterJNA.java
@@ -41,21 +41,13 @@ final class WindowsPrinterJNA extends WindowsPrinter {
             String description = WmiUtil.getString(result, PrinterProperty.DESCRIPTION, i);
             int statusCode = WmiUtil.getUint16(result, PrinterProperty.PRINTERSTATUS, i);
             int errorState = WmiUtil.getUint16(result, PrinterProperty.DETECTEDERRORSTATE, i);
-            boolean isDefault = getBooleanValue(result, PrinterProperty.DEFAULT, i);
-            boolean isLocal = getBooleanValue(result, PrinterProperty.LOCAL, i);
+            boolean isDefault = WmiUtil.getBoolean(result, PrinterProperty.DEFAULT, i);
+            boolean isLocal = WmiUtil.getBoolean(result, PrinterProperty.LOCAL, i);
             String portName = WmiUtil.getString(result, PrinterProperty.PORTNAME, i);
 
             printers.add(new WindowsPrinterJNA(name, driverName, description, parseStatus(statusCode, errorState),
                     parseErrorState(errorState), isDefault, isLocal, portName));
         }
         return printers;
-    }
-
-    private static boolean getBooleanValue(WmiResult<PrinterProperty> result, PrinterProperty property, int index) {
-        Object o = result.getValue(property, index);
-        if (o instanceof Boolean) {
-            return (Boolean) o;
-        }
-        return false;
     }
 }


### PR DESCRIPTION
Both `WindowsPrinterJNA` and `WindowsPrinterFFM` carried a private `getBooleanValue` that pulled an `Object` out of a `WmiResult` and loosely tested it with `instanceof`. Replaced both with a `WmiUtil.getBoolean`, which is where it belongs — next to `getString`, `getUint16` and `getFloat`.

The hoisted accessor follows the shape of its siblings: a null value returns `false`, the CIM and VT types are checked, and a mismatch throws `ClassCastException` instead of silently returning a plausible-looking `false`. `WmiConstants` gains `CIM_BOOLEAN` and `VT_BOOL` (11 each, matching the values already used in `WbemcliFFM` and `VariantFFM`).

The one behavior difference is that throw. `Win32_Printer` exposes `Default` and `Local` as `CIM_BOOLEAN`, so no real query reaches it — it now signals a mis-typed property enum rather than returning `false`. Verified that both backends store a `Boolean` for `VT_BOOL` (`WbemcliUtilFFM` and JNA's `WbemcliUtil`), and that both record a column's VT type from the first non-null row, so a column that is null in every row takes the null path rather than the throw.

This also clears Coverity CID 1677157, which read the FFM copy's `o instanceof Boolean bool` pattern variable as nullable and reported an unboxing NPE that cannot occur.

Three tests added in `WmiUtilTest` covering the valid, null, and wrong-type cases. No CHANGELOG entry: nothing user-visible changes.

Verified on macOS with the full gate on `oshi-common`, `oshi-core` and `oshi-core-ffm` — spotless, checkstyle (0 violations), `clean install` with tests (1329 passed, 0 failed), forbiddenapis, javadoc. The printer code itself is Windows-only and was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows printer detection by correctly interpreting default and local printer properties.
  * Added consistent handling for Windows Management Instrumentation (WMI) Boolean values, including null and incompatible values.
  * Expanded test coverage for Boolean property handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->