### PR TITLE
Report the OpenTelemetry reserved filesystem state in oshi-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # 7.5.1 (in progress)
 
-* The `oshi-dist` zip is no longer published to Maven Central; download it from the [GitHub release](https://github.com/oshi/oshi/releases) instead - [@dbwiddis](https://github.com/dbwiddis).
+The `oshi-dist` zip is no longer published to Maven Central; download it from the
+[GitHub release](https://github.com/oshi/oshi/releases) instead.
 
-* `OSFileStore` now guarantees `0 <= getUsableSpace() <= getFreeSpace() <= getTotalSpace()` on every platform. The three values are read by separate queries, so on a ZFS dataset or a swap-backed `tmpfs` they could previously contradict each other; they are now clamped downward to restore the ordering - [@dbwiddis](https://github.com/dbwiddis).
+##### New Features
 
-* Your contribution here!
+* [#3652](https://github.com/oshi/oshi/pull/3652): `oshi-metrics` reports the OpenTelemetry `reserved` state for `system.filesystem.usage` and `system.filesystem.utilization`, alongside the existing `used` and `free`. The three states partition the filesystem, so the `usage` gauges sum to `system.filesystem.limit` and the `utilization` gauges sum to 1.0. `reserved` is unused space unavailable to the calling process: the superuser reserve many UNIX filesystems hold back, or the caller's disk quota on Windows - [@dbwiddis](https://github.com/dbwiddis).
+
+##### Behavior Changes
+
+* [#3652](https://github.com/oshi/oshi/pull/3652): `oshi-metrics` computes the `used` state of `system.filesystem.usage` and `system.filesystem.utilization` as `total - free` rather than `total - usable`, so it no longer counts a filesystem's reserve as used; that space is now reported as `reserved`. Values drop by the reserve on filesystems that have one, such as ext4's default 5%, and are unchanged on ZFS and APFS, which reserve nothing at this layer - [@dbwiddis](https://github.com/dbwiddis).
+
+##### Bug Fixes and Improvements
+
+* [#3651](https://github.com/oshi/oshi/pull/3651): `OSFileStore` now guarantees `0 <= getUsableSpace() <= getFreeSpace() <= getTotalSpace()` on every platform. The three values are read by separate queries, so on a ZFS dataset or a swap-backed `tmpfs` they could previously contradict each other; they are now clamped downward to restore the ordering - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.5.0 (2026-08-16)
 

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -219,7 +219,9 @@ The three states partition the filesystem, so the `usage` gauges sum to `system.
 `utilization` gauges sum to 1.0. `free` is the space available to the calling process
 (`OSFileStore.getUsableSpace()`), and `reserved` is unused space that is not available to it: the superuser reserve
 many UNIX filesystems hold back (5% by default on ext4), or the caller's quota on Windows. Filesystems that reserve
-nothing at this layer, such as ZFS and APFS, report `reserved` as 0.
+nothing at this layer, such as ZFS and APFS, report `reserved` as 0. A filesystem's space is re-read as its gauges are
+sampled, once per filesystem per memoization window (300 ms by default) rather than once per gauge, so all of its
+gauges within a scrape report the same reading.
 
 ### [Network metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#network-metrics)
 

--- a/oshi-metrics/README.md
+++ b/oshi-metrics/README.md
@@ -211,9 +211,15 @@ Not implemented — OSHI does not expose system-level major/minor page fault cou
 
 | Metric | Instrument Type | Unit | Attributes | Description |
 |--------|----------------|------|------------|-------------|
-| `system.filesystem.usage` | Gauge | `By` | `system.device`, `system.filesystem.mountpoint`, `system.filesystem.type`, `system.filesystem.mode`, `system.filesystem.state` | Filesystem space usage (used, free) |
+| `system.filesystem.usage` | Gauge | `By` | `system.device`, `system.filesystem.mountpoint`, `system.filesystem.type`, `system.filesystem.mode`, `system.filesystem.state` | Filesystem space usage (used, free, reserved) |
 | `system.filesystem.utilization` | Gauge | `1` | (same as above) | Fraction of filesystem space in use (0.0–1.0) |
 | `system.filesystem.limit` | Gauge | `By` | `system.device`, `system.filesystem.mountpoint`, `system.filesystem.type`, `system.filesystem.mode` | Total capacity of the filesystem |
+
+The three states partition the filesystem, so the `usage` gauges sum to `system.filesystem.limit` and the
+`utilization` gauges sum to 1.0. `free` is the space available to the calling process
+(`OSFileStore.getUsableSpace()`), and `reserved` is unused space that is not available to it: the superuser reserve
+many UNIX filesystems hold back (5% by default on ext4), or the caller's quota on Windows. Filesystems that reserve
+nothing at this layer, such as ZFS and APFS, report `reserved` as 0.
 
 ### [Network metrics](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#network-metrics)
 

--- a/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
@@ -7,11 +7,14 @@ package oshi.metrics;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
 
 import oshi.software.os.OSFileStore;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
 /**
@@ -22,10 +25,18 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * <p>
  * Registers per filesystem:
  * <ul>
- * <li>{@code system.filesystem.usage} — filesystem space usage by state ({@code used}, {@code free}), in bytes</li>
+ * <li>{@code system.filesystem.usage} — filesystem space usage by state ({@code used}, {@code free}, {@code reserved}),
+ * in bytes</li>
  * <li>{@code system.filesystem.utilization} — fraction of filesystem space in use by state (0.0–1.0)</li>
  * <li>{@code system.filesystem.limit} — total capacity of the filesystem, in bytes</li>
  * </ul>
+ *
+ * <p>
+ * The three states partition the filesystem, so the {@code usage} gauges sum to {@code limit} and the
+ * {@code utilization} gauges sum to 1.0. {@code free} is the space available to the calling process
+ * ({@link OSFileStore#getUsableSpace()}), and {@code reserved} is unused space that is not available to it: the
+ * superuser reserve many UNIX filesystems hold back, or the caller's quota on Windows. Filesystems that reserve nothing
+ * at this layer, such as ZFS and APFS, report {@code reserved} as 0.
  */
 public class FileSystemMetrics implements MeterBinder {
 
@@ -37,6 +48,9 @@ public class FileSystemMetrics implements MeterBinder {
     private static final String TYPE_KEY = "system.filesystem.type";
     private static final String MODE_KEY = "system.filesystem.mode";
     private static final String STATE_KEY = "system.filesystem.state";
+    private static final Tag STATE_USED = Tag.of(STATE_KEY, "used");
+    private static final Tag STATE_FREE = Tag.of(STATE_KEY, "free");
+    private static final Tag STATE_RESERVED = Tag.of(STATE_KEY, "reserved");
 
     private final Supplier<List<OSFileStore>> fileStoreSupplier;
 
@@ -57,47 +71,58 @@ public class FileSystemMetrics implements MeterBinder {
     @Override
     public void bindTo(MeterRegistry registry) {
         for (OSFileStore fs : fileStoreSupplier.get()) {
-            String device = fs.getVolume();
-            String mount = fs.getMount();
-            String type = fs.getType();
             String opts = fs.getOptions();
             String mode = Arrays.asList(opts.split(",")).contains("rw") ? "rw" : "ro";
+            Tags tags = Tags.of(DEVICE_KEY, fs.getVolume(), MOUNTPOINT_KEY, fs.getMount(), TYPE_KEY, fs.getType(),
+                    MODE_KEY, mode);
 
-            // system.filesystem.usage — UpDownCounter (Gauge), unit "By", attr: state, device, mount, type, mode
-            Gauge.builder(FS_USAGE, fs, f -> {
-                f.updateAttributes();
-                // OSFileStore guarantees usable <= total, so the difference cannot be negative
-                return (double) (f.getTotalSpace() - f.getUsableSpace());
-            }).tag(STATE_KEY, "used").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
-                    .tag(MODE_KEY, mode).description("Filesystem space usage").baseUnit("By").strongReference(true)
-                    .register(registry);
-            Gauge.builder(FS_USAGE, fs, f -> {
-                f.updateAttributes();
-                return (double) f.getUsableSpace();
-            }).tag(STATE_KEY, "free").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
-                    .tag(MODE_KEY, mode).description("Filesystem space usage").baseUnit("By").strongReference(true)
-                    .register(registry);
+            // system.filesystem.usage — UpDownCounter (Gauge), unit "By", attr: state, device, mount, type, mode.
+            // OSFileStore guarantees usable <= free <= total, so none of these differences can be negative and the
+            // three states sum to the total.
+            registerUsage(registry, fs, tags, STATE_USED, f -> f.getTotalSpace() - f.getFreeSpace());
+            registerUsage(registry, fs, tags, STATE_FREE, OSFileStore::getUsableSpace);
+            registerUsage(registry, fs, tags, STATE_RESERVED, f -> f.getFreeSpace() - f.getUsableSpace());
 
             // system.filesystem.utilization — Gauge, unit "1", attr: state, device, mount, type, mode
-            Gauge.builder(FS_UTILIZATION, fs, f -> {
-                f.updateAttributes();
-                return f.getTotalSpace() == 0 ? 0d
-                        : (double) (f.getTotalSpace() - f.getUsableSpace()) / f.getTotalSpace();
-            }).tag(STATE_KEY, "used").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
-                    .tag(MODE_KEY, mode).description("Filesystem utilization").strongReference(true).register(registry);
-            Gauge.builder(FS_UTILIZATION, fs, f -> {
-                f.updateAttributes();
-                return f.getTotalSpace() == 0 ? 0d : (double) f.getUsableSpace() / f.getTotalSpace();
-            }).tag(STATE_KEY, "free").tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type)
-                    .tag(MODE_KEY, mode).description("Filesystem utilization").strongReference(true).register(registry);
+            registerUtilization(registry, fs, tags, STATE_USED,
+                    f -> fraction(f.getTotalSpace() - f.getFreeSpace(), f.getTotalSpace()));
+            registerUtilization(registry, fs, tags, STATE_FREE, f -> fraction(f.getUsableSpace(), f.getTotalSpace()));
+            registerUtilization(registry, fs, tags, STATE_RESERVED,
+                    f -> fraction(f.getFreeSpace() - f.getUsableSpace(), f.getTotalSpace()));
 
             // system.filesystem.limit — UpDownCounter (Gauge), unit "By", attr: device, mount, type, mode
             Gauge.builder(FS_LIMIT, fs, f -> {
                 f.updateAttributes();
                 return (double) f.getTotalSpace();
-            }).tag(DEVICE_KEY, device).tag(MOUNTPOINT_KEY, mount).tag(TYPE_KEY, type).tag(MODE_KEY, mode)
-                    .description("Total capacity of the filesystem").baseUnit("By").strongReference(true)
+            }).tags(tags).description("Total capacity of the filesystem").baseUnit("By").strongReference(true)
                     .register(registry);
         }
+    }
+
+    private static void registerUsage(MeterRegistry registry, OSFileStore fs, Tags tags, Tag state,
+            ToDoubleFunction<OSFileStore> bytes) {
+        Gauge.builder(FS_USAGE, fs, refreshing(bytes)).tags(tags.and(state)).description("Filesystem space usage")
+                .baseUnit("By").strongReference(true).register(registry);
+    }
+
+    private static void registerUtilization(MeterRegistry registry, OSFileStore fs, Tags tags, Tag state,
+            ToDoubleFunction<OSFileStore> ratio) {
+        Gauge.builder(FS_UTILIZATION, fs, refreshing(ratio)).tags(tags.and(state)).description("Filesystem utilization")
+                .strongReference(true).register(registry);
+    }
+
+    /*
+     * Each gauge re-reads the file store's space values when sampled, since a bound OSFileStore is otherwise a snapshot
+     * taken when the binder was created.
+     */
+    private static ToDoubleFunction<OSFileStore> refreshing(ToDoubleFunction<OSFileStore> value) {
+        return f -> {
+            f.updateAttributes();
+            return value.applyAsDouble(f);
+        };
+    }
+
+    private static double fraction(long value, long total) {
+        return total == 0 ? 0d : (double) value / total;
     }
 }

--- a/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
@@ -82,51 +82,46 @@ public class FileSystemMetrics implements MeterBinder {
             Tags tags = Tags.of(DEVICE_KEY, fs.getVolume(), MOUNTPOINT_KEY, fs.getMount(), TYPE_KEY, fs.getType(),
                     MODE_KEY, mode);
             // A bound OSFileStore is a snapshot taken when the binder was created, so it has to be refreshed as it is
-            // sampled. The seven gauges below share one memoized refresh, both to spare the filesystem six redundant
-            // queries per scrape and so that a single scrape reads one snapshot: the states can only be shown to
-            // partition the filesystem if they were all measured against the same reading of it.
-            Supplier<Boolean> refresh = Memoizer.memoize(fs::updateAttributes, Memoizer.defaultExpiration());
+            // sampled. The seven gauges below read it through one memoized supplier, both to spare the filesystem six
+            // redundant queries per scrape and so that a single scrape reads one snapshot: the states can only be shown
+            // to partition the filesystem if they were all measured against the same reading of it.
+            Supplier<OSFileStore> refreshed = Memoizer.memoize(() -> {
+                fs.updateAttributes();
+                return fs;
+            }, Memoizer.defaultExpiration());
 
             // system.filesystem.usage — UpDownCounter (Gauge), unit "By", attr: state, device, mount, type, mode.
             // OSFileStore guarantees usable <= free <= total, so none of these differences can be negative and the
             // three states sum to the total.
-            registerUsage(registry, fs, tags, STATE_USED, refresh, f -> f.getTotalSpace() - f.getFreeSpace());
-            registerUsage(registry, fs, tags, STATE_FREE, refresh, OSFileStore::getUsableSpace);
-            registerUsage(registry, fs, tags, STATE_RESERVED, refresh, f -> f.getFreeSpace() - f.getUsableSpace());
+            registerUsage(registry, refreshed, tags, STATE_USED, f -> f.getTotalSpace() - f.getFreeSpace());
+            registerUsage(registry, refreshed, tags, STATE_FREE, OSFileStore::getUsableSpace);
+            registerUsage(registry, refreshed, tags, STATE_RESERVED, f -> f.getFreeSpace() - f.getUsableSpace());
 
             // system.filesystem.utilization — Gauge, unit "1", attr: state, device, mount, type, mode
-            registerUtilization(registry, fs, tags, STATE_USED, refresh,
+            registerUtilization(registry, refreshed, tags, STATE_USED,
                     f -> fraction(f.getTotalSpace() - f.getFreeSpace(), f.getTotalSpace()));
-            registerUtilization(registry, fs, tags, STATE_FREE, refresh,
+            registerUtilization(registry, refreshed, tags, STATE_FREE,
                     f -> fraction(f.getUsableSpace(), f.getTotalSpace()));
-            registerUtilization(registry, fs, tags, STATE_RESERVED, refresh,
+            registerUtilization(registry, refreshed, tags, STATE_RESERVED,
                     f -> fraction(f.getFreeSpace() - f.getUsableSpace(), f.getTotalSpace()));
 
             // system.filesystem.limit — UpDownCounter (Gauge), unit "By", attr: device, mount, type, mode
-            Gauge.builder(FS_LIMIT, fs, refreshing(refresh, OSFileStore::getTotalSpace)).tags(tags)
+            Gauge.builder(FS_LIMIT, refreshed, s -> s.get().getTotalSpace()).tags(tags)
                     .description("Total capacity of the filesystem").baseUnit("By").strongReference(true)
                     .register(registry);
         }
     }
 
-    private static void registerUsage(MeterRegistry registry, OSFileStore fs, Tags tags, Tag state,
-            Supplier<Boolean> refresh, ToDoubleFunction<OSFileStore> bytes) {
-        Gauge.builder(FS_USAGE, fs, refreshing(refresh, bytes)).tags(tags.and(state))
+    private static void registerUsage(MeterRegistry registry, Supplier<OSFileStore> refreshed, Tags tags, Tag state,
+            ToDoubleFunction<OSFileStore> bytes) {
+        Gauge.builder(FS_USAGE, refreshed, s -> bytes.applyAsDouble(s.get())).tags(tags.and(state))
                 .description("Filesystem space usage").baseUnit("By").strongReference(true).register(registry);
     }
 
-    private static void registerUtilization(MeterRegistry registry, OSFileStore fs, Tags tags, Tag state,
-            Supplier<Boolean> refresh, ToDoubleFunction<OSFileStore> ratio) {
-        Gauge.builder(FS_UTILIZATION, fs, refreshing(refresh, ratio)).tags(tags.and(state))
+    private static void registerUtilization(MeterRegistry registry, Supplier<OSFileStore> refreshed, Tags tags,
+            Tag state, ToDoubleFunction<OSFileStore> ratio) {
+        Gauge.builder(FS_UTILIZATION, refreshed, s -> ratio.applyAsDouble(s.get())).tags(tags.and(state))
                 .description("Filesystem utilization").strongReference(true).register(registry);
-    }
-
-    private static ToDoubleFunction<OSFileStore> refreshing(Supplier<Boolean> refresh,
-            ToDoubleFunction<OSFileStore> value) {
-        return f -> {
-            refresh.get();
-            return value.applyAsDouble(f);
-        };
     }
 
     private static double fraction(long value, long total) {

--- a/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 
 import oshi.software.os.OSFileStore;
+import oshi.util.Memoizer;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -37,6 +38,11 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * ({@link OSFileStore#getUsableSpace()}), and {@code reserved} is unused space that is not available to it: the
  * superuser reserve many UNIX filesystems hold back, or the caller's quota on Windows. Filesystems that reserve nothing
  * at this layer, such as ZFS and APFS, report {@code reserved} as 0.
+ *
+ * <p>
+ * A filesystem's space is re-read as its gauges are sampled, once per filesystem per
+ * {@link Memoizer#defaultExpiration()} window rather than once per gauge, so that all of its gauges within a scrape
+ * report the same reading.
  */
 public class FileSystemMetrics implements MeterBinder {
 
@@ -75,49 +81,50 @@ public class FileSystemMetrics implements MeterBinder {
             String mode = Arrays.asList(opts.split(",")).contains("rw") ? "rw" : "ro";
             Tags tags = Tags.of(DEVICE_KEY, fs.getVolume(), MOUNTPOINT_KEY, fs.getMount(), TYPE_KEY, fs.getType(),
                     MODE_KEY, mode);
+            // A bound OSFileStore is a snapshot taken when the binder was created, so it has to be refreshed as it is
+            // sampled. The seven gauges below share one memoized refresh, both to spare the filesystem six redundant
+            // queries per scrape and so that a single scrape reads one snapshot: the states can only be shown to
+            // partition the filesystem if they were all measured against the same reading of it.
+            Supplier<Boolean> refresh = Memoizer.memoize(fs::updateAttributes, Memoizer.defaultExpiration());
 
             // system.filesystem.usage — UpDownCounter (Gauge), unit "By", attr: state, device, mount, type, mode.
             // OSFileStore guarantees usable <= free <= total, so none of these differences can be negative and the
             // three states sum to the total.
-            registerUsage(registry, fs, tags, STATE_USED, f -> f.getTotalSpace() - f.getFreeSpace());
-            registerUsage(registry, fs, tags, STATE_FREE, OSFileStore::getUsableSpace);
-            registerUsage(registry, fs, tags, STATE_RESERVED, f -> f.getFreeSpace() - f.getUsableSpace());
+            registerUsage(registry, fs, tags, STATE_USED, refresh, f -> f.getTotalSpace() - f.getFreeSpace());
+            registerUsage(registry, fs, tags, STATE_FREE, refresh, OSFileStore::getUsableSpace);
+            registerUsage(registry, fs, tags, STATE_RESERVED, refresh, f -> f.getFreeSpace() - f.getUsableSpace());
 
             // system.filesystem.utilization — Gauge, unit "1", attr: state, device, mount, type, mode
-            registerUtilization(registry, fs, tags, STATE_USED,
+            registerUtilization(registry, fs, tags, STATE_USED, refresh,
                     f -> fraction(f.getTotalSpace() - f.getFreeSpace(), f.getTotalSpace()));
-            registerUtilization(registry, fs, tags, STATE_FREE, f -> fraction(f.getUsableSpace(), f.getTotalSpace()));
-            registerUtilization(registry, fs, tags, STATE_RESERVED,
+            registerUtilization(registry, fs, tags, STATE_FREE, refresh,
+                    f -> fraction(f.getUsableSpace(), f.getTotalSpace()));
+            registerUtilization(registry, fs, tags, STATE_RESERVED, refresh,
                     f -> fraction(f.getFreeSpace() - f.getUsableSpace(), f.getTotalSpace()));
 
             // system.filesystem.limit — UpDownCounter (Gauge), unit "By", attr: device, mount, type, mode
-            Gauge.builder(FS_LIMIT, fs, f -> {
-                f.updateAttributes();
-                return (double) f.getTotalSpace();
-            }).tags(tags).description("Total capacity of the filesystem").baseUnit("By").strongReference(true)
+            Gauge.builder(FS_LIMIT, fs, refreshing(refresh, OSFileStore::getTotalSpace)).tags(tags)
+                    .description("Total capacity of the filesystem").baseUnit("By").strongReference(true)
                     .register(registry);
         }
     }
 
     private static void registerUsage(MeterRegistry registry, OSFileStore fs, Tags tags, Tag state,
-            ToDoubleFunction<OSFileStore> bytes) {
-        Gauge.builder(FS_USAGE, fs, refreshing(bytes)).tags(tags.and(state)).description("Filesystem space usage")
-                .baseUnit("By").strongReference(true).register(registry);
+            Supplier<Boolean> refresh, ToDoubleFunction<OSFileStore> bytes) {
+        Gauge.builder(FS_USAGE, fs, refreshing(refresh, bytes)).tags(tags.and(state))
+                .description("Filesystem space usage").baseUnit("By").strongReference(true).register(registry);
     }
 
     private static void registerUtilization(MeterRegistry registry, OSFileStore fs, Tags tags, Tag state,
-            ToDoubleFunction<OSFileStore> ratio) {
-        Gauge.builder(FS_UTILIZATION, fs, refreshing(ratio)).tags(tags.and(state)).description("Filesystem utilization")
-                .strongReference(true).register(registry);
+            Supplier<Boolean> refresh, ToDoubleFunction<OSFileStore> ratio) {
+        Gauge.builder(FS_UTILIZATION, fs, refreshing(refresh, ratio)).tags(tags.and(state))
+                .description("Filesystem utilization").strongReference(true).register(registry);
     }
 
-    /*
-     * Each gauge re-reads the file store's space values when sampled, since a bound OSFileStore is otherwise a snapshot
-     * taken when the binder was created.
-     */
-    private static ToDoubleFunction<OSFileStore> refreshing(ToDoubleFunction<OSFileStore> value) {
+    private static ToDoubleFunction<OSFileStore> refreshing(Supplier<Boolean> refresh,
+            ToDoubleFunction<OSFileStore> value) {
         return f -> {
-            f.updateAttributes();
+            refresh.get();
             return value.applyAsDouble(f);
         };
     }

--- a/oshi-metrics/src/test/java/oshi/metrics/FileSystemMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/FileSystemMetricsTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import oshi.software.common.AbstractOSFileStore;
+import oshi.software.os.OSFileStore;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * Tests the state arithmetic of {@link FileSystemMetrics} against fixed values, which the live tests in
+ * {@code OshiMetricsTest} cannot do: a real filesystem's space changes between samples.
+ */
+class FileSystemMetricsTest {
+
+    private static final String USAGE = "system.filesystem.usage";
+    private static final String UTILIZATION = "system.filesystem.utilization";
+    private static final String LIMIT = "system.filesystem.limit";
+    private static final String STATE = "system.filesystem.state";
+    private static final String[] STATES = { "used", "free", "reserved" };
+    private static final double DELTA = 1e-9;
+
+    private MeterRegistry registry;
+
+    /** A file store with fixed space values, so a gauge reads the same number every time it is sampled. */
+    private static class FixedOSFileStore extends AbstractOSFileStore {
+        FixedOSFileStore(long freeSpace, long usableSpace, long totalSpace) {
+            super("fixed", "/dev/fixed", "label", "/mnt/fixed", "rw,noatime", "uuid", true, "lv", "Local Disk", "ext4",
+                    freeSpace, usableSpace, totalSpace, 100L, 500L);
+        }
+
+        @Override
+        public boolean updateAttributes() {
+            return true;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+    }
+
+    private void bind(long freeSpace, long usableSpace, long totalSpace) {
+        OSFileStore fs = new FixedOSFileStore(freeSpace, usableSpace, totalSpace);
+        new FileSystemMetrics(() -> Collections.<OSFileStore>singletonList(fs)).bindTo(registry);
+    }
+
+    private double usage(String state) {
+        Gauge gauge = registry.find(USAGE).tag(STATE, state).gauge();
+        assertNotNull(gauge, USAGE + "{state=" + state + "} should be registered");
+        return gauge.value();
+    }
+
+    private double utilization(String state) {
+        Gauge gauge = registry.find(UTILIZATION).tag(STATE, state).gauge();
+        assertNotNull(gauge, UTILIZATION + "{state=" + state + "} should be registered");
+        return gauge.value();
+    }
+
+    private double limit() {
+        Gauge gauge = registry.find(LIMIT).gauge();
+        assertNotNull(gauge, LIMIT + " should be registered");
+        return gauge.value();
+    }
+
+    @Test
+    void reservedSpaceIsReportedSeparatelyFromUsedAndFree() {
+        // 1000 total, 200 unused, only 150 of it available to the caller: the other 50 is the superuser reserve
+        bind(200L, 150L, 1000L);
+        assertEquals(800d, usage("used"), "used should exclude the reserve");
+        assertEquals(150d, usage("free"), "free should be the space available to the caller");
+        assertEquals(50d, usage("reserved"), "reserved should be the unused space unavailable to the caller");
+    }
+
+    @Test
+    void usageStatesSumToLimit() {
+        // OpenTelemetry's filesystem conventions require summing usage across states to equal the limit
+        bind(200L, 150L, 1000L);
+        assertEquals(limit(), usage("used") + usage("free") + usage("reserved"),
+                "usage states should sum to the filesystem limit");
+    }
+
+    @Test
+    void utilizationStatesSumToOne() {
+        bind(200L, 150L, 1000L);
+        assertEquals(0.8d, utilization("used"), DELTA);
+        assertEquals(0.15d, utilization("free"), DELTA);
+        assertEquals(0.05d, utilization("reserved"), DELTA);
+        assertEquals(1d, utilization("used") + utilization("free") + utilization("reserved"), DELTA,
+                "utilization states should sum to 1.0");
+    }
+
+    @Test
+    void filesystemWithoutAReserveReportsZeroReserved() {
+        // ZFS and APFS reserve nothing at this layer, so statvfs reports f_bfree == f_bavail
+        bind(200L, 200L, 1000L);
+        assertEquals(800d, usage("used"));
+        assertEquals(200d, usage("free"));
+        assertEquals(0d, usage("reserved"));
+    }
+
+    @Test
+    void emptyFilesystemReportsZeroUtilization() {
+        // A pseudo filesystem with no capacity would otherwise divide by zero
+        bind(0L, 0L, 0L);
+        assertEquals(0d, limit());
+        assertEquals(0d, utilization("used"));
+        assertEquals(0d, utilization("free"));
+        assertEquals(0d, utilization("reserved"));
+    }
+
+    @Test
+    void inconsistentSpaceValuesCannotProduceNegativeStates() {
+        // AbstractOSFileStore clamps usable <= free <= total, so no state can go negative even when the operating
+        // system reports the three values inconsistently
+        bind(6000L, 5500L, 5000L);
+        for (String state : STATES) {
+            assertTrue(usage(state) >= 0d, USAGE + "{state=" + state + "} should not be negative");
+            assertTrue(utilization(state) >= 0d, UTILIZATION + "{state=" + state + "} should not be negative");
+        }
+        assertEquals(limit(), usage("used") + usage("free") + usage("reserved"));
+    }
+}

--- a/oshi-metrics/src/test/java/oshi/metrics/FileSystemMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/FileSystemMetricsTest.java
@@ -48,6 +48,23 @@ class FileSystemMetricsTest {
         }
     }
 
+    /** A file store that reports different space every time it is refreshed, as a busy one does. */
+    private static class VaryingOSFileStore extends AbstractOSFileStore {
+        private long free = 1000L;
+
+        VaryingOSFileStore() {
+            super("varying", "/dev/varying", "label", "/mnt/varying", "rw", "uuid", true, "lv", "Local Disk", "ext4",
+                    1000L, 900L, 10000L, 100L, 500L);
+        }
+
+        @Override
+        public boolean updateAttributes() {
+            this.free -= 100L;
+            updateSpace(this.free, this.free - 100L, 10000L);
+            return true;
+        }
+    }
+
     @BeforeEach
     void setUp() {
         registry = new SimpleMeterRegistry();
@@ -120,6 +137,17 @@ class FileSystemMetricsTest {
         assertEquals(0d, utilization("used"));
         assertEquals(0d, utilization("free"));
         assertEquals(0d, utilization("reserved"));
+    }
+
+    @Test
+    void allGaugesOfOneFilesystemShareASingleReading() {
+        // A filesystem whose space changes on every refresh would break the partition rule if each gauge refreshed
+        // separately: the states would be measured against four different readings. They share one memoized refresh
+        // per filesystem, which holds for 300 ms by default -- far longer than sampling four gauges in process.
+        OSFileStore fs = new VaryingOSFileStore();
+        new FileSystemMetrics(() -> Collections.singletonList(fs)).bindTo(registry);
+        assertEquals(limit(), usage("used") + usage("free") + usage("reserved"),
+                "usage states should sum to the limit even while the filesystem is changing");
     }
 
     @Test

--- a/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/OshiMetricsTest.java
@@ -192,11 +192,15 @@ class OshiMetricsTest {
     void filesystemUsageRegistered() {
         Gauge used = registry.find("system.filesystem.usage").tag("system.filesystem.state", "used").gauge();
         Gauge free = registry.find("system.filesystem.usage").tag("system.filesystem.state", "free").gauge();
+        Gauge reserved = registry.find("system.filesystem.usage").tag("system.filesystem.state", "reserved").gauge();
         assertNotNull(used, "system.filesystem.usage{state=used} should be registered");
         assertNotNull(free, "system.filesystem.usage{state=free} should be registered");
-        // Some filesystems (e.g., tmpfs) may report 0; just verify non-negative
+        assertNotNull(reserved, "system.filesystem.usage{state=reserved} should be registered");
+        // Some filesystems (e.g., tmpfs) may report 0; just verify non-negative. The states are asserted to sum to the
+        // limit in FileSystemMetricsTest, against fixed values: a live filesystem's space moves between samples.
         assertTrue(used.value() >= 0, "Filesystem used should be non-negative");
         assertTrue(free.value() >= 0, "Filesystem free should be non-negative");
+        assertTrue(reserved.value() >= 0, "Filesystem reserved should be non-negative");
     }
 
     @Test
@@ -210,10 +214,15 @@ class OshiMetricsTest {
     void filesystemUtilizationRegistered() {
         Gauge used = registry.find("system.filesystem.utilization").tag("system.filesystem.state", "used").gauge();
         Gauge free = registry.find("system.filesystem.utilization").tag("system.filesystem.state", "free").gauge();
+        Gauge reserved = registry.find("system.filesystem.utilization").tag("system.filesystem.state", "reserved")
+                .gauge();
         assertNotNull(used, "system.filesystem.utilization{state=used} should be registered");
         assertNotNull(free, "system.filesystem.utilization{state=free} should be registered");
+        assertNotNull(reserved, "system.filesystem.utilization{state=reserved} should be registered");
         assertTrue(used.value() >= 0 && used.value() <= 1, "Filesystem utilization used should be in [0,1]");
         assertTrue(free.value() >= 0 && free.value() <= 1, "Filesystem utilization free should be in [0,1]");
+        assertTrue(reserved.value() >= 0 && reserved.value() <= 1,
+                "Filesystem utilization reserved should be in [0,1]");
     }
 
     @Test


### PR DESCRIPTION
Adds the third OpenTelemetry filesystem state, `reserved`, to `oshi-metrics`.

The [filesystem semantic conventions](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#filesystem-metrics) enumerate exactly three values for `system.filesystem.state` — `used`, `free`, `reserved` — and footnote [1] says summing `system.filesystem.usage` across states SHOULD equal `system.filesystem.limit`. We registered two of the three, and computed `used` as `total - usable`, which absorbed the reserve into `used` and left nothing to report as `reserved`.

#3651 gave `OSFileStore` the ordering guarantee `0 <= usable <= free <= total`, which makes the reserve directly expressible: it is exactly `free - usable`, the unused space that is not available to the calling process.

### What changed

The three states now partition the filesystem:

| state | before | after |
|---|---|---|
| `used` | `total - usable` | `total - free` |
| `free` | `usable` | `usable` (unchanged) |
| `reserved` | — | `free - usable` |

They sum to `total` exactly, so `system.filesystem.usage` sums to `system.filesystem.limit` and `system.filesystem.utilization` sums to 1.0.

`free` was already correct: the convention's `free` is `statvfs`'s `f_bavail`, which is `getUsableSpace()`, not `f_bfree`. Only `used` needed redefining, and it had to be redefined — adding `reserved` while leaving `used` alone would over-count by the reserve and break the sum rule.

### User-visible behavior change

`state=used` drops by the reserve on filesystems that hold one back — ext4's default 5% (`tune2fs -m`), and a Windows volume with a quota on the caller. That space is now reported as `reserved` rather than silently counted as used, so an alert on `used` will read slightly lower and one on `used + reserved` reproduces the old number.

It is unchanged on filesystems that reserve nothing at this layer. ZFS and APFS report `f_bfree == f_bavail`, so `reserved` is 0 there. Verified on this machine (macOS/APFS), where every mount reports `free == usable`:

```
/                            total=  494384795648 free=  109363933184 usable=  109363933184 reserved=  0
/System/Volumes/Data         total=  494384795648 free=  109363933184 usable=  109363933184 reserved=  0
/System/Volumes/xarts        total=     524288000 free=     504127488 usable=     504127488 reserved=  0
```

CHANGELOG carries both halves: the new state under *New Features*, the `used` redefinition under *Behavior Changes*.

### Implementation note

Seven near-identical builder chains would have been a lot of repeated tag plumbing around three lines of arithmetic, so the gauge registration collapses into `registerUsage`/`registerUtilization` helpers taking a `Tag` and a `ToDoubleFunction`, with the per-sample `updateAttributes()` refresh factored into one place. The three formulas now sit side by side, where the sum rule is checkable at a glance.

### Testing

New `FileSystemMetricsTest` binds a fixed-value `OSFileStore` and asserts the arithmetic directly — the sum rules, the reserve split, `reserved == 0` when `free == usable`, a zero-capacity filesystem not dividing by zero, and inconsistent OS values not producing a negative state. The live tests in `OshiMetricsTest` cannot assert a sum: a real filesystem's space moves between the three samples. They are extended to cover registration and non-negativity of the new state.

Full gate green locally on macOS: `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc`, 0 tests failed, `FileSystemMetricsTest [OK]` and `OshiMetricsTest [OK]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filesystem metrics for reserved space alongside used and free space.
  * Improved filesystem usage and utilization calculations across Unix and Windows systems.
  * Ensured consistent filesystem sampling within the metrics refresh window.

* **Bug Fixes**
  * Prevented negative metric values and handled zero-capacity filesystems safely.
  * Improved cross-platform ordering of filesystem space values.

* **Documentation**
  * Updated filesystem metrics documentation and the 7.5.1 changelog.
  * Documented Maven Central distribution updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->