### PR TITLE
Convert plain command-output fixtures to text blocks

### DIFF
--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LscfgTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LscfgTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import org.jspecify.annotations.Nullable;
@@ -21,12 +20,13 @@ class LscfgTest {
     @Test
     void testParseModelSerial() {
         // lscfg -vl hdisk0: the "Machine Type and Model" line overrides the first-line description
-        Pair<@Nullable String, @Nullable String> modSer = Lscfg.parseModelSerial(Arrays.asList(//
-                "  hdisk0           U78CB.001.WZS00MP-P1-C2-T1-L0  MPIO IBM 2076 FC Disk", //
-                "        Manufacturer................IBM", //
-                "        Machine Type and Model......2076", //
-                "        Serial Number...............0123456789AB", //
-                "        EC Level....................D77161"), "hdisk0");
+        Pair<@Nullable String, @Nullable String> modSer = Lscfg.parseModelSerial("""
+                  hdisk0           U78CB.001.WZS00MP-P1-C2-T1-L0  MPIO IBM 2076 FC Disk
+                        Manufacturer................IBM
+                        Machine Type and Model......2076
+                        Serial Number...............0123456789AB
+                        EC Level....................D77161
+                """.lines().toList(), "hdisk0");
         assertThat(modSer.getA(), is("2076"));
         assertThat(modSer.getB(), is("0123456789AB"));
     }

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LspvTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LspvTest.java
@@ -26,11 +26,12 @@ class LspvTest {
     @Test
     void testParsePpSize() {
         // lspv -L: an active volume with a 128 MB physical-partition size, returned in bytes
-        long ppSize = Lspv.parsePpSize(Arrays.asList(//
-                "PHYSICAL VOLUME:    hdisk0                   VOLUME GROUP:     rootvg", //
-                "PV STATE:           active", //
-                "PP SIZE:            128 megabyte(s)          LOGICAL VOLUMES:  12", //
-                "TOTAL PPs:          271 (34688 megabytes)    VG DESCRIPTORS:   2"));
+        long ppSize = Lspv.parsePpSize("""
+                PHYSICAL VOLUME:    hdisk0                   VOLUME GROUP:     rootvg
+                PV STATE:           active
+                PP SIZE:            128 megabyte(s)          LOGICAL VOLUMES:  12
+                TOTAL PPs:          271 (34688 megabytes)    VG DESCRIPTORS:   2
+                """.lines().toList());
         assertThat(ppSize, is(128L << 20));
     }
 

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LssradTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LssradTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
@@ -26,14 +25,15 @@ class LssradTest {
     void testParseNodesPackages() {
         // lssrad -av: leading-digit lines set the REF (node); indented lines carry SRAD (slot) + CPU ranges.
         // A range line without a decimal MEM column is a continuation that keeps the previous slot.
-        Map<Integer, Pair<Integer, Integer>> map = Lssrad.parseNodesPackages(Arrays.asList(//
-                "REF1        SRAD        MEM        CPU", //
-                "0", //
-                "               0       32749.12    0-63", //
-                "               1        9462.00    64-67 72-75", //
-                "                                   80-83 88-91", //
-                "1", //
-                "               2        2471.19    92-95"));
+        Map<Integer, Pair<Integer, Integer>> map = Lssrad.parseNodesPackages("""
+                REF1        SRAD        MEM        CPU
+                0
+                               0       32749.12    0-63
+                               1        9462.00    64-67 72-75
+                                                   80-83 88-91
+                1
+                               2        2471.19    92-95
+                """.lines().toList());
         // node 0, slot 0
         Pair<Integer, Integer> cpu0 = map.get(0);
         Pair<Integer, Integer> cpu63 = map.get(63);

--- a/oshi-common/src/test/java/oshi/driver/common/unix/bsd/SystatTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/bsd/SystatTest.java
@@ -29,8 +29,14 @@ class SystatTest {
     @Test
     void testParseSensorsExtractsCpuTempVoltsAndFans() {
         // CPU rows go to cpuTemps/volts; non-cpu temp rows go to allTemps; "fan" rows to fanRPMs.
-        List<String> systat = Arrays.asList("cpu0.temp0    55.00 degC", "cpu0.volt0    1.25 V DC",
-                "acpitz0.temp0 40.00 degC", "acpitz1.temp0 42.00 degC", "it0.fan0    1500 RPM", "it0.fan1    2000 RPM");
+        List<String> systat = """
+                cpu0.temp0    55.00 degC
+                cpu0.volt0    1.25 V DC
+                acpitz0.temp0 40.00 degC
+                acpitz1.temp0 42.00 degC
+                it0.fan0    1500 RPM
+                it0.fan1    2000 RPM
+                """.lines().toList();
 
         Triplet<Double, int[], Double> r = Systat.parseSensors(systat);
         // cpuTemps non-empty so the average of cpu temps wins over allTemps.
@@ -89,10 +95,15 @@ class SystatTest {
 
     @Test
     void testParseBatteryFieldsWatthour() {
-        List<String> systat = Arrays.asList("acpibat0.volt0 11.10 V DC", "acpibat0.current0 0.500 A",
-                "acpibat0.temp0 30.0 degC", "acpibat0.watthour0 12.00 Wh (remaining capacity)",
-                "acpibat0.watthour1 24.00 Wh (last full capacity)", "acpibat0.watthour2 36.00 Wh (design capacity)",
-                "acpibat1.volt0 99.0 V DC"); // different name — ignored
+        List<String> systat = """
+                acpibat0.volt0 11.10 V DC
+                acpibat0.current0 0.500 A
+                acpibat0.temp0 30.0 degC
+                acpibat0.watthour0 12.00 Wh (remaining capacity)
+                acpibat0.watthour1 24.00 Wh (last full capacity)
+                acpibat0.watthour2 36.00 Wh (design capacity)
+                acpibat1.volt0 99.0 V DC
+                """.lines().toList(); // different name — ignored
 
         BatteryFields b = Systat.parseBatteryFields("acpibat0", systat);
         assertThat(b.getVoltage(), is(closeTo(11.10, 1e-9)));
@@ -107,8 +118,11 @@ class SystatTest {
 
     @Test
     void testParseBatteryFieldsAmphour() {
-        List<String> systat = Arrays.asList("acpibat0.amphour0 1.50 Ah (remaining capacity)",
-                "acpibat0.amphour1 3.00 Ah (last full capacity)", "acpibat0.amphour2 4.00 Ah (new capacity)");
+        List<String> systat = """
+                acpibat0.amphour0 1.50 Ah (remaining capacity)
+                acpibat0.amphour1 3.00 Ah (last full capacity)
+                acpibat0.amphour2 4.00 Ah (new capacity)
+                """.lines().toList();
 
         BatteryFields b = Systat.parseBatteryFields("acpibat0", systat);
         assertThat(b.getCapacityUnits(), is(CapacityUnits.MAH));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/GeomDiskListTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/GeomDiskListTest.java
@@ -23,11 +23,27 @@ class GeomDiskListTest {
 
     @Test
     void testParseGeomDiskListTypicalOutput() {
-        List<String> geom = Arrays.asList("Geom name: ada0", "Providers:", "1. Name: ada0",
-                "   Mediasize: 500107862016 (465G)", "   Sectorsize: 512", "   Mode: r2w2e3",
-                "   descr: Samsung SSD 860 EVO 500GB", "   ident: S3Z2NB0K123456X", "   rotationrate: 0", "",
-                "Geom name: da0", "Providers:", "1. Name: da0", "   Mediasize: 8053063680 (7.5G)", "   Sectorsize: 512",
-                "   Mode: r0w0e0", "   descr: USB Flash Drive", "   ident: (null)", "   rotationrate: unknown");
+        List<String> geom = """
+                Geom name: ada0
+                Providers:
+                1. Name: ada0
+                   Mediasize: 500107862016 (465G)
+                   Sectorsize: 512
+                   Mode: r2w2e3
+                   descr: Samsung SSD 860 EVO 500GB
+                   ident: S3Z2NB0K123456X
+                   rotationrate: 0
+
+                Geom name: da0
+                Providers:
+                1. Name: da0
+                   Mediasize: 8053063680 (7.5G)
+                   Sectorsize: 512
+                   Mode: r0w0e0
+                   descr: USB Flash Drive
+                   ident: (null)
+                   rotationrate: unknown
+                """.lines().toList();
 
         Map<String, Triplet<String, String, Long>> result = GeomDiskList.parseGeomDiskList(geom);
 

--- a/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/MountTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/MountTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -19,9 +18,12 @@ class MountTest {
 
     @Test
     void testParseMountOutputTypicalOutput() {
-        List<String> mountOutput = Arrays.asList("/dev/ada0p2 on / (ufs, local, journaled, soft-updates)",
-                "devfs on /dev (devfs)", "/dev/ada0p3 on /usr (ufs, local, journaled, soft-updates)",
-                "/dev/da0p1 on /mnt/usb (msdosfs, local)");
+        List<String> mountOutput = """
+                /dev/ada0p2 on / (ufs, local, journaled, soft-updates)
+                devfs on /dev (devfs)
+                /dev/ada0p3 on /usr (ufs, local, journaled, soft-updates)
+                /dev/da0p1 on /mnt/usb (msdosfs, local)
+                """.lines().toList();
 
         Map<String, String> result = Mount.parseMountOutput(mountOutput);
 
@@ -39,8 +41,11 @@ class MountTest {
 
     @Test
     void testParseMountOutputNonMatchingLinesIgnored() {
-        List<String> mountOutput = Arrays.asList("devfs on /dev (devfs)", "procfs on /proc (procfs, local)",
-                "tmpfs on /tmp (tmpfs, local)");
+        List<String> mountOutput = """
+                devfs on /dev (devfs)
+                procfs on /proc (procfs, local)
+                tmpfs on /tmp (tmpfs, local)
+                """.lines().toList();
 
         Map<String, String> result = Mount.parseMountOutput(mountOutput);
         assertThat(result, is(anEmptyMap()));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/IostatTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/IostatTest.java
@@ -65,10 +65,12 @@ class IostatTest {
 
     @Test
     void testParseDeviceStringsTypicalOutput() {
-        List<String> iostat = Arrays.asList("cmdk0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0",
-                "Model: VBOX HARDDISK,Serial No: VB12345678-abcdefgh,Size: 21.47GB <21474836480 bytes>",
-                "sd0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0",
-                "Vendor: ATA,Product: Samsung SSD 860,Serial No: S3Z2NB0K999999,Size: 500.11GB <500107862016 bytes>");
+        List<String> iostat = """
+                cmdk0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0
+                Model: VBOX HARDDISK,Serial No: VB12345678-abcdefgh,Size: 21.47GB <21474836480 bytes>
+                sd0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0
+                Vendor: ATA,Product: Samsung SSD 860,Serial No: S3Z2NB0K999999,Size: 500.11GB <500107862016 bytes>
+                """.lines().toList();
 
         Set<String> diskSet = new HashSet<>(Arrays.asList("cmdk0", "sd0"));
 
@@ -95,10 +97,12 @@ class IostatTest {
 
     @Test
     void testParseDeviceStringsFiltersByDiskSet() {
-        List<String> iostat = Arrays.asList("cmdk0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0",
-                "Model: VBOX HARDDISK,Serial No: VB12345,Size: 21.47GB <21474836480 bytes>",
-                "sd0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0",
-                "Vendor: ATA,Product: Test,Serial No: SN999,Size: 100GB <100000000000 bytes>");
+        List<String> iostat = """
+                cmdk0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0
+                Model: VBOX HARDDISK,Serial No: VB12345,Size: 21.47GB <21474836480 bytes>
+                sd0,Soft Errors: 0,Hard Errors: 0,Transport Errors: 0
+                Vendor: ATA,Product: Test,Serial No: SN999,Size: 100GB <100000000000 bytes>
+                """.lines().toList();
 
         // Only include cmdk0 in the disk set
         Set<String> diskSet = new HashSet<>(Arrays.asList("cmdk0"));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/LshalTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/LshalTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -19,11 +18,16 @@ class LshalTest {
 
     @Test
     void testParseLshalTypicalOutput() {
-        List<String> lshal = Arrays.asList("udi = '/org/freedesktop/Hal/devices/storage_serial_VBOX_HARDDISK_VB12345'",
-                "  block.major = 102  (0x66)  (int)", "  block.minor = 0  (0x0)  (int)",
-                "  info.category = 'storage'  (string)", "",
-                "udi = '/org/freedesktop/Hal/devices/storage_serial_disk1'", "  block.major = 91  (0x5b)  (int)",
-                "  block.minor = 1  (0x1)  (int)");
+        List<String> lshal = """
+                udi = '/org/freedesktop/Hal/devices/storage_serial_VBOX_HARDDISK_VB12345'
+                  block.major = 102  (0x66)  (int)
+                  block.minor = 0  (0x0)  (int)
+                  info.category = 'storage'  (string)
+
+                udi = '/org/freedesktop/Hal/devices/storage_serial_disk1'
+                  block.major = 91  (0x5b)  (int)
+                  block.minor = 1  (0x1)  (int)
+                """.lines().toList();
 
         Map<String, Integer> result = Lshal.parseLshal(lshal);
 
@@ -40,8 +44,11 @@ class LshalTest {
 
     @Test
     void testParseLshalNoBlockMajorLine() {
-        List<String> lshal = Arrays.asList("udi = '/org/freedesktop/Hal/devices/computer'",
-                "  info.category = 'computer'  (string)", "  info.product = 'Computer'  (string)");
+        List<String> lshal = """
+                udi = '/org/freedesktop/Hal/devices/computer'
+                  info.category = 'computer'  (string)
+                  info.product = 'Computer'  (string)
+                """.lines().toList();
 
         Map<String, Integer> result = Lshal.parseLshal(lshal);
         assertThat(result, is(anEmptyMap()));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/PrtvtocTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/PrtvtocTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -22,16 +21,30 @@ class PrtvtocTest {
     @Test
     void testParsePrtvtocTypicalOutput() {
         // Typical prtvtoc output for a Solaris disk
-        List<String> prtvtoc = Arrays.asList("* /dev/dsk/c1t0d0s0 partition map", "*", "* Dimensions:",
-                "*     512 bytes/sector", "*      63 sectors/track", "*      16 tracks/cylinder",
-                "*    1008 sectors/cylinder", "*   16384 cylinders", "*   16382 accessible cylinders", "*", "* Flags:",
-                "*   1: unmountable", "*  10: read-only", "*", "* Volume Name: MyVolume", "*",
-                "*          First     Sector    Last",
-                "* Partition  Tag  Flags  Sector     Count    Sector  Mount Directory",
-                "       0      2    00       1008   14329440   14330447   /",
-                "       1      3    01    14330448    2097648   16428095",
-                "       2      5    00           0   16515072   16515071",
-                "       3      7    00    16428096      86976   16515071   /var");
+        List<String> prtvtoc = """
+                * /dev/dsk/c1t0d0s0 partition map
+                *
+                * Dimensions:
+                *     512 bytes/sector
+                *      63 sectors/track
+                *      16 tracks/cylinder
+                *    1008 sectors/cylinder
+                *   16384 cylinders
+                *   16382 accessible cylinders
+                *
+                * Flags:
+                *   1: unmountable
+                *  10: read-only
+                *
+                * Volume Name: MyVolume
+                *
+                *          First     Sector    Last
+                * Partition  Tag  Flags  Sector     Count    Sector  Mount Directory
+                       0      2    00       1008   14329440   14330447   /
+                       1      3    01    14330448    2097648   16428095
+                       2      5    00           0   16515072   16515071
+                       3      7    00    16428096      86976   16515071   /var
+                """.lines().toList();
 
         List<HWPartition> result = Prtvtoc.parsePrtvtoc(prtvtoc, "c1t0d0", 102);
 
@@ -73,13 +86,22 @@ class PrtvtocTest {
     @Test
     void testParsePrtvtocTagMappings() {
         // Test various tag values to verify name mappings
-        List<String> prtvtoc = Arrays.asList("* header line", "*     512 bytes/sector",
-                "       0      1    00       0   1000    999", "       1     24    00       0   1000    999",
-                "       3      4    10       0   1000    999", "       4      6    00       0   1000    999",
-                "       5      8    00       0   1000    999", "       6      9    00       0   1000    999",
-                "       7     10    00       0   1000    999", "       8     11    00       0   1000    999",
-                "       9     12    00       0   1000    999", "      10     14    00       0   1000    999",
-                "      11     15    00       0   1000    999", "      12     99    00       0   1000    999");
+        List<String> prtvtoc = """
+                * header line
+                *     512 bytes/sector
+                       0      1    00       0   1000    999
+                       1     24    00       0   1000    999
+                       3      4    10       0   1000    999
+                       4      6    00       0   1000    999
+                       5      8    00       0   1000    999
+                       6      9    00       0   1000    999
+                       7     10    00       0   1000    999
+                       8     11    00       0   1000    999
+                       9     12    00       0   1000    999
+                      10     14    00       0   1000    999
+                      11     15    00       0   1000    999
+                      12     99    00       0   1000    999
+                """.lines().toList();
 
         List<HWPartition> result = Prtvtoc.parsePrtvtoc(prtvtoc, "c0d0", 10);
 
@@ -113,9 +135,14 @@ class PrtvtocTest {
     @Test
     void testParsePrtvtocFlagMappings() {
         // Test flag values: 00=wm, 10=rm, 01=wu, other=ru
-        List<String> prtvtoc = Arrays.asList("* header", "*     512 bytes/sector",
-                "       0      2    00       0   1000    999", "       1      2    10       0   1000    999",
-                "       3      2    01       0   1000    999", "       4      2    11       0   1000    999");
+        List<String> prtvtoc = """
+                * header
+                *     512 bytes/sector
+                       0      2    00       0   1000    999
+                       1      2    10       0   1000    999
+                       3      2    01       0   1000    999
+                       4      2    11       0   1000    999
+                """.lines().toList();
 
         List<HWPartition> result = Prtvtoc.parsePrtvtoc(prtvtoc, "c0d0", 5);
 
@@ -142,8 +169,11 @@ class PrtvtocTest {
     @Test
     void testParsePrtvtocNoBytesPerSectorIgnoresPartitions() {
         // If bytes/sector is never set, partition lines are ignored
-        List<String> prtvtoc = Arrays.asList("* header line without bytes/sector info", "* another comment",
-                "       0      2    00       0   1000    999");
+        List<String> prtvtoc = """
+                * header line without bytes/sector info
+                * another comment
+                       0      2    00       0   1000    999
+                """.lines().toList();
 
         List<HWPartition> result = Prtvtoc.parsePrtvtoc(prtvtoc, "c0d0", 10);
         assertThat(result, is(empty()));
@@ -151,8 +181,12 @@ class PrtvtocTest {
 
     @Test
     void testParsePrtvtocVolumeNameUsedAsLabel() {
-        List<String> prtvtoc = Arrays.asList("* header", "*     512 bytes/sector", "* Volume Name: TestLabel",
-                "       0      2    00       0   2048    2047   /");
+        List<String> prtvtoc = """
+                * header
+                *     512 bytes/sector
+                * Volume Name: TestLabel
+                       0      2    00       0   2048    2047   /
+                """.lines().toList();
 
         List<HWPartition> result = Prtvtoc.parsePrtvtoc(prtvtoc, "c0d0", 5);
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacBluetoothDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacBluetoothDeviceTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -23,29 +22,30 @@ class MacBluetoothDeviceTest {
     // controller block (ignored, not in a Connected/Not Connected section), then Connected and Not Connected device
     // sections. Devices carry ignored fields (Vendor ID, Product ID, Services) plus the parsed Address/Minor Type/
     // Battery Level.
-    private static final List<String> SPBLUETOOTH = Arrays.asList(//
-            "Bluetooth:", //
-            "", //
-            "      Bluetooth Controller:", //
-            "          Address: 5C:E9:1E:83:67:4F", //
-            "          State: On", //
-            "          Chipset: BCM_4388", //
-            "          Vendor ID: 0x004C (Apple)", //
-            "      Connected:", //
-            "          Wireless Keyboard:", //
-            "              Address: 11:22:33:aa:bb:cc", //
-            "              Vendor ID: 0x046D", //
-            "              Product ID: 0xB359", //
-            "              Minor Type: Keyboard", //
-            "              Battery Level: 80%", //
-            "              Services: 0x400000 < BLE >", //
-            "          Wireless Headphones:", //
-            "              Address: 22:33:44:55:66:77", //
-            "              Minor Type: Headphones", //
-            "      Not Connected:", //
-            "          Wireless Mouse:", //
-            "              Address: 33:44:55:66:77:88", //
-            "              Major Type: Peripheral");
+    private static final List<String> SPBLUETOOTH = """
+            Bluetooth:
+
+                  Bluetooth Controller:
+                      Address: 5C:E9:1E:83:67:4F
+                      State: On
+                      Chipset: BCM_4388
+                      Vendor ID: 0x004C (Apple)
+                  Connected:
+                      Wireless Keyboard:
+                          Address: 11:22:33:aa:bb:cc
+                          Vendor ID: 0x046D
+                          Product ID: 0xB359
+                          Minor Type: Keyboard
+                          Battery Level: 80%
+                          Services: 0x400000 < BLE >
+                      Wireless Headphones:
+                          Address: 22:33:44:55:66:77
+                          Minor Type: Headphones
+                  Not Connected:
+                      Wireless Mouse:
+                          Address: 33:44:55:66:77:88
+                          Major Type: Peripheral
+            """.lines().toList();
 
     @Test
     void testParseSystemProfiler() {
@@ -78,8 +78,12 @@ class MacBluetoothDeviceTest {
     @Test
     void testParseSystemProfilerNoDevices() {
         // Controller present but no Connected/Not Connected sections -> no devices
-        assertThat(MacBluetoothDevice.parseSystemProfiler(Arrays.asList("Bluetooth:", "      Bluetooth Controller:",
-                "          Address: AA:BB:CC:DD:EE:FF", "          State: On")), is(empty()));
+        assertThat(MacBluetoothDevice.parseSystemProfiler("""
+                Bluetooth:
+                      Bluetooth Controller:
+                          Address: AA:BB:CC:DD:EE:FF
+                          State: On
+                """.lines().toList()), is(empty()));
         assertThat(MacBluetoothDevice.parseSystemProfiler(Collections.emptyList()), is(empty()));
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGlobalMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGlobalMemoryTest.java
@@ -20,14 +20,34 @@ import oshi.hardware.PhysicalMemory;
 
 class MacGlobalMemoryTest {
 
-    private static final List<String> SP_MEMORY_TWO_BANKS = Arrays.asList("Memory:", "", "    Memory Slots:", "",
-            "      ECC: Disabled", "      Upgradeable Memory: Yes", "", "        BANK 0/DIMM0 :", "",
-            "          Size: 8 GB", "          Type: DDR4", "          Speed: 2400 MHz",
-            "          Manufacturer: Samsung", "          Part Number: M471A1K43CB1-CRC",
-            "          Serial Number: 12345678", "          Status: OK", "", "        BANK 1/DIMM0 :", "",
-            "          Size: 8 GB", "          Type: DDR4", "          Speed: 2400 MHz",
-            "          Manufacturer: Hynix", "          Part Number: HMA81GS6AFR8N-UH",
-            "          Serial Number: 87654321", "          Status: OK");
+    private static final List<String> SP_MEMORY_TWO_BANKS = """
+            Memory:
+
+                Memory Slots:
+
+                  ECC: Disabled
+                  Upgradeable Memory: Yes
+
+                    BANK 0/DIMM0 :
+
+                      Size: 8 GB
+                      Type: DDR4
+                      Speed: 2400 MHz
+                      Manufacturer: Samsung
+                      Part Number: M471A1K43CB1-CRC
+                      Serial Number: 12345678
+                      Status: OK
+
+                    BANK 1/DIMM0 :
+
+                      Size: 8 GB
+                      Type: DDR4
+                      Speed: 2400 MHz
+                      Manufacturer: Hynix
+                      Part Number: HMA81GS6AFR8N-UH
+                      Serial Number: 87654321
+                      Status: OK
+            """.lines().toList();
 
     @Test
     void testParseSystemProfilerMemoryTwoBanks() {
@@ -57,9 +77,15 @@ class MacGlobalMemoryTest {
 
     @Test
     void testParseSystemProfilerMemorySingleBank() {
-        List<String> singleBank = Arrays.asList("        BANK 0/DIMM0 :", "          Size: 16 GB",
-                "          Type: LPDDR4X", "          Speed: 4267 MHz", "          Manufacturer: Micron",
-                "          Part Number: MT53E1G32D4NQ-046", "          Serial Number: ABCDEF01");
+        List<String> singleBank = """
+                        BANK 0/DIMM0 :
+                          Size: 16 GB
+                          Type: LPDDR4X
+                          Speed: 4267 MHz
+                          Manufacturer: Micron
+                          Part Number: MT53E1G32D4NQ-046
+                          Serial Number: ABCDEF01
+                """.lines().toList();
         List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(singleBank);
         assertThat(result, hasSize(1));
         assertThat(result.get(0).getBankLabel(), is("BANK 0/DIMM0"));
@@ -78,8 +104,13 @@ class MacGlobalMemoryTest {
 
     @Test
     void testParseSystemProfilerMemoryAppleSilicon() {
-        List<String> appleSilicon = Arrays.asList("Memory:", "", "      Memory: 36 GB", "      Type: LPDDR5",
-                "      Manufacturer: Micron");
+        List<String> appleSilicon = """
+                Memory:
+
+                      Memory: 36 GB
+                      Type: LPDDR5
+                      Manufacturer: Micron
+                """.lines().toList();
         List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(appleSilicon);
         assertThat(result, hasSize(1));
         assertThat(result.get(0).getCapacity(), is(greaterThan(0L)));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGraphicsCardTest.java
@@ -33,16 +33,33 @@ class MacGraphicsCardTest {
     @Test
     void testSingleCard() {
         // Real output from system_profiler SPDisplaysDataType on Apple M3 Pro
-        List<String> sp = Arrays.asList("Graphics/Displays:", "", "    Apple M3 Pro:", "",
-                "      Chipset Model: Apple M3 Pro", "      Type: GPU", "      Bus: Built-In",
-                "      Total Number of Cores: 18", "      Vendor: Apple (0x106b)", "      Metal Support: Metal 4",
-                "      Displays:", "        LG ULTRAWIDE:",
-                "          Resolution: 3440 x 1440 (UWQHD - Ultra-Wide Quad HD)",
-                "          UI Looks like: 3440 x 1440 @ 50.00Hz", "          Main Display: Yes",
-                "          Mirror: Off", "          Online: Yes", "          Rotation: Supported", "        Color LCD:",
-                "          Display Type: Built-in Liquid Retina XDR Display",
-                "          Resolution: 3456 x 2234 Retina", "          Mirror: Off", "          Online: Yes",
-                "          Automatically Adjust Brightness: Yes", "          Connection Type: Internal");
+        List<String> sp = """
+                Graphics/Displays:
+
+                    Apple M3 Pro:
+
+                      Chipset Model: Apple M3 Pro
+                      Type: GPU
+                      Bus: Built-In
+                      Total Number of Cores: 18
+                      Vendor: Apple (0x106b)
+                      Metal Support: Metal 4
+                      Displays:
+                        LG ULTRAWIDE:
+                          Resolution: 3440 x 1440 (UWQHD - Ultra-Wide Quad HD)
+                          UI Looks like: 3440 x 1440 @ 50.00Hz
+                          Main Display: Yes
+                          Mirror: Off
+                          Online: Yes
+                          Rotation: Supported
+                        Color LCD:
+                          Display Type: Built-in Liquid Retina XDR Display
+                          Resolution: 3456 x 2234 Retina
+                          Mirror: Off
+                          Online: Yes
+                          Automatically Adjust Brightness: Yes
+                          Connection Type: Internal
+                """.lines().toList();
         List<GraphicsCard> cards = MacGraphicsCard.parseGraphicsCards(sp, FACTORY, SYSCTL);
         assertThat(cards, hasSize(1));
         assertThat(cards.get(0).getName(), is("Apple M3 Pro"));
@@ -53,11 +70,25 @@ class MacGraphicsCardTest {
     @Test
     void testTwoCards() {
         // Representative output from a 2017 MacBook Pro with Intel + AMD GPUs
-        List<String> sp = Arrays.asList("Graphics/Displays:", "", "    Intel HD Graphics 630:", "",
-                "      Chipset Model: Intel HD Graphics 630", "      Device ID: 0x591b", "      Vendor: Intel (0x8086)",
-                "      VRAM (Dynamic, Max): 1536 MB", "      Revision ID: 0x0004", "", "    Radeon Pro 560:", "",
-                "      Chipset Model: Radeon Pro 560", "      Device ID: 0x67ef", "      Vendor: AMD (0x1002)",
-                "      VRAM (Total): 4096 MB", "      EFI Driver Version: 01.00.560");
+        List<String> sp = """
+                Graphics/Displays:
+
+                    Intel HD Graphics 630:
+
+                      Chipset Model: Intel HD Graphics 630
+                      Device ID: 0x591b
+                      Vendor: Intel (0x8086)
+                      VRAM (Dynamic, Max): 1536 MB
+                      Revision ID: 0x0004
+
+                    Radeon Pro 560:
+
+                      Chipset Model: Radeon Pro 560
+                      Device ID: 0x67ef
+                      Vendor: AMD (0x1002)
+                      VRAM (Total): 4096 MB
+                      EFI Driver Version: 01.00.560
+                """.lines().toList();
         List<GraphicsCard> cards = MacGraphicsCard.parseGraphicsCards(sp, FACTORY, SYSCTL);
         assertThat(cards, hasSize(2));
         assertThat(cards.get(0).getName(), is("Intel HD Graphics 630"));
@@ -70,8 +101,12 @@ class MacGraphicsCardTest {
 
     @Test
     void testVersionInfo() {
-        List<String> sp = Arrays.asList("    Card:", "      Chipset Model: Test GPU", "      EFI Driver Version: 1.2.3",
-                "      Metal Revision: 42");
+        List<String> sp = """
+                    Card:
+                      Chipset Model: Test GPU
+                      EFI Driver Version: 1.2.3
+                      Metal Revision: 42
+                """.lines().toList();
         List<GraphicsCard> cards = MacGraphicsCard.parseGraphicsCards(sp, FACTORY, SYSCTL);
         assertThat(cards, hasSize(1));
         assertThat(cards.get(0).getVersionInfo(), is("EFI Driver Version: 1.2.3, Metal Revision: 42"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacLogicalVolumeGroupTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacLogicalVolumeGroupTest.java
@@ -22,20 +22,31 @@ import oshi.hardware.LogicalVolumeGroup;
 class MacLogicalVolumeGroupTest {
 
     // Fixture: typical diskutil cs list output with one CoreStorage volume group
-    private static final List<String> DISKUTIL_CS_OUTPUT = Arrays.asList("CoreStorage logical volume groups (1 found)",
-            "|", "+-- Logical Volume Group B6D1A2C3-4E5F-6789-ABCD-EF0123456789",
-            "    =========================================================", "    Name:         Macintosh HD",
-            "    Status:       Online", "    Size:         499248103424 B (499.2 GB)",
-            "    Free Space:   12345678 B (12.3 MB)", "    |",
-            "    +-< Physical Volume 0A1B2C3D-4E5F-6789-ABCD-EF0123456789",
-            "    |   ----------------------------------------------------", "    |   Index:    0",
-            "    |   Disk:     disk0s2", "    |   Status:   Online", "    |   Size:     499248103424 B (499.2 GB)",
-            "    |", "    +-> Logical Volume Family 1A2B3C4D-5E6F-7890-ABCD-EF0123456789",
-            "        ----------------------------------------------------------",
-            "        +-> Logical Volume 2A3B4C5D-6E7F-8901-ABCD-EF0123456789",
-            "            ---------------------------------------------------",
-            "            Disk:                  disk1", "            Status:                Online",
-            "            Size (Total):          498877931520 B (498.9 GB)");
+    private static final List<String> DISKUTIL_CS_OUTPUT = """
+            CoreStorage logical volume groups (1 found)
+            |
+            +-- Logical Volume Group B6D1A2C3-4E5F-6789-ABCD-EF0123456789
+                =========================================================
+                Name:         Macintosh HD
+                Status:       Online
+                Size:         499248103424 B (499.2 GB)
+                Free Space:   12345678 B (12.3 MB)
+                |
+                +-< Physical Volume 0A1B2C3D-4E5F-6789-ABCD-EF0123456789
+                |   ----------------------------------------------------
+                |   Index:    0
+                |   Disk:     disk0s2
+                |   Status:   Online
+                |   Size:     499248103424 B (499.2 GB)
+                |
+                +-> Logical Volume Family 1A2B3C4D-5E6F-7890-ABCD-EF0123456789
+                    ----------------------------------------------------------
+                    +-> Logical Volume 2A3B4C5D-6E7F-8901-ABCD-EF0123456789
+                        ---------------------------------------------------
+                        Disk:                  disk1
+                        Status:                Online
+                        Size (Total):          498877931520 B (498.9 GB)
+            """.lines().toList();
 
     @Test
     void testParseDiskutilCsListSingleGroup() {
@@ -63,11 +74,20 @@ class MacLogicalVolumeGroupTest {
 
     @Test
     void testParseDiskutilCsListMultipleGroups() {
-        List<String> twoGroups = Arrays.asList("+-- Logical Volume Group AAA", "    Name:         Group One",
-                "    +-< Physical Volume PV1", "    |   Disk:     disk0s2", "    +-> Logical Volume LV1",
-                "            Disk:                  disk1", "+-- Logical Volume Group BBB",
-                "    Name:         Group Two", "    +-< Physical Volume PV2", "    |   Disk:     disk2s1",
-                "    +-> Logical Volume LV2", "            Disk:                  disk3");
+        List<String> twoGroups = """
+                +-- Logical Volume Group AAA
+                    Name:         Group One
+                    +-< Physical Volume PV1
+                    |   Disk:     disk0s2
+                    +-> Logical Volume LV1
+                            Disk:                  disk1
+                +-- Logical Volume Group BBB
+                    Name:         Group Two
+                    +-< Physical Volume PV2
+                    |   Disk:     disk2s1
+                    +-> Logical Volume LV2
+                            Disk:                  disk3
+                """.lines().toList();
         List<LogicalVolumeGroup> groups = MacLogicalVolumeGroup.parseDiskutilCsList(twoGroups);
         assertThat(groups, hasSize(2));
         assertThat(groups.get(0).getName(), is("Group One"));
@@ -78,10 +98,18 @@ class MacLogicalVolumeGroupTest {
 
     @Test
     void testParseDiskutilCsListMultiplePVsAndLVs() {
-        List<String> multiPvLv = Arrays.asList("+-- Logical Volume Group CCC", "    Name:         Fusion Drive",
-                "    +-< Physical Volume PV1", "    |   Disk:     disk0s2", "    +-< Physical Volume PV2",
-                "    |   Disk:     disk1s1", "    +-> Logical Volume LV1", "            Disk:                  disk2",
-                "    +-> Logical Volume LV2", "            Disk:                  disk3");
+        List<String> multiPvLv = """
+                +-- Logical Volume Group CCC
+                    Name:         Fusion Drive
+                    +-< Physical Volume PV1
+                    |   Disk:     disk0s2
+                    +-< Physical Volume PV2
+                    |   Disk:     disk1s1
+                    +-> Logical Volume LV1
+                            Disk:                  disk2
+                    +-> Logical Volume LV2
+                            Disk:                  disk3
+                """.lines().toList();
         List<LogicalVolumeGroup> groups = MacLogicalVolumeGroup.parseDiskutilCsList(multiPvLv);
         assertThat(groups, hasSize(1));
         assertThat(groups.get(0).getPhysicalVolumes(), hasItem("disk0s2"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdCentralProcessorTest.java
@@ -24,11 +24,12 @@ import oshi.util.tuples.Pair;
 class BsdCentralProcessorTest {
 
     // Representative OpenBSD/NetBSD dmesg topology lines
-    private static final List<String> DMESG_TOPOLOGY = Arrays.asList(//
-            "cpu0: smt 0, core 0, package 0", //
-            "cpu1: smt 0, core 1, package 0", //
-            "cpu2: smt 0, core 0, package 1", //
-            "cpu3: smt 0, core 1, package 1");
+    private static final List<String> DMESG_TOPOLOGY = """
+            cpu0: smt 0, core 0, package 0
+            cpu1: smt 0, core 1, package 0
+            cpu2: smt 0, core 0, package 1
+            cpu3: smt 0, core 1, package 1
+            """.lines().toList();
 
     @Test
     void testParseTopology() {
@@ -55,11 +56,12 @@ class BsdCentralProcessorTest {
     @Test
     void testParseDmesgModelsAndCachesIntel() {
         // Representative x86 dmesg — cache entries are split across separate lines but each line ends with "cache"
-        List<String> dmesg = Arrays.asList(//
-                "cpu0: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01", //
-                "cpu0: 32KB 64b/line 8-way D-cache, 32KB 64b/line 8-way I-cache", //
-                "cpu0: 4MB 64b/line 16-way L2 cache", //
-                "cpu0: FPU,VME,DE,PSE,TSC,MSR,PAE,MCE");
+        List<String> dmesg = """
+                cpu0: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01
+                cpu0: 32KB 64b/line 8-way D-cache, 32KB 64b/line 8-way I-cache
+                cpu0: 4MB 64b/line 16-way L2 cache
+                cpu0: FPU,VME,DE,PSE,TSC,MSR,PAE,MCE
+                """.lines().toList();
         DmesgStrings result = BsdCentralProcessor.parseDmesgModelsAndCaches(dmesg);
         assertThat(result.getCpuMap().get(0), is("Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01"));
         assertThat(result.getCaches(), is(not(empty())));
@@ -70,13 +72,14 @@ class BsdCentralProcessorTest {
     @Test
     void testParseDmesgModelsAndCachesArm() {
         // Representative ARM big.LITTLE dmesg
-        List<String> dmesg = Arrays.asList(//
-                "cpu0 at mainbus0 mpidr 0: ARM Cortex-A53 r0p4", //
-                "cpu0: 32KB 64b/line 2-way L1 VIPT I-cache, 32KB 64b/line 4-way L1 D-cache", //
-                "cpu0: 512KB 64b/line 16-way L2 cache", //
-                "cpu4 at mainbus0 mpidr 100: ARM Cortex-A72 r0p2", //
-                "cpu4: 48KB 64b/line 3-way L1 PIPT I-cache, 32KB 64b/line 2-way L1 D-cache", //
-                "cpu4: 1024KB 64b/line 16-way L2 cache");
+        List<String> dmesg = """
+                cpu0 at mainbus0 mpidr 0: ARM Cortex-A53 r0p4
+                cpu0: 32KB 64b/line 2-way L1 VIPT I-cache, 32KB 64b/line 4-way L1 D-cache
+                cpu0: 512KB 64b/line 16-way L2 cache
+                cpu4 at mainbus0 mpidr 100: ARM Cortex-A72 r0p2
+                cpu4: 48KB 64b/line 3-way L1 PIPT I-cache, 32KB 64b/line 2-way L1 D-cache
+                cpu4: 1024KB 64b/line 16-way L2 cache
+                """.lines().toList();
         DmesgStrings result = BsdCentralProcessor.parseDmesgModelsAndCaches(dmesg);
         assertThat(result.getCpuMap().get(0), is("ARM Cortex-A53 r0p4"));
         assertThat(result.getCpuMap().get(4), is("ARM Cortex-A72 r0p2"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdFirmwareTest.java
@@ -46,10 +46,11 @@ class BsdFirmwareTest {
     @Test
     void testParseDmesgNetBsd() {
         // Representative NetBSD dmesg bios0 output
-        List<String> dmesg = Arrays.asList(//
-                "bios0 at mainbus0: SMBIOS rev. 2.7 @ 0xdcc0e000 (67 entries)", //
-                "bios0: vendor LENOVO version \"GLET90WW (2.44 )\" date 09/13/2017", //
-                "bios0: LENOVO 20AWA08J00");
+        List<String> dmesg = """
+                bios0 at mainbus0: SMBIOS rev. 2.7 @ 0xdcc0e000 (67 entries)
+                bios0: vendor LENOVO version "GLET90WW (2.44 )" date 09/13/2017
+                bios0: LENOVO 20AWA08J00
+                """.lines().toList();
         Triplet<@Nullable String, @Nullable String, @Nullable String> fw = parse(dmesg);
         assertThat(fw.getA(), is("LENOVO"));
         assertThat(fw.getB(), is("GLET90WW (2.44 )"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdPowerSourceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdPowerSourceTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -23,9 +22,14 @@ class BsdPowerSourceTest {
 
     // Real `systat -ab sensors` battery rows (watt-hour battery): voltage 11.10 V, current 0.5 A, temp 30 degC,
     // remaining/full/design capacity 12/24/36 Wh -> current/max/design 12000/24000/36000 mWh.
-    private static final List<String> SYSTAT_WATTHOUR = Arrays.asList("acpibat0.volt0 11.10 V DC",
-            "acpibat0.current0 0.500 A", "acpibat0.temp0 30.0 degC", "acpibat0.watthour0 12.00 Wh (remaining capacity)",
-            "acpibat0.watthour1 24.00 Wh (last full capacity)", "acpibat0.watthour2 36.00 Wh (design capacity)");
+    private static final List<String> SYSTAT_WATTHOUR = """
+            acpibat0.volt0 11.10 V DC
+            acpibat0.current0 0.500 A
+            acpibat0.temp0 30.0 degC
+            acpibat0.watthour0 12.00 Wh (remaining capacity)
+            acpibat0.watthour1 24.00 Wh (last full capacity)
+            acpibat0.watthour2 36.00 Wh (design capacity)
+            """.lines().toList();
 
     private static BatteryFields watthourFields() {
         return Systat.parseBatteryFields("acpibat0", SYSTAT_WATTHOUR);
@@ -101,8 +105,11 @@ class BsdPowerSourceTest {
     @Test
     void testMaxCapacityRaisedToDesign() {
         // remaining/full/design 30/10/20 Wh: max (10) < design (20) and max < current (30) -> max raised to design
-        List<String> systat = Arrays.asList("acpibat0.watthour0 30.00 Wh (remaining capacity)",
-                "acpibat0.watthour1 10.00 Wh (last full capacity)", "acpibat0.watthour2 20.00 Wh (design capacity)");
+        List<String> systat = """
+                acpibat0.watthour0 30.00 Wh (remaining capacity)
+                acpibat0.watthour1 10.00 Wh (last full capacity)
+                acpibat0.watthour2 20.00 Wh (design capacity)
+                """.lines().toList();
         PowerSource ps = BsdPowerSource.buildPowerSource("acpibat0", Systat.parseBatteryFields("acpibat0", systat), 1,
                 10, 90);
         assertThat(ps.getCurrentCapacity(), is(30000));
@@ -113,8 +120,11 @@ class BsdPowerSourceTest {
     @Test
     void testDesignCapacityRaisedToMax() {
         // remaining/full/design 30/25/5 Wh: design (5) < max (25) and design < current (30) -> design raised to max
-        List<String> systat = Arrays.asList("acpibat0.watthour0 30.00 Wh (remaining capacity)",
-                "acpibat0.watthour1 25.00 Wh (last full capacity)", "acpibat0.watthour2 5.00 Wh (design capacity)");
+        List<String> systat = """
+                acpibat0.watthour0 30.00 Wh (remaining capacity)
+                acpibat0.watthour1 25.00 Wh (last full capacity)
+                acpibat0.watthour2 5.00 Wh (design capacity)
+                """.lines().toList();
         PowerSource ps = BsdPowerSource.buildPowerSource("acpibat0", Systat.parseBatteryFields("acpibat0", systat), 1,
                 10, 90);
         assertThat(ps.getMaxCapacity(), is(25000));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdSoundCardTest.java
@@ -22,13 +22,14 @@ import oshi.util.Constants;
 class BsdSoundCardTest {
 
     // Representative NetBSD/OpenBSD dmesg output with audio devices
-    private static final List<String> DMESG = Arrays.asList(//
-            "azalia0 at pci0 dev 27 function 0 \"Intel 82801I HD Audio\" rev 0x03: msi", //
-            "azalia0: codec[0]: Realtek ALC888", //
-            "audio0 at azalia0", //
-            "hdaudio0 at pci0 dev 3 function 0 \"Intel HD Graphics Audio\" rev 0x05: msi", //
-            "hdaudio0: codec[0]: Intel Haswell HDMI", //
-            "audio1 at hdaudio0");
+    private static final List<String> DMESG = """
+            azalia0 at pci0 dev 27 function 0 "Intel 82801I HD Audio" rev 0x03: msi
+            azalia0: codec[0]: Realtek ALC888
+            audio0 at azalia0
+            hdaudio0 at pci0 dev 3 function 0 "Intel HD Graphics Audio" rev 0x05: msi
+            hdaudio0: codec[0]: Intel Haswell HDMI
+            audio1 at hdaudio0
+            """.lines().toList();
 
     @Test
     void testParseDmesg() {
@@ -62,10 +63,11 @@ class BsdSoundCardTest {
     @Test
     void testParseDmesgNoCodec() {
         // Audio device is present but no codec line follows the PCI match
-        List<String> dmesg = Arrays.asList(//
-                "audio0 at azalia0", //
-                "azalia0 at pci0 dev 27 function 0 \"Intel Audio\" rev 0x01: msi", //
-                "unrelated line here");
+        List<String> dmesg = """
+                audio0 at azalia0
+                azalia0 at pci0 dev 27 function 0 "Intel Audio" rev 0x01: msi
+                unrelated line here
+                """.lines().toList();
         List<SoundCard> cards = BsdSoundCard.parseDmesg(dmesg);
         assertThat(cards, hasSize(1));
         assertThat(cards.get(0).getName(), is("Intel Audio"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdUsbDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdUsbDeviceTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -21,12 +20,13 @@ class BsdUsbDeviceTest {
 
     // Representative usbdevs -v output from OpenBSD/NetBSD
     // Format: "addr NN: VVVV:PPPP VendorName, ProductName" (colon at pos 7, comma separates vendor from product)
-    private static final List<String> USBDEVS = Arrays.asList(//
-            "Controller /dev/usb0:", //
-            "addr 01: 0000:0000 UHCI, root hub", //
-            "  iSerial 12345", //
-            "addr 02: 8087:0024 Intel, Rate Matching Hub", //
-            "addr 03: 046d:c52b Logitech, Unifying Receiver");
+    private static final List<String> USBDEVS = """
+            Controller /dev/usb0:
+            addr 01: 0000:0000 UHCI, root hub
+              iSerial 12345
+            addr 02: 8087:0024 Intel, Rate Matching Hub
+            addr 03: 046d:c52b Logitech, Unifying Receiver
+            """.lines().toList();
 
     @Test
     void testParseUsbDevices() {
@@ -42,11 +42,12 @@ class BsdUsbDeviceTest {
 
     @Test
     void testParseUsbDevicesMultipleControllers() {
-        List<String> usbdevs = Arrays.asList(//
-                "Controller /dev/usb0:", //
-                "addr 01: 0000:0000 UHCI, root hub 0", //
-                "Controller /dev/usb1:", //
-                "addr 01: 0000:0000 EHCI, root hub 1");
+        List<String> usbdevs = """
+                Controller /dev/usb0:
+                addr 01: 0000:0000 UHCI, root hub 0
+                Controller /dev/usb1:
+                addr 01: 0000:0000 EHCI, root hub 1
+                """.lines().toList();
         List<UsbDevice> devices = BsdUsbDevice.parseUsbDevices(usbdevs);
         assertThat(devices, hasSize(2));
         assertThat(devices.get(0).getName(), is("root hub 0"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/CupsPrinterTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/CupsPrinterTest.java
@@ -77,9 +77,11 @@ class CupsPrinterTest {
 
     @Test
     void testGetPrintersFromLpstatSkipsNonPrinterLines() {
-        List<String> mixed = Arrays.asList("scheduler is running",
-                "printer MyPrinter now printing MyPrinter-42. enabled since Mon 01 Jan",
-                "no system default destination");
+        List<String> mixed = """
+                scheduler is running
+                printer MyPrinter now printing MyPrinter-42. enabled since Mon 01 Jan
+                no system default destination
+                """.lines().toList();
         List<Printer> printers = CupsPrinter.getPrintersFromLpstat(mixed, "", Collections.emptyMap(),
                 Collections.emptyMap(), name -> "", STUB_FACTORY);
         assertThat(printers, hasSize(1));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessorTest.java
@@ -24,12 +24,13 @@ class AixCentralProcessorTest {
     @Test
     void testParseProcessorId() {
         // prtconf excerpt
-        Quartet<String, String, String, Boolean> id = AixCentralProcessor.parseProcessorId(Arrays.asList(//
-                "System Model: IBM,9114-275", //
-                "Processor Type: PowerPC_POWER7", //
-                "Processor Version: PV_7_Compat", //
-                "Number Of Processors: 8", //
-                "CPU Type: 64-bit"));
+        Quartet<String, String, String, Boolean> id = AixCentralProcessor.parseProcessorId("""
+                System Model: IBM,9114-275
+                Processor Type: PowerPC_POWER7
+                Processor Version: PV_7_Compat
+                Number Of Processors: 8
+                CPU Type: 64-bit
+                """.lines().toList());
         assertThat(id.getA(), is("IBM"));
         assertThat(id.getB(), is("PowerPC_POWER7"));
         assertThat(id.getC(), is("PV_7_Compat"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessorTest.java
@@ -24,11 +24,12 @@ import oshi.util.tuples.Pair;
 class FreeBsdCentralProcessorTest {
 
     // Representative dmesg.boot header (indented Origin/Features lines, as FreeBSD writes them)
-    private static final List<String> DMESG_ID = Arrays.asList(
-            "CPU: Intel(R) Xeon(R) CPU E5-2683 v3 @ 2.00GHz (2000.05-MHz K8-class CPU)",
-            "  Origin=\"GenuineIntel\"  Id=0x306f2  Family=0x6  Model=0x3f  Stepping=2",
-            "  Features=0xbfebfbff<FPU,VME,DE,PSE,TSC,MSR,PAE,MCE,CX8,APIC>",
-            "  Features2=0x7ffefbff<SSE3,PCLMULQDQ,DTES64>");
+    private static final List<String> DMESG_ID = """
+            CPU: Intel(R) Xeon(R) CPU E5-2683 v3 @ 2.00GHz (2000.05-MHz K8-class CPU)
+              Origin="GenuineIntel"  Id=0x306f2  Family=0x6  Model=0x3f  Stepping=2
+              Features=0xbfebfbff<FPU,VME,DE,PSE,TSC,MSR,PAE,MCE,CX8,APIC>
+              Features2=0x7ffefbff<SSE3,PCLMULQDQ,DTES64>
+            """.lines().toList();
 
     @Test
     void testParseProcessorIdFromDmesg() {
@@ -60,9 +61,14 @@ class FreeBsdCentralProcessorTest {
 
     @Test
     void testParseProcModelsAndFlags() {
-        List<String> dmesg = Arrays.asList("cpu0: <ACPI CPU> on acpi0", "cpu1: <ACPI CPU> on acpi0",
-                "  Origin=\"GenuineIntel\"  Id=0x306f2", "  Features=0xbfebfbff<FPU,VME>",
-                "  Features2=0x7ffefbff<SSE3>", "real memory  = 8589934592");
+        List<String> dmesg = """
+                cpu0: <ACPI CPU> on acpi0
+                cpu1: <ACPI CPU> on acpi0
+                  Origin="GenuineIntel"  Id=0x306f2
+                  Features=0xbfebfbff<FPU,VME>
+                  Features2=0x7ffefbff<SSE3>
+                real memory  = 8589934592
+                """.lines().toList();
         Pair<Map<Integer, String>, List<String>> r = FreeBsdCentralProcessor.parseProcModelsAndFlags(dmesg);
         assertThat(r.getA().get(0), is("<ACPI CPU>"));
         assertThat(r.getA().get(1), is("<ACPI CPU>"));
@@ -81,9 +87,12 @@ class FreeBsdCentralProcessorTest {
 
     @Test
     void testParseCachesFromLscpu() {
-        List<String> lscpu = Arrays.asList("L1d cache:                       32K",
-                "L1i cache:                       32K", "L2 cache:                        256K",
-                "L3 cache:                        8M");
+        List<String> lscpu = """
+                L1d cache:                       32K
+                L1i cache:                       32K
+                L2 cache:                        256K
+                L3 cache:                        8M
+                """.lines().toList();
         List<ProcessorCache> caches = FreeBsdCentralProcessor.parseCachesFromLscpu(lscpu);
         assertThat(caches, hasSize(4));
         assertThat(caches.stream().anyMatch(c -> c.getLevel() == 3), is(true));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdSoundCardTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -22,13 +21,14 @@ class FreeBsdSoundCardTest {
     @Test
     void testParseSoundCards() {
         // A pcm-driven node carries the product/vendor; other nodes (e.g. the parent hdac) are ignored.
-        List<String> lshal = Arrays.asList(//
-                "udi = '/org/freedesktop/Hal/devices/pci_8086_a348'", //
-                "  info.product = 'Cannon Lake PCH cAVS'  (string)", //
-                "udi = '/org/freedesktop/Hal/devices/pcm0'", //
-                "  info.product = 'Realtek ALC892 (Analog)'  (string)", //
-                "  info.vendor = 'Realtek'  (string)", //
-                "  freebsd.driver = 'pcm'  (string)");
+        List<String> lshal = """
+                udi = '/org/freedesktop/Hal/devices/pci_8086_a348'
+                  info.product = 'Cannon Lake PCH cAVS'  (string)
+                udi = '/org/freedesktop/Hal/devices/pcm0'
+                  info.product = 'Realtek ALC892 (Analog)'  (string)
+                  info.vendor = 'Realtek'  (string)
+                  freebsd.driver = 'pcm'  (string)
+                """.lines().toList();
         List<SoundCard> cards = FreeBsdSoundCard.parseSoundCards(lshal);
         assertThat(cards, hasSize(1));
         SoundCard card = cards.get(0);
@@ -39,10 +39,11 @@ class FreeBsdSoundCardTest {
     @Test
     void testParseSoundCardsMissingVendor() {
         // With no info.vendor, the name is just the product (leading space from the "vendor product" join).
-        List<String> lshal = Arrays.asList(//
-                "udi = '/org/freedesktop/Hal/devices/pcm0'", //
-                "  info.product = 'HDA Generic'  (string)", //
-                "  freebsd.driver = 'pcm'  (string)");
+        List<String> lshal = """
+                udi = '/org/freedesktop/Hal/devices/pcm0'
+                  info.product = 'HDA Generic'  (string)
+                  freebsd.driver = 'pcm'  (string)
+                """.lines().toList();
         List<SoundCard> cards = FreeBsdSoundCard.parseSoundCards(lshal);
         assertThat(cards, hasSize(1));
         assertThat(cards.get(0).getCodec(), is("HDA Generic"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdUsbDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdUsbDeviceTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -21,19 +20,20 @@ class FreeBsdUsbDeviceTest {
 
     // A minimal but real-shaped lshal tree: a host controller, its usbus, and one device beneath the usbus.
     // getUsbDevices() promotes the usbus's children onto the controller and drops the usbus node itself.
-    private static final List<String> LSHAL = Arrays.asList(//
-            "udi = '/org/freedesktop/Hal/devices/pci_1022_43d5'", //
-            "  info.product = 'xHCI Host Controller'  (string)", //
-            "udi = '/org/freedesktop/Hal/devices/usb_device_0_0_usbus0'", //
-            "  freebsd.driver = 'usbus'  (string)", //
-            "  info.parent = '/org/freedesktop/Hal/devices/pci_1022_43d5'  (string)", //
-            "udi = '/org/freedesktop/Hal/devices/usb_device_781_5567'", //
-            "  info.parent = '/org/freedesktop/Hal/devices/usb_device_0_0_usbus0'  (string)", //
-            "  usb_device.product = 'Ultra USB 3.0'  (string)", //
-            "  usb_device.vendor = 'SanDisk'  (string)", //
-            "  usb_device.vendor_id = 1921  (0x781)  (int)", //
-            "  usb_device.product_id = 21863  (0x5567)  (int)", //
-            "  usb_device.serial = '4C530001120510117433'  (string)");
+    private static final List<String> LSHAL = """
+            udi = '/org/freedesktop/Hal/devices/pci_1022_43d5'
+              info.product = 'xHCI Host Controller'  (string)
+            udi = '/org/freedesktop/Hal/devices/usb_device_0_0_usbus0'
+              freebsd.driver = 'usbus'  (string)
+              info.parent = '/org/freedesktop/Hal/devices/pci_1022_43d5'  (string)
+            udi = '/org/freedesktop/Hal/devices/usb_device_781_5567'
+              info.parent = '/org/freedesktop/Hal/devices/usb_device_0_0_usbus0'  (string)
+              usb_device.product = 'Ultra USB 3.0'  (string)
+              usb_device.vendor = 'SanDisk'  (string)
+              usb_device.vendor_id = 1921  (0x781)  (int)
+              usb_device.product_id = 21863  (0x5567)  (int)
+              usb_device.serial = '4C530001120510117433'  (string)
+            """.lines().toList();
 
     @Test
     void testParseUsbDevices() {
@@ -57,15 +57,16 @@ class FreeBsdUsbDeviceTest {
     @Test
     void testParseUsbDevicesHexSerial() {
         // A 0x-prefixed serial is decoded from its hex byte string.
-        List<String> lshal = Arrays.asList(//
-                "udi = '/org/freedesktop/Hal/devices/pci_0'", //
-                "  info.product = 'Root Hub'  (string)", //
-                "udi = '/org/freedesktop/Hal/devices/usbus0'", //
-                "  freebsd.driver = 'usbus'  (string)", //
-                "  info.parent = '/org/freedesktop/Hal/devices/pci_0'  (string)", //
-                "udi = '/org/freedesktop/Hal/devices/dev0'", //
-                "  info.parent = '/org/freedesktop/Hal/devices/usbus0'  (string)", //
-                "  usb_device.serial = '0x41424344'  (string)");
+        List<String> lshal = """
+                udi = '/org/freedesktop/Hal/devices/pci_0'
+                  info.product = 'Root Hub'  (string)
+                udi = '/org/freedesktop/Hal/devices/usbus0'
+                  freebsd.driver = 'usbus'  (string)
+                  info.parent = '/org/freedesktop/Hal/devices/pci_0'  (string)
+                udi = '/org/freedesktop/Hal/devices/dev0'
+                  info.parent = '/org/freedesktop/Hal/devices/usbus0'  (string)
+                  usb_device.serial = '0x41424344'  (string)
+                """.lines().toList();
         List<UsbDevice> controllers = FreeBsdUsbDevice.parseUsbDevices(lshal);
         assertThat(controllers, hasSize(1));
         assertThat(controllers.get(0).getConnectedDevices(), hasSize(1));
@@ -77,18 +78,19 @@ class FreeBsdUsbDeviceTest {
     void testParseUsbDevicesSkipsInterfaceNodes() {
         // An interface node's udi is "<device-udi>_ifN"; its .parent points at the device, so key.replace(parent)
         // begins with "_if" and the node must be skipped rather than treated as a child device.
-        List<String> lshal = Arrays.asList(//
-                "udi = '/dev/pci0'", //
-                "  info.product = 'Root Hub'  (string)", //
-                "udi = '/dev/usbus0'", //
-                "  freebsd.driver = 'usbus'  (string)", //
-                "  info.parent = '/dev/pci0'  (string)", //
-                "udi = '/dev/dev0'", //
-                "  info.parent = '/dev/usbus0'  (string)", //
-                "  usb_device.product = 'Widget'  (string)", //
-                "udi = '/dev/dev0_if0'", //
-                "  info.parent = '/dev/dev0'  (string)", //
-                "  usb.interface.number = 0  (int)");
+        List<String> lshal = """
+                udi = '/dev/pci0'
+                  info.product = 'Root Hub'  (string)
+                udi = '/dev/usbus0'
+                  freebsd.driver = 'usbus'  (string)
+                  info.parent = '/dev/pci0'  (string)
+                udi = '/dev/dev0'
+                  info.parent = '/dev/usbus0'  (string)
+                  usb_device.product = 'Widget'  (string)
+                udi = '/dev/dev0_if0'
+                  info.parent = '/dev/dev0'  (string)
+                  usb.interface.number = 0  (int)
+                """.lines().toList();
         List<UsbDevice> controllers = FreeBsdUsbDevice.parseUsbDevices(lshal);
         assertThat(controllers, hasSize(1));
         // Only the real device hangs off the controller; the _if interface node is not a child.

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessorTest.java
@@ -20,11 +20,12 @@ class NetBsdCentralProcessorTest {
 
     @Test
     void testParseVmStats() {
-        List<String> vmstat = Arrays.asList(//
-                "       42983 CPU context switches", //
-                "        8301 device interrupts", //
-                "           0 software interrupts", //
-                "       12345 some other stat");
+        List<String> vmstat = """
+                       42983 CPU context switches
+                        8301 device interrupts
+                           0 software interrupts
+                       12345 some other stat
+                """.lines().toList();
         Pair<Long, Long> result = NetBsdCentralProcessor.parseVmStats(vmstat);
         assertThat(result.getA(), is(42983L));
         assertThat(result.getB(), is(8301L));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/openbsd/OpenBsdCentralProcessorTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -96,11 +95,12 @@ class OpenBsdCentralProcessorTest {
     @Test
     void testParseVmStats() {
         // Real OpenBSD vmstat -s: "software interrupts" appears before bare "interrupts"
-        List<String> vmstat = Arrays.asList(//
-                "      142983 cpu context switches", //
-                "           0 software interrupts", //
-                "       28301 interrupts", //
-                "       50000 some other stat");
+        List<String> vmstat = """
+                      142983 cpu context switches
+                           0 software interrupts
+                       28301 interrupts
+                       50000 some other stat
+                """.lines().toList();
         Pair<Long, Long> result = OpenBsdCentralProcessor.parseVmStats(vmstat);
         assertThat(result.getA(), is(142983L));
         assertThat(result.getB(), is(28301L));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessorTest.java
@@ -20,10 +20,12 @@ class SolarisCentralProcessorTest {
 
     @Test
     void testParseDmesgCpuInfo() {
-        List<String> dmesg = Arrays.asList(//
-                "Jan  9 14:04:28 solaris unix: [ID 950921 kern.info] cpu0: Intel(r) Celeron(r) CPU J3455 @ 1.50GHz", //
-                "Jan  9 14:04:28 solaris unix: [ID 950921 kern.info] cpu0: x86 (chipid 0x0 GenuineIntel 506C9 family 6 model 92 step 9 clock 1500 MHz)", //
-                "Jan  9 14:04:28 solaris unix: [ID 950921 kern.info] cpu1: Intel(r) Celeron(r) CPU J3455 @ 1.50GHz");
+        List<String> dmesg = """
+                Jan  9 14:04:28 solaris unix: [ID 950921 kern.info] cpu0: Intel(r) Celeron(r) CPU J3455 @ 1.50GHz
+                Jan  9 14:04:28 solaris unix: [ID 950921 kern.info] cpu0: x86 (chipid 0x0 GenuineIntel 506C9 family 6 model 92 step 9 clock 1500 MHz)
+                Jan  9 14:04:28 solaris unix: [ID 950921 kern.info] cpu1: Intel(r) Celeron(r) CPU J3455 @ 1.50GHz
+                """
+                .lines().toList();
         Map<Integer, String> result = SolarisCentralProcessor.parseDmesgCpuInfo(dmesg);
         // Only lines matching ".* cpu(\d+): ((ARM|AMD|Intel).+)" are captured
         assertThat(result.size(), is(2));
@@ -39,11 +41,12 @@ class SolarisCentralProcessorTest {
 
     @Test
     void testParseNumaNodes() {
-        List<String> lgrpinfo = Arrays.asList(//
-                "lgroup 0 (root):", //
-                "CPUs: 0-3", //
-                "lgroup 1 (leaf):", //
-                "CPUs: 4 5 6 7");
+        List<String> lgrpinfo = """
+                lgroup 0 (root):
+                CPUs: 0-3
+                lgroup 1 (leaf):
+                CPUs: 4 5 6 7
+                """.lines().toList();
         Map<Integer, Integer> result = SolarisCentralProcessor.parseNumaNodes(lgrpinfo);
         assertThat(result.size(), is(8));
         assertThat(result, hasEntry(0, 0));
@@ -65,11 +68,12 @@ class SolarisCentralProcessorTest {
     @Test
     void testParseIsainfoFlags() {
         // isainfo -v output: first a 64-bit header, then indented flags, then 32-bit header
-        List<String> isainfo = Arrays.asList(//
-                "64-bit amd64 applications", //
-                "        avx512f avx512cd sha sse4.2 popcnt", //
-                "32-bit i386 applications", //
-                "        sse2 sse mmx");
+        List<String> isainfo = """
+                64-bit amd64 applications
+                        avx512f avx512cd sha sse4.2 popcnt
+                32-bit i386 applications
+                        sse2 sse mmx
+                """.lines().toList();
         String[] flags = SolarisCentralProcessor.parseIsainfoFlags(isainfo);
         // Should only contain flags from the 64-bit section, lowercased, split on whitespace.
         // The first element is empty because the flags StringBuilder starts with a space.

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystemTest.java
@@ -23,31 +23,32 @@ class SolarisComputerSystemTest {
     @Test
     void testParseSmbios() {
         // Representative smbios output with BIOS, System, and Baseboard sections
-        List<String> smbios = Arrays.asList(//
-                "ID    SIZE TYPE", //
-                "0     87   SMB_TYPE_BIOS (BIOS Information)", //
-                "", //
-                "  Vendor: Parallels Software International Inc.", //
-                "  Version String: 11.2.1 (32686)", //
-                "  Release Date: 07/15/2016", //
-                "  Address Segment: 0xf000", //
-                "", //
-                "ID    SIZE TYPE", //
-                "1     177  SMB_TYPE_SYSTEM (system information)", //
-                "", //
-                "  Manufacturer: Parallels Software International Inc.", //
-                "  Product: Parallels Virtual Platform", //
-                "  Version: None", //
-                "  Serial Number: Parallels-45 2E 7E 2D 57 5C 4B 59 B1 30 28 81 B7 81 89 34", //
-                "  UUID: 452e7e2d-575c04b59-b130-2881b7818934", //
-                "", //
-                "ID    SIZE TYPE", //
-                "2     90   SMB_TYPE_BASEBOARD (base board)", //
-                "", //
-                "  Manufacturer: Parallels Software International Inc.", //
-                "  Product: Parallels Virtual Platform", //
-                "  Version: None", //
-                "  Serial Number: None");
+        List<String> smbios = """
+                ID    SIZE TYPE
+                0     87   SMB_TYPE_BIOS (BIOS Information)
+
+                  Vendor: Parallels Software International Inc.
+                  Version String: 11.2.1 (32686)
+                  Release Date: 07/15/2016
+                  Address Segment: 0xf000
+
+                ID    SIZE TYPE
+                1     177  SMB_TYPE_SYSTEM (system information)
+
+                  Manufacturer: Parallels Software International Inc.
+                  Product: Parallels Virtual Platform
+                  Version: None
+                  Serial Number: Parallels-45 2E 7E 2D 57 5C 4B 59 B1 30 28 81 B7 81 89 34
+                  UUID: 452e7e2d-575c04b59-b130-2881b7818934
+
+                ID    SIZE TYPE
+                2     90   SMB_TYPE_BASEBOARD (base board)
+
+                  Manufacturer: Parallels Software International Inc.
+                  Product: Parallels Virtual Platform
+                  Version: None
+                  Serial Number: None
+                """.lines().toList();
 
         EnumMap<SmbType, Map<String, String>> result = SolarisComputerSystem.parseSmbios(smbios);
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisGraphicsCardTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -22,14 +21,15 @@ class SolarisGraphicsCardTest {
     @Test
     void testParsePrtconf() {
         // prtconf -pv output with a display-class device (class-code 0003xxxx)
-        List<String> prtconf = Arrays.asList(//
-                "    Node 0x1f8e610", //
-                "      name:  'pci8086,2a42'", //
-                "      model:  'Intel GM45 Integrated Graphics'", //
-                "      vendor-id:  00008086", //
-                "      device-id:  00002a42", //
-                "      revision-id:  00000007", //
-                "      class-code:  00030000");
+        List<String> prtconf = """
+                    Node 0x1f8e610
+                      name:  'pci8086,2a42'
+                      model:  'Intel GM45 Integrated Graphics'
+                      vendor-id:  00008086
+                      device-id:  00002a42
+                      revision-id:  00000007
+                      class-code:  00030000
+                """.lines().toList();
         List<GraphicsCard> cards = SolarisGraphicsCard.parsePrtconf(prtconf);
         assertThat(cards, hasSize(1));
         GraphicsCard card = cards.get(0);
@@ -43,12 +43,13 @@ class SolarisGraphicsCardTest {
     @Test
     void testParsePrtconfNoDisplayDevice() {
         // prtconf -pv output with NO display-class device
-        List<String> prtconf = Arrays.asList(//
-                "    Node 0x1f8e610", //
-                "      name:  'pci8086,29c0'", //
-                "      vendor-id:  00008086", //
-                "      device-id:  000029c0", //
-                "      class-code:  00060000"); // class 0006 = Bridge, not Display
+        List<String> prtconf = """
+                    Node 0x1f8e610
+                      name:  'pci8086,29c0'
+                      vendor-id:  00008086
+                      device-id:  000029c0
+                      class-code:  00060000
+                """.lines().toList(); // class 0006 = Bridge, not Display
         List<GraphicsCard> cards = SolarisGraphicsCard.parsePrtconf(prtconf);
         assertThat(cards, is(empty()));
     }
@@ -62,14 +63,15 @@ class SolarisGraphicsCardTest {
     @Test
     void testParsePrtconfDisplayAtEnd() {
         // Display device at end of output (no following Node header to flush)
-        List<String> prtconf = Arrays.asList(//
-                "    Node 0xaabbcc", //
-                "      name:  'pci1002,67df'", //
-                "      model:  'AMD Radeon RX 580'", //
-                "      vendor-id:  00001002", //
-                "      device-id:  000067df", //
-                "      revision-id:  000000e7", //
-                "      class-code:  00030000");
+        List<String> prtconf = """
+                    Node 0xaabbcc
+                      name:  'pci1002,67df'
+                      model:  'AMD Radeon RX 580'
+                      vendor-id:  00001002
+                      device-id:  000067df
+                      revision-id:  000000e7
+                      class-code:  00030000
+                """.lines().toList();
         List<GraphicsCard> cards = SolarisGraphicsCard.parsePrtconf(prtconf);
         assertThat(cards, hasSize(1));
         assertThat(cards.get(0).getName(), is("AMD Radeon RX 580"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisSoundCardTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -22,16 +21,17 @@ class SolarisSoundCardTest {
     @Test
     void testParseLshal() {
         // Representative lshal output with a sound device
-        List<String> lshal = Arrays.asList(//
-                "udi = '/org/freedesktop/Hal/devices/pci_8086_293e'", //
-                "  info.solaris.driver = 'audio810'  (string)", //
-                "  info.product = 'ICH9 HD Audio Controller'  (string)", //
-                "  info.vendor = 'Intel Corporation'  (string)", //
-                "", //
-                "udi = '/org/freedesktop/Hal/devices/pci_8086_0001'", //
-                "  info.solaris.driver = 'e1000g'  (string)", //
-                "  info.product = 'Network Adapter'  (string)", //
-                "  info.vendor = 'Intel Corporation'  (string)");
+        List<String> lshal = """
+                udi = '/org/freedesktop/Hal/devices/pci_8086_293e'
+                  info.solaris.driver = 'audio810'  (string)
+                  info.product = 'ICH9 HD Audio Controller'  (string)
+                  info.vendor = 'Intel Corporation'  (string)
+
+                udi = '/org/freedesktop/Hal/devices/pci_8086_0001'
+                  info.solaris.driver = 'e1000g'  (string)
+                  info.product = 'Network Adapter'  (string)
+                  info.vendor = 'Intel Corporation'  (string)
+                """.lines().toList();
         List<SoundCard> cards = SolarisSoundCard.parseLshal(lshal);
         assertThat(cards, hasSize(1));
         SoundCard card = cards.get(0);
@@ -42,16 +42,17 @@ class SolarisSoundCardTest {
 
     @Test
     void testParseLshalMultipleAudioDevices() {
-        List<String> lshal = Arrays.asList(//
-                "udi = '/org/freedesktop/Hal/devices/pci_8086_293e'", //
-                "  info.solaris.driver = 'audio810'  (string)", //
-                "  info.product = 'HD Audio'  (string)", //
-                "  info.vendor = 'Intel'  (string)", //
-                "", //
-                "udi = '/org/freedesktop/Hal/devices/pci_1002_aa38'", //
-                "  info.solaris.driver = 'audio810'  (string)", //
-                "  info.product = 'Radeon Audio'  (string)", //
-                "  info.vendor = 'AMD'  (string)");
+        List<String> lshal = """
+                udi = '/org/freedesktop/Hal/devices/pci_8086_293e'
+                  info.solaris.driver = 'audio810'  (string)
+                  info.product = 'HD Audio'  (string)
+                  info.vendor = 'Intel'  (string)
+
+                udi = '/org/freedesktop/Hal/devices/pci_1002_aa38'
+                  info.solaris.driver = 'audio810'  (string)
+                  info.product = 'Radeon Audio'  (string)
+                  info.vendor = 'AMD'  (string)
+                """.lines().toList();
         List<SoundCard> cards = SolarisSoundCard.parseLshal(lshal);
         assertThat(cards, hasSize(2));
         assertThat(cards.get(0).getName(), is("Intel HD Audio"));
@@ -67,11 +68,12 @@ class SolarisSoundCardTest {
     @Test
     void testParseLshalNoAudioDriver() {
         // Devices exist but none have audio810 driver
-        List<String> lshal = Arrays.asList(//
-                "udi = '/org/freedesktop/Hal/devices/pci_8086_0001'", //
-                "  info.solaris.driver = 'e1000g'  (string)", //
-                "  info.product = 'Network Adapter'  (string)", //
-                "  info.vendor = 'Intel Corporation'  (string)");
+        List<String> lshal = """
+                udi = '/org/freedesktop/Hal/devices/pci_8086_0001'
+                  info.solaris.driver = 'e1000g'  (string)
+                  info.product = 'Network Adapter'  (string)
+                  info.vendor = 'Intel Corporation'  (string)
+                """.lines().toList();
         List<SoundCard> cards = SolarisSoundCard.parseLshal(lshal);
         assertThat(cards, is(empty()));
     }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisUsbDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisUsbDeviceTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,17 +27,19 @@ class SolarisUsbDeviceTest {
     @Test
     void testParsePrtconfUsbController() {
         // A USB controller (class-code 000c) with one child device
-        List<String> prtconf = Arrays.asList("    Node 0xf0a8b0", //
-                "      name:  'usb-controller'", //
-                "      model:  'EHCI Host Controller'", //
-                "      vendor-id:  00008086", //
-                "      device-id:  00002934", //
-                "      class-code:  000c0320", //
-                "        Node 0xf0a900", //
-                "          name:  'storage'", //
-                "          model:  'USB Flash Drive'", //
-                "          vendor-id:  00000781", //
-                "          device-id:  00005567");
+        List<String> prtconf = """
+                    Node 0xf0a8b0
+                      name:  'usb-controller'
+                      model:  'EHCI Host Controller'
+                      vendor-id:  00008086
+                      device-id:  00002934
+                      class-code:  000c0320
+                        Node 0xf0a900
+                          name:  'storage'
+                          model:  'USB Flash Drive'
+                          vendor-id:  00000781
+                          device-id:  00005567
+                """.lines().toList();
         List<UsbDevice> devices = SolarisUsbDevice.parsePrtconf(prtconf);
         assertThat(devices, hasSize(1));
         UsbDevice controller = devices.get(0);
@@ -57,11 +58,13 @@ class SolarisUsbDeviceTest {
     @Test
     void testParsePrtconfDeviceTypeUsb() {
         // A controller identified by device_type 'usb' rather than class-code
-        List<String> prtconf = Arrays.asList("    Node 0xaabb00", //
-                "      name:  'usb'", //
-                "      device_type:  'usb'", //
-                "      vendor-id:  00001033", //
-                "      device-id:  00000194");
+        List<String> prtconf = """
+                    Node 0xaabb00
+                      name:  'usb'
+                      device_type:  'usb'
+                      vendor-id:  00001033
+                      device-id:  00000194
+                """.lines().toList();
         List<UsbDevice> devices = SolarisUsbDevice.parsePrtconf(prtconf);
         assertThat(devices, hasSize(1));
         assertThat(devices.get(0).getName(), is("usb"));
@@ -70,11 +73,13 @@ class SolarisUsbDeviceTest {
     @Test
     void testParsePrtconfNonUsbController() {
         // A non-USB controller (class-code 0006 = bridge)
-        List<String> prtconf = Arrays.asList("    Node 0xdead00", //
-                "      name:  'pci-bridge'", //
-                "      vendor-id:  00008086", //
-                "      device-id:  0000244e", //
-                "      class-code:  00060400");
+        List<String> prtconf = """
+                    Node 0xdead00
+                      name:  'pci-bridge'
+                      vendor-id:  00008086
+                      device-id:  0000244e
+                      class-code:  00060400
+                """.lines().toList();
         List<UsbDevice> devices = SolarisUsbDevice.parsePrtconf(prtconf);
         assertThat(devices, is(empty()));
     }

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixFileSystemTest.java
@@ -22,9 +22,12 @@ class AixFileSystemTest {
 
     @Test
     void testParseDfInodesTypical() {
-        List<String> lines = Arrays.asList("Filesystem    512-blocks     Ifree    Iused",
-                "/dev/hd4         4194304   164951    15969", "/dev/hd2        52690944  2894117   196692",
-                "/dev/hd9var      6291456   605443     2317");
+        List<String> lines = """
+                Filesystem    512-blocks     Ifree    Iused
+                /dev/hd4         4194304   164951    15969
+                /dev/hd2        52690944  2894117   196692
+                /dev/hd9var      6291456   605443     2317
+                """.lines().toList();
         Pair<Map<String, Long>, Map<String, Long>> result = AixFileSystem.parseDfInodes(lines);
         Map<String, Long> freeMap = result.getA();
         Map<String, Long> totalMap = result.getB();

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixNetworkParamsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixNetworkParamsTest.java
@@ -17,12 +17,13 @@ class AixNetworkParamsTest {
     @Test
     void testParseDefaultGateway() {
         // netstat -rnf inet: the "default" route's gateway is the second column
-        String gw = AixNetworkParams.parseDefaultGateway(Arrays.asList(//
-                "Routing tables", //
-                "Destination      Gateway         Flags  Refs   Use  If  Exp  Groups", //
-                "Route Tree for Protocol Family 2 (Internet):", //
-                "default          192.168.1.1     UG      1     123  en0   -    -", //
-                "127/8            127.0.0.1       U       3       0  lo0   -    -"));
+        String gw = AixNetworkParams.parseDefaultGateway("""
+                Routing tables
+                Destination      Gateway         Flags  Refs   Use  If  Exp  Groups
+                Route Tree for Protocol Family 2 (Internet):
+                default          192.168.1.1     UG      1     123  en0   -    -
+                127/8            127.0.0.1       U       3       0  lo0   -    -
+                """.lines().toList());
         assertThat(gw, is("192.168.1.1"));
     }
 

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/freebsd/FreeBsdFileSystemTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -22,10 +21,16 @@ class FreeBsdFileSystemTest {
 
     @Test
     void testParseGeomPartListTypical() {
-        List<String> lines = Arrays.asList("Geom name: ada0", "Providers:", "1. Name: ada0p1",
-                "   rawuuid: 3e1cbe42-e2b9-11e6-85c6-0025909460ac", "2. Name: ada0p2",
-                "   rawuuid: 3e2e5580-e2b9-11e6-85c6-0025909460ac", "3. Name: ada0p3",
-                "   rawuuid: 3e3ed3be-e2b9-11e6-85c6-0025909460ac");
+        List<String> lines = """
+                Geom name: ada0
+                Providers:
+                1. Name: ada0p1
+                   rawuuid: 3e1cbe42-e2b9-11e6-85c6-0025909460ac
+                2. Name: ada0p2
+                   rawuuid: 3e2e5580-e2b9-11e6-85c6-0025909460ac
+                3. Name: ada0p3
+                   rawuuid: 3e3ed3be-e2b9-11e6-85c6-0025909460ac
+                """.lines().toList();
         Map<String, String> result = FreeBsdFileSystem.parseGeomPartList(lines);
         assertThat(result, is(aMapWithSize(3)));
         assertThat(result.get("ada0p1"), is("3e1cbe42-e2b9-11e6-85c6-0025909460ac"));
@@ -41,10 +46,11 @@ class FreeBsdFileSystemTest {
 
     @Test
     void testParseDfInodesTypical() {
-        List<String> lines = Arrays.asList(
-                "Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on",
-                "/dev/twed0s1a   2026030 584112 1279836    31%    2751 279871    1%   /",
-                "/dev/twed0s1e  10240000 2048000 8192000    20%    5000 100000    5%   /usr");
+        List<String> lines = """
+                Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on
+                /dev/twed0s1a   2026030 584112 1279836    31%    2751 279871    1%   /
+                /dev/twed0s1e  10240000 2048000 8192000    20%    5000 100000    5%   /usr
+                """.lines().toList();
         Pair<Map<String, Long>, Map<String, Long>> result = FreeBsdFileSystem.parseDfInodes(lines);
         Map<String, Long> freeMap = result.getA();
         Map<String, Long> totalMap = result.getB();
@@ -64,10 +70,11 @@ class FreeBsdFileSystemTest {
 
     @Test
     void testParseDfInodesSkipsHeaderIncludesNonDevFs() {
-        List<String> lines = Arrays.asList(
-                "Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on",
-                "devfs               1      1       0   100%       0      0  100%   /dev",
-                "zroot/ROOT    95678456 8234567  87443889     9%  234567 9999999    2%   /");
+        List<String> lines = """
+                Filesystem    1K-blocks   Used   Avail Capacity iused  ifree %iused  Mounted on
+                devfs               1      1       0   100%       0      0  100%   /dev
+                zroot/ROOT    95678456 8234567  87443889     9%  234567 9999999    2%   /
+                """.lines().toList();
         Pair<Map<String, Long>, Map<String, Long>> result = FreeBsdFileSystem.parseDfInodes(lines);
         Map<String, Long> freeMap = result.getA();
         Map<String, Long> totalMap = result.getB();

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/netbsd/NetBsdFileSystemTest.java
@@ -22,11 +22,12 @@ class NetBsdFileSystemTest {
 
     @Test
     void testParseDfInodesTypical() {
-        List<String> lines = Arrays.asList(
-                "Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on",
-                "/dev/wd0a      2149212    908676   1133076    45%    8355  147163     5%   /",
-                "/dev/wd0e      4050876        36   3848300     0%      10  285108     0%   /home",
-                "/dev/wd0d      6082908   3343172   2435592    58%   27813  386905     7%   /usr");
+        List<String> lines = """
+                Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on
+                /dev/wd0a      2149212    908676   1133076    45%    8355  147163     5%   /
+                /dev/wd0e      4050876        36   3848300     0%      10  285108     0%   /home
+                /dev/wd0d      6082908   3343172   2435592    58%   27813  386905     7%   /usr
+                """.lines().toList();
         Pair<Map<String, Long>, Map<String, Long>> result = NetBsdFileSystem.parseDfInodes(lines);
         Map<String, Long> freeMap = result.getA();
         Map<String, Long> usedMap = result.getB();

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystemTest.java
@@ -22,10 +22,11 @@ class OpenBsdFileSystemTest {
 
     @Test
     void testParseDfInodesTypical() {
-        List<String> lines = Arrays.asList(
-                "Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on",
-                "/dev/sd0a      2149212    908676   1133076    45%    8355  147163     5%   /",
-                "/dev/sd0e      4050876        36   3848300     0%      10  285108     0%   /home");
+        List<String> lines = """
+                Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on
+                /dev/sd0a      2149212    908676   1133076    45%    8355  147163     5%   /
+                /dev/sd0e      4050876        36   3848300     0%      10  285108     0%   /home
+                """.lines().toList();
         Pair<Map<String, Long>, Map<String, Long>> result = OpenBsdFileSystem.parseDfInodes(lines);
         Map<String, Long> freeMap = result.getA();
         Map<String, Long> usedMap = result.getB();

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisFileSystemTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -22,15 +21,16 @@ class SolarisFileSystemTest {
 
     @Test
     void testParseDfgInodesTypical() {
-        List<String> lines = Arrays.asList(
-                "/                  (/dev/md/dsk/d0    ):         8192 block size          1024 frag size",
-                "41310292 total blocks   18193814 free blocks 17780712 available        2486848 total files",
-                " 2293351 free files     22282240 filesys id",
-                "     ufs fstype       0x00000004 flag             255 filename length",
-                "/usr               (/dev/md/dsk/d1    ):         8192 block size          1024 frag size",
-                "20000000 total blocks    5000000 free blocks  4800000 available        1000000 total files",
-                "  800000 free files     33333333 filesys id",
-                "     ufs fstype       0x00000004 flag             255 filename length");
+        List<String> lines = """
+                /                  (/dev/md/dsk/d0    ):         8192 block size          1024 frag size
+                41310292 total blocks   18193814 free blocks 17780712 available        2486848 total files
+                 2293351 free files     22282240 filesys id
+                     ufs fstype       0x00000004 flag             255 filename length
+                /usr               (/dev/md/dsk/d1    ):         8192 block size          1024 frag size
+                20000000 total blocks    5000000 free blocks  4800000 available        1000000 total files
+                  800000 free files     33333333 filesys id
+                     ufs fstype       0x00000004 flag             255 filename length
+                """.lines().toList();
         Pair<Map<String, Long>, Map<String, Long>> result = SolarisFileSystem.parseDfgInodes(lines);
         Map<String, Long> freeMap = result.getA();
         Map<String, Long> totalMap = result.getB();
@@ -50,11 +50,12 @@ class SolarisFileSystemTest {
 
     @Test
     void testParseDfgInodesSingleMount() {
-        List<String> lines = Arrays.asList(
-                "/export/home       (/dev/dsk/c0t0d0s7):         8192 block size          1024 frag size",
-                "10000000 total blocks    3000000 free blocks  2900000 available         500000 total files",
-                "  450000 free files     44444444 filesys id",
-                "     ufs fstype       0x00000004 flag             255 filename length");
+        List<String> lines = """
+                /export/home       (/dev/dsk/c0t0d0s7):         8192 block size          1024 frag size
+                10000000 total blocks    3000000 free blocks  2900000 available         500000 total files
+                  450000 free files     44444444 filesys id
+                     ufs fstype       0x00000004 flag             255 filename length
+                """.lines().toList();
         Pair<Map<String, Long>, Map<String, Long>> result = SolarisFileSystem.parseDfgInodes(lines);
         Map<String, Long> freeMap = result.getA();
         Map<String, Long> totalMap = result.getB();

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStatsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStatsTest.java
@@ -22,12 +22,13 @@ class SolarisInternetProtocolStatsTest {
     @Test
     void testParseTcpStats() {
         // netstat -s -P tcp output: two stats per line separated by spaces
-        List<String> netstat = Arrays.asList(//
-                "tcpCurrEstab =    42   tcpActiveOpens =  1000", //
-                "tcpPassiveOpens = 500   tcpAttemptFails =   10", //
-                "tcpEstabResets =    5   tcpOutSegs    = 50000", //
-                "tcpInSegs     = 60000   tcpRetransSegs =   200", //
-                "tcpInErr      =     3   tcpOutRsts    =    15");
+        List<String> netstat = """
+                tcpCurrEstab =    42   tcpActiveOpens =  1000
+                tcpPassiveOpens = 500   tcpAttemptFails =   10
+                tcpEstabResets =    5   tcpOutSegs    = 50000
+                tcpInSegs     = 60000   tcpRetransSegs =   200
+                tcpInErr      =     3   tcpOutRsts    =    15
+                """.lines().toList();
         TcpStats stats = SolarisInternetProtocolStats.parseTcpStats(netstat);
         assertThat(stats.getConnectionsEstablished(), is(42L));
         assertThat(stats.getConnectionsActive(), is(1000L));

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOSProcessTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOSProcessTest.java
@@ -67,8 +67,11 @@ class SolarisOSProcessTest {
 
     @Test
     void testParsePsrinfo() {
-        List<String> psrinfo = Arrays.asList("0       on-line   since 01/01/2020 00:00:00",
-                "1       on-line   since 01/01/2020 00:00:00", "4       on-line   since 01/01/2020 00:00:00");
+        List<String> psrinfo = """
+                0       on-line   since 01/01/2020 00:00:00
+                1       on-line   since 01/01/2020 00:00:00
+                4       on-line   since 01/01/2020 00:00:00
+                """.lines().toList();
         long mask = SolarisOSProcess.parsePsrinfo(psrinfo);
         // bits 0, 1, 4 set = 0b10011 = 19
         assertThat(mask, is(19L));

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystemTest.java
@@ -22,10 +22,12 @@ class SolarisOperatingSystemTest {
 
     @Test
     void testParseSvcsTypical() {
-        List<String> svcs = Arrays.asList("online         23:56:25 svc:/system/svc/restarter:default",
-                "                        23:56:24       13 svc.startd",
-                "legacy_run     23:56:49 lrc:/etc/rc2_d/S47pppd",
-                "online         23:56:25 svc:/network/loopback:default");
+        List<String> svcs = """
+                online         23:56:25 svc:/system/svc/restarter:default
+                                        23:56:24       13 svc.startd
+                legacy_run     23:56:49 lrc:/etc/rc2_d/S47pppd
+                online         23:56:25 svc:/network/loopback:default
+                """.lines().toList();
         List<String> legacySvcs = Arrays.asList("S47pppd", "S89PRESERVE");
 
         List<OSService> services = SolarisOperatingSystem.parseSvcs(svcs, legacySvcs);

--- a/oshi-common/src/test/java/oshi/util/driver/linux/LshalTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/LshalTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -21,11 +20,14 @@ import oshi.TestConstants;
 class LshalTest {
 
     // Fixture: lshal output with system hardware info
-    private static final List<String> LSHAL_OUTPUT = Arrays.asList("udi = '/org/freedesktop/Hal/devices/computer'",
-            "  system.hardware.vendor = 'Dell Inc.'  (string)",
-            "  system.hardware.product = 'PowerEdge R720'  (string)", "  system.hardware.serial = 'ABC1234'  (string)",
-            "  system.hardware.uuid = '4C4C4544-0044-4810-8031-B4C04F333132'  (string)",
-            "  system.firmware.vendor = 'Dell Inc.'  (string)");
+    private static final List<String> LSHAL_OUTPUT = """
+            udi = '/org/freedesktop/Hal/devices/computer'
+              system.hardware.vendor = 'Dell Inc.'  (string)
+              system.hardware.product = 'PowerEdge R720'  (string)
+              system.hardware.serial = 'ABC1234'  (string)
+              system.hardware.uuid = '4C4C4544-0044-4810-8031-B4C04F333132'  (string)
+              system.firmware.vendor = 'Dell Inc.'  (string)
+            """.lines().toList();
 
     @Test
     void testQuerySerialNumber() {

--- a/oshi-common/src/test/java/oshi/util/driver/unix/NetstatRouteTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/NetstatRouteTest.java
@@ -315,10 +315,14 @@ class NetstatRouteTest {
      */
     @Test
     void testParseOpenBsdPrioMetric() {
-        List<String> openBsd = Arrays.asList("Routing tables", "", "Internet:",
-                "Destination        Gateway            Flags   Refs      Use   Mtu  Prio Iface",
-                "default            192.168.1.1        UGS        0        8     -     8 em0",
-                "224/4              127.0.0.1          URS        0        0 32768     8 lo0");
+        List<String> openBsd = """
+                Routing tables
+
+                Internet:
+                Destination        Gateway            Flags   Refs      Use   Mtu  Prio Iface
+                default            192.168.1.1        UGS        0        8     -     8 em0
+                224/4              127.0.0.1          URS        0        0 32768     8 lo0
+                """.lines().toList();
         List<IPRoute> routes = NetstatRoute.parseRoutes(openBsd, false, 7, NO_INDICES);
         assertThat(routes, hasSize(2));
         assertThat(routes.get(0).getDestination(), is(new byte[] { 0, 0, 0, 0 }));

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoParsingTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoParsingTest.java
@@ -118,9 +118,12 @@ class XwininfoParsingTest {
 
     @Test
     void testParseWindowTreeNonMatchingLines() {
-        List<String> nonMatching = Arrays.asList("xwininfo: Window id: 0x1e3 (the root window) \"i3\"",
-                "  Root window id: 0x1e3 (the root window) (has no name)", "  Parent window id: 0x0 (none)",
-                "     2 children:");
+        List<String> nonMatching = """
+                xwininfo: Window id: 0x1e3 (the root window) "i3"
+                  Root window id: 0x1e3 (the root window) (has no name)
+                  Parent window id: 0x0 (none)
+                     2 children:
+                """.lines().toList();
         Map<String, String> nameMap = new HashMap<>();
         Map<String, String> pathMap = new HashMap<>();
 

--- a/oshi-core/src/test/java/oshi/driver/unix/aix/perfstat/PerfstatJNATest.java
+++ b/oshi-core/src/test/java/oshi/driver/unix/aix/perfstat/PerfstatJNATest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -94,8 +93,19 @@ class PerfstatJNATest {
     void testQueryProtocol() {
         perfstat_protocol_t[] protos = PerfstatProtocolJNA.queryProtocols();
         assertThat("Should have at least one protocol", protos.length, greaterThan(0));
-        List<String> validProtos = Arrays.asList("ip", "ipv6", "icmp", "icmpv6", "udp", "tcp", "rpc", "nfs", "nfsv2",
-                "nfsv3", "nfsv4");
+        List<String> validProtos = """
+                ip
+                ipv6
+                icmp
+                icmpv6
+                udp
+                tcp
+                rpc
+                nfs
+                nfsv2
+                nfsv3
+                nfsv4
+                """.lines().toList();
         for (perfstat_protocol_t proto : protos) {
             String protoName = Native.toString(proto.name);
             assertTrue(validProtos.contains(protoName), "Protocol must be in defined list of names");


### PR DESCRIPTION
Second of four batches. **81 fixtures across 43 files**, all captured command output with no tabs and no trailing whitespace, converted from `Arrays.asList` to a text block read back with `.lines().toList()`. Files are disjoint from #3692 and from the two batches still to come.

## Why, concretely

Spotless runs the Eclipse formatter at `lineSplit=120`, so an `Arrays.asList` fixture gets machine-reflowed and its source lines stop corresponding to the output's lines. Before and after, same fixture:

```java
List<String> prtvtoc = Arrays.asList("* /dev/dsk/c1t0d0s0 partition map", "*", "* Dimensions:",
        "*     512 bytes/sector", "*      63 sectors/track", "*      16 tracks/cylinder",
        ...
        "       0      2    00       1008   14329440   14330447   /",
```

```java
List<String> prtvtoc = """
        * /dev/dsk/c1t0d0s0 partition map
        *
        * Dimensions:
        *     512 bytes/sector
        ...
               0      2    00       1008   14329440   14330447   /
        """.lines().toList();
```

The second can be read against real `prtvtoc` output; the first cannot, and adding one line to it reflows the whole block into the diff.

## Every conversion is machine-verified

Not eyeballed. The emitted text block is decoded per JLS 3.10.6 — common indentation stripped, incidental trailing whitespace removed, escapes processed *after* both — and the resulting lines are compared element-for-element against the literals being replaced. A mismatch fails the conversion instead of producing a plausible-looking fixture.

That check matters specifically here: these parsers are deliberately lenient about real-world output, so a dropped tab or trailing space can leave the test green while the fixture has quietly stopped matching the command it copies. A passing suite is not evidence for this kind of change.

## Six fixtures deliberately left alone

Each carries a per-element comment explaining why one specific line is in the fixture — *"not a block device, skipped"*, *"3-token active form (no group column)"*, *"free rows are skipped"*. A text block cannot hold a comment, and that commentary is worth more than the formatting. They stay as `Arrays.asList`.

## Verification

Full gate from clean — `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc -Paggregate-coverage` — green, zero test failures, plus `-Perror-prone` clean.

Test-only, no CHANGELOG entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized test fixtures across platform-specific test suites using Java text blocks and line-based list construction.
  * Removed unused imports associated with the previous fixture format.
* **Tests**
  * Preserved all existing test data, assertions, parsing scenarios, and expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->