### PR TITLE
Use Files.writeString and Stream.toList in tests

### DIFF
--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxBluetoothDeviceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxBluetoothDeviceTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -186,6 +185,6 @@ class LinuxBluetoothDeviceTest {
     }
 
     private static void writeFile(Path path, String content) throws IOException {
-        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+        Files.writeString(path, content);
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxGraphicsCardTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.is;
 import static oshi.util.TestFileUtil.writeFile;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -172,7 +171,7 @@ class LinuxGraphicsCardTest {
     void testReadUeventValue(@TempDir Path tempDir) throws IOException {
         Path uevent = tempDir.resolve("uevent");
         String content = "DRIVER=amdgpu\nPCI_SLOT_NAME=0000:01:00.0\nPCI_ID=1002:744C\n";
-        Files.write(uevent, content.getBytes(StandardCharsets.UTF_8));
+        Files.writeString(uevent, content);
 
         assertThat(LinuxGraphicsCard.readUeventValue(uevent.toString(), "PCI_SLOT_NAME"), is("0000:01:00.0"));
         assertThat(LinuxGraphicsCard.readUeventValue(uevent.toString(), "DRIVER"), is("amdgpu"));
@@ -218,7 +217,7 @@ class LinuxGraphicsCardTest {
         Files.createDirectories(driverTarget);
         Files.createSymbolicLink(deviceDir.resolve("driver"), driverTarget);
         // Write uevent with PCI_SLOT_NAME
-        Files.write(deviceDir.resolve("uevent"), ("PCI_SLOT_NAME=" + slotName + "\n").getBytes(StandardCharsets.UTF_8));
+        Files.writeString(deviceDir.resolve("uevent"), ("PCI_SLOT_NAME=" + slotName + "\n"));
     }
 
     // -------------------------------------------------------------------------

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxPowerSourceTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/LinuxPowerSourceTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -271,7 +270,7 @@ class LinuxPowerSourceTest {
                 + "POWER_SUPPLY_ENERGY_NOW=20712000\n" + "POWER_SUPPLY_ENERGY_FULL=40877000\n"
                 + "POWER_SUPPLY_ENERGY_FULL_DESIGN=48248000\n" + "POWER_SUPPLY_POWER_NOW=9361000\n"
                 + "POWER_SUPPLY_CAPACITY=50\n" + "IGNORED_KEY=should_be_skipped\n" + "MALFORMED_LINE\n";
-        Files.write(bat.resolve("uevent"), uevent.getBytes(StandardCharsets.UTF_8));
+        Files.writeString(bat.resolve("uevent"), uevent);
 
         List<PowerSource> result = LinuxPowerSource.getPowerSources(tempDir.toString());
 
@@ -303,7 +302,7 @@ class LinuxPowerSourceTest {
         Files.createDirectories(bat);
         String uevent = "POWER_SUPPLY_NAME=BAT0\nPOWER_SUPPLY_STATUS=Charging\n"
                 + "POWER_SUPPLY_ENERGY_NOW=20000000\nPOWER_SUPPLY_ENERGY_FULL=40000000\n";
-        Files.write(bat.resolve("uevent"), uevent.getBytes(StandardCharsets.UTF_8));
+        Files.writeString(bat.resolve("uevent"), uevent);
 
         List<PowerSource> sources = LinuxPowerSource.getPowerSources(tempDir.toString());
         assertThat(sources, hasSize(1));

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNFTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/linux/nativefree/LinuxUsbDeviceNFTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -136,6 +135,6 @@ class LinuxUsbDeviceNFTest {
     }
 
     private static void writeFile(Path path, String content) throws IOException {
-        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+        Files.writeString(path, content);
     }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGraphicsCardTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsGraphicsCardTest.java
@@ -19,7 +19,6 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -105,7 +104,7 @@ class WindowsGraphicsCardTest {
     }
 
     private static List<String> names(List<GraphicsCard> cards) {
-        return cards.stream().map(GraphicsCard::getName).collect(Collectors.toList());
+        return cards.stream().map(GraphicsCard::getName).toList();
     }
 
     @Test
@@ -154,7 +153,7 @@ class WindowsGraphicsCardTest {
                 result(row("Shared", "PCI\\VEN_10DE&DEV_1C03", "NVIDIA", "1.2.3", 0, 111),
                         row("Shared", "PCI\\VEN_10DE&DEV_1C03", "NVIDIA", "1.2.3", 0, 222)));
         assertThat("both rows are returned", cards.size(), is(2));
-        List<Long> vram = cards.stream().map(GraphicsCard::getVRam).collect(Collectors.toList());
+        List<Long> vram = cards.stream().map(GraphicsCard::getVRam).toList();
         assertThat("only one row got the DXGI VRAM", vram, contains(9999L, 222L));
     }
 

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoTest.java
@@ -13,7 +13,6 @@ import static oshi.software.os.CgroupInfo.UNLIMITED_CPUS;
 import static oshi.software.os.CgroupInfo.UNLIMITED_MEMORY;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -30,13 +29,13 @@ class LinuxCgroupInfoTest {
 
     @Test
     void readCpuQuotaV2WithLimit(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.max"), "200000 100000\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.max"), "200000 100000\n");
         assertEquals(200000L, cgroup.readCpuQuotaV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readCpuQuotaV2Unlimited(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.max"), "max 100000\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.max"), "max 100000\n");
         assertEquals(UNLIMITED, cgroup.readCpuQuotaV2(tempDir.toString() + "/"));
     }
 
@@ -47,49 +46,49 @@ class LinuxCgroupInfoTest {
 
     @Test
     void readCpuPeriodV2(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.max"), "200000 50000\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.max"), "200000 50000\n");
         assertEquals(50000L, cgroup.readCpuPeriodV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readCpuPeriodV2Default(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.max"), "max\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.max"), "max\n");
         assertEquals(DEFAULT_CPU_PERIOD, cgroup.readCpuPeriodV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readMemoryLimitV2WithLimit(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.max"), "1073741824\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.max"), "1073741824\n");
         assertEquals(1073741824L, cgroup.readMemoryLimitV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readMemoryLimitV2Unlimited(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.max"), "max\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.max"), "max\n");
         assertEquals(UNLIMITED_MEMORY, cgroup.readMemoryLimitV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readMemoryUsageV2(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.current"), "536870912\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.current"), "536870912\n");
         assertEquals(536870912L, cgroup.readMemoryUsageV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidLimitV2WithLimit(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.max"), "1024\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.max"), "1024\n");
         assertEquals(1024L, cgroup.readPidLimitV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidLimitV2Unlimited(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.max"), "max\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.max"), "max\n");
         assertEquals(UNLIMITED, cgroup.readPidLimitV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidCurrentV2(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.current"), "42\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.current"), "42\n");
         assertEquals(42L, cgroup.readPidCurrentV2(tempDir.toString() + "/"));
     }
 
@@ -248,13 +247,13 @@ class LinuxCgroupInfoTest {
 
     @Test
     void readCpuQuotaV1WithLimit(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.cfs_quota_us"), "50000\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.cfs_quota_us"), "50000\n");
         assertEquals(50000L, cgroup.readCpuQuotaV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readCpuQuotaV1Unlimited(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.cfs_quota_us"), "-1\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.cfs_quota_us"), "-1\n");
         assertEquals(-1L, cgroup.readCpuQuotaV1(tempDir.toString() + "/"));
     }
 
@@ -265,7 +264,7 @@ class LinuxCgroupInfoTest {
 
     @Test
     void readCpuPeriodV1(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.cfs_period_us"), "50000\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.cfs_period_us"), "50000\n");
         assertEquals(50000L, cgroup.readCpuPeriodV1(tempDir.toString() + "/"));
     }
 
@@ -276,13 +275,13 @@ class LinuxCgroupInfoTest {
 
     @Test
     void readCpuUsageV1(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpuacct.usage"), "123456789\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpuacct.usage"), "123456789\n");
         assertEquals(123456789L, cgroup.readCpuUsageV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readMemoryLimitV1WithLimit(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.limit_in_bytes"), "2147483648\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.limit_in_bytes"), "2147483648\n");
         assertEquals(2147483648L, cgroup.readMemoryLimitV1(tempDir.toString() + "/"));
     }
 
@@ -290,7 +289,7 @@ class LinuxCgroupInfoTest {
     void readMemoryLimitV1Unlimited(@TempDir Path tempDir) throws IOException {
         // Kernel reports near-max value for unlimited
         String nearMax = String.valueOf(Long.MAX_VALUE - 4095);
-        Files.write(tempDir.resolve("memory.limit_in_bytes"), (nearMax + "\n").getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.limit_in_bytes"), (nearMax + "\n"));
         assertEquals(UNLIMITED_MEMORY, cgroup.readMemoryLimitV1(tempDir.toString() + "/"));
     }
 
@@ -298,31 +297,31 @@ class LinuxCgroupInfoTest {
     void readMemoryLimitV1BelowThreshold(@TempDir Path tempDir) throws IOException {
         // A large but valid limit (8 TiB) should be returned as-is, not treated as unlimited
         long eightTiB = 8L * 1024 * 1024 * 1024 * 1024;
-        Files.write(tempDir.resolve("memory.limit_in_bytes"), (eightTiB + "\n").getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.limit_in_bytes"), (eightTiB + "\n"));
         assertEquals(eightTiB, cgroup.readMemoryLimitV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readMemoryUsageV1(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.usage_in_bytes"), "1048576\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.usage_in_bytes"), "1048576\n");
         assertEquals(1048576L, cgroup.readMemoryUsageV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidLimitV1WithLimit(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.max"), "512\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.max"), "512\n");
         assertEquals(512L, cgroup.readPidLimitV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidLimitV1Unlimited(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.max"), "max\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.max"), "max\n");
         assertEquals(UNLIMITED, cgroup.readPidLimitV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidCurrentV1(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.current"), "17\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.current"), "17\n");
         assertEquals(17L, cgroup.readPidCurrentV1(tempDir.toString() + "/"));
     }
 
@@ -330,42 +329,42 @@ class LinuxCgroupInfoTest {
 
     @Test
     void dispatchV2CpuUsage(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.stat"), "usage_usec 1000\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.stat"), "usage_usec 1000\n");
         TestableLinuxCgroupInfo testable = new TestableLinuxCgroupInfo(2, tempDir.toString() + "/");
         assertEquals(1_000_000L, testable.getCpuUsage());
     }
 
     @Test
     void dispatchV2MemoryUsage(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.current"), "4096\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.current"), "4096\n");
         TestableLinuxCgroupInfo testable = new TestableLinuxCgroupInfo(2, tempDir.toString() + "/");
         assertEquals(4096L, testable.getMemoryUsage());
     }
 
     @Test
     void dispatchV2PidCurrent(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.current"), "5\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.current"), "5\n");
         TestableLinuxCgroupInfo testable = new TestableLinuxCgroupInfo(2, tempDir.toString() + "/");
         assertEquals(5L, testable.getPidCurrent());
     }
 
     @Test
     void dispatchV1CpuUsage(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpuacct.usage"), "999\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpuacct.usage"), "999\n");
         TestableLinuxCgroupInfo testable = new TestableLinuxCgroupInfo(1, tempDir.toString() + "/");
         assertEquals(999L, testable.getCpuUsage());
     }
 
     @Test
     void dispatchV1MemoryUsage(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.usage_in_bytes"), "2048\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.usage_in_bytes"), "2048\n");
         TestableLinuxCgroupInfo testable = new TestableLinuxCgroupInfo(1, tempDir.toString() + "/");
         assertEquals(2048L, testable.getMemoryUsage());
     }
 
     @Test
     void dispatchV1PidCurrent(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.current"), "3\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.current"), "3\n");
         TestableLinuxCgroupInfo testable = new TestableLinuxCgroupInfo(1, tempDir.toString() + "/");
         assertEquals(3L, testable.getPidCurrent());
     }

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoV1DispatchTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxCgroupInfoV1DispatchTest.java
@@ -10,7 +10,6 @@ import static oshi.software.os.CgroupInfo.UNLIMITED;
 import static oshi.software.os.CgroupInfo.UNLIMITED_MEMORY;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -33,62 +32,62 @@ class LinuxCgroupInfoV1DispatchTest {
 
     @Test
     void readCpuQuotaV1WithPositiveValue(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.cfs_quota_us"), "250000\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.cfs_quota_us"), "250000\n");
         assertEquals(250000L, cgroup.readCpuQuotaV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readCpuQuotaV1ZeroMeansUnlimited(@TempDir Path tempDir) throws IOException {
         // A zero value from getLongFromFile (file empty or parse failure) should map to UNLIMITED
-        Files.write(tempDir.resolve("cpu.cfs_quota_us"), "0\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.cfs_quota_us"), "0\n");
         assertEquals(UNLIMITED, cgroup.readCpuQuotaV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readCpuPeriodV1WithValue(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.cfs_period_us"), "100000\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.cfs_period_us"), "100000\n");
         assertEquals(100000L, cgroup.readCpuPeriodV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readCpuPeriodV1ZeroMeansDefault(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpu.cfs_period_us"), "0\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.cfs_period_us"), "0\n");
         assertEquals(DEFAULT_CPU_PERIOD, cgroup.readCpuPeriodV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readMemoryLimitV1ZeroMeansUnlimited(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.limit_in_bytes"), "0\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.limit_in_bytes"), "0\n");
         assertEquals(UNLIMITED_MEMORY, cgroup.readMemoryLimitV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidLimitV1ZeroMeansUnlimited(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.max"), "0\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.max"), "0\n");
         assertEquals(UNLIMITED, cgroup.readPidLimitV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidLimitV1WithNumericValue(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.max"), "2048\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.max"), "2048\n");
         assertEquals(2048L, cgroup.readPidLimitV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidCurrentV1WithValue(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.current"), "99\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.current"), "99\n");
         assertEquals(99L, cgroup.readPidCurrentV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readCpuUsageV1WithValue(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("cpuacct.usage"), "987654321\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpuacct.usage"), "987654321\n");
         assertEquals(987654321L, cgroup.readCpuUsageV1(tempDir.toString() + "/"));
     }
 
     @Test
     void readMemoryUsageV1WithValue(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.usage_in_bytes"), "67108864\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.usage_in_bytes"), "67108864\n");
         assertEquals(67108864L, cgroup.readMemoryUsageV1(tempDir.toString() + "/"));
     }
 
@@ -97,26 +96,26 @@ class LinuxCgroupInfoV1DispatchTest {
     @Test
     void readCpuQuotaV2SingleTokenMax(@TempDir Path tempDir) throws IOException {
         // cpu.max with just "max" (no period)
-        Files.write(tempDir.resolve("cpu.max"), "max\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.max"), "max\n");
         assertEquals(UNLIMITED, cgroup.readCpuQuotaV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readCpuPeriodV2SingleToken(@TempDir Path tempDir) throws IOException {
         // cpu.max with just one token (no period specified)
-        Files.write(tempDir.resolve("cpu.max"), "200000\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("cpu.max"), "200000\n");
         assertEquals(DEFAULT_CPU_PERIOD, cgroup.readCpuPeriodV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readMemoryLimitV2EmptyFile(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.max"), "".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.max"), "");
         assertEquals(UNLIMITED_MEMORY, cgroup.readMemoryLimitV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidLimitV2EmptyFile(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.max"), "".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.max"), "");
         assertEquals(UNLIMITED, cgroup.readPidLimitV2(tempDir.toString() + "/"));
     }
 
@@ -132,13 +131,13 @@ class LinuxCgroupInfoV1DispatchTest {
 
     @Test
     void readMemoryUsageV2EmptyFile(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("memory.current"), "".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("memory.current"), "");
         assertEquals(0L, cgroup.readMemoryUsageV2(tempDir.toString() + "/"));
     }
 
     @Test
     void readPidCurrentV2EmptyFile(@TempDir Path tempDir) throws IOException {
-        Files.write(tempDir.resolve("pids.current"), "".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(tempDir.resolve("pids.current"), "");
         assertEquals(0L, cgroup.readPidCurrentV2(tempDir.toString() + "/"));
     }
 

--- a/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
+++ b/oshi-common/src/test/java/oshi/software/common/os/linux/LinuxOperatingSystemTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -354,7 +353,7 @@ class LinuxOperatingSystemTest {
     void testParseServicesSystemctlFoundSuppressesFallback(@TempDir Path initDir) throws IOException {
         // The only enabled unit is already running, so no stopped service is emitted -- but systemctl DID produce
         // output, so the /etc/init fallback must not run even though a .conf job is present in the init dir
-        Files.write(initDir.resolve("tty1.conf"), "start on runlevel\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(initDir.resolve("tty1.conf"), "start on runlevel\n");
         List<String> systemctl = List.of("UNIT FILE          STATE      VENDOR PRESET",
                 "ssh.service        enabled    enabled");
         Set<String> running = new HashSet<>(List.of("ssh"));
@@ -365,9 +364,9 @@ class LinuxOperatingSystemTest {
     @Test
     void testParseServicesInitFallback(@TempDir Path initDir) throws IOException {
         // No systemctl services -> scan the init directory for *.conf upstart jobs
-        Files.write(initDir.resolve("tty1.conf"), "start on runlevel\n".getBytes(StandardCharsets.UTF_8));
-        Files.write(initDir.resolve("ssh.conf"), "start on runlevel\n".getBytes(StandardCharsets.UTF_8));
-        Files.write(initDir.resolve("README.txt"), "not a job\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(initDir.resolve("tty1.conf"), "start on runlevel\n");
+        Files.writeString(initDir.resolve("ssh.conf"), "start on runlevel\n");
+        Files.writeString(initDir.resolve("README.txt"), "not a job\n");
         Set<String> running = new HashSet<>(List.of("ssh"));
         List<OSService> services = LinuxOperatingSystem.parseServices(Collections.emptyList(), running,
                 initDir.toString());
@@ -391,7 +390,7 @@ class LinuxOperatingSystemTest {
 
     @Test
     void testGetReleaseFilenameMatchesDistribFile(@TempDir Path etc) throws IOException {
-        Files.write(etc.resolve("redhat-release"), "CentOS release 7\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(etc.resolve("redhat-release"), "CentOS release 7\n");
         assertThat(LinuxOperatingSystem.getReleaseFilename(etc.toString()),
                 is(etc.resolve("redhat-release").toString()));
     }
@@ -400,9 +399,9 @@ class LinuxOperatingSystemTest {
     void testGetReleaseFilenameSkipsExcludedThenReleaseFallback(@TempDir Path etc) throws IOException {
         // os-release/lsb-release/system-release are handled elsewhere and excluded from the scan; with only those
         // present the scan falls back to the "release" file (Solaris-style) when it exists
-        Files.write(etc.resolve("os-release"), "NAME=Ubuntu\n".getBytes(StandardCharsets.UTF_8));
-        Files.write(etc.resolve("lsb-release"), "DISTRIB_ID=Ubuntu\n".getBytes(StandardCharsets.UTF_8));
-        Files.write(etc.resolve("release"), "Solaris\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(etc.resolve("os-release"), "NAME=Ubuntu\n");
+        Files.writeString(etc.resolve("lsb-release"), "DISTRIB_ID=Ubuntu\n");
+        Files.writeString(etc.resolve("release"), "Solaris\n");
         assertThat(LinuxOperatingSystem.getReleaseFilename(etc.toString()), is(etc.resolve("release").toString()));
     }
 

--- a/oshi-common/src/test/java/oshi/util/GlobalConfigTest.java
+++ b/oshi-common/src/test/java/oshi/util/GlobalConfigTest.java
@@ -17,7 +17,6 @@ import static oshi.util.GlobalConfig.remove;
 import static oshi.util.GlobalConfig.set;
 import static oshi.util.GlobalConfigTest.GlobalConfigAsserter.asserter;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
@@ -133,7 +132,7 @@ class GlobalConfigTest {
     void testLoadExternalConfig(@TempDir Path tempDir) throws Exception {
         // Write a temp properties file
         Path propsFile = tempDir.resolve("test-oshi.properties");
-        Files.write(propsFile, "oshi.test.external=fromfile\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(propsFile, "oshi.test.external=fromfile\n");
 
         // Set system property to point to it
         System.setProperty("oshi.properties.file", propsFile.toString());

--- a/oshi-common/src/test/java/oshi/util/PrivilegedUtilEscalationTest.java
+++ b/oshi-common/src/test/java/oshi/util/PrivilegedUtilEscalationTest.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
@@ -81,7 +80,7 @@ class PrivilegedUtilEscalationTest {
     @Test
     void testReadFilePrivilegedWithPrefixAndReadableFile(@TempDir Path tempDir) throws IOException {
         Path testFile = tempDir.resolve("readable.txt");
-        Files.write(testFile, "content\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(testFile, "content\n");
 
         String filePath = testFile.toString();
         GlobalConfig.set(GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_FILE_ALLOWLIST, filePath);
@@ -96,7 +95,7 @@ class PrivilegedUtilEscalationTest {
     @Test
     void testReadFilePrivilegedEscalationPath(@TempDir Path tempDir) throws IOException {
         Path testFile = tempDir.resolve("restricted.txt");
-        Files.write(testFile, "secret\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(testFile, "secret\n");
         assumeTrue(testFile.toFile().setReadable(false) && !Files.isReadable(testFile),
                 "Could not make file unreadable (possibly running as root)");
 
@@ -203,7 +202,7 @@ class PrivilegedUtilEscalationTest {
     @Test
     void testGetStringFromFilePrivilegedWithAllowlist(@TempDir Path tempDir) throws IOException {
         Path testFile = tempDir.resolve("single-line.txt");
-        Files.write(testFile, "hello world\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(testFile, "hello world\n");
 
         String filePath = testFile.toString();
         GlobalConfig.set(GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_FILE_ALLOWLIST, filePath);
@@ -242,7 +241,7 @@ class PrivilegedUtilEscalationTest {
     @Test
     void testReadFilePrivilegedNotInAllowlist(@TempDir Path tempDir) throws IOException {
         Path testFile = tempDir.resolve("not-allowed.txt");
-        Files.write(testFile, "data\n".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(testFile, "data\n");
 
         GlobalConfig.set(GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_FILE_ALLOWLIST, "/some/other/path");
         GlobalConfig.set(GlobalConfig.OSHI_OS_LINUX_PRIVILEGED_PREFIX, "sudo -n");

--- a/oshi-common/src/test/java/oshi/util/TestFileUtil.java
+++ b/oshi-common/src/test/java/oshi/util/TestFileUtil.java
@@ -5,7 +5,6 @@
 package oshi.util;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -26,6 +25,6 @@ public final class TestFileUtil {
      */
     public static void writeFile(Path path, String content) throws IOException {
         Files.createDirectories(path.getParent());
-        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+        Files.writeString(path, content);
     }
 }

--- a/oshi-common/src/test/java/oshi/util/driver/linux/WhoSystemdTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/linux/WhoSystemdTest.java
@@ -17,7 +17,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.ThrowingSupplier;
@@ -37,7 +36,7 @@ class WhoSystemdTest {
     }
 
     private static List<String> users(List<OSSession> sessions) {
-        return sessions.stream().map(OSSession::getUserName).collect(Collectors.toList());
+        return sessions.stream().map(OSSession::getUserName).toList();
     }
 
     @Test


### PR DESCRIPTION
66 call sites across 12 test files, closing out the Java 17 modernization of the test sources.

## Files.writeString — 63 sites, 10 files

```java
Files.write(path, content.getBytes(StandardCharsets.UTF_8));
Files.writeString(path, content);
```

All 63 were the same shape — no open options, no charset other than UTF-8 — and that argument was the only reason these files imported `StandardCharsets`. The text-block batches (#3692–#3695) converted only the *multi-line* writes, so this finishes the job.

`TestFileUtil.writeFile`, the shared helper the whole suite builds fixture files with, loses its charset plumbing too.

## Stream.toList() — 3 sites

`Collectors.toList()` → `Stream.toList()`. The difference worth knowing: `Stream.toList()` is **unmodifiable** where `Collectors.toList()` returns a mutable `ArrayList`. Nothing here mutates the result, and an attempt would throw rather than pass quietly.

## Records were considered and do not apply

Worth recording so it is not re-investigated. Of **187 nested classes** in the test sources:

- **39 extend a class** — the `StubLinuxGpuStats extends LinuxGpuStats` shape. A record cannot extend, so these are structurally excluded.
- **The rest implement interfaces with behaviour** — `StubOperatingSystem`, `MinimalParams`, `NoConnections` return canned values; they are test doubles, not data carriers. And a record's accessors are `name()`, not `getName()`, so even those would need explicit methods and gain nothing.

The underlying reason: OSHI's actual data carriers — `Pair`, `Triplet`, `HWPartition`, `OSProcess` — live in **main** sources at release 8, where records do not exist. The tests hold fixtures and stubs.

## Also checked, nothing to do

Three statement switches a survey still reported are already in arrow form from #3688 — the pattern that finds them matches both forms.

`Collections.emptyList()`/`emptyMap()`/`singleton*` (246 sites) were deliberately left alone: they and their `List.of()`/`Map.of()` equivalents are both immutable singletons with identical behaviour and allocation, so the change would touch ~100 files for no functional gain.

## Verification

Full gate from clean — `spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc -Paggregate-coverage` — green, zero test failures, plus `-Perror-prone` clean.

Net −12 lines. Test-only, no CHANGELOG entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modernized test file handling for text fixtures, improving readability and consistency.
  * Updated collection handling in platform tests using current Java APIs.
  * Existing test coverage, behavior, and assertions remain unchanged.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->