### PR TITLE
Use List.of for small fixed lists where the language level allows

### DIFF
--- a/oshi-common/src/test/java/oshi/driver/common/mac/CpuFrequencyResidencyTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/mac/CpuFrequencyResidencyTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
@@ -184,7 +185,7 @@ class CpuFrequencyResidencyTest {
         complexes.put("PCPU", complexAt(P_STATES, 19));
         complexes.put("PCPM", complexAt(P_STATES, 13));
         Map<Integer, Map<String, Long>> byRank = CpuFrequencyResidency.realizedComplexStates(complexes);
-        assertThat("one entry per core type", byRank.keySet(), is(new TreeSet<>(Arrays.asList(RANK_E, RANK_P))));
+        assertThat("one entry per core type", byRank.keySet(), is(new TreeSet<>(List.of(RANK_E, RANK_P))));
         Map<String, Long> efficiency = byRank.get(RANK_E);
         Map<String, Long> performance = byRank.get(RANK_P);
         assertNotNull(efficiency, "efficiency complex");
@@ -199,8 +200,7 @@ class CpuFrequencyResidencyTest {
     void testEveryClusterOfOneCoreTypeIsSummed() {
         // An Ultra prefixes each die's complex, and a chip with two clusters of one type on a die is expected to number
         // them. Every cluster of a type runs the same frequencies, so one type ran at the average of its clusters.
-        for (String[] names : Arrays.asList(new String[] { "DIE_0_PCPM", "DIE_1_PCPM" },
-                new String[] { "PCPM0", "PCPM1" })) {
+        for (String[] names : List.of(new String[] { "DIE_0_PCPM", "DIE_1_PCPM" }, new String[] { "PCPM0", "PCPM1" })) {
             Map<String, Map<String, Long>> complexes = new LinkedHashMap<>();
             complexes.put(names[0], complexAt(P_STATES, 5));
             complexes.put(names[1], complexAt(P_STATES, 15));
@@ -235,31 +235,29 @@ class CpuFrequencyResidencyTest {
 
     @Test
     void testChannelsAreOrderedByCoreTypeThenCore() {
-        assertThat("M3 Pro",
-                CpuFrequencyResidency.orderChannels(Arrays.asList("PCPU5", "ECPU0", "PCPU0", "ECPU5", "ECPU1")),
-                is(Arrays.asList("ECPU0", "ECPU1", "ECPU5", "PCPU0", "PCPU5")));
+        assertThat("M3 Pro", CpuFrequencyResidency.orderChannels(List.of("PCPU5", "ECPU0", "PCPU0", "ECPU5", "ECPU1")),
+                is(List.of("ECPU0", "ECPU1", "ECPU5", "PCPU0", "PCPU5")));
         // The M5 Pro and Max name their performance cores MCPU and their fastest cores PCPU, with no ECPU at all, so
         // the letters shift but the order does not
-        assertThat("M5 Max",
-                CpuFrequencyResidency.orderChannels(Arrays.asList("PCPU1", "MCPU11", "PCPU0", "MCPU0", "MCPU2")),
-                is(Arrays.asList("MCPU0", "MCPU2", "MCPU11", "PCPU0", "PCPU1")));
+        assertThat("M5 Max", CpuFrequencyResidency.orderChannels(List.of("PCPU1", "MCPU11", "PCPU0", "MCPU0", "MCPU2")),
+                is(List.of("MCPU0", "MCPU2", "MCPU11", "PCPU0", "PCPU1")));
         // An Ultra prefixes its channels with the die, and macOS numbers both dies' cores of one type before the next
         assertThat("Ultra",
                 CpuFrequencyResidency
-                        .orderChannels(Arrays.asList("DIE_1_PCPU0", "DIE_0_ECPU0", "DIE_1_ECPU0", "DIE_0_PCPU0")),
-                is(Arrays.asList("DIE_0_ECPU0", "DIE_1_ECPU0", "DIE_0_PCPU0", "DIE_1_PCPU0")));
+                        .orderChannels(List.of("DIE_1_PCPU0", "DIE_0_ECPU0", "DIE_1_ECPU0", "DIE_0_PCPU0")),
+                is(List.of("DIE_0_ECPU0", "DIE_1_ECPU0", "DIE_0_PCPU0", "DIE_1_PCPU0")));
     }
 
     @Test
     void testACoreIndexIsOrderedNumericallyNotAsText() {
-        assertThat(CpuFrequencyResidency.orderChannels(Arrays.asList("PCPU10", "PCPU9", "PCPU2")),
-                is(Arrays.asList("PCPU2", "PCPU9", "PCPU10")));
+        assertThat(CpuFrequencyResidency.orderChannels(List.of("PCPU10", "PCPU9", "PCPU2")),
+                is(List.of("PCPU2", "PCPU9", "PCPU10")));
     }
 
     @Test
     void testANameThatIsNotACoreChannelSortsLast() {
-        assertThat(CpuFrequencyResidency.orderChannels(Arrays.asList("ECPM", "PCPU0", "ECPU0", "GPU")),
-                is(Arrays.asList("ECPU0", "PCPU0", "ECPM", "GPU")));
+        assertThat(CpuFrequencyResidency.orderChannels(List.of("ECPM", "PCPU0", "ECPU0", "GPU")),
+                is(List.of("ECPU0", "PCPU0", "ECPM", "GPU")));
         // Both a core type no release knows and a name that is not a core channel at all, so a caller can tell that a
         // sample holds something it cannot place
         assertThat("unrecognized core type", CpuFrequencyResidency.prefixRank("XCPU0"),

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LsDevicesTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LsDevicesTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +31,7 @@ class LsDevicesTest {
     @Test
     void testParseDeviceMajorMinor() {
         // ls -l /dev: block devices begin with 'b'; major,minor are the 2nd and 3rd integers, name is the last token
-        Map<String, Pair<Integer, Integer>> map = Ls.parseDeviceMajorMinor(Arrays.asList(//
+        Map<String, Pair<Integer, Integer>> map = Ls.parseDeviceMajorMinor(List.of(//
                 "total 0", //
                 "crw-rw-rw-  1 root system  2,  2 Jun 28  1970 null", // not a block device, skipped
                 "brw-rw----  1 root system 10,  5 Sep 12  2017 hd2", //

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LscfgTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LscfgTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -34,8 +35,8 @@ class LscfgTest {
     @Test
     void testParseModelSerialFallsBackToDescription() {
         // With no "Machine Type and Model" line, the model is the description after the location code
-        Pair<@Nullable String, @Nullable String> modSer = Lscfg.parseModelSerial(
-                Collections.singletonList("  cd0              U78CB.001.WZS00MP-P2-D1  SATA DVD-RAM Drive"), "cd0");
+        Pair<@Nullable String, @Nullable String> modSer = Lscfg
+                .parseModelSerial(List.of("  cd0              U78CB.001.WZS00MP-P2-D1  SATA DVD-RAM Drive"), "cd0");
         assertThat(modSer.getA(), is("SATA DVD-RAM Drive"));
         assertThat(modSer.getB(), is(nullValue()));
     }
@@ -43,8 +44,8 @@ class LscfgTest {
     @Test
     void testParseModelSerialDeviceAtEndOfLine() {
         // A line ending in the device name splits to a single element; the fallback must be skipped, not crash
-        Pair<@Nullable String, @Nullable String> modSer = Lscfg
-                .parseModelSerial(Collections.singletonList("  Adapter containing hdisk0"), "hdisk0");
+        Pair<@Nullable String, @Nullable String> modSer = Lscfg.parseModelSerial(List.of("  Adapter containing hdisk0"),
+                "hdisk0");
         assertThat(modSer.getA(), is(nullValue()));
         assertThat(modSer.getB(), is(nullValue()));
     }

--- a/oshi-common/src/test/java/oshi/driver/common/unix/aix/LspvTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/aix/LspvTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -38,15 +37,14 @@ class LspvTest {
     @Test
     void testParsePpSizeInactiveOrEmpty() {
         // A non-active PV yields 0 (no partitions to enumerate)
-        assertThat(
-                Lspv.parsePpSize(Arrays.asList("PV STATE:           missing", "PP SIZE:            128 megabyte(s)")),
+        assertThat(Lspv.parsePpSize(List.of("PV STATE:           missing", "PP SIZE:            128 megabyte(s)")),
                 is(0L));
         assertThat(Lspv.parsePpSize(Collections.emptyList()), is(0L));
     }
 
     @Test
     void testParsePartitions() {
-        List<String> lspvP = Arrays.asList(//
+        List<String> lspvP = List.of(//
                 "hdisk0:", //
                 "PP RANGE  STATE   REGION        LV NAME             TYPE       MOUNT POINT", //
                 "1-1     used    outer edge    hd5                 boot       N/A", //

--- a/oshi-common/src/test/java/oshi/driver/common/unix/bsd/SystatTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/bsd/SystatTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -49,7 +48,7 @@ class SystatTest {
 
     @Test
     void testParseSensorsFallsBackToAllTempsWhenNoCpuTemp() {
-        List<String> systat = Arrays.asList("acpitz0.temp0 30.00 degC", "acpitz1.temp0 50.00 degC");
+        List<String> systat = List.of("acpitz0.temp0 30.00 degC", "acpitz1.temp0 50.00 degC");
         Triplet<Double, int[], Double> r = Systat.parseSensors(systat);
         // Average of acpitz0 and acpitz1.
         assertThat(r.getA(), is(closeTo(40.0, 1e-9)));
@@ -59,7 +58,7 @@ class SystatTest {
 
     @Test
     void testParseSensorsAveragesMultipleCpuTemps() {
-        List<String> systat = Arrays.asList("cpu0.temp0 50.00 degC", "cpu1.temp0 70.00 degC");
+        List<String> systat = List.of("cpu0.temp0 50.00 degC", "cpu1.temp0 70.00 degC");
         Triplet<Double, int[], Double> r = Systat.parseSensors(systat);
         assertThat(r.getA(), is(closeTo(60.0, 1e-9)));
     }
@@ -67,7 +66,7 @@ class SystatTest {
     @Test
     void testParseSensorsIgnoresMalformedRowsAndEmptyInput() {
         // Single-token rows (no value) and blank lines must be skipped without NaN propagation.
-        List<String> systat = Arrays.asList("", "cpu0.temp0", "junk", "cpu0.temp0 not-a-number");
+        List<String> systat = List.of("", "cpu0.temp0", "junk", "cpu0.temp0 not-a-number");
         Triplet<Double, int[], Double> r = Systat.parseSensors(systat);
         // "not-a-number" parses to NaN and is excluded by listAverage; result is 0.
         assertThat(r.getA(), is(closeTo(0.0, 1e-9)));
@@ -81,7 +80,7 @@ class SystatTest {
 
     @Test
     void testParsePowerSourceNamesExtractsPrefixesAndDedupes() {
-        List<String> systat = Arrays.asList("acpibat0.watthour0 12.0 Wh", "acpibat0.amphour1 5.0 Ah",
+        List<String> systat = List.of("acpibat0.watthour0 12.0 Wh", "acpibat0.amphour1 5.0 Ah",
                 "acpibat1.watthour0 10.0 Wh", "cpu0.temp0 55 degC", // not a power source row
                 "noise without dot");
 
@@ -146,22 +145,22 @@ class SystatTest {
     @Test
     void testParseBatteryFieldsVoltMatchesWhenRowDescribesCurrent() {
         // Some sensors report "volt" without trailing 0 but include "current" in the line text.
-        List<String> systat = Collections.singletonList("acpibat0.volt 12.00 V (current voltage)");
+        List<String> systat = List.of("acpibat0.volt 12.00 V (current voltage)");
         BatteryFields b = Systat.parseBatteryFields("acpibat0", systat);
         assertThat(b.getVoltage(), is(closeTo(12.0, 1e-9)));
     }
 
     @Test
     void testListAverageSkipsNaNs() {
-        assertThat(Systat.listAverage(Arrays.asList(10.0, Double.NaN, 20.0)), is(closeTo(15.0, 1e-9)));
-        assertThat(Systat.listAverage(Arrays.asList(Double.NaN, Double.NaN)), is(closeTo(0.0, 1e-9)));
+        assertThat(Systat.listAverage(List.of(10.0, Double.NaN, 20.0)), is(closeTo(15.0, 1e-9)));
+        assertThat(Systat.listAverage(List.of(Double.NaN, Double.NaN)), is(closeTo(0.0, 1e-9)));
         assertThat(Systat.listAverage(Collections.<Double>emptyList()), is(closeTo(0.0, 1e-9)));
     }
 
     @Test
     void testParseSensorsFanZeroDefaultForNonNumeric() {
         // Fan row with a non-numeric value should default the parsed RPM to 0 rather than throw.
-        List<String> systat = Arrays.asList("it0.fan0 broken RPM");
+        List<String> systat = List.of("it0.fan0 broken RPM");
         Triplet<Double, int[], Double> r = Systat.parseSensors(systat);
         assertThat("one fan parsed", r.getB().length, is(1));
         assertThat(r.getB()[0], is(0));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/bsd/disk/DisklabelTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/bsd/disk/DisklabelTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -100,7 +99,7 @@ class DisklabelTest {
     void testParseDiskParamsLargeDiskWithoutIntOverflow() {
         // 5 TiB disk at 512-byte sectors = 10737418240 sectors, > Integer.MAX_VALUE.
         long sectors = 10_737_418_240L;
-        List<String> disklabelOut = Arrays.asList("label: Big Disk", "duid: deadbeefdeadbeef", "bytes/sector: 512",
+        List<String> disklabelOut = List.of("label: Big Disk", "duid: deadbeefdeadbeef", "bytes/sector: 512",
                 "total sectors: " + sectors);
 
         Quartet<String, String, Long, List<HWPartition>> result = Disklabel.parseDiskParams("sd1", disklabelOut,
@@ -166,7 +165,7 @@ class DisklabelTest {
 
     @Test
     void testParseDfFallbackIgnoresOtherDisks() {
-        List<String> dfOut = Collections.singletonList("/dev/sd1a   1000   500   500   50%  /home");
+        List<String> dfOut = List.of("/dev/sd1a   1000   500   500   50%  /home");
         Quartet<String, String, Long, List<HWPartition>> result = Disklabel.parseDfFallback("sd0", dfOut,
                 ZERO_MAJOR_MINOR);
         assertThat(result.getD(), is(empty()));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/GeomDiskListTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/freebsd/disk/GeomDiskListTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +69,7 @@ class GeomDiskListTest {
 
     @Test
     void testParseGeomDiskListNoMediasizeDefaultsToZero() {
-        List<String> geom = Arrays.asList("Geom name: vtbd0", "   descr: VirtIO Block Device", "   ident: serial123");
+        List<String> geom = List.of("Geom name: vtbd0", "   descr: VirtIO Block Device", "   ident: serial123");
 
         Map<String, Triplet<String, String, Long>> result = GeomDiskList.parseGeomDiskList(geom);
 
@@ -84,7 +83,7 @@ class GeomDiskListTest {
 
     @Test
     void testParseGeomDiskListMissingFieldsDefaultToUnknown() {
-        List<String> geom = Arrays.asList("Geom name: nvd0", "   Mediasize: 1024000000000 (953G)");
+        List<String> geom = List.of("Geom name: nvd0", "   Mediasize: 1024000000000 (953G)");
 
         Map<String, Triplet<String, String, Long>> result = GeomDiskList.parseGeomDiskList(geom);
 

--- a/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/IostatTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/IostatTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -25,9 +24,9 @@ class IostatTest {
     @Test
     void testParsePartitionToMountMapTypicalOutput() {
         // iostat -er output: errors with device name in first column
-        List<String> mountNames = Arrays.asList("errors", "device,s/w,h/w,trn,tot", "cmdk0,0,0,0,0", "sd0,0,0,0,0");
+        List<String> mountNames = List.of("errors", "device,s/w,h/w,trn,tot", "cmdk0,0,0,0,0", "sd0,0,0,0,0");
         // iostat -ern output: errors with device name in last column
-        List<String> mountPoints = Arrays.asList("errors", "s/w,h/w,trn,tot,device", "0,0,0,0,c1d0", "0,0,0,0,c1t1d0");
+        List<String> mountPoints = List.of("errors", "s/w,h/w,trn,tot,device", "0,0,0,0,c1d0", "0,0,0,0,c1t1d0");
 
         Map<String, String> result = Iostat.parsePartitionToMountMap(mountNames, mountPoints);
 
@@ -44,8 +43,8 @@ class IostatTest {
 
     @Test
     void testParsePartitionToMountMapHeaderOnly() {
-        List<String> mountNames = Arrays.asList("errors", "device,s/w,h/w,trn,tot");
-        List<String> mountPoints = Arrays.asList("errors", "s/w,h/w,trn,tot,device");
+        List<String> mountNames = List.of("errors", "device,s/w,h/w,trn,tot");
+        List<String> mountPoints = List.of("errors", "s/w,h/w,trn,tot,device");
 
         Map<String, String> result = Iostat.parsePartitionToMountMap(mountNames, mountPoints);
         assertThat(result, is(anEmptyMap()));
@@ -54,8 +53,8 @@ class IostatTest {
     @Test
     void testParsePartitionToMountMapMismatchedLengths() {
         // mountNames has more entries than mountPoints - only paired entries are processed
-        List<String> mountNames = Arrays.asList("errors", "device,s/w,h/w,trn,tot", "cmdk0,0,0,0,0", "sd0,0,0,0,0");
-        List<String> mountPoints = Arrays.asList("errors", "s/w,h/w,trn,tot,device", "0,0,0,0,c1d0");
+        List<String> mountNames = List.of("errors", "device,s/w,h/w,trn,tot", "cmdk0,0,0,0,0", "sd0,0,0,0,0");
+        List<String> mountPoints = List.of("errors", "s/w,h/w,trn,tot,device", "0,0,0,0,c1d0");
 
         Map<String, String> result = Iostat.parsePartitionToMountMap(mountNames, mountPoints);
 
@@ -72,7 +71,7 @@ class IostatTest {
                 Vendor: ATA,Product: Samsung SSD 860,Serial No: S3Z2NB0K999999,Size: 500.11GB <500107862016 bytes>
                 """.lines().toList();
 
-        Set<String> diskSet = new HashSet<>(Arrays.asList("cmdk0", "sd0"));
+        Set<String> diskSet = new HashSet<>(List.of("cmdk0", "sd0"));
 
         Map<String, Quintet<String, String, String, String, Long>> result = Iostat.parseDeviceStrings(iostat, diskSet);
 
@@ -105,7 +104,7 @@ class IostatTest {
                 """.lines().toList();
 
         // Only include cmdk0 in the disk set
-        Set<String> diskSet = new HashSet<>(Arrays.asList("cmdk0"));
+        Set<String> diskSet = new HashSet<>(List.of("cmdk0"));
 
         Map<String, Quintet<String, String, String, String, Long>> result = Iostat.parseDeviceStrings(iostat, diskSet);
 
@@ -116,7 +115,7 @@ class IostatTest {
 
     @Test
     void testParseDeviceStringsEmptyInput() {
-        Set<String> diskSet = new HashSet<>(Arrays.asList("cmdk0"));
+        Set<String> diskSet = new HashSet<>(List.of("cmdk0"));
         Map<String, Quintet<String, String, String, String, Long>> result = Iostat
                 .parseDeviceStrings(Collections.emptyList(), diskSet);
         assertThat(result, is(anEmptyMap()));

--- a/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/PrtvtocTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/unix/solaris/disk/PrtvtocTest.java
@@ -162,7 +162,7 @@ class PrtvtocTest {
     @Test
     void testParsePrtvtocSingleLineInput() {
         // size <= 1 returns empty
-        List<HWPartition> result = Prtvtoc.parsePrtvtoc(Collections.singletonList("* header"), "c0d0", 10);
+        List<HWPartition> result = Prtvtoc.parsePrtvtoc(List.of("* header"), "c0d0", 10);
         assertThat(result, is(empty()));
     }
 

--- a/oshi-common/src/test/java/oshi/driver/common/windows/perfmon/LoadAverageTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/windows/perfmon/LoadAverageTest.java
@@ -7,7 +7,6 @@ package oshi.driver.common.windows.perfmon;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -48,10 +47,10 @@ class LoadAverageTest {
     @Test
     void testQueryNonIdleTicksSumsTotalMinusIdle() {
         Map<IdleProcessorTimeProperty, List<Long>> valueMap = new EnumMap<>(IdleProcessorTimeProperty.class);
-        valueMap.put(IdleProcessorTimeProperty.PERCENTPROCESSORTIME, Arrays.asList(1000L, 300L));
-        valueMap.put(IdleProcessorTimeProperty.ELAPSEDTIME, Arrays.asList(5000L, 4000L));
-        Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> counters = new Pair<>(
-                Arrays.asList("_Total", "Idle"), valueMap);
+        valueMap.put(IdleProcessorTimeProperty.PERCENTPROCESSORTIME, List.of(1000L, 300L));
+        valueMap.put(IdleProcessorTimeProperty.ELAPSEDTIME, List.of(5000L, 4000L));
+        Pair<List<String>, Map<IdleProcessorTimeProperty, List<Long>>> counters = new Pair<>(List.of("_Total", "Idle"),
+                valueMap);
 
         Pair<Long, Long> ticks = stub(counters, Collections.emptyMap()).queryNonIdleTicks();
         // _Total contributes ticks 1000 and base 5000; Idle subtracts its 300 ticks and leaves base untouched
@@ -61,9 +60,9 @@ class LoadAverageTest {
 
     @Test
     void testQueryNonIdleTicksMissingCountersReturnsZero() {
-        Pair<Long, Long> ticks = stub(new Pair<>(Collections.singletonList("_Total"),
-                Collections.<IdleProcessorTimeProperty, List<Long>>emptyMap()), Collections.emptyMap())
-                        .queryNonIdleTicks();
+        Pair<Long, Long> ticks = stub(
+                new Pair<>(List.of("_Total"), Collections.<IdleProcessorTimeProperty, List<Long>>emptyMap()),
+                Collections.emptyMap()).queryNonIdleTicks();
         assertThat(ticks.getA(), is(0L));
         assertThat(ticks.getB(), is(0L));
     }

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractCentralProcessorTest.java
@@ -15,7 +15,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,8 +39,7 @@ class AbstractCentralProcessorTest {
         return new AbstractCentralProcessor() {
             @Override
             protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
-                return new Quartet<>(Collections.singletonList(new LogicalProcessor(0, 0, 0)), null, null,
-                        Collections.emptyList());
+                return new Quartet<>(List.of(new LogicalProcessor(0, 0, 0)), null, null, Collections.emptyList());
             }
 
             @Override
@@ -193,14 +191,14 @@ class AbstractCentralProcessorTest {
         return new AbstractCentralProcessor() {
             @Override
             protected Quartet<List<LogicalProcessor>, @Nullable List<PhysicalProcessor>, @Nullable List<ProcessorCache>, List<String>> initProcessorCounts() {
-                List<LogicalProcessor> logProcs = Arrays.asList(new LogicalProcessor(0, 0, 0),
-                        new LogicalProcessor(1, 1, 0), new LogicalProcessor(2, 2, 0), new LogicalProcessor(3, 3, 0));
-                List<PhysicalProcessor> physProcs = Arrays.asList(new PhysicalProcessor(0, 0, 1, "P-core"),
+                List<LogicalProcessor> logProcs = List.of(new LogicalProcessor(0, 0, 0), new LogicalProcessor(1, 1, 0),
+                        new LogicalProcessor(2, 2, 0), new LogicalProcessor(3, 3, 0));
+                List<PhysicalProcessor> physProcs = List.of(new PhysicalProcessor(0, 0, 1, "P-core"),
                         new PhysicalProcessor(0, 1, 1, "P-core"), new PhysicalProcessor(0, 2, 0, "E-core"),
                         new PhysicalProcessor(0, 3, 0, "E-core"));
                 List<ProcessorCache> caches = Collections
                         .singletonList(new ProcessorCache(2, 0, 64, 4 * 1024 * 1024, ProcessorCache.Type.UNIFIED));
-                return new Quartet<>(logProcs, physProcs, caches, Arrays.asList("sse", "avx"));
+                return new Quartet<>(logProcs, physProcs, caches, List.of("sse", "avx"));
             }
 
             @Override
@@ -271,7 +269,7 @@ class AbstractCentralProcessorTest {
     @Test
     void testCreateProcListFromDmesg() {
         AbstractCentralProcessor cpu = createProcessor();
-        List<LogicalProcessor> logProcs = Arrays.asList(new LogicalProcessor(0, 0, 0), new LogicalProcessor(1, 1, 0));
+        List<LogicalProcessor> logProcs = List.of(new LogicalProcessor(0, 0, 0), new LogicalProcessor(1, 1, 0));
         Map<Integer, String> dmesg = new HashMap<>();
         dmesg.put(0, "ARM Cortex-A73");
         dmesg.put(1, "ARM Cortex-A53");
@@ -286,7 +284,7 @@ class AbstractCentralProcessorTest {
     @Test
     void testCreateProcListFromDmesgAppleSilicon() {
         AbstractCentralProcessor cpu = createProcessor();
-        List<LogicalProcessor> logProcs = Arrays.asList(new LogicalProcessor(0, 0, 0), new LogicalProcessor(1, 1, 0));
+        List<LogicalProcessor> logProcs = List.of(new LogicalProcessor(0, 0, 0), new LogicalProcessor(1, 1, 0));
         Map<Integer, String> dmesg = new HashMap<>();
         dmesg.put(0, "Apple Firestorm");
         dmesg.put(1, "Apple Icestorm");
@@ -300,7 +298,7 @@ class AbstractCentralProcessorTest {
     @Test
     void testCreateProcListFromDmesgHomogeneous() {
         AbstractCentralProcessor cpu = createProcessor();
-        List<LogicalProcessor> logProcs = Arrays.asList(new LogicalProcessor(0, 0, 0), new LogicalProcessor(1, 1, 0));
+        List<LogicalProcessor> logProcs = List.of(new LogicalProcessor(0, 0, 0), new LogicalProcessor(1, 1, 0));
         Map<Integer, String> dmesg = new HashMap<>();
         dmesg.put(0, "ARM Cortex-A73");
         dmesg.put(1, "ARM Cortex-A73");

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractHardwareAbstractionLayerTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractHardwareAbstractionLayerTest.java
@@ -95,8 +95,8 @@ class AbstractHardwareAbstractionLayerTest {
     @Test
     void testGetUsbDevicesTreeReturnsCachedTree() {
         UsbDevice child = createUsb("child", Collections.emptyList());
-        UsbDevice root = createUsb("root", Collections.singletonList(child));
-        AbstractHardwareAbstractionLayer hal = createHal(Collections.singletonList(root));
+        UsbDevice root = createUsb("root", List.of(child));
+        AbstractHardwareAbstractionLayer hal = createHal(List.of(root));
 
         List<UsbDevice> tree = hal.getUsbDevices(true);
         assertThat(tree, hasSize(1));
@@ -107,9 +107,9 @@ class AbstractHardwareAbstractionLayerTest {
     @Test
     void testGetUsbDevicesFlatFlattensTree() {
         UsbDevice grandchild = createUsb("grandchild", Collections.emptyList());
-        UsbDevice child = createUsb("child", Collections.singletonList(grandchild));
-        UsbDevice root = createUsb("root", Collections.singletonList(child));
-        AbstractHardwareAbstractionLayer hal = createHal(Collections.singletonList(root));
+        UsbDevice child = createUsb("child", List.of(grandchild));
+        UsbDevice root = createUsb("root", List.of(child));
+        AbstractHardwareAbstractionLayer hal = createHal(List.of(root));
 
         List<UsbDevice> flat = hal.getUsbDevices(false);
         assertThat(flat, hasSize(2));

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractPowerSourceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractPowerSourceTest.java
@@ -105,7 +105,7 @@ class AbstractPowerSourceTest {
                 PowerSource.CapacityUnits.MWH, 0, 0, 0, 0, "", null, "", "", 0) {
             @Override
             protected List<PowerSource> queryPowerSources() {
-                return Collections.singletonList(createSource("BAT0"));
+                return List.of(createSource("BAT0"));
             }
         };
         assertThat(ps.updateAttributes(), is(true));

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractUsbDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractUsbDeviceTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -46,8 +45,7 @@ class AbstractUsbDeviceTest {
     void testConnectedDevices() {
         AbstractUsbDevice child = new AbstractUsbDevice("Mouse", "Logitech", "", "", "", "", Collections.emptyList()) {
         };
-        AbstractUsbDevice parent = new AbstractUsbDevice("Hub", "Generic", "", "", "", "",
-                Collections.singletonList(child)) {
+        AbstractUsbDevice parent = new AbstractUsbDevice("Hub", "Generic", "", "", "", "", List.of(child)) {
         };
         assertThat(parent.getConnectedDevices(), hasSize(1));
         assertThat(parent.getConnectedDevices().get(0).getName(), is("Mouse"));
@@ -67,7 +65,7 @@ class AbstractUsbDeviceTest {
         AbstractUsbDevice child = new AbstractUsbDevice("Mouse", "Logitech", "", "", "SN1", "",
                 Collections.emptyList()) {
         };
-        AbstractUsbDevice parent = new AbstractUsbDevice("Hub", "", "", "", "", "", Collections.singletonList(child)) {
+        AbstractUsbDevice parent = new AbstractUsbDevice("Hub", "", "", "", "", "", List.of(child)) {
         };
         assertThat(parent.toString(), is(" Hub\n |-- Mouse (Logitech) [s/n: SN1]"));
     }
@@ -141,7 +139,7 @@ class AbstractUsbDeviceTest {
         productIdMap.put("usb1/1-2", "0002");
         Map<String, String> serialMap = Collections.emptyMap();
         Map<String, List<String>> hubMap = new HashMap<>();
-        hubMap.put("usb1", Arrays.asList("usb1/1-1", "usb1/1-2"));
+        hubMap.put("usb1", List.of("usb1/1-1", "usb1/1-2"));
 
         UsbDevice hub = AbstractUsbDevice.buildDeviceTree("usb1", "0000", "0000", nameMap, vendorMap, vendorIdMap,
                 productIdMap, serialMap, hubMap, FACTORY);
@@ -173,8 +171,8 @@ class AbstractUsbDeviceTest {
         productIdMap.put("usb1/1-1", "2514");
         productIdMap.put("usb1/1-1/1-1.1", "0112");
         Map<String, List<String>> hubMap = new HashMap<>();
-        hubMap.put("usb1", Collections.singletonList("usb1/1-1"));
-        hubMap.put("usb1/1-1", Collections.singletonList("usb1/1-1/1-1.1"));
+        hubMap.put("usb1", List.of("usb1/1-1"));
+        hubMap.put("usb1/1-1", List.of("usb1/1-1/1-1.1"));
 
         UsbDevice root = AbstractUsbDevice.buildDeviceTree("usb1", "0000", "0000", nameMap, Collections.emptyMap(),
                 vendorIdMap, productIdMap, Collections.emptyMap(), hubMap, FACTORY);

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxCentralProcessorTest.java
@@ -16,7 +16,6 @@ import static oshi.util.TestFileUtil.writeFile;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +54,7 @@ class LinuxCentralProcessorTest {
 
     @Test
     void testParseCpuidOutputNoMatch() {
-        List<String> lines = Arrays.asList("CPU 0:",
+        List<String> lines = List.of("CPU 0:",
                 "   0x00000000 0x00: eax=0x00000016 ebx=0x756e6547 ecx=0x6c65746e edx=0x49656e69");
         assertThat(LinuxCentralProcessor.parseCpuidOutput(lines), is(nullValue()));
     }
@@ -63,7 +62,7 @@ class LinuxCentralProcessorTest {
     @Test
     void testParseCpuidOutputMalformed() {
         // Leaf 0x00000001 present but edx missing — should return null to allow fallback
-        List<String> lines = Arrays.asList("   0x00000001 0x00: eax=0x000906ea ebx=0x00100800 ecx=0x7ffafbbf");
+        List<String> lines = List.of("   0x00000001 0x00: eax=0x000906ea ebx=0x00100800 ecx=0x7ffafbbf");
         assertThat(LinuxCentralProcessor.parseCpuidOutput(lines), is(nullValue()));
     }
 
@@ -333,7 +332,7 @@ class LinuxCentralProcessorTest {
 
     @Test
     void testReadTopologyFromCpuinfoSingleProcessor() {
-        List<String> lines = Arrays.asList("processor\t: 0", "core id\t\t: 0", "physical id\t: 0");
+        List<String> lines = List.of("processor\t: 0", "core id\t\t: 0", "physical id\t: 0");
         Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
                 .readTopologyFromCpuinfo(lines);
         assertThat(result.getA(), hasSize(1));
@@ -373,7 +372,7 @@ class LinuxCentralProcessorTest {
     @Test
     void testReadTopologyFromCpuinfoCpuNumber() {
         // Some architectures use "cpu number" instead of "core id"
-        List<String> lines = Arrays.asList("processor\t: 0", "cpu number\t: 5", "physical id\t: 0");
+        List<String> lines = List.of("processor\t: 0", "cpu number\t: 5", "physical id\t: 0");
         Quartet<List<LogicalProcessor>, List<ProcessorCache>, Map<Integer, Integer>, Map<Integer, String>> result = LinuxCentralProcessor
                 .readTopologyFromCpuinfo(lines);
         assertThat(result.getA().get(0).getPhysicalProcessorNumber(), is(5));
@@ -472,7 +471,7 @@ class LinuxCentralProcessorTest {
 
     @Test
     void testMapNumaNodesFromLscpuCommentsOnly() {
-        List<String> comments = Arrays.asList("# comment1", "# comment2");
+        List<String> comments = List.of("# comment1", "# comment2");
         Map<Integer, Integer> result = LinuxCentralProcessor.mapNumaNodesFromLscpu(comments);
         assertThat(result.isEmpty(), is(true));
     }
@@ -618,7 +617,7 @@ class LinuxCentralProcessorTest {
     void testParseProcessorIdFromCpuinfoIgnoresNumericProcessorName() {
         // The "processor : N" line on ARM must not become the CPU name
         LinuxCentralProcessor.CpuInfoIdentity id = LinuxCentralProcessor
-                .parseProcessorIdFromCpuinfo(Arrays.asList("processor\t: 3"));
+                .parseProcessorIdFromCpuinfo(List.of("processor\t: 3"));
         assertThat(id.name(), is(""));
     }
 
@@ -641,7 +640,7 @@ class LinuxCentralProcessorTest {
 
     @Test
     void testParseLscpuIdentityArchitectureOnlyOverridesHexVendor() {
-        List<String> lscpu = Arrays.asList("Architecture:                    x86_64");
+        List<String> lscpu = List.of("Architecture:                    x86_64");
         // Non-hex vendor is left alone by the Architecture line
         assertThat(LinuxCentralProcessor.parseLscpuIdentity(lscpu, "GenuineIntel", "158", "Xeon").getA(),
                 is("GenuineIntel"));
@@ -651,7 +650,7 @@ class LinuxCentralProcessorTest {
 
     @Test
     void testParseLscpuIdentityKeepsExistingModelAndName() {
-        List<String> lscpu = Arrays.asList("Model name:                      Ignored");
+        List<String> lscpu = List.of("Model name:                      Ignored");
         Triplet<String, String, String> id = LinuxCentralProcessor.parseLscpuIdentity(lscpu, "GenuineIntel", "158",
                 "i7");
         assertThat(id.getB(), is("158"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxFirmwareTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -63,7 +62,7 @@ class LinuxFirmwareTest {
 
     @Test
     void testQueryVcGenCmdTooFewLines() {
-        VcGenCmdStrings result = LinuxFirmware.queryVcGenCmd(Arrays.asList("Jan 13 2013 16:24:29"));
+        VcGenCmdStrings result = LinuxFirmware.queryVcGenCmd(List.of("Jan 13 2013 16:24:29"));
         assertThat(result.getReleaseDate(), is(nullValue()));
         assertThat(result.getManufacturer(), is(nullValue()));
         assertThat(result.getVersion(), is(nullValue()));
@@ -73,7 +72,7 @@ class LinuxFirmwareTest {
 
     @Test
     void testQueryVcGenCmdInvalidDate() {
-        List<String> badDate = Arrays.asList("not a date", "Copyright (c) 2012 Broadcom", "version abc123");
+        List<String> badDate = List.of("not a date", "Copyright (c) 2012 Broadcom", "version abc123");
         VcGenCmdStrings result = LinuxFirmware.queryVcGenCmd(badDate);
         assertThat(result.getReleaseDate(), is(Constants.UNKNOWN));
         assertThat(result.getManufacturer(), is("Broadcom"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -227,7 +226,7 @@ class LinuxGraphicsCardTest {
     // -------------------------------------------------------------------------
 
     // Fixture: lspci -vnnmm output with one VGA card
-    private static final List<String> LSPCI_VNNMM = Arrays.asList("Slot:\t01:00.0",
+    private static final List<String> LSPCI_VNNMM = List.of("Slot:\t01:00.0",
             "Class:\tVGA compatible controller [0300]", "Vendor:\tNVIDIA Corporation [10de]",
             "Device:\tGA102 [GeForce RTX 3090] [2204]", "SVendor:\tASUS [1043]",
             "SDevice:\tGA102 [GeForce RTX 3090] [8687]", "Rev:\ta1", "");
@@ -335,8 +334,8 @@ class LinuxGraphicsCardTest {
         });
 
         // Each card must be correlated using its own PCI slot, not null and not a shared one
-        assertThat(drmSlots, is(Arrays.asList("00:02.0", "01:00.0")));
-        assertThat(vramSlots, is(Arrays.asList("00:02.0", "01:00.0")));
+        assertThat(drmSlots, is(List.of("00:02.0", "01:00.0")));
+        assertThat(vramSlots, is(List.of("00:02.0", "01:00.0")));
         assertThat(((LinuxGraphicsCard) cards.get(0)).getPciBusId(), is("00:02.0"));
         assertThat(((LinuxGraphicsCard) cards.get(1)).getPciBusId(), is("01:00.0"));
         assertThat(cards.get(0).getVRam(), is(1024L));
@@ -373,7 +372,7 @@ class LinuxGraphicsCardTest {
         });
         assertThat(cards.size(), is(1));
         assertThat(cards.get(0).getDeviceId(), is("0x1cb3"));
-        assertThat(drmSlots, is(Collections.singletonList("01:00.0")));
+        assertThat(drmSlots, is(List.of("01:00.0")));
     }
 
     @Test
@@ -423,13 +422,13 @@ class LinuxGraphicsCardTest {
         assertThat(second.getDeviceId(), is("0x2000"));
         assertThat(second.getVendor(), is(Constants.UNKNOWN));
         assertThat(second.getVersionInfo(), is(Constants.UNKNOWN));
-        assertThat(drmSlots, is(Arrays.asList("01:00.0", "00:02.0")));
+        assertThat(drmSlots, is(List.of("01:00.0", "00:02.0")));
     }
 
     @Test
     void testGetGraphicsCardsFromLspciValuelessClassLine() {
         // A "Class:" line with no value must not be treated as a display controller
-        List<String> lspci = Arrays.asList("Slot:\t01:00.0", "Class:", "Vendor:\tNVIDIA Corporation [10de]",
+        List<String> lspci = List.of("Slot:\t01:00.0", "Class:", "Vendor:\tNVIDIA Corporation [10de]",
                 "Device:\tGP107GL [Quadro P400] [1cb3]", "");
         assertThat(LinuxGraphicsCard.getGraphicsCardsFromLspci(lspci, STUB_FACTORY, NO_VRAM, NO_DRM), is(empty()));
     }
@@ -454,7 +453,7 @@ class LinuxGraphicsCardTest {
 
     @Test
     void testQueryLspciMemorySizeNoPrefetchable() {
-        List<String> noPrefetch = Arrays.asList("01:00.0 VGA compatible controller: Intel",
+        List<String> noPrefetch = List.of("01:00.0 VGA compatible controller: Intel",
                 "\tMemory at f6000000 (32-bit, non-prefetchable) [size=16M]");
         assertThat(LinuxGraphicsCard.queryLspciMemorySize(noPrefetch), is(0L));
     }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroupTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxLogicalVolumeGroupTest.java
@@ -15,7 +15,6 @@ import static org.hamcrest.Matchers.is;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,7 +39,7 @@ class LinuxLogicalVolumeGroupTest {
     @Test
     void testParsePhysicalVolumes() {
         // pvs -o vg_name,pv_name output: header row, then "vg pv" rows (leading whitespace)
-        List<String> pvs = Arrays.asList("  VG   PV", "  vg0  /dev/sda2", "  vg0  /dev/sdb1", "  vg1  /dev/sdc1");
+        List<String> pvs = List.of("  VG   PV", "  vg0  /dev/sda2", "  vg0  /dev/sdb1", "  vg1  /dev/sdc1");
         Map<String, Set<String>> map = LinuxLogicalVolumeGroup.parsePhysicalVolumes(pvs);
         assertThat(map.keySet(), containsInAnyOrder("vg0", "vg1"));
         assertThat(map.get("vg0"), containsInAnyOrder("/dev/sda2", "/dev/sdb1"));
@@ -50,7 +49,7 @@ class LinuxLogicalVolumeGroupTest {
     @Test
     void testParsePhysicalVolumesSkipsNonDeviceAndMalformed() {
         // A single-token line (length != 2) and a second token that is not a /dev path are both ignored
-        List<String> pvs = Arrays.asList("  novg", "  vg2  notadevice", "  vg3  /dev/mapper/pv");
+        List<String> pvs = List.of("  novg", "  vg2  notadevice", "  vg3  /dev/mapper/pv");
         Map<String, Set<String>> map = LinuxLogicalVolumeGroup.parsePhysicalVolumes(pvs);
         assertThat(map.keySet(), contains("vg3"));
         assertThat(map.get("vg3"), contains("/dev/mapper/pv"));
@@ -90,7 +89,7 @@ class LinuxLogicalVolumeGroupTest {
     @Test
     void testAssemblesGroupFromSlavesDirectory(@TempDir Path tmp) throws IOException {
         String syspath = syspathWithSlaves(tmp, "dm-0", "sda2", "sdb1");
-        List<LogicalVolumeGroup> lvgs = build(Collections.singletonList(lvmDevice(syspath, "vg0", "root")));
+        List<LogicalVolumeGroup> lvgs = build(List.of(lvmDevice(syspath, "vg0", "root")));
 
         assertThat(lvgs, hasSize(1));
         assertThat(lvgs.get(0).getName(), is("vg0"));
@@ -101,7 +100,7 @@ class LinuxLogicalVolumeGroupTest {
 
     @Test
     void testTwoLogicalVolumesShareOneGroup(@TempDir Path tmp) throws IOException {
-        List<UdevBlockDevice> devices = Arrays.asList(lvmDevice(syspathWithSlaves(tmp, "dm-0", "sda2"), "vg0", "root"),
+        List<UdevBlockDevice> devices = List.of(lvmDevice(syspathWithSlaves(tmp, "dm-0", "sda2"), "vg0", "root"),
                 lvmDevice(syspathWithSlaves(tmp, "dm-1", "sdb1"), "vg0", "swap"));
         List<LogicalVolumeGroup> lvgs = build(devices);
 
@@ -116,7 +115,7 @@ class LinuxLogicalVolumeGroupTest {
     @Test
     void testNonLvmDevicesAreFiltered(@TempDir Path tmp) throws IOException {
         String syspath = syspathWithSlaves(tmp, "dev", "sda1");
-        List<UdevBlockDevice> devices = Arrays.asList(
+        List<UdevBlockDevice> devices = List.of(
                 // not a device-mapper node
                 new UdevBlockDevice(syspath, "/dev/sda", "LVM-abcdef", "vg0", "root"),
                 // device-mapper, but owned by something other than LVM, e.g. LUKS
@@ -132,8 +131,7 @@ class LinuxLogicalVolumeGroupTest {
     @Test
     void testMissingSlavesDirectoryStillReportsTheGroup(@TempDir Path tmp) {
         // A volume whose sysfs entry has no slaves directory is still a volume group, just with no physical volumes.
-        List<LogicalVolumeGroup> lvgs = build(
-                Collections.singletonList(lvmDevice(tmp.resolve("absent").toString(), "vg0", "root")));
+        List<LogicalVolumeGroup> lvgs = build(List.of(lvmDevice(tmp.resolve("absent").toString(), "vg0", "root")));
         assertThat(lvgs, hasSize(1));
         assertThat(lvgs.get(0).getName(), is("vg0"));
         assertThat(lvgs.get(0).getPhysicalVolumes(), is(empty()));
@@ -144,10 +142,9 @@ class LinuxLogicalVolumeGroupTest {
     void testPhysicalVolumesFromPvsAreMergedWithSlaves(@TempDir Path tmp) throws IOException {
         // pvs already reported a volume for this group; the slaves scan adds to that set rather than replacing it.
         Map<String, Set<String>> fromPvs = new HashMap<>();
-        fromPvs.put("vg0", new HashSet<>(Collections.singletonList("/dev/sdc1")));
+        fromPvs.put("vg0", new HashSet<>(List.of("/dev/sdc1")));
         List<LogicalVolumeGroup> lvgs = LinuxLogicalVolumeGroup.buildLogicalVolumeGroups(
-                Collections.singletonList(lvmDevice(syspathWithSlaves(tmp, "dm-0", "sda2"), "vg0", "root")), fromPvs,
-                TestLvg::new);
+                List.of(lvmDevice(syspathWithSlaves(tmp, "dm-0", "sda2"), "vg0", "root")), fromPvs, TestLvg::new);
 
         assertThat(lvgs, hasSize(1));
         assertThat(lvgs.get(0).getPhysicalVolumes(), containsInAnyOrder("/dev/sdc1", "/dev/sda2"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGlobalMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGlobalMemoryTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -96,7 +95,7 @@ class MacGlobalMemoryTest {
 
     @Test
     void testParseSystemProfilerMemoryNoColon() {
-        List<String> noColon = Arrays.asList("        BANK 0", "          Size: 4 GB", "          Type: DDR3");
+        List<String> noColon = List.of("        BANK 0", "          Size: 4 GB", "          Type: DDR3");
         List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(noColon);
         assertThat(result, hasSize(1));
         assertThat(result.get(0).getBankLabel(), is("BANK 0"));
@@ -120,7 +119,7 @@ class MacGlobalMemoryTest {
 
     @Test
     void testParseSystemProfilerMemoryAppleSiliconMinimal() {
-        List<String> minimal = Arrays.asList("      Memory: 8 GB");
+        List<String> minimal = List.of("      Memory: 8 GB");
         List<PhysicalMemory> result = MacGlobalMemory.parseSystemProfilerMemory(minimal);
         assertThat(result, hasSize(1));
         assertThat(result.get(0).getCapacity(), is(greaterThan(0L)));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacGraphicsCardTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -117,7 +116,7 @@ class MacGraphicsCardTest {
         // Apple Silicon GPUs have no VRAM line; resolveVram falls back to hw.memsize
         long memsize = 36L * 1024 * 1024 * 1024;
         MacGraphicsCard.SysctlLong sysctl = (name, def) -> "hw.memsize".equals(name) ? memsize : def;
-        List<String> sp = Arrays.asList("      Chipset Model: Apple M3 Pro", "      Vendor: Apple (0x106b)");
+        List<String> sp = List.of("      Chipset Model: Apple M3 Pro", "      Vendor: Apple (0x106b)");
         List<GraphicsCard> cards = MacGraphicsCard.parseGraphicsCards(sp, FACTORY, sysctl);
         assertThat(cards, hasSize(1));
         assertThat(cards.get(0).getVRam(), is(memsize));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacLogicalVolumeGroupTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/mac/MacLogicalVolumeGroupTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -67,7 +66,7 @@ class MacLogicalVolumeGroupTest {
 
     @Test
     void testParseDiskutilCsListNoGroups() {
-        List<String> noGroups = Arrays.asList("No CoreStorage logical volume groups found");
+        List<String> noGroups = List.of("No CoreStorage logical volume groups found");
         List<LogicalVolumeGroup> groups = MacLogicalVolumeGroup.parseDiskutilCsList(noGroups);
         assertThat(groups, is(empty()));
     }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdCentralProcessorTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +89,7 @@ class BsdCentralProcessorTest {
     @Test
     void testParseDmesgModelsAndCachesFeatureFlags() {
         // Feature flags are lines starting with "cpu" having ": " with 4+ comma-delimited items
-        List<String> dmesg = Arrays.asList(//
+        List<String> dmesg = List.of(//
                 "cpu0: FPU,VME,DE,PSE,TSC,MSR,PAE,MCE", //
                 "cpu0: SSE3,PCLMULQDQ,DTES64,MONITOR");
         DmesgStrings result = BsdCentralProcessor.parseDmesgModelsAndCaches(dmesg);

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdFirmwareTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdFirmwareTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -60,7 +59,7 @@ class BsdFirmwareTest {
     @Test
     void testParseDmesgOpenBsd() {
         // Representative OpenBSD dmesg bios0 output with multi-word vendor
-        List<String> dmesg = Arrays.asList(//
+        List<String> dmesg = List.of(//
                 "bios0 at mainbus0: SMBIOS rev. 2.8 @ 0xe9cb0 (53 entries)", //
                 "bios0: vendor American Megatrends Inc. version \"F5\" date 03/18/2016");
         Triplet<@Nullable String, @Nullable String, @Nullable String> fw = parse(dmesg);
@@ -71,7 +70,7 @@ class BsdFirmwareTest {
 
     @Test
     void testParseDmesgMultiWordVendor() {
-        List<String> dmesg = Arrays.asList("bios0: vendor Phoenix Technologies LTD version \"6.00\" date 04/14/2014");
+        List<String> dmesg = List.of("bios0: vendor Phoenix Technologies LTD version \"6.00\" date 04/14/2014");
         Triplet<@Nullable String, @Nullable String, @Nullable String> fw = parse(dmesg);
         assertThat(fw.getA(), is("Phoenix Technologies LTD"));
         assertThat(fw.getB(), is("6.00"));
@@ -88,7 +87,7 @@ class BsdFirmwareTest {
 
     @Test
     void testParseDmesgNoMatch() {
-        List<String> dmesg = Arrays.asList(//
+        List<String> dmesg = List.of(//
                 "cpu0 at mainbus0: AMD EPYC 7313P", //
                 "some other line");
         Triplet<@Nullable String, @Nullable String, @Nullable String> fw = parse(dmesg);
@@ -108,7 +107,7 @@ class BsdFirmwareTest {
 
     @Test
     void testParsedAttributesArePassedThrough() {
-        BsdFirmware fw = new TestFirmware(Arrays.asList("bios0: vendor LENOVO version \"GLET90WW\" date 09/13/2017"));
+        BsdFirmware fw = new TestFirmware(List.of("bios0: vendor LENOVO version \"GLET90WW\" date 09/13/2017"));
         assertThat(fw.getManufacturer(), is("LENOVO"));
         assertThat(fw.getVersion(), is("GLET90WW"));
         assertThat(fw.getReleaseDate(), is("2017-09-13"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdSoundCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/BsdSoundCardTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -46,7 +45,7 @@ class BsdSoundCardTest {
 
     @Test
     void testParseDmesgNoAudio() {
-        List<String> dmesg = Arrays.asList(//
+        List<String> dmesg = List.of(//
                 "azalia0 at pci0 dev 27 function 0 \"Intel Audio\" rev 0x03: msi", //
                 "azalia0: codec[0]: Realtek ALC888");
         // No "audio0 at azalia0" line means azalia0 is not in the names set

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/CupsPrinterTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/CupsPrinterTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -33,7 +32,7 @@ class CupsPrinterTest {
     private static final CupsPrinter.PrinterFactory STUB_FACTORY = StubPrinter::new;
 
     // Fixture: lpstat -p output with two printers
-    private static final List<String> LPSTAT_P = Arrays.asList(
+    private static final List<String> LPSTAT_P = List.of(
             "printer HP_LaserJet is idle.  enabled since Mon 01 Jan 2024 12:00:00 AM",
             "printer PDF_Printer disabled since Tue 02 Jan 2024 - paused by admin");
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixCentralProcessorTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -50,7 +49,7 @@ class AixCentralProcessorTest {
     void testParseProcessorIdEmptyMarkerValues() {
         // Bare marker lines (no value after the colon) must not throw; they yield empty fields
         Quartet<String, String, String, Boolean> id = AixCentralProcessor
-                .parseProcessorId(Arrays.asList("Processor Type:", "Processor Version:", "CPU Type:"));
+                .parseProcessorId(List.of("Processor Type:", "Processor Version:", "CPU Type:"));
         assertThat(id.getA(), is(Constants.UNKNOWN));
         assertThat(id.getB(), is(""));
         assertThat(id.getC(), is(""));
@@ -60,7 +59,7 @@ class AixCentralProcessorTest {
     @Test
     void testParsePowerVersion() {
         // Real prtconf excerpt from a POWER8 box (IBM,8284-22A): the Processor Version line carries the generation
-        List<String> prtconf = Arrays.asList(//
+        List<String> prtconf = List.of(//
                 "System Model: IBM,8284-22A", //
                 "Processor Type: PowerPC_POWER8", //
                 "Processor Implementation Mode: POWER 8", //
@@ -69,15 +68,14 @@ class AixCentralProcessorTest {
                 "CPU Type: 64-bit");
         assertThat(AixCentralProcessor.parsePowerVersion(prtconf), is(8));
         // POWER9 form
-        assertThat(AixCentralProcessor.parsePowerVersion(Collections.singletonList("Processor Version: PV_9_Compat")),
-                is(9));
+        assertThat(AixCentralProcessor.parsePowerVersion(List.of("Processor Version: PV_9_Compat")), is(9));
         // No Processor Version line -> 0 (selects no caches, same as an unknown generation)
         assertThat(AixCentralProcessor.parsePowerVersion(Collections.emptyList()), is(0));
     }
 
     @Test
     void testParseCurrentFreq() {
-        List<String> pmcycles = Arrays.asList("Cpu 0 runs at 3000 MHz", "Cpu 1 runs at 3000 MHz");
+        List<String> pmcycles = List.of("Cpu 0 runs at 3000 MHz", "Cpu 1 runs at 3000 MHz");
         // exactly two CPUs
         assertThat(AixCentralProcessor.parseCurrentFreq(pmcycles, 2),
                 is(new long[] { 3_000_000_000L, 3_000_000_000L }));
@@ -90,10 +88,10 @@ class AixCentralProcessorTest {
 
     @Test
     void testParseSbits() {
-        assertThat(AixCentralProcessor.parseSbits(Collections.singletonList("#define SBITS 16")), is(16));
-        assertThat(AixCentralProcessor.parseSbits(Collections.singletonList("#define  SBITS  10")), is(10));
+        assertThat(AixCentralProcessor.parseSbits(List.of("#define SBITS 16")), is(16));
+        assertThat(AixCentralProcessor.parseSbits(List.of("#define  SBITS  10")), is(10));
         // default when not present
-        assertThat(AixCentralProcessor.parseSbits(Collections.singletonList("#define OTHER 5")), is(16));
+        assertThat(AixCentralProcessor.parseSbits(List.of("#define OTHER 5")), is(16));
         assertThat(AixCentralProcessor.parseSbits(Collections.emptyList()), is(16));
     }
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/aix/AixComputerSystemTest.java
@@ -7,7 +7,6 @@ package oshi.hardware.common.platform.unix.aix;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -18,14 +17,14 @@ import oshi.util.Constants;
 class AixComputerSystemTest {
 
     // lsattr -El sys0: attr, value, description, user-settable columns (whitespace-separated)
-    private static final List<String> LSATTR = Arrays.asList(//
+    private static final List<String> LSATTR = List.of(//
             "fwversion       IBM,RG080425_d79e22_r                Firmware version and revision levels   False", //
             "modelname       IBM,9114-275                         Machine name                           False", //
             "os_uuid         789f930f-b15c-4639-b842-b42603862704 N/A                                     True", //
             "systemid        IBM,0110ACFDE                        Hardware system identifier             False");
 
     // lsmcode -c
-    private static final List<String> LSMCODE = Arrays.asList(//
+    private static final List<String> LSMCODE = List.of(//
             "Platform Firmware level is 3F080425", //
             "System Firmware level is RG080425_d79e22_regatta");
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdCentralProcessorTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +76,7 @@ class FreeBsdCentralProcessorTest {
 
     @Test
     void testParseProcModelsAndFlagsArmHybrid() {
-        List<String> dmesg = Arrays.asList("CPU 0: ARM Cortex-A53 r0p4 affinity: 0 0",
+        List<String> dmesg = List.of("CPU 0: ARM Cortex-A53 r0p4 affinity: 0 0",
                 "CPU 1: ARM Cortex-A72 r0p3 affinity: 0 1");
         Pair<Map<Integer, String>, List<String>> r = FreeBsdCentralProcessor.parseProcModelsAndFlags(dmesg);
         assertThat(r.getA().get(0), is("ARM Cortex-A53 r0p4"));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdVirtualMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/freebsd/FreeBsdVirtualMemoryTest.java
@@ -8,7 +8,6 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -53,7 +52,7 @@ class FreeBsdVirtualMemoryTest {
 
     @Test
     void sumsAcrossMultipleSwapDevices() {
-        List<String> swapinfo = Arrays.asList("Device          1K-blocks     Used    Avail Capacity",
+        List<String> swapinfo = List.of("Device          1K-blocks     Used    Avail Capacity",
                 "/dev/da0p2.eli     524288   100000   424288    19%",
                 "/dev/da1p2.eli     524288    50000   474288    10%");
         assertThat("Multi-device used should sum to 150000 KB", FreeBsdVirtualMemory.sumSwapUsed(swapinfo),
@@ -63,7 +62,7 @@ class FreeBsdVirtualMemoryTest {
     @Test
     void totalSummaryRowOverridesPerDeviceSum() {
         // -hT output: per-device rows would sum to 150_000, but the Total row reports a different (canonical) value.
-        List<String> swapinfo = Arrays.asList("Device          1K-blocks     Used    Avail Capacity",
+        List<String> swapinfo = List.of("Device          1K-blocks     Used    Avail Capacity",
                 "/dev/da0p2.eli     524288   100000   424288    19%",
                 "/dev/da1p2.eli     524288    50000   474288    10%",
                 "Total             1048576   123456   925120    11%");
@@ -72,7 +71,7 @@ class FreeBsdVirtualMemoryTest {
 
     @Test
     void sumSwapUsedHandlesSingleDevice() {
-        List<String> swapinfo = Arrays.asList("Device          1K-blocks     Used    Avail Capacity",
+        List<String> swapinfo = List.of("Device          1K-blocks     Used    Avail Capacity",
                 "/dev/da0p2.eli     524288   123456   400832    24%");
         assertThat("Single device matches the per-row parser", FreeBsdVirtualMemory.sumSwapUsed(swapinfo),
                 is(123456L << 10));
@@ -81,7 +80,7 @@ class FreeBsdVirtualMemoryTest {
     @Test
     void sumSwapUsedReturnsZeroForHeaderOnly() {
         assertThat("Header row alone implies no swap is configured",
-                FreeBsdVirtualMemory.sumSwapUsed(Arrays.asList("Device 1K-blocks Used Avail Capacity")), is(0L));
+                FreeBsdVirtualMemory.sumSwapUsed(List.of("Device 1K-blocks Used Avail Capacity")), is(0L));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/netbsd/NetBsdCentralProcessorTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -40,7 +39,7 @@ class NetBsdCentralProcessorTest {
 
     @Test
     void testParseFamilyModelStepping() {
-        List<String> dmesg = Arrays.asList(//
+        List<String> dmesg = List.of(//
                 "cpu0: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01", //
                 "cpu1: Intel(R) Celeron(R) N4000 CPU @ 1.10GHz, 2491.67 MHz, 06-7a-01");
         String[] fms = NetBsdCentralProcessor.parseFamilyModelStepping(dmesg);
@@ -49,7 +48,7 @@ class NetBsdCentralProcessorTest {
 
     @Test
     void testParseFamilyModelSteppingAmd() {
-        List<String> dmesg = Arrays.asList(//
+        List<String> dmesg = List.of(//
                 "cpu0: AMD EPYC 7313P 16-Core Processor, 2994.74 MHz, 19-01-01");
         String[] fms = NetBsdCentralProcessor.parseFamilyModelStepping(dmesg);
         assertThat(fms, is(arrayContaining("19", "01", "01")));
@@ -63,7 +62,7 @@ class NetBsdCentralProcessorTest {
 
     @Test
     void testParseFamilyModelSteppingNoMatch() {
-        List<String> dmesg = Arrays.asList(//
+        List<String> dmesg = List.of(//
                 "cpu0 at mainbus0 mpidr 0: ARM Cortex-A53 r0p4", //
                 "cpu0: 32KB 64b/line 2-way L1 VIPT I-cache");
         String[] fms = NetBsdCentralProcessor.parseFamilyModelStepping(dmesg);

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisCentralProcessorTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +89,7 @@ class SolarisCentralProcessorTest {
 
     @Test
     void testSumKstatLong() {
-        List<String> kstat = Arrays.asList(//
+        List<String> kstat = List.of(//
                 "cpu_stat:0:cpu_stat0:pswitch\t1000", //
                 "cpu_stat:1:cpu_stat1:pswitch\t2000", //
                 "cpu_stat:0:cpu_stat0:inv_swtch\t500");

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystemTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisComputerSystemTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -88,7 +87,7 @@ class SolarisComputerSystemTest {
 
     @Test
     void testParseSerialFromPrtconf() {
-        List<String> prtconf = Arrays.asList(//
+        List<String> prtconf = List.of(//
                 "System Configuration:  Sun Microsystems  sun4u", //
                 "    name:  'SUNW,Ultra-5_10'", //
                 "      chassis-sn:  'ABC123'", //
@@ -103,7 +102,7 @@ class SolarisComputerSystemTest {
 
     @Test
     void testParseSerialFromPrtconfNoMatch() {
-        List<String> prtconf = Arrays.asList(//
+        List<String> prtconf = List.of(//
                 "System Configuration:  Sun Microsystems  sun4u", //
                 "    name:  'SUNW,Ultra-5_10'");
         assertThat(SolarisComputerSystem.parseSerialFromPrtconf(prtconf), is(""));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisSensorsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisSensorsTest.java
@@ -8,8 +8,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,14 +19,13 @@ class SolarisSensorsTest {
     void testParseCpuTemperature() {
         assertThat(
                 SolarisSensors.parseCpuTemperature(
-                        Arrays.asList("  :Temperature  42", "    Temperature:  36", "    Temperature:  42")),
+                        List.of("  :Temperature  42", "    Temperature:  36", "    Temperature:  42")),
                 is(closeTo(42.0, 0.001)));
     }
 
     @Test
     void testParseCpuTemperatureMillidegrees() {
-        assertThat(
-                SolarisSensors.parseCpuTemperature(Arrays.asList("    Temperature:  45000", "    Temperature:  42000")),
+        assertThat(SolarisSensors.parseCpuTemperature(List.of("    Temperature:  45000", "    Temperature:  42000")),
                 is(closeTo(45.0, 0.001)));
     }
 
@@ -38,7 +37,7 @@ class SolarisSensorsTest {
     @Test
     void testParseFanSpeeds() {
         int[] speeds = SolarisSensors
-                .parseFanSpeeds(Arrays.asList("    Speed:  1200", "    Speed:  1500", "    Speed:  900"));
+                .parseFanSpeeds(List.of("    Speed:  1200", "    Speed:  1500", "    Speed:  900"));
         assertThat(speeds.length, is(3));
         assertThat(speeds[0], is(1200));
         assertThat(speeds[1], is(1500));
@@ -53,7 +52,7 @@ class SolarisSensorsTest {
 
     @Test
     void testParseVoltage() {
-        assertThat(SolarisSensors.parseVoltage(Arrays.asList("    Voltage:  1.200", "    Voltage:  3.300")),
+        assertThat(SolarisSensors.parseVoltage(List.of("    Voltage:  1.200", "    Voltage:  3.300")),
                 is(closeTo(1.2, 0.001)));
     }
 
@@ -64,7 +63,7 @@ class SolarisSensorsTest {
 
     @Test
     void testParseVoltageNoMatch() {
-        assertThat(SolarisSensors.parseVoltage(Arrays.asList("  Other:  1.200", "  Something:  3.300")),
+        assertThat(SolarisSensors.parseVoltage(List.of("  Other:  1.200", "  Something:  3.300")),
                 is(closeTo(0.0, 0.001)));
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisVirtualMemoryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/solaris/SolarisVirtualMemoryTest.java
@@ -7,7 +7,6 @@ package oshi.hardware.common.platform.unix.solaris;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -19,7 +18,7 @@ class SolarisVirtualMemoryTest {
 
     @Test
     void testSumKstatLong() {
-        List<String> kstat = Arrays.asList(//
+        List<String> kstat = List.of(//
                 "cpu_stat:0:cpu_stat0:pgswapin\t42", //
                 "cpu_stat:1:cpu_stat1:pgswapin\t18");
         assertThat(SolarisVirtualMemory.sumKstatLong(kstat), is(60L));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsCentralProcessorTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsCentralProcessorTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -56,9 +55,9 @@ class WindowsCentralProcessorTest {
     @Test
     void testOnlyRequestedFeaturesReported() {
         // 3 = PF_MMX_INSTRUCTIONS_AVAILABLE, 39 = PF_AVX_INSTRUCTIONS_AVAILABLE
-        Set<Integer> present = new HashSet<>(Arrays.asList(3, 39));
+        Set<Integer> present = new HashSet<>(List.of(3, 39));
         IntPredicate predicate = present::contains;
-        assertEquals(Arrays.asList("PF_MMX_INSTRUCTIONS_AVAILABLE", "PF_AVX_INSTRUCTIONS_AVAILABLE"),
+        assertEquals(List.of("PF_MMX_INSTRUCTIONS_AVAILABLE", "PF_AVX_INSTRUCTIONS_AVAILABLE"),
                 WindowsCentralProcessor.queryFeatureFlags(predicate));
     }
 

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGpuStatsTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGpuStatsTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -177,19 +176,19 @@ class WindowsGpuStatsTest {
 
         /** Publishes one engine counter instance belonging to this adapter, plus one belonging to another. */
         StubWindowsGpuStats withEngineTicks(long runningTime, long runningTimeBase) {
-            this.engineInstances = Arrays.asList(LUID + "_engtype_3D", "luid_0x00000000_0x0000ffff_engtype_3D");
+            this.engineInstances = List.of(LUID + "_engtype_3D", "luid_0x00000000_0x0000ffff_engtype_3D");
             Map<GpuEngineProperty, List<Long>> values = new HashMap<>();
-            values.put(GpuEngineProperty.RUNNING_TIME, Arrays.asList(runningTime, 999_999L));
-            values.put(GpuEngineProperty.RUNNING_TIME_BASE, Arrays.asList(runningTimeBase, 999_999L));
+            values.put(GpuEngineProperty.RUNNING_TIME, List.of(runningTime, 999_999L));
+            values.put(GpuEngineProperty.RUNNING_TIME_BASE, List.of(runningTimeBase, 999_999L));
             this.engineValues = values;
             return this;
         }
 
         StubWindowsGpuStats withAdapterMemory(long dedicated, long shared) {
-            this.memoryInstances = Arrays.asList("luid_0x00000000_0x0000ffff_phys_0", LUID);
+            this.memoryInstances = List.of("luid_0x00000000_0x0000ffff_phys_0", LUID);
             Map<GpuAdapterMemoryProperty, List<Long>> values = new HashMap<>();
-            values.put(GpuAdapterMemoryProperty.DEDICATED_USAGE, Arrays.asList(-1L, dedicated));
-            values.put(GpuAdapterMemoryProperty.SHARED_USAGE, Arrays.asList(-1L, shared));
+            values.put(GpuAdapterMemoryProperty.DEDICATED_USAGE, List.of(-1L, dedicated));
+            values.put(GpuAdapterMemoryProperty.SHARED_USAGE, List.of(-1L, shared));
             this.memoryValues = values;
             return this;
         }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGraphicsCardTest.java
@@ -14,7 +14,6 @@ import static oshi.driver.common.windows.wmi.WmiConstants.VT_BSTR;
 import static oshi.driver.common.windows.wmi.WmiConstants.VT_I4;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -71,7 +70,7 @@ class WindowsGraphicsCardTest {
     }
 
     private static WmiResult<VideoControllerProperty> result(Row... rows) {
-        List<Row> list = Arrays.asList(rows);
+        List<Row> list = List.of(rows);
         return new WmiResult<VideoControllerProperty>() {
             @Override
             public int getResultCount() {
@@ -137,7 +136,7 @@ class WindowsGraphicsCardTest {
     @Test
     void testMatchedCardsAreOrderedByDxgiIndex() {
         // DXGI enumerates the primary desktop adapter first, so the result follows DXGI order, not WMI row order.
-        List<DxgiAdapterInfo> adapters = Arrays.asList(new DxgiAdapterInfo("Primary", 0x10DE, 0x1C03, 100L, 1, 0),
+        List<DxgiAdapterInfo> adapters = List.of(new DxgiAdapterInfo("Primary", 0x10DE, 0x1C03, 100L, 1, 0),
                 new DxgiAdapterInfo("Secondary", 0x8086, 0x56A0, 200L, 2, 0));
         List<GraphicsCard> cards = build(adapters,
                 result(row("Secondary", "PCI\\VEN_8086&DEV_56A0", "Intel", "4.5.6", 0, 1),

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroupTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsLogicalVolumeGroupTest.java
@@ -16,7 +16,6 @@ import static oshi.driver.common.windows.wmi.WmiConstants.CIM_STRING;
 import static oshi.driver.common.windows.wmi.WmiConstants.VT_BSTR;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -247,7 +246,7 @@ class WindowsLogicalVolumeGroupTest {
                 build(pools("Pool1", SP_GUID), virtualDisks(), physicalDisks("Disk1", "PCISlot1", PD1_GUID),
                         poolToDisk(SP_GUID, PD1_GUID)).get(0).getPhysicalVolumes(),
                 contains("Disk1 @ PCISlot1"));
-        assertThat("VD fixture must parse into 'name guid'", Arrays.asList(
+        assertThat("VD fixture must parse into 'name guid'", List.of(
                 build(pools("Pool1", SP_GUID), virtualDisks("Volume1", SP_GUID, VD_GUID), physicalDisks(), poolToDisk())
                         .get(0).getLogicalVolumes().keySet().iterator().next()),
                 contains("Volume1 " + VD_GUID));

--- a/oshi-common/src/test/java/oshi/software/common/AbstractNetworkParamsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/AbstractNetworkParamsTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 import java.net.InetAddress;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -86,7 +85,7 @@ class AbstractNetworkParamsTest {
 
     @Test
     void testSearchGatewayFound() {
-        List<String> lines = Arrays.asList("  route to: default", "  gateway: 192.168.1.1%en0", "  interface: en0");
+        List<String> lines = List.of("  route to: default", "  gateway: 192.168.1.1%en0", "  interface: en0");
         assertThat(AbstractNetworkParams.searchGateway(lines), is("192.168.1.1"));
     }
 

--- a/oshi-common/src/test/java/oshi/software/common/AbstractOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/AbstractOperatingSystemTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -146,20 +145,20 @@ class AbstractOperatingSystemTest {
 
     @Test
     void testGetProcessesNoFilterNoSortNoLimit() {
-        AbstractOperatingSystem os = createOS(Arrays.asList(stubProcess(1), stubProcess(2), stubProcess(3)));
+        AbstractOperatingSystem os = createOS(List.of(stubProcess(1), stubProcess(2), stubProcess(3)));
         assertThat(os.getProcesses(null, null, 0), hasSize(3));
     }
 
     @Test
     void testGetProcessesWithFilter() {
-        AbstractOperatingSystem os = createOS(Arrays.asList(stubProcess(1), stubProcess(2), stubProcess(3)));
+        AbstractOperatingSystem os = createOS(List.of(stubProcess(1), stubProcess(2), stubProcess(3)));
         Predicate<OSProcess> filter = p -> p.getProcessID() > 1;
         assertThat(os.getProcesses(filter, null, 0), hasSize(2));
     }
 
     @Test
     void testGetProcessesWithSortAndLimit() {
-        AbstractOperatingSystem os = createOS(Arrays.asList(stubProcess(1), stubProcess(2), stubProcess(3)));
+        AbstractOperatingSystem os = createOS(List.of(stubProcess(1), stubProcess(2), stubProcess(3)));
         Comparator<OSProcess> sort = Comparator.comparingInt(OSProcess::getProcessID).reversed();
         List<OSProcess> result = os.getProcesses(null, sort, 1);
         assertThat(result, hasSize(1));

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoV1DispatchTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoV1DispatchTest.java
@@ -13,8 +13,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -148,7 +146,7 @@ class LinuxCgroupInfoV1DispatchTest {
 
     // Real hybrid (v1 + unified) /proc/self/cgroup: numbered v1 hierarchies with comma-separated controllers, plus
     // a trailing "0::" unified (v2) line whose controllers field is empty.
-    private static final List<String> SELF_CGROUP = Arrays.asList("12:hugetlb:/",
+    private static final List<String> SELF_CGROUP = List.of("12:hugetlb:/",
             "11:cpu,cpuacct:/user.slice/user-1000.slice", "10:memory:/user.slice/user-1000.slice/session-3.scope",
             "3:pids:/user.slice/user-1000.slice", "1:name=systemd:/user.slice/user-1000.slice/session-3.scope",
             "0::/user.slice/user-1000.slice/session-3.scope");
@@ -182,7 +180,7 @@ class LinuxCgroupInfoV1DispatchTest {
     @EnabledOnOs(OS.LINUX)
     void resolveV1ControllerPathSkipsUnifiedLine() {
         // A pure-v2 cgroup (only the "0::" unified line, empty controllers) never matches -> default path
-        List<String> unifiedOnly = Collections.singletonList("0::/user.slice/user-1000.slice/session-3.scope");
+        List<String> unifiedOnly = List.of("0::/user.slice/user-1000.slice/session-3.scope");
         assertEquals(SysPath.CGROUP + "cpu/", LinuxCgroupInfo.resolveV1ControllerPath(unifiedOnly, "cpu"));
     }
 }

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxInstalledAppsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxInstalledAppsTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -43,7 +42,7 @@ class LinuxInstalledAppsTest {
 
     @Test
     void testMultipleValidLines() {
-        List<String> lines = Arrays.asList(
+        List<String> lines = List.of(
                 "firefox|120.0|amd64|250000|1700000000|Mozilla Team|firefox-source|https://firefox.com",
                 "vim|9.0|amd64|3500|1690000000|Vim Maintainers|vim-source|https://vim.org");
 
@@ -56,7 +55,7 @@ class LinuxInstalledAppsTest {
 
     @Test
     void testLineWithFewerThanEightFieldsIsSkipped() {
-        List<String> lines = Arrays.asList("firefox|120.0|amd64|250000|1700000000|Mozilla Team|firefox-source",
+        List<String> lines = List.of("firefox|120.0|amd64|250000|1700000000|Mozilla Team|firefox-source",
                 "vim|9.0|amd64|3500|1690000000|Vim Maintainers|vim-source|https://vim.org");
 
         List<ApplicationInfo> result = LinuxInstalledApps.parseLinuxAppInfo(lines);
@@ -67,7 +66,7 @@ class LinuxInstalledAppsTest {
 
     @Test
     void testLineWithEmptyFieldsUsesUnknown() {
-        List<String> lines = Collections.singletonList("|||0|||| ");
+        List<String> lines = List.of("|||0|||| ");
 
         List<ApplicationInfo> result = LinuxInstalledApps.parseLinuxAppInfo(lines);
 
@@ -91,7 +90,7 @@ class LinuxInstalledAppsTest {
 
     @Test
     void testDuplicateEntriesAreDeduplicated() {
-        List<String> lines = Arrays.asList(
+        List<String> lines = List.of(
                 "firefox|120.0|amd64|250000|1700000000|Mozilla Team|firefox-source|https://firefox.com",
                 "firefox|120.0|amd64|250000|1700000000|Mozilla Team|firefox-source|https://firefox.com");
 

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemDistroTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemDistroTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -26,25 +25,25 @@ class LinuxOperatingSystemDistroTest {
 
     // --- os-release fixtures ---
 
-    private static final List<String> OS_RELEASE_FEDORA = Arrays.asList("NAME=\"Fedora Linux\"",
+    private static final List<String> OS_RELEASE_FEDORA = List.of("NAME=\"Fedora Linux\"",
             "VERSION=\"39 (Workstation Edition)\"", "ID=fedora", "VERSION_ID=39",
             "PRETTY_NAME=\"Fedora Linux 39 (Workstation Edition)\"");
 
-    private static final List<String> OS_RELEASE_ARCH = Arrays.asList("NAME=\"Arch Linux\"", "ID=arch",
+    private static final List<String> OS_RELEASE_ARCH = List.of("NAME=\"Arch Linux\"", "ID=arch",
             "PRETTY_NAME=\"Arch Linux\"", "BUILD_ID=rolling");
 
-    private static final List<String> OS_RELEASE_DEBIAN = Arrays.asList("NAME=\"Debian GNU/Linux\"",
+    private static final List<String> OS_RELEASE_DEBIAN = List.of("NAME=\"Debian GNU/Linux\"",
             "VERSION=\"12 (bookworm)\"", "VERSION_ID=\"12\"", "ID=debian",
             "PRETTY_NAME=\"Debian GNU/Linux 12 (bookworm)\"");
 
-    private static final List<String> OS_RELEASE_ALPINE = Arrays.asList("NAME=\"Alpine Linux\"", "ID=alpine",
+    private static final List<String> OS_RELEASE_ALPINE = List.of("NAME=\"Alpine Linux\"", "ID=alpine",
             "VERSION_ID=3.19.0", "PRETTY_NAME=\"Alpine Linux v3.19\"");
 
-    private static final List<String> OS_RELEASE_RHEL = Arrays.asList("NAME=\"Red Hat Enterprise Linux\"",
+    private static final List<String> OS_RELEASE_RHEL = List.of("NAME=\"Red Hat Enterprise Linux\"",
             "VERSION=\"9.3 (Plow)\"", "ID=\"rhel\"", "VERSION_ID=\"9.3\"",
             "PRETTY_NAME=\"Red Hat Enterprise Linux 9.3 (Plow)\"");
 
-    private static final List<String> OS_RELEASE_OPENSUSE = Arrays.asList("NAME=\"openSUSE Leap\"", "VERSION=\"15.5\"",
+    private static final List<String> OS_RELEASE_OPENSUSE = List.of("NAME=\"openSUSE Leap\"", "VERSION=\"15.5\"",
             "ID=\"opensuse-leap\"", "VERSION_ID=\"15.5\"", "PRETTY_NAME=\"openSUSE Leap 15.5\"");
 
     @Test
@@ -106,7 +105,7 @@ class LinuxOperatingSystemDistroTest {
 
     @Test
     void testReadDistribReleaseAmazonLinux() {
-        List<String> lines = Arrays.asList("Amazon Linux release 2023 (Amazon Linux)");
+        List<String> lines = List.of("Amazon Linux release 2023 (Amazon Linux)");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Amazon Linux"));
@@ -116,7 +115,7 @@ class LinuxOperatingSystemDistroTest {
 
     @Test
     void testReadDistribReleaseOracle() {
-        List<String> lines = Arrays.asList("Oracle Linux Server release 8.9");
+        List<String> lines = List.of("Oracle Linux Server release 8.9");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Oracle Linux Server"));
@@ -126,7 +125,7 @@ class LinuxOperatingSystemDistroTest {
 
     @Test
     void testReadDistribReleaseRocky() {
-        List<String> lines = Arrays.asList("Rocky Linux release 9.3 (Blue Onyx)");
+        List<String> lines = List.of("Rocky Linux release 9.3 (Blue Onyx)");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Rocky Linux"));
@@ -138,7 +137,7 @@ class LinuxOperatingSystemDistroTest {
 
     @Test
     void testReadLsbReleaseFedora() {
-        List<String> lines = Arrays.asList("DISTRIB_ID=Fedora", "DISTRIB_RELEASE=39", "DISTRIB_CODENAME=ThirtyNine");
+        List<String> lines = List.of("DISTRIB_ID=Fedora", "DISTRIB_RELEASE=39", "DISTRIB_CODENAME=ThirtyNine");
         Triplet<String, String, String> result = LinuxOperatingSystem.readLsbRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Fedora"));

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -35,16 +34,16 @@ import oshi.util.tuples.Triplet;
 class LinuxOperatingSystemTest {
 
     // Fixture: /etc/os-release from Ubuntu 22.04
-    private static final List<String> OS_RELEASE_UBUNTU = Arrays.asList("NAME=\"Ubuntu\"",
+    private static final List<String> OS_RELEASE_UBUNTU = List.of("NAME=\"Ubuntu\"",
             "VERSION=\"22.04.3 LTS (Jammy Jellyfish)\"", "ID=ubuntu", "VERSION_ID=\"22.04\"",
             "PRETTY_NAME=\"Ubuntu 22.04.3 LTS\"");
 
     // Fixture: /etc/os-release from CentOS Stream (no codename in VERSION)
-    private static final List<String> OS_RELEASE_CENTOS = Arrays.asList("NAME=\"CentOS Stream\"", "VERSION=\"9\"",
+    private static final List<String> OS_RELEASE_CENTOS = List.of("NAME=\"CentOS Stream\"", "VERSION=\"9\"",
             "ID=\"centos\"", "VERSION_ID=\"9\"");
 
     // Fixture: lsb_release -a output
-    private static final List<String> LSB_RELEASE = Arrays.asList(
+    private static final List<String> LSB_RELEASE = List.of(
             "LSB Version:\tcore-11.1.0ubuntu4-noarch:security-11.1.0ubuntu4-noarch", "Distributor ID:\tUbuntu",
             "Description:\tUbuntu 22.04.3 LTS", "Release:\t22.04", "Codename:\tjammy");
 
@@ -72,7 +71,7 @@ class LinuxOperatingSystemTest {
 
     @Test
     void testReadOsReleaseNoName() {
-        List<String> noName = Arrays.asList("VERSION=\"1.0\"", "VERSION_ID=\"1\"");
+        List<String> noName = List.of("VERSION=\"1.0\"", "VERSION_ID=\"1\"");
         assertThat(LinuxOperatingSystem.readOsRelease(noName), is(nullValue()));
     }
 
@@ -92,7 +91,7 @@ class LinuxOperatingSystemTest {
 
     @Test
     void testExecLsbReleaseDescriptionOnly() {
-        List<String> descOnly = Arrays.asList("Description:\tFedora release 38 (Thirty Eight)");
+        List<String> descOnly = List.of("Description:\tFedora release 38 (Thirty Eight)");
         Triplet<String, String, String> result = LinuxOperatingSystem.execLsbRelease(descOnly);
         assertNotNull(result);
         assertThat(result.getA(), is("Fedora"));
@@ -154,7 +153,7 @@ class LinuxOperatingSystemTest {
 
     @Test
     void testReadLsbReleaseDescriptionWithRelease() {
-        List<String> lines = Arrays.asList("DISTRIB_DESCRIPTION=\"Fedora release 38 (Thirty Eight)\"");
+        List<String> lines = List.of("DISTRIB_DESCRIPTION=\"Fedora release 38 (Thirty Eight)\"");
         Triplet<String, String, String> result = LinuxOperatingSystem.readLsbRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Fedora"));
@@ -173,7 +172,7 @@ class LinuxOperatingSystemTest {
 
     @Test
     void testReadDistribRelease() {
-        List<String> lines = Arrays.asList("CentOS release 6.10 (Final)");
+        List<String> lines = List.of("CentOS release 6.10 (Final)");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("CentOS"));
@@ -183,7 +182,7 @@ class LinuxOperatingSystemTest {
 
     @Test
     void testReadDistribReleaseVersion() {
-        List<String> lines = Arrays.asList("SUSE Linux Enterprise Server VERSION 15");
+        List<String> lines = List.of("SUSE Linux Enterprise Server VERSION 15");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("SUSE Linux Enterprise Server"));
@@ -254,7 +253,7 @@ class LinuxOperatingSystemTest {
     @Test
     void testReadOsReleaseCommaSeparator() {
         // VERSION uses ", " separator instead of parentheses
-        List<String> lines = Arrays.asList("NAME=\"Ubuntu\"", "VERSION=\"22.04, Jammy\"", "VERSION_ID=\"22.04\"");
+        List<String> lines = List.of("NAME=\"Ubuntu\"", "VERSION=\"22.04, Jammy\"", "VERSION_ID=\"22.04\"");
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Ubuntu"));
@@ -265,7 +264,7 @@ class LinuxOperatingSystemTest {
     @Test
     void testReadOsReleaseVersionIdFallback() {
         // No VERSION= line, falls back to VERSION_ID=
-        List<String> lines = Arrays.asList("NAME=\"Alpine Linux\"", "VERSION_ID=\"3.18.4\"");
+        List<String> lines = List.of("NAME=\"Alpine Linux\"", "VERSION_ID=\"3.18.4\"");
         Triplet<String, String, String> result = LinuxOperatingSystem.readOsRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("Alpine Linux"));
@@ -317,7 +316,7 @@ class LinuxOperatingSystemTest {
     @Test
     void testReadDistribReleaseVersionWithCodename() {
         // " VERSION " delimiter with a codename in parentheses
-        List<String> lines = Arrays.asList("SUSE Linux Enterprise Server VERSION 15 (SP3)");
+        List<String> lines = List.of("SUSE Linux Enterprise Server VERSION 15 (SP3)");
         Triplet<String, String, String> result = LinuxOperatingSystem.readDistribRelease(lines);
         assertNotNull(result);
         assertThat(result.getA(), is("SUSE Linux Enterprise Server"));
@@ -342,7 +341,7 @@ class LinuxOperatingSystemTest {
 
                 247 unit files listed.
                 """.lines().toList();
-        Set<String> running = new HashSet<>(Arrays.asList("ssh", "resolve1"));
+        Set<String> running = new HashSet<>(List.of("ssh", "resolve1"));
         List<OSService> services = LinuxOperatingSystem.parseServices(systemctl, running, "/nonexistent-init-dir");
         // ssh (full-name match) and resolve1 (short-name match) deduped; bluetooth disabled; only cron remains
         assertThat(services, hasSize(1));
@@ -356,9 +355,9 @@ class LinuxOperatingSystemTest {
         // The only enabled unit is already running, so no stopped service is emitted -- but systemctl DID produce
         // output, so the /etc/init fallback must not run even though a .conf job is present in the init dir
         Files.write(initDir.resolve("tty1.conf"), "start on runlevel\n".getBytes(StandardCharsets.UTF_8));
-        List<String> systemctl = Arrays.asList("UNIT FILE          STATE      VENDOR PRESET",
+        List<String> systemctl = List.of("UNIT FILE          STATE      VENDOR PRESET",
                 "ssh.service        enabled    enabled");
-        Set<String> running = new HashSet<>(Collections.singletonList("ssh"));
+        Set<String> running = new HashSet<>(List.of("ssh"));
         List<OSService> services = LinuxOperatingSystem.parseServices(systemctl, running, initDir.toString());
         assertThat(services, is(empty()));
     }
@@ -369,7 +368,7 @@ class LinuxOperatingSystemTest {
         Files.write(initDir.resolve("tty1.conf"), "start on runlevel\n".getBytes(StandardCharsets.UTF_8));
         Files.write(initDir.resolve("ssh.conf"), "start on runlevel\n".getBytes(StandardCharsets.UTF_8));
         Files.write(initDir.resolve("README.txt"), "not a job\n".getBytes(StandardCharsets.UTF_8));
-        Set<String> running = new HashSet<>(Collections.singletonList("ssh"));
+        Set<String> running = new HashSet<>(List.of("ssh"));
         List<OSService> services = LinuxOperatingSystem.parseServices(Collections.emptyList(), running,
                 initDir.toString());
         // ssh.conf deduped against running, README.txt is not a .conf; only tty1 remains

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixFileSystemTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +41,7 @@ class AixFileSystemTest {
 
     @Test
     void testParseDfInodesNfsMounts() {
-        List<String> lines = Arrays.asList("Filesystem    512-blocks     Ifree    Iused",
+        List<String> lines = List.of("Filesystem    512-blocks     Ifree    Iused",
                 "nfshost:/export  8388608   500000    10000");
         Pair<Map<String, Long>, Map<String, Long>> result = AixFileSystem.parseDfInodes(lines);
         Map<String, Long> freeMap = result.getA();
@@ -55,7 +54,7 @@ class AixFileSystemTest {
 
     @Test
     void testParseDfInodesSkipsProcAndHeader() {
-        List<String> lines = Arrays.asList("Filesystem    512-blocks     Ifree    Iused",
+        List<String> lines = List.of("Filesystem    512-blocks     Ifree    Iused",
                 "/proc                  -        -        -");
         Pair<Map<String, Long>, Map<String, Long>> result = AixFileSystem.parseDfInodes(lines);
         // Header doesn't match FS_PATTERN, /proc has dashes so parseLong returns 0
@@ -74,7 +73,7 @@ class AixFileSystemTest {
     @Test
     void testParseOpenFileDescriptors() {
         // lsof -nl: every row after the COMMAND header counts
-        List<String> lsof = Arrays.asList(//
+        List<String> lsof = List.of(//
                 "COMMAND     PID     USER   FD   TYPE             DEVICE  SIZE/OFF  NODE NAME", //
                 "init          1     root  cwd  VDIR              10,  5      256     2 /", //
                 "init          1     root  txt  VREG              10,  6    12345    17 /usr/sbin/init");
@@ -84,13 +83,13 @@ class AixFileSystemTest {
     @Test
     void testParseOpenFileDescriptorsNoHeaderOrEmpty() {
         // No COMMAND header line: nothing is counted
-        assertThat(AixFileSystem.parseOpenFileDescriptors(Arrays.asList("garbage", "more garbage")), is(0L));
+        assertThat(AixFileSystem.parseOpenFileDescriptors(List.of("garbage", "more garbage")), is(0L));
         assertThat(AixFileSystem.parseOpenFileDescriptors(Collections.emptyList()), is(0L));
     }
 
     @Test
     void testParseMaxFileDescriptorsPerProcess() {
-        List<String> limits = Arrays.asList("default:", "        fsize = -1", "        nofiles = 2000",
+        List<String> limits = List.of("default:", "        fsize = -1", "        nofiles = 2000",
                 "        core = 2097151");
         assertThat(AixFileSystem.parseMaxFileDescriptorsPerProcess(limits), is(2000L));
     }
@@ -98,7 +97,7 @@ class AixFileSystemTest {
     @Test
     void testParseMaxFileDescriptorsPerProcessMissing() {
         // No nofiles line: unlimited (Long.MAX_VALUE)
-        assertThat(AixFileSystem.parseMaxFileDescriptorsPerProcess(Arrays.asList("default:", "        fsize = -1")),
+        assertThat(AixFileSystem.parseMaxFileDescriptorsPerProcess(List.of("default:", "        fsize = -1")),
                 is(Long.MAX_VALUE));
     }
 }

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixNetworkParamsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixNetworkParamsTest.java
@@ -7,8 +7,8 @@ package oshi.software.common.os.unix.aix;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +29,7 @@ class AixNetworkParamsTest {
 
     @Test
     void testParseDefaultGatewayNoDefaultRoute() {
-        String gw = AixNetworkParams.parseDefaultGateway(Arrays.asList(//
+        String gw = AixNetworkParams.parseDefaultGateway(List.of(//
                 "Destination      Gateway         Flags  Refs   Use  If  Exp  Groups", //
                 "127/8            127.0.0.1       U       3       0  lo0   -    -"));
         // The NetworkParams contract, and every other platform, reports an absent default route as an empty string

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/aix/AixOperatingSystemTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +24,7 @@ class AixOperatingSystemTest {
     @Test
     void testParseServices() {
         // lssrc -a: header row, active subsystems (with/without a Group column), and an inoperative one
-        List<OSService> services = AixOperatingSystem.parseServices(Arrays.asList(//
+        List<OSService> services = AixOperatingSystem.parseServices(List.of(//
                 "Subsystem         Group            PID          Status", //
                 " syslogd          ras              4194320      active", //
                 " inetd            5218374          active", // 3-token active form (no group column)
@@ -49,8 +48,7 @@ class AixOperatingSystemTest {
 
     @Test
     void testParseServicesHeaderOnlyOrEmpty() {
-        assertThat(AixOperatingSystem.parseServices(Collections.singletonList("Subsystem Group PID Status")),
-                is(empty()));
+        assertThat(AixOperatingSystem.parseServices(List.of("Subsystem Group PID Status")), is(empty()));
         assertThat(AixOperatingSystem.parseServices(Collections.emptyList()), is(empty()));
     }
 

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/openbsd/OpenBsdFileSystemTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,7 @@ class OpenBsdFileSystemTest {
 
     @Test
     void testParseDfInodesIncludesMfsAndSkipsHeader() {
-        List<String> lines = Arrays.asList(
+        List<String> lines = List.of(
                 "Filesystem  512-blocks      Used     Avail Capacity iused   ifree  %iused  Mounted on",
                 "mfs:12345      1048576    10240   1038336     1%       5   65531     0%   /tmp");
         Pair<Map<String, Long>, Map<String, Long>> result = OpenBsdFileSystem.parseDfInodes(lines);

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStatsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisInternetProtocolStatsTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -46,7 +45,7 @@ class SolarisInternetProtocolStatsTest {
     void testParseTcpStatsMixedPrefix() {
         // Real netstat output: tcpInErr is paired with a non-tcp stat (from IP section),
         // so splitOnPrefix finds only one "tcp" occurrence and the remainder contains "="
-        List<String> netstat = Arrays.asList(//
+        List<String> netstat = List.of(//
                 "tcpCurrEstab =    10   tcpActiveOpens =   100", //
                 "tcpInErr     =     7   udpNoPorts    =    99");
         TcpStats stats = SolarisInternetProtocolStats.parseTcpStats(netstat);
@@ -65,7 +64,7 @@ class SolarisInternetProtocolStatsTest {
 
     @Test
     void testParseUdpStats() {
-        List<String> netstat = Arrays.asList(//
+        List<String> netstat = List.of(//
                 "udpOutDatagrams = 10000   udpInDatagrams = 20000", //
                 "udpNoPorts      =   100   udpInErrors    =    50");
         UdpStats stats = SolarisInternetProtocolStats.parseUdpStats(netstat);

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOSProcessTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOSProcessTest.java
@@ -7,7 +7,6 @@ package oshi.software.common.os.unix.solaris;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -17,14 +16,14 @@ class SolarisOSProcessTest {
 
     @Test
     void testParseOpenFileLimitSoft() {
-        List<String> plimit = Arrays.asList("1234:", "   coredumpsize      0           unlimited",
+        List<String> plimit = List.of("1234:", "   coredumpsize      0           unlimited",
                 "   nofiles(descriptors)  256         65536", "   vmemorysize       unlimited   unlimited");
         assertThat(SolarisOSProcess.parseOpenFileLimit(plimit, 1), is(256L));
     }
 
     @Test
     void testParseOpenFileLimitHard() {
-        List<String> plimit = Arrays.asList("1234:", "   nofiles(descriptors)  256         65536");
+        List<String> plimit = List.of("1234:", "   nofiles(descriptors)  256         65536");
         assertThat(SolarisOSProcess.parseOpenFileLimit(plimit, 2), is(65536L));
     }
 
@@ -35,13 +34,13 @@ class SolarisOSProcessTest {
 
     @Test
     void testParseOpenFileLimitNoNofilesLine() {
-        List<String> plimit = Arrays.asList("1234:", "   coredumpsize      0           unlimited");
+        List<String> plimit = List.of("1234:", "   coredumpsize      0           unlimited");
         assertThat(SolarisOSProcess.parseOpenFileLimit(plimit, 1), is(-1L));
     }
 
     @Test
     void testParseOpenFileLimitIndexOutOfBounds() {
-        List<String> plimit = Arrays.asList("   nofiles(descriptors)  256         unlimited");
+        List<String> plimit = List.of("   nofiles(descriptors)  256         unlimited");
         // "unlimited" is non-numeric, so split yields only ["", "256"]
         assertThat(SolarisOSProcess.parseOpenFileLimit(plimit, 2), is(-1L));
     }

--- a/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/unix/solaris/SolarisOperatingSystemTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,7 +27,7 @@ class SolarisOperatingSystemTest {
                 legacy_run     23:56:49 lrc:/etc/rc2_d/S47pppd
                 online         23:56:25 svc:/network/loopback:default
                 """.lines().toList();
-        List<String> legacySvcs = Arrays.asList("S47pppd", "S89PRESERVE");
+        List<String> legacySvcs = List.of("S47pppd", "S89PRESERVE");
 
         List<OSService> services = SolarisOperatingSystem.parseSvcs(svcs, legacySvcs);
 
@@ -63,8 +62,8 @@ class SolarisOperatingSystemTest {
 
     @Test
     void testParseSvcsLegacyNoMatch() {
-        List<String> svcs = Arrays.asList("legacy_run     23:56:49 lrc:/etc/rc2_d/S47pppd");
-        List<String> legacySvcs = Arrays.asList("S89PRESERVE");
+        List<String> svcs = List.of("legacy_run     23:56:49 lrc:/etc/rc2_d/S47pppd");
+        List<String> legacySvcs = List.of("S89PRESERVE");
 
         List<OSService> services = SolarisOperatingSystem.parseSvcs(svcs, legacySvcs);
         assertThat(services, is(empty()));
@@ -72,7 +71,7 @@ class SolarisOperatingSystemTest {
 
     @Test
     void testParseSvcsOnlineWithoutDefaultSuffix() {
-        List<String> svcs = Arrays.asList("online         23:56:25 svc:/system/manifest-import:refresh");
+        List<String> svcs = List.of("online         23:56:25 svc:/system/manifest-import:refresh");
         List<OSService> services = SolarisOperatingSystem.parseSvcs(svcs, Collections.emptyList());
         assertThat(services, hasSize(1));
         // No :default suffix, so name includes everything after the last :/

--- a/oshi-common/src/test/java/oshi/software/common/os/windows/WindowsNetworkParamsTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/windows/WindowsNetworkParamsTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -52,8 +51,7 @@ class WindowsNetworkParamsTest {
     void testAnUnspecifiedNextHopIsNotAGateway() {
         // Windows publishes no flags column, so an on-link route is recognized by its all-zero next hop
         List<IPRoute> routes = new StubParams(
-                Collections.singletonList(row(new byte[] { 10, 0, 0, 0 }, 24, new byte[] { 0, 0, 0, 0 }, 5, 256L)))
-                        .getRoutes();
+                List.of(row(new byte[] { 10, 0, 0, 0 }, 24, new byte[] { 0, 0, 0, 0 }, 5, 256L))).getRoutes();
         assertThat(routes, hasSize(1));
         assertThat(routes.get(0).isGateway(), is(false));
         assertThat("A non-gateway route reports no gateway address", routes.get(0).getGateway(), is(new byte[0]));
@@ -63,8 +61,7 @@ class WindowsNetworkParamsTest {
     @Test
     void testARealNextHopIsAGateway() {
         List<IPRoute> routes = new StubParams(
-                Collections.singletonList(row(new byte[] { 0, 0, 0, 0 }, 0, new byte[] { -64, -88, 1, 1 }, 5, 25L)))
-                        .getRoutes();
+                List.of(row(new byte[] { 0, 0, 0, 0 }, 0, new byte[] { -64, -88, 1, 1 }, 5, 25L))).getRoutes();
         assertThat(routes.get(0).isGateway(), is(true));
         assertThat(routes.get(0).getGateway(), is(new byte[] { -64, -88, 1, 1 }));
         assertThat(routes.get(0).getPrefixLength(), is(0));
@@ -76,7 +73,7 @@ class WindowsNetworkParamsTest {
         byte[] v6 = new byte[16];
         v6[15] = 1;
         List<IPRoute> routes = new StubParams(
-                Arrays.asList(row(new byte[] { 127, 0, 0, 1 }, 32, new byte[] { 0, 0, 0, 0 }, 1, 331L),
+                List.of(row(new byte[] { 127, 0, 0, 1 }, 32, new byte[] { 0, 0, 0, 0 }, 1, 331L),
                         row(v6, 128, new byte[16], 1, 331L))).getRoutes();
         assertThat(routes, hasSize(2));
         assertThat("A /32 IPv4 route is a host route", routes.get(0).isHost(), is(true));
@@ -99,8 +96,8 @@ class WindowsNetworkParamsTest {
     @Test
     void testAnUnknownInterfaceIndexReportsAnEmptyName() {
         // Index 999999 will not be present in this machine's interface list
-        List<IPRoute> routes = new StubParams(
-                Collections.singletonList(row(new byte[] { 10, 0, 0, 0 }, 8, new byte[0], 999999, 0L))).getRoutes();
+        List<IPRoute> routes = new StubParams(List.of(row(new byte[] { 10, 0, 0, 0 }, 8, new byte[0], 999999, 0L)))
+                .getRoutes();
         assertThat(routes.get(0).getInterfaceName(), is(""));
         assertThat(routes.get(0).getInterfaceIndex(), is(999999));
     }

--- a/oshi-common/src/test/java/oshi/software/os/OperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/os/OperatingSystemTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -159,23 +158,23 @@ class OperatingSystemTest {
 
         @Override
         public List<OSService> getServices() {
-            return Collections.singletonList(new OSService("svc", 1, OSService.State.RUNNING));
+            return List.of(new OSService("svc", 1, OSService.State.RUNNING));
         }
 
         @Override
         public List<OSSession> getSessions() {
-            return Collections.singletonList(new OSSession("user", "tty1", 0L, "localhost"));
+            return List.of(new OSSession("user", "tty1", 0L, "localhost"));
         }
 
         @Override
         public List<OSDesktopWindow> getDesktopWindows(boolean visibleOnly) {
-            return Collections.singletonList(
-                    new OSDesktopWindow(1L, "Title", "cmd", new java.awt.Rectangle(0, 0, 100, 100), 1L, 0, true));
+            return List
+                    .of(new OSDesktopWindow(1L, "Title", "cmd", new java.awt.Rectangle(0, 0, 100, 100), 1L, 0, true));
         }
 
         @Override
         public List<ApplicationInfo> getInstalledApplications() {
-            return Collections.singletonList(new ApplicationInfo("App", "1.0", "Vendor", 0L, null));
+            return List.of(new ApplicationInfo("App", "1.0", "Vendor", 0L, null));
         }
     };
 
@@ -188,7 +187,7 @@ class OperatingSystemTest {
     @Test
     void testDefaultGetProcessesCollection() {
         // getProcess returns null, so filtered out
-        assertThat(MINIMAL.getProcesses(Arrays.asList(1, 2, 3)), is(empty()));
+        assertThat(MINIMAL.getProcesses(List.of(1, 2, 3)), is(empty()));
     }
 
     /**

--- a/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/ParseUtilTest.java
@@ -605,7 +605,7 @@ class ParseUtilTest {
 
     @Test
     void testFilePathStartsWith() {
-        List<String> prefixList = Arrays.asList("/foo", "/bar");
+        List<String> prefixList = List.of("/foo", "/bar");
         assertThat(ParseUtil.filePathStartsWith(prefixList, "/foo"), is(true));
         assertThat(ParseUtil.filePathStartsWith(prefixList, "/foo/bar"), is(true));
         assertThat(ParseUtil.filePathStartsWith(prefixList, "/foobar"), is(false));
@@ -985,7 +985,7 @@ class ParseUtilTest {
     @Test
     void teststringToEnumMapWithKeys() {
         // Explicit key order independent of ordinal order; last key slurps the remainder
-        List<TestEnum> keys = Arrays.asList(TestEnum.BAZ, TestEnum.FOO);
+        List<TestEnum> keys = List.of(TestEnum.BAZ, TestEnum.FOO);
         Map<TestEnum, String> map = ParseUtil.stringToEnumMap(TestEnum.class, keys, "one two,three four", ' ');
         assertThat(map.get(TestEnum.BAZ), is("one"));
         assertThat(map.get(TestEnum.FOO), is("two,three four"));
@@ -997,7 +997,7 @@ class ParseUtilTest {
         assertThat(map.containsKey(TestEnum.FOO), is(false));
 
         // Consecutive delimiters are treated as one
-        List<TestEnum> three = Arrays.asList(TestEnum.FOO, TestEnum.BAR, TestEnum.BAZ);
+        List<TestEnum> three = List.of(TestEnum.FOO, TestEnum.BAR, TestEnum.BAZ);
         map = ParseUtil.stringToEnumMap(TestEnum.class, three, "one,,two,three", ',');
         assertThat(map.get(TestEnum.FOO), is("one"));
         assertThat(map.get(TestEnum.BAR), is("two"));

--- a/oshi-common/src/test/java/oshi/util/ProcUtilsTest.java
+++ b/oshi-common/src/test/java/oshi/util/ProcUtilsTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -87,8 +87,8 @@ class ProcUtilsTest {
     @Test
     void testParseStatisticsWithTrailingWhitespace() {
         // A trailing space on the line must not prevent it from producing exactly two fields
-        Map<String, Long> results = ProcUtil
-                .parseStatistics(Collections.singletonList("SomeStatistic             12345 "), ParseUtil.whitespaces);
+        Map<String, Long> results = ProcUtil.parseStatistics(List.of("SomeStatistic             12345 "),
+                ParseUtil.whitespaces);
 
         assertThat(results.get("SomeStatistic"), is(12345L));
     }

--- a/oshi-common/src/test/java/oshi/util/VirtualizationDetectorTest.java
+++ b/oshi-common/src/test/java/oshi/util/VirtualizationDetectorTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -145,20 +144,16 @@ class VirtualizationDetectorTest {
     @Test
     void testMatchMac() {
         Properties props = shippedMacProps();
-        assertThat(VirtualizationDetector.matchMac(Collections.singletonList("08:00:27:12:34:56"), props),
-                is(Optional.of("VirtualBox")));
+        assertThat(VirtualizationDetector.matchMac(List.of("08:00:27:12:34:56"), props), is(Optional.of("VirtualBox")));
         // The library formats MAC addresses in lowercase; the table is keyed uppercase
-        assertThat(VirtualizationDetector.matchMac(Collections.singletonList("00:15:5d:aa:bb:cc"), props),
+        assertThat(VirtualizationDetector.matchMac(List.of("00:15:5d:aa:bb:cc"), props),
                 is(Optional.of("Microsoft Hyper-V")));
-        assertThat(VirtualizationDetector.matchMac(Collections.singletonList("42:01:0a:80:00:01"), props),
+        assertThat(VirtualizationDetector.matchMac(List.of("42:01:0a:80:00:01"), props),
                 is(Optional.of("Google Cloud Platform")));
         // The first matching address wins, and unparseable entries are skipped rather than throwing
-        assertThat(
-                VirtualizationDetector
-                        .matchMac(Arrays.asList(Constants.UNKNOWN, "3c:22:fb:11:22:33", "08:00:27:12:34:56"), props),
-                is(Optional.of("VirtualBox")));
-        assertThat(VirtualizationDetector.matchMac(Collections.singletonList("3c:22:fb:11:22:33"), props),
-                is(Optional.empty()));
+        assertThat(VirtualizationDetector.matchMac(List.of(Constants.UNKNOWN, "3c:22:fb:11:22:33", "08:00:27:12:34:56"),
+                props), is(Optional.of("VirtualBox")));
+        assertThat(VirtualizationDetector.matchMac(List.of("3c:22:fb:11:22:33"), props), is(Optional.empty()));
         assertThat(VirtualizationDetector.matchMac(Collections.<String>emptyList(), props), is(Optional.empty()));
     }
 }

--- a/oshi-common/src/test/java/oshi/util/common/gpu/NvmlQueryTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/gpu/NvmlQueryTest.java
@@ -8,10 +8,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -120,7 +120,7 @@ class NvmlQueryTest {
 
     @Test
     void testMatchBusIdReturnsTheEnumeratedForm() {
-        Set<String> busIds = new LinkedHashSet<>(Arrays.asList("00000000:0a:00.0", "00000000:02:00.0"));
+        Set<String> busIds = new LinkedHashSet<>(List.of("00000000:0a:00.0", "00000000:02:00.0"));
         assertThat("returns the canonical enumerated id", NvmlQuery.matchBusId(busIds, "02:00.0"),
                 is("00000000:02:00.0"));
         assertThat("is case-insensitive", NvmlQuery.matchBusId(busIds, "0A:00.0"), is("00000000:0a:00.0"));
@@ -132,7 +132,7 @@ class NvmlQueryTest {
     void testMatchBusIdRejectsABlankFragment() {
         // Every string contains the empty string, so without an explicit guard a blank fragment would match every
         // enumerated id and resolve to the longest of them.
-        Set<String> busIds = new LinkedHashSet<>(Arrays.asList("0000:01:00.0", "00000000:01:00.0"));
+        Set<String> busIds = new LinkedHashSet<>(List.of("0000:01:00.0", "00000000:01:00.0"));
         assertThat("an empty fragment matches nothing", NvmlQuery.matchBusId(busIds, ""), is(nullValue()));
         assertThat("a null fragment matches nothing", NvmlQuery.matchBusId(busIds, null), is(nullValue()));
     }
@@ -141,8 +141,8 @@ class NvmlQueryTest {
     void testMatchBusIdPrefersTheQualifiedForm() {
         // Both of a device's forms are enumerated and a bare fragment matches both, so the answer must not depend on
         // which one iteration happens to reach first.
-        Set<String> legacyFirst = new LinkedHashSet<>(Arrays.asList("0000:01:00.0", "00000000:01:00.0"));
-        Set<String> modernFirst = new LinkedHashSet<>(Arrays.asList("00000000:01:00.0", "0000:01:00.0"));
+        Set<String> legacyFirst = new LinkedHashSet<>(List.of("0000:01:00.0", "00000000:01:00.0"));
+        Set<String> modernFirst = new LinkedHashSet<>(List.of("00000000:01:00.0", "0000:01:00.0"));
         assertThat("the domain-qualified form wins", NvmlQuery.matchBusId(legacyFirst, "01:00.0"),
                 is("00000000:01:00.0"));
         assertThat("regardless of iteration order", NvmlQuery.matchBusId(modernFirst, "01:00.0"),
@@ -153,7 +153,7 @@ class NvmlQueryTest {
     void testDeviceCacheRetriesUntilEnumerationSucceeds() {
         NvmlDeviceCache cache = new NvmlDeviceCache("test");
         int[] calls = new int[1];
-        Set<String> ids = new HashSet<>(Collections.singletonList("00000000:01:00.0"));
+        Set<String> ids = new HashSet<>(List.of("00000000:01:00.0"));
 
         calls[0] = 0;
         assertThat("a failed enumeration is not cached", cache.get(() -> {

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyCacheTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyCacheTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,7 +28,7 @@ import oshi.util.GlobalConfig;
  */
 class SmcKeyCacheTest {
 
-    private static final List<String> FALLBACK = Collections.unmodifiableList(Arrays.asList("Tg05", "Tg0D"));
+    private static final List<String> FALLBACK = Collections.unmodifiableList(List.of("Tg05", "Tg0D"));
 
     /** A discovery function that records how many times it ran. */
     private static final class CountingDiscovery implements Supplier<@Nullable List<String>> {
@@ -53,7 +52,7 @@ class SmcKeyCacheTest {
 
     @Test
     void testCompletedDiscoveryIsCached() {
-        CountingDiscovery discovery = new CountingDiscovery(Arrays.asList("Tg0f", "Tg0j"));
+        CountingDiscovery discovery = new CountingDiscovery(List.of("Tg0f", "Tg0j"));
         SmcKeyCache keys = cache("oshi.test.smckeycache.completed");
         assertThat(keys.get(discovery), contains("Tg0f", "Tg0j"));
         assertThat(keys.get(discovery), contains("Tg0f", "Tg0j"));
@@ -86,7 +85,7 @@ class SmcKeyCacheTest {
         String property = "oshi.test.smckeycache.configured";
         GlobalConfig.set(property, "Tg1k,Tg1l");
         try {
-            CountingDiscovery discovery = new CountingDiscovery(Arrays.asList("Tg0f"));
+            CountingDiscovery discovery = new CountingDiscovery(List.of("Tg0f"));
             SmcKeyCache keys = cache(property);
             assertThat(keys.get(discovery), contains("Tg1k", "Tg1l"));
             assertThat(keys.get(discovery), contains("Tg1k", "Tg1l"));
@@ -103,7 +102,7 @@ class SmcKeyCacheTest {
         String property = "oshi.test.smckeycache.malformed";
         GlobalConfig.set(property, "TOOLONG,ab");
         try {
-            CountingDiscovery discovery = new CountingDiscovery(Arrays.asList("Tg0f"));
+            CountingDiscovery discovery = new CountingDiscovery(List.of("Tg0f"));
             assertThat(cache(property).get(discovery), contains("Tg0f"));
             assertThat(discovery.calls.get(), is(1));
         } finally {

--- a/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/mac/SmcKeyIndexTest.java
@@ -245,7 +245,7 @@ class SmcKeyIndexTest {
 
     @Test
     void testReconcileFanKeysPrefersDiscovered() {
-        List<String> discovered = Arrays.asList("F0Ac", "F1Ac");
+        List<String> discovered = List.of("F0Ac", "F1Ac");
         // Non-empty discovery is authoritative regardless of FNum, including when the two disagree.
         assertThat(SmcKeyIndex.reconcileFanKeys(discovered, 2), contains("F0Ac", "F1Ac"));
         assertThat(SmcKeyIndex.reconcileFanKeys(discovered, 5), contains("F0Ac", "F1Ac"));
@@ -305,7 +305,7 @@ class SmcKeyIndexTest {
 
     @Test
     void testMaxPlausibleIgnoresSentinels() {
-        List<String> keys = Arrays.asList("Tg0W", "Tg0X", "Tg0f", "Tg1h");
+        List<String> keys = List.of("Tg0W", "Tg0X", "Tg0f", "Tg1h");
         assertThat("Returns the hottest genuine reading, not the global max",
                 SmcKeyIndex.maxPlausible(keys, SmcKeyIndexTest::read, v -> v >= FLOOR), is(63.4d));
     }
@@ -313,14 +313,13 @@ class SmcKeyIndexTest {
     @Test
     void testMaxPlausibleWithNothingUsable() {
         assertThat("All-sentinel reads must report unavailable",
-                SmcKeyIndex.maxPlausible(Arrays.asList("Tg0W", "Tg1h"), SmcKeyIndexTest::read, v -> v >= FLOOR),
-                is(0d));
+                SmcKeyIndex.maxPlausible(List.of("Tg0W", "Tg1h"), SmcKeyIndexTest::read, v -> v >= FLOOR), is(0d));
         assertThat(SmcKeyIndex.maxPlausible(Arrays.<String>asList(), SmcKeyIndexTest::read, v -> v >= FLOOR), is(0d));
     }
 
     @Test
     void testMaxPlausibleNeverReturnsBelowTheFloor() {
-        double result = SmcKeyIndex.maxPlausible(Arrays.asList("Tg0W", "Tg0X"), SmcKeyIndexTest::read, v -> v >= FLOOR);
+        double result = SmcKeyIndex.maxPlausible(List.of("Tg0W", "Tg0X"), SmcKeyIndexTest::read, v -> v >= FLOOR);
         assertThat("A result is either 0 or at least the floor, never in between", result == 0d || result >= FLOOR,
                 is(true));
         assertThat(6.7d, is(lessThanOrEqualTo(result)));
@@ -332,21 +331,19 @@ class SmcKeyIndexTest {
     void testFirstPlausibleReturnsTheFirstNotTheBest() {
         // Order is preference order, so an earlier plausible reading wins even though a later one is higher. This is
         // what distinguishes it from maxPlausible.
-        List<String> keys = Arrays.asList("Tg0W", "Tg0X", "Tg0f");
+        List<String> keys = List.of("Tg0W", "Tg0X", "Tg0f");
         assertThat(SmcKeyIndex.firstPlausible(keys, SmcKeyIndexTest::read, v -> v >= FLOOR, "temperature"), is(40.7d));
     }
 
     @Test
     void testFirstPlausibleSkipsImplausibleAndSentinelReads() {
-        assertThat("A leading sentinel must not stop the scan",
-                SmcKeyIndex.firstPlausible(Arrays.asList("Tg1h", "Tg0W", "Tg0f"), SmcKeyIndexTest::read,
-                        v -> v >= FLOOR, "temperature"),
-                is(63.4d));
+        assertThat("A leading sentinel must not stop the scan", SmcKeyIndex.firstPlausible(
+                List.of("Tg1h", "Tg0W", "Tg0f"), SmcKeyIndexTest::read, v -> v >= FLOOR, "temperature"), is(63.4d));
     }
 
     @Test
     void testFirstPlausibleWithNothingUsable() {
-        assertThat(SmcKeyIndex.firstPlausible(Arrays.asList("Tg0W", "Tg1h"), SmcKeyIndexTest::read, v -> v >= FLOOR,
+        assertThat(SmcKeyIndex.firstPlausible(List.of("Tg0W", "Tg1h"), SmcKeyIndexTest::read, v -> v >= FLOOR,
                 "temperature"), is(0d));
         assertThat(SmcKeyIndex.firstPlausible(Arrays.<String>asList(), SmcKeyIndexTest::read, v -> v >= FLOOR,
                 "temperature"), is(0d));
@@ -354,7 +351,7 @@ class SmcKeyIndexTest {
 
     @Test
     void testFirstPlausibleAndMaxPlausibleAgreeOnASingleKey() {
-        List<String> one = Arrays.asList("Tg0f");
+        List<String> one = List.of("Tg0f");
         assertThat(SmcKeyIndex.firstPlausible(one, SmcKeyIndexTest::read, v -> v >= FLOOR, "temperature"),
                 is(SmcKeyIndex.maxPlausible(one, SmcKeyIndexTest::read, v -> v >= FLOOR)));
     }

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/dragonflybsd/ProcstatUtilTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import java.lang.management.ManagementFactory;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,7 +32,7 @@ class ProcstatUtilTest {
 
     @Test
     void testParseCwdFromFstatFindsWdRow() {
-        List<String> fstat = Arrays.asList("USER     CMD       PID    NLWP   FD MOUNT INUM MODE NAME",
+        List<String> fstat = List.of("USER     CMD       PID    NLWP   FD MOUNT INUM MODE NAME",
                 "dan      bash      1234   1      wd /     45   drwx /home/dan",
                 "dan      bash      1234   1      0  /dev  12   crw  /dev/tty");
         assertThat(ProcstatUtil.parseCwdFromFstat(fstat), is("/home/dan"));
@@ -41,7 +40,7 @@ class ProcstatUtilTest {
 
     @Test
     void testParseCwdFromFstatNoWdRowReturnsEmpty() {
-        List<String> fstat = Arrays.asList("USER CMD PID NLWP FD MOUNT INUM MODE NAME",
+        List<String> fstat = List.of("USER CMD PID NLWP FD MOUNT INUM MODE NAME",
                 "dan  bash 1234 1 0  /dev 12 crw /dev/tty");
         assertThat(ProcstatUtil.parseCwdFromFstat(fstat), is(emptyString()));
     }
@@ -56,7 +55,7 @@ class ProcstatUtilTest {
         // 5 rows total. The wd, root, and text rows are excluded; the header (token "FD" at index 4) is not excluded
         // by the filter but is removed via the -1 adjustment at the end. With 2 countable rows minus the header
         // adjustment, the result is 1.
-        List<String> fstat = Arrays.asList("USER CMD PID NLWP FD MOUNT INUM MODE NAME",
+        List<String> fstat = List.of("USER CMD PID NLWP FD MOUNT INUM MODE NAME",
                 "dan  bash 1234 1 wd   /    45 drwx /home/dan", "dan  bash 1234 1 root /    1  drwx /",
                 "dan  bash 1234 1 text /    99 -rxr /bin/bash", "dan  bash 1234 1 0    /dev 12 crw  /dev/tty",
                 "dan  bash 1234 1 1    /dev 12 crw  /dev/tty");
@@ -66,7 +65,7 @@ class ProcstatUtilTest {
     @Test
     void testParseOpenFilesNoCountableRowsReturnsZero() {
         // Only header + excluded rows → no fd counted → returns 0 (per implementation: fd > 0 ? fd - 1 : 0)
-        List<String> fstat = Arrays.asList("USER CMD PID NLWP FD MOUNT INUM MODE NAME",
+        List<String> fstat = List.of("USER CMD PID NLWP FD MOUNT INUM MODE NAME",
                 "dan  bash 1234 1 wd /home 45 drwx /home/dan");
         // Header row counts (split[4]="FD" not in {wd,root,text}), then the wd row is excluded.
         // Count=1 (header) → returns 1-1=0.

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/freebsd/ProcstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/freebsd/ProcstatUtilTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 import java.lang.management.ManagementFactory;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,7 +32,7 @@ class ProcstatUtilTest {
 
     @Test
     void testParseCwdReturnsFirstCwdPath() {
-        List<String> procstat = Arrays.asList("PID COMM             FD T V FLAGS    REF  OFFSET PRO NAME",
+        List<String> procstat = List.of("PID COMM             FD T V FLAGS    REF  OFFSET PRO NAME",
                 "1234 bash             cwd v d r---- 1 0 - /home/dan",
                 "1234 bash               0 t s rw--- 1 0 - /dev/tty");
         assertThat(ProcstatUtil.parseCwd(procstat), is("/home/dan"));
@@ -48,7 +47,7 @@ class ProcstatUtilTest {
     void testParseOpenFilesExcludesVdAndDash() {
         // The 5th column (index 4) is the file type: V (vnode), d (cwd/root/text), - (jail/text/etc.) are excluded.
         // Rows with t (terminal), s (socket), p (pipe), k (kqueue), etc., count.
-        List<String> procstat = Arrays.asList("PID COMM             FD T V FLAGS    REF  OFFSET PRO NAME",
+        List<String> procstat = List.of("PID COMM             FD T V FLAGS    REF  OFFSET PRO NAME",
                 "1234 bash             cwd v d r---- 1 0 - /home/dan", // excluded (d)
                 "1234 bash            text v V r---- 1 0 - /usr/bin/bash", // excluded (V)
                 "1234 bash             jail v - r---- 1 0 - /", // excluded (-)

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/netbsd/FstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/netbsd/FstatUtilTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import java.lang.management.ManagementFactory;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,7 +28,7 @@ class FstatUtilTest {
     @Test
     void testParseCwdFromFstatFindsWdRow() {
         // Sample NetBSD `fstat -p <pid>` output. The wd row's 5th column (index 4) is the working directory path.
-        List<String> fstat = Arrays.asList("USER     CMD          PID   FD MOUNT      INUM MODE         SZ|DV R/W",
+        List<String> fstat = List.of("USER     CMD          PID   FD MOUNT      INUM MODE         SZ|DV R/W",
                 "root     bash        1234   wd /home/dan      12 drwxr-xr-x   512 r",
                 "root     bash        1234    0 /dev          678 crw-rw-rw-  /dev/tty r",
                 "root     bash        1234    1 /dev          678 crw-rw-rw-  /dev/tty w");
@@ -39,7 +38,7 @@ class FstatUtilTest {
 
     @Test
     void testParseCwdFromFstatNoWdRow() {
-        List<String> fstat = Arrays.asList("USER  CMD  PID  FD  MOUNT  INUM  MODE  SZ|DV  R/W",
+        List<String> fstat = List.of("USER  CMD  PID  FD  MOUNT  INUM  MODE  SZ|DV  R/W",
                 "root  bash 1234  0  /dev   678   crw   tty    r");
         assertThat(FstatUtil.parseCwdFromFstat(fstat), is(emptyString()));
     }
@@ -51,7 +50,7 @@ class FstatUtilTest {
 
     @Test
     void testParseOpenFilesSubtractsHeader() {
-        List<String> fstat = Arrays.asList("USER  CMD  PID  FD  MOUNT  INUM  MODE  SZ|DV  R/W",
+        List<String> fstat = List.of("USER  CMD  PID  FD  MOUNT  INUM  MODE  SZ|DV  R/W",
                 "root  bash 1234  0  /dev   678   crw   tty    r", "root  bash 1234  1  /dev   678   crw   tty    w",
                 "root  bash 1234  2  /dev   678   crw   tty    w");
         // 4 lines - 1 header = 3 open files
@@ -60,7 +59,7 @@ class FstatUtilTest {
 
     @Test
     void testParseOpenFilesHeaderOnlyOrEmpty() {
-        assertThat(FstatUtil.parseOpenFiles(Collections.singletonList("USER CMD PID FD ...")), is(0L));
+        assertThat(FstatUtil.parseOpenFiles(List.of("USER CMD PID FD ...")), is(0L));
         assertThat(FstatUtil.parseOpenFiles(Collections.<String>emptyList()), is(0L));
     }
 

--- a/oshi-common/src/test/java/oshi/util/common/platform/unix/openbsd/FstatUtilTest.java
+++ b/oshi-common/src/test/java/oshi/util/common/platform/unix/openbsd/FstatUtilTest.java
@@ -7,7 +7,6 @@ package oshi.util.common.platform.unix.openbsd;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -20,7 +19,7 @@ class FstatUtilTest {
 
     @Test
     void testParseOpenFilesCountsNonPipeAndNonUnixRows() {
-        List<String> fstat = Arrays.asList("USER CMD PID FD MOUNT INUM MODE RW SZ FLAGS XS",
+        List<String> fstat = List.of("USER CMD PID FD MOUNT INUM MODE RW SZ FLAGS XS",
                 "dan bash 123 0 /     12345 crw r  64 0 0", "dan bash 123 1 /dev  67890 crw rw 64 0 0",
                 "dan bash 123 2 /dev  67890 crw rw 64 0 0", "dan bash 123 3 pipe  0     fff rw 0  0 0",
                 "dan bash 123 4 unix  0     fff rw 0  0 0");
@@ -29,8 +28,7 @@ class FstatUtilTest {
 
     @Test
     void testParseOpenFilesHeaderOnly() {
-        assertThat(FstatUtil.parseOpenFiles(Collections.singletonList("USER CMD PID FD MOUNT INUM MODE RW SZ FL XS")),
-                is(0L));
+        assertThat(FstatUtil.parseOpenFiles(List.of("USER CMD PID FD MOUNT INUM MODE RW SZ FL XS")), is(0L));
     }
 
     @Test
@@ -40,7 +38,7 @@ class FstatUtilTest {
 
     @Test
     void testParseOpenFilesPartialTokenMounts() {
-        List<String> fstat = Arrays.asList("USER CMD PID FD MOUNT INUM MODE RW SZ FLAGS XS",
+        List<String> fstat = List.of("USER CMD PID FD MOUNT INUM MODE RW SZ FLAGS XS",
                 "dan bash 123 0 pipex 12345 crw r  64 0 0", "dan bash 123 1 unpipe 6789 crw rw 64 0 0",
                 "dan bash 123 2 unixsocket 0 crw rw 64 0 0", "dan bash 123 3 pipe  0     fff rw 0  0 0",
                 "dan bash 123 4 unix  0     fff rw 0  0 0");

--- a/oshi-common/src/test/java/oshi/util/driver/linux/DmidecodeTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/DmidecodeTest.java
@@ -75,7 +75,7 @@ class DmidecodeTest {
 
     @Test
     void testQueryBiosNameRevNoRevision() {
-        List<String> noRev = Arrays.asList("SMBIOS 3.0 present.", "Handle 0x0000, DMI type 0, 24 bytes");
+        List<String> noRev = List.of("SMBIOS 3.0 present.", "Handle 0x0000, DMI type 0, 24 bytes");
         Pair<@Nullable String, @Nullable String> result = Dmidecode.queryBiosNameRev(noRev);
         assertThat(result.getA(), is("SMBIOS 3.0"));
         assertThat(result.getB(), is(nullValue()));
@@ -83,7 +83,7 @@ class DmidecodeTest {
 
     @Test
     void testQueryBiosNameRevLowercaseVariant() {
-        List<String> lowerCase = Arrays.asList("SMBIOS 3.1 present.", "\tbios revision: 1.2");
+        List<String> lowerCase = List.of("SMBIOS 3.1 present.", "\tbios revision: 1.2");
         Pair<@Nullable String, @Nullable String> result = Dmidecode.queryBiosNameRev(lowerCase);
         assertThat(result.getA(), is("SMBIOS 3.1"));
         assertThat(result.getB(), is("1.2"));

--- a/oshi-common/src/test/java/oshi/util/driver/linux/LshwTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/LshwTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,12 +28,12 @@ import oshi.util.tuples.Triplet;
 class LshwTest {
 
     // Fixture: lshw -C system output
-    private static final List<String> SYSTEM_OUTPUT = Arrays.asList("  *-system", "       description: Computer",
+    private static final List<String> SYSTEM_OUTPUT = List.of("  *-system", "       description: Computer",
             "       product: PowerEdge R720", "       vendor: Dell Inc.", "       serial: ABC1234",
             "       width: 64 bits", "       uuid: 4C4C4544-0044-4810-8031-B4C04F333132");
 
     // Fixture: lshw -class processor output
-    private static final List<String> PROCESSOR_OUTPUT = Arrays.asList("  *-cpu",
+    private static final List<String> PROCESSOR_OUTPUT = List.of("  *-cpu",
             "       product: Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz", "       vendor: Intel Corp.",
             "       capacity: 3300MHz", "       width: 64 bits");
 
@@ -57,7 +56,7 @@ class LshwTest {
 
     @Test
     void testParseSystemInfoPartial() {
-        List<String> partial = Arrays.asList("       product: MyServer");
+        List<String> partial = List.of("       product: MyServer");
         Triplet<@Nullable String, @Nullable String, @Nullable String> result = Lshw.parseSystemInfo(partial);
         assertThat(result.getA(), is("MyServer"));
         assertThat(result.getB(), is(nullValue()));
@@ -76,7 +75,7 @@ class LshwTest {
 
     @Test
     void testQueryCpuCapacityNoCapacityLine() {
-        List<String> noCapacity = Arrays.asList("  *-cpu", "       product: ARM Cortex-A72");
+        List<String> noCapacity = List.of("  *-cpu", "       product: ARM Cortex-A72");
         assertThat(Lshw.queryCpuCapacity(noCapacity), is(-1L));
     }
 

--- a/oshi-common/src/test/java/oshi/util/driver/linux/WhoSystemdTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/WhoSystemdTest.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,7 +33,7 @@ class WhoSystemdTest {
 
     // Writes one session file: systemd session files are KEY=value lines, named by numeric session id.
     private static void session(Path dir, String name, String... keyValues) throws IOException {
-        Files.write(dir.resolve(name), Arrays.asList(keyValues), StandardCharsets.UTF_8);
+        Files.write(dir.resolve(name), List.of(keyValues), StandardCharsets.UTF_8);
     }
 
     private static List<String> users(List<OSSession> sessions) {

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/CpuInfoTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/CpuInfoTest.java
@@ -34,7 +34,7 @@ class CpuInfoTest {
             "Revision\t: a020d3", "Serial\t\t: 00000000abcdef01");
 
     // Fixture: x86 /proc/cpuinfo
-    private static final List<String> CPUINFO_X86 = Arrays.asList("processor\t: 0", "vendor_id\t: GenuineIntel",
+    private static final List<String> CPUINFO_X86 = List.of("processor\t: 0", "vendor_id\t: GenuineIntel",
             "model name\t: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
             "flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic", "", "processor\t: 1", "vendor_id\t: GenuineIntel",
             "model name\t: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
@@ -47,13 +47,13 @@ class CpuInfoTest {
 
     @Test
     void testQueryCpuManufacturerQualcomm() {
-        List<String> qualcomm = Arrays.asList("CPU implementer\t: 0x51");
+        List<String> qualcomm = List.of("CPU implementer\t: 0x51");
         assertThat(CpuInfo.queryCpuManufacturer(qualcomm), is("Qualcomm"));
     }
 
     @Test
     void testQueryCpuManufacturerUnknown() {
-        List<String> unknown = Arrays.asList("CPU implementer\t: 0xff");
+        List<String> unknown = List.of("CPU implementer\t: 0xff");
         assertThat(CpuInfo.queryCpuManufacturer(unknown), is(nullValue()));
     }
 
@@ -80,7 +80,7 @@ class CpuInfoTest {
 
     @Test
     void testQueryBoardInfoEgoman() {
-        List<String> egoman = Arrays.asList("Revision\t: a120d3");
+        List<String> egoman = List.of("Revision\t: a120d3");
         Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> info = CpuInfo
                 .queryBoardInfo(egoman);
         assertThat(info.getA(), is("Egoman"));
@@ -88,7 +88,7 @@ class CpuInfoTest {
 
     @Test
     void testQueryBoardInfoUnknownManufacturer() {
-        List<String> unknown = Arrays.asList("Revision\t: a920d3");
+        List<String> unknown = List.of("Revision\t: a920d3");
         Quartet<@Nullable String, @Nullable String, @Nullable String, @Nullable String> info = CpuInfo
                 .queryBoardInfo(unknown);
         assertThat(info.getA(), is(Constants.UNKNOWN));

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/CpuStatTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/CpuStatTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -21,7 +20,7 @@ import oshi.hardware.CentralProcessor.TickType;
 class CpuStatTest {
 
     // /proc/stat overall line: cpu user nice system idle iowait irq softirq steal (guest guest_nice ignored)
-    private static final List<String> PROC_STAT = Arrays.asList("cpu  100 200 300 400 500 600 700 800 900 1000",
+    private static final List<String> PROC_STAT = List.of("cpu  100 200 300 400 500 600 700 800 900 1000",
             "cpu0 10 20 30 40 50 60 70 80 90 100", "cpu1 11 21 31 41 51 61 71 81 91 101", "intr 12345 0 0 0",
             "ctxt 987654", "btime 1600000000", "processes 54321");
 
@@ -46,9 +45,9 @@ class CpuStatTest {
     void testParseSystemCpuLoadTicksEmptyOrShort() {
         // Empty input and a too-short line (caught by the user/nice/system/idle guard) both yield all-zero ticks
         assertThat(CpuStat.parseSystemCpuLoadTicks(Collections.emptyList())[TickType.USER.getIndex()], is(0L));
-        assertThat(CpuStat.parseSystemCpuLoadTicks(Arrays.asList("cpu 1 2"))[TickType.USER.getIndex()], is(0L));
+        assertThat(CpuStat.parseSystemCpuLoadTicks(List.of("cpu 1 2"))[TickType.USER.getIndex()], is(0L));
         // A line that clears the guard but is still truncated must not overrun: present fields parse, rest stay 0
-        long[] ticks = CpuStat.parseSystemCpuLoadTicks(Arrays.asList("cpu 1 2 3 4"));
+        long[] ticks = CpuStat.parseSystemCpuLoadTicks(List.of("cpu 1 2 3 4"));
         assertThat(ticks[TickType.IDLE.getIndex()], is(4L));
         assertThat(ticks[TickType.IOWAIT.getIndex()], is(0L));
         assertThat(ticks[TickType.STEAL.getIndex()], is(0L));

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/DiskStatsTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/DiskStatsTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
@@ -28,7 +27,7 @@ class DiskStatsTest {
     @Test
     void testParseDiskStats() {
         // /proc/diskstats: major minor name reads reads_merged sectors_read ms_read writes writes_merged ...
-        List<String> diskstats = Arrays.asList("   8       0 sda 100 5 2000 50 200 10 4000 80 0 130 130",
+        List<String> diskstats = List.of("   8       0 sda 100 5 2000 50 200 10 4000 80 0 130 130",
                 "   8       1 sda1 40 2 800 20 90 3 1200 30 0 45 45");
         Map<String, Map<IoStat, Long>> map = DiskStats.parseDiskStats(diskstats);
         assertThat(map.keySet(), containsInAnyOrder("sda", "sda1"));

--- a/oshi-common/src/test/java/oshi/util/driver/linux/proc/RouteTableTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/proc/RouteTableTest.java
@@ -52,7 +52,7 @@ class RouteTableTest {
     // Verbatim /proc/net/ipv6_route from a container given an IPv6 default route, which the capture above had none of.
     // The matching `ip -6 route show` reported:
     // default via 2001:db8::1 dev eth0 metric 1024
-    private static final List<String> PROC_NET_IPV6_ROUTE_GATEWAY = Collections.singletonList(
+    private static final List<String> PROC_NET_IPV6_ROUTE_GATEWAY = List.of(
             "00000000000000000000000000000000 00 00000000000000000000000000000000 00 20010db8000000000000000000000001 00000400 00000001 00000000 00000003     eth0");
 
     @Test
@@ -143,14 +143,13 @@ class RouteTableTest {
     void testEmptyAndMalformedInput() {
         assertThat(RouteTable.parseIpv4Routes(Collections.emptyList(), NO_INDICES), hasSize(0));
         assertThat(RouteTable.parseIpv6Routes(Collections.emptyList(), NO_INDICES), hasSize(0));
-        assertThat(RouteTable.parseIpv4Routes(Collections.singletonList("truncated\tline"), NO_INDICES), hasSize(0));
-        assertThat(RouteTable.parseIpv6Routes(Collections.singletonList("not hex at all"), NO_INDICES), hasSize(0));
+        assertThat(RouteTable.parseIpv4Routes(List.of("truncated\tline"), NO_INDICES), hasSize(0));
+        assertThat(RouteTable.parseIpv6Routes(List.of("not hex at all"), NO_INDICES), hasSize(0));
         // A line with the right number of columns but a destination that is not thirty-two hex digits. This is how the
         // IPv6 file rejects anything unexpected, since unlike the IPv4 one it has no header to skip. The token is
         // exactly thirty-two characters so that it is rejected for not being hex rather than for its length.
         assertThat(RouteTable.parseIpv6Routes(
-                Collections.singletonList(
-                        "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz 40 0 00 0 00000100 00000001 00000000 00000001 eth0"),
+                List.of("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz 40 0 00 0 00000100 00000001 00000000 00000001 eth0"),
                 NO_INDICES), hasSize(0));
     }
 }

--- a/oshi-common/src/test/java/oshi/util/driver/unix/LpstatTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/LpstatTest.java
@@ -19,15 +19,15 @@ import oshi.hardware.Printer.PrinterStatus;
 class LpstatTest {
 
     // Fixture: lpstat -d
-    private static final List<String> LPSTAT_D = Arrays.asList("system default destination: HP_LaserJet");
+    private static final List<String> LPSTAT_D = List.of("system default destination: HP_LaserJet");
 
     // Fixture: lpstat -v
-    private static final List<String> LPSTAT_V = Arrays.asList(
+    private static final List<String> LPSTAT_V = List.of(
             "device for HP_LaserJet: usb://HP/LaserJet%20Pro?serial=ABC123", "device for PDF_Printer: cups-pdf:/",
             "device for Network_Printer: ipp://192.168.1.100/ipp/print");
 
     // Fixture: lpstat -l -p
-    private static final List<String> LPSTAT_LP = Arrays.asList(
+    private static final List<String> LPSTAT_LP = List.of(
             "printer HP_LaserJet is idle.  enabled since Mon 01 Jan 2024 12:00:00 AM",
             "\tDescription: HP LaserJet Pro MFP", "\tLocation: Office",
             "printer PDF_Printer disabled since Tue 02 Jan 2024 01:00:00 AM -",
@@ -49,7 +49,7 @@ class LpstatTest {
 
     @Test
     void testQueryDefaultPrinterNoDefault() {
-        List<String> noDefault = Arrays.asList("no system default destination");
+        List<String> noDefault = List.of("no system default destination");
         assertThat(Lpstat.queryDefaultPrinter(noDefault), is(""));
     }
 
@@ -87,7 +87,7 @@ class LpstatTest {
 
     @Test
     void testQueryDriverNotFound() {
-        assertThat(Lpstat.queryDriver(Arrays.asList("copies=1 device-uri=usb://HP")), is(""));
+        assertThat(Lpstat.queryDriver(List.of("copies=1 device-uri=usb://HP")), is(""));
     }
 
     @Test

--- a/oshi-common/src/test/java/oshi/util/driver/unix/NetStatTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/NetStatTest.java
@@ -31,7 +31,7 @@ import oshi.util.tuples.Pair;
 class NetStatTest {
 
     // Fixture: netstat -n -p tcp output (macOS style)
-    private static final List<String> TCP_NETSTAT = Arrays.asList("Active Internet connections",
+    private static final List<String> TCP_NETSTAT = List.of("Active Internet connections",
             "Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)",
             "tcp4       0      0  192.168.1.5.55362      93.184.216.34.443      ESTABLISHED",
             "tcp4       0      0  192.168.1.5.55363      93.184.216.34.443      ESTABLISHED",
@@ -39,7 +39,7 @@ class NetStatTest {
             "tcp4       0      0  192.168.1.5.55365      10.0.0.1.80            TIME_WAIT");
 
     // Fixture: netstat -n output
-    private static final List<String> NETSTAT_N = Arrays.asList("Active Internet connections",
+    private static final List<String> NETSTAT_N = List.of("Active Internet connections",
             "Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)",
             "tcp4       0      0  192.168.1.5.55362      93.184.216.34.443      ESTABLISHED",
             "udp4       0      0  192.168.1.5.5353       *.* ");
@@ -52,34 +52,33 @@ class NetStatTest {
             "    45 resets sent");
 
     // Fixture: netstat -su4 output (Linux UDP stats)
-    private static final List<String> UDP_STATS_LINUX = Arrays.asList("Udp:", "    12345 packets received",
+    private static final List<String> UDP_STATS_LINUX = List.of("Udp:", "    12345 packets received",
             "    67 packets to unknown port received", "    0 packet receive errors", "    8901 packets sent");
 
     // Fixture: netstat -s -p tcp output (OpenBSD/FreeBSD style)
-    private static final List<String> TCP_STATS_BSD = Arrays.asList("tcp:", "    100 packet sent",
-            "    200 packet received", "    5 bad connection attempts",
-            "    15 connection established (including accepts)", "    7 dropped due to RST",
-            "    42 retransmitted 3 data packet", "    2 discarded for bad checksum",
+    private static final List<String> TCP_STATS_BSD = List.of("tcp:", "    100 packet sent", "    200 packet received",
+            "    5 bad connection attempts", "    15 connection established (including accepts)",
+            "    7 dropped due to RST", "    42 retransmitted 3 data packet", "    2 discarded for bad checksum",
             "    3 discarded for bad header offset field", "    10 resets sent");
 
     // Fixture: netstat -s -p udp output (OpenBSD/FreeBSD style)
-    private static final List<String> UDP_STATS_BSD = Arrays.asList("udp:", "    5000 datagram output",
+    private static final List<String> UDP_STATS_BSD = List.of("udp:", "    5000 datagram output",
             "    3000 datagram received", "    50 dropped due to no socket",
             "    10 broadcast/multicast datagram dropped due to no socket", "    2 with incomplete header",
             "    1 with bad data length field", "    3 with bad checksum", "    4 with no checksum");
 
     // Fixture: netstat -n with SYN_RCVD state (should map to SYN_RECV)
-    private static final List<String> NETSTAT_SYN_RCVD = Arrays.asList("Active Internet connections",
+    private static final List<String> NETSTAT_SYN_RCVD = List.of("Active Internet connections",
             "Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)",
             "tcp4       0      0  10.0.0.1.8080          10.0.0.2.54321         SYN_RCVD");
 
     // Fixture: netstat -n with short lines (fewer than 5 elements) that should be ignored
-    private static final List<String> NETSTAT_SHORT_LINES = Arrays.asList(
+    private static final List<String> NETSTAT_SHORT_LINES = List.of(
             "tcp4       0      0  192.168.1.5.55362      93.184.216.34.443      ESTABLISHED", "tcp4 short",
             "tcp4    0    0", "tcp4       0      0  192.168.1.5.55365      10.0.0.1.80            TIME_WAIT");
 
     // Fixture: netstat -n with IPv6 addresses
-    private static final List<String> NETSTAT_IPV6 = Arrays.asList(
+    private static final List<String> NETSTAT_IPV6 = List.of(
             "tcp6       0      0  2001:db8::1.443        2001:db8::2.54321      ESTABLISHED",
             "tcp6       0      0  fe80::1:.8080          fe80::2:.9090          TIME_WAIT",
             "tcp6       0      0  ::1.55364              ::1.8080               ESTABLISHED");
@@ -176,7 +175,7 @@ class NetStatTest {
     @Test
     void testQueryTcpStatsRetransmitSpecialCase() {
         // Test the "N retransmitted M data packet" pattern in isolation (BSD format)
-        List<String> retransmitLines = Arrays.asList("tcp:", "    99 retransmitted 5 data packet");
+        List<String> retransmitLines = List.of("tcp:", "    99 retransmitted 5 data packet");
         TcpStats stats = NetStat.queryTcpStats(retransmitLines);
         // The special-case pattern uses += on segmentsRetransmitted
         assertThat(stats.getSegmentsRetransmitted(), is(99L));

--- a/oshi-common/src/test/java/oshi/util/driver/unix/NetstatRouteTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/NetstatRouteTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -355,7 +354,7 @@ class NetstatRouteTest {
     /** A header naming no interface column at all leaves the caller's default index in place. */
     @Test
     void testHeaderWithoutAnInterfaceColumn() {
-        List<String> lines = Arrays.asList("Destination        Gateway            Flags",
+        List<String> lines = List.of("Destination        Gateway            Flags",
                 "default            10.0.0.1           UGSc                  en0");
         List<IPRoute> routes = NetstatRoute.parseRoutes(lines, false, 3, NO_INDICES);
         assertThat(routes, hasSize(1));
@@ -365,7 +364,7 @@ class NetstatRouteTest {
     /** A line with enough columns but no flags field is not a route. */
     @Test
     void testLineWithoutAFlagsColumnIsSkipped() {
-        List<String> lines = Arrays.asList("10.0.0.1           10.0.0.254         1198                  en0",
+        List<String> lines = List.of("10.0.0.1           10.0.0.254         1198                  en0",
                 "default            10.0.0.1           UGSc                  en0");
         List<IPRoute> routes = NetstatRoute.parseRoutes(lines, false, 3, NO_INDICES);
         assertThat("Only the row whose third column is a flags field should parse", routes, hasSize(1));
@@ -375,8 +374,7 @@ class NetstatRouteTest {
     /** A row shorter than the interface column reports no name rather than throwing. */
     @Test
     void testRowShorterThanTheInterfaceColumn() {
-        List<IPRoute> routes = NetstatRoute.parseRoutes(Collections.singletonList("default   10.0.0.1   UGSc"), false,
-                3, NO_INDICES);
+        List<IPRoute> routes = NetstatRoute.parseRoutes(List.of("default   10.0.0.1   UGSc"), false, 3, NO_INDICES);
         assertThat(routes, hasSize(1));
         assertThat(routes.get(0).getInterfaceName(), is(""));
         assertThat(routes.get(0).getInterfaceIndex(), is(-1));

--- a/oshi-common/src/test/java/oshi/util/driver/unix/ProcLimitsTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/ProcLimitsTest.java
@@ -7,7 +7,6 @@ package oshi.util.driver.unix;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -24,7 +23,7 @@ class ProcLimitsTest {
     private static final String HEADER = "Limit                     Soft Limit           Hard Limit           Units";
 
     private static List<String> limits(String maxOpenFilesRow) {
-        return Arrays.asList(HEADER, "Max cpu time              unlimited            unlimited            seconds",
+        return List.of(HEADER, "Max cpu time              unlimited            unlimited            seconds",
                 maxOpenFilesRow, "Max processes             31573                31573                processes");
     }
 
@@ -57,7 +56,7 @@ class ProcLimitsTest {
 
     @Test
     void testRowAbsentOrEmpty() {
-        List<String> noRow = Arrays.asList(HEADER,
+        List<String> noRow = List.of(HEADER,
                 "Max processes             31573                31573                processes");
         assertThat("no Max open files row", ProcLimits.parseOpenFileLimit(noRow, SOFT), is(-1L));
         assertThat("empty input", ProcLimits.parseOpenFileLimit(Collections.emptyList(), SOFT), is(-1L));

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoParsingTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoParsingTest.java
@@ -26,7 +26,7 @@ class XwininfoParsingTest {
             .asList("_NET_CLIENT_LIST_STACKING(WINDOW): window id # 0x1400003, 0x1600003, 0x1800003");
 
     // Fixture: xwininfo -root -tree output (trimmed)
-    private static final List<String> XWININFO_TREE = Arrays.asList(
+    private static final List<String> XWININFO_TREE = List.of(
             "     0x1400003 \"Terminal\": (\"gnome-terminal\" \"Gnome-terminal\")  800x600+0+0  +100+200",
             "     0x1600003 \"Firefox\": (\"Navigator\" \"firefox\")  1920x1080+0+0  +0+0",
             "     0x1800003 (has no name): ()  200x200+0+0  +50+-10",
@@ -49,7 +49,7 @@ class XwininfoParsingTest {
 
     @Test
     void testParseZOrderNoHexIds() {
-        List<String> noIds = Arrays.asList("_NET_CLIENT_LIST_STACKING: no such atom on any window.");
+        List<String> noIds = List.of("_NET_CLIENT_LIST_STACKING: no such atom on any window.");
         Map<String, Integer> zOrder = Xwininfo.parseZOrder(noIds);
         assertThat(zOrder, is(anEmptyMap()));
     }

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XwininfoTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.Rectangle;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +25,7 @@ class XwininfoTest {
             .singletonList("_NET_CLIENT_LIST_STACKING(WINDOW): window id # 0x1400003, 0x1600003, 0x1800003");
 
     // Fixture: xwininfo -root -tree output with window entries
-    private static final List<String> WINDOW_TREE = Arrays.asList(
+    private static final List<String> WINDOW_TREE = List.of(
             "xwininfo: Window id: 0x1e7 (the root window) (has no name)",
             "  Root window id: 0x1e7 (the root window) (has no name)",
             "     0x1400003 \"Terminal\": (\"gnome-terminal\" \"Gnome-terminal\")  800x600+0+0  +100+200",
@@ -50,7 +49,7 @@ class XwininfoTest {
 
     @Test
     void testParseZOrderNoHexId() {
-        List<String> noHex = Collections.singletonList("_NET_CLIENT_LIST_STACKING(WINDOW): window id # ");
+        List<String> noHex = List.of("_NET_CLIENT_LIST_STACKING(WINDOW): window id # ");
         Map<String, Integer> zOrder = Xwininfo.parseZOrder(noHex);
         assertThat(zOrder, is(anEmptyMap()));
     }
@@ -125,7 +124,7 @@ class XwininfoTest {
     @Test
     void testParseWindowTreeAnonymousWindow() {
         // A window line with no quoted name
-        List<String> tree = Collections.singletonList("     0x2000001 (has no name): ()  320x240+0+0  +0+0");
+        List<String> tree = List.of("     0x2000001 (has no name): ()  320x240+0+0  +0+0");
         Map<String, Integer> zOrderMap = new HashMap<>();
         zOrderMap.put("0x2000001", 1);
 

--- a/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/InstalledAppsDataFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/driver/windows/registry/InstalledAppsDataFFM.java
@@ -21,7 +21,6 @@ import static oshi.util.LogLevel.TRACE;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -46,10 +45,10 @@ public final class InstalledAppsDataFFM {
 
     static {
         REGISTRY_PATHS.put(MemorySegment.ofAddress(HKEY_LOCAL_MACHINE),
-                Arrays.asList("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+                List.of("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
                         "SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall"));
         REGISTRY_PATHS.put(MemorySegment.ofAddress(HKEY_CURRENT_USER),
-                Arrays.asList("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall"));
+                List.of("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall"));
     }
 
     private InstalledAppsDataFFM() {

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsPowerSourceFFM.java
@@ -42,7 +42,6 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -91,7 +90,7 @@ public final class WindowsPowerSourceFFM extends WindowsPowerSource {
      * @return A list of PowerSource objects representing batteries, etc.
      */
     public static List<PowerSource> getPowerSources() {
-        return Arrays.asList(getPowerSource("System Battery"));
+        return List.of(getPowerSource("System Battery"));
     }
 
     private static WindowsPowerSource getPowerSource(String name) {

--- a/oshi-core/src/test/java/oshi/util/gpu/DxgiUtilTest.java
+++ b/oshi-core/src/test/java/oshi/util/gpu/DxgiUtilTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,7 +32,7 @@ class DxgiUtilTest {
                 16L * 1024 * 1024 * 1024, 0, 0);
         DxgiAdapterInfo igpu = new DxgiAdapterInfo("Intel(R) UHD Graphics 770", 0x8086, 0x4680, 128L * 1024 * 1024, 0,
                 0);
-        List<DxgiAdapterInfo> adapters = Arrays.asList(arc, igpu);
+        List<DxgiAdapterInfo> adapters = List.of(arc, igpu);
 
         DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0x8086, 0x56A0, "Intel Arc A770");
         assertNotNull(match);
@@ -48,7 +47,7 @@ class DxgiUtilTest {
                 0, 0);
         DxgiAdapterInfo second = new DxgiAdapterInfo("NVIDIA GeForce RTX 4090", 0x10DE, 0x2684,
                 24L * 1024 * 1024 * 1024, 0, 0);
-        List<DxgiAdapterInfo> adapters = Arrays.asList(first, second);
+        List<DxgiAdapterInfo> adapters = List.of(first, second);
 
         DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0x10DE, 0x2684, "NVIDIA GeForce RTX 4090");
         assertThat(match, is(first));
@@ -61,7 +60,7 @@ class DxgiUtilTest {
         // typically omits them. Verify that normalization bridges the difference.
         DxgiAdapterInfo adapter = new DxgiAdapterInfo("Intel(R) Arc(TM) A770 Graphics", 0x8086, 0x56A0,
                 16L * 1024 * 1024 * 1024, 0, 0);
-        List<DxgiAdapterInfo> adapters = Collections.singletonList(adapter);
+        List<DxgiAdapterInfo> adapters = List.of(adapter);
 
         DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0, 0, "Intel Arc A770 Graphics");
         assertNotNull(match);
@@ -73,7 +72,7 @@ class DxgiUtilTest {
     void testFindMatchNoMatchReturnsNull() {
         DxgiAdapterInfo adapter = new DxgiAdapterInfo("AMD Radeon RX 7900 XTX", 0x1002, 0x744C,
                 24L * 1024 * 1024 * 1024, 0, 0);
-        List<DxgiAdapterInfo> adapters = Collections.singletonList(adapter);
+        List<DxgiAdapterInfo> adapters = List.of(adapter);
 
         DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0x8086, 0x56A0, "Intel Arc A770");
         assertThat("Different vendor+device should not match", match, is(nullValue()));
@@ -89,7 +88,7 @@ class DxgiUtilTest {
     void testFindMatchZeroIdsUsesNameFallback() {
         DxgiAdapterInfo adapter = new DxgiAdapterInfo("AMD Radeon RX 7900 XTX", 0x1002, 0x744C,
                 24L * 1024 * 1024 * 1024, 0, 0);
-        List<DxgiAdapterInfo> adapters = Collections.singletonList(adapter);
+        List<DxgiAdapterInfo> adapters = List.of(adapter);
 
         // vendorId=0 and deviceId=0 should skip ID matching and try name
         DxgiAdapterInfo match = DxgiUtilJNA.findMatch(adapters, 0, 0, "AMD Radeon RX 7900 XTX");

--- a/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterWildcardQueryTest.java
+++ b/oshi-core/src/test/java/oshi/util/platform/windows/PerfCounterWildcardQueryTest.java
@@ -17,7 +17,6 @@ import static oshi.driver.common.windows.wmi.WmiConstants.CIM_UINT64;
 import static oshi.driver.common.windows.wmi.WmiConstants.VT_BSTR;
 import static oshi.driver.common.windows.wmi.WmiConstants.VT_I4;
 
-import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +50,7 @@ class PerfCounterWildcardQueryTest {
         private StubResult put(Prop p, int cim, int vt, Object... rowValues) {
             cimTypes.put(p, cim);
             vtTypes.put(p, vt);
-            values.put(p, Arrays.asList(rowValues));
+            values.put(p, List.of(rowValues));
             rows = Math.max(rows, rowValues.length);
             return this;
         }

--- a/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
+++ b/oshi-metrics/src/main/java/oshi/metrics/FileSystemMetrics.java
@@ -4,7 +4,6 @@
  */
 package oshi.metrics;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
@@ -78,7 +77,7 @@ public class FileSystemMetrics implements MeterBinder {
     public void bindTo(MeterRegistry registry) {
         for (OSFileStore fs : fileStoreSupplier.get()) {
             String opts = fs.getOptions();
-            String mode = Arrays.asList(opts.split(",")).contains("rw") ? "rw" : "ro";
+            String mode = List.of(opts.split(",")).contains("rw") ? "rw" : "ro";
             Tags tags = Tags.of(DEVICE_KEY, fs.getVolume(), MOUNTPOINT_KEY, fs.getMount(), TYPE_KEY, fs.getType(),
                     MODE_KEY, mode);
             // A bound OSFileStore is a snapshot taken when the binder was created, so it has to be refreshed as it is

--- a/oshi-metrics/src/test/java/oshi/metrics/FileSystemMetricsTest.java
+++ b/oshi-metrics/src/test/java/oshi/metrics/FileSystemMetricsTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -145,7 +146,7 @@ class FileSystemMetricsTest {
         // separately: the states would be measured against four different readings. They share one memoized refresh
         // per filesystem, which holds for 300 ms by default -- far longer than sampling four gauges in process.
         OSFileStore fs = new VaryingOSFileStore();
-        new FileSystemMetrics(() -> Collections.singletonList(fs)).bindTo(registry);
+        new FileSystemMetrics(() -> List.of(fs)).bindTo(registry);
         assertEquals(limit(), usage("used") + usage("free") + usage("reserved"),
                 "usage states should sum to the limit even while the filesystem is changing");
     }


### PR DESCRIPTION
292 calls across 82 files, replacing `Arrays.asList` and `Collections.singletonList` with `List.of` where the call has **ten or fewer arguments** — the point at which `List.of` stops using its fixed-arity overloads and falls back to varargs, allocating an array.

## Scope is set by language level, not taste

`List.of` is Java 9, so the release-8 main sources are untouched:

| source set | calls | converted |
|---|---|---|
| `oshi-common` main, `oshi-core` main, `oshi-demo` main | 32 | no — release 8 |
| `oshi-common` / `oshi-core` test | 293 | yes — release 17 since #3688 |
| `oshi-core-ffm` main, `oshi-metrics` main + test | 5 | yes |

## Six calls deliberately left alone

Four hold more than ten elements. The other two are `Collections.singletonList(null)` in `HardwareAbstractionLayerTest` — `List.of` **refuses null elements**, and that test exists precisely to feed a null through the layer.

## Hazards measured, not assumed

Before converting anything I checked the candidate sites for the three ways `List.of` differs from what it replaces:

- **Structural mutation** — `List.of` is immutable, and `Arrays.asList` supports `set`. Zero occurrences of `add`, `remove`, `set`, `sort`, `clear` or friends on any candidate list.
- **`contains(null)` / `indexOf(null)`** — `List.of` throws where `Arrays.asList` returns `false`. Zero occurrences.
- **Null elements** — two, both skipped above.

Fourteen sites are already wrapped in a copying constructor (`new ArrayList<>(...)`) and are unaffected either way.

## Why the test suite is a real check here

Worth contrasting with the fixture conversions that preceded this. Those could fail *silently* — a lost tab still satisfies a lenient parser — which is why they needed an explicit round-trip verifier.

This change fails **loudly**: an immutable list that something tries to mutate throws `UnsupportedOperationException`, and a null element throws at construction. A green suite is meaningful evidence rather than weak evidence.

## Verification

Full gate from clean — `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc -Paggregate-coverage` — green, zero test failures, plus `-Perror-prone` clean. Confirmed no release-8 main source was touched.

Net −86 lines. Test-only apart from five calls in `oshi-core-ffm`/`oshi-metrics`; no behaviour change, no CHANGELOG entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized collection creation across system monitoring and parsing components.
  * Preserved existing runtime behavior and API compatibility.

* **Tests**
  * Updated test fixtures across supported operating systems to use modern immutable collections.
  * Added coverage for averaging multiple CPU temperature readings.
  * Existing assertions and expected results remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->