### PR TITLE
Convert tab-bearing command-output fixtures to text blocks

### DIFF
--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractGlobalMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractGlobalMemoryTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -52,23 +51,67 @@ class AbstractGlobalMemoryTest {
     }
 
     // Fixture: dmidecode --type 17 with two populated DIMMs and one empty slot
-    private static final List<String> DMI_TYPE_17 = Arrays.asList("# dmidecode 3.2", "Getting SMBIOS data from sysfs.",
-            "SMBIOS 3.0.0 present.", "", "Handle 0x0038, DMI type 17, 40 bytes", "Memory Device",
-            "\tArray Handle: 0x0036", "\tError Information Handle: Not Provided", "\tTotal Width: 72 bits",
-            "\tData Width: 64 bits", "\tSize: 16384 MB", "\tForm Factor: DIMM", "\tSet: None", "\tLocator: DIMM_A1",
-            "\tBank Locator: NODE 0", "\tType: DDR4", "\tType Detail: Synchronous Registered (Buffered)",
-            "\tSpeed: 2666 MT/s", "\tManufacturer: Samsung", "\tSerial Number: 12345ABC",
-            "\tAsset Tag: DIMM_A1_AssetTag", "\tPart Number: M393A2K43CB2-CTD", "\tRank: 2",
-            "\tConfigured Memory Speed: 2666 MT/s", "", "Handle 0x0039, DMI type 17, 40 bytes", "Memory Device",
-            "\tArray Handle: 0x0036", "\tError Information Handle: Not Provided", "\tTotal Width: 72 bits",
-            "\tData Width: 64 bits", "\tSize: 8192 MB", "\tForm Factor: DIMM", "\tSet: None", "\tLocator: DIMM_B1",
-            "\tBank Locator: NODE 1", "\tType: DDR4", "\tType Detail: Synchronous Registered (Buffered)",
-            "\tSpeed: 2400 MT/s", "\tManufacturer: Micron", "\tSerial Number: 67890DEF",
-            "\tAsset Tag: DIMM_B1_AssetTag", "\tPart Number: MTA18ASF1G72PZ", "\tRank: 1",
-            "\tConfigured Memory Speed: 2400 MT/s", "", "Handle 0x003A, DMI type 17, 40 bytes", "Memory Device",
-            "\tArray Handle: 0x0036", "\tError Information Handle: Not Provided", "\tTotal Width: Unknown",
-            "\tData Width: Unknown", "\tSize: No Module Installed", "\tForm Factor: DIMM", "\tSet: None",
-            "\tLocator: DIMM_C1", "\tBank Locator: NODE 2", "\tType: Unknown", "\tType Detail: None");
+    private static final List<String> DMI_TYPE_17 = """
+            # dmidecode 3.2
+            Getting SMBIOS data from sysfs.
+            SMBIOS 3.0.0 present.
+
+            Handle 0x0038, DMI type 17, 40 bytes
+            Memory Device
+            \tArray Handle: 0x0036
+            \tError Information Handle: Not Provided
+            \tTotal Width: 72 bits
+            \tData Width: 64 bits
+            \tSize: 16384 MB
+            \tForm Factor: DIMM
+            \tSet: None
+            \tLocator: DIMM_A1
+            \tBank Locator: NODE 0
+            \tType: DDR4
+            \tType Detail: Synchronous Registered (Buffered)
+            \tSpeed: 2666 MT/s
+            \tManufacturer: Samsung
+            \tSerial Number: 12345ABC
+            \tAsset Tag: DIMM_A1_AssetTag
+            \tPart Number: M393A2K43CB2-CTD
+            \tRank: 2
+            \tConfigured Memory Speed: 2666 MT/s
+
+            Handle 0x0039, DMI type 17, 40 bytes
+            Memory Device
+            \tArray Handle: 0x0036
+            \tError Information Handle: Not Provided
+            \tTotal Width: 72 bits
+            \tData Width: 64 bits
+            \tSize: 8192 MB
+            \tForm Factor: DIMM
+            \tSet: None
+            \tLocator: DIMM_B1
+            \tBank Locator: NODE 1
+            \tType: DDR4
+            \tType Detail: Synchronous Registered (Buffered)
+            \tSpeed: 2400 MT/s
+            \tManufacturer: Micron
+            \tSerial Number: 67890DEF
+            \tAsset Tag: DIMM_B1_AssetTag
+            \tPart Number: MTA18ASF1G72PZ
+            \tRank: 1
+            \tConfigured Memory Speed: 2400 MT/s
+
+            Handle 0x003A, DMI type 17, 40 bytes
+            Memory Device
+            \tArray Handle: 0x0036
+            \tError Information Handle: Not Provided
+            \tTotal Width: Unknown
+            \tData Width: Unknown
+            \tSize: No Module Installed
+            \tForm Factor: DIMM
+            \tSet: None
+            \tLocator: DIMM_C1
+            \tBank Locator: NODE 2
+            \tType: Unknown
+            \tType Detail: None
+            """.lines().toList();
 
     @Test
     void testParsePhysicalMemoryTwoDimms() {
@@ -101,9 +144,18 @@ class AbstractGlobalMemoryTest {
 
     @Test
     void testParsePhysicalMemorySingleDimm() {
-        List<String> single = Arrays.asList("Handle 0x0038, DMI type 17, 40 bytes", "Memory Device", "\tSize: 4096 MB",
-                "\tLocator: DIMM0", "\tBank Locator: Bank0", "\tType: DDR3", "\tSpeed: 1600 MT/s",
-                "\tManufacturer: Kingston", "\tPart Number: KVR16N11/4", "\tSerial Number: AABB1122");
+        List<String> single = """
+                Handle 0x0038, DMI type 17, 40 bytes
+                Memory Device
+                \tSize: 4096 MB
+                \tLocator: DIMM0
+                \tBank Locator: Bank0
+                \tType: DDR3
+                \tSpeed: 1600 MT/s
+                \tManufacturer: Kingston
+                \tPart Number: KVR16N11/4
+                \tSerial Number: AABB1122
+                """.lines().toList();
         List<PhysicalMemory> result = AbstractGlobalMemory.getPhysicalMemory(single);
         assertThat(result, hasSize(1));
         assertThat(result.get(0).getBankLabel(), is("Bank0/DIMM0"));
@@ -113,11 +165,26 @@ class AbstractGlobalMemoryTest {
     @Test
     void testParsePhysicalMemoryNoStateLeak() {
         // Second DIMM omits Manufacturer and Part Number — should NOT inherit from first
-        List<String> twoEntries = Arrays.asList("Handle 0x0038, DMI type 17, 40 bytes", "Memory Device",
-                "\tSize: 8192 MB", "\tLocator: DIMM_A1", "\tBank Locator: Bank0", "\tType: DDR4", "\tSpeed: 2666 MT/s",
-                "\tManufacturer: Samsung", "\tPart Number: M393A2K43CB2-CTD", "\tSerial Number: SN111",
-                "Handle 0x0039, DMI type 17, 40 bytes", "Memory Device", "\tSize: 4096 MB", "\tLocator: DIMM_B1",
-                "\tBank Locator: Bank1", "\tType: DDR4", "\tSpeed: 2400 MT/s", "\tSerial Number: SN222");
+        List<String> twoEntries = """
+                Handle 0x0038, DMI type 17, 40 bytes
+                Memory Device
+                \tSize: 8192 MB
+                \tLocator: DIMM_A1
+                \tBank Locator: Bank0
+                \tType: DDR4
+                \tSpeed: 2666 MT/s
+                \tManufacturer: Samsung
+                \tPart Number: M393A2K43CB2-CTD
+                \tSerial Number: SN111
+                Handle 0x0039, DMI type 17, 40 bytes
+                Memory Device
+                \tSize: 4096 MB
+                \tLocator: DIMM_B1
+                \tBank Locator: Bank1
+                \tType: DDR4
+                \tSpeed: 2400 MT/s
+                \tSerial Number: SN222
+                """.lines().toList();
         List<PhysicalMemory> result = AbstractGlobalMemory.getPhysicalMemory(twoEntries);
         assertThat(result, hasSize(2));
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
@@ -44,9 +44,11 @@ class LinuxCentralProcessorTest {
     @Test
     void testParseCpuidOutputValid() {
         // Real cpuid -1r output for leaf 0x00000001
-        List<String> lines = Arrays.asList("CPU 0:", //
-                "   0x00000000 0x00: eax=0x00000016 ebx=0x756e6547 ecx=0x6c65746e edx=0x49656e69",
-                "   0x00000001 0x00: eax=0x000906ea ebx=0x00100800 ecx=0x7ffafbbf edx=0xbfebfbff");
+        List<String> lines = """
+                CPU 0:
+                   0x00000000 0x00: eax=0x00000016 ebx=0x756e6547 ecx=0x6c65746e edx=0x49656e69
+                   0x00000001 0x00: eax=0x000906ea ebx=0x00100800 ecx=0x7ffafbbf edx=0xbfebfbff
+                """.lines().toList();
         String result = LinuxCentralProcessor.parseCpuidOutput(lines);
         assertThat(result, is("bfebfbff000906ea"));
     }
@@ -343,8 +345,19 @@ class LinuxCentralProcessorTest {
 
     @Test
     void testReadTopologyFromCpuinfoMultiProcessor() {
-        List<String> lines = Arrays.asList("processor\t: 0", "core id\t\t: 0", "physical id\t: 0", "", "processor\t: 1",
-                "core id\t\t: 1", "physical id\t: 0", "", "processor\t: 2", "core id\t\t: 0", "physical id\t: 1");
+        List<String> lines = """
+                processor\t: 0
+                core id\t\t: 0
+                physical id\t: 0
+
+                processor\t: 1
+                core id\t\t: 1
+                physical id\t: 0
+
+                processor\t: 2
+                core id\t\t: 0
+                physical id\t: 1
+                """.lines().toList();
         Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
                 .readTopologyFromCpuinfo(lines);
         assertThat(result.getA(), hasSize(3));
@@ -430,10 +443,16 @@ class LinuxCentralProcessorTest {
     // -------------------------------------------------------------------------
 
     // Fixture: lscpu -p=cpu,node output
-    private static final List<String> LSCPU_NUMA = Arrays.asList(
-            "# The following is the parsable format, which can be fed to other",
-            "# programs. Each different item in every column has an unique ID", "# starting from zero.", "# CPU,Node",
-            "0,0", "1,0", "2,1", "3,1");
+    private static final List<String> LSCPU_NUMA = """
+            # The following is the parsable format, which can be fed to other
+            # programs. Each different item in every column has an unique ID
+            # starting from zero.
+            # CPU,Node
+            0,0
+            1,0
+            2,1
+            3,1
+            """.lines().toList();
 
     @Test
     void testMapNumaNodesFromLscpu() {
@@ -463,19 +482,52 @@ class LinuxCentralProcessorTest {
     // -------------------------------------------------------------------------
 
     // Fixture: lscpu -B -C --json output
-    private static final List<String> LSCPU_CACHE_JSON = Arrays.asList("{", "   \"caches\": [", "      {",
-            "         \"name\": \"L1d\",", "         \"one-size\": \"32768\",", "         \"all-size\": null,",
-            "         \"ways\": 8,", "         \"type\": \"Data\",", "         \"level\": 1,",
-            "         \"sets\": null,", "         \"coherency-size\": 64", "      },", "      {",
-            "         \"name\": \"L1i\",", "         \"one-size\": \"32768\",", "         \"all-size\": null,",
-            "         \"ways\": 8,", "         \"type\": \"Instruction\",", "         \"level\": 1,",
-            "         \"sets\": null,", "         \"coherency-size\": 64", "      },", "      {",
-            "         \"name\": \"L2\",", "         \"one-size\": \"262144\",", "         \"all-size\": null,",
-            "         \"ways\": 4,", "         \"type\": \"Unified\",", "         \"level\": 2,",
-            "         \"sets\": null,", "         \"coherency-size\": 64", "      },", "      {",
-            "         \"name\": \"L3\",", "         \"one-size\": \"16777216\",", "         \"all-size\": null,",
-            "         \"ways\": null,", "         \"type\": \"Unified\",", "         \"level\": 3,",
-            "         \"sets\": null,", "         \"coherency-size\": 64", "      }", "   ]", "}");
+    private static final List<String> LSCPU_CACHE_JSON = """
+            {
+               "caches": [
+                  {
+                     "name": "L1d",
+                     "one-size": "32768",
+                     "all-size": null,
+                     "ways": 8,
+                     "type": "Data",
+                     "level": 1,
+                     "sets": null,
+                     "coherency-size": 64
+                  },
+                  {
+                     "name": "L1i",
+                     "one-size": "32768",
+                     "all-size": null,
+                     "ways": 8,
+                     "type": "Instruction",
+                     "level": 1,
+                     "sets": null,
+                     "coherency-size": 64
+                  },
+                  {
+                     "name": "L2",
+                     "one-size": "262144",
+                     "all-size": null,
+                     "ways": 4,
+                     "type": "Unified",
+                     "level": 2,
+                     "sets": null,
+                     "coherency-size": 64
+                  },
+                  {
+                     "name": "L3",
+                     "one-size": "16777216",
+                     "all-size": null,
+                     "ways": null,
+                     "type": "Unified",
+                     "level": 3,
+                     "sets": null,
+                     "coherency-size": 64
+                  }
+               ]
+            }
+            """.lines().toList();
 
     @Test
     void testMapCachesFromLscpu() {
@@ -508,9 +560,15 @@ class LinuxCentralProcessorTest {
 
     @Test
     void testParseProcessorIdFromCpuinfoX86() {
-        List<String> cpuinfo = Arrays.asList("processor\t: 0", "vendor_id\t: GenuineIntel", "cpu family\t: 6",
-                "model\t\t: 158", "model name\t: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz", "stepping\t: 10",
-                "flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic sep lm constant_tsc");
+        List<String> cpuinfo = """
+                processor\t: 0
+                vendor_id\t: GenuineIntel
+                cpu family\t: 6
+                model\t\t: 158
+                model name\t: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
+                stepping\t: 10
+                flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic sep lm constant_tsc
+                """.lines().toList();
         LinuxCentralProcessor.CpuInfoIdentity id = LinuxCentralProcessor.parseProcessorIdFromCpuinfo(cpuinfo);
         assertThat(id.vendor(), is("GenuineIntel"));
         assertThat(id.name(), is("Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz"));
@@ -524,9 +582,16 @@ class LinuxCentralProcessorTest {
     void testParseProcessorIdFromCpuinfoArm() {
         // Raspberry Pi style aarch64 /proc/cpuinfo: vendor from implementer, family from architecture, model from part,
         // stepping synthesized from variant (r0) + revision (p3)
-        List<String> cpuinfo = Arrays.asList("processor\t: 0", "BogoMIPS\t: 108.00",
-                "Features\t: fp asimd evtstrm crc32 cpuid", "CPU implementer\t: 0x41", "CPU architecture: 8",
-                "CPU variant\t: 0x0", "CPU part\t: 0xd08", "CPU revision\t: 3");
+        List<String> cpuinfo = """
+                processor\t: 0
+                BogoMIPS\t: 108.00
+                Features\t: fp asimd evtstrm crc32 cpuid
+                CPU implementer\t: 0x41
+                CPU architecture: 8
+                CPU variant\t: 0x0
+                CPU part\t: 0xd08
+                CPU revision\t: 3
+                """.lines().toList();
         LinuxCentralProcessor.CpuInfoIdentity id = LinuxCentralProcessor.parseProcessorIdFromCpuinfo(cpuinfo);
         assertThat(id.vendor(), is("0x41"));
         assertThat(id.family(), is("8"));
@@ -563,8 +628,11 @@ class LinuxCentralProcessorTest {
 
     @Test
     void testParseLscpuIdentityFillsFromLscpu() {
-        List<String> lscpu = Arrays.asList("Architecture:                    aarch64",
-                "Vendor ID:                       ARM", "Model name:                      Cortex-A72");
+        List<String> lscpu = """
+                Architecture:                    aarch64
+                Vendor ID:                       ARM
+                Model name:                      Cortex-A72
+                """.lines().toList();
         Triplet<String, String, String> id = LinuxCentralProcessor.parseLscpuIdentity(lscpu, "0x41", "", "");
         assertThat(id.getA(), is("ARM"));
         assertThat(id.getB(), is("Cortex-A72"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
@@ -272,10 +272,20 @@ class LinuxGraphicsCardTest {
 
     @Test
     void testGetGraphicsCardsFromLspciTwoCards() {
-        List<String> twoCards = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
-                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1", "",
-                "Slot:\t00:02.0", "Class:\tVGA compatible controller [0300]", "Vendor:\tIntel Corporation [8086]",
-                "Device:\tUHD Graphics 630 [3E92]", "Rev:\t00", "");
+        List<String> twoCards = """
+                Slot:\t01:00.0
+                Class:\tVGA compatible controller [0300]
+                Vendor:\tNVIDIA Corporation [10de]
+                Device:\tGA102 [GeForce RTX 3090] [2204]
+                Rev:\ta1
+
+                Slot:\t00:02.0
+                Class:\tVGA compatible controller [0300]
+                Vendor:\tIntel Corporation [8086]
+                Device:\tUHD Graphics 630 [3E92]
+                Rev:\t00
+
+                """.lines().toList();
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(twoCards, STUB_FACTORY, NO_VRAM, NO_DRM);
         assertThat(cards.size(), is(2));
         assertThat(cards.get(0).getName(), is("GA102 [GeForce RTX 3090]"));
@@ -285,8 +295,13 @@ class LinuxGraphicsCardTest {
 
     @Test
     void testGetGraphicsCardsFromLspci3DController() {
-        List<String> threeD = Arrays.asList("Slot:\t01:00.0", "Class:\t3D controller [0302]",
-                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tTesla V100 [1db4]", "");
+        List<String> threeD = """
+                Slot:\t01:00.0
+                Class:\t3D controller [0302]
+                Vendor:\tNVIDIA Corporation [10de]
+                Device:\tTesla V100 [1db4]
+
+                """.lines().toList();
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(threeD, STUB_FACTORY, NO_VRAM, NO_DRM);
         assertThat(cards.size(), is(1));
         assertThat(cards.get(0).getName(), is("Tesla V100"));
@@ -294,10 +309,20 @@ class LinuxGraphicsCardTest {
 
     @Test
     void testGetGraphicsCardsFromLspciPassesEachSlotToLookups() {
-        List<String> twoCards = Arrays.asList("Slot:\t00:02.0", "Class:\tVGA compatible controller [0300]",
-                "Vendor:\tIntel Corporation [8086]", "Device:\tUHD Graphics 630 [3E92]", "Rev:\t00", "",
-                "Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]", "Vendor:\tNVIDIA Corporation [10de]",
-                "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1", "");
+        List<String> twoCards = """
+                Slot:\t00:02.0
+                Class:\tVGA compatible controller [0300]
+                Vendor:\tIntel Corporation [8086]
+                Device:\tUHD Graphics 630 [3E92]
+                Rev:\t00
+
+                Slot:\t01:00.0
+                Class:\tVGA compatible controller [0300]
+                Vendor:\tNVIDIA Corporation [10de]
+                Device:\tGA102 [GeForce RTX 3090] [2204]
+                Rev:\ta1
+
+                """.lines().toList();
 
         List<String> drmSlots = new ArrayList<>();
         List<String> vramSlots = new ArrayList<>();
@@ -321,13 +346,26 @@ class LinuxGraphicsCardTest {
     void testGetGraphicsCardsFromLspciSkipsNonGraphicsSlots() {
         // PCI class 0x0000 renders as "Non-VGA unclassified device", which contains "VGA"; 0x1180 is a signal
         // processing controller. Neither is a graphics card and neither may reach the DRM lookup.
-        List<String> mixed = Arrays.asList("Slot:\t00:13.0", "Class:\tNon-VGA unclassified device [0000]",
-                "Vendor:\tIntel Corporation [8086]",
-                "Device:\t100 Series/C230 Series Chipset Family Integrated Sensor Hub [a135]", "Rev:\t31", "",
-                "Slot:\t00:11.0", "Class:\tSignal processing controller [1180]", "Vendor:\tIntel Corporation [8086]",
-                "Device:\tIntegrated Sensor Hub [a135]", "Rev:\t31", "", "Slot:\t01:00.0",
-                "Class:\tVGA compatible controller [0300]", "Vendor:\tNVIDIA Corporation [10de]",
-                "Device:\tGP107GL [Quadro P400] [1cb3]", "Rev:\ta1", "");
+        List<String> mixed = """
+                Slot:\t00:13.0
+                Class:\tNon-VGA unclassified device [0000]
+                Vendor:\tIntel Corporation [8086]
+                Device:\t100 Series/C230 Series Chipset Family Integrated Sensor Hub [a135]
+                Rev:\t31
+
+                Slot:\t00:11.0
+                Class:\tSignal processing controller [1180]
+                Vendor:\tIntel Corporation [8086]
+                Device:\tIntegrated Sensor Hub [a135]
+                Rev:\t31
+
+                Slot:\t01:00.0
+                Class:\tVGA compatible controller [0300]
+                Vendor:\tNVIDIA Corporation [10de]
+                Device:\tGP107GL [Quadro P400] [1cb3]
+                Rev:\ta1
+
+                """.lines().toList();
         List<String> drmSlots = new ArrayList<>();
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(mixed, STUB_FACTORY, NO_VRAM, slot -> {
             drmSlots.add(slot);
@@ -359,10 +397,18 @@ class LinuxGraphicsCardTest {
     @Test
     void testGetGraphicsCardsFromLspciNewRecordClearsPreviousCardState() {
         // The second card omits Vendor and Rev, so any value it reports for them would be leaked from the first card
-        List<String> lspci = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
-                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGP107GL [Quadro P400] [1cb3]", "Rev:\ta1", "",
-                "Slot:\t00:02.0", "Class:\tVGA compatible controller [0300]", "Device:\tASPEED Graphics Family [2000]",
-                "");
+        List<String> lspci = """
+                Slot:\t01:00.0
+                Class:\tVGA compatible controller [0300]
+                Vendor:\tNVIDIA Corporation [10de]
+                Device:\tGP107GL [Quadro P400] [1cb3]
+                Rev:\ta1
+
+                Slot:\t00:02.0
+                Class:\tVGA compatible controller [0300]
+                Device:\tASPEED Graphics Family [2000]
+
+                """.lines().toList();
         List<String> drmSlots = new ArrayList<>();
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(lspci, STUB_FACTORY, NO_VRAM, slot -> {
             drmSlots.add(slot);
@@ -394,10 +440,13 @@ class LinuxGraphicsCardTest {
 
     @Test
     void testQueryLspciMemorySize() {
-        List<String> lspciV = Arrays.asList("01:00.0 VGA compatible controller: NVIDIA Corporation",
-                "\tMemory at f6000000 (32-bit, non-prefetchable) [size=16M]",
-                "\tMemory at e0000000 (64-bit, prefetchable) [size=256M]",
-                "\tMemory at f0000000 (64-bit, prefetchable) [size=32M]", "\tI/O ports at e000 [size=128]");
+        List<String> lspciV = """
+                01:00.0 VGA compatible controller: NVIDIA Corporation
+                \tMemory at f6000000 (32-bit, non-prefetchable) [size=16M]
+                \tMemory at e0000000 (64-bit, prefetchable) [size=256M]
+                \tMemory at f0000000 (64-bit, prefetchable) [size=32M]
+                \tI/O ports at e000 [size=128]
+                """.lines().toList();
         long vram = LinuxGraphicsCard.queryLspciMemorySize(lspciV);
         // 256M + 32M = 288M
         assertThat(vram, is(256L * 1024 * 1024 + 32L * 1024 * 1024));
@@ -418,8 +467,13 @@ class LinuxGraphicsCardTest {
     @Test
     void testGetGraphicsCardsFromLspciVendorWithoutBracket() {
         // A Vendor line whose value has no "[hex]" id does not parse as machine-readable; the raw text is used
-        List<String> lspci = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
-                "Vendor:\tRedHat, Inc.", "Device:\tVirtio GPU [1050]", "");
+        List<String> lspci = """
+                Slot:\t01:00.0
+                Class:\tVGA compatible controller [0300]
+                Vendor:\tRedHat, Inc.
+                Device:\tVirtio GPU [1050]
+
+                """.lines().toList();
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(lspci, STUB_FACTORY, NO_VRAM, NO_DRM);
         assertThat(cards.size(), is(1));
         assertThat(cards.get(0).getVendor(), is("RedHat, Inc."));
@@ -429,8 +483,13 @@ class LinuxGraphicsCardTest {
     @Test
     void testGetGraphicsCardsFromLspciNoTrailingBlankLine() {
         // Output that ends mid-card (no terminating blank line) still flushes the last card
-        List<String> lspci = Arrays.asList("Slot:\t01:00.0", "Class:\tVGA compatible controller [0300]",
-                "Vendor:\tNVIDIA Corporation [10de]", "Device:\tGA102 [GeForce RTX 3090] [2204]", "Rev:\ta1");
+        List<String> lspci = """
+                Slot:\t01:00.0
+                Class:\tVGA compatible controller [0300]
+                Vendor:\tNVIDIA Corporation [10de]
+                Device:\tGA102 [GeForce RTX 3090] [2204]
+                Rev:\ta1
+                """.lines().toList();
         List<GraphicsCard> cards = LinuxGraphicsCard.getGraphicsCardsFromLspci(lspci, STUB_FACTORY, NO_VRAM, NO_DRM);
         assertThat(cards.size(), is(1));
         assertThat(cards.get(0).getName(), is("GA102 [GeForce RTX 3090]"));
@@ -443,16 +502,26 @@ class LinuxGraphicsCardTest {
 
     // Fixture: `lshw -C display` output (real structure) with two display nodes. The second card has no bus info so
     // its DRM lookup is with a null slot; resources memory ranges drive the VRAM total.
-    private static final List<String> LSHW = Arrays.asList("  *-display",
-            "       description: VGA compatible controller", "       product: GA102 [GeForce RTX 3090]",
-            "       vendor: NVIDIA Corporation", "       physical id: 0", "       bus info: pci@0000:01:00.0",
-            "       version: a1", "       width: 64 bits", "       clock: 33MHz",
-            "       capabilities: pm msi pciexpress vga_controller bus_master cap_list rom",
-            "       configuration: driver=nvidia latency=0",
-            "       resources: irq:178 memory:f6000000-f6ffffff memory:e0000000-efffffff", "  *-display",
-            "       description: VGA compatible controller", "       product: UHD Graphics 630",
-            "       vendor: Intel Corporation", "       physical id: 2",
-            "       resources: irq:24 memory:db000000-dbffffff");
+    private static final List<String> LSHW = """
+              *-display
+                   description: VGA compatible controller
+                   product: GA102 [GeForce RTX 3090]
+                   vendor: NVIDIA Corporation
+                   physical id: 0
+                   bus info: pci@0000:01:00.0
+                   version: a1
+                   width: 64 bits
+                   clock: 33MHz
+                   capabilities: pm msi pciexpress vga_controller bus_master cap_list rom
+                   configuration: driver=nvidia latency=0
+                   resources: irq:178 memory:f6000000-f6ffffff memory:e0000000-efffffff
+              *-display
+                   description: VGA compatible controller
+                   product: UHD Graphics 630
+                   vendor: Intel Corporation
+                   physical id: 2
+                   resources: irq:24 memory:db000000-dbffffff
+            """.lines().toList();
 
     @Test
     void testGetGraphicsCardsFromLshwTwoCards() {

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdGraphicsCardTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -20,20 +19,21 @@ import oshi.hardware.GraphicsCard;
 class BsdGraphicsCardTest {
 
     // Representative pcidump -v output from OpenBSD with one display and one network device
-    private static final List<String> PCIDUMP = Arrays.asList(//
-            " 0:0:0: Intel 82G33/G31/P35/P31 DRAM Controller", //
-            "\tVendor ID: 8086", //
-            "\tProduct ID: 29c0", //
-            "\tClass: 06 Bridge, Host", //
-            " 0:2:0: Intel 82G33/G31 Integrated Graphics Controller", //
-            "\tVendor ID: 8086", //
-            "\tProduct ID: 29c2", //
-            "\tClass: 03 Display, VGA", //
-            "\tRevision: 02", //
-            " 0:25:0: Intel 82801I (ICH9) LAN Controller", //
-            "\tVendor ID: 8086", //
-            "\tProduct ID: 10f0", //
-            "\tClass: 02 Network, Ethernet");
+    private static final List<String> PCIDUMP = """
+             0:0:0: Intel 82G33/G31/P35/P31 DRAM Controller
+            \tVendor ID: 8086
+            \tProduct ID: 29c0
+            \tClass: 06 Bridge, Host
+             0:2:0: Intel 82G33/G31 Integrated Graphics Controller
+            \tVendor ID: 8086
+            \tProduct ID: 29c2
+            \tClass: 03 Display, VGA
+            \tRevision: 02
+             0:25:0: Intel 82801I (ICH9) LAN Controller
+            \tVendor ID: 8086
+            \tProduct ID: 10f0
+            \tClass: 02 Network, Ethernet
+            """.lines().toList();
 
     @Test
     void testParsePciDump() {
@@ -49,21 +49,22 @@ class BsdGraphicsCardTest {
 
     @Test
     void testParsePciDumpMultipleDisplayDevices() {
-        List<String> pcidump = Arrays.asList(//
-                " 0:2:0: NVIDIA GeForce GTX 1080", //
-                "\tVendor ID: 10de", //
-                "\tProduct ID: 1b80", //
-                "\tClass: 03 Display, VGA", //
-                "\tRevision: a1", //
-                " 0:3:0: NVIDIA GeForce GTX 1080 Audio", //
-                "\tVendor ID: 10de", //
-                "\tProduct ID: 10f0", //
-                "\tClass: 04 Multimedia, Audio", //
-                " 0:5:0: AMD Radeon RX 580", //
-                "\tVendor ID: 1002", //
-                "\tProduct ID: 67df", //
-                "\tClass: 03 Display, VGA", //
-                "\tRevision: e7");
+        List<String> pcidump = """
+                 0:2:0: NVIDIA GeForce GTX 1080
+                \tVendor ID: 10de
+                \tProduct ID: 1b80
+                \tClass: 03 Display, VGA
+                \tRevision: a1
+                 0:3:0: NVIDIA GeForce GTX 1080 Audio
+                \tVendor ID: 10de
+                \tProduct ID: 10f0
+                \tClass: 04 Multimedia, Audio
+                 0:5:0: AMD Radeon RX 580
+                \tVendor ID: 1002
+                \tProduct ID: 67df
+                \tClass: 03 Display, VGA
+                \tRevision: e7
+                """.lines().toList();
         List<GraphicsCard> cards = BsdGraphicsCard.parsePciDump(pcidump);
         assertThat(cards, hasSize(2));
         assertThat(cards.get(0).getName(), is("NVIDIA GeForce GTX 1080"));
@@ -75,11 +76,12 @@ class BsdGraphicsCardTest {
 
     @Test
     void testParsePciDumpNoDisplayDevices() {
-        List<String> pcidump = Arrays.asList(//
-                " 0:0:0: Intel Host Bridge", //
-                "\tVendor ID: 8086", //
-                "\tProduct ID: 0001", //
-                "\tClass: 06 Bridge, Host");
+        List<String> pcidump = """
+                 0:0:0: Intel Host Bridge
+                \tVendor ID: 8086
+                \tProduct ID: 0001
+                \tClass: 06 Bridge, Host
+                """.lines().toList();
         List<GraphicsCard> cards = BsdGraphicsCard.parsePciDump(pcidump);
         assertThat(cards, is(empty()));
     }
@@ -93,12 +95,13 @@ class BsdGraphicsCardTest {
     @Test
     void testParsePciDumpDisplayAtEndOfOutput() {
         // Display device is the last entry (no following header to flush it)
-        List<String> pcidump = Arrays.asList(//
-                " 0:2:0: VGA Compatible Controller", //
-                "\tVendor ID: abcd", //
-                "\tProduct ID: 1234", //
-                "\tClass: 03 Display, VGA", //
-                "\tRevision: ff");
+        List<String> pcidump = """
+                 0:2:0: VGA Compatible Controller
+                \tVendor ID: abcd
+                \tProduct ID: 1234
+                \tClass: 03 Display, VGA
+                \tRevision: ff
+                """.lines().toList();
         List<GraphicsCard> cards = BsdGraphicsCard.parsePciDump(pcidump);
         assertThat(cards, hasSize(1));
         assertThat(cards.get(0).getVendor(), is("0xabcd"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdComputerSystemTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -22,17 +21,18 @@ class FreeBsdComputerSystemTest {
     @Test
     void testParseDmiDecode() {
         // Representative `dmidecode -t system` (DMI type 1) block.
-        List<String> dmidecode = Arrays.asList(//
-                "Handle 0x0001, DMI type 1, 27 bytes", //
-                "System Information", //
-                "\tManufacturer: Dell Inc.", //
-                "\tProduct Name: PowerEdge R640", //
-                "\tVersion: Not Specified", //
-                "\tSerial Number: 7XY1234", //
-                "\tUUID: 4c4c4544-0058-5910-8034-c4c04f313233", //
-                "\tWake-up Type: Power Switch", //
-                "\tSKU Number: SKU=NotProvided", //
-                "\tFamily: PowerEdge");
+        List<String> dmidecode = """
+                Handle 0x0001, DMI type 1, 27 bytes
+                System Information
+                \tManufacturer: Dell Inc.
+                \tProduct Name: PowerEdge R640
+                \tVersion: Not Specified
+                \tSerial Number: 7XY1234
+                \tUUID: 4c4c4544-0058-5910-8034-c4c04f313233
+                \tWake-up Type: Power Switch
+                \tSKU Number: SKU=NotProvided
+                \tFamily: PowerEdge
+                """.lines().toList();
         Quintet<@Nullable String, @Nullable String, @Nullable String, @Nullable String, @Nullable String> dmi = FreeBsdComputerSystem
                 .parseDmiDecode(dmidecode);
         assertThat(dmi.getA(), is("Dell Inc."));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdFirmwareTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -24,14 +23,15 @@ class FreeBsdFirmwareTest {
     @Test
     void testParseDmiDecode() {
         // Representative `dmidecode -t bios` (DMI type 0) block; MM/DD/YYYY date is normalized to ISO.
-        List<String> dmidecode = Arrays.asList(//
-                "Handle 0x0000, DMI type 0, 24 bytes", //
-                "BIOS Information", //
-                "\tVendor: Parallels Software International Inc.", //
-                "\tVersion: 11.2.1 (32626)", //
-                "\tRelease Date: 07/15/2016", //
-                "\tBIOS Revision: 11.2", //
-                "\tFirmware Revision: 11.2");
+        List<String> dmidecode = """
+                Handle 0x0000, DMI type 0, 24 bytes
+                BIOS Information
+                \tVendor: Parallels Software International Inc.
+                \tVersion: 11.2.1 (32626)
+                \tRelease Date: 07/15/2016
+                \tBIOS Revision: 11.2
+                \tFirmware Revision: 11.2
+                """.lines().toList();
         Triplet<@Nullable String, @Nullable String, @Nullable String> fw = FreeBsdFirmware.parseDmiDecode(dmidecode);
         assertThat(fw.getA(), is("Parallels Software International Inc."));
         assertThat(fw.getB(), is("11.2.1 (32626)"));

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemDistroTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemDistroTest.java
@@ -150,8 +150,12 @@ class LinuxOperatingSystemDistroTest {
 
     @Test
     void testExecLsbReleaseDebian() {
-        List<String> lines = Arrays.asList("Distributor ID:\tDebian", "Description:\tDebian GNU/Linux 12 (bookworm)",
-                "Release:\t12", "Codename:\tbookworm");
+        List<String> lines = """
+                Distributor ID:\tDebian
+                Description:\tDebian GNU/Linux 12 (bookworm)
+                Release:\t12
+                Codename:\tbookworm
+                """.lines().toList();
         Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Debian"));
@@ -161,8 +165,12 @@ class LinuxOperatingSystemDistroTest {
 
     @Test
     void testExecLsbReleaseNoCodename() {
-        List<String> lines = Arrays.asList("Distributor ID:\tArch", "Description:\tArch Linux", "Release:\trolling",
-                "Codename:\tn/a");
+        List<String> lines = """
+                Distributor ID:\tArch
+                Description:\tArch Linux
+                Release:\trolling
+                Codename:\tn/a
+                """.lines().toList();
         Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Arch"));

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
@@ -139,8 +139,12 @@ class LinuxOperatingSystemTest {
 
     @Test
     void testReadLsbRelease() {
-        List<String> lines = Arrays.asList("DISTRIB_ID=Ubuntu", "DISTRIB_RELEASE=20.04", "DISTRIB_CODENAME=focal",
-                "DISTRIB_DESCRIPTION=\"Ubuntu 20.04.6 LTS\"");
+        List<String> lines = """
+                DISTRIB_ID=Ubuntu
+                DISTRIB_RELEASE=20.04
+                DISTRIB_CODENAME=focal
+                DISTRIB_DESCRIPTION="Ubuntu 20.04.6 LTS"
+                """.lines().toList();
         Triplet<String, String, String> result = LinuxOperatingSystem.readLsbRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Ubuntu"));
@@ -272,8 +276,11 @@ class LinuxOperatingSystemTest {
     @Test
     void testReadOsReleaseNameAfterVersion() {
         // NAME= appears after VERSION= to verify order independence
-        List<String> lines = Arrays.asList("VERSION=\"20.04.6 LTS (Focal Fossa)\"", "VERSION_ID=\"20.04\"",
-                "NAME=\"Ubuntu\"");
+        List<String> lines = """
+                VERSION="20.04.6 LTS (Focal Fossa)"
+                VERSION_ID="20.04"
+                NAME="Ubuntu"
+                """.lines().toList();
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Ubuntu"));
@@ -290,8 +297,12 @@ class LinuxOperatingSystemTest {
         // When Release:/Codename: lines appear before Description:, the explicit
         // values are set first. Description's parsed version/codename do not override
         // because the code only sets them when versionId/codeName are still UNKNOWN.
-        List<String> lines = Arrays.asList("Distributor ID:\tFedora", "Release:\t39", "Codename:\tThirtyNine",
-                "Description:\tFedora release 38 (Thirty Eight)");
+        List<String> lines = """
+                Distributor ID:\tFedora
+                Release:\t39
+                Codename:\tThirtyNine
+                Description:\tFedora release 38 (Thirty Eight)
+                """.lines().toList();
         Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Fedora"));
@@ -322,11 +333,15 @@ class LinuxOperatingSystemTest {
     void testParseServicesSystemctl() {
         // Real `systemctl list-unit-files` columns: UNIT FILE, STATE, [VENDOR PRESET]. Only ".service"/"enabled"
         // rows count; already-running services are dropped by full name or short (last dotted segment) name.
-        List<String> systemctl = Arrays.asList("UNIT FILE                              STATE      VENDOR PRESET",
-                "cron.service                           enabled    enabled",
-                "ssh.service                            enabled    enabled",
-                "dbus-org.freedesktop.resolve1.service  enabled    enabled",
-                "bluetooth.service                      disabled   enabled", "", "247 unit files listed.");
+        List<String> systemctl = """
+                UNIT FILE                              STATE      VENDOR PRESET
+                cron.service                           enabled    enabled
+                ssh.service                            enabled    enabled
+                dbus-org.freedesktop.resolve1.service  enabled    enabled
+                bluetooth.service                      disabled   enabled
+
+                247 unit files listed.
+                """.lines().toList();
         Set<String> running = new HashSet<>(Arrays.asList("ssh", "resolve1"));
         List<OSService> services = LinuxOperatingSystem.parseServices(systemctl, running, "/nonexistent-init-dir");
         // ssh (full-name match) and resolve1 (short-name match) deduped; bluetooth disabled; only cron remains


### PR DESCRIPTION
Third of four batches. **31 fixtures across 8 files** whose captured output contains tab characters: `dmidecode --type 17`, `lspci -vnnmm`, `/proc/cpuinfo` key/value rows, `os-release` and `lsb_release`. Files are disjoint from #3692 and #3693.

## Tabs need no special handling

This turned out to be simpler than I expected when scoping the arc. Escape sequences are processed **after** incidental-whitespace removal, so a `\t` opening a content line cannot be mistaken for indentation and cannot be stripped. The existing escapes carry into the block unchanged:

```java
"\tSize: 16384 MB", "\tForm Factor: DIMM", "\tSet: None",
```
```java
        \tSize: 16384 MB
        \tForm Factor: DIMM
        \tSet: None
```

Literal tabs survive too, but the escape is kept deliberately — unambiguous, visible in review, and immune to anyone re-indenting the block later. Blank lines between `dmidecode` handles round-trip as empty elements, matching the `""` they replace.

## Verified twice, before and after spotless

Each emitted text block is decoded per JLS 3.10.6 — common indentation stripped, incidental trailing whitespace removed, escapes processed after both — and compared element-for-element against the literals in `git HEAD`.

The **post-spotless** pass is the one that matters here: the formatter rewrites these files, and a blank line inside a text block is whitespace it is entitled to trim. All 31 blocks match after it runs.

## One thing deliberately not done

`LinuxCentralProcessorTest` and `LinuxOperatingSystemTest` mix command output with file content from `/proc/cpuinfo`, `/etc/os-release` and `/etc/lsb-release`. Their file-content fixtures stay list-based rather than moving to the write-a-file-and-read-it-back form used in #3692.

Most are `static final` constants shared by several tests, so the end-to-end treatment would mean restructuring shared state rather than converting a fixture — and the content is small key/value text with no whitespace sensitivity, which is exactly where that treatment earns least. Worth revisiting if those constants are ever reworked.

## Verification

Full gate from clean — `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc -Paggregate-coverage` — green, zero test failures, plus `-Perror-prone` clean.

Test-only, no CHANGELOG entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reformatted test fixtures using Java text blocks for improved readability and maintainability.
  * Preserved existing fixture data, assertions, and test behavior across memory, processor, graphics, operating system, and firmware tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->