### PR TITLE
Compile test sources at Java 17

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,10 +185,33 @@ confirm it runs, and delete it.
 
 ## Hard rules that CI enforces
 
-**Language level.** `oshi-common` and `oshi-core` compile with `release 8`. No `var`, no `List.of`,
-no records, no switch expressions, no text blocks, no `Stream.toList()`. Only `oshi-core-ffm`
-(25), `oshi-metrics` (17), and `oshi-benchmark` (25) get modern Java. Agents get this wrong
-constantly.
+**Language level.** `oshi-common` and `oshi-core` compile **main** sources with `release 8`. No
+`var`, no `List.of`, no records, no switch expressions, no text blocks, no `Stream.toList()`. Only
+`oshi-core-ffm` (25), `oshi-metrics` (17), and `oshi-benchmark` (25) get modern Java in main
+sources. Agents get this wrong constantly.
+
+**Their `src/test` compiles at `release 17`**, set by `maven.compiler.testRelease` in the root
+`pom.xml`. Test classes are never published, so the Java 8 guarantee to consumers does not reach
+them. Use text blocks for captured command or file output, `Files.writeString` over
+`Files.write(path, s.getBytes(UTF_8))`, and `Stream.toList()`; `var` is fine and is already the
+house style in `oshi-core-ffm`. Two cautions:
+
+- **NullAway runs at WARN on test sources, not ERROR.** Compiling tests at 17 put them on the module
+  path, which brought `module-info.java`'s `@NullMarked` into scope for test packages for the first
+  time and surfaced 178 pre-existing findings across 41 files. Do not add to them: new test code
+  should be NullAway-clean, and the severity goes back to ERROR once the backlog is drained.
+- **17 is a ceiling.** It is exactly the lowest JDK running tests in CI — AppVeyor Windows and
+  Solaris SPARC, both with no headroom. Do not raise it without moving those first.
+- **Do not sweep `Arrays.asList` to `List.of`.** `List.of` rejects nulls and is immutable, and
+  fixtures here model real-world output where a null is sometimes deliberate. Prefer `List.of` in
+  new code; leave working call sites alone.
+
+Text blocks strip incidental leading and trailing whitespace, and spotless applies
+`trimTrailingWhitespace` to Java sources, so a fixture whose real output carries trailing spaces or
+tab alignment needs explicit `\s` or `\t` escapes. Converting a fixture is a judgment call, never a
+find-and-replace — and not every fixture wants one. `FileUtilTest.testReadProcIo` deliberately keeps
+generating its file body from the map it asserts against, because a text block there would duplicate
+the data.
 
 **Banned APIs** (`config/forbidden-apis.txt` and friends, enforced by `forbiddenapis:check`):
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGpuStatsTest.java
@@ -110,14 +110,11 @@ class WindowsGpuStatsTest {
 
         @Override
         public @Nullable Object getValue(LhmSensorProperty property, int index) {
-            switch (property) {
-                case NAME:
-                    return names.get(index);
-                case VALUE:
-                    return values.get(index);
-                default:
-                    return null;
-            }
+            return switch (property) {
+                case NAME -> names.get(index);
+                case VALUE -> values.get(index);
+                default -> null;
+            };
         }
 
         @Override

--- a/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/EdidUtilTest.java
@@ -74,28 +74,30 @@ class EdidUtilTest {
             String timing = EdidUtil.getTimingDescriptor(descs[i]);
             String range = EdidUtil.getDescriptorRangeLimits(descs[i]);
             switch (i) {
-                case 0:
+                case 0 -> {
                     assertThat("desc 0 type", type, is(0x565E00A0));
                     assertThat("desc 0 timing", timing, is("Clock 241MHz, Active Pixels 2560x1440 "));
                     assertThat("desc 0 range", range,
                             is("Field Rate -96-41 Hz vertical, 80-48 Hz horizontal, Max clock: 320 MHz"));
-                    break;
-                case 1:
+                }
+                case 1 -> {
                     assertThat("desc 1 type", type, is(0x1A1D0080));
                     assertThat("desc 1 timing", timing, is("Clock 74MHz, Active Pixels 1280x720 "));
                     assertThat("desc 1 range", range,
                             is("Field Rate -48-28 Hz vertical, 32-64 Hz horizontal, Max clock: -1280 MHz"));
-                    break;
-                case 2:
+                }
+                case 2 -> {
                     assertThat("desc 2 type", type, is(0xFF));
                     assertThat("desc 2 descriptorText", EdidUtil.getDescriptorText(descs[i]), is("C02JM2PFF2GC"));
                     assertThat("desc 2 descriptorHex", ParseUtil.byteArrayToHexString(descs[i]), is(EDID_DESC3));
-                    break;
-                case 3:
+                }
+                case 3 -> {
                     assertThat("desc 3 type", type, is(0xFC));
                     assertThat("desc 3 descriptorText", EdidUtil.getDescriptorText(descs[i]), is("Thunderbolt"));
-                    break;
-                default:
+                }
+                default -> {
+                    // no further descriptors
+                }
             }
         }
     }

