### PR TITLE
Drain the remaining NullAway findings and restore ERROR severity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,10 +196,10 @@ them. Use text blocks for captured command or file output, `Files.writeString` o
 `Files.write(path, s.getBytes(UTF_8))`, and `Stream.toList()`; `var` is fine and is already the
 house style in `oshi-core-ffm`. Two cautions:
 
-- **NullAway runs at WARN on test sources, not ERROR.** Compiling tests at 17 put them on the module
-  path, which brought `module-info.java`'s `@NullMarked` into scope for test packages for the first
-  time and surfaced 178 pre-existing findings across 41 files. Do not add to them: new test code
-  should be NullAway-clean, and the severity goes back to ERROR once the backlog is drained.
+- **NullAway checks test sources too**, at ERROR, the same as main. Compiling tests at 17 put them
+  on the module path, which brings `module-info.java`'s `@NullMarked` into scope for test packages.
+  A stub override must repeat the parent's `@Nullable`; a `Map.get()` needs a local plus
+  `assertNotNull`, which narrows where Hamcrest's `is(notNullValue())` does not.
 - **17 is a ceiling.** It is exactly the lowest JDK running tests in CI — AppVeyor Windows and
   Solaris SPARC, both with no headroom. Do not raise it without moving those first.
 - **Do not sweep `Arrays.asList` to `List.of`.** `List.of` rejects nulls and is immutable, and

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroup.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroup.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
+
 import oshi.hardware.LogicalVolumeGroup;
 import oshi.hardware.common.AbstractLogicalVolumeGroup;
 import oshi.util.ExecutingCommand;
