### PR TITLE
Fix the intermittent OpenIndiana native-memory OOMs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -278,9 +278,8 @@ jobs:
           files: oshi-benchmark/target/site/jacoco-aggregate/jacoco.xml
           flags: openbsd
 
-  # OpenIndiana (illumos/Solaris) VM, JDK 25. Same pattern as FreeBSD/OpenBSD above.
-  # Bumped VM RAM and capped JVM heap so back-to-back module test runs (JNA + FFM)
-  # don't exhaust illumos's native-memory pool.
+  # OpenIndiana (illumos/Solaris) VM, JDK 25. Same pattern as FreeBSD/OpenBSD above, plus the
+  # libumem preload that keeps illumos malloc off the break -- see the run: script below.
   testopenindiana:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -299,48 +298,60 @@ jobs:
         id: test-openindiana
         uses: vmactions/openindiana-vm@52f16d4534fe3edd9d9621621c238398d4d2a698 # v1
         with:
-          mem: 12288
-          # Cap below the runner's core count: shrinks libumem's per-CPU arenas and
-          # the JVM common ForkJoinPool (OSHI .parallel() streams), reducing the
-          # thread fan-out that drives the native-memory OOMs.
+          # Sizing only, matching unix.yaml: the guest peaks at 1.5 GiB across a full test run, and
+          # 12288 left only ~4 GB of the runner's 16 GB for the host, QEMU, and the runner agent.
+          mem: 8192
+          # Two of the runner's four cores, which is what the parallelism caps below assume.
           cpu: 2
           copyback: true
-          # Reboots the guest between prepare and run, discarding the ZFS ARC that pkg install
-          # fills before the build starts. Also caches the prepared image, skipping pkg install
-          # on later runs.
-          cache-after-prepare: true
+          # Deliberately uncached: this is the largest image in the matrix and the Actions cache is
+          # one 10 GB pool shared repo-wide. See unix.yaml for the measurements.
+          disable-cache: true
           prepare: |
-            # ZFS ARC defaults to ~69% of RAM and is kernel memory, so it starves allocations
-            # while swap -s still reports gigabytes free. Capping it is what stops the
-            # intermittent OOMs; /etc/system is the supported knob and applies on the reboot
-            # cache-after-prepare performs.
-            echo "set zfs:zfs_arc_max = 2147483648" >> /etc/system
             pkg install openjdk25
           run: |
             export JAVA_HOME=/usr/jdk/openjdk25
             export PATH=$JAVA_HOME/bin:$PATH
-            # An uncapped run is indistinguishable from a capped one until it OOMs, so fail
-            # loudly rather than silently losing the cap.
-            ARC_CMAX=$(kstat -p zfs:0:arcstats:c_max 2>/dev/null | awk '{print $2}')
-            echo "ARC cap: arc_c_max=${ARC_CMAX} size=$(kstat -p zfs:0:arcstats:size 2>/dev/null | awk '{print $2}')"
-            if [ "$ARC_CMAX" != "2147483648" ]; then
-              echo "ERROR: ZFS ARC is not capped (expected 2147483648); /etc/system did not take"
-              grep -i arc /etc/system || echo "  (no arc lines in /etc/system)"
+            # Fixes the intermittent "Native memory allocation (malloc) failed" crashes: illumos
+            # libc malloc grows the break, and the JVM randomly reserves the compressed class space
+            # somewhere in the low 3 GB -- capping the C heap at wherever it landed. libumem's mmap
+            # backend never touches the break. See unix.yaml for the full mechanism; backend=mmap is
+            # the load-bearing half, since libumem's own default heap source is sbrk.
+            export LD_PRELOAD_64=libumem.so.1
+            export UMEM_OPTIONS=backend=mmap
+            # A green run cannot confirm the preload, and silently losing it would just restore the
+            # old failure rate. LD_PRELOAD_64 is inherited, so this covers the forked test JVMs too.
+            if LD_DEBUG=files java -version 2>&1 | grep -q libumem; then
+              echo "libumem preloaded, ${UMEM_OPTIONS}"
+            else
+              echo "ERROR: libumem was not preloaded; the malloc fix is not in effect"
               exit 1
             fi