--- a/oshi-common/src/test/java/oshi/util/FileUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/FileUtilTest.java
@@ -14,13 +14,11 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -30,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,27 +41,23 @@ class FileUtilTest {
      * Test read file.
      */
     @Test
-    void testReadFile() {
-        // Write to a temp file
-        Path multilineFile = assertDoesNotThrow(() -> {
-            Path file = Files.createTempFile("oshitest.multiline", null);
-            String s = "Line 1\nLine 2\nThe third line\nLine 4\nLine 5\n";
-            Files.write(file, s.getBytes(StandardCharsets.UTF_8));
-            return file;
-        }, "IO Exception creating or writing to temporary multiline file.");
+    void testReadFile(@TempDir Path tempDir) throws IOException {
+        Path multilineFile = tempDir.resolve("multiline");
+        Files.writeString(multilineFile, """
+                Line 1
+                Line 2
+                The third line
+                Line 4
+                Line 5
+                """);
 
-        // Try the new temp file
         List<String> tempFileStrings = FileUtil.readFile(multilineFile.toString());
         assertThat("Temp file line one mismatch", tempFileStrings.get(0), is("Line 1"));
-        List<String> matchingLines = tempFileStrings.stream().filter(s -> s.startsWith("Line "))
-                .collect(Collectors.toList());
+        List<String> matchingLines = tempFileStrings.stream().filter(s -> s.startsWith("Line ")).toList();
         assertThat("Matching lines mismatch", matchingLines.size(), is(4));
 
-        // Delete the temp file
-        assertDoesNotThrow(() -> Files.deleteIfExists(multilineFile),
-                "IO Exception deleting temporary multiline file.");
-
-        // Try file not found on deleted file
+        // Deleting is the assertion here, not cleanup: readFile must return empty for a file that is not there
+        Files.deleteIfExists(multilineFile);
         assertThat("Deleted file should return empty", FileUtil.readFile(multilineFile.toString()), is(empty()));
     }
 
@@ -72,36 +65,24 @@ class FileUtilTest {
      * Test get*FromFile
      */
     @Test
-    void testGetFromFile() {
-        // Write to temp file
-        Path integerFile = assertDoesNotThrow(() -> {
-            Path file = Files.createTempFile("oshitest.int", null);
-            Files.write(file, "123\n".getBytes(StandardCharsets.UTF_8));
-            return file;
-        }, "IO Exception creating or writing to temporary integer file.");
+    void testGetFromFile(@TempDir Path tempDir) throws IOException {
+        Path integerFile = tempDir.resolve("int");
+        Files.writeString(integerFile, "123\n");
         assertThat("unsigned long from int", FileUtil.getUnsignedLongFromFile(integerFile.toString()), is(123L));
         assertThat("long from int", FileUtil.getLongFromFile(integerFile.toString()), is(123L));
         assertThat("int from int", FileUtil.getIntFromFile(integerFile.toString()), is(123));
         assertThat("string from int", FileUtil.getStringFromFile(integerFile.toString()), is("123"));
 
-        // Delete the temp file
-        assertDoesNotThrow(() -> Files.deleteIfExists(integerFile), "IO Exception deleting temporary integer file.");
-
-        // Write to temp file
-        Path stringFile = assertDoesNotThrow(() -> {
-            Path file = Files.createTempFile("oshitest.str", null);
-            Files.write(file, "foo bar\n".getBytes(StandardCharsets.UTF_8));
-            return file;
-        }, "IO Exception creating or writing to temporary string file.");
+        Path stringFile = tempDir.resolve("str");
+        Files.writeString(stringFile, "foo bar\n");
 
         assertThat("unsigned long from string", FileUtil.getUnsignedLongFromFile(stringFile.toString()), is(0L));
         assertThat("long from string", FileUtil.getLongFromFile(stringFile.toString()), is(0L));
         assertThat("int from string", FileUtil.getIntFromFile(stringFile.toString()), is(0));
         assertThat("string from string", FileUtil.getStringFromFile(stringFile.toString()), is("foo bar"));
-        // Delete the temp file
-        assertDoesNotThrow(() -> Files.deleteIfExists(stringFile), "IO Exception deleting temporary string file.");
 
-        // Try file not found on deleted file
+        // Deleting is the assertion here, not cleanup: every getter must fall back for a file that is not there
+        Files.deleteIfExists(stringFile);
         assertThat("unsigned long from invalid", FileUtil.getUnsignedLongFromFile(stringFile.toString()), is(0L));
         assertThat("long from invalid", FileUtil.getLongFromFile(stringFile.toString()), is(0L));
         assertThat("int from invalid", FileUtil.getIntFromFile(stringFile.toString()), is(0));
@@ -114,19 +95,19 @@ class FileUtilTest {
     @Test
     void testGetFromFileWithDefault(@TempDir Path tempDir) throws IOException {
         Path integerFile = tempDir.resolve("int");
-        Files.write(integerFile, "123\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(integerFile, "123\n");
         assertThat("long from int", FileUtil.getLongFromFile(integerFile.toString(), -1L), is(123L));
         assertThat("int from int", FileUtil.getIntFromFile(integerFile.toString(), -1), is(123));
 
         Path zeroFile = tempDir.resolve("zero");
-        Files.write(zeroFile, "0\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(zeroFile, "0\n");
         // A file holding a genuine zero must not be confused with an absent one, which is the whole point of the
         // overload: the no-argument form returns 0 for both.
         assertThat("long from zero", FileUtil.getLongFromFile(zeroFile.toString(), -1L), is(0L));
         assertThat("int from zero", FileUtil.getIntFromFile(zeroFile.toString(), -1), is(0));
 
         Path stringFile = tempDir.resolve("str");
-        Files.write(stringFile, "foo bar\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(stringFile, "foo bar\n");
         assertThat("long from string", FileUtil.getLongFromFile(stringFile.toString(), -1L), is(-1L));
         assertThat("int from string", FileUtil.getIntFromFile(stringFile.toString(), -1), is(-1));
 
@@ -136,7 +117,7 @@ class FileUtilTest {
     }
 
     @Test
-    void testReadProcIo() {
+    void testReadProcIo(@TempDir Path tempDir) throws IOException {
         Map<String, String> expected = new LinkedHashMap<>();
         expected.put("rchar", "124788352");
         expected.put("wchar", "124802481");
@@ -145,15 +126,12 @@ class FileUtilTest {
         expected.put("read_bytes", "40304640");
         expected.put("write_bytes", "124780544");
         expected.put("cancelled_write_bytes", "42");
-        // Write this to a temp file
-        Path procIoFile = assertDoesNotThrow(() -> {
-            Path file = Files.createTempFile("oshitest.procio", null);
-            for (Entry<String, String> e : expected.entrySet()) {
-                String s = e.getKey() + ": " + e.getValue() + "\n";
-                Files.write(file, s.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
-            }
-            return file;
-        }, "IO Exception creating or writing to temporary procIo file.");
+        // Deliberately NOT a text block: the file body is derived from the map asserted against below, so a
+        // literal would duplicate the data. Not every fixture wants the new syntax.
+        Path procIoFile = Files.createFile(tempDir.resolve("procio"));
+        for (Entry<String, String> e : expected.entrySet()) {
+            Files.writeString(procIoFile, e.getKey() + ": " + e.getValue() + "\n", StandardOpenOption.APPEND);
+        }
         // Read into map
         Map<String, String> actual = FileUtil.getKeyValueMapFromFile(procIoFile.toString(), ":");
         assertThat("procio size", actual, is(aMapWithSize(expected.size())));
@@ -161,10 +139,8 @@ class FileUtilTest {
             assertThat("procio entry", actual, hasEntry(entry.getKey(), entry.getValue()));
         }
 
-        // Cleanup
-        assertDoesNotThrow(() -> Files.deleteIfExists(procIoFile), "IO Exception deleting temporary procIo file.");
-
-        // Test deleted file
+        // Deleting is the assertion here, not cleanup
+        Files.deleteIfExists(procIoFile);
         actual = FileUtil.getKeyValueMapFromFile(procIoFile.toString(), ":");
         assertThat("procio size", actual, anEmptyMap());
     }
@@ -178,15 +154,14 @@ class FileUtilTest {
     }
 
     @Test
-    void testReadBytesFromURL() throws IOException {
-        // Create temporary files
-        Path file1 = Files.createTempFile("oshitest.file1", null);
-        Path file2 = Files.createTempFile("oshitest.file2", null);
-        Path file3 = Files.createTempFile("oshitest.file3", null);
+    void testReadBytesFromURL(@TempDir Path tempDir) throws IOException {
+        Path file1 = tempDir.resolve("file1");
+        Path file2 = tempDir.resolve("file2");
+        Path file3 = tempDir.resolve("file3");
 
-        Files.write(file1, "Same".getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
-        Files.write(file2, "Same".getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
-        Files.write(file3, "Different".getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+        Files.writeString(file1, "Same");
+        Files.writeString(file2, "Same");
+        Files.writeString(file3, "Different");
 
         byte[] bytes1 = FileUtil.readFileAsBytes(file1.toUri().toURL());
         byte[] bytes2 = FileUtil.readFileAsBytes(file2.toUri().toURL());
@@ -197,7 +172,7 @@ class FileUtilTest {
     }
 
     @Test
-    void testReadBinaryFile() {
+    void testReadBinaryFile(@TempDir Path tempDir) throws IOException {
         ByteBuffer buff = ByteBuffer.allocate(18);
         buff.order(ByteOrder.nativeOrder());
         buff.putLong(123L);
@@ -207,13 +182,9 @@ class FileUtilTest {
         byte[] arr = new byte[] { 1, 2, 3 };
         buff.put(arr);
 
-        // Write to temp file (snapshot the backing array since buff is reassigned below)
-        byte[] binaryData = buff.array();
-        Path binaryFile = assertDoesNotThrow(() -> {
-            Path file = Files.createTempFile("oshitest.binary", null);
-            Files.write(file, binaryData);
-            return file;
-        }, "IO Exception creating or writing to temporary binary file.");
+        // Snapshot the backing array since buff is reassigned below
+        Path binaryFile = tempDir.resolve("binary");
+        Files.write(binaryFile, buff.array());
 
         // Read from file
         buff = FileUtil.readAllBytesAsBuffer(binaryFile.toString());
@@ -234,9 +205,6 @@ class FileUtilTest {
         array = new byte[3];
         FileUtil.readByteArrayFromBuffer(buff, array);
         assertArrayEquals(arr0, array, "Byte array from buffer at limit should be all 0s");
-
-        // Cleanup
-        assertDoesNotThrow(() -> Files.deleteIfExists(binaryFile), "IO Exception deleting temporary binary file.");
     }
 
     @Test
@@ -248,7 +216,13 @@ class FileUtilTest {
     @Test
     void testReadLinesFromFile(@TempDir Path tempDir) throws IOException {
         Path file = tempDir.resolve("lines.txt");
-        Files.write(file, "line1\nline2\nline3\nline4\nline5\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(file, """
+                line1
+                line2
+                line3
+                line4
+                line5
+                """);
 
         List<String> lines = FileUtil.readLines(file.toString(), 3);
         assertThat("should read 3 lines", lines, hasSize(3));

--- a/oshi-common/src/test/java/oshi/util/GlobalConfigTest.java
+++ b/oshi-common/src/test/java/oshi/util/GlobalConfigTest.java
@@ -206,16 +206,16 @@ class GlobalConfigTest {
                 // No default supplied: exercise the single-argument overload, which is the only one that can
                 // report an absent property as null
                 assertThat(message, get(property), is(expected));
-            } else if (def instanceof String) {
-                assertThat(message, get(property, (String) def), is(expected));
-            } else if (def instanceof Boolean) {
-                assertThat(message, get(property, (boolean) def), is(expected));
-            } else if (def instanceof Integer) {
-                assertThat(message, get(property, (Integer) def), is(expected));
-            } else if (def instanceof Double) {
+            } else if (def instanceof String s) {
+                assertThat(message, get(property, s), is(expected));
+            } else if (def instanceof Boolean b) {
+                assertThat(message, get(property, (boolean) b), is(expected));
+            } else if (def instanceof Integer i) {
+                assertThat(message, get(property, i), is(expected));
+            } else if (def instanceof Double d) {
                 Double expectedDouble = (Double) expected;
                 assertNotNull(expectedDouble, message);
-                assertThat(message, get(property, (Double) def), is(closeTo(expectedDouble, EPSILON)));
+                assertThat(message, get(property, d), is(closeTo(expectedDouble, EPSILON)));
             }
             return this;
         }

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
@@ -294,18 +294,13 @@ class SmcKeyIndexTest {
     private static final double FLOOR = 15d;
 
     private static double read(String key) {
-        switch (key) {
-            case "Tg0W":
-                return 6.7d; // idle-gated sentinel
-            case "Tg0X":
-                return 40.7d;
-            case "Tg0f":
-                return 63.4d;
-            case "Tg1h":
-                return -4.0d; // negative sentinel, seen on M4 Max
-            default:
-                return 0d;
-        }
+        return switch (key) {
+            case "Tg0W" -> 6.7d; // idle-gated sentinel
+            case "Tg0X" -> 40.7d;
+            case "Tg0f" -> 63.4d;
+            case "Tg1h" -> -4.0d; // negative sentinel, seen on M4 Max
+            default -> 0d;
+        };
     }
 
     @Test

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/CentralProcessorTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/CentralProcessorTest.java
@@ -151,7 +151,7 @@ class CentralProcessorTest {
             assertThat("Logical processor number is negative", p.getLogicalProcessors().get(lp).getProcessorNumber(),
                     is(greaterThanOrEqualTo(0)));
             switch (PlatformEnum.getCurrentPlatform()) {
-                case WINDOWS:
+                case WINDOWS -> {
                     if (p.getLogicalProcessorCount() < 64) {
                         assertThat(
                                 "Processor group should be 0 for Windows systems with less than 64 logical processors",
@@ -159,36 +159,34 @@ class CentralProcessorTest {
                     }
                     assertThat("NUMA node number is negative", p.getLogicalProcessors().get(lp).getNumaNode(),
                             is(greaterThanOrEqualTo(0)));
-                    break;
-                case LINUX:
+                }
+                case LINUX -> {
                     assertThat("Processor group should be 0 for Linux systems",
                             p.getLogicalProcessors().get(lp).getProcessorGroup(), is(0));
                     assertThat("NUMA node number is negative", p.getLogicalProcessors().get(lp).getNumaNode(),
                             is(greaterThanOrEqualTo(0)));
-                    break;
-                case MACOS:
+                }
+                case MACOS -> {
                     assertThat("Processor group should be 0 for macOS systems",
                             p.getLogicalProcessors().get(lp).getProcessorGroup(), is(0));
                     assertThat("NUMA Node should be 0 for macOS systems",
                             p.getLogicalProcessors().get(lp).getNumaNode(), is(0));
-                    break;
-                case SOLARIS:
+                }
+                case SOLARIS -> {
                     assertThat("Processor group should be 0 for Solaris systems",
                             p.getLogicalProcessors().get(lp).getProcessorGroup(), is(0));
                     assertThat("NUMA node number is negative", p.getLogicalProcessors().get(lp).getNumaNode(),
                             is(greaterThanOrEqualTo(0)));
-                    break;
-                case FREEBSD:
-                case DRAGONFLYBSD:
-                case NETBSD:
-                case AIX:
+                }
+                case FREEBSD, DRAGONFLYBSD, NETBSD, AIX -> {
                     assertThat("Processor group should be 0 for FreeBSD or AIX systems",
                             p.getLogicalProcessors().get(lp).getProcessorGroup(), is(0));
                     assertThat("NUMA Node should be 0 for FreeBSD or AIX systems",
                             p.getLogicalProcessors().get(lp).getNumaNode(), is(0));
-                    break;
-                default:
-                    break;
+                }
+                default -> {
+                    // Remaining platforms make no processor group or NUMA node guarantee
+                }
             }
         }
     }

--- a/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
@@ -448,14 +448,11 @@ class OperatingSystemTest {
             for (OSService svc : services) {
                 assertThat(svc.getName(), is(not(emptyString())));
                 switch (svc.getState()) {
-                    case STOPPED:
-                        stopped++;
-                        break;
-                    case RUNNING:
-                        running++;
-                        break;
-                    default:
-                        break;
+                    case STOPPED -> stopped++;
+                    case RUNNING -> running++;
+                    default -> {
+                        // OTHER is neither counted nor asserted on
+                    }
                 }
             }
             // Should be at least one of each

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,13 @@
         <!-- Build Settings -->
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
         <maven.compiler.release>8</maven.compiler.release>
-        <maven.compiler.testRelease>8</maven.compiler.testRelease>
+        <!-- Test sources compile at a higher level than main sources: they are never published, so the Java 8
+        guarantee oshi-core makes to consumers does not apply to them. 17 is a ceiling, not a preference - it is
+        exactly the lowest JDK that runs tests anywhere in CI, in two places with no headroom: AppVeyor Windows
+        (appveyor.yml, pinned to jdk17) and Solaris SPARC on the GCC compile farm (.github/workflows/cfarm.yaml,
+        whose JDK comes from the remote host's profile and is not set in this repository). Raising this above 17
+        means moving both of those first. Modules needing a different level set their own testRelease. -->
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
         <!-- Release level for the FFM-based modules (oshi-core-ffm, oshi-benchmark). Defaults to the 25 baseline
         OSHI ships. Overridable on the command line (e.g. -Doshi.ffm.release=23) so the Coverity scan can compile the
         FFM code on an older JDK toolchain: cov-build 2024.12.1 cannot capture JDK 25 bytecode. OSHI's FFM code needs
@@ -1230,6 +1236,13 @@
             "-Xep:Check:OFF"-style flags; it's also JMH-only and never carries JSpecify
             annotations, so it isn't worth the extra plumbing to fix. -->
             <id>error-prone</id>
+            <properties>
+                <!-- The Error Prone plugin argument, split so main and test compilation can differ in exactly one
+                place: NullAway's severity. Everything else is identical, and the two <arg> elements below must stay
+                that way. Each must remain a single token; javac takes one -Xplugin value. -->
+                <errorprone.checks>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF -Xep:MissingSummary:OFF -Xep:StringSplitter:ERROR -Xep:EnumOrdinal:ERROR -Xep:OperatorPrecedence:ERROR -Xep:MixedMutabilityReturnType:ERROR -Xep:ReferenceEquality:ERROR -Xep:BoxingComparator:ERROR -Xep:NarrowCalculation:ERROR -Xep:LongDoubleConversion:ERROR -Xep:IntLiteralCast:ERROR -Xep:UnnecessaryLongToIntConversion:ERROR -Xep:IntLongMath:ERROR -Xep:BadImport:ERROR -Xep:ModifyCollectionInEnhancedForLoop:ERROR -Xep:EqualsGetClass:ERROR -Xep:DuplicateBranches:ERROR -Xep:InconsistentCapitalization:ERROR -Xep:NonApiType:ERROR -Xep:InvalidParam:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:UnnecessaryLambda:ERROR -Xep:UnnecessaryParentheses:ERROR -Xep:AssignmentExpression:ERROR -Xep:UnusedVariable:ERROR -Xep:PatternMatchingInstanceof:ERROR -Xep:EscapedEntity:ERROR -Xep:NotJavadoc:ERROR -Xep:AlmostJavadoc:ERROR -Xep:InvalidInlineTag:ERROR -Xep:InlineFormatString:ERROR -Xep:Slf4jLoggerShouldBeNonStatic:OFF -Xep:Slf4jSignOnlyFormat:OFF -Xep:Slf4jDoNotLogMessageOfExceptionExplicitly:ERROR -Xep:Slf4jPlaceholderMismatch:ERROR -Xep:Slf4jFormatShouldBeConst:ERROR -Xep:Slf4jLoggerShouldBePrivate:ERROR -Xep:Slf4jLoggerShouldBeFinal:ERROR -Xep:Slf4jIllegalPassedClass:ERROR</errorprone.checks>
+                <errorprone.nullaway.opts>-XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:HandleTestAssertionLibraries=true</errorprone.nullaway.opts>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -1277,7 +1290,7 @@
                                 74-site backlog was drained; every log call now passes the throwable rather than
                                 its message, so it is back at the plugin's default ERROR. Note the severity token
                                 Error Prone accepts is WARN, not WARNING. -->
-                                <arg>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF -Xep:MissingSummary:OFF -Xep:StringSplitter:ERROR -Xep:EnumOrdinal:ERROR -Xep:OperatorPrecedence:ERROR -Xep:MixedMutabilityReturnType:ERROR -Xep:ReferenceEquality:ERROR -Xep:BoxingComparator:ERROR -Xep:NarrowCalculation:ERROR -Xep:LongDoubleConversion:ERROR -Xep:IntLiteralCast:ERROR -Xep:UnnecessaryLongToIntConversion:ERROR -Xep:IntLongMath:ERROR -Xep:BadImport:ERROR -Xep:ModifyCollectionInEnhancedForLoop:ERROR -Xep:EqualsGetClass:ERROR -Xep:DuplicateBranches:ERROR -Xep:InconsistentCapitalization:ERROR -Xep:NonApiType:ERROR -Xep:InvalidParam:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:UnnecessaryLambda:ERROR -Xep:UnnecessaryParentheses:ERROR -Xep:AssignmentExpression:ERROR -Xep:UnusedVariable:ERROR -Xep:PatternMatchingInstanceof:ERROR -Xep:EscapedEntity:ERROR -Xep:NotJavadoc:ERROR -Xep:AlmostJavadoc:ERROR -Xep:InvalidInlineTag:ERROR -Xep:InlineFormatString:ERROR -Xep:Slf4jLoggerShouldBeNonStatic:OFF -Xep:Slf4jSignOnlyFormat:OFF -Xep:Slf4jDoNotLogMessageOfExceptionExplicitly:ERROR -Xep:Slf4jPlaceholderMismatch:ERROR -Xep:Slf4jFormatShouldBeConst:ERROR -Xep:Slf4jLoggerShouldBePrivate:ERROR -Xep:Slf4jLoggerShouldBeFinal:ERROR -Xep:Slf4jIllegalPassedClass:ERROR -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:HandleTestAssertionLibraries=true</arg>
+                                <arg>${errorprone.checks} -Xep:NullAway:ERROR ${errorprone.nullaway.opts}</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>
@@ -1297,6 +1310,31 @@
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>
+                        <executions>
+                            <!-- Test sources run NullAway at WARN, not ERROR. Raising maven.compiler.testRelease to
+                            17 moved test compilation from the classpath onto the module path, which brought
+                            module-info.java's @NullMarked into scope for test packages for the first time and
+                            surfaced 178 findings across 41 files that had never been checked. They are real, and
+                            mostly mechanical (assertNotNull for a dereference, a @Nullable type argument for a
+                            generic mismatch), but a drain job of their own rather than a build-config change. WARN
+                            keeps them visible while the backlog is worked; raise this to ERROR once it reaches
+                            zero. Every other check stays at its configured severity here - only NullAway moves. -->
+                            <execution>
+                                <id>default-testCompile</id>
+                                <configuration>
+                                    <compilerArgs>
+                                        <arg>-Xlint:-options</arg>
+                                        <arg>-Xmaxwarns</arg>
+                                        <arg>100000</arg>
+                                        <arg>-Xmaxerrs</arg>
+                                        <arg>100000</arg>
+                                        <arg>-XDcompilePolicy=simple</arg>
+                                        <arg>--should-stop=ifError=FLOW</arg>
+                                        <arg>${errorprone.checks} -Xep:NullAway:WARN ${errorprone.nullaway.opts}</arg>
+                                    </compilerArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Raises `maven.compiler.testRelease` from 8 to 17. Main sources stay at release 8 and `module-info` at release 9 — verified by class file version (52 / 53 / 61), so the published jars are byte-for-byte unaffected and the Java 8 guarantee in FAQ.md is untouched.

## Why

Test fixtures here are captured OS output — `prtvtoc` dumps, `netstat` tables, `dmidecode` blocks — written as `Arrays.asList("line", "line", ...)`. Spotless reflows those lists at `lineSplit=120`, so **source lines stop corresponding to fixture lines**: you cannot read a fixture against the real command output it copies, and adding one line reflows the whole block and pollutes the diff. Text blocks are exempt from that reflow. That is the motivation — fidelity of data whose whole job is to be a faithful copy, not cosmetics.

There are 188 such multi-line fixtures across 82 of the 199 `oshi-common` test files, plus 77 `Files.write(p, s.getBytes(UTF_8))` sites that become `Files.writeString`.

## Why 17 specifically

17 is a **ceiling, not a preference**. It is exactly the lowest JDK running tests anywhere in CI, reached in two places with no headroom:

- AppVeyor Windows — `appveyor.yml`, pinned to `C:\Program Files\Java\jdk17`
- Solaris SPARC — `.github/workflows/cfarm.yaml`, JDK from the remote host's `.profile`

Text blocks arrived in Java 15, so there is no safer lower level that delivers the reason for the change. The property carries a comment saying so, so a future bump has to confront it.

Scope is `oshi-common` and `oshi-core` only: the other modules set their own `testRelease`, `oshi-demo` has no tests, and no module depends on another's test-jar.

## The proof file

`FileUtilTest` is converted, which also finishes moving it off hand-rolled `Files.createTempFile` — 8 of its methods already used `@TempDir` while 6 hand-rolled a temp file plus a manual delete that leaked on any assertion failure. Its multiline fixture becomes a text block, writes become `Files.writeString`, and `Collectors.toList()` becomes `Stream.toList()`.

Two deliberate non-conversions, both kept as worked examples:
- Mid-test deletes that feed a file-not-found assertion are **behaviour, not cleanup**, and stay.
- `testReadProcIo` keeps generating its file body from the map it asserts against; a text block there would duplicate the data. Not every fixture wants the new syntax.

## Two consequences the build surfaced

Neither was predicted; both came out of running the gate.

**1. Two Error Prone checks were inert at release 8.** `StatementSwitchToExpressionSwitch` and `PatternMatchingInstanceof` are already configured at ERROR, but neither feature exists in Java 8, so they never fired on test sources. They flag 8 sites, all converted here.

**2. NullAway had never run on test sources at all.** Raising `testRelease` moves test compilation from the classpath onto the **module path** (`javac [debug release 17 module-path]`), which brings `module-info.java`'s `@NullMarked` into scope for test packages for the first time. That surfaces **178 pre-existing findings across 41 files** (166 `oshi-common`, 12 `oshi-core`) — real, and mostly mechanical (`assertNotNull` for a dereference, a `@Nullable` type argument for a generic mismatch), but a drain job of their own rather than part of a build-config change.

The `error-prone` profile now runs NullAway at **WARN for test compilation only**. Main compilation stays at ERROR, as does every other check on both. The Error Prone argument is split into two properties so the main and test variants differ in exactly one token. This follows the project's established survey-at-WARN, enforce-at-ERROR pattern, and is explicitly transitional — the severity goes back to ERROR once the backlog reaches zero. I'll open an issue to track the drain.

## Verification

Full gate from clean — `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc -Paggregate-coverage` — and `-Perror-prone clean install`, both green. Class file versions confirmed on a normal (non-profile) build: `oshi-common` main 52, `module-info` 53, tests 61.

Spotless was checked specifically against the text blocks, since there was not a single one anywhere in this repository before — it leaves their interior untouched and removes only the newly-dead imports.

No CHANGELOG entry: build config and test-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test code to use modern Java 17 syntax and APIs.
  * Improved temporary-file handling with managed test directories and clearer text-based fixtures.
  * Preserved existing assertions, expected values, and test behavior.

* **Chores**
  * Updated Java compatibility guidance and test compilation settings.
  * Added consistent static-analysis checks for test code with warning-level reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->