### PR TITLE
Publish the whole Windows process refresh under one lock

### DIFF
--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
@@ -87,8 +87,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
         super(pid);
         this.os = os;
         this.bitness = os.getBitness();
-        this.tcb.set(threadMap);
-        updateAttributes(processMap.get(pid), processWtsMap.get(pid));
+        updateAttributes(processMap.get(pid), processWtsMap.get(pid), threadMap);
     }
 
     /**
@@ -188,7 +187,7 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     public List<OSThread> getThreadDetails() {
         Map<Integer, ThreadPerfCounterBlock> threads = this.tcb.get();
         if (threads == null) {
-            threads = queryMatchingThreads(Collections.singleton(this.getProcessID()));
+            threads = queryMatchingThreads(Collections.singleton(this.getProcessID()), this.name);
         }
         if (threads == null) {
             threads = Collections.emptyMap();
@@ -212,13 +211,20 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
 
     /**
      * Updates process attributes from performance counter and WTS data, then performs native-specific updates.
-     * Subclasses should call {@code super.updateAttributes(pcb, wts)} and then perform native handle-based updates.
+     * Subclasses should call {@code super.updateAttributes(pcb, wts, threadMap)} and then perform native handle-based
+     * updates.
      *
-     * @param pcb Performance counter block for this process, or null if unavailable
-     * @param wts WTS info for this process, or null if unavailable
+     * @param pcb       Performance counter block for this process, or null if unavailable
+     * @param wts       WTS info for this process, or null if unavailable
+     * @param threadMap Thread performance counter blocks for this process, or null if they were queried and none were
+     *                  found. Passed in rather than published beforehand so that one refresh's name, thread map and
+     *                  counters all become visible together. A caller that did not query must pass {@link #getTcb()},
+     *                  not null, which would discard the map it already holds.
      * @return true if the process is valid after the update
      */