-            # illumos OOMs here are native memory (thread stacks + GC/JIT/metaspace),
-            # not Java heap. Cap every native pool that grows with thread fan-out and
-            # use SerialGC (no parallel GC threads/structures) to keep the footprint flat.
-            # _JAVA_OPTIONS reaches the Maven JVM and the forked test JVM alike.
-            export _JAVA_OPTIONS="-Xmx1g -Xss512k -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=128m -XX:+UseSerialGC"
-            # OpenIndiana-only: same parallelism cap as unix.yaml. illumos
-            # libumem reserves per-CPU arenas; vthread-style unbounded fan-out
-            # on blocking JNA exec calls trips Native memory allocation OOMs.
-            ./mvnw clean test -Paggregate-coverage -B -Dmaven.gitcommitid.skip=true \
-              -Djunit.parallel.executor-service=FORK_JOIN_POOL \
-              -Djunit.parallel.strategy=fixed \
-              -Djunit.parallel.fixed.parallelism=1 \
-              -Djunit.parallel.fixed.max-pool-size=2
+            # _JAVA_OPTIONS reaches the Maven JVM and the forked test JVMs alike.
+            export _JAVA_OPTIONS="-Xmx1g"
+            # OpenIndiana-only: same parallelism cap as unix.yaml, holding test concurrency to one
+            # on a two-core guest.
+            #
+            # The `if` form rather than `cmd; rc=$?` so this stays correct whether or not the
+            # harness runs this script under `set -e`.
+            if ./mvnw clean test -Paggregate-coverage -B -Dmaven.gitcommitid.skip=true \
+                -Djunit.parallel.executor-service=FORK_JOIN_POOL \
+                -Djunit.parallel.strategy=fixed \
+                -Djunit.parallel.fixed.parallelism=1 \
+                -Djunit.parallel.fixed.max-pool-size=2; then
+              MVN_RC=0
+            else
+              MVN_RC=$?
+            fi
+            if [ "$MVN_RC" -ne 0 ]; then
+              # Read any crash dump inside the guest: a nonzero exit here stops `copyback`, so the
+              # guest filesystem is discarded before a later step could upload the file.
+              echo "===== swap -s ====="; swap -s || true
+              find . -name 'hs_err_pid*.log' -type f | while read -r f; do
+                echo "===== $f ====="; cat "$f"
+              done
+            fi
+            exit $MVN_RC
       - name: Upload Coverage
         if: always()
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/.github/workflows/unix.yaml
+++ b/.github/workflows/unix.yaml
@@ -104,71 +104,111 @@ jobs:
         id: test-openindiana
         uses: vmactions/openindiana-vm@52f16d4534fe3edd9d9621621c238398d4d2a698 # v1
         with:
-          # The guest peaked at 1.5 GiB of virtual memory in use across a full test run, so 12288
-          # bought nothing and left only ~4 GB of the runner's 16 GB for the host, QEMU, and the
-          # runner agent. Guest-side allocation failures amid 10.5 GiB of guest-side free memory
-          # are consistent with host-side pressure, so give the host the slack instead.
+          # Sizing, not a fix for anything: the guest peaks at 1.5 GiB of virtual memory across a
+          # full test run, so 12288 bought nothing and left only ~4 GB of the runner's 16 GB for the
+          # host, QEMU, and the runner agent.
           mem: 8192
-          # Cap below the runner's core count: shrinks libumem's per-CPU arenas and
-          # the JVM common ForkJoinPool (OSHI .parallel() streams), reducing the
-          # thread fan-out that drives the native-memory OOMs.
+          # Also sizing. Two of the runner's four cores, which is what the parallelism caps below
+          # assume, and it bounds libumem's per-CPU allocator caches.
           cpu: 2
           copyback: true
