### PR TITLE
Fix the OpenIndiana OOM failures by capping the ZFS ARC

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -254,9 +254,13 @@ jobs:
           prepare: |
             pkg_add curl
             pkg_add jdk%25
-            pkg_add maven
           run: |
-            mvn test -Paggregate-coverage -B
+            # The packaged mvn found its own JVM; the wrapper needs to be told. Glob the version
+            # so a jdk package bump doesn't silently break this.
+            export JAVA_HOME=$(ls -d /usr/local/jdk-* | tail -1)
+            export PATH=$JAVA_HOME/bin:$PATH
+            java -version
+            ./mvnw test -Paggregate-coverage -B
       - name: Upload Coverage
         if: always()
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -197,6 +197,9 @@ jobs:
   # the FreeBSD-specific classes.
   testfreebsd:
     runs-on: ubuntu-24.04
+    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
+    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
+    timeout-minutes: 30
     name: Test JDK 25, FreeBSD
     needs: changes
     permissions:
@@ -232,6 +235,9 @@ jobs:
   # OpenBSD VM, JDK 25. Same pattern as FreeBSD above.
   testopenbsd:
     runs-on: ubuntu-24.04
+    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
+    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
+    timeout-minutes: 30
     name: Test JDK 25, OpenBSD
     needs: changes
     permissions:
@@ -274,6 +280,9 @@ jobs:
   # don't exhaust illumos's native-memory pool.
   testopenindiana:
     runs-on: ubuntu-24.04
+    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
+    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
+    timeout-minutes: 30
     name: Test JDK 25, OpenIndiana
     needs: changes
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -145,10 +145,11 @@ jobs:
     permissions:
       contents: read
     strategy:
-      # Latest LTS (JDK 25) across all three OSes — this is the coverage + JNA==FFM
-      # row (uploads linux/macos/windows flags). The version floor/ceiling checks
-      # (JDK 21 and 26) run on ubuntu only; an OS-specific bug that is also
-      # JDK-version-specific in a way ubuntu wouldn't catch is vanishingly rare.
+      # Latest LTS (JDK 25) across all three OSes — the row that uploads the
+      # linux/macos/windows coverage flags and runs the JNA/FFM comparison tests.
+      # The version floor/ceiling checks (JDK 21 and 26) run on ubuntu only; an
+      # OS-specific bug that is also JDK-version-specific in a way ubuntu wouldn't
+      # catch is vanishingly rare.
       matrix:
         include:
           - os: ubuntu-latest
@@ -165,7 +166,7 @@ jobs:
             java: 25
             coverage-flag: windows
       fail-fast: false
-    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}${{ contains(matrix.java, '25') && ' (+ JNA==FFM)' || '' }}
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -196,7 +197,7 @@ jobs:
   # the FreeBSD-specific classes.
   testfreebsd:
     runs-on: ubuntu-24.04
-    name: Test JDK 25, FreeBSD (+ JNA==FFM)
+    name: Test JDK 25, FreeBSD
     needs: changes
     permissions:
       contents: read
@@ -231,7 +232,7 @@ jobs:
   # OpenBSD VM, JDK 25. Same pattern as FreeBSD above.
   testopenbsd:
     runs-on: ubuntu-24.04
-    name: Test JDK 25, OpenBSD (+ JNA==FFM)
+    name: Test JDK 25, OpenBSD
     needs: changes
     permissions:
       contents: read
@@ -269,7 +270,7 @@ jobs:
   # don't exhaust illumos's native-memory pool.
   testopenindiana:
     runs-on: ubuntu-24.04
-    name: Test JDK 25, OpenIndiana (+ JNA==FFM)
+    name: Test JDK 25, OpenIndiana
     needs: changes
     permissions:
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -197,8 +197,6 @@ jobs:
   # the FreeBSD-specific classes.
   testfreebsd:
     runs-on: ubuntu-24.04
-    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
-    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
     timeout-minutes: 30
     name: Test JDK 25, FreeBSD
     needs: changes
@@ -215,6 +213,10 @@ jobs:
         id: test-freebsd
         uses: vmactions/freebsd-vm@83b151f58c6047089f4c80eb5ba2039d158ce093 # v1
         with:
+          # Caching the base image is a slower copy of a download that happens anyway: restoring
+          # it measured 54s against 48s to fetch from source, and a miss also uploads ~970 MB.
+          # Only prepared images earn their space, by skipping work rather than moving bytes.
+          disable-cache: true
           usesh: true
           copyback: true
           prepare: |
@@ -235,8 +237,6 @@ jobs:
   # OpenBSD VM, JDK 25. Same pattern as FreeBSD above.
   testopenbsd:
     runs-on: ubuntu-24.04
-    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
-    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
     timeout-minutes: 30
     name: Test JDK 25, OpenBSD
     needs: changes
@@ -257,6 +257,9 @@ jobs:
           usesh: false
           mem: 2048
           copyback: true
+          # Skips pkg_add on later runs. This mirror has shown the widest download variance in
+          # the matrix, measured at 1.6, 10.0 and 11.2 minutes across three runs.
+          cache-after-prepare: true
           prepare: |
             pkg_add curl
             pkg_add jdk%25
@@ -280,8 +283,6 @@ jobs:
   # don't exhaust illumos's native-memory pool.
   testopenindiana:
     runs-on: ubuntu-24.04
-    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
-    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
     timeout-minutes: 30
     name: Test JDK 25, OpenIndiana
     needs: changes
@@ -304,11 +305,29 @@ jobs:
           # thread fan-out that drives the native-memory OOMs.
           cpu: 2
           copyback: true
+          # Reboots the guest between prepare and run, discarding the ZFS ARC that pkg install
+          # fills before the build starts. Also caches the prepared image, skipping pkg install
+          # on later runs.
+          cache-after-prepare: true
           prepare: |
+            # ZFS ARC defaults to ~69% of RAM and is kernel memory, so it starves allocations
+            # while swap -s still reports gigabytes free. Capping it is what stops the
+            # intermittent OOMs; /etc/system is the supported knob and applies on the reboot
+            # cache-after-prepare performs.
+            echo "set zfs:zfs_arc_max = 2147483648" >> /etc/system
             pkg install openjdk25
           run: |
             export JAVA_HOME=/usr/jdk/openjdk25
             export PATH=$JAVA_HOME/bin:$PATH
+            # An uncapped run is indistinguishable from a capped one until it OOMs, so fail
+            # loudly rather than silently losing the cap.
+            ARC_CMAX=$(kstat -p zfs:0:arcstats:c_max 2>/dev/null | awk '{print $2}')
+            echo "ARC cap: arc_c_max=${ARC_CMAX} size=$(kstat -p zfs:0:arcstats:size 2>/dev/null | awk '{print $2}')"
+            if [ "$ARC_CMAX" != "2147483648" ]; then
+              echo "ERROR: ZFS ARC is not capped (expected 2147483648); /etc/system did not take"
+              grep -i arc /etc/system || echo "  (no arc lines in /etc/system)"
+              exit 1
+            fi
             # illumos OOMs here are native memory (thread stacks + GC/JIT/metaspace),
             # not Java heap. Cap every native pool that grows with thread fan-out and
             # use SerialGC (no parallel GC threads/structures) to keep the footprint flat.

--- a/.github/workflows/unix.yaml
+++ b/.github/workflows/unix.yaml
@@ -21,8 +21,6 @@ jobs:
   testfreebsd:
     name: Test JDK 25, FreeBSD
     runs-on: ubuntu-24.04
-    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
-    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -32,6 +30,10 @@ jobs:
         id: test-freebsd
         uses: vmactions/freebsd-vm@83b151f58c6047089f4c80eb5ba2039d158ce093 # v1
         with:
+          # Caching the base image is a slower copy of a download that happens anyway: restoring
+          # it measured 54s against 48s to fetch from source, and a miss also uploads ~970 MB.
+          # Only prepared images earn their space, by skipping work rather than moving bytes.
+          disable-cache: true
           usesh: true
           copyback: true
           prepare: |
@@ -53,8 +55,6 @@ jobs:
   # to Codecov under the `openbsd` flag.
   testopenbsd:
     runs-on: ubuntu-24.04
