### PR TITLE
Read Apple Silicon cluster frequencies lazily, not as a side effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The `oshi-dist` zip is no longer published to Maven Central; download it from th
 * [#3665](https://github.com/oshi/oshi/pull/3665): `NetworkParams.getRoutes()` reads the routing table from the kernel through a `NET_RT_DUMP` sysctl on macOS, FreeBSD, DragonFly BSD and OpenBSD, rather than by running `netstat` twice - [@dbwiddis](https://github.com/dbwiddis).
 * [#3670](https://github.com/oshi/oshi/pull/3670): `NetworkParams.getHostName()` on Linux reads the kernel host name from `/proc/sys/kernel/hostname` in every backend, fixing the native-free implementation, which truncated a fully qualified name at the first dot and reported `localhost` when the name did not resolve - [@dbwiddis](https://github.com/dbwiddis).
 * [#3671](https://github.com/oshi/oshi/pull/3671): `NetworkParams.getHostName()` and `getDomainName()` report the empty-string sentinel when the local host name does not resolve, rather than the loopback address's `localhost`. NetBSD is the most affected platform, having no native host name query of its own - [@dbwiddis](https://github.com/dbwiddis).
+* [#3672](https://github.com/oshi/oshi/pull/3672): `CentralProcessor.getMaxFreq()` and `getCurrentFreq()` on Apple Silicon report the real cluster frequencies regardless of call order. Both previously returned a 2.4 GHz placeholder unless `getProcessorIdentifier()` happened to be called first - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.5.0 (2026-08-16)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacCentralProcessor.java
@@ -75,8 +75,10 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     private final Supplier<String> vendor = memoize(this::platformExpert);
     private final boolean isArmCpu = isArmCpu();
 
-    private volatile long performanceCoreFrequency = DEFAULT_FREQUENCY;
-    private volatile long efficiencyCoreFrequency = DEFAULT_FREQUENCY;
+    // Nominal cluster frequencies are fixed hardware properties, so this is memoized indefinitely. It is queried
+    // lazily rather than populated as a side effect of queryProcessorId(): a caller asking for a frequency first
+    // would otherwise be answered with the DEFAULT_FREQUENCY placeholder.
+    private final Supplier<Pair<Long, Long>> nominalFrequencies = memoize(this::queryNominalFrequencies);
 
     /**
      * Returns the sysctl provider for this implementation.
@@ -370,18 +372,23 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     }
 
     /**
-     * Calculates nominal frequencies for performance and efficiency cores.
+     * Queries the nominal maximum frequencies of the performance and efficiency core clusters from the power manager's
+     * voltage state tables.
+     *
+     * @return a pair of (performance, efficiency) core frequency in Hz, each {@link #DEFAULT_FREQUENCY} if its table
+     *         could not be read
      */
-    protected void calculateNominalFrequencies() {
+    protected Pair<Long, Long> queryNominalFrequencies() {
+        long[] freqs = { DEFAULT_FREQUENCY, DEFAULT_FREQUENCY };
         ioKitProvider().forEachMatchingServiceUntil("AppleARMIODevice", entry -> {
             if ("pmgr".equalsIgnoreCase(entry.getName())) {
-                setPerformanceCoreFrequency(
-                        getMaxFreqFromByteArray(entry.getByteArrayProperty("voltage-states5-sram")));
-                setEfficiencyCoreFrequency(getMaxFreqFromByteArray(entry.getByteArrayProperty("voltage-states1-sram")));
+                freqs[0] = getMaxFreqFromByteArray(entry.getByteArrayProperty("voltage-states5-sram"));
+                freqs[1] = getMaxFreqFromByteArray(entry.getByteArrayProperty("voltage-states1-sram"));
                 return true;
             }
             return false;
         });
+        return new Pair<>(freqs[0], freqs[1]);
     }
 
     /**
@@ -390,16 +397,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @return the performance core frequency in Hz
      */
     protected long getPerformanceCoreFrequency() {
-        return performanceCoreFrequency;
-    }
-
-    /**
-     * Sets the performance core frequency.
-     *
-     * @param freq the frequency in Hz
-     */
-    protected void setPerformanceCoreFrequency(long freq) {
-        this.performanceCoreFrequency = freq;
+        return nominalFrequencies.get().getA();
     }
 
     /**
@@ -408,16 +406,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
      * @return the efficiency core frequency in Hz
      */
     protected long getEfficiencyCoreFrequency() {
-        return efficiencyCoreFrequency;
-    }
-
-    /**
-     * Sets the efficiency core frequency.
-     *
-     * @param freq the frequency in Hz
-     */
-    protected void setEfficiencyCoreFrequency(long freq) {
-        this.efficiencyCoreFrequency = freq;
+        return nominalFrequencies.get().getB();
     }
 
     /**
@@ -470,10 +459,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
             processorIdBits |= (sysctlLong("machdep.cpu.feature_bits", 0L) & 0xffffffff) << 32;
             processorID = String.format(Locale.ROOT, "%016x", processorIdBits);
         }
-        if (isArmCpu) {
-            calculateNominalFrequencies();
-        }
-        long cpuFreq = isArmCpu ? performanceCoreFrequency : sysctlLong("hw.cpufrequency", 0L);
+        long cpuFreq = isArmCpu ? getPerformanceCoreFrequency() : sysctlLong("hw.cpufrequency", 0L);
         boolean cpu64bit = sysctlInt("hw.cpu64bit_capable", 0) != 0;
 
         return new ProcessorIdentifier(cpuVendor, cpuName, cpuFamily, cpuModel, cpuStepping, processorID, cpu64bit,
@@ -551,11 +537,13 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     @Override
     public long[] queryCurrentFreq() {
         if (isArmCpu) {
+            long perfFreq = getPerformanceCoreFrequency();
+            long effFreq = getEfficiencyCoreFrequency();
             Map<Integer, Long> physFreqMap = new HashMap<>();
-            getPhysicalProcessors().forEach(p -> physFreqMap.put(p.getPhysicalProcessorNumber(),
-                    p.getEfficiency() > 0 ? performanceCoreFrequency : efficiencyCoreFrequency));
+            getPhysicalProcessors().forEach(
+                    p -> physFreqMap.put(p.getPhysicalProcessorNumber(), p.getEfficiency() > 0 ? perfFreq : effFreq));
             return getLogicalProcessors().stream().map(LogicalProcessor::getPhysicalProcessorNumber)
-                    .map(p -> physFreqMap.getOrDefault(p, performanceCoreFrequency)).mapToLong(f -> f).toArray();
+                    .map(p -> physFreqMap.getOrDefault(p, perfFreq)).mapToLong(f -> f).toArray();
         }
         return new long[] { getProcessorIdentifier().getVendorFreq() };
     }
@@ -563,7 +551,7 @@ public abstract class MacCentralProcessor extends AbstractCentralProcessor {
     @Override
     public long queryMaxFreq() {
         if (isArmCpu) {
-            return performanceCoreFrequency;
+            return getPerformanceCoreFrequency();
         }
         return sysctlLong("hw.cpufrequency_max", getProcessorIdentifier().getVendorFreq());
     }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
@@ -13,11 +13,13 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
@@ -155,6 +157,38 @@ class MacCentralProcessorTest {
         assertThat(avg[0], is(-1.0));
         assertThat(avg[1], is(-1.0));
         assertThat(avg[2], is(-1.0));
+    }
+
+    // -- Apple Silicon cluster frequencies --
+
+    @Test
+    void testArmMaxFreqWithoutFirstQueryingTheProcessorIdentifier() {
+        // The nominal frequencies were once read as a side effect of queryProcessorId(), so a caller asking for a
+        // frequency before the identifier was answered with the DEFAULT_FREQUENCY placeholder instead.
+        StubArmCentralProcessor cpu = new StubArmCentralProcessor();
+        assertThat(cpu.queryMaxFreq(), is(StubArmCentralProcessor.PERF_FREQ));
+    }
+
+    @Test
+    void testArmCurrentFreqIsPerCluster() {
+        StubArmCentralProcessor cpu = new StubArmCentralProcessor();
+        long[] freqs = cpu.queryCurrentFreq();
+        assertThat(freqs.length, is(8));
+        for (int i = 0; i < 4; i++) {
+            assertThat("efficiency core " + i, freqs[i], is(StubArmCentralProcessor.EFF_FREQ));
+        }
+        for (int i = 4; i < 8; i++) {
+            assertThat("performance core " + i, freqs[i], is(StubArmCentralProcessor.PERF_FREQ));
+        }
+    }
+
+    @Test
+    void testNominalFrequenciesAreQueriedOnceForAllThreeConsumers() {
+        StubArmCentralProcessor cpu = new StubArmCentralProcessor();
+        cpu.queryMaxFreq();
+        cpu.queryCurrentFreq();
+        assertThat("vendor frequency", cpu.queryProcessorId().getVendorFreq(), is(StubArmCentralProcessor.PERF_FREQ));
+        assertThat("IORegistry walks", cpu.nominalFrequencyQueries(), is(1));
     }
 
     // -- efficiency class derivation --
@@ -454,7 +488,7 @@ class MacCentralProcessorTest {
 
         @Override
         protected IOKitProvider ioKitProvider() {
-            return null; // Not used; platformExpert/queryCoreProperties/calculateNominalFrequencies are overridden
+            return null; // Not used; platformExpert/queryCoreProperties/queryNominalFrequencies are overridden
         }
 
         @Override
@@ -468,7 +502,8 @@ class MacCentralProcessorTest {
         }
 
         @Override
-        protected void calculateNominalFrequencies() {
+        protected Pair<Long, Long> queryNominalFrequencies() {
+            return new Pair<>(DEFAULT_FREQUENCY, DEFAULT_FREQUENCY);
         }
 
         @Override
@@ -490,16 +525,6 @@ class MacCentralProcessorTest {
         }
 
         @Override
-        public long queryMaxFreq() {
-            return 0L;
-        }
-
-        @Override
-        public long[] queryCurrentFreq() {
-            return new long[] { 0L };
-        }
-
-        @Override
         public long queryContextSwitches() {
             return 0L;
         }
@@ -507,6 +532,54 @@ class MacCentralProcessorTest {
         @Override
         public long queryInterrupts() {
             return 0L;
+        }
+    }
+
+    /**
+     * An Apple Silicon variant of the stub: four efficiency plus four performance cores, with the two cluster
+     * frequencies standing in for the {@code pmgr} voltage-state tables. The core count and cluster types must come
+     * from constants rather than instance fields, because the superclass derives the processor topology during
+     * construction, before any subclass field is assigned.
+     */
+    static class StubArmCentralProcessor extends StubMacCentralProcessor {
+
+        static final long PERF_FREQ = 4_056_000_000L;
+        static final long EFF_FREQ = 2_748_000_000L;
+        private static final int CORE_COUNT = 8;
+
+        private final AtomicInteger nominalFrequencyQueries = new AtomicInteger();
+
+        StubArmCentralProcessor() {
+            super(Collections.singletonMap("machdep.cpu.brand_string", "Apple M3 Pro"));
+        }
+
+        @Override
+        protected int sysctlInt(String name, int def) {
+            if ("hw.logicalcpu".equals(name) || "hw.physicalcpu".equals(name)) {
+                return CORE_COUNT;
+            }
+            return super.sysctlInt(name, def);
+        }
+
+        @Override
+        protected Map<Integer, Pair<String, String>> queryCoreProperties() {
+            Map<Integer, Pair<String, String>> props = new HashMap<>();
+            for (int i = 0; i < CORE_COUNT; i++) {
+                boolean performance = i >= CORE_COUNT / 2;
+                props.put(i, new Pair<>(performance ? "apple,everest arm,v8" : "apple,sawtooth arm,v8",
+                        performance ? "P" : "E"));
+            }
+            return props;
+        }
+
+        @Override
+        protected Pair<Long, Long> queryNominalFrequencies() {
+            nominalFrequencyQueries.incrementAndGet();
+            return new Pair<>(PERF_FREQ, EFF_FREQ);
+        }
+
+        int nominalFrequencyQueries() {
+            return nominalFrequencyQueries.get();
         }
     }
 }


### PR DESCRIPTION
On Apple Silicon the nominal performance and efficiency cluster frequencies come from the power manager's voltage-state tables (`voltage-states5-sram` and `voltage-states1-sram` on the `pmgr` `AppleARMIODevice` node). `MacCentralProcessor` read them in `calculateNominalFrequencies()` and stored them in two `volatile long` fields — but nothing called that method except `queryProcessorId()`.

So `getMaxFreq()` and `getCurrentFreq()` returned the `DEFAULT_FREQUENCY` placeholder, 2.4 GHz for every core, unless a caller happened to ask for the processor identifier first. Measured on an M3 Pro before this change:

| call order | `getMaxFreq()` | `getCurrentFreq()` |
|---|---|---|
| `getMaxFreq()` first | 2.400 GHz | 2.4 GHz × 12 |
| `getProcessorIdentifier()` first | 4.056 GHz | 2.748 × 6, 4.056 × 6 |

This is also why `oshi.comparison.NativeComparisonTest.processorFrequencies` failed on Apple Silicon: not JNA/FFM divergence, just which instance had its `cpuid` warmed first. The bug lives in `oshi-common`, so both backends had it.

## Change

The two fields and their setters are replaced by a `Supplier<Pair<Long, Long>>` memoized indefinitely — these are fixed hardware properties — behind a new `protected Pair<Long, Long> queryNominalFrequencies()` seam. `getPerformanceCoreFrequency()` / `getEfficiencyCoreFrequency()` keep their signatures and now read the supplier, so all three consumers (`queryProcessorId`, `queryMaxFreq`, `queryCurrentFreq`) get the real values in any order, from one IORegistry walk. `queryProcessorId()` no longer has a frequency side effect.

Three tests in `MacCentralProcessorTest` cover it against a new Apple Silicon stub (4 E + 4 P cores, distinct cluster frequencies): max frequency without first querying the identifier, per-cluster current frequencies, and one walk shared by all three consumers. Making the real frequency code paths reachable meant dropping the stub's `queryMaxFreq`/`queryCurrentFreq` overrides, which had returned 0.

## Verification

Verified on an M3 Pro (macOS 15, JNA and FFM): both call orders now report 4.056 GHz max and `[2.748 × 6, 4.056 × 6]` current, and `NativeComparisonTest.processorFrequencies` passes. Full gate green including `-Paggregate-coverage`, `forbiddenapis:check`, `javadoc:javadoc` and `-Perror-prone`.

Not verified: Intel Macs. That branch is untouched by this change — `isArmCpu` is false there and both methods still read `hw.cpufrequency*` sysctls.

## Not in scope

Apple M5 renumbered the pmgr voltage-state power domains, so the hardcoded index 1 is absent there and the efficiency frequency will fall back to the placeholder. Filed separately; it needs dynamic discovery via pmgr `acc-clusters`, which does not exist on M1–M4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Apple Silicon processor frequency reporting.
  * Maximum and current frequencies now reflect the actual performance and efficiency cluster frequencies.
  * Frequency results are accurate regardless of whether processor identification or frequency queries occur first.
  * Improved reporting for systems with different performance and efficiency core configurations.

* **Documentation**
  * Added release notes for version 7.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->