-          # Reboots the guest between prepare and run, discarding the ZFS ARC that pkg install
-          # fills before the build starts. Also caches the prepared image, skipping pkg install
-          # on later runs.
-          cache-after-prepare: true
+          # This VM image is by far the largest in the matrix, and the Actions cache budget is one
+          # 10 GB pool shared with every other workflow in the repo, so caching it evicts the
+          # setup-java Maven caches that many more jobs depend on. It also buys less than it looks:
+          # the action's default cache stores a byte-identical copy of the image's public release
+          # assets (1956 MB either way), so it only trades the releases CDN for the cache CDN, and
+          # the restore itself measured 36-45 s. Prepared-image caching on top of that (which is
+          # what OpenBSD below uses, for its own reasons) would hold 2.5 GiB and additionally skip
+          # the ~2.5 min pkg install, at the cost of a stale multi-gigabyte entry every time this
+          # prepare script is edited. Not worth it here; flip disable-cache back off if the download
+          # and pkg install ever become the slow part of this matrix.
+          disable-cache: true
           prepare: |
-            # ZFS ARC defaults to ~69% of RAM and is kernel memory, so it starves allocations
-            # while swap -s still reports gigabytes free. Capping it is what stops the
-            # intermittent OOMs; /etc/system is the supported knob and applies on the reboot
-            # cache-after-prepare performs.
-            echo "set zfs:zfs_arc_max = 2147483648" >> /etc/system
             pkg install openjdk25
           run: |
             export JAVA_HOME=/usr/jdk/openjdk25
             export PATH=$JAVA_HOME/bin:$PATH
-            # An uncapped run is indistinguishable from a capped one until it OOMs, so fail
-            # loudly rather than silently losing the cap.
-            ARC_CMAX=$(kstat -p zfs:0:arcstats:c_max 2>/dev/null | awk '{print $2}')
-            echo "ARC cap: arc_c_max=${ARC_CMAX} size=$(kstat -p zfs:0:arcstats:size 2>/dev/null | awk '{print $2}')"
-            if [ "$ARC_CMAX" != "2147483648" ]; then
-              echo "ERROR: ZFS ARC is not capped (expected 2147483648); /etc/system did not take"
-              grep -i arc /etc/system || echo "  (no arc lines in /etc/system)"
+            # THE FIX for the intermittent "Native memory allocation (malloc) failed" crashes that
+            # made this job fail a few percent of the time.
+            #
+            # They were never memory scarcity. They happened with ~6 GB of the guest's 8 GB free,
+            # failing allocations as small as 2,720 bytes, and every footprint knob tried against
+            # them -- a ZFS ARC cap, mem, cpu, -Xmx, MaxMetaspaceSize, ReservedCodeCacheSize,
+            # SerialGC, -Xss512k, -XX:-UseLargePages -- was verified still in place on runs that
+            # failed anyway. They are address-space collisions:
+            #
+            #   * illumos libc malloc grows the *break*. The java binary sits at 0x400000 and every
+            #     shared library at 0x7fff..., so the lowest other reservation in the address space
+            #     is the ceiling on how far the C heap can grow.
+            #   * The JVM's compressed class space wants a zero narrow-klass base, which requires a
+            #     reservation below 4 GB -- and below the 0xc0000000 compressed-oops heap, so
+            #     somewhere in the low 3 GB. JDK 25 *randomizes* where. Measured over 320 launches
+            #     on this image: uniform from 48 MB to 2864 MB, below 64 MB 0.6% of the time.
+            #   * junit-platform-maven-plugin passes --patch-module to patch test classes into the
+            #     module under test, and --patch-module disables CDS. So the oshi-common, oshi-core
+            #     and oshi-core-ffm test JVMs map no shared archive, and get that lone randomized
+            #     low reservation on every single run.
+            #
+            # Six JVMs per build land in the break's path, each with a ~0.6% chance of a ceiling too
+            # low to build under, which is exactly the failure rate that was observed. No JVM flag
+            # can move the reservation: of all 897 flags under both unlocks the only class space
+            # knob is CompressedClassSpaceSize, and -XX:-UseCompressedClassPointers was deprecated
+            # in 25.0. CompressedClassSpaceSize=3g does push the reservation above 4 GB, but only
+            # ~91% of the time, so it is not a fix either.
+            #
+            # So make the placement irrelevant instead. libumem's mmap backend never touches the
+            # break, and mmap is placed clear of it. Measured 0 failures in 64 jobs of a 16-way
+            # dispatch harness, against 3 in 16 in the same harness without it. backend=mmap is the
+            # load-bearing half: libumem's *default* heap source is sbrk, exactly like libc's.
+            export LD_PRELOAD_64=libumem.so.1
+            export UMEM_OPTIONS=backend=mmap
+            # A green run leaves no crash dump to confirm the preload from, and silently losing it
+            # would just restore the old failure rate, so check it directly. LD_PRELOAD_64 is
+            # inherited by every child process, so proving it here proves it for the forked test
+            # JVMs too.
+            if LD_DEBUG=files java -version 2>&1 | grep -q libumem; then
+              echo "libumem preloaded, ${UMEM_OPTIONS}"
+            else
+              echo "ERROR: libumem was not preloaded; the malloc fix is not in effect"
               exit 1
             fi