-    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
-    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
     timeout-minutes: 30
     name: Test JDK 25, OpenBSD
     steps:
@@ -69,6 +69,9 @@ jobs:
           usesh: false
           mem: 2048
           copyback: true
+          # Skips pkg_add on later runs. This mirror has shown the widest download variance in
+          # the matrix, measured at 1.6, 10.0 and 11.2 minutes across three runs.
+          cache-after-prepare: true
           prepare: |
             pkg_add curl
             pkg_add jdk%25
@@ -92,8 +95,6 @@ jobs:
   testopenindiana:
     name: Test JDK 25, OpenIndiana
     runs-on: ubuntu-24.04
-    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
-    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -109,11 +110,29 @@ jobs:
           # thread fan-out that drives the native-memory OOMs.
           cpu: 2
           copyback: true
+          # Reboots the guest between prepare and run, discarding the ZFS ARC that pkg install
+          # fills before the build starts. Also caches the prepared image, skipping pkg install
+          # on later runs.
+          cache-after-prepare: true
           prepare: |
+            # ZFS ARC defaults to ~69% of RAM and is kernel memory, so it starves allocations
+            # while swap -s still reports gigabytes free. Capping it is what stops the
+            # intermittent OOMs; /etc/system is the supported knob and applies on the reboot
+            # cache-after-prepare performs.
+            echo "set zfs:zfs_arc_max = 2147483648" >> /etc/system
             pkg install openjdk25
           run: |
             export JAVA_HOME=/usr/jdk/openjdk25
             export PATH=$JAVA_HOME/bin:$PATH
+            # An uncapped run is indistinguishable from a capped one until it OOMs, so fail
+            # loudly rather than silently losing the cap.
+            ARC_CMAX=$(kstat -p zfs:0:arcstats:c_max 2>/dev/null | awk '{print $2}')
+            echo "ARC cap: arc_c_max=${ARC_CMAX} size=$(kstat -p zfs:0:arcstats:size 2>/dev/null | awk '{print $2}')"
+            if [ "$ARC_CMAX" != "2147483648" ]; then
+              echo "ERROR: ZFS ARC is not capped (expected 2147483648); /etc/system did not take"
+              grep -i arc /etc/system || echo "  (no arc lines in /etc/system)"
+              exit 1
+            fi
             # illumos OOMs here are native memory (thread stacks + GC/JIT/metaspace),
             # not Java heap. Cap every native pool that grows with thread fan-out and
             # use SerialGC (no parallel GC threads/structures) to keep the footprint flat.
@@ -141,8 +160,6 @@ jobs:
   testdragonflybsd:
     name: Test JDK 21, DragonFly BSD
     runs-on: ubuntu-24.04
-    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
-    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -152,6 +169,9 @@ jobs:
         id: test-dragonflybsd
         uses: vmactions/dragonflybsd-vm@bc8ccbaa091ce3624c93f2dc328ae48129b07580 # v1
         with:
+          # See the FreeBSD job: caching a base image costs more than it saves. These also have
+          # no pr.yaml counterpart, so nothing could restore them in the first place.
+          disable-cache: true
           release: "6.4.2"
           usesh: true
           copyback: true
@@ -177,8 +197,6 @@ jobs:
   testnetbsd:
     name: Test JDK 21, NetBSD (no JNA)
     runs-on: ubuntu-24.04
-    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
-    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -188,6 +206,9 @@ jobs:
         id: test-netbsd
         uses: vmactions/netbsd-vm@00081e82b14bc40114eb97f32b4455306828516b # v1
         with:
+          # See the FreeBSD job: caching a base image costs more than it saves. These also have
+          # no pr.yaml counterpart, so nothing could restore them in the first place.
+          disable-cache: true
           release: "10.1"
           usesh: true
           copyback: true
@@ -213,8 +234,6 @@ jobs:
   testnetbsdjna:
     name: Test JDK 21, NetBSD (JNA)
     runs-on: ubuntu-24.04
-    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
-    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -224,6 +243,9 @@ jobs:
         id: test-netbsd-jna
         uses: vmactions/netbsd-vm@00081e82b14bc40114eb97f32b4455306828516b # v1
         with:
+          # See the FreeBSD job: caching a base image costs more than it saves. These also have
+          # no pr.yaml counterpart, so nothing could restore them in the first place.
+          disable-cache: true
           release: "10.1"
           usesh: true
           copyback: true

--- a/.github/workflows/unix.yaml
+++ b/.github/workflows/unix.yaml
@@ -66,9 +66,13 @@ jobs:
           prepare: |
             pkg_add curl
             pkg_add jdk%25
-            pkg_add maven
           run: |
-            mvn clean test -Paggregate-coverage -B
+            # The packaged mvn found its own JVM; the wrapper needs to be told. Glob the version
+            # so a jdk package bump doesn't silently break this.
+            export JAVA_HOME=$(ls -d /usr/local/jdk-* | tail -1)
+            export PATH=$JAVA_HOME/bin:$PATH
+            java -version
+            ./mvnw clean test -Paggregate-coverage -B
       - name: Upload Coverage
         if: always()
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/.github/workflows/unix.yaml
+++ b/.github/workflows/unix.yaml
@@ -21,6 +21,9 @@ jobs:
   testfreebsd:
     name: Test JDK 25, FreeBSD
     runs-on: ubuntu-24.04
+    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
+    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -50,6 +53,9 @@ jobs:
   # to Codecov under the `openbsd` flag.
   testopenbsd:
     runs-on: ubuntu-24.04
+    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
+    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
+    timeout-minutes: 30
     name: Test JDK 25, OpenBSD
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -86,6 +92,9 @@ jobs:
   testopenindiana:
     name: Test JDK 25, OpenIndiana
     runs-on: ubuntu-24.04
+    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
+    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -132,6 +141,9 @@ jobs:
   testdragonflybsd:
     name: Test JDK 21, DragonFly BSD
     runs-on: ubuntu-24.04
+    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
+    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -165,6 +177,9 @@ jobs:
   testnetbsd:
     name: Test JDK 21, NetBSD (no JNA)
     runs-on: ubuntu-24.04
+    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
+    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -198,6 +213,9 @@ jobs:
   testnetbsdjna:
     name: Test JDK 21, NetBSD (JNA)
     runs-on: ubuntu-24.04
+    # Bound a hung guest. These normally finish well inside this; NetBSD has been seen
+    # wedged for over an hour, which the 6-hour GitHub default lets burn a runner.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
OpenIndiana fails roughly 8% of first attempts on `unix.yaml` (2 of the last 25 master runs, counting first attempts rather than re-runs). The cause turns out not to be the JVM, and the accumulated workarounds on that job were built on a memory model that does not hold.

## What is actually happening

A 32 KB `malloc` was refused 1.3 seconds after a sample showing **3.2 GB available**. The failing process held 41 memory mappings, 61 MB of metaspace and 36 MB of code cache — small and healthy — and `hs_err` reported:

```
#  The system is out of physical RAM or swap space
#  Out of Memory Error (arena.cpp:186)
```

Those statements are only reconcilable one way. `swap -s` reports the *anonymous* memory pool; the ZFS ARC is *kernel* memory and never appears in it. Measured on a 2560 MB guest, ARC held **1.25 GB** while free physical memory was down to **~130 MB**.

That also explains the result which defeated every other theory: the failure rate was **identical at 4096, 3072 and 2560 MB**. ARC sizes itself to about 69% of RAM, so shrinking the guest shrinks the cache with it. The existing `mem: 12288` was handing ARC a ~9 GB budget — the workaround was feeding the problem.

Failures cluster at `oshi-metrics [6/8]` and `oshi-benchmark [7/8]` not because those modules are heavy, but because ARC grows with VM uptime and I/O.

## The fix

`cache-after-prepare` shuts the guest down after `prepare`, caches the image, and boots it again before `run`. That does two things:

1. **Discards the ARC that `pkg install` fills** before the build even starts. Measured, peak ARC during the build halves: **1.28 GB → 646 MB**.
2. **Makes `/etc/system` usable.** It is the supported knob for `zfs_arc_max` and needs a reboot, which these ephemeral guests otherwise cannot take. `arc_c_max` then reads the configured 2 GB instead of the ~9 GB default.

