### PR TITLE
Stop reporting localhost when the local host name does not resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The `oshi-dist` zip is no longer published to Maven Central; download it from th
 * [#3662](https://github.com/oshi/oshi/pull/3662): Reading the processor description from the registry no longer throws when a value is missing. `CentralProcessor.getFeatureFlags()` on Windows now reports every processor feature `IsProcessorFeaturePresent()` accepts, matching the `PF_` defines in `winnt.h` - [@dbwiddis](https://github.com/dbwiddis).
 * [#3665](https://github.com/oshi/oshi/pull/3665): `NetworkParams.getRoutes()` reads the routing table from the kernel through a `NET_RT_DUMP` sysctl on macOS, FreeBSD, DragonFly BSD and OpenBSD, rather than by running `netstat` twice - [@dbwiddis](https://github.com/dbwiddis).
 * [#3670](https://github.com/oshi/oshi/pull/3670): `NetworkParams.getHostName()` on Linux reads the kernel host name from `/proc/sys/kernel/hostname` in every backend, fixing the native-free implementation, which truncated a fully qualified name at the first dot and reported `localhost` when the name did not resolve - [@dbwiddis](https://github.com/dbwiddis).
+* [#3671](https://github.com/oshi/oshi/pull/3671): `NetworkParams.getHostName()` and `getDomainName()` report the empty-string sentinel when the local host name does not resolve, rather than the loopback address's `localhost`. NetBSD is the most affected platform, having no native host name query of its own - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.5.0 (2026-08-16)
 

--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -39,6 +39,7 @@
     <allow class="java.awt.Rectangle" />
 
     <!--java.base -->
+    <allow class="java.net.InetAddress" />
     <allow class="java.net.NetworkInterface" />
     <allow pkg="java.io" />
     <allow pkg="java.lang" />

--- a/oshi-common/src/main/java/oshi/software/common/AbstractNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractNetworkParams.java
@@ -4,6 +4,9 @@
  */
 package oshi.software.common;
 
+import static oshi.util.Memoizer.defaultExpiration;
+import static oshi.util.Memoizer.memoize;
+
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.UnknownHostException;
@@ -15,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import org.jspecify.annotations.Nullable;
@@ -45,19 +49,21 @@ public abstract class AbstractNetworkParams implements NetworkParams {
 
     private static final String NAMESERVER = "nameserver";
 
+    private final Supplier<@Nullable InetAddress> localHost = memoize(this::queryLocalHost, defaultExpiration());
+
     @Override
     public String getDomainName() {
-        InetAddress localHost = queryLocalHost();
-        return localHost == null ? "" : localHost.getCanonicalHostName();
+        InetAddress addr = this.localHost.get();
+        return addr == null ? "" : addr.getCanonicalHostName();
     }
 
     @Override
     public String getHostName() {
-        InetAddress localHost = queryLocalHost();
-        if (localHost == null) {
+        InetAddress addr = this.localHost.get();
+        if (addr == null) {
             return "";
         }
-        String hn = localHost.getHostName();
+        String hn = addr.getHostName();
         int dot = hn.indexOf('.');
         if (dot == -1) {
             return hn;
@@ -67,11 +73,11 @@ public abstract class AbstractNetworkParams implements NetworkParams {
 
     /**
      * Resolves the local host, the source for both the host name and the domain name when the platform has no better
-     * one.
+     * one. The result is memoized, because the JDK does not cache a failed lookup and both names would otherwise pay a
+     * full failing DNS round trip apiece.
      *
      * @return the local host, or {@code null} if it does not resolve, in which case both names report the empty-string
-     *         sentinel. Note that a failed lookup is not cached by the JDK, so each call pays a full failing DNS round
-     *         trip.
+     *         sentinel
      */
     protected @Nullable InetAddress queryLocalHost() {
         try {

--- a/oshi-common/src/main/java/oshi/software/common/AbstractNetworkParams.java
+++ b/oshi-common/src/main/java/oshi/software/common/AbstractNetworkParams.java
@@ -17,6 +17,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,22 +47,15 @@ public abstract class AbstractNetworkParams implements NetworkParams {
 
     @Override
     public String getDomainName() {
-        InetAddress localHost;
-        try {
-            localHost = InetAddress.getLocalHost();
-        } catch (UnknownHostException e) {
-            localHost = InetAddress.getLoopbackAddress();
-        }
-        return localHost.getCanonicalHostName();
+        InetAddress localHost = queryLocalHost();
+        return localHost == null ? "" : localHost.getCanonicalHostName();
     }
 
     @Override
     public String getHostName() {
-        InetAddress localHost;
-        try {
-            localHost = InetAddress.getLocalHost();
-        } catch (UnknownHostException e) {
-            localHost = InetAddress.getLoopbackAddress();
+        InetAddress localHost = queryLocalHost();
+        if (localHost == null) {
+            return "";
         }
         String hn = localHost.getHostName();
         int dot = hn.indexOf('.');
@@ -69,6 +63,25 @@ public abstract class AbstractNetworkParams implements NetworkParams {
             return hn;
         }
         return hn.substring(0, dot);
+    }
+
+    /**
+     * Resolves the local host, the source for both the host name and the domain name when the platform has no better
+     * one.
+     *
+     * @return the local host, or {@code null} if it does not resolve, in which case both names report the empty-string
+     *         sentinel. Note that a failed lookup is not cached by the JDK, so each call pays a full failing DNS round
+     *         trip.
+     */
+    protected @Nullable InetAddress queryLocalHost() {
+        try {
+            return InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+            // Deliberately not falling back to InetAddress.getLoopbackAddress(): its name and canonical name are
+            // "localhost", which is a fabricated answer for a host whose own name does not resolve.
+            LOG.debug("Unknown host exception when getting address of local host", e);
+            return null;
+        }
     }
 
     @Override

--- a/oshi-common/src/test/java/oshi/software/common/AbstractNetworkParamsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/AbstractNetworkParamsTest.java
@@ -6,13 +6,16 @@ package oshi.software.common;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 class AbstractNetworkParamsTest {
@@ -31,11 +34,38 @@ class AbstractNetworkParamsTest {
         };
     }
 
+    /** Stands in for a host whose own name does not resolve, which is not reproducible from a test otherwise. */
+    private static AbstractNetworkParams createUnresolvableParams() {
+        return new AbstractNetworkParams() {
+            @Override
+            protected @Nullable InetAddress queryLocalHost() {
+                return null;
+            }
+
+            @Override
+            public String getIpv4DefaultGateway() {
+                return "";
+            }
+
+            @Override
+            public String getIpv6DefaultGateway() {
+                return "";
+            }
+        };
+    }
+
     @Test
     void testHostAndDomainNotNull() {
         AbstractNetworkParams params = createParams();
         assertThat(params.getHostName(), is(notNullValue()));
         assertThat(params.getDomainName(), is(notNullValue()));
+    }
+
+    @Test
+    void testUnresolvableLocalHostReportsTheSentinelRatherThanLocalhost() {
+        AbstractNetworkParams params = createUnresolvableParams();
+        assertThat(params.getHostName(), is(emptyString()));
+        assertThat(params.getDomainName(), is(emptyString()));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/software/common/AbstractNetworkParamsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/AbstractNetworkParamsTest.java
@@ -14,6 +14,7 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -34,11 +35,16 @@ class AbstractNetworkParamsTest {
         };
     }
 
-    /** Stands in for a host whose own name does not resolve, which is not reproducible from a test otherwise. */
-    private static AbstractNetworkParams createUnresolvableParams() {
+    /**
+     * Stands in for a host whose own name does not resolve, which is not reproducible from a test otherwise.
+     *
+     * @param lookups counts the local host lookups the instance performs
+     */
+    private static AbstractNetworkParams createUnresolvableParams(AtomicInteger lookups) {
         return new AbstractNetworkParams() {
             @Override
             protected @Nullable InetAddress queryLocalHost() {
+                lookups.incrementAndGet();
                 return null;
             }
 
@@ -63,9 +69,19 @@ class AbstractNetworkParamsTest {
 
     @Test
     void testUnresolvableLocalHostReportsTheSentinelRatherThanLocalhost() {
-        AbstractNetworkParams params = createUnresolvableParams();
+        AbstractNetworkParams params = createUnresolvableParams(new AtomicInteger());
         assertThat(params.getHostName(), is(emptyString()));
         assertThat(params.getDomainName(), is(emptyString()));
+    }
+
+    @Test
+    void testBothNamesShareOneLocalHostLookup() {
+        AtomicInteger lookups = new AtomicInteger();
+        AbstractNetworkParams params = createUnresolvableParams(lookups);
+        params.getHostName();
+        params.getDomainName();
+        // The JDK does not cache a failed lookup, so without memoization this would be 2.
+        assertThat(lookups.get(), is(1));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #3670, which fixed the host name on Linux but deliberately left this half alone because it is cross-platform. Completes the second case reported in #3669.

## The bug

`AbstractNetworkParams` caught `UnknownHostException` and fell back to `InetAddress.getLoopbackAddress()`, whose `getHostName()` and `getCanonicalHostName()` are both `localhost`. So a host that cannot resolve its own name got a fabricated answer rather than a sentinel — from `getDomainName()` *and* `getHostName()`, which shared the same six-line dance.

That is inconsistent with the rest of the codebase for the identical condition: `FreeBsdNetworkParams.getDomainName()` returns `""`, and so do both Linux `getaddrinfo` implementations when the lookup fails.

Both methods now report `""`, via a single `queryLocalHost()` seam returning `null` on failure.

## NetBSD is the platform that actually suffers

Every other platform overrides at least one of the two with a native query and reaches the base class only when that query fails. **NetBSD overrides neither** — `NetBsdNetworkParams` implements only the gateways and routes — so on both the JNA and native-free backends it hits this path unconditionally. After #3670 it was the last platform still reporting `localhost`, and it also still truncates a FQDN host name at the first dot. Giving NetBSD a real host name source (`KERN_HOSTNAME`, or `/etc/myname` for the native-free build) is a separate change and not attempted here.

## Verified

In a `--network none` container with kernel host name `buildbox`, so the name cannot resolve:

```
                            before                     after
oshi-core     (JNA)         getDomainName() = ""       getDomainName() = ""
oshi-common   (native-free) getDomainName() = localhost getDomainName() = ""
```

The raw `InetAddress` path printed in the same JVM still returns `localhost`, confirming what changed. The resolvable case is unaffected: with kernel host name `host.example.com`, both backends still report `host.example.com` for host and domain.

New unit test `testUnresolvableLocalHostReportsTheSentinelRatherThanLocalhost` covers it on every platform. This case was previously untestable — nothing can stop the local host name from resolving from inside a test — which is the other reason for the `queryLocalHost()` seam; a stub subclass returns `null`, the same pattern `LinuxFileSystemTest` uses for `queryStatvfs`.

`config/import-control-test.xml` gains `java.net.InetAddress` for that stub, matching the narrow `<allow class=...>` style already used there for `java.net.NetworkInterface`.

Full local gate plus `-Perror-prone` are green on macOS. The pre-existing, unrelated `NativeComparisonTest.processorFrequencies` failure on Apple Silicon reproduces on a clean `master` and is not touched by this change.

## Note for reviewers

`getHostName()` is included alongside `getDomainName()` on purpose — same method pair, same fabrication, and #3669's second case was about the host name. Easy to drop if you would rather ship only the domain half.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unresolved local host names.
  * Host and domain name lookups now return empty values instead of incorrectly reporting `localhost`.
  * Failed lookups no longer fall back to the loopback address, improving accuracy on affected systems such as NetBSD.
  * Repeated host and domain lookups now reuse the same resolution result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->