### PR TITLE
Clear the Sonar findings from the routing table work

### DIFF
--- a/config/sonar-project.properties
+++ b/config/sonar-project.properties
@@ -4,18 +4,18 @@ sonar.projectKey=oshi_oshi
 
 sonar.issue.ignore.multicriteria=s1191,s2160,s1104,s100,s115
 
-sonar.issue.ignore.multicriteria.s1191.ruleKey=squid:S1191
+sonar.issue.ignore.multicriteria.s1191.ruleKey=java:S1191
 sonar.issue.ignore.multicriteria.s1191.resourceKey=**/*.java
 # No need for equals on JNA Structures
-sonar.issue.ignore.multicriteria.s2160.ruleKey=squid:S2160
+sonar.issue.ignore.multicriteria.s2160.ruleKey=java:S2160
 sonar.issue.ignore.multicriteria.s2160.resourceKey=**/jna/**/*.java
 # JNA Structures require public fields
-sonar.issue.ignore.multicriteria.s1104.ruleKey=squid:S1104
+sonar.issue.ignore.multicriteria.s1104.ruleKey=java:S1104
 sonar.issue.ignore.multicriteria.s1104.resourceKey=**/jna/**/*.java
 # JNA method naming conventions match c source
-sonar.issue.ignore.multicriteria.s100.ruleKey=squid:S100
+sonar.issue.ignore.multicriteria.s100.ruleKey=java:S100
 sonar.issue.ignore.multicriteria.s100.resourceKey=**/jna/**/*.java
 # JNA field naming conventions match c source