The job asserts `arc_c_max` and fails with the contents of `/etc/system` if the cap did not apply — an uncapped run is indistinguishable from a capped one until it OOMs.

## Caching policy

The action caches VM images by default, and both repositories are at the 10 GB ceiling (upstream: 9.99 GB across 108 entries, 4.46 GB of it VM images). Spend is now matched to benefit per guest:

**Caching a base VM image costs more than it saves.** Measured on FreeBSD's 970 MB image:

| | boot + image acquisition |
|---|---|
| cache **hit** (restore from Actions cache) | **54s** |
| cache **miss** (download from source) | **48s** |

Both are GitHub-hosted downloads at comparable speed (the restore ran at 127 MB/s), so the cache is a slower copy of a download that happens anyway — and a miss additionally *uploads* ~970 MB at the end, which is pure loss. **Only prepared images earn their space**, because they skip work rather than moving the same bytes through a different door.

| Guest | Caching | Why |
|---|---|---|
| OpenIndiana | prepared image | the only way to get the reboot the ARC cap needs |
| OpenBSD | prepared image | `pkg_add` measured at 1.6, 10.0 and 11.2 minutes across three runs |
| FreeBSD | **disabled** | `pkg_add` is a steady 0.3–0.4m, so a prepared image buys ~20s; the base image buys nothing |
| DragonFly, NetBSD ×2 | **disabled** | same, and no `pr.yaml` counterpart could restore them anyway |

Consistent with that, NetBSD (no JNA) went from 8.5–11.6 minutes cached to **3.2–8.7** uncached, and NetBSD (JNA) from 15.0–15.6 to 14.5. Upstream this reclaims about **2 GB** from a budget already at its 10 GB ceiling, where VM images were evicting entries that are shared.

## Also included

- **OpenBSD builds with `./mvnw`** rather than the packaged `mvn`, which dated from the job's origin against a local VM that already had Maven configured. This drops `pkg_add maven` from `prepare`. The packaged `mvn` located a JVM itself, so `JAVA_HOME` is now exported explicitly, globbed by version so a jdk package bump surfaces as a missing directory rather than silently reverting.
- **`timeout-minutes: 30`** on every VM job. NetBSD has been observed wedged for 67 minutes against a normal 9–17, which the 6-hour GitHub default happily burns.
- **The `(+ JNA==FFM)` suffix** is dropped from four job names; the comparison tests have been a settled part of every JDK 25 run for a while.

## Verification

Six full `unix.yaml` runs on the fork, **36 job executions, zero failures**, with `arc_c_max=2147483648` confirmed on every OpenIndiana run. OpenBSD's prepared image was observed saving cleanly with the wrapper finding `openjdk version "25.0.3"` after the reboot.

Stated honestly: six clean runs at a ~10% base rate is **not** statistical proof — that would happen by chance more often than not. The argument rests on the measured mechanism, not the pass count.

## Deliberately not included

Each of these was tried and dropped when measurement contradicted it: a per-module Maven split (tests already fork a JVM per module via `<executor>JAVA</executor>`, and it shares one VM so it never resets ARC); `-Xmx` and `CompressedClassSpaceSize` tuning (NMT showed 1.55 GB reserved against 157 MB committed, and reserved memory is `MAP_NORESERVE`, so it was never the constraint); an in-job retry (same VM, same full ARC — it would fail again); and Maven offline mode (it fixed a regression that turned out to be `pkg_add` mirror variance).

The existing `mem: 12288`, `cpu: 2` and `_JAVA_OPTIONS` caps are left alone. Their comments describe a memory rationale this PR disproves, but removing them on top of everything else would change too much at once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of Unix-platform testing with standardized 30-minute job timeouts.
  * Enhanced OpenBSD test setup with Java availability checks and more consistent build execution.
  * Improved OpenIndiana validation by enforcing and checking memory configuration before tests run.
  * Added environment caching where supported to streamline platform test runs.
  * Disabled caching on platforms where it is unsuitable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