@@ -79,22 +81,23 @@ public class LinuxLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
      * assembly can be shared. Any field may be null if udev did not report that property.
      */
     public static final class UdevBlockDevice {
-        private final String syspath;
-        private final String devnode;
-        private final String uuid;
-        private final String vgName;
-        private final String lvName;
+        private final @Nullable String syspath;
+        private final @Nullable String devnode;
+        private final @Nullable String uuid;
+        private final @Nullable String vgName;
+        private final @Nullable String lvName;
 
         /**
          * Creates a block device record.
          *
-         * @param syspath the sysfs path of the device
-         * @param devnode the device node path, e.g. {@code /dev/dm-0}
-         * @param uuid    the {@code DM_UUID} property
-         * @param vgName  the {@code DM_VG_NAME} property
-         * @param lvName  the {@code DM_LV_NAME} property
+         * @param syspath the sysfs path of the device, or {@code null} if udev reported none
+         * @param devnode the device node path, e.g. {@code /dev/dm-0}, or {@code null} if udev reported none
+         * @param uuid    the {@code DM_UUID} property, or {@code null} if absent
+         * @param vgName  the {@code DM_VG_NAME} property, or {@code null} if absent
+         * @param lvName  the {@code DM_LV_NAME} property, or {@code null} if absent
          */
-        public UdevBlockDevice(String syspath, String devnode, String uuid, String vgName, String lvName) {
+        public UdevBlockDevice(@Nullable String syspath, @Nullable String devnode, @Nullable String uuid,
+                @Nullable String vgName, @Nullable String lvName) {
             this.syspath = syspath;
             this.devnode = devnode;
             this.uuid = uuid;
@@ -149,14 +152,17 @@ public class LinuxLogicalVolumeGroup extends AbstractLogicalVolumeGroup {
                     || !device.uuid.startsWith("LVM-") || Util.isBlank(device.vgName) || Util.isBlank(device.lvName)) {
                 continue;
             }
-            Map<String, Set<String>> lvMapForGroup = logicalVolumesMap.computeIfAbsent(device.vgName,
-                    k -> new HashMap<>());
-            Set<String> pvSetForGroup = physicalVolumesMap.computeIfAbsent(device.vgName, k -> new HashSet<>());
+            // The isBlank guards above already establish these, but a predicate does not narrow for the analyzer;
+            // the normalizer's return type does.
+            String vgName = ParseUtil.getStringValueOrEmpty(device.vgName);
+            String lvName = ParseUtil.getStringValueOrEmpty(device.lvName);
+            Map<String, Set<String>> lvMapForGroup = logicalVolumesMap.computeIfAbsent(vgName, k -> new HashMap<>());
+            Set<String> pvSetForGroup = physicalVolumesMap.computeIfAbsent(vgName, k -> new HashSet<>());
             File[] slaves = new File(device.syspath + "/slaves").listFiles();
             if (slaves != null) {
                 for (File f : slaves) {
                     String pvName = DevPath.DEV + f.getName();
-                    lvMapForGroup.computeIfAbsent(device.lvName, k -> new HashSet<>()).add(pvName);
+                    lvMapForGroup.computeIfAbsent(lvName, k -> new HashSet<>()).add(pvName);
                     pvSetForGroup.add(pvName);
                 }
             }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGpuStats.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/mac/MacGpuStats.java
@@ -112,10 +112,10 @@ public abstract class MacGpuStats implements GpuStats {
     /**
      * Tests whether an IOAccelerator model name refers to this card, ignoring case and trademark symbols.
      *
-     * @param model the model name read from the registry
+     * @param model the model name read from the registry, or {@code null} if the card reports none
      * @return true if it names this card
      */
-    protected final boolean matchesName(String model) {
+    protected final boolean matchesName(@Nullable String model) {
         if (model == null || model.isEmpty()) {
             return false;
         }

--- a/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/linux/LinuxOSProcess.java
@@ -429,7 +429,7 @@ public abstract class LinuxOSProcess extends AbstractOSProcess {
      * @param status status map to fill.
      * @param stat   string to read from.
      */
-    static void getMissingDetails(Map<String, String> status, String stat) {
+    static void getMissingDetails(@Nullable Map<String, String> status, @Nullable String stat) {
         if (status == null || stat == null) {
             return;
         }

--- a/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
+++ b/oshi-common/src/main/java/oshi/software/common/os/mac/MacInstalledApps.java
@@ -152,7 +152,7 @@ public final class MacInstalledApps {
         return obtainedFrom;
     }
 
-    static List<Map<String, String>> parseItems(String xml) {
+    static List<Map<String, String>> parseItems(@Nullable String xml) {
         if (xml == null) {
             return Collections.emptyList();
         }

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractCentralProcessorTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.hardware.CentralProcessor.LogicalProcessor;
@@ -38,7 +39,7 @@ class AbstractCentralProcessorTest {
     private static AbstractCentralProcessor createProcessor() {
         return new AbstractCentralProcessor() {
             @Override
-            protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+            protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
                 return new Quartet<>(Collections.singletonList(new LogicalProcessor(0, 0, 0)), null, null,
                         Collections.emptyList());
             }
@@ -191,7 +192,7 @@ class AbstractCentralProcessorTest {
     private static AbstractCentralProcessor createHybridProcessor() {
         return new AbstractCentralProcessor() {
             @Override
-            protected Quartet<List<LogicalProcessor>, List<PhysicalProcessor>, List<ProcessorCache>, List<String>> initProcessorCounts() {
+            protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
                 List<LogicalProcessor> logProcs = Arrays.asList(new LogicalProcessor(0, 0, 0),
                         new LogicalProcessor(1, 1, 0), new LogicalProcessor(2, 2, 0), new LogicalProcessor(3, 3, 0));
                 List<PhysicalProcessor> physProcs = Arrays.asList(new PhysicalProcessor(0, 0, 1, "P-core"),

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractGlobalMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractGlobalMemoryTest.java
@@ -42,7 +42,7 @@ class AbstractGlobalMemoryTest {
 
             @Override
             public VirtualMemory getVirtualMemory() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
         };
         String s = mem.toString();

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractHardwareAbstractionLayerTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractHardwareAbstractionLayerTest.java
@@ -32,22 +32,22 @@ class AbstractHardwareAbstractionLayerTest {
         return new AbstractHardwareAbstractionLayer() {
             @Override
             protected ComputerSystem createComputerSystem() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
 
             @Override
             protected CentralProcessor createProcessor() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
 
             @Override
             protected GlobalMemory createMemory() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
 
             @Override
             protected Sensors createSensors() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
 
             @Override

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractPowerSourceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractPowerSourceTest.java
@@ -13,6 +13,7 @@ import java.time.Month;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.hardware.PowerSource;
@@ -28,7 +29,7 @@ class AbstractPowerSourceTest {
     private static AbstractPowerSource createSource(String name, double remainPct, double timeEst, double timeInst,
             double power, double voltage, double amperage, boolean onLine, boolean charging, boolean discharging,
             PowerSource.CapacityUnits units, int current, int max, int design, int cycles, String chemistry,
-            LocalDate mfgDate, String mfg, String serial, double temp) {
+            @Nullable LocalDate mfgDate, String mfg, String serial, double temp) {
         return new AbstractPowerSource(name, "Device-" + name, remainPct, timeEst, timeInst, power, voltage, amperage,
                 onLine, charging, discharging, units, current, max, design, cycles, chemistry, mfgDate, mfg, serial,
                 temp) {

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -604,7 +605,7 @@ class LinuxCentralProcessorTest {
         }
 
         @Override
-        protected List<String> enumerateCpuSyspathsViaUdev() {
+        protected @Nullable List<String> enumerateCpuSyspathsViaUdev() {
             return null;
         }
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGpuStatsTest.java
@@ -7,6 +7,7 @@ package oshi.hardware.common.platform.linux;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static oshi.util.TestFileUtil.writeFile;
 
@@ -14,6 +15,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -48,13 +50,13 @@ class LinuxGpuStatsTest {
         }
 
         @Override
-        protected String nvmlFindDevice(String busId) {
+        protected @Nullable String nvmlFindDevice(String busId) {
             findDeviceCallCount++;
             return null;
         }
 
         @Override
-        protected String nvmlFindDeviceByName(String name) {
+        protected @Nullable String nvmlFindDeviceByName(String name) {
             return null;
         }
 
@@ -128,13 +130,13 @@ class LinuxGpuStatsTest {
         }
 
         @Override
-        protected String nvmlFindDevice(String busId) {
+        protected @Nullable String nvmlFindDevice(String busId) {
             findDeviceCallCount++;
             return "nvml-device-0";
         }
 
         @Override
-        protected String nvmlFindDeviceByName(String name) {
+        protected @Nullable String nvmlFindDeviceByName(String name) {
             return "nvml-device-0";
         }
 
@@ -177,6 +179,13 @@ class LinuxGpuStatsTest {
     // -------------------------------------------------------------------------
     // Empty / missing path — all metrics return sentinel
     // -------------------------------------------------------------------------
+
+    /** The card's gt/gt0 directory, given its device directory. Path.getParent() is nullable; here it is not. */
+    private static Path gt0Of(Path device) {
+        Path card = device.getParent();
+        assertNotNull(card);
+        return card.resolve("gt/gt0");
+    }
 
     @Test
     void testEmptyPathReturnsSentinels() {
@@ -364,7 +373,7 @@ class LinuxGpuStatsTest {
     @Test
     void testI915Utilization(@TempDir Path tmp) throws IOException {
         Path device = createCardWithGt(tmp);
-        Path gt0 = device.getParent().resolve("gt/gt0");
+        Path gt0 = gt0Of(device);
         writeFile(gt0.resolve("rps_act_freq_mhz"), "1200\n");
         writeFile(gt0.resolve("rps_max_freq_mhz"), "1500\n");
 
@@ -377,7 +386,7 @@ class LinuxGpuStatsTest {
     @Test
     void testI915UtilizationZeroActual(@TempDir Path tmp) throws IOException {
         Path device = createCardWithGt(tmp);
-        Path gt0 = device.getParent().resolve("gt/gt0");
+        Path gt0 = gt0Of(device);
         writeFile(gt0.resolve("rps_act_freq_mhz"), "0\n");
         writeFile(gt0.resolve("rps_max_freq_mhz"), "1500\n");
 
@@ -389,7 +398,7 @@ class LinuxGpuStatsTest {
     @Test
     void testI915CoreClock(@TempDir Path tmp) throws IOException {
         Path device = createCardWithGt(tmp);
-        Path gt0 = device.getParent().resolve("gt/gt0");
+        Path gt0 = gt0Of(device);
         writeFile(gt0.resolve("rps_cur_freq_mhz"), "1350\n");
 
         try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "i915", "", "Intel GPU")) {
@@ -404,7 +413,7 @@ class LinuxGpuStatsTest {
     @Test
     void testXeUtilization(@TempDir Path tmp) throws IOException {
         Path device = createCardWithGt(tmp);
-        Path gt0 = device.getParent().resolve("gt/gt0");
+        Path gt0 = gt0Of(device);
         writeFile(gt0.resolve("rps_act_freq_mhz"), "900\n");
         writeFile(gt0.resolve("rps_max_freq_mhz"), "1800\n");
 
@@ -581,7 +590,7 @@ class LinuxGpuStatsTest {
     @Test
     void testI915UtilizationCappedAt100(@TempDir Path tmp) throws IOException {
         Path device = createCardWithGt(tmp);
-        Path gt0 = device.getParent().resolve("gt/gt0");
+        Path gt0 = gt0Of(device);
         writeFile(gt0.resolve("rps_act_freq_mhz"), "2000\n");
         writeFile(gt0.resolve("rps_max_freq_mhz"), "1500\n");
 
@@ -707,12 +716,12 @@ class LinuxGpuStatsTest {
             }
 
             @Override
-            protected String nvmlFindDevice(String busId) {
+            protected @Nullable String nvmlFindDevice(String busId) {
                 return null;
             }
 
             @Override
-            protected String nvmlFindDeviceByName(String name) {
+            protected @Nullable String nvmlFindDeviceByName(String name) {
                 return "nvml-by-name";
             }
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.ToLongFunction;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -240,13 +241,13 @@ class LinuxGraphicsCardTest {
 
     // No-op lookups for pure parsing tests
     private static final ToLongFunction<String> NO_VRAM = LinuxGraphicsCardTest::noVram;
-    private static final Function<String, Triplet<String, String, String>> NO_DRM = LinuxGraphicsCardTest::noDrm;
+    private static final Function<@Nullable String, Triplet<String, String, String>> NO_DRM = LinuxGraphicsCardTest::noDrm;
 
     private static long noVram(String slot) {
         return 0L;
     }
 
-    private static Triplet<String, String, String> noDrm(String slot) {
+    private static Triplet<String, String, String> noDrm(@Nullable String slot) {
         return new Triplet<>("", "", "");
     }
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxPowerSourceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxPowerSourceTest.java
@@ -10,11 +10,13 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -166,9 +168,11 @@ class LinuxPowerSourceTest {
 
         LinuxPowerSource ps = LinuxPowerSource.buildPowerSource("BAT0", props);
 
-        assertThat(ps.getManufactureDate().getYear(), is(2021));
-        assertThat(ps.getManufactureDate().getMonthValue(), is(6));
-        assertThat(ps.getManufactureDate().getDayOfMonth(), is(15));
+        LocalDate manufactureDate = ps.getManufactureDate();
+        assertNotNull(manufactureDate);
+        assertThat(manufactureDate.getYear(), is(2021));
+        assertThat(manufactureDate.getMonthValue(), is(6));
+        assertThat(manufactureDate.getDayOfMonth(), is(15));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGpuStatsTest.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.hardware.GpuTicks;
@@ -30,7 +31,7 @@ class MacGpuStatsTest {
     private static final String TEMPERATURE = "Temperature(C)";
 
     /** Records whether a sampler was requested, and hands out a fixed one. */
-    private static final class RecordingFactory implements Supplier<IOReportSampler> {
+    private static final class RecordingFactory implements Supplier<@Nullable IOReportSampler> {
         private final IOReportSampler sampler;
         private int calls;
 
@@ -79,19 +80,19 @@ class MacGpuStatsTest {
 
     /** Serves canned PerformanceStatistics, with null meaning the dictionary itself could not be read. */
     private static final class StubGpuStats extends MacGpuStats {
-        private final Map<String, Long> stats;
+        private final @Nullable Map<String, Long> stats;
         private final double smcTemp;
         private int perfStatQueries;
 
-        StubGpuStats(boolean isAppleSilicon, String cardName, Supplier<IOReportSampler> samplerFactory,
-                Map<String, Long> stats, double smcTemp) {
+        StubGpuStats(boolean isAppleSilicon, String cardName, Supplier<@Nullable IOReportSampler> samplerFactory,
+                @Nullable Map<String, Long> stats, double smcTemp) {
             super(isAppleSilicon, cardName, samplerFactory);
             this.stats = stats;
             this.smcTemp = smcTemp;
         }
 
         @Override
-        protected Map<String, Long> queryPerfStats(String... keys) {
+        protected @Nullable Map<String, Long> queryPerfStats(String... keys) {
             perfStatQueries++;
             if (stats == null) {
                 return null;
@@ -256,7 +257,7 @@ class MacGpuStatsTest {
         assertThat("empty does not match", gpu.matchesName(""), is(false));
     }
 
-    private static IOReportSampler nullSampler() {
+    private static @Nullable IOReportSampler nullSampler() {
         return null;
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdFirmwareTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.util.Constants;
@@ -33,12 +34,12 @@ class BsdFirmwareTest {
         }
 
         @Override
-        protected Triplet<String, String, String> readFirmware() {
+        protected Triplet<@Nullable String, @Nullable String, @Nullable String> readFirmware() {
             return parseDmesg(dmesg);
         }
     }
 
-    private static Triplet<String, String, String> parse(List<String> dmesg) {
+    private static Triplet<@Nullable String, @Nullable String, @Nullable String> parse(List<String> dmesg) {
         return BsdFirmware.parseDmesg(dmesg);
     }
 
@@ -49,7 +50,7 @@ class BsdFirmwareTest {
                 "bios0 at mainbus0: SMBIOS rev. 2.7 @ 0xdcc0e000 (67 entries)", //
                 "bios0: vendor LENOVO version \"GLET90WW (2.44 )\" date 09/13/2017", //
                 "bios0: LENOVO 20AWA08J00");
-        Triplet<String, String, String> fw = parse(dmesg);
+        Triplet<@Nullable String, @Nullable String, @Nullable String> fw = parse(dmesg);
         assertThat(fw.getA(), is("LENOVO"));
         assertThat(fw.getB(), is("GLET90WW (2.44 )"));
         assertThat(fw.getC(), is("2017-09-13"));
@@ -61,7 +62,7 @@ class BsdFirmwareTest {
         List<String> dmesg = Arrays.asList(//
                 "bios0 at mainbus0: SMBIOS rev. 2.8 @ 0xe9cb0 (53 entries)", //
                 "bios0: vendor American Megatrends Inc. version \"F5\" date 03/18/2016");
-        Triplet<String, String, String> fw = parse(dmesg);
+        Triplet<@Nullable String, @Nullable String, @Nullable String> fw = parse(dmesg);
         assertThat(fw.getA(), is("American Megatrends Inc."));
         assertThat(fw.getB(), is("F5"));
         assertThat(fw.getC(), is("2016-03-18"));
@@ -70,7 +71,7 @@ class BsdFirmwareTest {
     @Test
     void testParseDmesgMultiWordVendor() {
         List<String> dmesg = Arrays.asList("bios0: vendor Phoenix Technologies LTD version \"6.00\" date 04/14/2014");
-        Triplet<String, String, String> fw = parse(dmesg);
+        Triplet<@Nullable String, @Nullable String, @Nullable String> fw = parse(dmesg);
         assertThat(fw.getA(), is("Phoenix Technologies LTD"));
         assertThat(fw.getB(), is("6.00"));
         assertThat(fw.getC(), is("2014-04-14"));
@@ -78,7 +79,7 @@ class BsdFirmwareTest {
 
     @Test
     void testParseDmesgEmpty() {
-        Triplet<String, String, String> fw = parse(Collections.emptyList());
+        Triplet<@Nullable String, @Nullable String, @Nullable String> fw = parse(Collections.emptyList());
         assertThat(fw.getA(), is(nullValue()));
         assertThat(fw.getB(), is(nullValue()));
         assertThat(fw.getC(), is(emptyString()));
@@ -89,7 +90,7 @@ class BsdFirmwareTest {
         List<String> dmesg = Arrays.asList(//
                 "cpu0 at mainbus0: AMD EPYC 7313P", //
                 "some other line");
-        Triplet<String, String, String> fw = parse(dmesg);
+        Triplet<@Nullable String, @Nullable String, @Nullable String> fw = parse(dmesg);
         assertThat(fw.getA(), is(nullValue()));
         assertThat(fw.getB(), is(nullValue()));
         assertThat(fw.getC(), is(emptyString()));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdSoundCardTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,7 +36,7 @@ class BsdSoundCardTest {
         assertThat(cards, hasSize(2));
         // Find the azalia card
         SoundCard azalia = cards.stream().filter(c -> c.getName().contains("82801I")).findFirst().orElse(null);
-        assertThat(azalia != null, is(true));
+        assertNotNull(azalia);
         assertThat(azalia.getName(), is("Intel 82801I HD Audio"));
         // Parser uses indexOf(':') to split — captures everything after the first colon in the codec line
         assertThat(azalia.getCodec(), is("codec[0]: Realtek ALC888"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystemTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.util.tuples.Quintet;
@@ -32,7 +33,8 @@ class FreeBsdComputerSystemTest {
                 "\tWake-up Type: Power Switch", //
                 "\tSKU Number: SKU=NotProvided", //
                 "\tFamily: PowerEdge");
-        Quintet<String, String, String, String, String> dmi = FreeBsdComputerSystem.parseDmiDecode(dmidecode);
+        Quintet<@Nullable String, @Nullable String, @Nullable String, @Nullable String, @Nullable String> dmi = FreeBsdComputerSystem
+                .parseDmiDecode(dmidecode);
         assertThat(dmi.getA(), is("Dell Inc."));
         assertThat(dmi.getB(), is("PowerEdge R640"));
         assertThat(dmi.getC(), is("7XY1234"));
@@ -43,7 +45,7 @@ class FreeBsdComputerSystemTest {
     @Test
     void testParseDmiDecodeEmpty() {
         // No output (e.g. dmidecode not available / not root): every field is null so the caller can fall back.
-        Quintet<String, String, String, String, String> dmi = FreeBsdComputerSystem
+        Quintet<@Nullable String, @Nullable String, @Nullable String, @Nullable String, @Nullable String> dmi = FreeBsdComputerSystem
                 .parseDmiDecode(Collections.emptyList());
         assertThat(dmi.getA(), is(nullValue()));
         assertThat(dmi.getC(), is(nullValue()));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmwareTest.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.util.tuples.Triplet;
@@ -31,7 +32,7 @@ class FreeBsdFirmwareTest {
                 "\tRelease Date: 07/15/2016", //
                 "\tBIOS Revision: 11.2", //
                 "\tFirmware Revision: 11.2");
-        Triplet<String, String, String> fw = FreeBsdFirmware.parseDmiDecode(dmidecode);
+        Triplet<@Nullable String, @Nullable String, @Nullable String> fw = FreeBsdFirmware.parseDmiDecode(dmidecode);
         assertThat(fw.getA(), is("Parallels Software International Inc."));
         assertThat(fw.getB(), is("11.2.1 (32626)"));
         assertThat(fw.getC(), is("2016-07-15"));
@@ -41,7 +42,8 @@ class FreeBsdFirmwareTest {
     void testParseDmiDecodeEmpty() {
         // No output (e.g. dmidecode not available / not root): the parser returns raw absent values (null
         // manufacturer/version, empty date); the BsdFirmware base applies the Constants.UNKNOWN fallbacks.
-        Triplet<String, String, String> fw = FreeBsdFirmware.parseDmiDecode(Collections.emptyList());
+        Triplet<@Nullable String, @Nullable String, @Nullable String> fw = FreeBsdFirmware
+                .parseDmiDecode(Collections.emptyList());
         assertThat(fw.getA(), is(nullValue()));
         assertThat(fw.getB(), is(nullValue()));
         assertThat(fw.getC(), is(emptyString()));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystemTest.java
@@ -6,6 +6,7 @@ package oshi.hardware.common.platform.unix.solaris;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,17 +52,20 @@ class SolarisComputerSystemTest {
         EnumMap<SmbType, Map<String, String>> result = SolarisComputerSystem.parseSmbios(smbios);
 
         Map<String, String> bios = result.get(SmbType.SMB_TYPE_BIOS);
+        assertNotNull(bios);
         assertThat(bios.get("Vendor"), is("Parallels Software International Inc."));
         assertThat(bios.get("Version String"), is("11.2.1 (32686)"));
         assertThat(bios.get("Release Date"), is("07/15/2016"));
 
         Map<String, String> system = result.get(SmbType.SMB_TYPE_SYSTEM);
+        assertNotNull(system);
         assertThat(system.get("Manufacturer"), is("Parallels Software International Inc."));
         assertThat(system.get("Product"), is("Parallels Virtual Platform"));
         assertThat(system.get("Serial Number"), is("Parallels-45 2E 7E 2D 57 5C 4B 59 B1 30 28 81 B7 81 89 34"));
         assertThat(system.get("UUID"), is("452e7e2d-575c04b59-b130-2881b7818934"));
 
         Map<String, String> baseboard = result.get(SmbType.SMB_TYPE_BASEBOARD);
+        assertNotNull(baseboard);
         assertThat(baseboard.get("Manufacturer"), is("Parallels Software International Inc."));
         assertThat(baseboard.get("Product"), is("Parallels Virtual Platform"));
         assertThat(baseboard.get("Serial Number"), is("None"));
@@ -70,9 +74,15 @@ class SolarisComputerSystemTest {
     @Test
     void testParseSmbiosEmpty() {
         EnumMap<SmbType, Map<String, String>> result = SolarisComputerSystem.parseSmbios(Collections.emptyList());
-        assertThat(result.get(SmbType.SMB_TYPE_BIOS).isEmpty(), is(true));
-        assertThat(result.get(SmbType.SMB_TYPE_SYSTEM).isEmpty(), is(true));
-        assertThat(result.get(SmbType.SMB_TYPE_BASEBOARD).isEmpty(), is(true));
+        Map<String, String> bios = result.get(SmbType.SMB_TYPE_BIOS);
+        Map<String, String> system = result.get(SmbType.SMB_TYPE_SYSTEM);
+        Map<String, String> baseboard = result.get(SmbType.SMB_TYPE_BASEBOARD);
+        assertNotNull(bios);
+        assertNotNull(system);
+        assertNotNull(baseboard);
+        assertThat(bios.isEmpty(), is(true));
+        assertThat(system.isEmpty(), is(true));
+        assertThat(baseboard.isEmpty(), is(true));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsComputerSystemTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.driver.common.windows.wmi.WmiQuery;
@@ -39,7 +40,7 @@ class WindowsComputerSystemTest {
                 }
 
                 @Override
-                public Object getValue(T property, int index) {
+                public @Nullable Object getValue(T property, int index) {
                     return null;
                 }
 
@@ -65,12 +66,12 @@ class WindowsComputerSystemTest {
 
             @Override
             public Firmware createFirmware() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
 
             @Override
             public Baseboard createBaseboard() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
         };
     }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGraphicsCardTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.driver.common.windows.gpu.DxgiAdapterInfo;
@@ -46,7 +47,7 @@ class WindowsGraphicsCardTest {
 
         @Override
         public oshi.hardware.GpuStats createStatsSession() {
-            return null;
+            throw new UnsupportedOperationException("not exercised by this test");
         }
     }
 
@@ -78,7 +79,7 @@ class WindowsGraphicsCardTest {
             }
 
             @Override
-            public Object getValue(VideoControllerProperty property, int index) {
+            public @Nullable Object getValue(VideoControllerProperty property, int index) {
                 return list.get(index).values.get(property);
             }
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroupTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroupTest.java
@@ -21,6 +21,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.driver.common.windows.wmi.MSFTStorage.PhysicalDiskProperty;
@@ -61,7 +62,7 @@ class WindowsLogicalVolumeGroupTest {
             }
 
             @Override
-            public Object getValue(T property, int index) {
+            public @Nullable Object getValue(T property, int index) {
                 return rows.get(index).get(property);
             }
 

--- a/oshi-common/src/test/java/oshi/software/common/AbstractOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/AbstractOperatingSystemTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import oshi.software.os.FileSystem;
@@ -77,16 +78,16 @@ class AbstractOperatingSystemTest {
 
             @Override
             public FileSystem getFileSystem() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
 
             @Override
             public InternetProtocolStats getInternetProtocolStats() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
 
             @Override
-            public OSProcess getProcess(int pid) {
+            public @Nullable OSProcess getProcess(int pid) {
                 return allProcesses.stream().filter(p -> p.getProcessID() == pid).findFirst().orElse(null);
             }
 
@@ -102,7 +103,7 @@ class AbstractOperatingSystemTest {
 
             @Override
             public OSThread getCurrentThread() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
 
             @Override
@@ -127,7 +128,7 @@ class AbstractOperatingSystemTest {
 
             @Override
             public NetworkParams getNetworkParams() {
-                return null;
+                throw new UnsupportedOperationException("not exercised by this test");
             }
         };
     }
@@ -345,7 +346,7 @@ class AbstractOperatingSystemTest {
         }
 
         @Override
-        public double getProcessCpuLoadBetweenTicks(OSProcess proc) {
+        public double getProcessCpuLoadBetweenTicks(@Nullable OSProcess proc) {
             return 0;
         }
 

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxFileSystemTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -28,7 +29,7 @@ class LinuxFileSystemTest {
     /** Concrete subclass that falls back to File methods for space queries. */
     private static final class StubLinuxFileSystem extends LinuxFileSystem {
         @Override
-        protected long[] queryStatvfs(String path) {
+        protected long @Nullable [] queryStatvfs(String path) {
             return null;
         }
     }

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOSFileStoreTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOSFileStoreTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.not;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -29,7 +30,7 @@ class LinuxOSFileStoreTest {
     /** Subclass that returns null from queryStatvfs to test the JVM File fallback path. */
     private static final class NullStatvfsFileSystem extends LinuxFileSystem {
         @Override
-        protected long[] queryStatvfs(String path) {
+        protected long @Nullable [] queryStatvfs(String path) {
             return null;
         }
     }
@@ -37,7 +38,7 @@ class LinuxOSFileStoreTest {
     /** Subclass that returns zeros from queryStatvfs to test the JVM File fallback within updateAttributes. */
     private static final class ZeroStatvfsFileSystem extends LinuxFileSystem {
         @Override
-        protected long[] queryStatvfs(String path) {
+        protected long @Nullable [] queryStatvfs(String path) {
             // Return array with totalInodes, freeInodes, totalSpace=0, usableSpace=0, freeSpace=0
             // This triggers the JVM File fallback inside updateAttributes
             return new long[] { 1000L, 500L, 0L, 0L, 0L };

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemDistroTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemDistroTest.java
@@ -140,6 +140,7 @@ class LinuxOperatingSystemDistroTest {
     void testReadLsbReleaseFedora() {
         List<String> lines = Arrays.asList("DISTRIB_ID=Fedora", "DISTRIB_RELEASE=39", "DISTRIB_CODENAME=ThirtyNine");
         Triplet<String, String, String> result = LinuxOperatingSystem.readLsbRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Fedora"));
         assertThat(result.getB(), is("39"));
         assertThat(result.getC(), is("ThirtyNine"));
@@ -152,6 +153,7 @@ class LinuxOperatingSystemDistroTest {
         List<String> lines = Arrays.asList("Distributor ID:\tDebian", "Description:\tDebian GNU/Linux 12 (bookworm)",
                 "Release:\t12", "Codename:\tbookworm");
         Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Debian"));
         assertThat(result.getB(), is("12"));
         assertThat(result.getC(), is("bookworm"));
@@ -162,6 +164,7 @@ class LinuxOperatingSystemDistroTest {
         List<String> lines = Arrays.asList("Distributor ID:\tArch", "Description:\tArch Linux", "Release:\trolling",
                 "Codename:\tn/a");
         Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Arch"));
         assertThat(result.getB(), is("rolling"));
     }

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -50,6 +51,7 @@ class LinuxOperatingSystemTest {
     @Test
     void testReadOsReleaseUbuntu() {
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_UBUNTU);
+        assertNotNull(result);
         assertThat(result.getA(), is("Ubuntu"));
         assertThat(result.getB(), is("22.04.3 LTS"));
         assertThat(result.getC(), is("Jammy Jellyfish"));
@@ -58,6 +60,7 @@ class LinuxOperatingSystemTest {
     @Test
     void testReadOsReleaseCentOS() {
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(OS_RELEASE_CENTOS);
+        assertNotNull(result);
         assertThat(result.getA(), is("CentOS Stream"));
         assertThat(result.getB(), is("9"));
     }
@@ -76,6 +79,7 @@ class LinuxOperatingSystemTest {
     @Test
     void testExecLsbRelease() {
         Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(LSB_RELEASE);
+        assertNotNull(result);
         assertThat(result.getA(), is("Ubuntu"));
         assertThat(result.getB(), is("22.04"));
         assertThat(result.getC(), is("jammy"));
@@ -90,6 +94,7 @@ class LinuxOperatingSystemTest {
     void testExecLsbReleaseDescriptionOnly() {
         List<String> descOnly = Arrays.asList("Description:\tFedora release 38 (Thirty Eight)");
         Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(descOnly);
+        assertNotNull(result);
         assertThat(result.getA(), is("Fedora"));
         assertThat(result.getB(), is("38"));
         assertThat(result.getC(), is("Thirty Eight"));
@@ -137,6 +142,7 @@ class LinuxOperatingSystemTest {
         List<String> lines = Arrays.asList("DISTRIB_ID=Ubuntu", "DISTRIB_RELEASE=20.04", "DISTRIB_CODENAME=focal",
                 "DISTRIB_DESCRIPTION=\"Ubuntu 20.04.6 LTS\"");
         Triplet<String, String, String> result = LinuxOperatingSystem.readLsbRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Ubuntu"));
         assertThat(result.getB(), is("20.04"));
         assertThat(result.getC(), is("focal"));
@@ -146,6 +152,7 @@ class LinuxOperatingSystemTest {
     void testReadLsbReleaseDescriptionWithRelease() {
         List<String> lines = Arrays.asList("DISTRIB_DESCRIPTION=\"Fedora release 38 (Thirty Eight)\"");
         Triplet<String, String, String> result = LinuxOperatingSystem.readLsbRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Fedora"));
         assertThat(result.getB(), is("38"));
         assertThat(result.getC(), is("Thirty Eight"));
@@ -164,6 +171,7 @@ class LinuxOperatingSystemTest {
     void testReadDistribRelease() {
         List<String> lines = Arrays.asList("CentOS release 6.10 (Final)");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("CentOS"));
         assertThat(result.getB(), is("6.10"));
         assertThat(result.getC(), is("Final"));
@@ -173,6 +181,7 @@ class LinuxOperatingSystemTest {
     void testReadDistribReleaseVersion() {
         List<String> lines = Arrays.asList("SUSE Linux Enterprise Server VERSION 15");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("SUSE Linux Enterprise Server"));
         assertThat(result.getB(), is("15"));
         assertThat(result.getC(), is(Constants.UNKNOWN));
@@ -199,6 +208,7 @@ class LinuxOperatingSystemTest {
     @Test
     void testParseReleaseNoCodename() {
         Triplet<String, String, String> result = LinuxOperatingSystem.parseRelease("Debian release 11", " release ");
+        assertNotNull(result);
         assertThat(result.getA(), is("Debian"));
         assertThat(result.getB(), is("11"));
         assertThat(result.getC(), is(Constants.UNKNOWN));
@@ -207,6 +217,7 @@ class LinuxOperatingSystemTest {
     @Test
     void testParseReleaseNoVersion() {
         Triplet<String, String, String> result = LinuxOperatingSystem.parseRelease("MyLinux", " release ");
+        assertNotNull(result);
         assertThat(result.getA(), is("MyLinux"));
         assertThat(result.getB(), is(Constants.UNKNOWN));
         assertThat(result.getC(), is(Constants.UNKNOWN));
@@ -241,6 +252,7 @@ class LinuxOperatingSystemTest {
         // VERSION uses ", " separator instead of parentheses
         List<String> lines = Arrays.asList("NAME=\"Ubuntu\"", "VERSION=\"22.04, Jammy\"", "VERSION_ID=\"22.04\"");
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Ubuntu"));
         assertThat(result.getB(), is("22.04"));
         assertThat(result.getC(), is("Jammy"));
@@ -251,6 +263,7 @@ class LinuxOperatingSystemTest {
         // No VERSION= line, falls back to VERSION_ID=
         List<String> lines = Arrays.asList("NAME=\"Alpine Linux\"", "VERSION_ID=\"3.18.4\"");
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Alpine Linux"));
         assertThat(result.getB(), is("3.18.4"));
         assertThat(result.getC(), is(Constants.UNKNOWN));
@@ -262,6 +275,7 @@ class LinuxOperatingSystemTest {
         List<String> lines = Arrays.asList("VERSION=\"20.04.6 LTS (Focal Fossa)\"", "VERSION_ID=\"20.04\"",
                 "NAME=\"Ubuntu\"");
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Ubuntu"));
         assertThat(result.getB(), is("20.04.6 LTS"));
         assertThat(result.getC(), is("Focal Fossa"));
@@ -279,6 +293,7 @@ class LinuxOperatingSystemTest {
         List<String> lines = Arrays.asList("Distributor ID:\tFedora", "Release:\t39", "Codename:\tThirtyNine",
                 "Description:\tFedora release 38 (Thirty Eight)");
         Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("Fedora"));
         assertThat(result.getB(), is("39"));
         assertThat(result.getC(), is("ThirtyNine"));
@@ -293,6 +308,7 @@ class LinuxOperatingSystemTest {
         // " VERSION " delimiter with a codename in parentheses
         List<String> lines = Arrays.asList("SUSE Linux Enterprise Server VERSION 15 (SP3)");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
+        assertNotNull(result);
         assertThat(result.getA(), is("SUSE Linux Enterprise Server"));
         assertThat(result.getB(), is("15"));
         assertThat(result.getC(), is("SP3"));

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixOperatingSystemTest.java
@@ -7,6 +7,7 @@ package oshi.software.common.os.unix.aix;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,12 +33,18 @@ class AixOperatingSystemTest {
         Map<String, OSService> byName = services.stream()
                 .collect(Collectors.toMap(OSService::getName, Function.identity()));
 
-        assertThat(byName.get("syslogd").getProcessID(), is(4194320));
-        assertThat(byName.get("syslogd").getState(), is(OSService.State.RUNNING));
-        assertThat(byName.get("inetd").getProcessID(), is(5218374));
-        assertThat(byName.get("inetd").getState(), is(OSService.State.RUNNING));
-        assertThat(byName.get("portmap").getProcessID(), is(0));
-        assertThat(byName.get("portmap").getState(), is(OSService.State.STOPPED));
+        OSService syslogd = byName.get("syslogd");
+        OSService inetd = byName.get("inetd");
+        OSService portmap = byName.get("portmap");
+        assertNotNull(syslogd);
+        assertNotNull(inetd);
+        assertNotNull(portmap);
+        assertThat(syslogd.getProcessID(), is(4194320));
+        assertThat(syslogd.getState(), is(OSService.State.RUNNING));
+        assertThat(inetd.getProcessID(), is(5218374));
+        assertThat(inetd.getState(), is(OSService.State.RUNNING));
+        assertThat(portmap.getProcessID(), is(0));
+        assertThat(portmap.getState(), is(OSService.State.STOPPED));
     }
 
     @Test

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsGraphicsCardJNA.java
@@ -300,7 +300,7 @@ final class WindowsGraphicsCardJNA extends WindowsGraphicsCard {
      * @param locationInfo the LocationInformation registry value
      * @return PCI device number, or -1 if not parseable
      */
-    static int parsePciDevice(String locationInfo) {
+    static int parsePciDevice(@Nullable String locationInfo) {
         return DxgiUtil.parsePciDevice(locationInfo);
     }
 
@@ -310,7 +310,7 @@ final class WindowsGraphicsCardJNA extends WindowsGraphicsCard {
      * @param locationInfo the LocationInformation registry value
      * @return PCI function number, or -1 if not parseable
      */
-    static int parsePciFunction(String locationInfo) {
+    static int parsePciFunction(@Nullable String locationInfo) {
         return DxgiUtil.parsePciFunction(locationInfo);
     }
 

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/CentralProcessorTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/CentralProcessorTest.java
@@ -35,7 +35,7 @@ import oshi.util.Util;
 @TestInstance(Lifecycle.PER_CLASS)
 class CentralProcessorTest {
 
-    private CentralProcessor p = null;
+    private CentralProcessor p;
 
     @BeforeAll
     void setUp() {

--- a/oshi-core/src/test/java/oshi/hardware/platform/shared/GlobalMemoryTest.java
+++ b/oshi-core/src/test/java/oshi/hardware/platform/shared/GlobalMemoryTest.java
@@ -34,7 +34,7 @@ class GlobalMemoryTest {
         return new SystemInfo().getHardware().getMemory();
     }
 
-    private GlobalMemory memory = null;
+    private GlobalMemory memory;
 
     @BeforeAll
     void setUp() {

--- a/oshi-core/src/test/java/oshi/software/os/shared/InternetProtocolStatsTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/InternetProtocolStatsTest.java
@@ -31,7 +31,7 @@ import oshi.software.os.InternetProtocolStats.UdpStats;
 @TestInstance(Lifecycle.PER_CLASS)
 class InternetProtocolStatsTest {
 
-    private InternetProtocolStats ipStats = null;
+    private InternetProtocolStats ipStats;
 
     @BeforeAll
     void setUp() {

--- a/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
+++ b/oshi-core/src/test/java/oshi/software/os/shared/OperatingSystemTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.oneOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -63,17 +64,19 @@ class OperatingSystemTest {
     }
 
     protected OperatingSystem os = createOperatingSystem();
-    protected OSProcess proc = os.getProcess(os.getProcessId());
+    protected OSProcess proc;
 
     @BeforeAll
     void setUp() {
+        OSProcess current = os.getProcess(os.getProcessId());
         // In rare cases on procfs based systems the proc call may result in null, so
         // we'll try a second time
-        if (this.proc == null) {
-            this.proc = os.getProcess(os.getProcessId());
+        if (current == null) {
+            current = os.getProcess(os.getProcessId());
         }
         // Fail here rather than more confusing NPEs later
-        assertThat("Current process PID returned null", proc, is(notNullValue()));
+        assertNotNull(current, "Current process PID returned null");
+        this.proc = current;
     }
 
     @Test

--- a/oshi-core/src/test/java/oshi/software/os/windows/WindowsOperatingSystemJNATest.java
+++ b/oshi-core/src/test/java/oshi/software/os/windows/WindowsOperatingSystemJNATest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.oneOf;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -84,11 +85,11 @@ class WindowsOperatingSystemJNATest {
             return queryDescendantProcesses(parentPid);
         }
 
-        private Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCountersForTest() {
+        private @Nullable Map<Integer, ProcessPerfCounterBlock> buildProcessMapFromPerfCountersForTest() {
             return buildProcessMapFromPerfCounters(null);
         }
 
-        private Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCountersForTest() {
+        private @Nullable Map<Integer, ThreadPerfCounterBlock> buildThreadMapFromPerfCountersForTest() {
             return buildThreadMapFromPerfCounters(null);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1236,13 +1236,6 @@
             "-Xep:Check:OFF"-style flags; it's also JMH-only and never carries JSpecify
             annotations, so it isn't worth the extra plumbing to fix. -->
             <id>error-prone</id>
-            <properties>
-                <!-- The Error Prone plugin argument, split so main and test compilation can differ in exactly one
-                place: NullAway's severity. Everything else is identical, and the two <arg> elements below must stay
-                that way. Each must remain a single token; javac takes one -Xplugin value. -->
-                <errorprone.checks>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF -Xep:MissingSummary:OFF -Xep:StringSplitter:ERROR -Xep:EnumOrdinal:ERROR -Xep:OperatorPrecedence:ERROR -Xep:MixedMutabilityReturnType:ERROR -Xep:ReferenceEquality:ERROR -Xep:BoxingComparator:ERROR -Xep:NarrowCalculation:ERROR -Xep:LongDoubleConversion:ERROR -Xep:IntLiteralCast:ERROR -Xep:UnnecessaryLongToIntConversion:ERROR -Xep:IntLongMath:ERROR -Xep:BadImport:ERROR -Xep:ModifyCollectionInEnhancedForLoop:ERROR -Xep:EqualsGetClass:ERROR -Xep:DuplicateBranches:ERROR -Xep:InconsistentCapitalization:ERROR -Xep:NonApiType:ERROR -Xep:InvalidParam:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:UnnecessaryLambda:ERROR -Xep:UnnecessaryParentheses:ERROR -Xep:AssignmentExpression:ERROR -Xep:UnusedVariable:ERROR -Xep:PatternMatchingInstanceof:ERROR -Xep:EscapedEntity:ERROR -Xep:NotJavadoc:ERROR -Xep:AlmostJavadoc:ERROR -Xep:InvalidInlineTag:ERROR -Xep:InlineFormatString:ERROR -Xep:Slf4jLoggerShouldBeNonStatic:OFF -Xep:Slf4jSignOnlyFormat:OFF -Xep:Slf4jDoNotLogMessageOfExceptionExplicitly:ERROR -Xep:Slf4jPlaceholderMismatch:ERROR -Xep:Slf4jFormatShouldBeConst:ERROR -Xep:Slf4jLoggerShouldBePrivate:ERROR -Xep:Slf4jLoggerShouldBeFinal:ERROR -Xep:Slf4jIllegalPassedClass:ERROR</errorprone.checks>
-                <errorprone.nullaway.opts>-XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:HandleTestAssertionLibraries=true</errorprone.nullaway.opts>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -1290,7 +1283,7 @@
                                 74-site backlog was drained; every log call now passes the throwable rather than
                                 its message, so it is back at the plugin's default ERROR. Note the severity token
                                 Error Prone accepts is WARN, not WARNING. -->
-                                <arg>${errorprone.checks} -Xep:NullAway:ERROR ${errorprone.nullaway.opts}</arg>
+                                <arg>-Xplugin:ErrorProne -Xep:InlineMeSuggester:OFF -Xep:DoNotCallSuggester:OFF -Xep:MissingSummary:OFF -Xep:StringSplitter:ERROR -Xep:EnumOrdinal:ERROR -Xep:OperatorPrecedence:ERROR -Xep:MixedMutabilityReturnType:ERROR -Xep:ReferenceEquality:ERROR -Xep:BoxingComparator:ERROR -Xep:NarrowCalculation:ERROR -Xep:LongDoubleConversion:ERROR -Xep:IntLiteralCast:ERROR -Xep:UnnecessaryLongToIntConversion:ERROR -Xep:IntLongMath:ERROR -Xep:BadImport:ERROR -Xep:ModifyCollectionInEnhancedForLoop:ERROR -Xep:EqualsGetClass:ERROR -Xep:DuplicateBranches:ERROR -Xep:InconsistentCapitalization:ERROR -Xep:NonApiType:ERROR -Xep:InvalidParam:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ImmutableEnumChecker:ERROR -Xep:StatementSwitchToExpressionSwitch:ERROR -Xep:UnnecessaryLambda:ERROR -Xep:UnnecessaryParentheses:ERROR -Xep:AssignmentExpression:ERROR -Xep:UnusedVariable:ERROR -Xep:PatternMatchingInstanceof:ERROR -Xep:EscapedEntity:ERROR -Xep:NotJavadoc:ERROR -Xep:AlmostJavadoc:ERROR -Xep:InvalidInlineTag:ERROR -Xep:InlineFormatString:ERROR -Xep:Slf4jLoggerShouldBeNonStatic:OFF -Xep:Slf4jSignOnlyFormat:OFF -Xep:Slf4jDoNotLogMessageOfExceptionExplicitly:ERROR -Xep:Slf4jPlaceholderMismatch:ERROR -Xep:Slf4jFormatShouldBeConst:ERROR -Xep:Slf4jLoggerShouldBePrivate:ERROR -Xep:Slf4jLoggerShouldBeFinal:ERROR -Xep:Slf4jIllegalPassedClass:ERROR -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:HandleTestAssertionLibraries=true</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>
@@ -1310,31 +1303,6 @@
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>
-                        <executions>
-                            <!-- Test sources run NullAway at WARN, not ERROR. Raising maven.compiler.testRelease to
-                            17 moved test compilation from the classpath onto the module path, which brought
-                            module-info.java's @NullMarked into scope for test packages for the first time and
-                            surfaced 178 findings across 41 files that had never been checked. They are real, and
-                            mostly mechanical (assertNotNull for a dereference, a @Nullable type argument for a
-                            generic mismatch), but a drain job of their own rather than a build-config change. WARN
-                            keeps them visible while the backlog is worked; raise this to ERROR once it reaches
-                            zero. Every other check stays at its configured severity here - only NullAway moves. -->
-                            <execution>
-                                <id>default-testCompile</id>
-                                <configuration>
-                                    <compilerArgs>
-                                        <arg>-Xlint:-options</arg>
-                                        <arg>-Xmaxwarns</arg>
-                                        <arg>100000</arg>
-                                        <arg>-Xmaxerrs</arg>
-                                        <arg>100000</arg>
-                                        <arg>-XDcompilePolicy=simple</arg>
-                                        <arg>--should-stop=ifError=FLOW</arg>
-                                        <arg>${errorprone.checks} -Xep:NullAway:WARN ${errorprone.nullaway.opts}</arg>
-                                    </compilerArgs>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Closes #3689. The 89 findings left after #3690 are fixed, and **NullAway goes back to ERROR for test compilation**.

`pom.xml`'s `error-prone` profile is now byte-identical to its shape before #3688 — the WARN mechanism and the property split it needed are gone, and the only surviving pom change from that PR is the `testRelease` bump itself.

## Mostly the shapes from #3690

A local plus `assertNotNull` where a nullable expression was dereferenced; the nullable type arguments the API already declares on a `Triplet`/`Quartet`/`Quintet`; an override repeating the parent's `@Nullable`.

## Four more main annotations contradicted their own code

Same pattern as `LinuxHWDiskStore` in #3690 — the code handles null by design and the tests prove it, so the annotation is what was wrong:

| Class | The code |
|---|---|
| `LinuxLogicalVolumeGroup` | every `UdevBlockDevice` field is null-guarded in `buildLogicalVolumeGroups` |
| `MacGpuStats.matchesName` | `if (model == null \|\| model.isEmpty())` |
| `LinuxOSProcess.getMissingDetails` | `if (status == null \|\| stat == null)` |
| `MacInstalledApps.parseItems` | `if (xml == null)` |

`vgName`/`lvName` behind the `Util.isBlank` guard go through `ParseUtil.getStringValueOrEmpty` for the same reason as before: a predicate doesn't narrow, a return type does.

A fifth is a twin slip rather than a contract question — `WindowsGraphicsCardJNA.parsePciDevice`/`parsePciFunction` forward straight to `DxgiUtil`, which **already declares the parameter `@Nullable`**; the forwarders had simply dropped it.

## Two judgment calls

**Stub overrides returning `null` against a non-null contract now throw.** `createFirmware`, `getNetworkParams`, `createStatsSession`, the Mac providers and friends all claimed in a comment to be unreached. Throwing enforces that claim instead of merely asserting it — and the tests passing is what establishes it's true.

**`OperatingSystemTest.proc`** was a non-null field initialized from the `@Nullable` `getProcess`, guarded by a Hamcrest `notNullValue()` that doesn't narrow for NullAway. It's now resolved into a local in `@BeforeAll` with `assertNotNull`, keeping the field non-null and the retry logic intact.

## One review suggestion deliberately not taken

CodeRabbit suggested routing `fsType` through `ParseUtil.getStringValueOrEmpty` in `LinuxHWDiskStore` instead of its inline null ternary. Not applied, because it would change behaviour:

| `fsType` | today | as suggested |
|---|---|---|
| `null` | `"partition"` | `"partition"` |
| `""` | `""` | **`"partition"`** |
| `"ext4"` | `"ext4"` | `"ext4"` |

The normalizer returns `""` for null, so applying the `PARTITION` fallback to the normalized value would also map an empty-but-present `fsType` to `"partition"`. That might be desirable, but it is a user-visible behaviour change deserving its own decision and a CHANGELOG entry, not a refactor folded into a nullability sweep. The rule being invoked exists because predicates like `Util.isBlank` don't narrow for the analyzer; `fsType == null ? ... : fsType` is a direct comparison NullAway narrows through natively, and it was not producing a finding.

## Verification

Full gate from clean — `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc -Paggregate-coverage` — green, zero test failures, zero checkstyle violations. `-Perror-prone clean install` reports **0 NullAway errors and 0 warnings** with the check at ERROR on main *and* test.

As with #3690, the Linux/Windows/Mac-specific tests are skipped on the development machine, so those annotation changes ride on CI here.

No CHANGELOG entry — annotations and tests, no behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or incomplete hardware, operating system, graphics, and storage data.
  * Prevented errors when optional platform information is unavailable.

* **Tests**
  * Strengthened validation for nullable results and unsupported test operations.
  * Enhanced coverage across Linux, macOS, BSD, Solaris, Windows, and AIX integrations.

* **Chores**
  * Updated static analysis configuration to enforce null-safety checks consistently, including during test compilation.
  * Refined testing guidance for nullable values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->