### PR TITLE
Synchronize the process and thread refresh paths

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -302,7 +302,7 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         boolean result = updateAttributesFromProc();
         // getrusage reports more accurate context-switch counts than /proc, but only for the current process and only
         // when its /proc attributes were read successfully

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSThread.java
@@ -55,7 +55,7 @@ public class LinuxOSThread extends AbstractOSThread {
     // PROC_TASK_STAT_ORDERS
     @SuppressWarnings("EnumOrdinal")
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         this.name = FileUtil.getStringFromFile(
                 String.format(Locale.ROOT, ProcPath.TASK_COMM, this.getOwningProcessId(), this.threadId));
         Map<String, String> status = FileUtil.getKeyValueMapFromFile(

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSProcess.java
@@ -128,7 +128,7 @@ public abstract class AixOSProcess extends AbstractProcOSProcess {
      * @param cpuMem the quartet of (userTime, kernelTime, residentSetSize, privateResidentMemory)
      * @return {@code true} if attributes were updated
      */
-    protected boolean updateAttributes(Quartet<Long, Long, Long, Long> cpuMem) {
+    protected synchronized boolean updateAttributes(Quartet<Long, Long, Long, Long> cpuMem) {
         AixPsInfo info = psinfo.get();
         if (info == null) {
             this.state = INVALID;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/aix/AixOSThread.java
@@ -30,7 +30,7 @@ public class AixOSThread extends AbstractOSThread {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         AixLwpsInfo lwpsinfo = PsInfo.queryLwpsInfo(getOwningProcessId(), getThreadId());
         if (lwpsinfo == null) {
             this.state = OSProcess.State.INVALID;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSProcess.java
@@ -151,7 +151,7 @@ public abstract class SolarisOSProcess extends AbstractProcOSProcess {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         SolarisPsInfo info = psinfo.get();
         if (info == null) {
             this.state = INVALID;

--- a/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/unix/solaris/SolarisOSThread.java
@@ -48,7 +48,7 @@ public abstract class SolarisOSThread extends AbstractOSThread {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         SolarisLwpsInfo info = lwpsinfo.get();
         if (info == null) {
             this.state = INVALID;

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
@@ -218,7 +218,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
      * @param wts WTS info for this process, or null if unavailable
      * @return true if the process is valid after the update
      */
-    protected boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
+    protected synchronized boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
         if (pcb == null) {
             this.state = INVALID;
             return false;

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSThread.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSThread.java
@@ -55,7 +55,7 @@ public abstract class WindowsOSThread extends AbstractOSThread {
      * @param pcb      the thread performance counter block, or null if unavailable
      * @return true if the thread is valid after the update
      */
-    protected boolean updateAttributes(@Nullable String procName, @Nullable ThreadPerfCounterBlock pcb) {
+    protected synchronized boolean updateAttributes(@Nullable String procName, @Nullable ThreadPerfCounterBlock pcb) {
         if (pcb == null) {
             this.state = INVALID;
             return false;

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacOSProcessFFM.java
@@ -188,7 +188,7 @@ public class MacOSProcessFFM extends MacOSProcess {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         long now = System.currentTimeMillis();
         int pid = getProcessID();
         boolean updated = callInArenaBooleanOrDefault(arena -> {

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -121,7 +121,7 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
     }
 
     @Override
-    protected boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
+    protected synchronized boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
         if (!super.updateAttributes(pcb, wts)) {
             return false;
         }

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacOSProcessJNA.java
@@ -138,7 +138,7 @@ public class MacOSProcessJNA extends MacOSProcess {
     }
 
     @Override
-    public boolean updateAttributes() {
+    public synchronized boolean updateAttributes() {
         long now = System.currentTimeMillis();
         try (CloseableProcTaskAllInfo taskAllInfo = new CloseableProcTaskAllInfo()) {
             if (0 > SystemB.INSTANCE.proc_pidinfo(getProcessID(), PROC_PIDTASKALLINFO, 0, taskAllInfo,

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
@@ -106,7 +106,7 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
     }
 
     @Override
-    protected boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
+    protected synchronized boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
         if (!super.updateAttributes(pcb, wts)) {
             return false;
         }


### PR DESCRIPTION
Final chunk of the `updateAttributes()` consistency arc begun in #3586, after #3653 and #3654. **Every refreshable type is now covered**, and no `java:S3078` or `VOLATILE_ATOMICITY` suppression remains anywhere in the tree.

| Interface | Implementations | Locked |
|---|---|---|
| `OSProcess` | 9 | 9 |
| `OSThread` | 7 | 5 + 2 that write nothing |
| `HWDiskStore` | 11 | 11 |
| `OSFileStore` | 10 | via one write path in `AbstractOSFileStore` |
| `NetworkIF` | 7 | 7 |
| `PowerSource` | 1 | 1 |

## Lock the writer, not the public method

The arc flagged this phase as its highest risk. Both reasons turn out to be answered by the same decision.

**Constructor paths.** Where a class writes in an overload — AIX process, Windows process and thread — the lock goes there, matching what #3586 did for the BSD pair. That is not stylistic: *every one of those overloads is called from a subclass constructor doing bulk population*, so locking only the public no-arg would leave the list-building path unguarded while appearing to cover it. The same shape appeared in #3654, where `MacNetworkIF`'s writer is reached from the `MacNetworkIfJNA`/`FFM` constructors.

**Expensive work stays outside the lock.** The Windows twins do all their registry, performance counter and WTS querying in the public method before delegating, so **no WMI or COM call happens under the monitor** — checked, not assumed. That was the arc's specific worry about `WmiQueryHandler`/`UserComInit`, and targeting the writer removes it rather than mitigating it. The BSD pair likewise spawns `ps` outside its lock.

## Where there is no separate writer

Solaris process and thread, Linux process and thread, AIX thread, and both macOS process backends assign inline, so the no-arg takes the lock and its queries come with it. macOS interleaves `proc_pidinfo`, `proc_pidpath` and `getpwuid` with the assignments, so there is nothing to separate. This matches the six `NetworkIF` platforms in #3654.

`WindowsOSThreadJNA` and `WindowsOSThreadFFM` need nothing — they write no fields and delegate to the base overload now locked.

## Locking safety

As in the previous two chunks: **no locked body acquires a second lock**, so there is no ordering hazard to reason about.

## Not included

Hoisting `BsdOSProcess.monotonic(long, long)` to share with `AixHWDiskStore`'s inline clamps — the arc's last open item. Both are lock-protected as of #3653 and this PR, so it is now purely a duplication question, and it wants a home neutral to both hierarchies rather than being wedged into either. Better as its own small change.

## Verification

Full gate and `-Perror-prone` clean, all tests passing. `synchronized` is not part of the method signature, so `japicmp` is unaffected. No CHANGELOG entry: this closes races no OSHI-internal caller can reach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of process and thread information refreshes by preventing overlapping updates across supported Linux, Windows, macOS, AIX, and Solaris environments.
  * Preserved existing attribute retrieval, validation, state handling, and error behavior while ensuring updates are processed sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->