### PR TITLE
Read the Linux host name from procfs in every backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The `oshi-dist` zip is no longer published to Maven Central; download it from th
 * [#3661](https://github.com/oshi/oshi/pull/3661): Setting `oshi.os.windows.hkeyperfdata` to `false` now also skips the registry when fetching thread counters, matching its documented behavior and the existing handling for processes - [@dbwiddis](https://github.com/dbwiddis).
 * [#3662](https://github.com/oshi/oshi/pull/3662): Reading the processor description from the registry no longer throws when a value is missing. `CentralProcessor.getFeatureFlags()` on Windows now reports every processor feature `IsProcessorFeaturePresent()` accepts, matching the `PF_` defines in `winnt.h` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3665](https://github.com/oshi/oshi/pull/3665): `NetworkParams.getRoutes()` reads the routing table from the kernel through a `NET_RT_DUMP` sysctl on macOS, FreeBSD, DragonFly BSD and OpenBSD, rather than by running `netstat` twice - [@dbwiddis](https://github.com/dbwiddis).
+* [#3670](https://github.com/oshi/oshi/pull/3670): `NetworkParams.getHostName()` on Linux reads the kernel host name from `/proc/sys/kernel/hostname` in every backend, fixing the native-free implementation, which truncated a fully qualified name at the first dot and reported `localhost` when the name did not resolve - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.5.0 (2026-08-16)
 

--- a/oshi-benchmark/src/test/java/oshi/comparison/NativeFreeComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/NativeFreeComparisonTest.java
@@ -247,8 +247,9 @@ class NativeFreeComparisonTest {
     void networkParams() {
         NetworkParams jna = jnaOs.getNetworkParams();
         NetworkParams nf = nfOs.getNetworkParams();
-        // NF uses Java InetAddress (short hostname); JNA uses native gethostname (may return FQDN)
-        assertThat(jna.getHostName()).startsWith(nf.getHostName());
+        // Both backends inherit the procfs host name read from LinuxNetworkParams, so they agree exactly, FQDN and
+        // all; this guards against either one re-introducing an override that diverges
+        assertThat(nf.getHostName()).isEqualTo(jna.getHostName());
         assertThat(nf.getDnsServers()).isEqualTo(jna.getDnsServers());
         assertThat(nf.getIpv4DefaultGateway()).isEqualTo(jna.getIpv4DefaultGateway());
         assertThat(nf.getIpv6DefaultGateway()).isEqualTo(jna.getIpv6DefaultGateway());

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxNetworkParams.java
@@ -12,12 +12,14 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.AbstractNetworkParams;
 import oshi.software.os.NetworkParams;
 import oshi.util.ExecutingCommand;
+import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.driver.linux.proc.RouteTable;
+import oshi.util.linux.ProcPath;
 
 /**
- * Linux network parameters. Provides default gateway implementations via command line. Subclasses provide
- * {@link #getDomainName()} and {@link #getHostName()} via native calls.
+ * Linux network parameters. Provides the host name and default gateway implementations shared by all backends.
+ * Subclasses provide {@link #getDomainName()} via native calls.
  */
 @ThreadSafe
 public abstract class LinuxNetworkParams extends AbstractNetworkParams {
@@ -31,6 +33,16 @@ public abstract class LinuxNetworkParams extends AbstractNetworkParams {
     private static final String IPV4_DEFAULT_DEST = "0.0.0.0"; // NOSONAR java:S1313 - the kernel route table's literal
                                                                // wildcard destination, not a configurable address
     private static final String IPV6_DEFAULT_DEST = "::/0";
+
+    @Override
+    public String getHostName() {
+        // The kernel.hostname sysctl is the same utsname.nodename that gethostname(2) returns, per UTS namespace, so
+        // this stays correct inside a container. Reading it avoids the name resolution the AbstractNetworkParams
+        // fallback performs, which truncates an FQDN at the first dot and reports "localhost" when the host name does
+        // not resolve.
+        String hostname = FileUtil.getStringFromFile(ProcPath.SYS_KERNEL_HOSTNAME);
+        return hostname.isEmpty() ? super.getHostName() : hostname;
+    }
 
     @Override
     public String getIpv4DefaultGateway() {

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxNetworkParams.java
@@ -18,8 +18,9 @@ import oshi.util.driver.linux.proc.RouteTable;
 import oshi.util.linux.ProcPath;
 
 /**
- * Linux network parameters. Provides the host name and default gateway implementations shared by all backends.
- * Subclasses provide {@link #getDomainName()} via native calls.
+ * Linux network parameters. Provides the host name and default gateway implementations shared by all backends. The JNA
+ * and FFM subclasses override {@link #getDomainName()} with a native call; the native-free subclass inherits the
+ * Java-based resolution from {@link AbstractNetworkParams}.
  */
 @ThreadSafe
 public abstract class LinuxNetworkParams extends AbstractNetworkParams {

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxNetworkParamsNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxNetworkParamsNF.java
@@ -5,11 +5,12 @@
 package oshi.software.common.os.linux.nativefree;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.software.common.AbstractNetworkParams;
 import oshi.software.common.os.linux.LinuxNetworkParams;
 
 /**
  * Native-free Linux network parameters implementation. Extends {@link LinuxNetworkParams}, inheriting its procfs host
- * name read and using the Java-based domain name resolution from {@link oshi.software.common.AbstractNetworkParams}.
+ * name read and using the Java-based domain name resolution from {@link AbstractNetworkParams}.
  */
 @ThreadSafe
 public class LinuxNetworkParamsNF extends LinuxNetworkParams {

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxNetworkParamsNF.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/nativefree/LinuxNetworkParamsNF.java
@@ -8,8 +8,8 @@ import oshi.annotation.concurrent.ThreadSafe;
 import oshi.software.common.os.linux.LinuxNetworkParams;
 
 /**
- * Native-free Linux network parameters implementation. Extends {@link LinuxNetworkParams}, using the Java-based
- * hostname and domain name resolution from {@link oshi.software.common.AbstractNetworkParams}.
+ * Native-free Linux network parameters implementation. Extends {@link LinuxNetworkParams}, inheriting its procfs host
+ * name read and using the Java-based domain name resolution from {@link oshi.software.common.AbstractNetworkParams}.
  */
 @ThreadSafe
 public class LinuxNetworkParamsNF extends LinuxNetworkParams {

--- a/oshi-common/src/main/java/oshi/util/linux/ProcPath.java
+++ b/oshi-common/src/main/java/oshi/util/linux/ProcPath.java
@@ -75,6 +75,8 @@ public final class ProcPath {
     public static final String SYS_FS_FILE_NR = PROC + "/sys/fs/file-nr";
     /** Path to /proc/sys/fs/file max. */
     public static final String SYS_FS_FILE_MAX = PROC + "/sys/fs/file-max";
+    /** Path to /proc/sys/kernel/hostname. */
+    public static final String SYS_KERNEL_HOSTNAME = PROC + "/sys/kernel/hostname";
     /** Path to /proc/[pid]/task/path. */
     public static final String TASK_PATH = PROC + "/%d/task";
     /** Path to /proc/[pid]/task/comm. */

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxNetworkParamsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxNetworkParamsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.software.common.os.linux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+@EnabledOnOs(OS.LINUX)
+class LinuxNetworkParamsTest {
+
+    /** Concrete subclass; every method under test is inherited. */
+    private static final class StubLinuxNetworkParams extends LinuxNetworkParams {
+    }
+
+    /**
+     * The host name must be the kernel's, read here independently of {@code FileUtil} and {@code ProcPath}. A name
+     * resolution based implementation fails this whenever the kernel host name is a FQDN, because it truncates at the
+     * first dot, or whenever the host name does not resolve, because it reports {@code localhost}.
+     */
+    @Test
+    void testHostNameIsTheKernelHostName() throws IOException {
+        byte[] raw = Files.readAllBytes(Paths.get("/proc/sys/kernel/hostname"));
+        String kernelHostName = new String(raw, StandardCharsets.UTF_8).trim();
+        assertThat("The kernel always has a host name", kernelHostName, is(not(emptyString())));
+        assertThat(new StubLinuxNetworkParams().getHostName(), is(kernelHostName));
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/software/os/linux/LinuxNetworkParamsFFM.java
@@ -17,30 +17,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.ffm.platform.linux.LinuxLibcFunctions;
-import oshi.ffm.platform.unix.PosixLibcFunctions;
 import oshi.software.common.os.linux.LinuxNetworkParams;
 
 /**
- * FFM-based Linux network parameters. Overrides {@code gethostname} and {@code getaddrinfo} calls to use FFM.
+ * FFM-based Linux network parameters. Implements {@code getDomainName} via {@code getaddrinfo}; the host name is read
+ * from procfs by {@link LinuxNetworkParams}.
  */
 final class LinuxNetworkParamsFFM extends LinuxNetworkParams {
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxNetworkParamsFFM.class);
-
-    private static final int HOST_NAME_MAX = 255;
-
-    @Override
-    public String getHostName() {
-        @Nullable
-        String hostname = callInArenaOrDefault(arena -> {
-            MemorySegment buf = arena.allocate(HOST_NAME_MAX + 1L);
-            if (0 == PosixLibcFunctions.gethostname(buf, HOST_NAME_MAX + 1L)) {
-                return buf.getString(0);
-            }
-            return null;
-        }, LOG, WARN, "FFM gethostname failed", null);
-        return hostname == null ? super.getHostName() : hostname;
-    }
 
     @Override
     public String getDomainName() {

--- a/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParamsJNA.java
+++ b/oshi-core/src/main/java/oshi/software/os/linux/LinuxNetworkParamsJNA.java
@@ -4,16 +4,11 @@
  */
 package oshi.software.os.linux;
 
-import static com.sun.jna.platform.unix.LibCAPI.HOST_NAME_MAX;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.sun.jna.Native;
-import com.sun.jna.platform.linux.LibC;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.jna.ByRef.CloseablePointerByReference;
@@ -23,8 +18,8 @@ import oshi.jna.platform.unix.CLibrary.Addrinfo;
 import oshi.software.common.os.linux.LinuxNetworkParams;
 
 /**
- * JNA-based Linux network parameters. Implements {@code getDomainName} via {@code getaddrinfo} and {@code getHostName}
- * via {@code gethostname}.
+ * JNA-based Linux network parameters. Implements {@code getDomainName} via {@code getaddrinfo}; the host name is read
+ * from procfs by {@link LinuxNetworkParams}.
  */
 @ThreadSafe
 class LinuxNetworkParamsJNA extends LinuxNetworkParams {
@@ -62,12 +57,4 @@ class LinuxNetworkParamsJNA extends LinuxNetworkParams {
         }
     }
 
-    @Override
-    public String getHostName() {
-        byte[] hostnameBuffer = new byte[HOST_NAME_MAX + 1];
-        if (0 != LibC.INSTANCE.gethostname(hostnameBuffer, hostnameBuffer.length)) {
-            return super.getHostName();
-        }
-        return Native.toString(hostnameBuffer);
-    }
 }


### PR DESCRIPTION
Fixes #3669.

## The bug

`LinuxNetworkParamsNF` is an empty class body, so the native-free provider inherits `AbstractNetworkParams.getHostName()`, which resolves the local address and truncates at the first dot. JNA and FFM both override it with `gethostname(2)`. Reproduced against `master` in a container on aarch64:

```
######## case 1: FQDN kernel host name, resolvable
kernel host name = host.example.com
oshi-core     (JNA)          getHostName() = host.example.com
oshi-common   (native-free)  getHostName() = host

######## case 2: short kernel host name, NOT resolvable
kernel host name = buildbox
oshi-core     (JNA)          getHostName() = buildbox
oshi-common   (native-free)  getHostName() = localhost
```

## The fix

`/proc/sys/kernel/hostname` is the same `utsname.nodename` that `gethostname(2)` returns, read from the same UTS namespace, so it stays correct inside a container and needs no native call. Reading it in `LinuxNetworkParams` fixes the native-free provider *and* lets both twin overrides go, leaving one implementation where there were three. The empty-string return from `FileUtil` doubles as the signal to fall back to `super`.

The kernel caps `nodename` at 63 characters plus NUL (`__NEW_UTS_LEN`), so there is no truncation difference against the 256-byte buffer the native calls used — verified at a 63-character host name, where all three sources agree.

`getDomainName()` is deliberately untouched. `/proc/sys/kernel/domainname` is the NIS/YP domain, not the DNS domain; it reads `(none)` on a host that does not use NIS, even when the kernel host name is `host.example.com`. The `getaddrinfo(AI_CANONNAME)` implementations stay.

Not a breaking change: `NetworkParams.getHostName()` documents only "the HostName of the machine executing OSHI", with no promise of the short form, and the two native backends already returned the FQDN.

## On overhead

The syscall is cheaper than the file read, but by an irrelevant margin next to what is being removed. Steady state, best of 5 × 200k:

| | ns/call |
|---|---|
| `gethostname(2)` | 513 |
| `Files.readAllBytes` + decode | 1,992 |
| `FileUtil.getStringFromFile` | 2,641 |

Against that ~2 µs, the `InetAddress` path this replaces costs 2.57 ms on a cold first call, 0.59–3.11 ms once the JDK's 5 s localhost cache expires, and — because *failures are never cached* — 4.57 ms on **every** call when the host name does not resolve.

## Testing

New `LinuxNetworkParamsTest` asserts `getHostName()` equals `/proc/sys/kernel/hostname`, read independently of `FileUtil` and `ProcPath`. It runs green on Linux with a FQDN host name, which is the case that previously returned the truncated name.

`NativeFreeComparisonTest` compared host names with `startsWith()` under a comment excusing the difference, which is why case 1 never failed CI; it now requires equality. Case 2 would have failed it, but CI runners always resolve their own name.

Verified locally on macOS (full gate plus `-Perror-prone`) and in Linux containers for the behavior above. The pre-existing, unrelated `NativeComparisonTest.processorFrequencies` failure on Apple Silicon reproduces identically on a clean `master` checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux hostname detection across all supported backends.
  * Preserved fully qualified hostnames instead of truncating them.
  * Avoided incorrect `localhost` results when hostnames cannot be resolved.
* **Tests**
  * Added coverage to verify hostname consistency and accurate kernel-provided values.
* **Documentation**
  * Updated the changelog and hostname behavior documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->