-sonar.issue.ignore.multicriteria.s115.ruleKey=squid:S115
+sonar.issue.ignore.multicriteria.s115.ruleKey=java:S115
 sonar.issue.ignore.multicriteria.s115.resourceKey=**/jna/**/*.java
  

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsNetworkParams.java
@@ -43,10 +43,6 @@ public abstract class WindowsNetworkParams extends AbstractNetworkParams {
         public int interfaceIndex = -1;
         /** The route metric. */
         public long metric = -1L;
-
-        /** Default constructor. */
-        public RouteRow() {
-        }
     }
 
     /**

--- a/oshi-common/src/main/java/oshi/util/ParseUtil.java
+++ b/oshi-common/src/main/java/oshi/util/ParseUtil.java
@@ -1779,18 +1779,6 @@ public final class ParseUtil {
     }
 
     /**
-     * Checks if value exists in map for the given key or not and returns value or unknown based on it
-     *
-     * @param map A map of String key-value pairs
-     * @param key Fetch value for the given key
-     * @return Returns the value for the key if it exists in the map else it returns unknown
-     */
-    public static String getValueOrUnknown(Map<String, String> map, String key) {
-        String value = map.getOrDefault(key, "");
-        return value.isEmpty() ? Constants.UNKNOWN : value;
-    }
-
-    /**
      * Checks if a value exists in the map for the given key and returns the value or unknown based on it
      *
      * @param map A map where the keys can be of any type and the values are Strings.

--- a/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
@@ -1246,19 +1246,30 @@ class ParseUtilTest {
         assertThat(ParseUtil.parseRouteDestination("10.0.0.1", false).getA(), is(new byte[] { 10, 0, 0, 1 }));
         assertThat(ParseUtil.parseRouteDestination("10.0.0.1", false).getB(), is(-1));
         assertThat(ParseUtil.parseRouteDestination("129.70.163.176", false).getB(), is(-1));
-        // A stated but unparseable prefix stays unknown. It must not fall through to the octet-count inference, which
-        // would silently turn malformed input into a plausible-looking /8.
-        assertThat(ParseUtil.parseRouteDestination("10/foo", false).getA(), is(new byte[] { 10, 0, 0, 0 }));
-        assertThat(ParseUtil.parseRouteDestination("10/foo", false).getB(), is(-1));
-        assertThat(ParseUtil.parseRouteDestination("10/-1", false).getB(), is(-1));
-        assertThat(ParseUtil.parseRouteDestination("192.168.122/", false).getB(), is(-1));
         assertThat(ParseUtil.parseRouteDestination("::1%1", true).getB(), is(-1));
         // IPv6 with an inline prefix
         assertThat(ParseUtil.parseRouteDestination("fe80::/10", true).getB(), is(10));
         assertThat(ParseUtil.parseRouteDestination("2601:601:d47c:3090::/64", true).getB(), is(64));
         // A prefix wider than the address is clamped
         assertThat(ParseUtil.parseRouteDestination("10.0.0.1/99", false).getB(), is(32));
-        // Header, banner and separator tokens are not addresses, which is how they are skipped
+    }
+
+    /**
+     * Test parseRouteDestination keeping a stated but unparseable prefix unknown rather than inferring one
+     */
+    @Test
+    void testParseRouteDestinationMalformedPrefix() {
+        assertThat(ParseUtil.parseRouteDestination("10/foo", false).getA(), is(new byte[] { 10, 0, 0, 0 }));
+        assertThat(ParseUtil.parseRouteDestination("10/foo", false).getB(), is(-1));
+        assertThat(ParseUtil.parseRouteDestination("10/-1", false).getB(), is(-1));
+        assertThat(ParseUtil.parseRouteDestination("192.168.122/", false).getB(), is(-1));
+    }
+
+    /**
+     * Test parseRouteDestination rejecting the header, banner and separator lines it is used to skip
+     */
+    @Test
+    void testParseRouteDestinationRejectsNonAddresses() {
         assertThat(ParseUtil.parseRouteDestination("Destination", false).getA(), is(new byte[0]));
         assertThat(ParseUtil.parseRouteDestination("Destination", false).getB(), is(-1));
         assertThat(ParseUtil.parseRouteDestination("Destination/Mask", true).getA(), is(new byte[0]));

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/IPHlpAPIFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/windows/IPHlpAPIFFM.java
@@ -147,7 +147,7 @@ public class IPHlpAPIFFM extends WindowsForeignFunctions {
     // FreeMibTable returns void, hence the null return layout, as for WTSFreeMemory.
     private static final MethodHandle FreeMibTable = downcall(IPHlpAPI, "FreeMibTable", null, ADDRESS);
 
-    // MIB_IPFORWARD_TABLE2 { ULONG NumEntries; MIB_IPFORWARD_ROW2 Table[ANY_SIZE]; }
+    // A MIB_IPFORWARD_TABLE2 is a ULONG entry count followed by the row array.
     // MIB_IPFORWARD_ROW2 is 8-byte aligned because NET_LUID is a ULONG64, so the row array begins at offset 8
     // rather than immediately after the 4-byte NumEntries.
     public static final long OFFSET_IPFORWARD_TABLE2_NUM_ENTRIES = 0;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsNetworkParamsFFM.java
@@ -54,7 +54,7 @@ public final class WindowsNetworkParamsFFM extends WindowsNetworkParams {
             }
             MemorySegment table = pTable.get(ADDRESS, 0);
             // The table is allocated by the system, so it must be released with FreeMibTable however this exits
-            try (NativeHandle handle = NativeHandle.of(table, IPHlpAPIFFM::FreeMibTable)) {
+            try (var _ = NativeHandle.of(table, IPHlpAPIFFM::FreeMibTable)) {
                 return readRows(table);
             }
         } catch (Throwable e) { // NOSONAR java:S1181 - an FFM downcall can throw any Throwable

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsNetworkParamsJNA.java
@@ -4,6 +4,10 @@
  */
 package oshi.software.os.windows;
 
+import static com.sun.jna.platform.win32.IPHlpAPI.AF_INET;
+import static com.sun.jna.platform.win32.IPHlpAPI.AF_INET6;
+import static com.sun.jna.platform.win32.IPHlpAPI.AF_UNSPEC;
+
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -101,7 +105,7 @@ final class WindowsNetworkParamsJNA extends WindowsNetworkParams {
     @Override
     protected List<RouteRow> queryRouteRows() {
         try (CloseablePointerByReference tableRef = new CloseablePointerByReference()) {
-            int ret = IPHlpAPI.INSTANCE.GetIpForwardTable2((short) IPHlpAPI.AF_UNSPEC, tableRef);
+            int ret = IPHlpAPI.INSTANCE.GetIpForwardTable2((short) AF_UNSPEC, tableRef);
             if (ret != WinError.NO_ERROR) {
                 LOG.error("Failed to get the IP forward table. Error code: {}", ret);
                 return new ArrayList<>();
@@ -141,10 +145,10 @@ final class WindowsNetworkParamsJNA extends WindowsNetworkParams {
     }
 
     private static byte[] addressBytes(SOCKADDR_INET address) {
-        if (address.si_family == IPHlpAPI.AF_INET) {
+        if (address.si_family == AF_INET) {
             // sin_addr occupies the same four bytes the IPv6 arm uses for sin6_flowinfo, in network order
             return ParseUtil.parseIntToIP(address.ipv4AddrOrFlowInfo);
-        } else if (address.si_family == IPHlpAPI.AF_INET6) {
+        } else if (address.si_family == AF_INET6) {
             return Arrays.copyOf(address.ipv6Addr, 16);
         }
         return new byte[0];


### PR DESCRIPTION
Clears the Sonar findings raised by the routing table work in #3646/#3647, and fixes a config problem that turns out to sit underneath several of them.

## The config problem

`config/sonar-project.properties` already exempts the JNA mappings from four rules, but names them by the retired `squid:` repository prefix while findings report under `java:`:

```properties
sonar.issue.ignore.multicriteria.s2160.ruleKey=squid:S2160   # reported as java:S2160
```

So the exemptions were not matching. That is why the three new `MIB_IPFORWARD_ROW2`/`SOCKADDR_INET`/`IP_ADDRESS_PREFIX` structures raised S2160 while the equivalent structures in `NtDll` never have — those were presumably marked resolved by hand years ago. All five prefixes are updated, which should restore the intended S2160/S1104/S100/S115 exemptions for `**/jna/**` and stop new bindings re-raising them.

This is the one change here I cannot verify locally: the proof is the next scan showing S2160 gone from `oshi/jna/`.

## Fixes

**S3252 x3, static access through a subclass.** `oshi.jna.platform.windows.IPHlpAPI` extends JNA's, so `IPHlpAPI.AF_INET` reads as reaching a static through the wrong type. Static-importing the three constants from the class that declares them puts the qualification in the import and leaves the use sites unqualified. The static imports coexist with the shadowing type import.

**S1481, unused local.** The FFM table handle exists for its `close`, never to be read, so it becomes an unnamed variable — matching `catch (Throwable _)` already used in `NetSessionDataFFM`.

**S1186, empty method.** `RouteRow`'s explicit constructor is removed. `IfStats`, the carrier it was modelled on, declares none either, and doclint runs with `-missing`.

**S125, commented-out code.** A comment holding the C declaration of `MIB_IPFORWARD_TABLE2` is restated as prose. Sonar is not wrong that it was C in a comment, so rewording beats suppressing.

**S5961, 35 assertions in one test.** `testParseRouteDestination` had grown three separable concerns; split into 23 / 4 / 8 with each name matching its contents.

**Confusing overload**, reported separately by GitHub. The two `getValueOrUnknown` methods:

```java
public static String getValueOrUnknown(Map<String, String> map, String key)   // deleted
public static String getValueOrUnknown(Map<?, String> map, Object key)        // kept
```

The first is strictly more specific, so every call matching it also matches the second and Java silently picks the first. They produce identical results for every input except one, where the deleted method was wrong: `getOrDefault` substitutes its default only when the key is *absent*, so a key mapped to `null` reached `value.isEmpty()` and threw. The kept method routes through `getStringValueOrUnknown`, which is null-safe.

No call site changes, since the remaining signature already accepted every call. The erasures differ, so a caller compiled against 7.4.x and not recompiled would get a `NoSuchMethodError` — `oshi.util` sits outside the semver guarantee per FAQ.md, and this is a minor release.

## Accepted rather than fixed

- **S2176**, rename `IPHlpAPI` — the house convention, matching `Kernel32`, `NtDll` and `Dxgi`, which all extend a same-named JNA interface.
- **S2160 x3** — what the config fix above is for.
- **S107**, eight-parameter constructor — `IPRoute` is an immutable value row; every field is explicit by design.
- **S3776**, cognitive complexity 16 against a limit of 15, in the Solaris parser whose column handling is the reason it is not simpler.
- **S106 x2**, `System.out` in `DetectVM` — a demo `main`, as every demo is.

## Verification

Full gate and `-Perror-prone` clean, all tests passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of null and empty string values.
  - Broadened map key support when retrieving values.
  - Invalid or missing network route prefixes now remain marked as unknown instead of being inferred.

- **Documentation**
  - Clarified Windows network routing API documentation.

- **Refactor**
  - Simplified Windows network resource cleanup and address-family references without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->