### PR TITLE
Add getConnectionPort to the Display API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The `oshi-dist` zip is no longer published to Maven Central; download it from th
 ##### New Features
 
 * [#3652](https://github.com/oshi/oshi/pull/3652): `oshi-metrics` reports the OpenTelemetry `reserved` state for `system.filesystem.usage` and `system.filesystem.utilization`, alongside the existing `used` and `free`. The three states partition the filesystem, so the `usage` gauges sum to `system.filesystem.limit` and the `utilization` gauges sum to 1.0. `reserved` is unused space unavailable to the calling process: the superuser reserve many UNIX filesystems hold back, or the caller's disk quota on Windows - [@dbwiddis](https://github.com/dbwiddis).
+* [#3660](https://github.com/oshi/oshi/pull/3660): `Display.getDevicePort()` reports the port a display is attached to, and `Display.getOutputName()` the name `xrandr --output` accepts for it. On Linux the port is the DRM connector name (`HDMI-A-1`, `eDP-1`), read from sysfs, and the output name is resolved by matching the connector to an X output on its `CONNECTOR_ID`, falling back to its EDID. Both report a sentinel on platforms that have no implementation yet - [@ayonization](https://github.com/ayonization).
 
 ##### Bug Fixes and Improvements
 

--- a/oshi-common/src/main/java/oshi/hardware/Display.java
+++ b/oshi-common/src/main/java/oshi/hardware/Display.java
@@ -4,6 +4,8 @@
  */
 package oshi.hardware;
 
+import java.util.Optional;
+
 import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
 
@@ -53,4 +55,22 @@ public interface Display {
      * @return A {@link DisplayInfo} holding the display's decoded attributes.
      */
     DisplayInfo getDisplayInfo();
+
+    /**
+     * The system-level device identification for this display. On Linux this is the DRM connector name extracted from
+     * the sysfs directory (e.g. {@code HDMI-A-1}, {@code eDP-1}, {@code DP-2}).
+     *
+     * @return The device port identifier, or {@code "unknown"} if not available.
+     */
+    String getDevicePort();
+
+    /**
+     * The X11 output name for this display as reported by {@code xrandr} (e.g. {@code HDMI-1}, {@code DP2}). This is
+     * the name to pass to {@code xrandr --output}. Only meaningful on systems running an X server.
+     *
+     * @return An {@link Optional} containing the xrandr output name, or empty if not available.
+     */
+    default Optional<String> getOutputName() {
+        return Optional.empty();
+    }
 }

--- a/oshi-common/src/main/java/oshi/hardware/Display.java
+++ b/oshi-common/src/main/java/oshi/hardware/Display.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import oshi.annotation.PublicApi;
 import oshi.annotation.concurrent.Immutable;
+import oshi.util.Constants;
 
 /**
  * Display refers to the information regarding a video source and monitor identified by the EDID standard.
@@ -58,11 +59,14 @@ public interface Display {
 
     /**
      * The system-level device identification for this display. On Linux this is the DRM connector name extracted from
-     * the sysfs directory (e.g. {@code HDMI-A-1}, {@code eDP-1}, {@code DP-2}).
+     * the sysfs directory (e.g. {@code HDMI-A-1}, {@code eDP-1}, {@code DP-2}), or the {@code xrandr} output name when
+     * DRM sysfs is not available.
      *
-     * @return The device port identifier, or {@code "unknown"} if not available.
+     * @return The device port identifier, or {@link Constants#UNKNOWN} if not available.
      */
-    String getDevicePort();
+    default String getDevicePort() {
+        return Constants.UNKNOWN;
+    }
 
     /**
      * The X11 output name for this display as reported by {@code xrandr} (e.g. {@code HDMI-1}, {@code DP2}). This is

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractDisplay.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractDisplay.java
@@ -8,6 +8,7 @@ import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Display;
 import oshi.hardware.DisplayInfo;
 import oshi.hardware.DisplayInfoImpl;
+import oshi.util.Constants;
 
 /**
  * A Display
@@ -16,14 +17,35 @@ import oshi.hardware.DisplayInfoImpl;
 public abstract class AbstractDisplay implements Display {
 
     private final DisplayInfo displayInfo;
+    private final String devicePort;
 
     /**
-     * Constructor for AbstractDisplay from a raw EDID byte array.
+     * Constructor for AbstractDisplay from a raw EDID byte array, with no device port information.
      *
      * @param edid a byte array representing a display EDID
      */
     protected AbstractDisplay(byte[] edid) {
+        this(edid, Constants.UNKNOWN);
+    }
+
+    /**
+     * Constructor for AbstractDisplay from a raw EDID byte array.
+     *
+     * @param edid       a byte array representing a display EDID
+     * @param devicePort the system-level device port identifier (e.g. DRM connector name {@code HDMI-A-1})
+     */
+    protected AbstractDisplay(byte[] edid, String devicePort) {
         this.displayInfo = new DisplayInfoImpl(edid);
+        this.devicePort = devicePort;
+    }
+
+    /**
+     * Constructor for AbstractDisplay from decoded display information, with no device port information.
+     *
+     * @param displayInfo the decoded display information
+     */
+    protected AbstractDisplay(DisplayInfo displayInfo) {
+        this(displayInfo, Constants.UNKNOWN);
     }
 
     /**
@@ -31,9 +53,11 @@ public abstract class AbstractDisplay implements Display {
      * without providing an EDID. Pass a synthetic {@link DisplayInfo} to expose a synthesized EDID.
      *
      * @param displayInfo the decoded display information
+     * @param devicePort  the system-level device port identifier (e.g. DRM connector name {@code HDMI-A-1})
      */
-    protected AbstractDisplay(DisplayInfo displayInfo) {
+    protected AbstractDisplay(DisplayInfo displayInfo, String devicePort) {
         this.displayInfo = displayInfo;
+        this.devicePort = devicePort;
     }
 
     @Deprecated
@@ -45,6 +69,11 @@ public abstract class AbstractDisplay implements Display {
     @Override
     public DisplayInfo getDisplayInfo() {
         return this.displayInfo;
+    }
+
+    @Override
+    public String getDevicePort() {
+        return this.devicePort;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/AbstractDisplay.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/AbstractDisplay.java
@@ -8,7 +8,6 @@ import oshi.annotation.concurrent.Immutable;
 import oshi.hardware.Display;
 import oshi.hardware.DisplayInfo;
 import oshi.hardware.DisplayInfoImpl;
-import oshi.util.Constants;
 
 /**
  * A Display
@@ -17,35 +16,14 @@ import oshi.util.Constants;
 public abstract class AbstractDisplay implements Display {
 
     private final DisplayInfo displayInfo;
-    private final String devicePort;
-
-    /**
-     * Constructor for AbstractDisplay from a raw EDID byte array, with no device port information.
-     *
-     * @param edid a byte array representing a display EDID
-     */
-    protected AbstractDisplay(byte[] edid) {
-        this(edid, Constants.UNKNOWN);
-    }
 
     /**
      * Constructor for AbstractDisplay from a raw EDID byte array.
      *
-     * @param edid       a byte array representing a display EDID
-     * @param devicePort the system-level device port identifier (e.g. DRM connector name {@code HDMI-A-1})
+     * @param edid a byte array representing a display EDID
      */
-    protected AbstractDisplay(byte[] edid, String devicePort) {
+    protected AbstractDisplay(byte[] edid) {
         this.displayInfo = new DisplayInfoImpl(edid);
-        this.devicePort = devicePort;
-    }
-
-    /**
-     * Constructor for AbstractDisplay from decoded display information, with no device port information.
-     *
-     * @param displayInfo the decoded display information
-     */
-    protected AbstractDisplay(DisplayInfo displayInfo) {
-        this(displayInfo, Constants.UNKNOWN);
     }
 
     /**
@@ -53,11 +31,9 @@ public abstract class AbstractDisplay implements Display {
      * without providing an EDID. Pass a synthetic {@link DisplayInfo} to expose a synthesized EDID.
      *
      * @param displayInfo the decoded display information
-     * @param devicePort  the system-level device port identifier (e.g. DRM connector name {@code HDMI-A-1})
      */
-    protected AbstractDisplay(DisplayInfo displayInfo, String devicePort) {
+    protected AbstractDisplay(DisplayInfo displayInfo) {
         this.displayInfo = displayInfo;
-        this.devicePort = devicePort;
     }
 
     @Deprecated
@@ -69,11 +45,6 @@ public abstract class AbstractDisplay implements Display {
     @Override
     public DisplayInfo getDisplayInfo() {
         return this.displayInfo;
-    }
-
-    @Override
-    public String getDevicePort() {
-        return this.devicePort;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
@@ -4,8 +4,8 @@
  */
 package oshi.hardware.common.platform.linux;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.BluetoothDevice;
@@ -18,6 +18,7 @@ import oshi.hardware.SoundCard;
 import oshi.hardware.common.AbstractHardwareAbstractionLayer;
 import oshi.hardware.common.platform.unix.UnixDisplay;
 import oshi.util.driver.linux.DrmEdid;
+import oshi.util.tuples.Triplet;
 
 /**
  * LinuxHardwareAbstractionLayer class.
@@ -49,9 +50,13 @@ public abstract class LinuxHardwareAbstractionLayer extends AbstractHardwareAbst
 
     @Override
     protected List<Display> createDisplays() {
-        List<byte[]> edids = DrmEdid.getEdidArrays();
-        if (!edids.isEmpty()) {
-            return edids.stream().map(UnixDisplay::new).collect(Collectors.toList());
+        List<Triplet<String, Integer, byte[]>> drmData = DrmEdid.getDisplayData();
+        if (!drmData.isEmpty()) {
+            List<Display> displays = new ArrayList<>(drmData.size());
+            for (Triplet<String, Integer, byte[]> drm : drmData) {
+                displays.add(new UnixDisplay(drm.getC(), drm.getA(), drm.getB()));
+            }
+            return displays;
         }
         return UnixDisplay.getDisplays();
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
@@ -4,14 +4,15 @@
  */
 package oshi.hardware.common.platform.unix;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.ArrayList;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.Display;
 import oshi.hardware.common.AbstractDisplay;
+import oshi.util.Constants;
 import oshi.util.driver.unix.Xrandr;
 import oshi.util.tuples.Pair;
 
@@ -21,6 +22,7 @@ import oshi.util.tuples.Pair;
 @ThreadSafe
 public final class UnixDisplay extends AbstractDisplay {
 
+    private final String devicePort;
     private final int connectorId;
 
     /**
@@ -29,8 +31,7 @@ public final class UnixDisplay extends AbstractDisplay {
      * @param edid a byte array representing a display EDID
      */
     public UnixDisplay(byte[] edid) {
-        super(edid);
-        this.connectorId = -1;
+        this(edid, Constants.UNKNOWN, -1);
     }
 
     /**
@@ -41,8 +42,14 @@ public final class UnixDisplay extends AbstractDisplay {
      * @param connectorId the DRM connector ID ({@code -1} if not available)
      */
     public UnixDisplay(byte[] edid, String devicePort, int connectorId) {
-        super(edid, devicePort);
+        super(edid);
+        this.devicePort = devicePort;
         this.connectorId = connectorId;
+    }
+
+    @Override
+    public String getDevicePort() {
+        return this.devicePort;
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
@@ -5,18 +5,23 @@
 package oshi.hardware.common.platform.unix;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ArrayList;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.Display;
 import oshi.hardware.common.AbstractDisplay;
 import oshi.util.driver.unix.Xrandr;
+import oshi.util.tuples.Pair;
 
 /**
  * A Display
  */
 @ThreadSafe
 public final class UnixDisplay extends AbstractDisplay {
+
+    private final int connectorId;
 
     /**
      * Constructor for UnixDisplay.
@@ -25,14 +30,37 @@ public final class UnixDisplay extends AbstractDisplay {
      */
     public UnixDisplay(byte[] edid) {
         super(edid);
+        this.connectorId = -1;
     }
 
     /**
-     * Gets Display Information
+     * Constructor for UnixDisplay with device port and DRM connector ID.
+     *
+     * @param edid        a byte array representing a display EDID
+     * @param devicePort  the DRM connector name (e.g. {@code HDMI-A-1})
+     * @param connectorId the DRM connector ID ({@code -1} if not available)
+     */
+    public UnixDisplay(byte[] edid, String devicePort, int connectorId) {
+        super(edid, devicePort);
+        this.connectorId = connectorId;
+    }
+
+    @Override
+    public Optional<String> getOutputName() {
+        return Xrandr.findOutputName(this.connectorId, this.getDisplayInfo().getEdid());
+    }
+
+    /**
+     * Gets Display Information from xrandr. Used as a fallback when DRM sysfs is not available.
      *
      * @return An array of Display objects representing monitors, etc.
      */
     public static List<Display> getDisplays() {
-        return Xrandr.getEdidArrays().stream().map(UnixDisplay::new).collect(Collectors.toList());
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData();
+        List<Display> displays = new ArrayList<>(data.size());
+        for (Map.Entry<String, Pair<Integer, byte[]>> entry : data.entrySet()) {
+            displays.add(new UnixDisplay(entry.getValue().getB(), entry.getKey(), entry.getValue().getA()));
+        }
+        return displays;
     }
 }

--- a/oshi-common/src/main/java/oshi/util/driver/linux/DrmEdid.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/DrmEdid.java
@@ -11,7 +11,9 @@ import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.FileUtil;
+import oshi.util.ParseUtil;
 import oshi.util.linux.SysPath;
+import oshi.util.tuples.Triplet;
 
 /**
  * Utility to read EDID data from the Linux DRM (Direct Rendering Manager) subsystem. The kernel exposes raw EDID bytes
@@ -40,6 +42,32 @@ public final class DrmEdid {
      * @return a list of EDID byte arrays (at least 128 bytes each), or empty if none found
      */
     static List<byte[]> getEdidArrays(File drmDir) {
+        List<Triplet<String, Integer, byte[]>> data = getDisplayData(drmDir);
+        List<byte[]> edids = new ArrayList<>(data.size());
+        for (Triplet<String, Integer, byte[]> t : data) {
+            edids.add(t.getC());
+        }
+        return Collections.unmodifiableList(edids);
+    }
+
+    /**
+     * Read display data from /sys/class/drm for all connected displays.
+     *
+     * @return a list of {@link Triplet} of kernel connector name (e.g. {@code HDMI-A-1}), DRM connector ID ({@code -1}
+     *         if not available), and EDID byte array (at least 128 bytes each), or empty if none found
+     */
+    public static List<Triplet<String, Integer, byte[]>> getDisplayData() {
+        return getDisplayData(new File(SysPath.DRM));
+    }
+
+    /**
+     * Read display data from the given DRM directory.
+     *
+     * @param drmDir the directory containing card*-* subdirectories
+     * @return a list of {@link Triplet} of kernel connector name, DRM connector ID ({@code -1} if not available), and
+     *         EDID byte array (at least 128 bytes each), or empty if none found
+     */
+    static List<Triplet<String, Integer, byte[]>> getDisplayData(File drmDir) {
         if (!drmDir.isDirectory()) {
             return Collections.emptyList();
         }
@@ -47,7 +75,7 @@ public final class DrmEdid {
         if (connectors == null || connectors.length == 0) {
             return Collections.emptyList();
         }
-        List<byte[]> displays = new ArrayList<>();
+        List<Triplet<String, Integer, byte[]>> results = new ArrayList<>();
         for (File connector : connectors) {
             File statusFile = new File(connector, "status");
             if (statusFile.exists()) {
@@ -57,13 +85,22 @@ public final class DrmEdid {
                 }
             }
             File edidFile = new File(connector, "edid");
-            if (edidFile.exists() && edidFile.length() >= 128) {
+            if (edidFile.exists()) {
                 byte[] edid = FileUtil.readAllBytes(edidFile.getPath(), false);
                 if (edid.length >= 128) {
-                    displays.add(edid);
+                    // Extract connector name from directory name: "card0-HDMI-A-1" -> "HDMI-A-1"
+                    String dirName = connector.getName();
+                    String connectorName = dirName.substring(dirName.indexOf('-') + 1);
+                    int connectorId = -1;
+                    File connectorIdFile = new File(connector, "connector_id");
+                    if (connectorIdFile.exists()) {
+                        connectorId = ParseUtil.parseIntOrDefault(
+                                FileUtil.getStringFromFile(connectorIdFile.getPath()).trim(), -1);
+                    }
+                    results.add(new Triplet<>(connectorName, connectorId, edid));
                 }
             }
         }
-        return Collections.unmodifiableList(displays);
+        return Collections.unmodifiableList(results);
     }
 }

--- a/oshi-common/src/main/java/oshi/util/driver/linux/DrmEdid.java
+++ b/oshi-common/src/main/java/oshi/util/driver/linux/DrmEdid.java
@@ -94,8 +94,8 @@ public final class DrmEdid {
                     int connectorId = -1;
                     File connectorIdFile = new File(connector, "connector_id");
                     if (connectorIdFile.exists()) {
-                        connectorId = ParseUtil.parseIntOrDefault(
-                                FileUtil.getStringFromFile(connectorIdFile.getPath()).trim(), -1);
+                        connectorId = ParseUtil
+                                .parseIntOrDefault(FileUtil.getStringFromFile(connectorIdFile.getPath()).trim(), -1);
                     }
                     results.add(new Triplet<>(connectorName, connectorId, edid));
                 }

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
@@ -5,12 +5,17 @@
 package oshi.util.driver.unix;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
+import oshi.util.tuples.Pair;
 
 /**
  * Utility to query xrandr
@@ -30,7 +35,7 @@ public final class Xrandr {
      */
     public static List<byte[]> getEdidArrays() {
         // Special handling for X commands, don't use LC_ALL
-        return getEdidArrays(ExecutingCommand.runNative(XRANDR_VERBOSE, null));
+        return getEdidArrays(runXrandr());
     }
 
     /**
@@ -40,29 +45,124 @@ public final class Xrandr {
      * @return a list of EDID byte arrays (at least 128 bytes each)
      */
     static List<byte[]> getEdidArrays(List<String> xrandr) {
-        // xrandr reports edid in multiple lines. After seeing a line containing
-        // EDID, read subsequent lines of hex until 256 characters are reached
-        if (xrandr.isEmpty()) {
-            return Collections.emptyList();
+        Map<String, Pair<Integer, byte[]>> data = getDisplayData(xrandr);
+        List<byte[]> edids = new ArrayList<>(data.size());
+        for (Pair<Integer, byte[]> pair : data.values()) {
+            edids.add(pair.getB());
         }
-        List<byte[]> displays = new ArrayList<>();
+        return Collections.unmodifiableList(edids);
+    }
+
+    /**
+     * Gets display data from the running X server via xrandr, mapping each connected output's xrandr port name to its
+     * connector ID and EDID.
+     *
+     * @return an ordered map of xrandr port name to {@link Pair} of connector ID ({@code -1} if not available) and EDID
+     *         byte array
+     */
+    public static Map<String, Pair<Integer, byte[]>> getDisplayData() {
+        return getDisplayData(runXrandr());
+    }
+
+    /**
+     * Parse display data from xrandr verbose output. For each connected output, extracts the xrandr port name (the
+     * first whitespace-delimited token on the output header line), the {@code CONNECTOR_ID} property (if present,
+     * requires Linux 6.5+), and the EDID byte array. The parser is order-independent: {@code CONNECTOR_ID} may appear
+     * before or after {@code EDID:}.
+     *
+     * @param xrandr output of {@code xrandr --verbose}
+     * @return an ordered map of xrandr port name to {@link Pair} of connector ID ({@code -1} if not available) and EDID
+     *         byte array (at least 128 bytes). Only connected outputs with a valid EDID are included.
+     */
+    static Map<String, Pair<Integer, byte[]>> getDisplayData(List<String> xrandr) {
+        if (xrandr.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, Pair<Integer, byte[]>> results = new LinkedHashMap<>();
+        String currentPort = "";
+        boolean currentConnected = false;
+        int currentConnectorId = -1;
+        byte[] currentEdid = null;
         StringBuilder sb = null;
         for (String s : xrandr) {
-            if (s.contains("EDID")) {
+            // Output headers start at column 0; properties and modes are always indented
+            if (!s.isEmpty() && !Character.isWhitespace(s.charAt(0))) {
+                // Flush the previous output before starting a new one
+                if (currentConnected && currentEdid != null) {
+                    results.put(currentPort, new Pair<>(currentConnectorId, currentEdid));
+                }
+                String[] words = ParseUtil.whitespaces.split(s.trim(), -1);
+                currentPort = words[0];
+                currentConnected = words.length > 1 && "connected".equals(words[1]);
+                currentConnectorId = -1;
+                currentEdid = null;
+                sb = null;
+                continue;
+            }
+            String trimmed = s.trim();
+            if (trimmed.startsWith("CONNECTOR_ID:")) {
+                currentConnectorId = ParseUtil.parseLastInt(trimmed, -1);
+            } else if (trimmed.equals("EDID:")) {
                 sb = new StringBuilder();
             } else if (sb != null) {
-                sb.append(s.trim());
+                sb.append(trimmed);
                 if (sb.length() < 256) {
                     continue;
                 }
-                String edidStr = sb.toString();
-                byte[] edid = ParseUtil.hexStringToByteArray(edidStr);
-                if (edid.length >= 128) {
-                    displays.add(edid);
+                currentEdid = ParseUtil.hexStringToByteArray(sb.toString());
+                if (currentEdid.length < 128) {
+                    currentEdid = null;
                 }
                 sb = null;
             }
         }
-        return Collections.unmodifiableList(displays);
+        // Flush the last output
+        if (currentConnected && currentEdid != null) {
+            results.put(currentPort, new Pair<>(currentConnectorId, currentEdid));
+        }
+        return Collections.unmodifiableMap(results);
+    }
+
+    /**
+     * Finds the xrandr output name for a display identified by its DRM connector ID and/or EDID. This method runs
+     * {@code xrandr --verbose} on demand and matches the display by {@code CONNECTOR_ID} first (Linux 6.5+), falling
+     * back to EDID comparison.
+     *
+     * @param connectorId the DRM connector ID ({@code -1} if not available)
+     * @param edid        the EDID byte array from DRM sysfs
+     * @return an {@link Optional} containing the xrandr output name, or empty if no X server is available or no match
+     *         is found
+     */
+    public static Optional<String> findOutputName(int connectorId, byte[] edid) {
+        Map<String, Pair<Integer, byte[]>> xrandrData = getDisplayData();
+        if (xrandrData.isEmpty()) {
+            return Optional.empty();
+        }
+        // First try matching by CONNECTOR_ID (Linux 6.5+)
+        if (connectorId >= 0) {
+            for (Map.Entry<String, Pair<Integer, byte[]>> entry : xrandrData.entrySet()) {
+                if (entry.getValue().getA() == connectorId) {
+                    return Optional.of(entry.getKey());
+                }
+            }
+        }
+        // Fallback: match by first 128 bytes of EDID
+        if (edid != null && edid.length >= 128) {
+            byte[] edid128 = Arrays.copyOf(edid, 128);
+            for (Map.Entry<String, Pair<Integer, byte[]>> entry : xrandrData.entrySet()) {
+                byte[] xrandrEdid = entry.getValue().getB();
+                if (xrandrEdid.length >= 128 && Arrays.equals(edid128, Arrays.copyOf(xrandrEdid, 128))) {
+                    return Optional.of(entry.getKey());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static List<String> runXrandr() {
+        if (System.getenv("DISPLAY") == null) {
+            return Collections.emptyList();
+        }
+        return ExecutingCommand.runNative(XRANDR_VERBOSE, null);
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractDisplayTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractDisplayTest.java
@@ -77,13 +77,6 @@ class AbstractDisplayTest {
     }
 
     @Test
-    void testDevicePortFromTwoArgConstructor() {
-        AbstractDisplay display = new AbstractDisplay(new byte[128], "HDMI-A-1") {
-        };
-        assertThat(display.getDevicePort(), is("HDMI-A-1"));
-    }
-
-    @Test
     void testDefaultOutputNameIsEmpty() {
         AbstractDisplay display = new AbstractDisplay(new byte[128]) {
         };

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractDisplayTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractDisplayTest.java
@@ -68,4 +68,25 @@ class AbstractDisplayTest {
         assertThat(display.getDisplayInfo().isEdidSynthetic(), is(true));
         assertThat(display.getDisplayInfo().getModel(), is("Thunderbolt"));
     }
+
+    @Test
+    void testDefaultDevicePortIsUnknown() {
+        AbstractDisplay display = new AbstractDisplay(new byte[128]) {
+        };
+        assertThat(display.getDevicePort(), is("unknown"));
+    }
+
+    @Test
+    void testDevicePortFromTwoArgConstructor() {
+        AbstractDisplay display = new AbstractDisplay(new byte[128], "HDMI-A-1") {
+        };
+        assertThat(display.getDevicePort(), is("HDMI-A-1"));
+    }
+
+    @Test
+    void testDefaultOutputNameIsEmpty() {
+        AbstractDisplay display = new AbstractDisplay(new byte[128]) {
+        };
+        assertThat(display.getOutputName().isPresent(), is(false));
+    }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/UnixDisplayTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/UnixDisplayTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.unix;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link UnixDisplay}.
+ */
+class UnixDisplayTest {
+
+    @Test
+    void testDevicePortDefaultsToUnknown() {
+        assertThat(new UnixDisplay(new byte[128]).getDevicePort(), is("unknown"));
+    }
+
+    @Test
+    void testDevicePortFromConnectorConstructor() {
+        assertThat(new UnixDisplay(new byte[128], "HDMI-A-1", 96).getDevicePort(), is("HDMI-A-1"));
+    }
+}

--- a/oshi-common/src/test/java/oshi/util/driver/linux/DrmEdidTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/DrmEdidTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+import oshi.util.tuples.Triplet;
+
 @EnabledOnOs(OS.LINUX)
 class DrmEdidTest {
 
@@ -113,5 +115,46 @@ class DrmEdidTest {
         List<byte[]> edids = DrmEdid.getEdidArrays(tempDir.toFile());
         assertThat(edids, hasSize(1));
         assertThat(edids.get(0).length, greaterThanOrEqualTo(128));
+    }
+
+    @Test
+    void testGetDisplayDataExtractsConnectorName(@TempDir Path tempDir) throws IOException {
+        Path connector = Files.createDirectories(tempDir.resolve("card0-HDMI-A-1"));
+        writeFile(connector.resolve("status"), "connected\n");
+        Files.write(connector.resolve("edid"), VALID_EDID);
+
+        List<Triplet<String, Integer, byte[]>> data = DrmEdid.getDisplayData(tempDir.toFile());
+        assertThat(data, hasSize(1));
+        assertThat(data.get(0).getA(), is("HDMI-A-1"));
+        assertThat(data.get(0).getB(), is(-1));
+        assertThat(data.get(0).getC().length, greaterThanOrEqualTo(128));
+    }
+
+    @Test
+    void testGetDisplayDataReadsConnectorId(@TempDir Path tempDir) throws IOException {
+        Path connector = Files.createDirectories(tempDir.resolve("card0-DP-2"));
+        writeFile(connector.resolve("status"), "connected\n");
+        Files.write(connector.resolve("edid"), VALID_EDID);
+        writeFile(connector.resolve("connector_id"), "96\n");
+
+        List<Triplet<String, Integer, byte[]>> data = DrmEdid.getDisplayData(tempDir.toFile());
+        assertThat(data, hasSize(1));
+        assertThat(data.get(0).getA(), is("DP-2"));
+        assertThat(data.get(0).getB(), is(96));
+    }
+
+    @Test
+    void testGetDisplayDataMultipleConnectors(@TempDir Path tempDir) throws IOException {
+        Path hdmi = Files.createDirectories(tempDir.resolve("card0-HDMI-A-1"));
+        writeFile(hdmi.resolve("status"), "connected\n");
+        Files.write(hdmi.resolve("edid"), VALID_EDID);
+        writeFile(hdmi.resolve("connector_id"), "51\n");
+
+        Path dp = Files.createDirectories(tempDir.resolve("card0-eDP-1"));
+        writeFile(dp.resolve("status"), "connected\n");
+        Files.write(dp.resolve("edid"), VALID_EDID);
+
+        List<Triplet<String, Integer, byte[]>> data = DrmEdid.getDisplayData(tempDir.toFile());
+        assertThat(data, hasSize(2));
     }
 }

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.ArrayList;
@@ -151,6 +152,7 @@ class XrandrTest {
         assertThat(data.size(), is(1));
         assertThat(data.containsKey("DP2"), is(true));
         Pair<Integer, byte[]> pair = data.get("DP2");
+        assertNotNull(pair);
         assertThat(pair.getA(), is(96));
         assertThat(pair.getB().length, is(128));
         assertThat(pair.getB()[0], is((byte) 0x00));
@@ -163,6 +165,7 @@ class XrandrTest {
         assertThat(data.size(), is(1));
         assertThat(data.containsKey("HDMI-1"), is(true));
         Pair<Integer, byte[]> pair = data.get("HDMI-1");
+        assertNotNull(pair);
         assertThat(pair.getA(), is(-1));
         assertThat(pair.getB().length, is(128));
     }
@@ -173,12 +176,16 @@ class XrandrTest {
         assertThat(data.size(), is(2));
         assertThat(data.containsKey("DP2"), is(true));
         assertThat(data.containsKey("HDMI1"), is(true));
+        Pair<Integer, byte[]> dp2 = data.get("DP2");
+        Pair<Integer, byte[]> hdmi1 = data.get("HDMI1");
+        assertNotNull(dp2);
+        assertNotNull(hdmi1);
         // DP2 has CONNECTOR_ID, HDMI1 does not
-        assertThat(data.get("DP2").getA(), is(96));
-        assertThat(data.get("HDMI1").getA(), is(-1));
+        assertThat(dp2.getA(), is(96));
+        assertThat(hdmi1.getA(), is(-1));
         // Both have valid EDIDs
-        assertThat(data.get("DP2").getB().length, is(128));
-        assertThat(data.get("HDMI1").getB().length, is(128));
+        assertThat(dp2.getB().length, is(128));
+        assertThat(hdmi1.getB().length, is(128));
     }
 
     @Test
@@ -198,8 +205,10 @@ class XrandrTest {
         Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrDisconnectedWithConnectorId());
         assertThat(data.size(), is(1));
         assertThat(data.containsKey("eDP"), is(true));
+        Pair<Integer, byte[]> edp = data.get("eDP");
+        assertNotNull(edp);
         // eDP's own CONNECTOR_ID is 51, not 70 or 80 from the disconnected outputs
-        assertThat(data.get("eDP").getA(), is(51));
+        assertThat(edp.getA(), is(51));
         // Disconnected outputs should not appear
         assertThat(data.containsKey("DP-1"), is(false));
         assertThat(data.containsKey("HDMI-A-1"), is(false));

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
@@ -14,11 +14,14 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+
+import oshi.util.tuples.Pair;
 
 class XrandrTest {
 
@@ -65,6 +68,148 @@ class XrandrTest {
         noEdid.add("Screen 0: minimum 8 x 8, current 1920 x 1080");
         noEdid.add("HDMI-1 connected primary 1920x1080+0+0");
         assertThat(Xrandr.getEdidArrays(noEdid), is(empty()));
+    }
+
+    // Fixture: xrandr --verbose output with CONNECTOR_ID after EDID (real order)
+    private static List<String> createXrandrWithConnectorId() {
+        List<String> lines = new ArrayList<>();
+        lines.add("Screen 0: minimum 8 x 8, current 1920 x 1080, maximum 32767 x 32767");
+        lines.add("DP2 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 530mm x 300mm");
+        lines.add("\tEDID:");
+        lines.add("\t\t00ffffffffffff001e6d085b0b0b0b0b");
+        lines.add("\t\t0c1c0104b53c2278fb2eb5ae4f46a527");
+        lines.add("\t\t0d5054254b80714f81809500a9c0b300");
+        lines.add("\t\td1c001010101565e00a0a0a029503020");
+        lines.add("\t\t35000f282100001a000000fd00384b1e");
+        lines.add("\t\t5a1900000a202020202020000000fc00");
+        lines.add("\t\t4c4720554c545241474541520000ff00");
+        lines.add("\t\t3630344e54505a4832313337370a0100");
+        lines.add("\tCONNECTOR_ID: 96");
+        lines.add("\t\tsupported: 96");
+        lines.add("  1920x1080 (0x48) 148.500MHz +HSync +VSync *current +preferred");
+        return lines;
+    }
+
+    // Fixture: two connected displays, one with CONNECTOR_ID (after EDID), one without
+    private static List<String> createXrandrTwoDisplays() {
+        List<String> lines = new ArrayList<>();
+        lines.add("Screen 0: minimum 8 x 8, current 3840 x 1080, maximum 32767 x 32767");
+        lines.add("DP2 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 530mm x 300mm");
+        lines.add("\tEDID:");
+        lines.add("\t\t00ffffffffffff001e6d085b0b0b0b0b");
+        lines.add("\t\t0c1c0104b53c2278fb2eb5ae4f46a527");
+        lines.add("\t\t0d5054254b80714f81809500a9c0b300");
+        lines.add("\t\td1c001010101565e00a0a0a029503020");
+        lines.add("\t\t35000f282100001a000000fd00384b1e");
+        lines.add("\t\t5a1900000a202020202020000000fc00");
+        lines.add("\t\t4c4720554c545241474541520000ff00");
+        lines.add("\t\t3630344e54505a4832313337370a0100");
+        lines.add("\tCONNECTOR_ID: 96");
+        lines.add("\t\tsupported: 96");
+        lines.add("HDMI1 connected 1920x1080+1920+0 (normal left inverted right x axis y axis) 600mm x 340mm");
+        lines.add("\tEDID:");
+        lines.add("\t\t00ffffffffffff0010ac14414c305442");
+        lines.add("\t\t161c010380351e782eee95a3544c9926");
+        lines.add("\t\t0f5054a54b80714f81008180a9c0d1c0");
+        lines.add("\t\t010101010101023a801871382d40582c");
+        lines.add("\t\t45000f282100001e000000ff00545654");
+        lines.add("\t\t37463835554254304c0a000000fc0044");
+        lines.add("\t\t454c4c20503234313848540a000000fd");
+        lines.add("\t\t00324c1e5311000a202020202020017e");
+        lines.add("DP1 disconnected (normal left inverted right x axis y axis)");
+        return lines;
+    }
+
+    // Fixture: disconnected output with CONNECTOR_ID after a connected output (state-leak trap)
+    private static List<String> createXrandrDisconnectedWithConnectorId() {
+        List<String> lines = new ArrayList<>();
+        lines.add("Screen 0: minimum 8 x 8, current 1920 x 1080, maximum 32767 x 32767");
+        lines.add("eDP connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 340mm x 190mm");
+        lines.add("\tEDID:");
+        lines.add("\t\t00ffffffffffff001e6d085b0b0b0b0b");
+        lines.add("\t\t0c1c0104b53c2278fb2eb5ae4f46a527");
+        lines.add("\t\t0d5054254b80714f81809500a9c0b300");
+        lines.add("\t\td1c001010101565e00a0a0a029503020");
+        lines.add("\t\t35000f282100001a000000fd00384b1e");
+        lines.add("\t\t5a1900000a202020202020000000fc00");
+        lines.add("\t\t4c4720554c545241474541520000ff00");
+        lines.add("\t\t3630344e54505a4832313337370a0100");
+        lines.add("\tCONNECTOR_ID: 51");
+        lines.add("\t\tsupported: 51");
+        lines.add("DP-1 disconnected (normal left inverted right x axis y axis)");
+        lines.add("\tCONNECTOR_ID: 70");
+        lines.add("\t\tsupported: 70");
+        lines.add("HDMI-A-1 disconnected (normal left inverted right x axis y axis)");
+        lines.add("\tCONNECTOR_ID: 80");
+        lines.add("\t\tsupported: 80");
+        return lines;
+    }
+
+    @Test
+    void testGetDisplayDataSingleWithConnectorId() {
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrWithConnectorId());
+        assertThat(data.size(), is(1));
+        assertThat(data.containsKey("DP2"), is(true));
+        Pair<Integer, byte[]> pair = data.get("DP2");
+        assertThat(pair.getA(), is(96));
+        assertThat(pair.getB().length, is(128));
+        assertThat(pair.getB()[0], is((byte) 0x00));
+        assertThat(pair.getB()[1], is((byte) 0xFF));
+    }
+
+    @Test
+    void testGetDisplayDataWithoutConnectorId() {
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrWithEdid());
+        assertThat(data.size(), is(1));
+        assertThat(data.containsKey("HDMI-1"), is(true));
+        Pair<Integer, byte[]> pair = data.get("HDMI-1");
+        assertThat(pair.getA(), is(-1));
+        assertThat(pair.getB().length, is(128));
+    }
+
+    @Test
+    void testGetDisplayDataTwoDisplays() {
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        assertThat(data.size(), is(2));
+        assertThat(data.containsKey("DP2"), is(true));
+        assertThat(data.containsKey("HDMI1"), is(true));
+        // DP2 has CONNECTOR_ID, HDMI1 does not
+        assertThat(data.get("DP2").getA(), is(96));
+        assertThat(data.get("HDMI1").getA(), is(-1));
+        // Both have valid EDIDs
+        assertThat(data.get("DP2").getB().length, is(128));
+        assertThat(data.get("HDMI1").getB().length, is(128));
+    }
+
+    @Test
+    void testGetDisplayDataEmpty() {
+        assertThat(Xrandr.getDisplayData(Collections.emptyList()).isEmpty(), is(true));
+    }
+
+    @Test
+    void testGetDisplayDataDisconnectedSkipped() {
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        // DP1 is disconnected and has no EDID, should not appear
+        assertThat(data.containsKey("DP1"), is(false));
+    }
+
+    @Test
+    void testGetDisplayDataDisconnectedDoesNotLeakState() {
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrDisconnectedWithConnectorId());
+        assertThat(data.size(), is(1));
+        assertThat(data.containsKey("eDP"), is(true));
+        // eDP's own CONNECTOR_ID is 51, not 70 or 80 from the disconnected outputs
+        assertThat(data.get("eDP").getA(), is(51));
+        // Disconnected outputs should not appear
+        assertThat(data.containsKey("DP-1"), is(false));
+        assertThat(data.containsKey("HDMI-A-1"), is(false));
+    }
+
+    @Test
+    void testGetEdidArraysDelegatesToGetDisplayData() {
+        List<byte[]> edids = Xrandr.getEdidArrays(createXrandrWithConnectorId());
+        assertThat(edids, hasSize(1));
+        assertThat(edids.get(0).length, is(128));
     }
 
     @Nested


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added display device-port reporting through the public display API.
  - Added optional output-name reporting for connected displays.
  - Improved Linux and Unix display detection with connector IDs, port names, and EDID-based matching.
  - Display information now resolves more reliably through system graphics tools when available.
  - Unsupported or unavailable metadata returns clear default values without interrupting display detection.

- **Documentation**
  - Added release notes describing the new display metadata fields and platform behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->