### PR TITLE
Convert trailing-whitespace fixtures to text blocks, escaping the spaces

### DIFF
--- a/oshi-common/src/test/java/oshi/driver/common/unix/bsd/disk/DisklabelTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/bsd/disk/DisklabelTest.java
@@ -46,14 +46,30 @@ class DisklabelTest {
     @Test
     void testParseDiskParamsExtractsHeaderAndPartitions() {
         // Representative output of `disklabel -n sd0` on OpenBSD/NetBSD.
-        List<String> disklabelOut = Arrays.asList("# /dev/rsd0c:", "type: SCSI", "disk: SCSI disk",
-                "label: Storage Device", "duid: 0000000000000000", "flags:", "bytes/sector: 512", "sectors/track: 63",
-                "tracks/cylinder: 255", "sectors/cylinder: 16065", "cylinders: 976", "total sectors: 15693824",
-                "boundstart: 0", "boundend: 15693824", "drivedata: 0", "", "16 partitions:",
-                "#                size           offset  fstype [fsize bsize   cpg]",
-                "  a:          2097152             1024  4.2BSD   2048 16384 12958 # /",
-                "  b:         17023368          2098176    swap                    # none",
-                "  c:        500118192                0  unused", "  i:              960               64   MSDOS");
+        List<String> disklabelOut = """
+                # /dev/rsd0c:
+                type: SCSI
+                disk: SCSI disk
+                label: Storage Device
+                duid: 0000000000000000
+                flags:
+                bytes/sector: 512
+                sectors/track: 63
+                tracks/cylinder: 255
+                sectors/cylinder: 16065
+                cylinders: 976
+                total sectors: 15693824
+                boundstart: 0
+                boundend: 15693824
+                drivedata: 0
+
+                16 partitions:
+                #                size           offset  fstype [fsize bsize   cpg]
+                  a:          2097152             1024  4.2BSD   2048 16384 12958 # /
+                  b:         17023368          2098176    swap                    # none
+                  c:        500118192                0  unused
+                  i:              960               64   MSDOS
+                """.lines().toList();
 
         Quartet<String, String, Long, List<HWPartition>> result = Disklabel.parseDiskParams("sd0", disklabelOut,
                 ZERO_MAJOR_MINOR);
@@ -106,8 +122,13 @@ class DisklabelTest {
 
     @Test
     void testParseDiskParamsUsesMajorMinorLookup() {
-        List<String> disklabelOut = Arrays.asList("label: Test", "duid: aaaa", "bytes/sector: 512",
-                "total sectors: 100", "  a:  100  0  4.2BSD  2048  16384 12958 # /");
+        List<String> disklabelOut = """
+                label: Test
+                duid: aaaa
+                bytes/sector: 512
+                total sectors: 100
+                  a:  100  0  4.2BSD  2048  16384 12958 # /
+                """.lines().toList();
         BiFunction<String, String, Pair<Integer, Integer>> lookup = (disk, name) -> new Pair<>(7, 42);
 
         Quartet<String, String, Long, List<HWPartition>> result = Disklabel.parseDiskParams("sd0", disklabelOut,
@@ -121,10 +142,12 @@ class DisklabelTest {
     @Test
     void testParseDfFallbackBuildsUnknownLabeledQuartet() {
         // `df` columns: device 1k-blocks used avail capacity mounted
-        List<String> dfOut = Arrays.asList("Filesystem  1K-blocks    Used   Avail Capacity  Mounted on",
-                "/dev/sd0a     1024000  500000  524000     49%  /",
-                "/dev/sd0d     2048000 1000000 1048000     49%  /var",
-                "tmpfs           65536       0   65536      0%  /tmp");
+        List<String> dfOut = """
+                Filesystem  1K-blocks    Used   Avail Capacity  Mounted on
+                /dev/sd0a     1024000  500000  524000     49%  /
+                /dev/sd0d     2048000 1000000 1048000     49%  /var
+                tmpfs           65536       0   65536      0%  /tmp
+                """.lines().toList();
 
         Quartet<String, String, Long, List<HWPartition>> result = Disklabel.parseDfFallback("sd0", dfOut,
                 ZERO_MAJOR_MINOR);
@@ -152,8 +175,13 @@ class DisklabelTest {
     @Test
     void testParseDiskParamsRowWithoutFstypeIsSkipped() {
         // A partition row with fewer than 5 columns (no fstype) is discarded by the parser.
-        List<String> disklabelOut = Arrays.asList("label: X", "duid: x", "bytes/sector: 512", "total sectors: 10",
-                "  a:  10  0  ");
+        List<String> disklabelOut = """
+                label: X
+                duid: x
+                bytes/sector: 512
+                total sectors: 10
+                  a:  10  0 \s
+                """.lines().toList();
         Quartet<String, String, Long, List<HWPartition>> result = Disklabel.parseDiskParams("sd0", disklabelOut,
                 ZERO_MAJOR_MINOR);
         assertThat(result.getD(), is(empty()));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxFirmwareTest.java
@@ -20,8 +20,11 @@ import oshi.util.Constants;
 class LinuxFirmwareTest {
 
     // Fixture: typical vcgencmd version output from a Raspberry Pi
-    private static final List<String> VCGENCMD_OUTPUT = Arrays.asList("Jan 13 2013 16:24:29",
-            "Copyright (c) 2012 Broadcom", "version d292ce426b2d3fee875be2bfc220a76f3ef073fe (clean) (release)");
+    private static final List<String> VCGENCMD_OUTPUT = """
+            Jan 13 2013 16:24:29
+            Copyright (c) 2012 Broadcom
+            version d292ce426b2d3fee875be2bfc220a76f3ef073fe (clean) (release)
+            """.lines().toList();
 
     @Test
     void testQueryVcGenCmdParsesDate() {
@@ -80,8 +83,11 @@ class LinuxFirmwareTest {
     @Test
     void testQueryVcGenCmdParsesManufacturerWithTrailingWhitespace() {
         // A trailing space on the copyright line must not be mistaken for an empty final token
-        List<String> trailingWhitespace = Arrays.asList("Jan 13 2013 16:24:29", "Copyright (c) 2012 Broadcom ",
-                "version abc123");
+        List<String> trailingWhitespace = """
+                Jan 13 2013 16:24:29
+                Copyright (c) 2012 Broadcom\s
+                version abc123
+                """.lines().toList();
         VcGenCmdStrings result = LinuxFirmware.queryVcGenCmd(trailingWhitespace);
         assertThat(result.getManufacturer(), is("Broadcom"));
     }

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/RouteTableTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/RouteTableTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -30,22 +29,25 @@ class RouteTableTest {
     // Verbatim /proc/net/route. The matching `ip route show` reported:
     // default via 172.17.0.1 dev eth0
     // 172.17.0.0/16 dev eth0 scope link src 172.17.0.2
-    private static final List<String> PROC_NET_ROUTE = Arrays.asList(
-            "Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT                   ", //
-            "eth0\t00000000\t010011AC\t0003\t0\t0\t0\t00000000\t0\t0\t0                                           ", //
-            "eth0\t000011AC\t00000000\t0001\t0\t0\t0\t0000FFFF\t0\t0\t0                                           ");
+    private static final List<String> PROC_NET_ROUTE = """
+            Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT                  \s
+            eth0\t00000000\t010011AC\t0003\t0\t0\t0\t00000000\t0\t0\t0                                          \s
+            eth0\t000011AC\t00000000\t0001\t0\t0\t0\t0000FFFF\t0\t0\t0                                          \s
+            """.lines().toList();
 
     // Verbatim /proc/net/ipv6_route, with a 2001:db8:1122:3344::1/64 address added to lo so the byte order is
     // unambiguous. The matching `ip -6 route show` reported:
     // 2001:db8:1122:3344::/64 dev lo metric 256
     // fe80::/64 dev eth0 metric 256
-    private static final List<String> PROC_NET_IPV6_ROUTE = Arrays.asList(
-            "20010db8112233440000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000001 00000000 00200200       lo", //
-            "fe800000000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000001 00000000 00000001     eth0", //
-            "00000000000000000000000000000000 00 00000000000000000000000000000000 00 00000000000000000000000000000000 ffffffff 00000001 00000000 00200200       lo", //
-            "00000000000000000000000000000001 80 00000000000000000000000000000000 00 00000000000000000000000000000000 00000000 00000003 00000000 80200001       lo", //
-            "20010db8112233440000000000000001 80 00000000000000000000000000000000 00 00000000000000000000000000000000 00000000 00000002 00000000 80200001       lo", //
-            "ff000000000000000000000000000000 08 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000002 00000000 00000001     eth0");
+    private static final List<String> PROC_NET_IPV6_ROUTE = """
+            20010db8112233440000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000001 00000000 00200200       lo
+            fe800000000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000001 00000000 00000001     eth0
+            00000000000000000000000000000000 00 00000000000000000000000000000000 00 00000000000000000000000000000000 ffffffff 00000001 00000000 00200200       lo
+            00000000000000000000000000000001 80 00000000000000000000000000000000 00 00000000000000000000000000000000 00000000 00000003 00000000 80200001       lo
+            20010db8112233440000000000000001 80 00000000000000000000000000000000 00 00000000000000000000000000000000 00000000 00000002 00000000 80200001       lo
+            ff000000000000000000000000000000 08 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000002 00000000 00000001     eth0
+            """
+            .lines().toList();
 
     // Verbatim /proc/net/ipv6_route from a container given an IPv6 default route, which the capture above had none of.
     // The matching `ip -6 route show` reported:

--- a/oshi-common/src/test/java/oshi/util/driver/unix/NetstatRouteTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/NetstatRouteTest.java
@@ -29,65 +29,78 @@ class NetstatRouteTest {
 
     // Verbatim `netstat -rn -f inet` from macOS. Note the trailing "!" on two rows and the empty Expire column on the
     // default route, which make the field count vary from row to row.
-    private static final List<String> MACOS_V4 = Arrays.asList("Routing tables", //
-            "", //
-            "Internet:", //
-            "Destination        Gateway            Flags               Netif Expire", //
-            "default            10.0.0.1           UGScg                 en0       ", //
-            "10/24              link#14            UCS                   en0      !", //
-            "10.0.0.1/32        link#14            UCS                   en0      !", //
-            "10.0.0.1           40:f:c1:cb:2a:97   UHLWIir               en0   1198", //
-            "10.0.0.3           d4:80:8b:1e:6b:b9  UHLWI                 en0   1196");
+    private static final List<String> MACOS_V4 = """
+            Routing tables
+
+            Internet:
+            Destination        Gateway            Flags               Netif Expire
+            default            10.0.0.1           UGScg                 en0      \s
+            10/24              link#14            UCS                   en0      !
+            10.0.0.1/32        link#14            UCS                   en0      !
+            10.0.0.1           40:f:c1:cb:2a:97   UHLWIir               en0   1198
+            10.0.0.3           d4:80:8b:1e:6b:b9  UHLWI                 en0   1196
+            """.lines().toList();
 
     // Verbatim `netstat -rn -f inet6` from macOS.
-    private static final List<String> MACOS_V6 = Arrays.asList("Routing tables", //
-            "", //
-            "Internet6:", //
-            "Destination                             Gateway                                 Flags               Netif Expire", //
-            "default                                 fe80::420f:c1ff:fecb:2a97%en0           UGcg                  en0       ", //
-            "default                                 fe80::%utun0                            UGcIg               utun0       ", //
-            "::1                                     ::1                                     UHL                   lo0       ", //
-            "2601:601:d47c:3090::/64                 link#14                                 UC                    en0       ", //
-            "2601:601:d47c:3090::13e2                0:11:32:c5:e:9b                         UHLWI                 en0       ");
+    private static final List<String> MACOS_V6 = """
+            Routing tables
+
+            Internet6:
+            Destination                             Gateway                                 Flags               Netif Expire
+            default                                 fe80::420f:c1ff:fecb:2a97%en0           UGcg                  en0      \s
+            default                                 fe80::%utun0                            UGcIg               utun0      \s
+            ::1                                     ::1                                     UHL                   lo0      \s
+            2601:601:d47c:3090::/64                 link#14                                 UC                    en0      \s
+            2601:601:d47c:3090::13e2                0:11:32:c5:e:9b                         UHLWI                 en0      \s
+            """
+            .lines().toList();
 
     // Verbatim `netstat -rnf inet` from AIX. The column header precedes the section banner here, the reverse of the
     // macOS order, and two rows carry a trailing "=>".
-    private static final List<String> AIX_V4 = Arrays.asList("Routing tables", //
-            "Destination        Gateway           Flags   Refs     Use  If   Exp  Groups", //
-            "", //
-            "Route Tree for Protocol Family 2 (Internet):", //
-            "default            140.211.9.1       UG      124  27595284 en1      -      -   ", //
-            "10.1.0.0           10.1.0.3          UHSb      0         0 en0      -      -   =>", //
-            "10.1/23            10.1.0.3          U         0   1422409 en0      -      -   ", //
-            "10.1.0.3           127.0.0.1         UGHS      0    313680 lo0      -      -   ", //
-            "127/8              127.0.0.1         U         3   3564888 lo0      -      -   ", //
-            "140.211.9/24       140.211.9.96      U         1   1835134 en1      -      -   ");
+    private static final List<String> AIX_V4 = """
+            Routing tables
+            Destination        Gateway           Flags   Refs     Use  If   Exp  Groups
+
+            Route Tree for Protocol Family 2 (Internet):
+            default            140.211.9.1       UG      124  27595284 en1      -      -  \s
+            10.1.0.0           10.1.0.3          UHSb      0         0 en0      -      -   =>
+            10.1/23            10.1.0.3          U         0   1422409 en0      -      -  \s
+            10.1.0.3           127.0.0.1         UGHS      0    313680 lo0      -      -  \s
+            127/8              127.0.0.1         U         3   3564888 lo0      -      -  \s
+            140.211.9/24       140.211.9.96      U         1   1835134 en1      -      -  \s
+            """.lines().toList();
 
     // Verbatim `netstat -rnf inet6` from AIX.
-    private static final List<String> AIX_V6 = Arrays.asList("Routing tables", //
-            "Destination        Gateway           Flags   Refs     Use  If   Exp  Groups", //
-            "", //
-            "Route Tree for Protocol Family 24 (Internet v6):", //
-            "::1%1              ::1%1             UH        1    466765 lo0      -      -   ");
+    private static final List<String> AIX_V6 = """
+            Routing tables
+            Destination        Gateway           Flags   Refs     Use  If   Exp  Groups
+
+            Route Tree for Protocol Family 24 (Internet v6):
+            ::1%1              ::1%1             UH        1    466765 lo0      -      -  \s
+            """.lines().toList();
 
     // Verbatim `netstat -rnv -f inet` from Solaris 11.4. The default route has an empty Device column, which collapses
     // under whitespace splitting and shifts every following token left by one.
-    private static final List<String> SOLARIS_V4 = Arrays.asList("", //
-            "IRE Table: IPv4", //
-            "  Destination             Mask           Gateway          Device  MTU  Ref Flg  Out  In/Fwd ", //
-            "-------------------- --------------- -------------------- ------ ----- --- --- ----- ------ ", //
-            "default              0.0.0.0         129.70.163.177                  0   5 UG  5666596      0 ", //
-            "127.0.0.1            255.255.255.255 127.0.0.1            lo0     8232   2 UH   31396  31391 ", //
-            "129.70.163.176       255.255.255.248 129.70.163.179       net0    1500   3 U     2181      0 ");
+    private static final List<String> SOLARIS_V4 = """
+
+            IRE Table: IPv4
+              Destination             Mask           Gateway          Device  MTU  Ref Flg  Out  In/Fwd\s
+            -------------------- --------------- -------------------- ------ ----- --- --- ----- ------\s
+            default              0.0.0.0         129.70.163.177                  0   5 UG  5666596      0\s
+            127.0.0.1            255.255.255.255 127.0.0.1            lo0     8232   2 UH   31396  31391\s
+            129.70.163.176       255.255.255.248 129.70.163.179       net0    1500   3 U     2181      0\s
+            """.lines().toList();
 
     // Verbatim `netstat -rnv -f inet6` from Solaris 11.4. IPv6 has no Mask column and puts the flags one position
     // earlier than IPv4 does.
-    private static final List<String> SOLARIS_V6 = Arrays.asList("", //
-            "IRE Table: IPv6", //
-            "  Destination/Mask            Gateway                    If    MTU  Ref Flags  Out   In/Fwd ", //
-            "--------------------------- --------------------------- ----- ----- --- ----- ------ ------ ", //
-            "::1                         ::1                         lo0    8252   2 UH      1113   1113 ", //
-            "fe80::/10                   fe80::214:4fff:fefb:a5d7    net0   1500   2 U          0      0 ");
+    private static final List<String> SOLARIS_V6 = """
+
+            IRE Table: IPv6
+              Destination/Mask            Gateway                    If    MTU  Ref Flags  Out   In/Fwd\s
+            --------------------------- --------------------------- ----- ----- --- ----- ------ ------\s
+            ::1                         ::1                         lo0    8252   2 UH      1113   1113\s
+            fe80::/10                   fe80::214:4fff:fefb:a5d7    net0   1500   2 U          0      0\s
+            """.lines().toList();
 
     @Test
     void testParseMacOsIpv4() {
@@ -245,24 +258,28 @@ class NetstatRouteTest {
 
     // Verbatim `netstat -rn -f inet` from DragonFly BSD 6.4 in CI. Note "192.168.122": DragonFly abbreviates a network
     // whose mask falls on an octet boundary and omits the prefix entirely, where FreeBSD prints "192.168.122.0/24".
-    private static final List<String> DRAGONFLY_V4 = Arrays.asList("Routing tables", //
-            "", //
-            "Internet:", //
-            "Destination        Gateway            Flags    Refs      Use  Netif Expire", //
-            "default            192.168.122.2      UGSc       16        0 vtnet0       ", //
-            "127.0.0.1          127.0.0.1          UH          0        0    lo0       ", //
-            "192.168.122        link#1             UC          2        0 vtnet0       ", //
-            "192.168.122.2      52:55:c0:a8:7a:02  UHLW       17       58 vtnet0   1195");
+    private static final List<String> DRAGONFLY_V4 = """
+            Routing tables
+
+            Internet:
+            Destination        Gateway            Flags    Refs      Use  Netif Expire
+            default            192.168.122.2      UGSc       16        0 vtnet0      \s
+            127.0.0.1          127.0.0.1          UH          0        0    lo0      \s
+            192.168.122        link#1             UC          2        0 vtnet0      \s
+            192.168.122.2      52:55:c0:a8:7a:02  UHLW       17       58 vtnet0   1195
+            """.lines().toList();
 
     // Verbatim `netstat -rn -f inet6` from the same host. Its header has no Refs or Use, so Netif sits at index 3
     // rather than the 5 the IPv4 table uses on this very platform.
-    private static final List<String> DRAGONFLY_V6 = Arrays.asList("Routing tables", //
-            "", //
-            "Internet6:", //
-            "Destination                       Gateway                       Flags      Netif Expire", //
-            "::1                               ::1                           UH          lo0       ", //
-            "fe80::%vtnet0/64                  link#1                        UC       vtnet0       ", //
-            "ff01::/32                         ::1                           U           lo0       ");
+    private static final List<String> DRAGONFLY_V6 = """
+            Routing tables
+
+            Internet6:
+            Destination                       Gateway                       Flags      Netif Expire
+            ::1                               ::1                           UH          lo0      \s
+            fe80::%vtnet0/64                  link#1                        UC       vtnet0      \s
+            ff01::/32                         ::1                           U           lo0      \s
+            """.lines().toList();
 
     /**
      * DragonFly BSD prints Refs and Use columns that macOS does not, putting Netif at index 5 rather than 3, and


### PR DESCRIPTION
Last of four batches. **16 fixtures across 4 files** whose captured output has significant trailing whitespace — which a text block strips unless written as `\s`. Files are disjoint from #3694.

## The trailing whitespace is real, not a test artifact

This was the open question when scoping the arc, so I went and checked each one:

| source | verdict |
|---|---|
| `netstat -rn` (macOS, FreeBSD, Solaris, AIX captures) | **real** — pads columns to fixed width, so every route row ends in spaces. 20 of these lines. |
| `/proc/net/route` | **real** — pads records to a fixed width the same way |
| `vcgencmd version` | **real, and the point of the test** — `testQueryVcGenCmdParsesManufacturerWithTrailingWhitespace`, whose comment reads *"a trailing space on the copyright line must not be mistaken for an empty final token"* |
| `disklabel` short row | **incidental** — a hand-made malformed row; preserved anyway, since the row is deliberately short |

So only one of the four is a test artifact, and even there the whitespace is harmless to keep.

Written as `\s` the padding is also **more** visible than it was inside a quoted literal, where it was invisible in review and one careless edit from vanishing.

## One fixture deliberately not converted — and a near miss worth reporting

`"total sectors: " + sectors` concatenates a literal with a `long`, so it is not pure literal content. Extracting only its literals silently drops the value.

The first attempt did exactly that, producing a fixture that parsed to `512` instead of the intended 5 TiB. **The test suite caught it**, and it is reverted; the converters now refuse any fixture whose expression contains a `+` outside a literal.

That is worth stating plainly, because the round-trip verifier used throughout this arc **could not** have caught it. It compares the emitted text block against literals extracted from the original by the same routine that dropped the concatenation — so both sides agreed. The verifier validates escaping and whitespace handling; it does not validate that the source expression was literals to begin with.

I audited the three earlier batches for the same defect: **#3692, #3693 and #3694 contain no converted concatenated fixtures.** This was the only occurrence.

## Verification

Round trip checked before *and* after spotless: each block decoded per JLS 3.10.6 and compared element-for-element against the literals in `git HEAD`. All 16 match.

Full gate from clean — `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc -Paggregate-coverage` — green, zero test failures, plus `-Perror-prone` clean.

Test-only, no CHANGELOG entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized networking, disk, and firmware test fixtures into more readable multi-line text blocks.
  * Preserved all existing test data, including trailing whitespace and IPv4/IPv6 route cases.
  * No changes to tested behavior or expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->