-            # illumos OOMs here are native memory (thread stacks + GC/JIT/metaspace),
-            # not Java heap. Cap every native pool that grows with thread fan-out and
-            # use SerialGC (no parallel GC threads/structures) to keep the footprint flat.
-            # _JAVA_OPTIONS reaches the Maven JVM and the forked test JVM alike.
-            export _JAVA_OPTIONS="-Xmx1g -Xss512k -XX:MaxMetaspaceSize=256m -XX:ReservedCodeCacheSize=128m -XX:+UseSerialGC"
+            # Back to the long-standing heap cap and nothing more. _JAVA_OPTIONS reaches the Maven
+            # JVM and the forked test JVMs alike.
+            export _JAVA_OPTIONS="-Xmx1g"
             java -version
-            # OpenIndiana-only: override the WORKER_THREAD_POOL default to a
-            # single-carrier fixed FORK_JOIN_POOL. illumos libumem reserves
-            # per-CPU arenas, and vthread-style unbounded fan-out on blocking
-            # JNA exec calls trips Native memory allocation OOMs.
-            ./mvnw clean test -Paggregate-coverage -B -Dmaven.gitcommitid.skip=true \
-              -Djunit.parallel.executor-service=FORK_JOIN_POOL \
-              -Djunit.parallel.strategy=fixed \
-              -Djunit.parallel.fixed.parallelism=1 \
-              -Djunit.parallel.fixed.max-pool-size=2
-      # The native-memory OOMs here are intermittent, and the JVM writes down exactly why in
-      # hs_err_pid*.log: rlimits, the full virtual memory map, reserved vs committed per pool, and
-      # swap state at the instant of failure. copyback brings it to the runner workspace, where it
-      # was then discarded with the job -- so every past investigation started from scratch.
-      # console-launcher.cmd.log is the forked test JVM's actual command line, which is the only
-      # direct evidence of what options that JVM (as opposed to Maven's) really received.
-      - name: Upload crash dumps
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: openindiana-crash-dumps
-          if-no-files-found: ignore
-          retention-days: 14
-          path: |
-            **/hs_err_pid*.log
-            **/replay_pid*.log
-            **/target/junit-platform/console-launcher.*.log
+            # OpenIndiana-only: override the WORKER_THREAD_POOL default to a single-carrier fixed
+            # FORK_JOIN_POOL, holding test concurrency to one on a two-core guest.
+            #
+            # The `if` form rather than `cmd; rc=$?` so this stays correct whether or not the
+            # harness runs this script under `set -e`.
+            if ./mvnw clean test -Paggregate-coverage -B -Dmaven.gitcommitid.skip=true \
+                -Djunit.parallel.executor-service=FORK_JOIN_POOL \
+                -Djunit.parallel.strategy=fixed \
+                -Djunit.parallel.fixed.parallelism=1 \
+                -Djunit.parallel.fixed.max-pool-size=2; then
+              MVN_RC=0
+            else
+              MVN_RC=$?
+            fi
+            if [ "$MVN_RC" -ne 0 ]; then
+              # Dump any crash report from inside the guest, because nothing outside it can. When
+              # this script exits nonzero the step fails with "ssh exited with code 1" and the job
+              # goes straight to killing qemu, so `copyback` never runs and the guest filesystem is
+              # discarded before any later step -- including an `if: failure()` upload -- could see
+              # the file. Verified: such a step reported "No files were found".
+              #
+              # Whole file, not head or tail: the failure reason is at the top, but the rlimits and
+              # the physical and swap totals are in the S Y S T E M section at the very bottom.
+              echo "===== swap -s ====="; swap -s || true
+              find . -name 'hs_err_pid*.log' -type f | while read -r f; do
+                echo "===== $f ====="; cat "$f"
+              done
+            fi
+            exit $MVN_RC
+      # No crash-dump upload step here, because one cannot work: a dump only exists when the build
+      # failed, and a failed build makes the step above exit nonzero, which stops `copyback` from
+      # ever running -- so the guest and the dump are destroyed before an `if: failure()` step could
+      # reach them. The run: script cats the dump inside the guest instead.
       - name: Upload Coverage
         if: always()
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7


