### PR TITLE
Drain half the NullAway findings in test sources

### DIFF
--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxHWDiskStore.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.hardware.HWDiskStore;
 import oshi.hardware.HWPartition;
@@ -197,7 +199,7 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
      * @param dmUuid the device-mapper UUID
      * @return the model description
      */
-    protected static String getModelForDmDevice(String dmUuid) {
+    protected static String getModelForDmDevice(@Nullable String dmUuid) {
         if (isLogicalVolume(dmUuid)) {
             return LOGICAL_VOLUME_GROUP;
         } else if (isEncryptedVolume(dmUuid)) {
@@ -212,7 +214,7 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
      * @param dmUuid the device-mapper UUID
      * @return whether the UUID identifies an LVM logical volume
      */
-    protected static boolean isLogicalVolume(String dmUuid) {
+    protected static boolean isLogicalVolume(@Nullable String dmUuid) {
         return dmUuid != null && dmUuid.startsWith("LVM-");
     }
 
@@ -222,7 +224,7 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
      * @param dmUuid the device-mapper UUID
      * @return whether the UUID identifies an encrypted volume
      */
-    protected static boolean isEncryptedVolume(String dmUuid) {
+    protected static boolean isEncryptedVolume(@Nullable String dmUuid) {
         return dmUuid != null && dmUuid.startsWith("CRYPT-");
     }
 
@@ -233,7 +235,7 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
      * @param devnode the device node path
      * @return the device path
      */
-    protected static String getDmDevicePath(String dmName, String devnode) {
+    protected static String getDmDevicePath(@Nullable String dmName, String devnode) {
         return Util.isBlank(dmName) ? devnode : DevPath.MAPPER + dmName;
     }
 
@@ -241,13 +243,13 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
      * Gets the mount point for a device-mapper device.
      *
      * @param mountsMap the map of device paths to mount points
-     * @param dmName    the device-mapper name
+     * @param dmName    the device-mapper name, or {@code null} if unnamed
      * @param devnode   the device node path
      * @param sysPath   the sysfs path for the device
      * @return the mount point or dependent device names
      */
-    protected static String getMountPointForDmDevice(Map<String, String> mountsMap, String dmName, String devnode,
-            String sysPath) {
+    protected static String getMountPointForDmDevice(Map<String, String> mountsMap, @Nullable String dmName,
+            String devnode, String sysPath) {
         String devicePath = getDmDevicePath(dmName, devnode);
         String mountPoint = mountsMap.get(devicePath);
         if (mountPoint != null) {
@@ -267,29 +269,32 @@ public abstract class LinuxHWDiskStore extends AbstractHWDiskStore {
      *
      * @param store     the disk store to update
      * @param mountsMap the map of device paths to mount points
-     * @param dmUuid    the device-mapper UUID
-     * @param vgName    the LVM volume group name
-     * @param lvName    the LVM logical volume name
+     * @param dmUuid    the device-mapper UUID, or {@code null} if the device has none
+     * @param vgName    the LVM volume group name, or {@code null} if not an LVM volume
+     * @param lvName    the LVM logical volume name, or {@code null} if not an LVM volume
      * @param dmName    the device-mapper name
      * @param devnode   the device node path
      * @param sysname   the sysfs device name
      * @param sysPath   the sysfs path for the device
-     * @param fsType    the filesystem type
-     * @param fsUuid    the filesystem UUID
-     * @param fsLabel   the filesystem label
+     * @param fsType    the filesystem type, or {@code null} if unknown
+     * @param fsUuid    the filesystem UUID, or {@code null} if unknown
+     * @param fsLabel   the filesystem label, or {@code null} if unknown
      * @param size      the partition size in bytes
      * @param major     the major device ID
      * @param minor     the minor device ID
      */
-    protected static void addDeviceMapperPartition(LinuxHWDiskStore store, Map<String, String> mountsMap, String dmUuid,
-            String vgName, String lvName, String dmName, String devnode, String sysname, String sysPath, String fsType,
-            String fsUuid, String fsLabel, long size, int major, int minor) {
+    protected static void addDeviceMapperPartition(LinuxHWDiskStore store, Map<String, String> mountsMap,
+            @Nullable String dmUuid, @Nullable String vgName, @Nullable String lvName, @Nullable String dmName,
+            String devnode, String sysname, String sysPath, @Nullable String fsType, @Nullable String fsUuid,
+            @Nullable String fsLabel, long size, int major, int minor) {
         if (isLogicalVolume(dmUuid) && !Util.isBlank(vgName) && !Util.isBlank(lvName)) {
-            store.getMutablePartitionList()
-                    .add(new HWPartition(getPartitionNameForDmDevice(vgName, lvName), sysname,
-                            fsType == null ? PARTITION : fsType, ParseUtil.getStringValueOrEmpty(fsUuid),
-                            ParseUtil.getStringValueOrEmpty(fsLabel), size, major, minor,
-                            getMountPointOfDmDevice(vgName, lvName)));
+            // The isBlank guards above already establish these, but a predicate does not narrow for the analyzer;
+            // the normalizer's return type does.
+            String vg = ParseUtil.getStringValueOrEmpty(vgName);
+            String lv = ParseUtil.getStringValueOrEmpty(lvName);
+            store.getMutablePartitionList().add(new HWPartition(getPartitionNameForDmDevice(vg, lv), sysname,
+                    fsType == null ? PARTITION : fsType, ParseUtil.getStringValueOrEmpty(fsUuid),
+                    ParseUtil.getStringValueOrEmpty(fsLabel), size, major, minor, getMountPointOfDmDevice(vg, lv)));
         } else if (isEncryptedVolume(dmUuid)) {
             String name = getDmDevicePath(dmName, devnode);
             store.getMutablePartitionList()

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LsDevicesTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LsDevicesTest.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -37,10 +38,14 @@ class LsDevicesTest {
                 "brw-rw----  1 root system 10,  5 Sep 12  2017 hd2", //
                 "brw-------  1 root system 20,  0 Jun 28  1970 hdisk0"));
         assertThat(map, not(hasKey("null")));
-        assertThat(map.get("hd2").getA(), is(10));
-        assertThat(map.get("hd2").getB(), is(5));
-        assertThat(map.get("hdisk0").getA(), is(20));
-        assertThat(map.get("hdisk0").getB(), is(0));
+        Pair<Integer, Integer> hd2 = map.get("hd2");
+        Pair<Integer, Integer> hdisk0 = map.get("hdisk0");
+        assertNotNull(hd2);
+        assertNotNull(hdisk0);
+        assertThat(hd2.getA(), is(10));
+        assertThat(hd2.getB(), is(5));
+        assertThat(hdisk0.getA(), is(20));
+        assertThat(hdisk0.getB(), is(0));
     }
 
     @Test
@@ -57,7 +62,7 @@ class LsDevicesTest {
         boolean foundNonNull = false;
         boolean foundPartitions = false;
         for (String device : majMinMap.keySet()) {
-            Pair<String, String> modSer = Lscfg.queryModelSerial(device);
+            Pair<@Nullable String, @Nullable String> modSer = Lscfg.queryModelSerial(device);
             if (modSer.getA() != null || modSer.getB() != null) {
                 foundNonNull = true;
                 List<HWPartition> lvs = Lspv.queryLogicalVolumes(device, majMinMap);
@@ -75,7 +80,8 @@ class LsDevicesTest {
         List<String> lscfg = Lscfg.queryAllDevices();
         assertThat("Output of lscfg should be nonempty", lscfg.size(), greaterThan(0));
 
-        Triplet<String, String, String> modSerVer = Lscfg.queryBackplaneModelSerialVersion(lscfg);
+        Triplet<@Nullable String, @Nullable String, @Nullable String> modSerVer = Lscfg
+                .queryBackplaneModelSerialVersion(lscfg);
         // Either all should be null or none should be null
         if (!(modSerVer.getA() == null && modSerVer.getB() == null && modSerVer.getC() == null)) {
             assertNotNull(modSerVer.getA(), "Backplane Model should not be null");

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LscfgTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LscfgTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.nullValue;
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.util.tuples.Pair;
@@ -20,7 +21,7 @@ class LscfgTest {
     @Test
     void testParseModelSerial() {
         // lscfg -vl hdisk0: the "Machine Type and Model" line overrides the first-line description
-        Pair<String, String> modSer = Lscfg.parseModelSerial(Arrays.asList(//
+        Pair<@Nullable String, @Nullable String> modSer = Lscfg.parseModelSerial(Arrays.asList(//
                 "  hdisk0           U78CB.001.WZS00MP-P1-C2-T1-L0  MPIO IBM 2076 FC Disk", //
                 "        Manufacturer................IBM", //
                 "        Machine Type and Model......2076", //
@@ -33,7 +34,7 @@ class LscfgTest {
     @Test
     void testParseModelSerialFallsBackToDescription() {
         // With no "Machine Type and Model" line, the model is the description after the location code
-        Pair<String, String> modSer = Lscfg.parseModelSerial(
+        Pair<@Nullable String, @Nullable String> modSer = Lscfg.parseModelSerial(
                 Collections.singletonList("  cd0              U78CB.001.WZS00MP-P2-D1  SATA DVD-RAM Drive"), "cd0");
         assertThat(modSer.getA(), is("SATA DVD-RAM Drive"));
         assertThat(modSer.getB(), is(nullValue()));
@@ -42,15 +43,15 @@ class LscfgTest {
     @Test
     void testParseModelSerialDeviceAtEndOfLine() {
         // A line ending in the device name splits to a single element; the fallback must be skipped, not crash
-        Pair<String, String> modSer = Lscfg.parseModelSerial(Collections.singletonList("  Adapter containing hdisk0"),
-                "hdisk0");
+        Pair<@Nullable String, @Nullable String> modSer = Lscfg
+                .parseModelSerial(Collections.singletonList("  Adapter containing hdisk0"), "hdisk0");
         assertThat(modSer.getA(), is(nullValue()));
         assertThat(modSer.getB(), is(nullValue()));
     }
 
     @Test
     void testParseModelSerialEmpty() {
-        Pair<String, String> modSer = Lscfg.parseModelSerial(Collections.emptyList(), "hdisk0");
+        Pair<@Nullable String, @Nullable String> modSer = Lscfg.parseModelSerial(Collections.emptyList(), "hdisk0");
         assertThat(modSer.getA(), is(nullValue()));
         assertThat(modSer.getB(), is(nullValue()));
     }

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LspvTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LspvTest.java
@@ -7,6 +7,7 @@ package oshi.driver.common.unix.aix;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,19 +57,25 @@ class LspvTest {
         Map<String, HWPartition> byName = Lspv.parsePartitions(lspvP, ppSize, majMin).stream()
                 .collect(Collectors.toMap(HWPartition::getName, Function.identity()));
 
+        HWPartition hd5 = byName.get("hd5");
+        HWPartition hd6 = byName.get("hd6");
+        HWPartition hd4 = byName.get("hd4");
+        assertNotNull(hd5);
+        assertNotNull(hd6);
+        assertNotNull(hd4);
         // hd5: 1 PP, type/mount from the row, major/minor from the supplied map
-        assertThat(byName.get("hd5").getType(), is("boot"));
-        assertThat(byName.get("hd5").getMountPoint(), is("")); // N/A is normalized to empty
-        assertThat(byName.get("hd5").getSize(), is(ppSize));
-        assertThat(byName.get("hd5").getMajor(), is(10));
-        assertThat(byName.get("hd5").getMinor(), is(5));
+        assertThat(hd5.getType(), is("boot"));
+        assertThat(hd5.getMountPoint(), is("")); // N/A is normalized to empty
+        assertThat(hd5.getSize(), is(ppSize));
+        assertThat(hd5.getMajor(), is(10));
+        assertThat(hd5.getMinor(), is(5));
         // hd6: 4 PPs (56-59); not in the map, so major/minor fall back to the first int in the name
-        assertThat(byName.get("hd6").getType(), is("paging"));
-        assertThat(byName.get("hd6").getSize(), is(ppSize * 4));
-        assertThat(byName.get("hd6").getMajor(), is(6));
+        assertThat(hd6.getType(), is("paging"));
+        assertThat(hd6.getSize(), is(ppSize * 4));
+        assertThat(hd6.getMajor(), is(6));
         // hd4: 2 PPs (111-112), mounted at /
-        assertThat(byName.get("hd4").getMountPoint(), is("/"));
-        assertThat(byName.get("hd4").getSize(), is(ppSize * 2));
+        assertThat(hd4.getMountPoint(), is("/"));
+        assertThat(hd4.getSize(), is(ppSize * 2));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LssradTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LssradTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,18 +35,28 @@ class LssradTest {
                 "1", //
                 "               2        2471.19    92-95"));
         // node 0, slot 0
-        assertThat(map.get(0).getA(), is(0));
-        assertThat(map.get(0).getB(), is(0));
-        assertThat(map.get(63).getA(), is(0));
+        Pair<Integer, Integer> cpu0 = map.get(0);
+        Pair<Integer, Integer> cpu63 = map.get(63);
+        Pair<Integer, Integer> cpu64 = map.get(64);
+        Pair<Integer, Integer> cpu80 = map.get(80);
+        Pair<Integer, Integer> cpu92 = map.get(92);
+        assertNotNull(cpu0);
+        assertNotNull(cpu63);
+        assertNotNull(cpu64);
+        assertNotNull(cpu80);
+        assertNotNull(cpu92);
+        assertThat(cpu0.getA(), is(0));
+        assertThat(cpu0.getB(), is(0));
+        assertThat(cpu63.getA(), is(0));
         // node 0, slot 1
-        assertThat(map.get(64).getA(), is(0));
-        assertThat(map.get(64).getB(), is(1));
+        assertThat(cpu64.getA(), is(0));
+        assertThat(cpu64.getB(), is(1));
         // continuation line keeps node 0, slot 1
-        assertThat(map.get(80).getA(), is(0));
-        assertThat(map.get(80).getB(), is(1));
+        assertThat(cpu80.getA(), is(0));
+        assertThat(cpu80.getB(), is(1));
         // node 1, slot 2
-        assertThat(map.get(92).getA(), is(1));
-        assertThat(map.get(92).getB(), is(2));
+        assertThat(cpu92.getA(), is(1));
+        assertThat(cpu92.getB(), is(2));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/driver/common/windows/perfmon/LoadAverageTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/windows/perfmon/LoadAverageTest.java
@@ -26,6 +26,10 @@ class LoadAverageTest {
 
     // Builds a LoadAverage whose raw-counter hooks return the supplied fixtures, so the shared aggregation can be
     // exercised without the platform-specific perfmon drivers.
+    /** Idle counters for the queue-length tests, which never read them. */
+    private static final Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> NO_IDLE_COUNTERS = new Pair<>(
+            Collections.emptyList(), Collections.emptyMap());
+
     private static LoadAverage stub(Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> idleCounters,
             Map<ProcessorQueueLengthProperty, Long> queueLength) {
         return new LoadAverage() {
@@ -66,8 +70,10 @@ class LoadAverageTest {
 
     @Test
     void testQueryQueueLength() {
-        assertThat(stub(null, Collections.singletonMap(ProcessorQueueLengthProperty.PROCESSORQUEUELENGTH, 3L))
-                .queryQueueLength(), is(3L));
-        assertThat(stub(null, Collections.emptyMap()).queryQueueLength(), is(0L));
+        assertThat(
+                stub(NO_IDLE_COUNTERS, Collections.singletonMap(ProcessorQueueLengthProperty.PROCESSORQUEUELENGTH, 3L))
+                        .queryQueueLength(),
+                is(3L));
+        assertThat(stub(NO_IDLE_COUNTERS, Collections.emptyMap()).queryQueueLength(), is(0L));
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacCentralProcessorTest.java
@@ -475,8 +475,9 @@ class MacCentralProcessorTest {
     // -- efficiency class derivation --
 
     // Builds a core-properties map from parallel arrays, where a null element means the property is absent.
-    private static Map<Integer, Pair<String, String>> coreProps(String[] codenames, String[] clusterTypes) {
-        Map<Integer, Pair<String, String>> props = new HashMap<>();
+    private static Map<Integer, Pair<@Nullable String, @Nullable String>> coreProps(String[] codenames,
+            String[] clusterTypes) {
+        Map<Integer, Pair<@Nullable String, @Nullable String>> props = new HashMap<>();
         for (int i = 0; i < codenames.length; i++) {
             String compatible = codenames[i] == null ? null : "apple," + codenames[i] + " arm,v8";
             props.put(i, new Pair<>(compatible, clusterTypes[i]));
@@ -616,7 +617,7 @@ class MacCentralProcessorTest {
         // Some cores report a cluster-type and a codename while others expose no readable properties at all, as
         // happens when an IORegistry node cannot be read. The exact readings must survive: discarding them here
         // classified every performance core as class 0, which is worse than the codename table this replaced.
-        Map<Integer, Pair<String, String>> props = new HashMap<>();
+        Map<Integer, Pair<@Nullable String, @Nullable String>> props = new HashMap<>();
         for (int i = 0; i < 4; i++) {
             props.put(i, new Pair<>("apple,everest arm,v8", "P"));
         }
@@ -632,7 +633,7 @@ class MacCentralProcessorTest {
     void testOwnClusterTypeIsNotOverwrittenByPropagation() {
         // A core that reported its own cluster-type must keep that exact reading. Two cores here share a codename but
         // report different cluster types, so propagating by codename must not overwrite either one's own value.
-        Map<Integer, Pair<String, String>> props = new HashMap<>();
+        Map<Integer, Pair<@Nullable String, @Nullable String>> props = new HashMap<>();
         props.put(0, new Pair<>("apple,everest arm,v8", "E"));
         props.put(1, new Pair<>("apple,everest arm,v8", "P"));
         props.put(2, new Pair<>("apple,everest arm,v8", null));
@@ -839,14 +840,20 @@ class MacCentralProcessorTest {
             return sysctlStrings == null ? def : sysctlStrings.getOrDefault(name, def);
         }
 
+        /** Whether an IORegistry is available. The base stub has none; PmgrCentralProcessor supplies one. */
+        protected boolean hasIoKit() {
+            return false;
+        }
+
         @Override
         protected SysctlProvider sysctlProvider() {
-            return null; // Not used; sysctl methods are overridden directly
+            throw new UnsupportedOperationException("sysctl methods are overridden directly");
         }
 
         @Override
         protected IOKitProvider ioKitProvider() {
-            return null; // Not used; platformExpert/queryCoreProperties/queryClusterFrequencies are overridden
+            throw new UnsupportedOperationException(
+                    "platformExpert/queryCoreProperties/queryClusterFrequencies are overridden");
         }
 
         @Override
@@ -855,14 +862,14 @@ class MacCentralProcessorTest {
         }
 
         @Override
-        protected Map<Integer, Pair<String, String>> queryCoreProperties() {
+        protected Map<Integer, Pair<@Nullable String, @Nullable String>> queryCoreProperties() {
             return new HashMap<>();
         }
 
         @Override
         protected long[][] queryClusterFrequencyTables() {
             // With no IORegistry to walk there are no tables to read; PmgrCentralProcessor supplies one
-            return ioKitProvider() == null ? new long[0][] : super.queryClusterFrequencyTables();
+            return hasIoKit() ? super.queryClusterFrequencyTables() : new long[0][];
         }
 
         @Override
@@ -930,8 +937,8 @@ class MacCentralProcessorTest {
         }
 
         @Override
-        protected Map<Integer, Pair<String, String>> queryCoreProperties() {
-            Map<Integer, Pair<String, String>> props = new HashMap<>();
+        protected Map<Integer, Pair<@Nullable String, @Nullable String>> queryCoreProperties() {
+            Map<Integer, Pair<@Nullable String, @Nullable String>> props = new HashMap<>();
             for (int i = 0; i < CORE_COUNT; i++) {
                 boolean performance = i >= CORE_COUNT / 2;
                 props.put(i, new Pair<>(performance ? "apple,everest arm,v8" : "apple,sawtooth arm,v8",
@@ -977,6 +984,11 @@ class MacCentralProcessorTest {
         PmgrCentralProcessor(Map<String, byte[]> pmgrProperties) {
             super(Collections.singletonMap("machdep.cpu.brand_string", "Apple M0"));
             this.provider = new PmgrProvider(pmgrProperties);
+        }
+
+        @Override
+        protected boolean hasIoKit() {
+            return true;
         }
 
         @Override

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemDistroTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemDistroTest.java
@@ -6,6 +6,7 @@ package oshi.software.common.os.linux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.List;
@@ -49,6 +50,7 @@ class LinuxOperatingSystemDistroTest {
     @Test
     void testReadOsReleaseFedora() {
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_FEDORA);
+        assertNotNull(result);
         assertThat(result.getA(), is("Fedora Linux"));
         assertThat(result.getB(), is("39"));
         assertThat(result.getC(), is("Workstation Edition"));
@@ -57,6 +59,7 @@ class LinuxOperatingSystemDistroTest {
     @Test
     void testReadOsReleaseArch() {
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_ARCH);
+        assertNotNull(result);
         assertThat(result.getA(), is("Arch Linux"));
         // Arch has no VERSION or VERSION_ID
         assertThat(result.getB(), is(Constants.UNKNOWN));
@@ -66,6 +69,7 @@ class LinuxOperatingSystemDistroTest {
     @Test
     void testReadOsReleaseDebian() {
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_DEBIAN);
+        assertNotNull(result);
         assertThat(result.getA(), is("Debian GNU/Linux"));
         assertThat(result.getB(), is("12"));
         assertThat(result.getC(), is("bookworm"));
@@ -74,6 +78,7 @@ class LinuxOperatingSystemDistroTest {
     @Test
     void testReadOsReleaseAlpine() {
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_ALPINE);
+        assertNotNull(result);
         assertThat(result.getA(), is("Alpine Linux"));
         assertThat(result.getB(), is("3.19.0"));
         assertThat(result.getC(), is(Constants.UNKNOWN));
@@ -82,6 +87,7 @@ class LinuxOperatingSystemDistroTest {
     @Test
     void testReadOsReleaseRHEL() {
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_RHEL);
+        assertNotNull(result);
         assertThat(result.getA(), is("Red Hat Enterprise Linux"));
         assertThat(result.getB(), is("9.3"));
         assertThat(result.getC(), is("Plow"));
@@ -90,6 +96,7 @@ class LinuxOperatingSystemDistroTest {
     @Test
     void testReadOsReleaseOpenSUSE() {
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_OPENSUSE);
+        assertNotNull(result);
         assertThat(result.getA(), is("openSUSE Leap"));
         assertThat(result.getB(), is("15.5"));
         assertThat(result.getC(), is(Constants.UNKNOWN));
@@ -101,6 +108,7 @@ class LinuxOperatingSystemDistroTest {
     void testReadDistribReleaseAmazonLinux() {
         List<String> lines = Arrays.asList("Amazon Linux release 2023 (Amazon Linux)");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Amazon Linux"));
         assertThat(result.getB(), is("2023"));
         assertThat(result.getC(), is("Amazon Linux"));
@@ -110,6 +118,7 @@ class LinuxOperatingSystemDistroTest {
     void testReadDistribReleaseOracle() {
         List<String> lines = Arrays.asList("Oracle Linux Server release 8.9");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Oracle Linux Server"));
         assertThat(result.getB(), is("8.9"));
         assertThat(result.getC(), is(Constants.UNKNOWN));
@@ -119,6 +128,7 @@ class LinuxOperatingSystemDistroTest {
     void testReadDistribReleaseRocky() {
         List<String> lines = Arrays.asList("Rocky Linux release 9.3 (Blue Onyx)");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Rocky Linux"));
         assertThat(result.getB(), is("9.3"));
         assertThat(result.getC(), is("Blue Onyx"));

--- a/oshi-core/src/test/java/oshi/driver/windows/LogicalProcessorInformationTest.java
+++ b/oshi-core/src/test/java/oshi/driver/windows/LogicalProcessorInformationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The OSHI Project Contributors
+ * Copyright 2022-2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
 package oshi.driver.windows;
@@ -10,9 +10,11 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -26,7 +28,7 @@ import oshi.util.tuples.Triplet;
 class LogicalProcessorInformationTest {
     @Test
     void testGetLogicalProcessorInformation() {
-        Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> info = LogicalProcessorInformation
+        Triplet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>> info = LogicalProcessorInformation
                 .getLogicalProcessorInformation();
         assertThat("Logical Processor list must not be empty", info.getA(), is(not(empty())));
         assertThat("Physical Processor list is null", info.getB(), is(nullValue()));
@@ -35,13 +37,18 @@ class LogicalProcessorInformationTest {
 
     @Test
     void testGetLogicalProcessorInformationEx() {
-        Triplet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>> info = LogicalProcessorInformation
+        Triplet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>> info = LogicalProcessorInformation
                 .getLogicalProcessorInformationEx();
+        List<PhysicalProcessor> physical = info.getB();
+        List<ProcessorCache> caches = info.getC();
+        // Unlike the non-Ex path above, the Ex path is expected to populate both
+        assertNotNull(physical, "Physical Processor list should not be null");
+        assertNotNull(caches, "Cache list should not be null");
         assertThat("Must be more Logical Processors than Physical Ones", info.getA().size(),
-                greaterThanOrEqualTo(info.getB().size()));
-        assertThat("Must be more Physical Processors than L3 Caches", info.getB().size(),
-                greaterThanOrEqualTo((int) info.getC().stream().filter(c -> c.getLevel() == 3).count()));
-        assertThat("Must be more Physical Processors than L2 Caches", info.getB().size(),
-                greaterThanOrEqualTo((int) info.getC().stream().filter(c -> c.getLevel() == 2).count()));
+                greaterThanOrEqualTo(physical.size()));
+        assertThat("Must be more Physical Processors than L3 Caches", physical.size(),
+                greaterThanOrEqualTo((int) caches.stream().filter(c -> c.getLevel() == 3).count()));
+        assertThat("Must be more Physical Processors than L2 Caches", physical.size(),
+                greaterThanOrEqualTo((int) caches.stream().filter(c -> c.getLevel() == 2).count()));
     }
 }

--- a/oshi-core/src/test/java/oshi/driver/windows/registry/ProcessWtsDataTest.java
+++ b/oshi-core/src/test/java/oshi/driver/windows/registry/ProcessWtsDataTest.java
@@ -9,10 +9,12 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Collections;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -31,8 +33,8 @@ class ProcessWtsDataTest {
         assertWtsInfo(wtsMap.get(pid));
     }
 
-    private static void assertWtsInfo(WtsInfo info) {
-        assertThat("WTS info should not be null", info, is(notNullValue()));
+    private static void assertWtsInfo(@Nullable WtsInfo info) {
+        assertNotNull(info, "WTS info should not be null");
         assertThat("Process name should not be null", info.getName(), is(notNullValue()));
         assertThat("Thread count should be positive", info.getThreadCount(), is(greaterThan(0)));
         assertThat("Virtual size should be nonnegative", info.getVirtualSize(), is(greaterThanOrEqualTo(0L)));


### PR DESCRIPTION
First batch against #3689. **178 findings to 89.** NullAway stays at WARN for test compilation until the backlog reaches zero; that issue closes when it goes back to ERROR.

Most of this is mechanical:

- a local plus `assertNotNull` where a `Map.get()` was dereferenced directly — NullAway narrows a variable, not a repeated call expression
- the nullable type arguments the API already declares, where a local or an override had spelled `Pair<String, String>` instead of `Pair<@Nullable String, @Nullable String>`
- `ProcessWtsDataTest` swaps Hamcrest's `is(notNullValue())` for `assertNotNull`, because only the latter narrows for NullAway

Two changes are not mechanical, and are the ones worth reviewing.

## LinuxHWDiskStore's annotations were wrong

The tests here pass `null` literals to production methods. That is not a test bug — the production code handles null by design:

```java
protected static boolean isLogicalVolume(String dmUuid) {
    return dmUuid != null && dmUuid.startsWith("LVM-");
}
```

`isEncryptedVolume` is the same shape, `getDmDevicePath` routes its argument through `Util.isBlank`, and `addDeviceMapperPartition` null-checks `fsType` and normalizes `fsUuid`/`fsLabel` through `ParseUtil`. Every one of them accepts null; only the annotation said otherwise. Those parameters are now `@Nullable`, with javadoc saying when null is expected.

The alternative — changing the tests to stop passing null — would have deleted coverage of null-handling the production code deliberately implements, and left an annotation that misdescribes it.

NullAway cannot narrow through `Util.isBlank`, so the one branch that concatenates a guarded name goes through `ParseUtil.getStringValueOrEmpty`. That is a no-op at runtime behind the existing `isBlank` guard, but puts the non-null guarantee in a return type the analyzer reads — the pattern AGENTS.md already prescribes. **Main compilation still reports zero NullAway findings at ERROR.**

These are `protected static` members of an implementation class, not `@PublicApi`, so no semver implication. Widening a parameter to accept null is backwards compatible for callers either way.

## The Mac provider stubs were the opposite case

`MacCentralProcessor` dereferences `sysctlProvider()` and `ioKitProvider()` unconditionally, so non-null is the *correct* contract and the test stub returning `null` was the bug. Both overrides now throw, which enforces the "not used; these methods are overridden directly" claim the comments had only asserted. The stub's `ioKitProvider() == null` sentinel becomes an explicit `hasIoKit()` predicate that `PmgrCentralProcessor` overrides — same behaviour, no null.

## Verification

Full gate from clean — `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc -Paggregate-coverage` — green, zero test failures.

One gap: `LinuxHWDiskStoreTest` is disabled off Linux, so the annotation change is unverified locally and rides on CI here.

No CHANGELOG entry — test-only apart from annotations, no behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux device-mapper handling when volume, filesystem, or partition metadata is unavailable.
  * Normalized validated logical-volume information for more reliable partition details.

* **Tests**
  * Strengthened Linux, Windows, macOS, and AIX hardware and operating-system parsing tests.
  * Added explicit checks for missing or unavailable data to prevent invalid assumptions during parsing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->