### PR TITLE
Guarantee consistent OSFileStore space values on every platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * The `oshi-dist` zip is no longer published to Maven Central; download it from the [GitHub release](https://github.com/oshi/oshi/releases) instead - [@dbwiddis](https://github.com/dbwiddis).
 
+* `OSFileStore` now guarantees `0 <= getUsableSpace() <= getFreeSpace() <= getTotalSpace()` on every platform. The three values are read by separate queries, so on a ZFS dataset or a swap-backed `tmpfs` they could previously contradict each other; they are now clamped downward to restore the ordering - [@dbwiddis](https://github.com/dbwiddis).
+
 * Your contribution here!
 
 # 7.5.0 (2026-08-16)

--- a/oshi-common/src/main/java/oshi/software/common/AbstractOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOSFileStore.java
@@ -66,9 +66,7 @@ public abstract class AbstractOSFileStore implements OSFileStore {
         this.logicalVolume = logicalVolume;
         this.description = description;
         this.fsType = fsType;
-        this.freeSpace = freeSpace;
-        this.usableSpace = usableSpace;
-        this.totalSpace = totalSpace;
+        setSpace(freeSpace, usableSpace, totalSpace);
         this.freeInodes = freeInodes;
         this.totalInodes = totalInodes;
     }
@@ -157,9 +155,7 @@ public abstract class AbstractOSFileStore implements OSFileStore {
         this.logicalVolume = fileStore.getLogicalVolume();
         this.description = fileStore.getDescription();
         this.fsType = fileStore.getType();
-        this.freeSpace = fileStore.getFreeSpace();
-        this.usableSpace = fileStore.getUsableSpace();
-        this.totalSpace = fileStore.getTotalSpace();
+        setSpace(fileStore.getFreeSpace(), fileStore.getUsableSpace(), fileStore.getTotalSpace());
         this.freeInodes = fileStore.getFreeInodes();
         this.totalInodes = fileStore.getTotalInodes();
     }
@@ -175,9 +171,7 @@ public abstract class AbstractOSFileStore implements OSFileStore {
      */
     protected void updateSpaceAndInodes(long freeSpace, long usableSpace, long totalSpace, long freeInodes,
             long totalInodes) {
-        this.freeSpace = freeSpace;
-        this.usableSpace = usableSpace;
-        this.totalSpace = totalSpace;
+        setSpace(freeSpace, usableSpace, totalSpace);
         this.freeInodes = freeInodes;
         this.totalInodes = totalInodes;
     }
@@ -190,9 +184,25 @@ public abstract class AbstractOSFileStore implements OSFileStore {
      * @param totalSpace  total space in bytes
      */
     protected void updateSpace(long freeSpace, long usableSpace, long totalSpace) {
-        this.freeSpace = freeSpace;
-        this.usableSpace = usableSpace;
-        this.totalSpace = totalSpace;
+        setSpace(freeSpace, usableSpace, totalSpace);
+    }
+
+    /*
+     * Single write path for the three space values, so the invariant cannot depend on which platform, which native
+     * implementation, or which of the four update entry points supplied them.
+     *
+     * Most implementations obtain the three values from three separate queries -- three statvfs calls, by way of the
+     * File methods -- so on a filesystem whose capacity is computed rather than fixed they describe three adjacent
+     * instants rather than one, and can contradict each other: ZFS derives a dataset's total from its pool, and a
+     * swap-backed tmpfs derives it from free memory. Reading them atomically would take a native statvfs per platform
+     * (which LinuxFileSystem.queryStatvfs does, and the other platforms deliberately do not), so instead the ordering
+     * is restored here by clamping downward only. No value is ever reported higher than the OS reported it, which keeps
+     * the error in the direction that overstates fullness rather than free capacity.
+     */
+    private void setSpace(long freeSpace, long usableSpace, long totalSpace) {
+        this.totalSpace = Math.max(0L, totalSpace);
+        this.freeSpace = Math.min(Math.max(0L, freeSpace), this.totalSpace);
+        this.usableSpace = Math.min(Math.max(0L, usableSpace), this.freeSpace);
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSFileStore.java
@@ -109,8 +109,13 @@ public interface OSFileStore {
 
     /**
      * Free space on the drive. This space is unallocated but may require elevated permissions to write.
+     * <p>
+     * The difference between this value and {@link #getUsableSpace()} is space the operating system has reserved: on
+     * many UNIX filesystems a percentage held back for the superuser, on Windows the caller's disk quota. It is zero on
+     * filesystems that reserve nothing at this layer, such as ZFS and APFS.
      *
      * @return Free space on the drive (in bytes)
+     * @see #getTotalSpace()
      */
     long getFreeSpace();
 
@@ -118,11 +123,19 @@ public interface OSFileStore {
      * Usable space on the drive. This is space available to unprivileged users.
      *
      * @return Usable space on the drive (in bytes)
+     * @see #getTotalSpace()
      */
     long getUsableSpace();
 
     /**
      * Total space/capacity of the drive.
+     * <p>
+     * This value and those from {@link #getFreeSpace()} and {@link #getUsableSpace()} always satisfy
+     * {@code 0 <= usable <= free <= total}. Most platforms obtain the three from separate queries, so on a filesystem
+     * whose capacity is computed rather than fixed — a ZFS dataset drawing on its pool, or a swap-backed {@code tmpfs}
+     * — they are readings from adjacent instants rather than one coherent snapshot, and may contradict each other.
+     * Where that happens the values are clamped downward to restore the ordering; none is ever reported higher than the
+     * operating system reported it.
      *
      * @return Total capacity of the drive (in bytes)
      */

--- a/oshi-common/src/test/java/oshi/software/common/AbstractOSFileStoreTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/AbstractOSFileStoreTest.java
@@ -96,6 +96,40 @@ class AbstractOSFileStoreTest {
     }
 
     @Test
+    void testSpaceExceedingTotalIsClampedDown() {
+        // usable > total is reachable on ZFS, where a dataset's capacity is derived from its pool, and on a
+        // swap-backed tmpfs, where it is derived from free memory: total is sampled at a different instant than the
+        // other two values. Total stays as the OS reported it; the other two come down to meet it.
+        TestOSFileStore fs = new TestOSFileStore("TestFS", "/dev/sda1", "MyLabel", "/mnt/data", "rw", "1234-5678", true,
+                "lv0", "Local Disk", "zfs", 6000L, 5500L, 5000L, 100L, 500L);
+        assertThat(fs.getTotalSpace(), is(5000L));
+        assertThat(fs.getFreeSpace(), is(5000L));
+        assertThat(fs.getUsableSpace(), is(5000L));
+    }
+
+    @Test
+    void testUsableExceedingFreeIsClampedDown() {
+        // f_bavail underflowing past the superuser reserve on a full filesystem is the realistic source of this.
+        TestOSFileStore fs = createFileStore();
+        fs.callUpdateSpace(1000L, 4000L, 5000L);
+        assertThat(fs.getTotalSpace(), is(5000L));
+        assertThat(fs.getFreeSpace(), is(1000L));
+        assertThat(fs.getUsableSpace(), is(1000L));
+    }
+
+    @Test
+    void testNegativeSpaceIsFlooredAtZero() {
+        TestOSFileStore fs = createFileStore();
+        fs.callUpdateSpaceAndInodes(-1L, -2L, -3L, 200L, 1000L);
+        assertThat(fs.getTotalSpace(), is(0L));
+        assertThat(fs.getFreeSpace(), is(0L));
+        assertThat(fs.getUsableSpace(), is(0L));
+        // Inodes carry a documented -1 "unimplemented" sentinel and are not normalized
+        assertThat(fs.getFreeInodes(), is(200L));
+        assertThat(fs.getTotalInodes(), is(1000L));
+    }
+
+    @Test
     void testUpdateFrom() {
         TestOSFileStore fs = createFileStore();
         TestOSFileStore other = new TestOSFileStore("Other", "/dev/sdb1", "OtherLabel", "/mnt/other", "ro", "9999-0000",

--- a/oshi-core/src/test/java/oshi/software/os/shared/FileSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/FileSystemTest.java
@@ -7,11 +7,10 @@ package oshi.software.os.shared;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,12 +23,6 @@ import oshi.util.PlatformEnum;
  * Test File System
  */
 class FileSystemTest {
-
-    // Platforms whose default file systems (ZFS on Solaris and on FreeBSD's CI runner) report dynamically computed
-    // total space that can fluctuate by a few MB between back-to-back queries due to pool/dataset metadata refresh.
-    // The "total space should not change after update" check below is skipped on these.
-    private static final Set<PlatformEnum> FLUCTUATING_TOTAL_SPACE = EnumSet.of(PlatformEnum.SOLARIS,
-            PlatformEnum.FREEBSD);
 
     /**
      * Test file system.
@@ -58,9 +51,7 @@ class FileSystemTest {
             assertThat("File store options shouldn't be empty", store.getOptions().isEmpty(), is(false));
             assertThat("File store mount shouldn't be null", store.getMount(), is(notNullValue()));
             assertThat("File store UUID shouldn't be null", store.getUUID(), is(notNullValue()));
-            assertThat("File store total space should be 0 or higher", store.getTotalSpace() >= 0, is(true));
-            assertThat("File store usable space should be 0 or higher", store.getUsableSpace() >= 0, is(true));
-            assertThat("File store free space should be 0 or higher", store.getFreeSpace() >= 0, is(true));
+            assertSpaceInvariant(store);
             if (PlatformEnum.getCurrentPlatform() != PlatformEnum.WINDOWS) {
                 assertThat("Number of free inodes should be 0 or higher on non-Windows systems",
                         store.getFreeInodes() >= 0, is(true));
@@ -70,23 +61,32 @@ class FileSystemTest {
                             store.getTotalInodes() >= store.getFreeInodes(), is(true));
                 }
             }
-            if (!store.getDescription().equals("Network drive")) {
-                assertThat(
-                        "File store's usable space should be less than or equal to the total space on non-network drives",
-                        store.getUsableSpace() <= store.getTotalSpace(), is(true));
-            }
-            // updateAttributes should succeed and total space should not change
+            // updateAttributes should succeed and leave the values consistent. Total space is deliberately not asserted
+            // to be unchanged: a ZFS dataset draws its capacity from its pool and a swap-backed tmpfs from free memory,
+            // so a genuine change between two queries is correct behavior rather than a defect.
             if (++updateCount <= 10) {
-                long totalBefore = store.getTotalSpace();
                 assertThat("File store updateAttributes should succeed for " + store.getMount(),
                         store.updateAttributes(), is(true));
-                if (!FLUCTUATING_TOTAL_SPACE.contains(PlatformEnum.getCurrentPlatform())) {
-                    assertThat("File store total space should not change after update", store.getTotalSpace(),
-                            is(totalBefore));
-                }
-                assertThat("File store usable space should remain valid after update", store.getUsableSpace(),
-                        greaterThanOrEqualTo(0L));
+                assertSpaceInvariant(store);
             }
         }
+    }
+
+    /*
+     * Asserts the ordering OSFileStore guarantees for its three space values on every platform and filesystem,
+     * including network drives and dynamically sized filesystems. AbstractOSFileStore enforces it on the way in, so
+     * this needs no per-platform exemptions.
+     */
+    private static void assertSpaceInvariant(OSFileStore store) {
+        String on = " on " + store.getMount();
+        assertThat("File store total space should be 0 or higher" + on, store.getTotalSpace(),
+                greaterThanOrEqualTo(0L));
+        assertThat("File store free space should be 0 or higher" + on, store.getFreeSpace(), greaterThanOrEqualTo(0L));
+        assertThat("File store usable space should be 0 or higher" + on, store.getUsableSpace(),
+                greaterThanOrEqualTo(0L));
+        assertThat("File store free space should not exceed total space" + on, store.getFreeSpace(),
+                lessThanOrEqualTo(store.getTotalSpace()));
+        assertThat("File store usable space should not exceed free space" + on, store.getUsableSpace(),
+                lessThanOrEqualTo(store.getFreeSpace()));
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
@@ -66,7 +66,8 @@ public class FileSystemMetrics implements MeterBinder {
             // system.filesystem.usage — UpDownCounter (Gauge), unit "By", attr: state, device, mount, type, mode
             Gauge.builder(FS_USAGE, fs, f -> {
                 f.updateAttributes();
-                return Math.max(0L, f.getTotalSpace() - f.getUsableSpace());
+                // OSFileStore guarantees usable <= total, so the difference cannot be negative
+                return (double) (f.getTotalSpace() - f.getUsableSpace());
             }).tag(STATE_KEY, "used").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
                     .tag(MODE_KEY, mode).description("Filesystem space usage").baseUnit("By").strongReference(true)
                     .register(registry);
@@ -81,7 +82,7 @@ public class FileSystemMetrics implements MeterBinder {
             Gauge.builder(FS_UTILIZATION, fs, f -> {
                 f.updateAttributes();
                 return f.getTotalSpace() == 0 ? 0d
-                        : Math.max(0d, (double) (f.getTotalSpace() - f.getUsableSpace()) / f.getTotalSpace());
+                        : (double) (f.getTotalSpace() - f.getUsableSpace()) / f.getTotalSpace();
             }).tag(STATE_KEY, "used").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
                     .tag(MODE_KEY, mode).description("Filesystem utilization").strongReference(true).register(registry);
             Gauge.builder(FS_UTILIZATION, fs, f -> {


### PR DESCRIPTION
## The problem

Every platform except Windows reads a file store's total, free and usable space from **three separate queries** — three `statvfs` calls, by way of the `java.io.File` methods — and stores the results as one `OSFileStore` snapshot:

```java
File f = new File(path);
long totalSpace = f.getTotalSpace();
long usableSpace = f.getUsableSpace();
long freeSpace = f.getFreeSpace();
```

On a filesystem whose capacity is *computed* rather than fixed, those three readings describe three adjacent instants rather than one, and can contradict each other:

- **ZFS** derives a dataset's total from its pool. From memory of illumos's `zfs_statvfs`, it sets `f_blocks = (refd + available) >> bshift` and `f_bfree = f_bavail = available >> bshift` — so total is *literally* computed as used + available inside a single call. Take total from call 1 and usable from call 2 and the identity no longer holds.
- **illumos `/tmp` is tmpfs backed by swap**, so its total is a function of free anonymous memory and moves in both directions under memory churn.

Under churn, `usable > total` is reachable purely from call ordering. That surfaced as an intermittent `FileSystemTest.testFileSystem` failure on the OpenIndiana runner — *"File store's usable space should be less than or equal to the total space"* — and the test already carried two platform carve-outs papering over the same root cause.

## The approach

Reading the three atomically requires a native `statvfs` per platform. `LinuxFileSystem.queryStatvfs` already does exactly that (returning all five values from one call, with the `File` triple only as a fallback), but extending it to the other six UNIX platforms plus macOS means new native mappings in both JNA and FFM for each — a large amount of untestable per-platform code to fix an ordering violation of a few megabytes. **Deliberately not doing that here.**

Instead `OSFileStore` now documents and enforces an ordering, which is the relation these three values actually have:

```
0 <= getUsableSpace() <= getFreeSpace() <= getTotalSpace()
```

There is no additive identity to enforce — `usable + free != total`, and the three are independently meaningful. `free - usable` is space the OS has reserved (a superuser percentage on many UNIX filesystems, the caller's disk quota on Windows, zero on ZFS and APFS). Nor is `used + free = total` universally true: on APFS `total` is a *container* property while usage is a *volume* property, so they don't sum even from a perfect atomic snapshot. So `used` stays derived as `total - usable`, the way `FileSystemMetrics` already computes it.

## Where the fix lives

One private write path in `AbstractOSFileStore`. No class anywhere in the repo writes `freeSpace`/`usableSpace`/`totalSpace` directly — every value on every platform, both native implementations plus the native-free provider, already funnels through the constructor, `updateFrom`, `updateSpace` or `updateSpaceAndInodes`. So this needed **no per-platform change at all**:

```java
private void setSpace(long freeSpace, long usableSpace, long totalSpace) {
    this.totalSpace = Math.max(0L, totalSpace);
    this.freeSpace = Math.min(Math.max(0L, freeSpace), this.totalSpace);
    this.usableSpace = Math.min(Math.max(0L, usableSpace), this.freeSpace);
}
```

**Values are only ever clamped downward — none is reported higher than the OS reported it.** Two reasons for that direction:

1. For a monitoring library, the residual error should overstate fullness, not free capacity. A dashboard reading "fuller than it is" is a nuisance; "emptier than it is" is a missed page. `used = total - usable` can therefore only grow.
2. In the realistic `usable > free` case — `f_bavail` underflowing past the superuser reserve on a full filesystem, which wraps to an enormous unsigned value — `usable` is the corrupt reading and `free` is sound. Clamping `usable` to `free` repairs it rather than propagating it.

Raising `total` instead was rejected: it fabricates capacity, and `total` is the number users sanity-check against `df`.

## What that lets the test delete

With the invariant structural, `FileSystemTest` asserts the **full chain unconditionally** and both carve-outs go away:

- The `"Network drive"` exemption from `usable <= total` — `min()` is `min()` regardless of filesystem, so it's dead code.
- `FLUCTUATING_TOTAL_SPACE = {SOLARIS, FREEBSD}`, which skipped *"total space should not change after update"*. That assertion is simply false on any dynamically sized filesystem — the two ZFS platforms were just where it had been caught, and Linux and macOS both have tmpfs mounts that could trip it too. Rather than widen the exemption set, the assertion is replaced by re-checking the invariant after the update, which is what it was really protecting and is true everywhere.

Net effect on coverage: the test now checks strictly more (`free <= total` and `usable <= free` were never asserted before), on strictly more platforms, with no exemptions.

The two `Math.max` floors in `FileSystemMetrics` were papering over the same inconsistency at the consumer end. They're now unreachable and removed.

## Behavior changes a user could notice

- **Windows network drives with a disk quota** can report `lpFreeBytesAvailableToCaller` above the share's total; `getUsableSpace()` is now clamped to `getTotalSpace()` there. This is the case the deleted test exemption was accommodating.
- On ZFS and swap-backed tmpfs, an occasional reading is reduced by the amount the filesystem resized between two consecutive syscalls — kilobytes to a few megabytes.

## Explicitly not in scope

The Solaris exemption from `totalInodes >= freeInodes` **is left in place.** Those counts come from a single `df -g` run, so it is not a snapshot-timing problem and has some other cause (most likely mount-key matching in `parseDfgInodes`). Clamping inodes to silence it would risk zeroing real data on a platform I can't test, and the `-1` "unimplemented" sentinel documented on `getFreeInodes()` makes a blind clamp unsafe. Worth its own investigation.

## Testing

Verified on macOS (Apple Silicon, APFS) with the full gate:

```
./mvnw clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc
```

BUILD SUCCESS, 0 tests failed across all modules (1377 / 120 / 101 / 30). `SystemInfoTest` reports byte-identical file store output from the JNA and FFM implementations, with no value zeroed or distorted:

```
Macintosh HD (Volume) [apfs] 103.3 GiB of 460.4 GiB free (22.4%), 1.1 G of 1.1 G files free (100.0%)
```

APFS reports `free == usable` exactly, so the clamp is a no-op on this host — which is why the `full-coverage` label is on this PR: the platforms this actually changes are FreeBSD and OpenIndiana (ZFS), and the path filter in `pr.yaml` gates those VM jobs on `unix/` path segments, which these files don't have.

New unit tests in `AbstractOSFileStoreTest` cover each clamp directly (`usable > total`, `usable > free`, negative inputs, and that inodes are left untouched), so the normalization is verified independently of whatever filesystems the runner happens to have.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Filesystem storage readings are now consistently ordered: usable space never exceeds free space, and free space never exceeds total space.
  - Negative space values are normalized to zero, improving reliability across changing filesystem conditions.
  - Used-space metrics now accurately reflect the normalized storage values.

- **Documentation**
  - Clarified how free, usable, and total space are calculated, including reserved space and possible value adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->