### PR TITLE
Fix two xrandr follow-ups from the getConnectionPort work

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHardwareAbstractionLayer.java
@@ -4,7 +4,6 @@
  */
 package oshi.hardware.common.platform.linux;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import oshi.annotation.concurrent.ThreadSafe;
@@ -51,14 +50,7 @@ public abstract class LinuxHardwareAbstractionLayer extends AbstractHardwareAbst
     @Override
     protected List<Display> createDisplays() {
         List<Triplet<String, Integer, byte[]>> drmData = DrmEdid.getDisplayData();
-        if (!drmData.isEmpty()) {
-            List<Display> displays = new ArrayList<>(drmData.size());
-            for (Triplet<String, Integer, byte[]> drm : drmData) {
-                displays.add(new UnixDisplay(drm.getC(), drm.getA(), drm.getB()));
-            }
-            return displays;
-        }
-        return UnixDisplay.getDisplays();
+        return drmData.isEmpty() ? UnixDisplay.getDisplays() : UnixDisplay.getDisplays(drmData);
     }
 
     @Override

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
@@ -4,10 +4,13 @@
  */
 package oshi.hardware.common.platform.unix;
 
+import static oshi.util.Memoizer.memoize;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.Display;
@@ -15,6 +18,7 @@ import oshi.hardware.common.AbstractDisplay;
 import oshi.util.Constants;
 import oshi.util.driver.unix.Xrandr;
 import oshi.util.tuples.Pair;
+import oshi.util.tuples.Triplet;
 
 /**
  * A Display
@@ -24,6 +28,7 @@ public final class UnixDisplay extends AbstractDisplay {
 
     private final String devicePort;
     private final int connectorId;
+    private final Supplier<Map<String, Pair<Integer, byte[]>>> xrandrData;
 
     /**
      * Constructor for UnixDisplay.
@@ -42,9 +47,23 @@ public final class UnixDisplay extends AbstractDisplay {
      * @param connectorId the DRM connector ID ({@code -1} if not available)
      */
     public UnixDisplay(byte[] edid, String devicePort, int connectorId) {
+        this(edid, devicePort, connectorId, memoize(Xrandr::getDisplayData));
+    }
+
+    /**
+     * Constructor for UnixDisplay sharing xrandr data with the rest of its batch.
+     *
+     * @param edid        a byte array representing a display EDID
+     * @param devicePort  the DRM connector name (e.g. {@code HDMI-A-1})
+     * @param connectorId the DRM connector ID ({@code -1} if not available)
+     * @param xrandrData  the display's source of xrandr data, expected to be memoized or already realized
+     */
+    private UnixDisplay(byte[] edid, String devicePort, int connectorId,
+            Supplier<Map<String, Pair<Integer, byte[]>>> xrandrData) {
         super(edid);
         this.devicePort = devicePort;
         this.connectorId = connectorId;
+        this.xrandrData = xrandrData;
     }
 
     @Override
