### PR TITLE
Ask whether JNA loaded before reading the NetBSD routing table

### DIFF
--- a/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/unix/netbsd/NetBsdNetworkParamsJNA.java
@@ -22,6 +22,11 @@ public class NetBsdNetworkParamsJNA extends NetBsdNetworkParams {
 
     @Override
     protected byte[] queryRouteDump() {
+        // Every native call on this platform has to ask first: the runner without java-jna installed still uses this
+        // class, and reaching libc there fails while the library loads rather than by returning anything
+        if (!NetBsdSysctlUtil.JNA_AVAILABLE) {
+            return new byte[0];
+        }
         int[] mib = { CTL_NET, PF_ROUTE, 0, 0, NET_RT_DUMP, 0 };
         try (Memory buf = NetBsdSysctlUtil.sysctl(mib)) {
             if (buf == null) {


### PR DESCRIPTION
Fixes the NetBSD (no JNA) failure introduced by #3665.

```
=> java.lang.NoClassDefFoundError: Could not initialize class com.sun.jna.Native
   oshi.jna.util.SysctlUtilJNA.<clinit>
   oshi.util.platform.unix.netbsd.NetBsdSysctlUtil.sysctl
   oshi.software.os.unix.netbsd.NetBsdNetworkParamsJNA.queryRouteDump
   oshi.software.common.os.unix.netbsd.NetBsdNetworkParams.getRoutes
```

## What I got wrong

I assumed a build without `libjnidispatch` would not use `NetBsdOperatingSystemJNA`, so its `NetworkParams` would never be constructed and the base class would run the command as before. That is not how this platform works: the JNA operating system class **is** used, and each native method degrades on its own by checking `NetBsdSysctlUtil.JNA_AVAILABLE`. `NetBsdOperatingSystemJNA` guards two of its own methods that way, `NetBsdOSProcessJNA` four, `NetBsdCentralProcessorJNA` three, and the flag's own class javadoc says to.

`queryRouteDump()` was the only native method on NetBSD without the check, so it reached libc. The failure then arrives while the library loads rather than as a return value, which is why it escaped as an error out of `getRoutes()` instead of yielding nothing and falling back.

## The fix

The one guard the rest of the platform already uses. Where JNA is present nothing changes — the NetBSD JNA runner read 27 routes matching `netstat` exactly — and where it is absent the routing table is read by running a command, as it was before #3665.

## Verification

Full gate with `-Paggregate-coverage` and `-Perror-prone`, both clean. macOS unaffected: 141 routes, native and command identical. The case that matters is the `NetBSD (no JNA)` job, which is the one that caught this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network information handling on NetBSD systems when native integration is unavailable.
  * Prevented failures during route data retrieval in environments without JNA support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->