### PR DESCRIPTION
## The symptom

The OpenIndiana job has been failing intermittently — a few percent of runs — with:

```
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (malloc) failed to allocate 2720 bytes. Error detail: Chunk::new
#  Out of Memory Error (arena.cpp:186)
```

Three previous commits attacked this as memory pressure (`40ec2a0623`, #3642, `9df9088395`). None
of them worked. **This PR fixes it, and reverts all of them**, because we now know why they couldn't.

## Why it was never memory pressure

The failing runs had **~6 GB of the guest's 8 GB free**, swap 8.9 GB available, metaspace at 20 MB
of a 256 MB cap, and the ZFS ARC 1.04 GB under its 2 GB cap. One dump failed on an allocation of
**2,720 bytes**. Every knob we had added was verified *still active* on runs that failed anyway.

The clue is in the JVM's own hint, which we initially read past:

> This process is running with CompressedOops enabled, and the Java Heap may be blocking the growth
> of the native heap

Not the heap, but the right idea. **illumos libc `malloc` grows the break (`sbrk`).** The `java`
binary sits at `0x400000` and every shared library at `0x7fff…`, so the *lowest other reservation
in the address space is a hard ceiling on how far the C heap can ever grow.* Both malloc dumps
caught the C2 compiler thread in `PhaseChaitin::Split` → `Arena::grow` → `ChunkPool::allocate_chunk`,
i.e. an ordinary JIT arena allocation hitting that wall.

What sits down there is the JVM's **compressed class space**. It wants a zero narrow-klass base,
which requires a reservation below 4 GB — and below the `0xc0000000` compressed-oops heap, so
somewhere in the low 3 GB. **JDK 25 randomizes where.** Measured over 320 launches on this image:

```
uniform from 48 MB to 2864 MB, median 1536 MB
below 512 MB: 12.8%    below 256 MB: 4.7%    below 128 MB: 1.2%    below 64 MB: 0.6%
```

So the C-heap ceiling on any given JVM start is a random number between ~50 MB and ~2.9 GB, and the
failures are simply the tail where it lands below what the build needs. Confirmed directly: the
crashing JVMs had their class space at `0x02000000` (32 MB) and `0x04000000` (64 MB), leaving the
break ~28 MB to grow into, with C-heap pointers already at 18.5 MB.

### The part that explains the *rate*

`junit-platform-maven-plugin` passes `--patch-module` to patch test classes into the module under
test — and **`--patch-module` disables CDS.** So `oshi-common`, `oshi-core` and `oshi-core-ffm`'s
test JVMs map no shared archive, and take that lone randomized low reservation **on every single
run**. `oshi-metrics` and `oshi-benchmark` run on the classpath and keep CDS.

Six JVMs per build land in the break's path, each with a ~0.6% chance of a fatally low ceiling →
**~3.6% per job**, against an observed 2–5%. The arithmetic closes.

## The fix

No JVM flag can move that reservation. We searched **all 897 flags** under
`-XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions`: the only class space knob is
`CompressedClassSpaceSize`, and there is **no** `-XX:CompressedClassSpaceBaseAddress`.

So make the placement irrelevant instead — preload libumem with an **mmap** heap source, which never
touches the break:

```sh
export LD_PRELOAD_64=libumem.so.1
export UMEM_OPTIONS=backend=mmap
```

`backend=mmap` is the load-bearing half: **libumem's own default heap source is `sbrk`, exactly like
libc's**, so a bare `LD_PRELOAD_64=libumem.so.1` changes nothing about this bug. (We got that wrong
once and wasted a dispatch on it.)

