### PR TITLE
Fix the macOS FFM TCP connection state, misread by four bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The `oshi-dist` zip is no longer published to Maven Central; download it from th
 ##### Bug Fixes and Improvements
 
 * [#3651](https://github.com/oshi/oshi/pull/3651): `OSFileStore` now guarantees `0 <= getUsableSpace() <= getFreeSpace() <= getTotalSpace()` on every platform. The three values are read by separate queries, so on a ZFS dataset or a swap-backed `tmpfs` they could previously contradict each other; they are now clamped downward to restore the ordering - [@dbwiddis](https://github.com/dbwiddis).
+* [#3657](https://github.com/oshi/oshi/pull/3657): The FFM implementation of `InternetProtocolStats.getConnections()` on macOS reported the wrong `TcpState` for every TCP connection, most often `CLOSED` or `UNKNOWN`. Its mapping of `in_sockinfo` was six bytes short, which shifted `tcpsi_state` within the enclosing `tcp_sockinfo`. The JNA implementation was unaffected - [@dbwiddis](https://github.com/dbwiddis).
+* [#3657](https://github.com/oshi/oshi/pull/3657): `InternetProtocolStats.getConnections()` on macOS now sizes its process list from the kernel instead of capping it at 1024, so connections belonging to processes past that limit are no longer omitted - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.5.0 (2026-08-16)
 

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -9,6 +9,7 @@ import static oshi.comparison.ComparisonAssertions.assertWithinRatio;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -784,6 +785,35 @@ class NativeComparisonTest {
             assertThat(c.getLocalPort()).as("localPort").isBetween(0, 0xffff);
             assertThat(c.getForeignPort()).as("foreignPort").isBetween(0, 0xffff);
             assertThat(c.getState()).as("state").isNotNull();
+        }
+
+        // State is deliberately absent from the tuple key above, since a connection may legitimately change state
+        // between the two reads. Compare it separately on the connections both sides saw, requiring only majority
+        // agreement: ordinary churn moves a few, while a misread struct field moves every one at once.
+        Map<String, InternetProtocolStats.TcpState> jnaStates = new HashMap<>();
+        for (InternetProtocolStats.IPConnection c : jnaConns) {
+            if (c.getType().startsWith("tcp")) {
+                jnaStates.put(c.getType() + ":" + c.getLocalPort() + ":" + c.getForeignPort(), c.getState());
+            }
+        }
+        int matched = 0;
+        int agreed = 0;
+        for (InternetProtocolStats.IPConnection c : ffmConns) {
+            if (c.getType().startsWith("tcp")) {
+                InternetProtocolStats.TcpState jnaState = jnaStates
+                        .get(c.getType() + ":" + c.getLocalPort() + ":" + c.getForeignPort());
+                if (jnaState != null) {
+                    matched++;
+                    if (jnaState == c.getState()) {
+                        agreed++;
+                    }
+                }
+            }
+        }
+        // Skip on a near-idle host, where too few TCP connections exist for the fraction to mean anything
+        if (matched >= 4) {
+            assertThat(agreed).as("TCP state agreement on %d shared connections", matched)
+                    .isGreaterThanOrEqualTo(matched / 2);
         }
     }
 

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeComparisonTest.java
@@ -793,15 +793,14 @@ class NativeComparisonTest {
         Map<String, InternetProtocolStats.TcpState> jnaStates = new HashMap<>();
         for (InternetProtocolStats.IPConnection c : jnaConns) {
             if (c.getType().startsWith("tcp")) {
-                jnaStates.put(c.getType() + ":" + c.getLocalPort() + ":" + c.getForeignPort(), c.getState());
+                jnaStates.put(stateKey(c), c.getState());
             }
         }
         int matched = 0;
         int agreed = 0;
         for (InternetProtocolStats.IPConnection c : ffmConns) {
             if (c.getType().startsWith("tcp")) {
-                InternetProtocolStats.TcpState jnaState = jnaStates
-                        .get(c.getType() + ":" + c.getLocalPort() + ":" + c.getForeignPort());
+                InternetProtocolStats.TcpState jnaState = jnaStates.get(stateKey(c));
                 if (jnaState != null) {
                     matched++;
                     if (jnaState == c.getState()) {
@@ -813,8 +812,18 @@ class NativeComparisonTest {
         // Skip on a near-idle host, where too few TCP connections exist for the fraction to mean anything
         if (matched >= 4) {
             assertThat(agreed).as("TCP state agreement on %d shared connections", matched)
-                    .isGreaterThanOrEqualTo(matched / 2);
+                    .isGreaterThanOrEqualTo((matched + 1) / 2);
         }
+    }
+
+    /**
+     * Full identity of a connection, for matching one implementation's rows against the other's. Ports alone are not
+     * unique: two sockets listening on the same port for different local addresses share type, local port and foreign
+     * port, so a key omitting the addresses would collide and compare a connection against a different one's state.
+     */
+    private static String stateKey(InternetProtocolStats.IPConnection c) {
+        return c.getType() + ":" + Arrays.toString(c.getLocalAddress()) + ":" + c.getLocalPort() + ":"
+                + Arrays.toString(c.getForeignAddress()) + ":" + c.getForeignPort();
     }
 
     // ---- OS: Sessions ----

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/MacSystem.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/MacSystem.java
@@ -287,7 +287,14 @@ public interface MacSystem {
             sequenceLayout(4, JAVA_INT).withName("insi_faddr"), // foreign host table entry
             sequenceLayout(4, JAVA_INT).withName("insi_laddr"), // local host table entry
             JAVA_BYTE.withName("insi_v4"), // type of service
-            sequenceLayout(9, JAVA_BYTE).withName("insi_v6") // type of service for IPv6
+            paddingLayout(3), // align insi_v6 to 4 byte boundary
+            structLayout(// insi_v6, not read but must be sized correctly: it terminates in_sockinfo
+                    JAVA_BYTE.withName("in6_hlim"), //
+                    paddingLayout(3), // align in6_cksum to 4 byte boundary
+                    JAVA_INT.withName("in6_cksum"), //
+                    JAVA_SHORT.withName("in6_ifindex"), //
+                    JAVA_SHORT.withName("in6_hops") //
+            ).withName("insi_v6") //
     );
     PathElement INSI_FPORT = groupElement("insi_fport");
     PathElement INSI_LPORT = groupElement("insi_lport");
@@ -297,13 +304,11 @@ public interface MacSystem {
 
     StructLayout TCP_SOCK_INFO = structLayout(//
             IN_SOCK_INFO.withName("tcpsi_ini"), //
-            paddingLayout(2), // align to 4 byte boundary
             JAVA_INT.withName("tcpsi_state"), //
             sequenceLayout(TSI_T_NTIMERS, JAVA_INT).withName("tcpsi_timer"), //
             JAVA_INT.withName("tcpsi_mss"), //
             JAVA_INT.withName("tcpsi_flags"), //
             JAVA_INT.withName("rfu_1"), //
-            paddingLayout(4), // align to 8 byte boundary
             JAVA_LONG.withName("tcpsi_tp") // opaque handle of TCP protocol control block
     );
     PathElement TCPSI_INI = groupElement("tcpsi_ini");

--- a/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsFFM.java
@@ -75,8 +75,11 @@ public class MacInternetProtocolStatsFFM extends MacInternetProtocolStats {
     public List<IPConnection> getConnections() {
         List<IPConnection> conns = new ArrayList<>();
         return callInArenaOrDefault(arena -> {
-            // Match JNA approach: fixed-size buffer, single call
-            int bufferSize = 1024 * Integer.BYTES;
+            // Size the buffer from the kernel rather than a fixed cap. proc_listpids bounds its return by the
+            // buffer it was given, so an undersized buffer silently drops the connections of every process past
+            // the end. Pad, as MacOperatingSystem does, in case a process starts between the two calls.
+            int bufferSize = (proc_listpids(PROC_ALL_PIDS, 0, MemorySegment.NULL, 0) / Integer.BYTES + 10)
+                    * Integer.BYTES;
             MemorySegment pidBuffer = arena.allocate(bufferSize);
             int bytes = proc_listpids(PROC_ALL_PIDS, 0, pidBuffer, bufferSize);
             int numProcs = Math.min(bytes / Integer.BYTES, bufferSize / Integer.BYTES);

--- a/oshi-core-ffm/src/test/java/oshi/ffm/platform/mac/MacSystemLayoutTest.java
+++ b/oshi-core-ffm/src/test/java/oshi/ffm/platform/mac/MacSystemLayoutTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.ffm.platform.mac;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static oshi.ffm.platform.mac.MacSystem.INSI_FADDR;
+import static oshi.ffm.platform.mac.MacSystem.INSI_FPORT;
+import static oshi.ffm.platform.mac.MacSystem.INSI_LADDR;
+import static oshi.ffm.platform.mac.MacSystem.INSI_LPORT;
+import static oshi.ffm.platform.mac.MacSystem.INSI_VFLAG;
+import static oshi.ffm.platform.mac.MacSystem.IN_SOCK_INFO;
+import static oshi.ffm.platform.mac.MacSystem.PROC_FD;
+import static oshi.ffm.platform.mac.MacSystem.PROC_FDTYPE;
+import static oshi.ffm.platform.mac.MacSystem.PROC_FD_INFO;
+import static oshi.ffm.platform.mac.MacSystem.PSI;
+import static oshi.ffm.platform.mac.MacSystem.SOCKET_FD_INFO;
+import static oshi.ffm.platform.mac.MacSystem.SOCKET_INFO;
+import static oshi.ffm.platform.mac.MacSystem.SOI_FAMILY;
+import static oshi.ffm.platform.mac.MacSystem.SOI_INCQLEN;
+import static oshi.ffm.platform.mac.MacSystem.SOI_KIND;
+import static oshi.ffm.platform.mac.MacSystem.SOI_PROTO;
+import static oshi.ffm.platform.mac.MacSystem.SOI_QLEN;
+import static oshi.ffm.platform.mac.MacSystem.TCPSI_INI;
+import static oshi.ffm.platform.mac.MacSystem.TCPSI_STATE;
+import static oshi.ffm.platform.mac.MacSystem.TCP_SOCK_INFO;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Asserts the socket struct layouts against sizes and offsets taken from {@code <sys/proc_info.h>} on macOS 15
+ * (arm64/x86_64, which agree). These layouts are pure arithmetic over {@code MemoryLayout}, performing no native call,
+ * so this test runs on every platform and guards the mappings from a host that never executes them.
+ */
+class MacSystemLayoutTest {
+
+    @Test
+    void testProcFdInfoLayout() {
+        assertEquals(8, PROC_FD_INFO.byteSize());
+        assertEquals(0, PROC_FD_INFO.byteOffset(PROC_FD));
+        assertEquals(4, PROC_FD_INFO.byteOffset(PROC_FDTYPE));
+    }
+
+    @Test
+    void testInSockInfoLayout() {
+        // The trailing insi_v6 is a 12-byte struct aligned to 4, not a run of bytes. Modelling it as nine bytes
+        // leaves in_sockinfo six short, which silently shifts every field of an enclosing struct.
+        assertEquals(80, IN_SOCK_INFO.byteSize());
+        assertEquals(0, IN_SOCK_INFO.byteOffset(INSI_FPORT));
+        assertEquals(4, IN_SOCK_INFO.byteOffset(INSI_LPORT));
+        assertEquals(24, IN_SOCK_INFO.byteOffset(INSI_VFLAG));
+        assertEquals(32, IN_SOCK_INFO.byteOffset(INSI_FADDR));
+        assertEquals(48, IN_SOCK_INFO.byteOffset(INSI_LADDR));
+    }
+
+    @Test
+    void testTcpSockInfoLayout() {
+        assertEquals(120, TCP_SOCK_INFO.byteSize());
+        assertEquals(0, TCP_SOCK_INFO.byteOffset(TCPSI_INI));
+        assertEquals(80, TCP_SOCK_INFO.byteOffset(TCPSI_STATE));
+    }
+
+    @Test
+    void testSocketInfoLayout() {
+        assertEquals(768, SOCKET_INFO.byteSize());
+        assertEquals(160, SOCKET_INFO.byteOffset(SOI_FAMILY));
+        assertEquals(170, SOCKET_INFO.byteOffset(SOI_QLEN));
+        assertEquals(172, SOCKET_INFO.byteOffset(SOI_INCQLEN));
+        assertEquals(232, SOCKET_INFO.byteOffset(SOI_KIND));
+        assertEquals(240, SOCKET_INFO.byteOffset(SOI_PROTO));
+    }
+
+    @Test
+    void testSocketFdInfoLayout() {
+        assertEquals(792, SOCKET_FD_INFO.byteSize());
+        assertEquals(24, SOCKET_FD_INFO.byteOffset(PSI));
+    }
+}

--- a/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/mac/MacInternetProtocolStatsJNA.java
@@ -44,9 +44,12 @@ public class MacInternetProtocolStatsJNA extends MacInternetProtocolStats {
     @Override
     public List<IPConnection> getConnections() {
         List<IPConnection> conns = new ArrayList<>();
-        int[] pids = new int[1024];
-        int numberOfProcesses = SystemB.INSTANCE.proc_listpids(PROC_ALL_PIDS, 0, pids, pids.length * INT_SIZE)
-                / INT_SIZE;
+        // Size the buffer from the kernel rather than a fixed cap. proc_listpids bounds its return by the buffer
+        // it was given, so an undersized buffer silently drops the connections of every process past the end.
+        // Pad, as MacOperatingSystem does, in case a process starts between the two calls.
+        int[] pids = new int[SystemB.INSTANCE.proc_listpids(PROC_ALL_PIDS, 0, null, 0) / INT_SIZE + 10];
+        int numberOfProcesses = Math.min(
+                SystemB.INSTANCE.proc_listpids(PROC_ALL_PIDS, 0, pids, pids.length * INT_SIZE) / INT_SIZE, pids.length);
         for (int i = 0; i < numberOfProcesses; i++) {
             // Handle off-by-one bug in proc_listpids where the size returned
             // is: SystemB.INT_SIZE * (pids + 1)


### PR DESCRIPTION
Found by the JNA/FFM twin divergence sweep. The FFM implementation of `getConnections()` on macOS returns the wrong `TcpState` for **every TCP connection**.

## The bug

`MacSystem.IN_SOCK_INFO` modelled the trailing `insi_v6` as nine raw bytes:

```java
JAVA_BYTE.withName("insi_v4"),                    // type of service
sequenceLayout(9, JAVA_BYTE).withName("insi_v6")  // type of service for IPv6
```

`insi_v6` is really a twelve-byte struct at offset 68, after three bytes of padding:

```c
struct { uint8_t in6_hlim; int in6_cksum; u_short in6_ifindex; short in6_hops; } insi_v6;
```

So the mapping computed `in_sockinfo` as **74 bytes rather than 80**. `tcp_sockinfo` embeds it, which put `tcpsi_state` at **76 instead of 80** — on top of `in6_ifindex` and `in6_hops`, both zero for an IPv4 socket.

Measured on macOS 15, against `netstat -an -p tcp`:

```
JNA  {CLOSE_WAIT=9, ESTABLISHED=32, LISTEN=13}    <- agrees with netstat
FFM  {CLOSED=12, UNKNOWN=42}                      <- every state wrong
```

### Why nothing caught it

All the aggregate sizes were correct. A `paddingLayout(2)` after `tcpsi_ini` and a `paddingLayout(4)` before `tcpsi_tp` absorbed exactly the six missing bytes, so `tcp_sockinfo` still measured its true 120 and no bounds check ever fired. Only an interior offset was wrong.

Sizing `insi_v6` properly and dropping both compensating paddings reproduces every offset in `<sys/proc_info.h>`, and corrects `tcpsi_mss`, `tcpsi_flags` and `tcpsi_tp` along the way — none of which are read yet.

| | `IN_SOCK_INFO` | `tcpsi_state` | `TCP_SOCK_INFO` |
|---|---|---|---|
| header | 80 | 80 | 120 |
| before | 74 | 76 | 120 |
| after | 80 | 80 | 120 |

`SOCKET_INFO` (768), `SOCKET_FD_INFO` (792) and `PROC_FD_INFO` (8) were already correct, as were `insi_faddr` (32) and `insi_laddr` (48) — which is why addresses and ports were always right.

## Second fix, same method

`getConnections()` capped its process list at a fixed 1024 entries in **both** implementations, while `MacOperatingSystem` alongside it sizes from the kernel. `proc_listpids` bounds its return by the buffer it is handed, so the cap silently omitted the connections of every process past it rather than failing. Both now size from the kernel, padded as the neighbour is.

Not hypothetical: the test host runs **835** processes against a `kern.maxproc` of **16000**.

## Regression guards

Both fail on the old layout.

**`MacSystemLayoutTest`** asserts the five socket layouts against the header. `MacSystem` is pure `MemoryLayout` arithmetic performing no native call, so **this runs on every platform**, not only where the code executes — the Linux and Windows CI jobs would have caught this. Fails with `expected: <80> but was: <74>`.

**`NativeComparisonTest.internetProtocolConnections`** keyed connections on `type:localPort:foreignPort`, deliberately leaving state out, and asserted only that state was non-null — so it compared the twins on everything except the field that was broken. It now compares state on the connections both sides saw, requiring majority rather than exact agreement so ordinary churn cannot flake it. Fails on the old layout at **0 agreement out of 287**.

## Verification

Live on macOS 15 (arm64). After the fix, 225 connections with **all 225 tuples identical** across both implementations — addresses, ports and states — spanning `tcp4=112, tcp6=95, udp4=9, udp46=2, udp6=4`, including real IPv6 addresses.

Full gate and `-Perror-prone` clean, 0 tests failed. macOS-only code, verified on macOS; the new layout test is the part that runs everywhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TCP connection state reporting on macOS.
  * Improved process and network connection detection on systems with more than 1,024 processes.
  * Improved accuracy of macOS socket information handling, including IPv6 connections.
* **Tests**
  * Added validation for macOS socket layouts and TCP state comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->