### PR TITLE
Read multi-line file fixtures through FileUtil, from text blocks

### DIFF
--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxBluetoothDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxBluetoothDeviceTest.java
@@ -74,8 +74,13 @@ class LinuxBluetoothDeviceTest {
         Path varLib = tempDir.resolve("varlib");
         Path deviceDir = varLib.resolve("AA:BB:CC:DD:EE:FF/11:22:33:44:55:66");
         Files.createDirectories(deviceDir);
-        writeFile(deviceDir.resolve("info"),
-                "[General]\nName=My Headphones\nPaired=true\nConnected=true\nClass=0x240404\n");
+        writeFile(deviceDir.resolve("info"), """
+                [General]
+                Name=My Headphones
+                Paired=true
+                Connected=true
+                Class=0x240404
+                """);
 
         List<BluetoothDevice> devices = LinuxBluetoothDevice.queryBluetoothDevices(sysDir.toString(),
                 varLib.toString() + "/");
@@ -101,8 +106,14 @@ class LinuxBluetoothDeviceTest {
         // Lowercase adapter address in sysfs, uppercase in varlib
         Path deviceDir = varLib.resolve("AA:BB:CC:DD:EE:FF/11:22:33:44:55:66");
         Files.createDirectories(deviceDir);
-        writeFile(deviceDir.resolve("info"),
-                "[General]\nName=BT Mouse\nPaired=true\nConnected=false\nClass=0x002580\nBattery=75\n");
+        writeFile(deviceDir.resolve("info"), """
+                [General]
+                Name=BT Mouse
+                Paired=true
+                Connected=false
+                Class=0x002580
+                Battery=75
+                """);
 
         List<BluetoothDevice> devices = LinuxBluetoothDevice.queryBluetoothDevices(sysDir.toString(),
                 varLib.toString() + "/");
@@ -162,7 +173,10 @@ class LinuxBluetoothDeviceTest {
         // Use lowercase path (fallback case); no explicit Paired key means paired=true
         Path deviceDir = varLib.resolve("aa:bb:cc:dd:ee:ff/11:22:33:44:55:66");
         Files.createDirectories(deviceDir);
-        writeFile(deviceDir.resolve("info"), "[General]\nName=Speaker\n");
+        writeFile(deviceDir.resolve("info"), """
+                [General]
+                Name=Speaker
+                """);
 
         List<BluetoothDevice> devices = LinuxBluetoothDevice.queryBluetoothDevices(sysDir.toString(),
                 varLib.toString() + "/");

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGlobalMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGlobalMemoryTest.java
@@ -7,34 +7,49 @@ package oshi.hardware.common.platform.linux;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import oshi.util.FileUtil;
 import oshi.util.ParseUtil;
 import oshi.util.tuples.Pair;
 
 class LinuxGlobalMemoryTest {
 
     @Test
-    void testParseMemInfoUsesMemAvailable() {
-        List<String> meminfo = Arrays.asList("MemTotal:       16000000 kB", "MemFree:         1000000 kB",
-                "MemAvailable:    8000000 kB", "Active(file):    2000000 kB", "Inactive(file):  1000000 kB",
-                "SReclaimable:     500000 kB");
-        Pair<Long, Long> p = LinuxGlobalMemory.parseMemInfo(meminfo);
+    void testParseMemInfoUsesMemAvailable(@TempDir Path tmp) throws IOException {
+        Path meminfo = tmp.resolve("meminfo");
+        Files.writeString(meminfo, """
+                MemTotal:       16000000 kB
+                MemFree:         1000000 kB
+                MemAvailable:    8000000 kB
+                Active(file):    2000000 kB
+                Inactive(file):  1000000 kB
+                SReclaimable:     500000 kB
+                """);
+        Pair<Long, Long> p = LinuxGlobalMemory.parseMemInfo(FileUtil.readFile(meminfo.toString()));
         assertThat(p.getA(), is(ParseUtil.parseDecimalMemorySizeToBinary("8000000 kB")));
         assertThat(p.getB(), is(ParseUtil.parseDecimalMemorySizeToBinary("16000000 kB")));
     }
 
     @Test
-    void testParseMemInfoFallbackSumWhenNoMemAvailable() {
+    void testParseMemInfoFallbackSumWhenNoMemAvailable(@TempDir Path tmp) throws IOException {
         // Older kernels lack MemAvailable: available is estimated as MemFree + Active(file) + Inactive(file) +
         // SReclaimable
-        List<String> meminfo = Arrays.asList("MemTotal:       16000000 kB", "MemFree:         1000000 kB",
-                "Active(file):    2000000 kB", "Inactive(file):  1000000 kB", "SReclaimable:     500000 kB");
-        Pair<Long, Long> p = LinuxGlobalMemory.parseMemInfo(meminfo);
+        Path meminfo = tmp.resolve("meminfo");
+        Files.writeString(meminfo, """
+                MemTotal:       16000000 kB
+                MemFree:         1000000 kB
+                Active(file):    2000000 kB
+                Inactive(file):  1000000 kB
+                SReclaimable:     500000 kB
+                """);
+        Pair<Long, Long> p = LinuxGlobalMemory.parseMemInfo(FileUtil.readFile(meminfo.toString()));
         long expected = ParseUtil.parseDecimalMemorySizeToBinary("1000000 kB")
                 + ParseUtil.parseDecimalMemorySizeToBinary("2000000 kB")
                 + ParseUtil.parseDecimalMemorySizeToBinary("1000000 kB")

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGpuStatsTest.java
@@ -291,7 +291,11 @@ class LinuxGpuStatsTest {
         Path device = tmp.resolve("device");
         Files.createDirectories(device);
         // No hwmon freq1_input, fall back to pp_dpm_sclk
-        writeFile(device.resolve("pp_dpm_sclk"), "0: 500Mhz\n1: 1200Mhz *\n2: 1800Mhz\n");
+        writeFile(device.resolve("pp_dpm_sclk"), """
+                0: 500Mhz
+                1: 1200Mhz *
+                2: 1800Mhz
+                """);
 
         try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
             assertThat(stats.getCoreClockMhz(), is(1200L));
@@ -314,7 +318,11 @@ class LinuxGpuStatsTest {
     void testAmdgpuMemoryClockFallbackToDpm(@TempDir Path tmp) throws IOException {
         Path device = tmp.resolve("device");
         Files.createDirectories(device);
-        writeFile(device.resolve("pp_dpm_mclk"), "0: 400Mhz\n1: 800Mhz\n2: 1000Mhz *\n");
+        writeFile(device.resolve("pp_dpm_mclk"), """
+                0: 400Mhz
+                1: 800Mhz
+                2: 1000Mhz *
+                """);
 
         try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
             assertThat(stats.getMemoryClockMhz(), is(1000L));
@@ -548,7 +556,10 @@ class LinuxGpuStatsTest {
     void testDpmNoActiveEntry(@TempDir Path tmp) throws IOException {
         Path device = tmp.resolve("device");
         Files.createDirectories(device);
-        writeFile(device.resolve("pp_dpm_sclk"), "0: 500Mhz\n1: 1200Mhz\n");
+        writeFile(device.resolve("pp_dpm_sclk"), """
+                0: 500Mhz
+                1: 1200Mhz
+                """);
 
         try (LinuxGpuStats stats = new StubLinuxGpuStats(device.toString(), "amdgpu", "", "AMD GPU")) {
             assertThat(stats.getCoreClockMhz(), is(-1L));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxPowerSourceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxPowerSourceTest.java
@@ -288,8 +288,10 @@ class LinuxPowerSourceTest {
     void testGetPowerSourcesSkipsPresentZero(@TempDir Path tempDir) throws IOException {
         Path bat = tempDir.resolve("BAT0");
         Files.createDirectories(bat);
-        Files.write(bat.resolve("uevent"),
-                "POWER_SUPPLY_NAME=BAT0\nPOWER_SUPPLY_PRESENT=0\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(bat.resolve("uevent"), """
+                POWER_SUPPLY_NAME=BAT0
+                POWER_SUPPLY_PRESENT=0
+                """);
 
         List<PowerSource> result = LinuxPowerSource.getPowerSources(tempDir.toString());
         assertThat(result, hasSize(0));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxSoundCardTest.java
@@ -91,7 +91,10 @@ class LinuxSoundCardTest {
     void testGetCardCodecFromFile(@TempDir Path tempDir) throws IOException {
         Path card0 = tempDir.resolve("card0");
         Files.createDirectories(card0);
-        writeFile(card0.resolve("codec#0"), "Codec: Realtek ALC892\nAddress: 0\nVendor Id: 0x10ec0892");
+        writeFile(card0.resolve("codec#0"), """
+                Codec: Realtek ALC892
+                Address: 0
+                Vendor Id: 0x10ec0892""");
 
         String codec = LinuxSoundCard.getCardCodec(card0.toFile());
         assertThat(codec, is("Realtek ALC892"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxVirtualMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxVirtualMemoryTest.java
@@ -7,23 +7,31 @@ package oshi.hardware.common.platform.linux;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import oshi.util.FileUtil;
 import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
 class LinuxVirtualMemoryTest {
 
     @Test
-    void testParseMemInfoSwap() {
+    void testParseMemInfoSwap(@TempDir Path tmp) throws IOException {
         // kB values are multiplied by 1024; used swap = total - free
-        List<String> meminfo = Arrays.asList("MemTotal:       16000000 kB", "SwapTotal:       2000000 kB",
-                "SwapFree:         500000 kB", "CommitLimit:     8000000 kB");
-        Triplet<Long, Long, Long> t = LinuxVirtualMemory.parseMemInfo(meminfo);
+        Path meminfo = tmp.resolve("meminfo");
+        Files.writeString(meminfo, """
+                MemTotal:       16000000 kB
+                SwapTotal:       2000000 kB
+                SwapFree:         500000 kB
+                CommitLimit:     8000000 kB
+                """);
+        Triplet<Long, Long, Long> t = LinuxVirtualMemory.parseMemInfo(FileUtil.readFile(meminfo.toString()));
         assertThat(t.getA(), is(1_500_000L * 1024));
         assertThat(t.getB(), is(2_000_000L * 1024));
         assertThat(t.getC(), is(8_000_000L * 1024));
@@ -38,9 +46,15 @@ class LinuxVirtualMemoryTest {
     }
 
     @Test
-    void testParseVmStat() {
-        List<String> vmstat = Arrays.asList("pgpgin 12345", "pswpin 100", "pswpout 200", "pgfault 999");
-        Pair<Long, Long> p = LinuxVirtualMemory.parseVmStat(vmstat);
+    void testParseVmStat(@TempDir Path tmp) throws IOException {
+        Path vmstat = tmp.resolve("vmstat");
+        Files.writeString(vmstat, """
+                pgpgin 12345
+                pswpin 100
+                pswpout 200
+                pgfault 999
+                """);
+        Pair<Long, Long> p = LinuxVirtualMemory.parseVmStat(FileUtil.readFile(vmstat.toString()));
         assertThat(p.getA(), is(100L));
         assertThat(p.getB(), is(200L));
     }

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoTest.java
@@ -95,8 +95,10 @@ class LinuxCgroupInfoTest {
 
     @Test
     void readCpuUsageV2(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.stat"),
-                "usage_usec 5000000\nnr_periods 100\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.stat"), """
+                usage_usec 5000000
+                nr_periods 100
+                """);
         // 5000000 usec * 1000 ns/usec = 5000000000 ns
         assertEquals(5_000_000_000L, cgroup.readCpuUsageV2(tempDir.toString() + "/"));
     }
@@ -133,8 +135,11 @@ class LinuxCgroupInfoTest {
 
     @Test
     void readCpuUsageV2LineOrder(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.stat"),
-                "nr_periods 100\nusage_usec 3000\nnr_throttled 5\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.stat"), """
+                nr_periods 100
+                usage_usec 3000
+                nr_throttled 5
+                """);
         assertEquals(3_000_000L, cgroup.readCpuUsageV2(tempDir.toString() + "/"));
     }
 

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoV1DispatchTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoV1DispatchTest.java
@@ -125,7 +125,10 @@ class LinuxCgroupInfoV1DispatchTest {
     @Test
     void readCpuUsageV2NoUsageLine(@TempDir Path tempDir) throws IOException {
         // cpu.stat without usage_usec line
-        Files.write(tempDir.resolve("cpu.stat"), "nr_periods 100\nnr_throttled 5\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.stat"), """
+                nr_periods 100
+                nr_throttled 5
+                """);
         assertEquals(0L, cgroup.readCpuUsageV2(tempDir.toString() + "/"));
     }
 

--- a/oshi-common/src/test/java/oshi/util/PrivilegedUtilEscalationTest.java
+++ b/oshi-common/src/test/java/oshi/util/PrivilegedUtilEscalationTest.java
@@ -52,7 +52,10 @@ class PrivilegedUtilEscalationTest {
     @Test
     void testReadFilePrivilegedWithAllowlistAndPrefix(@TempDir Path tempDir) throws IOException {
         Path testFile = tempDir.resolve("test-data.txt");
-        Files.write(testFile, "line1\nline2\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(testFile, """
+                line1
+                line2
+                """);
 
         String filePath = testFile.toString();
         GlobalConfig.set(GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_FILE_ALLOWLIST, filePath);
@@ -182,7 +185,10 @@ class PrivilegedUtilEscalationTest {
     @Test
     void testGetKeyValueMapFromFilePrivileged(@TempDir Path tempDir) throws IOException {
         Path testFile = tempDir.resolve("kvmap.txt");
-        Files.write(testFile, "key1=value1\nkey2=value2\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(testFile, """
+                key1=value1
+                key2=value2
+                """);
 
         String filePath = testFile.toString();
         GlobalConfig.set(GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_FILE_ALLOWLIST, filePath);


### PR DESCRIPTION
First of four batches converting multi-line test fixtures to text blocks, now that test sources compile at Java 17 (#3688). **The four batches touch disjoint files** so they can be reviewed in parallel.

This one covers fixtures that represent **file contents**.

## What changes

Two shapes, both ending at the same place:

- Tests that **already** wrote a temp file built its content from `"a\nb\nc"` strings. Those become text blocks passed to `Files.writeString`.
- Tests that held `/proc` content in an `Arrays.asList` and handed it straight to the parser now **write that content to a temp file and read it back through `FileUtil.readFile`** — the call production makes:

```java
return parseMemInfo(FileUtil.readFile(ProcPath.MEMINFO));
```

So the `List<String>` under test is produced the same way at runtime and in the test, instead of being assembled by hand into something that merely resembles it. The fixture also now reads like the file it is a copy of, instead of being reflowed by spotless at `lineSplit=120` into lines that no longer correspond to the file's.

## Why this batch needs no fixture verification

The round trip through `FileUtil` **is** the verification. A text block converted to a `List` by other means can silently lose a tab or a trailing space and still satisfy a deliberately lenient parser — green test, fixture no longer matching reality. Content written to a file and read back cannot drift that way.

The later command-output batches do not have that luxury and will carry an explicit check.

## Fixtures converted

`/proc/meminfo`, `/proc/vmstat`, cgroup `cpu.stat`, sysfs GPU and power-supply attributes, `bluetoothctl` and `/proc/asound` node contents.

One keeps its closing delimiter on the last content line rather than its own: `/proc/asound/cardN/codec#0` has no trailing newline, and that is the only text-block form that omits it.

## Verification

Full gate from clean — `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc -Paggregate-coverage` — green, zero test failures, plus `-Perror-prone` clean.

Test-only, no CHANGELOG entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modernized Linux test fixtures with Java text blocks for improved readability.
  * Updated memory and virtual-memory parsing tests to use temporary files, better matching real system file inputs.
  * Preserved existing test scenarios, assertions, and expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->