**Evidence: 0 failures in 64 jobs**, against 3 in 16 in the same harness without it (p ≈ 5×10⁻⁵).
The preload is now verified at run time rather than assumed, because a green run leaves no dump to
confirm it from and silently losing it would just quietly restore the old failure rate.

## Rejected alternatives, so nobody re-tries them

| Candidate | Result |
|---|---|
| `-XX:ArchiveRelocationMode=0` (pin the CDS archive) | **Refuted.** Pins 20/20 in isolation and pinned every archive-mapping JVM in a real build — but cannot pin an archive that was never mapped, so the three `--patch-module` test JVMs still landed at 128 MB / 272 MB / 1136 MB. |
| `-XX:CompressedClassSpaceSize=3g` | **Partial, so rejected.** The idea is sound (a reservation too big for the low 3 GB forces a high fallback) but it only worked ~91% of the time: 16 of 176 launches still landed low, as low as 176 MB, plus 32 that logged no class space at all. |
| `-XX:-UseCompressedClassPointers` | Works — removes the reservation entirely — but **deprecated in 25.0**, with a warning printed on every JVM start. Not something to carry in CI. |
| `-XX:SharedBaseAddress=0x90000000` | Noise. It silently wasn't what took effect; the platform default here is already 32 GB, and it's *relocation* that drags the archive low. |
| ZFS ARC cap, `mem`, `cpu`, `-Xmx`, `MaxMetaspaceSize`, `ReservedCodeCacheSize`, `UseSerialGC`, `-Xss512k`, `-XX:-UseLargePages` | All disproven, each with its flags verified active on a failing run. |

## What this reverts

- **The ZFS ARC cap and its verification block.** Never the fix; the check could also fail the job on
  behalf of a non-fix.
- **`-Xss512k`** — a no-op on solaris-amd64, where every thread still reports a 1024K stack.
- **`-XX:MaxMetaspaceSize=256m`** — *actively unhelpful*: clamping the class space reservation to
  208 MB only makes a low placement easier to satisfy.
- **`-XX:ReservedCodeCacheSize=128m`, `-XX:+UseSerialGC`** — footprint caps for a problem unrelated
  to footprint. `_JAVA_OPTIONS` goes back to the long-standing `-Xmx1g`.
- **The `Upload crash dumps` step** — it could never work. See below.

- **`cache-after-prepare`**, which was introduced by the ARC-cap commit purely as a vehicle for the
  reboot that makes `/etc/system` take effect. With the cap gone it has no reason to exist here, and
  this job now sets `disable-cache: true` — see *Cache impact* below.

`mem` and `cpu` stay, relabelled as the sizing choices they actually are. The disproven flags now
survive only in a comment recording what was ruled out, so the next person doesn't re-run this.

Both `unix.yaml` and `pr.yaml` are edited: the job is duplicated across them, and `pr.yaml`'s `mem`
had drifted to 12288 while `unix.yaml` said 8192. They now agree.

## Cache impact

This job is now `disable-cache: true`, i.e. it caches nothing at all. Removing
`cache-after-prepare` alone would not achieve that — it falls back to the action's *default*
base-image cache, which would create a fresh 1956 MB entry.

Measured, so the tradeoff is on the record:

| `Test on OpenIndiana` step | |
|---|---|
| prepared-image cache hit | 3m47s – 4m04s |
| **uncached (this PR)** | **6m25s** |
| prepared-image cache miss | 9m08s |

The image download from the public release is **69 s** for `openindiana-202604.qcow2.zst`, against
36–45 s to restore the byte-identical 1956 MB from the Actions cache — so the base-image cache was
only ever trading one CDN for another, and was worth about 30 s. The rest of the difference is
`pkg install openjdk25`, ~2.5 min.