@@ -54,7 +73,7 @@ public final class UnixDisplay extends AbstractDisplay {
 
     @Override
     public Optional<String> getOutputName() {
-        return Xrandr.findOutputName(this.connectorId, this.getDisplayInfo().getEdid());
+        return Xrandr.findOutputName(this.xrandrData.get(), this.connectorId, this.getDisplayInfo().getEdid());
     }
 
     /**
@@ -65,8 +84,43 @@ public final class UnixDisplay extends AbstractDisplay {
     public static List<Display> getDisplays() {
         Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData();
         List<Display> displays = new ArrayList<>(data.size());
+        // The data is already in hand, so these displays need no further xrandr query
+        Supplier<Map<String, Pair<Integer, byte[]>>> sharedData = () -> data;
         for (Map.Entry<String, Pair<Integer, byte[]>> entry : data.entrySet()) {
-            displays.add(new UnixDisplay(entry.getValue().getB(), entry.getKey(), entry.getValue().getA()));
+            displays.add(new UnixDisplay(entry.getValue().getB(), entry.getKey(), entry.getValue().getA(), sharedData));
+        }
+        return displays;
+    }
+
+    /**
+     * Gets Display objects from DRM sysfs data, sharing one {@code xrandr --verbose} invocation among them rather than
+     * running it once per display per call.
+     *
+     * @param drmData a list of {@link Triplet} of DRM connector name, DRM connector ID, and EDID byte array, as read
+     *                from DRM sysfs
+     * @return An array of Display objects representing monitors, etc.
+     */
+    public static List<Display> getDisplays(List<Triplet<String, Integer, byte[]>> drmData) {
+        return getDisplays(drmData, Xrandr::getDisplayData);
+    }
+
+    /**
+     * Builds a batch of displays sharing one query for the xrandr data behind {@link #getOutputName()}.
+     * <p>
+     * The query is memoized indefinitely, because a {@link Display} is an immutable snapshot: the output name matching
+     * its connector cannot change over the object's lifetime. The hardware abstraction layer re-queries displays on its
+     * own schedule, building a new batch with a new supplier, so a topology change is picked up there.
+     *
+     * @param drmData     the DRM sysfs data to build displays from
+     * @param xrandrQuery the query for xrandr display data, run at most once for the whole batch
+     * @return An array of Display objects representing monitors, etc.
+     */
+    static List<Display> getDisplays(List<Triplet<String, Integer, byte[]>> drmData,
+            Supplier<Map<String, Pair<Integer, byte[]>>> xrandrQuery) {
+        List<Display> displays = new ArrayList<>(drmData.size());
+        Supplier<Map<String, Pair<Integer, byte[]>>> sharedData = memoize(xrandrQuery);
+        for (Triplet<String, Integer, byte[]> drm : drmData) {
+            displays.add(new UnixDisplay(drm.getC(), drm.getA(), drm.getB(), sharedData));
         }
         return displays;
     }

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
@@ -25,7 +25,29 @@ public final class Xrandr {
 
     private static final String[] XRANDR_VERBOSE = { "xrandr", "--verbose" };
 
+    /**
+     * Property names an X server may publish the EDID under, each as it appears in {@code xrandr --verbose} output,
+     * including the trailing colon. {@code EDID} is the name in randrproto 1.3 and later; {@code RANDR_EDID} is the
+     * name it replaced; {@code EDID_DATA} is the driver-side atom X.Org Server used through 1.6.
+     */
+    private static final String[] EDID_PROPERTIES = { "EDID:", "RANDR_EDID:", "EDID_DATA:" };
+
     private Xrandr() {
+    }
+
+    /**
+     * Tests whether a property line names the EDID, under any of the property names an X server may use for it.
+     *
+     * @param trimmed a whitespace-trimmed line of {@code xrandr --verbose} output
+     * @return true if the line is the header of an EDID property block
+     */
+    private static boolean isEdidProperty(String trimmed) {
+        for (String property : EDID_PROPERTIES) {
+            if (property.equals(trimmed)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -102,7 +124,7 @@ public final class Xrandr {
             String trimmed = s.trim();
             if (trimmed.startsWith("CONNECTOR_ID:")) {
                 currentConnectorId = ParseUtil.parseLastInt(trimmed, -1);
-            } else if (trimmed.equals("EDID:")) {
+            } else if (isEdidProperty(trimmed)) {
                 sb = new StringBuilder();
             } else if (sb != null) {
                 sb.append(trimmed);

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
@@ -124,17 +124,18 @@ public final class Xrandr {
     }
 
     /**
-     * Finds the xrandr output name for a display identified by its DRM connector ID and/or EDID. This method runs
-     * {@code xrandr --verbose} on demand and matches the display by {@code CONNECTOR_ID} first (Linux 6.5+), falling
-     * back to EDID comparison.
+     * Finds the xrandr output name for a display identified by its DRM connector ID and/or EDID, matching by
+     * {@code CONNECTOR_ID} first (Linux 6.5+) and falling back to EDID comparison.
      *
+     * @param xrandrData  xrandr display data as returned by {@link #getDisplayData()}, which the caller is expected to
+     *                    share among the displays it is naming rather than querying per display
      * @param connectorId the DRM connector ID ({@code -1} if not available)
      * @param edid        the EDID byte array from DRM sysfs
      * @return an {@link Optional} containing the xrandr output name, or empty if no X server is available or no match
      *         is found
      */
-    public static Optional<String> findOutputName(int connectorId, byte[] edid) {
-        Map<String, Pair<Integer, byte[]>> xrandrData = getDisplayData();
+    public static Optional<String> findOutputName(Map<String, Pair<Integer, byte[]>> xrandrData, int connectorId,
+            byte[] edid) {
         if (xrandrData.isEmpty()) {
             return Optional.empty();
         }
@@ -147,7 +148,7 @@ public final class Xrandr {
             }
         }
         // Fallback: match by first 128 bytes of EDID
-        if (edid != null && edid.length >= 128) {
+        if (edid.length >= 128) {
             byte[] edid128 = Arrays.copyOf(edid, 128);
             for (Map.Entry<String, Pair<Integer, byte[]>> entry : xrandrData.entrySet()) {
                 byte[] xrandrEdid = entry.getValue().getB();

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/UnixDisplayTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/UnixDisplayTest.java
@@ -7,7 +7,20 @@ package oshi.hardware.common.platform.unix;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
 import org.junit.jupiter.api.Test;
+
+import oshi.hardware.Display;
+import oshi.util.tuples.Pair;
+import oshi.util.tuples.Triplet;
 
 /**
  * Tests for {@link UnixDisplay}.
@@ -22,5 +35,56 @@ class UnixDisplayTest {
     @Test
     void testDevicePortFromConnectorConstructor() {
         assertThat(new UnixDisplay(new byte[128], "HDMI-A-1", 96).getDevicePort(), is("HDMI-A-1"));
+    }
+
+    @Test
+    void testBatchSharesOneXrandrQuery() {
+        AtomicInteger queries = new AtomicInteger();
+        Supplier<Map<String, Pair<Integer, byte[]>>> countingQuery = () -> {
+            queries.incrementAndGet();
+            return xrandrData();
+        };
+
+        List<Display> displays = UnixDisplay.getDisplays(drmData(), countingQuery);
+        assertThat(displays.size(), is(2));
+
+        // Every display in the batch resolves its output name, twice over, from a single query
+        for (int pass = 0; pass < 2; pass++) {
+            assertThat(displays.get(0).getOutputName(), is(Optional.of("DP-2")));
+            assertThat(displays.get(1).getOutputName(), is(Optional.of("HDMI-1")));
+        }
+        assertThat(queries.get(), is(1));
+    }
+
+    @Test
+    void testBatchQueryIsNotRunUntilOutputNameIsRequested() {
+        AtomicInteger queries = new AtomicInteger();
+        UnixDisplay.getDisplays(drmData(), () -> {
+            queries.incrementAndGet();
+            return xrandrData();
+        });
+        assertThat(queries.get(), is(0));
+    }
+
+    // Two displays as DRM sysfs reports them: connector name, connector ID, EDID
+    private static List<Triplet<String, Integer, byte[]>> drmData() {
+        List<Triplet<String, Integer, byte[]>> drmData = new ArrayList<>();
+        drmData.add(new Triplet<>("DP-2", 96, edid((byte) 0x01)));
+        drmData.add(new Triplet<>("HDMI-1", 80, edid((byte) 0x02)));
+        return drmData;
+    }
+
+    // The same two displays as xrandr names them, matched to the DRM data by connector ID
+    private static Map<String, Pair<Integer, byte[]>> xrandrData() {
+        Map<String, Pair<Integer, byte[]>> data = new LinkedHashMap<>();
+        data.put("DP-2", new Pair<>(96, edid((byte) 0x01)));
+        data.put("HDMI-1", new Pair<>(80, edid((byte) 0x02)));
+        return data;
+    }
+
+    private static byte[] edid(byte marker) {
+        byte[] edid = new byte[128];
+        Arrays.fill(edid, marker);
+        return edid;
     }
 }

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
@@ -13,9 +13,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -219,6 +221,43 @@ class XrandrTest {
         List<byte[]> edids = Xrandr.getEdidArrays(createXrandrWithConnectorId());
         assertThat(edids, hasSize(1));
         assertThat(edids.get(0).length, is(128));
+    }
+
+    @Test
+    void testFindOutputNameByConnectorId() {
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        // A connector ID match wins even though the EDID passed here belongs to no display
+        assertThat(Xrandr.findOutputName(data, 96, new byte[0]), is(Optional.of("DP2")));
+    }
+
+    @Test
+    void testFindOutputNameByEdid() {
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        Pair<Integer, byte[]> hdmi1 = data.get("HDMI1");
+        assertNotNull(hdmi1);
+        // HDMI1 has no connector ID in xrandr, so only the EDID can identify it
+        assertThat(Xrandr.findOutputName(data, -1, hdmi1.getB()), is(Optional.of("HDMI1")));
+    }
+
+    @Test
+    void testFindOutputNameFallsBackToEdidWhenConnectorIdIsUnmatched() {
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        Pair<Integer, byte[]> dp2 = data.get("DP2");
+        assertNotNull(dp2);
+        assertThat(Xrandr.findOutputName(data, 1234, dp2.getB()), is(Optional.of("DP2")));
+    }
+
+    @Test
+    void testFindOutputNameNoMatch() {
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        byte[] unknownEdid = new byte[128];
+        Arrays.fill(unknownEdid, (byte) 0x5A);
+        assertThat(Xrandr.findOutputName(data, 1234, unknownEdid).isPresent(), is(false));
+    }
+
+    @Test
+    void testFindOutputNameEmptyData() {
+        assertThat(Xrandr.findOutputName(Collections.emptyMap(), 96, new byte[128]).isPresent(), is(false));
     }
 
     @Nested

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
@@ -223,6 +223,40 @@ class XrandrTest {
         assertThat(edids.get(0).length, is(128));
     }
 
+    // Fixture: xrandr --verbose output using a legacy EDID property name
+    private static List<String> createXrandrWithEdidProperty(String property) {
+        List<String> lines = new ArrayList<>(createXrandrWithEdid());
+        lines.set(2, "\t" + property);
+        return lines;
+    }
+
+    @Test
+    void testGetDisplayDataLegacyEdidDataProperty() {
+        // X.Org Server through 1.6 published the driver-side atom EDID_DATA
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrWithEdidProperty("EDID_DATA:"));
+        assertThat(data.size(), is(1));
+        Pair<Integer, byte[]> pair = data.get("HDMI-1");
+        assertNotNull(pair);
+        assertThat(pair.getB().length, is(128));
+    }
+
+    @Test
+    void testGetDisplayDataLegacyRandrEdidProperty() {
+        // randrproto before 1.3 named the conventional property RANDR_EDID
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrWithEdidProperty("RANDR_EDID:"));
+        assertThat(data.size(), is(1));
+        Pair<Integer, byte[]> pair = data.get("HDMI-1");
+        assertNotNull(pair);
+        assertThat(pair.getB().length, is(128));
+    }
+
+    @Test
+    void testGetDisplayDataIgnoresOtherEdidNamedProperties() {
+        // A property whose name merely contains EDID must not start an EDID block
+        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrWithEdidProperty("EDID_HASH:"));
+        assertThat(data.isEmpty(), is(true));
+    }
+
     @Test
     void testFindOutputNameByConnectorId() {
         Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());


### PR DESCRIPTION
Two follow-ups deliberately deferred from #3660, both in `oshi-common` and both affecting the Linux/Unix display path only. No `CHANGELOG.md` entry: both defects live in code #3660 introduced, which is unreleased.

### 1. Share one xrandr query among a batch of displays

`UnixDisplay.getOutputName()` called `Xrandr.findOutputName()`, which ran `xrandr --verbose` itself, unmemoized. Naming the outputs of an *n*-display system therefore forked *n* processes and reparsed the whole output *n* times — and did it again on every subsequent call.

`findOutputName()` now takes the parsed data instead of fetching it, which also makes it a pure function, and `UnixDisplay` holds the supplier it reads from. `getDisplays(List<Triplet<…>>)` builds a batch around one memoized query, so a batch costs at most one invocation however many displays it holds and however often they are asked; the `xrandr` fallback `getDisplays()` hands its displays the map it already realized, so they query nothing further.

The memoization is indefinite rather than expiring, because a `Display` is an immutable snapshot — the output name matching its connector cannot change over the object's lifetime — and `AbstractHardwareAbstractionLayer` already re-queries the display list at `slowExpiration()`, rebuilding the batch with a fresh supplier. A topology change is still picked up at the same cadence as before.

This also drops a null check on the `edid` parameter that is dead under the package's `@NullMarked` contract, and adds unit tests for the connector-ID/EDID matching logic, which previously could not be reached from a test without a live X server.

### 2. Accept the legacy EDID property names an older X server publishes

#3660 tightened EDID block detection from a `startsWith("EDID")` prefix test to an exact match on `EDID:`, so that a property merely *containing* `EDID` — `EDID_HASH:` on some drivers — could no longer be mistaken for the EDID itself. That was the right fix for the false positive, but it also dropped the two names an older X server publishes the EDID under:

* **`RANDR_EDID`** (`RR_PROPERTY_RANDR_EDID`) — the conventional property name randrproto used before 1.3 renamed it to `EDID`.
* **`EDID_DATA`** — the driver-side atom (`EDID_ATOM_NAME` in `hw/xfree86/modes/xf86Crtc.c`) that X.Org Server set through 1.6.

Both are still what `xrandr --verbose` prints on those servers, and OSHI matched them by prefix before #3660, so a display on one now reports no EDID at all. This matches the three names exactly, keeping the false positive out, and pins all four cases with tests.

### Verification

Full gate green locally on macOS (`spotless`, `sortpom`, `checkstyle`, `install`, `forbiddenapis`, `javadoc`, `-Paggregate-coverage`; 1801 tests, 0 failures), plus `-Perror-prone` with no NullAway findings. Linux CI green on all eight jobs on the fork ([run](https://github.com/dbwiddis/oshi/actions/runs/32513880058)). The batch-sharing test was negative-tested — dropping the `memoize` makes it fail with 4 queries instead of 1.

I have no X server running against a pre-1.7 X.Org Server, so the two legacy property names are verified against fixture data and the upstream source history rather than a live server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux display detection and output-name matching.
  * Added support for additional EDID property formats used by display systems.
  * Improved handling of display data when resolving outputs.

* **Performance**
  * Reduced repeated display-system queries by sharing cached data across display batches.

* **Tests**
  * Added coverage for lazy display data retrieval, EDID matching, connector lookup, and unsupported property formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->