-    protected synchronized boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
+    protected synchronized boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts,
+            @Nullable Map<Integer, ThreadPerfCounterBlock> threadMap) {
+        this.tcb.set(threadMap);
         if (pcb == null) {
             this.state = INVALID;
             return false;
@@ -262,15 +268,6 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     }
 
     /**
-     * Sets the process name. Used by subclasses to ensure the name is current before querying threads.
-     *
-     * @param name the process name to set
-     */
-    protected void setName(String name) {
-        this.name = name;
-    }
-
-    /**
      * Sets the process bitness. Used by subclasses to update after WOW64 check.
      *
      * @param bitness the bitness to set
@@ -289,30 +286,24 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
     }
 
     /**
-     * Sets the process state. Used by subclasses to mark a process as invalid.
+     * Returns the thread performance counter blocks last published for this process.
      *
-     * @param state the state to set
+     * @return the thread counter block map, or {@code null} if none has been recorded
      */
-    protected void setState(State state) {
-        this.state = state;
-    }
-
-    /**
-     * Sets the thread counter block map. Used by subclasses during attribute updates.
-     *
-     * @param tcb the thread performance counter block map
-     */
-    protected void setTcb(@Nullable Map<Integer, ThreadPerfCounterBlock> tcb) {
-        this.tcb.set(tcb);
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> getTcb() {
+        return this.tcb.get();
     }
 
     /**
      * Queries thread performance data matching the given process IDs.
      *
-     * @param pids the set of process IDs to match
+     * @param pids     the set of process IDs to match
+     * @param procName the process name, supplied by the caller rather than read from this process, so a refresh can
+     *                 query threads against the name it just fetched without publishing it first
      * @return a map of thread ID to thread performance counter block
      */
-    protected abstract @Nullable Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids);
+    protected abstract @Nullable Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids,
+            String procName);
 
     /**
      * Queries the command line for this process.

--- a/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/windows/WindowsOSProcess.java
@@ -185,16 +185,23 @@ public abstract class WindowsOSProcess extends AbstractOSProcess {
 
     @Override
     public List<OSThread> getThreadDetails() {
-        Map<Integer, ThreadPerfCounterBlock> threads = this.tcb.get();
+        // Take both fields in one lock hold so the map and the name labelling it come from the same refresh.
+        // Reading them separately would let a concurrent update place a snapshot boundary between them.
+        Map<Integer, ThreadPerfCounterBlock> threads;
+        String procName;
+        synchronized (this) {
+            threads = this.tcb.get();
+            procName = this.name;
+        }
         if (threads == null) {
-            threads = queryMatchingThreads(Collections.singleton(this.getProcessID()), this.name);
+            threads = queryMatchingThreads(Collections.singleton(this.getProcessID()), procName);
         }
         if (threads == null) {
             threads = Collections.emptyMap();
         }
         return threads.entrySet().stream().parallel()
                 .filter(entry -> entry.getValue().getOwningProcessID() == this.getProcessID())
-                .map(entry -> createOSThread(getProcessID(), entry.getKey(), this.name, entry.getValue()))
+                .map(entry -> createOSThread(getProcessID(), entry.getKey(), procName, entry.getValue()))
                 .collect(Collectors.toList());
     }
 

--- a/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/windows/WindowsOSProcessFFM.java
@@ -109,20 +109,20 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
             pcbMap = ProcessPerformanceDataFFM.buildProcessMapFromPerfCounters(pids);
         }
         ProcessPerfCounterBlock pcb = pcbMap == null ? null : pcbMap.get(this.getProcessID());
-        if (USE_PROCSTATE_SUSPENDED) {
-            // Populate name from pcb before querying threads, since the fallback path uses getName()
-            if (pcb != null) {
-                setName(pcb.getName());
-            }
-            setTcb(queryMatchingThreads(pids));
-        }
+        // Query threads against the name just fetched, rather than publishing it to the field first so the callee
+        // can read it back. When this build does not query them, hand back the existing map so the writer republishes
+        // it unchanged rather than discarding it.
+        Map<Integer, ThreadPerfCounterBlock> threadMap = USE_PROCSTATE_SUSPENDED
+                ? queryMatchingThreads(pids, pcb == null ? getName() : pcb.getName())
+                : getTcb();
         Map<Integer, WtsInfo> wts = ProcessWtsDataFFM.queryProcessWtsMap(pids);
-        return updateAttributes(pcb, wts == null ? null : wts.get(this.getProcessID()));
+        return updateAttributes(pcb, wts == null ? null : wts.get(this.getProcessID()), threadMap);
     }
 
     @Override
-    protected synchronized boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
-        if (!super.updateAttributes(pcb, wts)) {
+    protected synchronized boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts,
+            @Nullable Map<Integer, ThreadPerfCounterBlock> threadMap) {
+        if (!super.updateAttributes(pcb, wts, threadMap)) {
             return false;
         }
 
@@ -156,10 +156,10 @@ public class WindowsOSProcessFFM extends WindowsOSProcess {
     }
 
     @Override
-    protected @Nullable Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids, String procName) {
         Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataFFM.buildThreadMapFromRegistry(pids);
         if (threads == null || threads.isEmpty()) {
-            threads = ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
+            threads = ThreadPerformanceDataFFM.buildThreadMapFromPerfCounters(pids, procName, -1);
         }
         return threads;
     }

--- a/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/windows/WindowsOSProcessJNA.java
@@ -94,20 +94,20 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
             pcbMap = ProcessPerformanceDataJNA.buildProcessMapFromPerfCounters(pids);
         }
         ProcessPerfCounterBlock pcb = pcbMap == null ? null : pcbMap.get(this.getProcessID());
-        if (USE_PROCSTATE_SUSPENDED) {
-            // Populate name from pcb before querying threads, since the fallback path uses getName()
-            if (pcb != null) {
-                setName(pcb.getName());
-            }
-            setTcb(queryMatchingThreads(pids));
-        }
+        // Query threads against the name just fetched, rather than publishing it to the field first so the callee
+        // can read it back. When this build does not query them, hand back the existing map so the writer republishes
+        // it unchanged rather than discarding it.
+        Map<Integer, ThreadPerfCounterBlock> threadMap = USE_PROCSTATE_SUSPENDED
+                ? queryMatchingThreads(pids, pcb == null ? getName() : pcb.getName())
+                : getTcb();
         Map<Integer, WtsInfo> wts = ProcessWtsData.queryProcessWtsMap(pids);
-        return updateAttributes(pcb, wts == null ? null : wts.get(this.getProcessID()));
+        return updateAttributes(pcb, wts == null ? null : wts.get(this.getProcessID()), threadMap);
     }
 
     @Override
-    protected synchronized boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts) {
-        if (!super.updateAttributes(pcb, wts)) {
+    protected synchronized boolean updateAttributes(@Nullable ProcessPerfCounterBlock pcb, @Nullable WtsInfo wts,
+            @Nullable Map<Integer, ThreadPerfCounterBlock> threadMap) {
+        if (!super.updateAttributes(pcb, wts, threadMap)) {
             return false;
         }
 
@@ -143,10 +143,10 @@ public class WindowsOSProcessJNA extends WindowsOSProcess {
     }
 
     @Override
-    protected @Nullable Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids) {
+    protected @Nullable Map<Integer, ThreadPerfCounterBlock> queryMatchingThreads(Set<Integer> pids, String procName) {
         Map<Integer, ThreadPerfCounterBlock> threads = ThreadPerformanceDataJNA.buildThreadMapFromRegistry(pids);
         if (threads == null || threads.isEmpty()) {
-            threads = ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids, this.getName(), -1);
+            threads = ThreadPerformanceDataJNA.buildThreadMapFromPerfCounters(pids, procName, -1);
         }
         return threads;
     }


### PR DESCRIPTION
Follows up the review comment on #3655, which observed that the Windows process refresh was still publishing in two steps.

## What was left

#3655 put the lock on the writer, covering twenty fields. But `setName` and `setTcb` were called from the twins' public method, before delegating:

```java
if (USE_PROCSTATE_SUSPENDED) {
    // Populate name from pcb before querying threads, since the fallback path uses getName()
    if (pcb != null) {
        setName(pcb.getName());
    }
    setTcb(queryMatchingThreads(pids));
}
...
return updateAttributes(pcb, wts);
```

Neither write can tear on its own — `name` is volatile, `tcb` an `AtomicReference` — but a refresh became visible in two stages rather than one.

## The cause was a field used as a channel

That comment explains it: the name was published early *only* so `queryMatchingThreads` could read it back off the process. Passing it as an argument removes the reason to publish it at all, and the thread map can then travel to the writer as a parameter rather than being assigned ahead of it.

- `queryMatchingThreads(Set<Integer> pids)` becomes `queryMatchingThreads(Set<Integer> pids, String procName)`
- `updateAttributes(pcb, wts)` becomes `updateAttributes(pcb, wts, threadMap)` and publishes the map with everything else, under the lock

One refresh, one lock hold, one moment at which it becomes visible. The twins' public methods now write nothing.

## Behaviour is unchanged, path by path

Worth spelling out, because the thread map's assignment rule is subtler than it looks:

| Path | Before | After |
|---|---|---|
| Constructor | `tcb.set(threadMap)`, null included | writer assigns the same, null included |
| Threads queried | `setTcb(query(...))`, null included | writer assigns the result, null included |
| Threads not queried | map left alone | callers pass `getTcb()`, republishing what they hold |
| No counter block | query used the name already on the process | `pcb == null ? getName() : pcb.getName()` |

The third row is the one that needed care. Passing `null` there would have discarded a map the constructor supplied, and since `getThreadDetails()` treats a null map as "query afresh", that would have sent the default configuration back to the wire on every call. A `getTcb()` accessor replaces the removed setter so those callers can round-trip it.

## Removals

`setName` and `setTcb` have no callers left. `setState` goes with them — it never had one. `setBitness` and `setPath` stay, and were already inside the lock: the twins call them from their synchronized override, after `super`.

## Verification

Full gate and `-Perror-prone` clean. This is a refactor with no intended behaviour change, so the existing Windows tests are the check; `NativeComparisonTest` forces `USE_PROCSTATE_SUSPENDED` on, which is the branch that changed most. Windows CI is the real gate, as I cannot execute this path locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows process refreshes so process names, thread information, and performance counters are updated consistently.
  * Preserved existing thread details when suspended-process querying is disabled.
  * Improved thread data retrieval and fallback behavior across supported Windows integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->