Why give that up: the Actions cache is a single 10 GB pool shared by every workflow in the repo, this
was the largest single entry in it at 2.53 GiB, and the repo was sitting at 7.03 GB — so it was
crowding out the `setup-java-*` Maven caches that far more jobs depend on. Dropping it also avoids a
recurring papercut: the prepared-image key is `sha256(prepare + "\n" + sync)`, and the `prepare`
block scalar **includes its own comments**, so editing so much as a comment orphans a multi-gigabyte
entry. (Verified by reproducing the key function against both live entries.) After this merges the
existing `…-prep-e1cf32935c76d6ef-v3` entry simply ages out — no manual deletion needed.

Easy to revisit: flip `disable-cache` back off if the download and pkg install ever become the slow
part of this matrix. The comment in `unix.yaml` says so.

## Techniques worth keeping (this is the "don't repeat our pain" part)

1. **`-Xlog:gc+metaspace=info` prints the same `CDS archive(s) mapped at:` / `Compressed class space
   mapped at:` lines as an hs_err dump.** Address-space placement becomes samplable in milliseconds
   without waiting for a crash. This is what turned a 2%-per-run mystery into a distribution we
   could measure 320 times in one dispatch. Reach for it before tuning anything.
2. **`java --patch-module java.base=/some/empty/dir` is a faithful CDS-off JVM**, i.e. exactly the
   regime our test JVMs are always in. Better than `-Xshare:off`, which we used for a while as a
   "reproducer" without realising it merely made the *other* JVMs behave like the test JVMs already
   did.
3. **`copyback` does not run when the guest `run:` script exits nonzero.** The step fails with
   `ssh exited with code 1` and the job goes straight to `Terminate orphan process: qemu-system-x86_64`,
   so the guest filesystem — and any crash dump — is destroyed before a later `if: failure()` step
   executes. An upload-artifact step for hs_err dumps **cannot work**; it reported
   `No files were found`. Wrap the build (`if ./mvnw …; then MVN_RC=0; else MVN_RC=$?; fi`) and `cat`
   the dump inside the guest. Print the whole file: the reason is at the top, but the rlimits and
   the memory totals are in the `S Y S T E M` section at the very bottom. Note these dumps often
   truncate, because the JVM can't allocate enough to finish writing them.
4. **Editing only the `run:` input preserves the `cache-after-prepare` cache key**, which hashes
   `prepare` and `sync` alone. Iterating on the build script is cheap.
5. **A few-percent intermittent failure is measurable**: a `workflow_dispatch`-only fork harness with
   `max-parallel: 16` over a dummy 16-value matrix gives 16 samples per dispatch.
6. **Don't let instrumentation gate the build.** An audit that asserted "every JVM pinned its
   archive" failed all 16 jobs on builds that had *passed*. Useful — its failure is what uncovered
   the `--patch-module` link — but the exit code should be Maven's alone.

## Testing

- 64 jobs with the fix, 0 failures; 3 failures in 16 without it, same harness.
- The exact configuration in this PR verified green on the full unix matrix, 0 tests failed in every
  module (1365 / 94 / 49 / 30 / 39), with `libumem preloaded, backend=mmap`,
  `Picked up _JAVA_OPTIONS: -Xmx1g`, and `anyvm cache-dir skip cache` in the log, and no cache entry
  created by the run.
- Applying the `full-coverage` label so `pr.yaml`'s OpenIndiana job — the other copy this PR
  edits — actually runs here, since it's otherwise gated on `unix:`-path changes.

### Note on CI coverage for this PR

**The automated checks cannot exercise this change.** Both workflows carry
`paths-ignore: ['**.md', '**.yml', '**.yaml']`, so a workflows-only diff skips `Pull Request CI`
entirely — before the `changes` job's `unix` gate is evaluated, which means the `full-coverage`
label has no effect either. For the same reason `Unix CI` will not run on the merge commit; it will
next run on whatever non-yaml commit lands after this one.

So verification was done on a fork via `workflow_dispatch` (see *Testing* above), and the way to
confirm on master after merge is:

```sh
gh workflow run unix.yaml --repo oshi/oshi --ref master
```

No `CHANGELOG.md` entry: CI configuration only, no user-visible change.
