### PR TITLE
Synchronize the network interface and power source refresh paths

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/PowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/PowerSource.java
@@ -40,6 +40,11 @@ import oshi.annotation.concurrent.ThreadSafe;
  * {@link #getTimeRemainingEstimated()} returns {@code -1.0} (calculating) or {@code -2.0} (unlimited).
  * <p>
  * <b>Platform notes:</b> On Android and some embedded systems, the power source list may be empty.
+ * <p>
+ * Thread safe for the designed use of retrieving the most recent data. Users should be aware that the
+ * {@link #updateAttributes()} method may update attributes, and should externally synchronize such usage to ensure
+ * consistent calculations. Unlike the other refreshable types, a failed update leaves this power source unchanged:
+ * {@link #updateAttributes()} assigns nothing unless it finds a source matching this one's name.
  */
 @PublicApi
 @ThreadSafe

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractPowerSource.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractPowerSource.java
@@ -210,7 +210,7 @@ public abstract class AbstractPowerSource implements PowerSource {
     protected abstract List<PowerSource> queryPowerSources();
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         List<PowerSource> psArr = queryPowerSources();
         for (PowerSource ps : psArr) {
             if (ps.getName().equals(this.name)) {

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxNetworkIF.java
@@ -90,7 +90,7 @@ public abstract class LinuxNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         String name = SysPath.NET + getName();
         try {
             File ifDir = new File(name + "/statistics");

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacNetworkIF.java
@@ -47,7 +47,7 @@ public abstract class MacNetworkIF extends AbstractNetworkIF {
      * @param data map of interface index to {@link IFdata}
      * @return {@code true} if this interface's index was present in the map
      */
-    protected boolean updateNetworkStats(Map<Integer, IFdata> data) {
+    protected synchronized boolean updateNetworkStats(Map<Integer, IFdata> data) {
         int index = queryNetworkInterface().getIndex();
         if (data.containsKey(index)) {
             IFdata ifData = data.get(index);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/BsdNetworkIF.java
@@ -41,7 +41,7 @@ public final class BsdNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         String stats = ExecutingCommand.getAnswerAt("netstat -bI " + getName(), 1);
         this.timeStamp = System.currentTimeMillis();
         String[] split = ParseUtil.whitespaces.split(stats, -1);

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/aix/AixNetworkIF.java
@@ -42,7 +42,7 @@ public abstract class AixNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         IfStats stats = queryStats();
         if (stats == null) {
             return false;

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/netbsd/NetBsdNetworkIF.java
@@ -41,7 +41,7 @@ public final class NetBsdNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         // NetBSD netstat -bI <name> output:
         // Name Mtu Network Address Ibytes Obytes
         // wm0 1500 <Link> 52:54:00:12:34:56 689584214 13656411

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/solaris/SolarisNetworkIF.java
@@ -43,7 +43,7 @@ public abstract class SolarisNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         // Initialize to a sane default value
         this.timeStamp = System.currentTimeMillis();
         IfStats stats = queryStats();

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsNetworkIF.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsNetworkIF.java
@@ -83,7 +83,7 @@ public abstract class WindowsNetworkIF extends AbstractNetworkIF {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         IfStats stats = queryStats();
         if (stats == null) {
             return false;


### PR DESCRIPTION
Third chunk of the `updateAttributes()` consistency arc, following #3586 and #3653. Same standard: the lock goes on the method that writes the fields, with no suppression beside it.

After this, every refreshable type is covered except `OSProcess` and `OSThread`.

## NetworkIF: no shared writer, so seven locks

Unlike `OSFileStore` — where #3651 had already made `AbstractOSFileStore` the sole writer, so #3653 needed one edit for ten implementations — each `NetworkIF` platform class assigns the counters itself. Six take the lock on their own `updateAttributes()`.

## macOS shows why the writer is the right target

Its fields are written by `updateNetworkStats(Map)`, which is reached from two places:

```java
// the public refresh
public boolean updateAttributes() {
    return updateNetworkStats(queryIFdata(queryNetworkInterface().getIndex()));
}

// and the bulk list path, in MacNetworkIfJNA / MacNetworkIfFFM
public MacNetworkIfJNA(NetworkInterface netint, Map<Integer, IFdata> data) {
    super(netint, queryIfDisplayName(netint));
    updateNetworkStats(data);
}
```

Locking only `updateAttributes()` would leave the constructor path unguarded, so the lock goes on `updateNetworkStats`. That also keeps the native `queryIFdata` call *outside* the lock, since the public method queries first and writes after.

This is the same shape the arc flagged for `OSProcess`, where `updateAttributes(Map)` is called from subclass constructors and the public no-arg is the wrong place to lock.

## Every platform reaches its writes from a constructor

Worth stating because it is easy to miss: the six `oshi-common` bases call `updateAttributes()` from their own constructors, and **AIX and Solaris additionally call it from their JNA and FFM subclass constructors** (`AixNetworkIFJNA`, `AixNetworkIFFFM`, `SolarisNetworkIFJNA`, `SolarisNetworkIFFFM`). All of those pass through the method now locked. Locking an object that has not been published yet is uncontended and harmless; leaving that path unlocked while locking the public one would not have been.

## Locking safety

Checked rather than assumed, as in #3653:

- **No body acquires a second lock** — no nested `synchronized`, no explicit `Lock`.
- **No call site sits inside a `synchronized` block.**

So there is no ordering hazard.

## PowerSource

The last interface carrying no thread-safety contract — `OSProcess`, `OSThread`, `NetworkIF`, `HWDiskStore` and now `OSFileStore` all have it. It gains the externally-synchronize paragraph, plus the one way it genuinely differs from the others: **a failed update leaves the source unchanged**, because it assigns nothing unless it finds a source matching this one's name. The other refreshable types set a sentinel or partial state on failure.

`AbstractPowerSource.updateAttributes()` is the sole writer and takes the lock.

## Verification

Full gate and `-Perror-prone` clean, all tests passing. `synchronized` is not part of the method signature, so `japicmp` is unaffected. No CHANGELOG entry: this closes a race no OSHI-internal caller can reach, and the rest is documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety when refreshing power-source information.
  * Improved thread safety for network interface statistics updates across supported platforms.
  * Prevented concurrent refresh operations from causing inconsistent attribute values.
* **Documentation**
  * Added guidance on safely using power-source updates and their behavior when no matching source is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->