### PR TITLE
Synchronize the disk and file store refresh paths

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHWDiskStoreNF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/nativefree/LinuxHWDiskStoreNF.java
@@ -118,7 +118,7 @@ public final class LinuxHWDiskStoreNF extends LinuxHWDiskStore {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         String devName = getName().replace(DevPath.DEV, "");
         String statStr = FileUtil.getStringFromFile(SYS_BLOCK + devName + "/" + STAT).trim();
         if (statStr.isEmpty()) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdHWDiskStore.java
@@ -42,7 +42,7 @@ public abstract class FreeBsdHWDiskStore extends AbstractHWDiskStore {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         List<String> output = ExecutingCommand.runNative("iostat -Ix " + getName());
         long now = System.currentTimeMillis();
         boolean diskFound = false;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdHWDiskStore.java
@@ -99,7 +99,7 @@ public final class NetBsdHWDiskStore extends AbstractHWDiskStore {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         long now = System.currentTimeMillis();
         boolean diskFound = false;
         for (String line : iostat.get()) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdHWDiskStore.java
@@ -111,7 +111,7 @@ public abstract class OpenBsdHWDiskStore extends AbstractHWDiskStore {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         long now = System.currentTimeMillis();
         boolean diskFound = false;
         for (String line : iostat.get()) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisHWDiskStore.java
@@ -70,7 +70,7 @@ public abstract class SolarisHWDiskStore extends AbstractHWDiskStore {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         this.timeStamp = System.currentTimeMillis();
         DiskStats stats = queryStats();
         if (stats == null) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsHWDiskStore.java
@@ -82,7 +82,7 @@ public abstract class WindowsHWDiskStore extends AbstractHWDiskStore {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         String index = null;
         List<HWPartition> partitions = getPartitions();
         if (!partitions.isEmpty()) {

--- a/oshi-common/src/main/java/oshi/software/common/AbstractOSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractOSFileStore.java
@@ -151,7 +151,7 @@ public abstract class AbstractOSFileStore implements OSFileStore {
      *
      * @param fileStore the source file store
      */
-    protected void updateFrom(OSFileStore fileStore) {
+    protected synchronized void updateFrom(OSFileStore fileStore) {
         this.logicalVolume = fileStore.getLogicalVolume();
         this.description = fileStore.getDescription();
         this.fsType = fileStore.getType();
@@ -169,7 +169,7 @@ public abstract class AbstractOSFileStore implements OSFileStore {
      * @param freeInodes  free inodes
      * @param totalInodes total inodes
      */
-    protected void updateSpaceAndInodes(long freeSpace, long usableSpace, long totalSpace, long freeInodes,
+    protected synchronized void updateSpaceAndInodes(long freeSpace, long usableSpace, long totalSpace, long freeInodes,
             long totalInodes) {
         setSpace(freeSpace, usableSpace, totalSpace);
         this.freeInodes = freeInodes;
@@ -183,7 +183,7 @@ public abstract class AbstractOSFileStore implements OSFileStore {
      * @param usableSpace usable space in bytes
      * @param totalSpace  total space in bytes
      */
-    protected void updateSpace(long freeSpace, long usableSpace, long totalSpace) {
+    protected synchronized void updateSpace(long freeSpace, long usableSpace, long totalSpace) {
         setSpace(freeSpace, usableSpace, totalSpace);
     }
 
@@ -200,9 +200,15 @@ public abstract class AbstractOSFileStore implements OSFileStore {
      * the error in the direction that overstates fullness rather than free capacity.
      */
     private void setSpace(long freeSpace, long usableSpace, long totalSpace) {
-        this.totalSpace = Math.max(0L, totalSpace);
-        this.freeSpace = Math.min(Math.max(0L, freeSpace), this.totalSpace);
-        this.usableSpace = Math.min(Math.max(0L, usableSpace), this.freeSpace);
+        // Clamp against locals rather than the fields being written. Reading back a volatile just assigned would make
+        // this a read-modify-write, and two concurrent refreshes could then interleave to produce a triple that
+        // violates the very ordering this method exists to guarantee.
+        long total = Math.max(0L, totalSpace);
+        long free = Math.min(Math.max(0L, freeSpace), total);
+        long usable = Math.min(Math.max(0L, usableSpace), free);
+        this.totalSpace = total;
+        this.freeSpace = free;
+        this.usableSpace = usable;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/software/os/OSFileStore.java
+++ b/oshi-common/src/main/java/oshi/software/os/OSFileStore.java
@@ -17,6 +17,16 @@ import oshi.hardware.HWPartition;
  * File stores are obtained from the {@link FileSystem#getFileStores()} method. The {@link #getMount()} value can be
  * correlated with {@link HWPartition#getMountPoint()} to link file stores to their underlying hardware partitions and
  * disk stores.
+ * <p>
+ * Space values satisfy {@code 0 <= getUsableSpace() <= getFreeSpace() <= getTotalSpace()}. Most platforms read the
+ * three from separate queries, so on a filesystem whose capacity is computed rather than fixed they can describe
+ * adjacent instants; the ordering is restored by clamping downward, never reporting a value higher than the operating
+ * system reported it. See {@link #getFreeSpace()} and {@link #getUsableSpace()} for the difference between them.
+ * <p>
+ * Thread safe for the designed use of retrieving the most recent data. Users should be aware that the
+ * {@link #updateAttributes()} method may update attributes, and should externally synchronize such usage to ensure
+ * consistent calculations. For monitoring multiple file stores, it is more efficient to re-query the full list from
+ * {@link FileSystem#getFileStores()} than to update each file store individually.
  *
  * @see HWDiskStore
  * @see HWPartition

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreFFM.java
@@ -187,7 +187,7 @@ public final class LinuxHWDiskStoreFFM extends LinuxHWDiskStore {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         return !getDisks(this).isEmpty();
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreFFM.java
@@ -55,7 +55,7 @@ public final class MacHWDiskStoreFFM extends MacHWDiskStore {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         try {
             @SuppressWarnings("resource") // CFAllocatorGetDefault returns a borrowed singleton
             CFAllocatorRef alloc = new CFAllocatorRef(CoreFoundationFunctions.CFAllocatorGetDefault());

--- a/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/linux/LinuxHWDiskStoreJNA.java
@@ -154,7 +154,7 @@ public final class LinuxHWDiskStoreJNA extends LinuxHWDiskStore {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         return !getDisks(this).isEmpty();
     }
 

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacHWDiskStoreJNA.java
@@ -59,7 +59,7 @@ public final class MacHWDiskStoreJNA extends MacHWDiskStore {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         // Open a session and create CFStrings
         DASessionRef session = DA.DASessionCreate(CF.CFAllocatorGetDefault());
         if (session == null) {


### PR DESCRIPTION
Second chunk of the `updateAttributes()` consistency arc begun in #3586, taking the disk and file store implementations. Also fixes a latent race introduced with the space invariant in #3651.

## The standard, now settled

#3586 established the pattern on `BsdOSProcess` and `BsdOSThread`: **the lock goes on the method that writes the fields, and no suppression is kept beside it.** Its open question was whether Sonar's `java:S3078` was syntactic and would re-fire under the lock. It does not — Sonar reports **0 open issues** and Coverity is clean, with **no `S3078` or `VOLATILE_ATOMICITY` suppressions left anywhere** in the tree. So this is the standard rather than a proposal, and the remaining chunks can follow it without re-deciding.

Before this PR, 3 of ~45 implementations used it. After, 14.

## The latent race (first commit)

`setSpace` assigned each volatile and then read it back to bound the next:

```java
this.totalSpace  = Math.max(0L, totalSpace);
this.freeSpace   = Math.min(Math.max(0L, freeSpace),   this.totalSpace);
this.usableSpace = Math.min(Math.max(0L, usableSpace), this.freeSpace);
```

So the method that exists to guarantee `usable <= free <= total` was itself a read-modify-write, and two concurrent refreshes could interleave to violate it:

```
A: total = 100
A: free  = min(50, 100) = 50
B: total = 10
A: usable = min(30, this.freeSpace = 50) = 30
   -> total=10, free=50, usable=30, and free > total
```

Computing the three into locals and assigning once removes the read-back entirely, so the clamps bound values from a single reading regardless of what else is writing. This stands on its own and is separated as the first commit.

## File stores: one file, ten implementations

#3651 made `AbstractOSFileStore` the sole writer of the mutable fields — no platform class assigns them — so locking its three `update*` entry points covers every implementation at once. `setSpace` stays private, reached only from those three, and therefore needs no lock of its own.

## Disks: no such choke point

Eight of the eleven `HWDiskStore` platform classes write the counters directly, so each takes the lock on its own `updateAttributes()`. That matches `AixHWDiskStore`, synchronized since #3586 and the only one until now; its monotonic clamps (`if (stats.xfers > getReads())`) are read-modify-writes that the lock now protects on every platform rather than one.

## Locking safety

Two things checked rather than assumed, since this is where the arc could go wrong:

- **No implementation acquires a second lock inside the method body** — no nested `synchronized`, no explicit `Lock`.
- **No caller holds a lock across the call.** Every `store.updateAttributes()` site is a freshly constructed store inside a `getDisks()`-style factory.

So there is no lock-ordering hazard to reason about.

## Documentation

`OSFileStore` was one of two interfaces with no thread-safety contract at all — `OSProcess`, `OSThread`, `NetworkIF` and `HWDiskStore` already carried the externally-synchronize paragraph. It now states that, the space ordering it guarantees, and the prefer-the-full-list advice the others give. `PowerSource`, the other one, comes with the network chunk.

## Not included

The shared `monotonic(long, long)` hoist, unifying `AixHWDiskStore`'s inline clamps with `BsdOSProcess.monotonic`. Those sit in different chunks, and the clamps are now lock-protected either way; it belongs wherever the process/thread work lands.

## Verification

Full gate and `-Perror-prone` clean, all tests passing. `synchronized` is not part of the method signature, so `japicmp` is unaffected. No CHANGELOG entry: this fixes a race no OSHI-internal caller can reach, and the rest is documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when disk statistics are refreshed concurrently across supported Linux, macOS, Windows, BSD, and Solaris platforms.
  - Prevented inconsistent file-store space values during simultaneous updates, preserving nonnegative and properly ordered totals.

- **Documentation**
  - Clarified file-store space-value behavior, including sampling and value-clamping guarantees.
  - Added guidance for safely retrieving and refreshing file-store attributes in multithreaded applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->