### PR TITLE
Add isPrimary to the Display API

### DIFF
--- a/oshi-common/src/main/java/oshi/driver/common/windows/DisplayConnector.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/DisplayConnector.java
@@ -64,6 +64,19 @@ public final class DisplayConnector {
     /** Offset of {@code monitorDevicePath} (a {@code WCHAR[128]}) within a {@code DISPLAYCONFIG_TARGET_DEVICE_NAME}. */
     public static final int TDN_MONITOR_DEVICE_PATH_OFFSET = 164;
 
+    // Offsets for determining the primary display from the DISPLAYCONFIG_PATH_INFO and DISPLAYCONFIG_MODE_INFO arrays.
+    // The Windows primary display is the active path whose source mode desktop position is (0, 0).
+    /** Offset of {@code sourceInfo.modeInfoIdx} (a {@code UINT32}) within a {@code DISPLAYCONFIG_PATH_INFO}. */
+    public static final int PATH_SOURCE_MODE_IDX_OFFSET = 12;
+    /** {@code DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE} value for the {@code infoType} field. */
+    public static final int MODE_INFO_TYPE_SOURCE = 1;
+    /** Offset of {@code sourceMode.position.x} (a {@code LONG}) within a {@code DISPLAYCONFIG_MODE_INFO}. */
+    public static final int SOURCE_MODE_POSITION_X_OFFSET = 28;
+    /** Offset of {@code sourceMode.position.y} (a {@code LONG}) within a {@code DISPLAYCONFIG_MODE_INFO}. */
+    public static final int SOURCE_MODE_POSITION_Y_OFFSET = 32;
+    /** Offset of {@code infoType} (a {@code UINT32}) within a {@code DISPLAYCONFIG_MODE_INFO}. */
+    public static final int MODE_INFO_TYPE_OFFSET = 0;
+
     // DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY values (shared with the D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY enum).
     private static final int VOT_HD15 = 0;
     private static final int VOT_SVIDEO = 1;

--- a/oshi-common/src/main/java/oshi/hardware/Display.java
+++ b/oshi-common/src/main/java/oshi/hardware/Display.java
@@ -88,4 +88,15 @@ public interface Display {
     default Optional<String> getOutputName() {
         return Optional.empty();
     }
+
+    /**
+     * Whether this display is the primary display. Returns {@code true} only when the platform positively identifies
+     * this display as primary; returns {@code false} when the primary display cannot be determined (e.g. under Wayland,
+     * on headless systems, or on platforms that do not expose primary-display information).
+     *
+     * @return {@code true} if this display is the primary display, {@code false} otherwise
+     */
+    default boolean isPrimary() {
+        return false;
+    }
 }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/unix/UnixDisplay.java
@@ -17,7 +17,6 @@ import oshi.hardware.Display;
 import oshi.hardware.common.AbstractDisplay;
 import oshi.util.Constants;
 import oshi.util.driver.unix.Xrandr;
-import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
 /**
@@ -28,7 +27,8 @@ public final class UnixDisplay extends AbstractDisplay {
 
     private final String devicePort;
     private final int connectorId;
-    private final Supplier<Map<String, Pair<Integer, byte[]>>> xrandrData;
+    private final boolean primary;
+    private final Supplier<Map<String, Triplet<Integer, byte[], Boolean>>> xrandrData;
 
     /**
      * Constructor for UnixDisplay.
@@ -36,7 +36,7 @@ public final class UnixDisplay extends AbstractDisplay {
      * @param edid a byte array representing a display EDID
      */
     public UnixDisplay(byte[] edid) {
-        this(edid, Constants.UNKNOWN, -1);
+        this(edid, Constants.UNKNOWN, -1, false);
     }
 
     /**
@@ -47,7 +47,19 @@ public final class UnixDisplay extends AbstractDisplay {
      * @param connectorId the DRM connector ID ({@code -1} if not available)
      */
     public UnixDisplay(byte[] edid, String devicePort, int connectorId) {
-        this(edid, devicePort, connectorId, memoize(Xrandr::getDisplayData));
+        this(edid, devicePort, connectorId, false);
+    }
+
+    /**
+     * Constructor for UnixDisplay with device port, DRM connector ID, and primary status.
+     *
+     * @param edid        a byte array representing a display EDID
+     * @param devicePort  the DRM connector name (e.g. {@code HDMI-A-1})
+     * @param connectorId the DRM connector ID ({@code -1} if not available)
+     * @param primary     whether this display is the primary display
+     */
+    public UnixDisplay(byte[] edid, String devicePort, int connectorId, boolean primary) {
+        this(edid, devicePort, connectorId, primary, memoize(Xrandr::getDisplayData));
     }
 
     /**
@@ -56,13 +68,15 @@ public final class UnixDisplay extends AbstractDisplay {
      * @param edid        a byte array representing a display EDID
      * @param devicePort  the DRM connector name (e.g. {@code HDMI-A-1})
      * @param connectorId the DRM connector ID ({@code -1} if not available)
+     * @param primary     whether this display is the primary display
      * @param xrandrData  the display's source of xrandr data, expected to be memoized or already realized
      */
-    private UnixDisplay(byte[] edid, String devicePort, int connectorId,
-            Supplier<Map<String, Pair<Integer, byte[]>>> xrandrData) {
+    private UnixDisplay(byte[] edid, String devicePort, int connectorId, boolean primary,
+            Supplier<Map<String, Triplet<Integer, byte[], Boolean>>> xrandrData) {
         super(edid);
         this.devicePort = devicePort;
         this.connectorId = connectorId;
+        this.primary = primary;
         this.xrandrData = xrandrData;
     }
 
@@ -76,18 +90,24 @@ public final class UnixDisplay extends AbstractDisplay {
         return Xrandr.findOutputName(this.xrandrData.get(), this.connectorId, this.getDisplayInfo().getEdid());
     }
 
+    @Override
+    public boolean isPrimary() {
+        return this.primary;
+    }
+
     /**
      * Gets Display Information from xrandr. Used as a fallback when DRM sysfs is not available.
      *
      * @return An array of Display objects representing monitors, etc.
      */
     public static List<Display> getDisplays() {
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData();
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData();
         List<Display> displays = new ArrayList<>(data.size());
         // The data is already in hand, so these displays need no further xrandr query
-        Supplier<Map<String, Pair<Integer, byte[]>>> sharedData = () -> data;
-        for (Map.Entry<String, Pair<Integer, byte[]>> entry : data.entrySet()) {
-            displays.add(new UnixDisplay(entry.getValue().getB(), entry.getKey(), entry.getValue().getA(), sharedData));
+        Supplier<Map<String, Triplet<Integer, byte[], Boolean>>> sharedData = () -> data;
+        for (Map.Entry<String, Triplet<Integer, byte[], Boolean>> entry : data.entrySet()) {
+            displays.add(new UnixDisplay(entry.getValue().getB(), entry.getKey(), entry.getValue().getA(),
+                    entry.getValue().getC(), sharedData));
         }
         return displays;
     }
@@ -105,22 +125,25 @@ public final class UnixDisplay extends AbstractDisplay {
     }
 
     /**
-     * Builds a batch of displays sharing one query for the xrandr data behind {@link #getOutputName()}.
+     * Builds a batch of displays sharing one query for the xrandr data behind {@link #getOutputName()} and
+     * {@link #isPrimary()}.
      * <p>
      * The query is memoized indefinitely, because a {@link Display} is an immutable snapshot: the output name matching
-     * its connector cannot change over the object's lifetime. The hardware abstraction layer re-queries displays on its
-     * own schedule, building a new batch with a new supplier, so a topology change is picked up there.
+     * its connector and primary status cannot change over the object's lifetime. The hardware abstraction layer
+     * re-queries displays on its own schedule, building a new batch with a new supplier, so a topology change is
+     * picked up there.
      *
      * @param drmData     the DRM sysfs data to build displays from
      * @param xrandrQuery the query for xrandr display data, run at most once for the whole batch
      * @return An array of Display objects representing monitors, etc.
      */
     static List<Display> getDisplays(List<Triplet<String, Integer, byte[]>> drmData,
-            Supplier<Map<String, Pair<Integer, byte[]>>> xrandrQuery) {
+            Supplier<Map<String, Triplet<Integer, byte[], Boolean>>> xrandrQuery) {
         List<Display> displays = new ArrayList<>(drmData.size());
-        Supplier<Map<String, Pair<Integer, byte[]>>> sharedData = memoize(xrandrQuery);
+        Supplier<Map<String, Triplet<Integer, byte[], Boolean>>> sharedData = memoize(xrandrQuery);
         for (Triplet<String, Integer, byte[]> drm : drmData) {
-            displays.add(new UnixDisplay(drm.getC(), drm.getA(), drm.getB(), sharedData));
+            boolean primary = Xrandr.findPrimaryStatus(sharedData.get(), drm.getB(), drm.getC());
+            displays.add(new UnixDisplay(drm.getC(), drm.getA(), drm.getB(), primary, sharedData));
         }
         return displays;
     }

--- a/oshi-common/src/main/java/oshi/util/EdidUtil.java
+++ b/oshi-common/src/main/java/oshi/util/EdidUtil.java
@@ -115,6 +115,41 @@ public final class EdidUtil {
                 getAlphaNumericOrHex(edid[SERIAL_NUMBER_OFFSET + 1]), getAlphaNumericOrHex(edid[SERIAL_NUMBER_OFFSET]));
     }
 
+    /**
+     * Gets the packed 16-bit manufacturer/vendor number from EDID bytes 8 and 9, as a numeric value matching the macOS
+     * {@code CGDisplayVendorNumber} and the IOKit {@code kDisplayVendorID} property.
+     *
+     * @param edid The EDID byte array
+     * @return The packed vendor number (unsigned 16-bit value in the low 16 bits)
+     */
+    public static int getVendorNumber(byte[] edid) {
+        return ((edid[MANUFACTURER_ID_OFFSET] & 0xFF) << 8) | (edid[MANUFACTURER_ID_OFFSET + 1] & 0xFF);
+    }
+
+    /**
+     * Gets the 16-bit product/model number from EDID bytes 10 and 11 (little-endian), as a numeric value matching the
+     * macOS {@code CGDisplayModelNumber} and the IOKit {@code kDisplayProductID} property.
+     *
+     * @param edid The EDID byte array
+     * @return The product/model number (unsigned 16-bit value in the low 16 bits)
+     */
+    public static int getProductNumber(byte[] edid) {
+        return (edid[PRODUCT_ID_OFFSET] & 0xFF) | ((edid[PRODUCT_ID_OFFSET + 1] & 0xFF) << 8);
+    }
+
+    /**
+     * Gets the 32-bit serial number from EDID bytes 12-15 (little-endian), as a numeric value matching the macOS
+     * {@code CGDisplaySerialNumber} and the IOKit {@code kDisplaySerialNumber} property. The bit pattern is preserved
+     * in a signed Java {@code int}; equality comparisons against the corresponding CoreGraphics value are valid.
+     *
+     * @param edid The EDID byte array
+     * @return The serial number (bit pattern of the unsigned 32-bit value)
+     */
+    public static int getSerialNumber(byte[] edid) {
+        return (edid[SERIAL_NUMBER_OFFSET] & 0xFF) | ((edid[SERIAL_NUMBER_OFFSET + 1] & 0xFF) << 8)
+                | ((edid[SERIAL_NUMBER_OFFSET + 2] & 0xFF) << 16) | ((edid[SERIAL_NUMBER_OFFSET + 3] & 0xFF) << 24);
+    }
+
     private static String getAlphaNumericOrHex(byte b) {
         return Character.isLetterOrDigit((char) b) ? String.format(Locale.ROOT, "%s", (char) b)
                 : String.format(Locale.ROOT, "%02X", b);

--- a/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
+++ b/oshi-common/src/main/java/oshi/util/driver/unix/Xrandr.java
@@ -4,18 +4,12 @@
  */
 package oshi.util.driver.unix;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import oshi.annotation.concurrent.ThreadSafe;
 import oshi.util.ExecutingCommand;
 import oshi.util.ParseUtil;
-import oshi.util.tuples.Pair;
+import oshi.util.tuples.Triplet;
 
 /**
  * Utility to query xrandr
@@ -67,42 +61,44 @@ public final class Xrandr {
      * @return a list of EDID byte arrays (at least 128 bytes each)
      */
     static List<byte[]> getEdidArrays(List<String> xrandr) {
-        Map<String, Pair<Integer, byte[]>> data = getDisplayData(xrandr);
+        Map<String, Triplet<Integer, byte[], Boolean>> data = getDisplayData(xrandr);
         List<byte[]> edids = new ArrayList<>(data.size());
-        for (Pair<Integer, byte[]> pair : data.values()) {
-            edids.add(pair.getB());
+        for (Triplet<Integer, byte[], Boolean> triplet : data.values()) {
+            edids.add(triplet.getB());
         }
         return Collections.unmodifiableList(edids);
     }
 
     /**
      * Gets display data from the running X server via xrandr, mapping each connected output's xrandr port name to its
-     * connector ID and EDID.
+     * connector ID, EDID, and primary status.
      *
-     * @return an ordered map of xrandr port name to {@link Pair} of connector ID ({@code -1} if not available) and EDID
-     *         byte array
+     * @return an ordered map of xrandr port name to {@link Triplet} of connector ID ({@code -1} if not available), EDID
+     *         byte array (at least 128 bytes), and primary status ({@code true} if the output is marked primary)
      */
-    public static Map<String, Pair<Integer, byte[]>> getDisplayData() {
+    public static Map<String, Triplet<Integer, byte[], Boolean>> getDisplayData() {
         return getDisplayData(runXrandr());
     }
 
     /**
      * Parse display data from xrandr verbose output. For each connected output, extracts the xrandr port name (the
      * first whitespace-delimited token on the output header line), the {@code CONNECTOR_ID} property (if present,
-     * requires Linux 6.5+), and the EDID byte array. The parser is order-independent: {@code CONNECTOR_ID} may appear
-     * before or after {@code EDID:}.
+     * requires Linux 6.5+), the EDID byte array, and the primary status. The parser is order-independent:
+     * {@code CONNECTOR_ID} may appear before or after {@code EDID:}.
      *
      * @param xrandr output of {@code xrandr --verbose}
-     * @return an ordered map of xrandr port name to {@link Pair} of connector ID ({@code -1} if not available) and EDID
-     *         byte array (at least 128 bytes). Only connected outputs with a valid EDID are included.
+     * @return an ordered map of xrandr port name to {@link Triplet} of connector ID ({@code -1} if not available), EDID
+     *         byte array (at least 128 bytes), and primary status ({@code true} if the output is marked primary). Only
+     *         connected outputs with a valid EDID are included.
      */
-    static Map<String, Pair<Integer, byte[]>> getDisplayData(List<String> xrandr) {
+    static Map<String, Triplet<Integer, byte[], Boolean>> getDisplayData(List<String> xrandr) {
         if (xrandr.isEmpty()) {
             return Collections.emptyMap();
         }
-        Map<String, Pair<Integer, byte[]>> results = new LinkedHashMap<>();
+        Map<String, Triplet<Integer, byte[], Boolean>> results = new LinkedHashMap<>();
         String currentPort = "";
         boolean currentConnected = false;
+        boolean currentPrimary = false;
         int currentConnectorId = -1;
         byte[] currentEdid = null;
         StringBuilder sb = null;
@@ -111,11 +107,12 @@ public final class Xrandr {
             if (!s.isEmpty() && !Character.isWhitespace(s.charAt(0))) {
                 // Flush the previous output before starting a new one
                 if (currentConnected && currentEdid != null) {
-                    results.put(currentPort, new Pair<>(currentConnectorId, currentEdid));
+                    results.put(currentPort, new Triplet<>(currentConnectorId, currentEdid, currentPrimary));
                 }
                 String[] words = ParseUtil.whitespaces.split(s.trim(), -1);
                 currentPort = words[0];
                 currentConnected = words.length > 1 && "connected".equals(words[1]);
+                currentPrimary = words.length > 2 && "primary".equals(words[2]);
                 currentConnectorId = -1;
                 currentEdid = null;
                 sb = null;
@@ -140,7 +137,7 @@ public final class Xrandr {
         }
         // Flush the last output
         if (currentConnected && currentEdid != null) {
-            results.put(currentPort, new Pair<>(currentConnectorId, currentEdid));
+            results.put(currentPort, new Triplet<>(currentConnectorId, currentEdid, currentPrimary));
         }
         return Collections.unmodifiableMap(results);
     }
@@ -156,14 +153,14 @@ public final class Xrandr {
      * @return an {@link Optional} containing the xrandr output name, or empty if no X server is available or no match
      *         is found
      */
-    public static Optional<String> findOutputName(Map<String, Pair<Integer, byte[]>> xrandrData, int connectorId,
+    public static Optional<String> findOutputName(Map<String, Triplet<Integer, byte[], Boolean>> xrandrData, int connectorId,
             byte[] edid) {
         if (xrandrData.isEmpty()) {
             return Optional.empty();
         }
         // First try matching by CONNECTOR_ID (Linux 6.5+)
         if (connectorId >= 0) {
-            for (Map.Entry<String, Pair<Integer, byte[]>> entry : xrandrData.entrySet()) {
+            for (Map.Entry<String, Triplet<Integer, byte[], Boolean>> entry : xrandrData.entrySet()) {
                 if (entry.getValue().getA() == connectorId) {
                     return Optional.of(entry.getKey());
                 }
@@ -172,7 +169,7 @@ public final class Xrandr {
         // Fallback: match by first 128 bytes of EDID
         if (edid.length >= 128) {
             byte[] edid128 = Arrays.copyOf(edid, 128);
-            for (Map.Entry<String, Pair<Integer, byte[]>> entry : xrandrData.entrySet()) {
+            for (Map.Entry<String, Triplet<Integer, byte[], Boolean>> entry : xrandrData.entrySet()) {
                 byte[] xrandrEdid = entry.getValue().getB();
                 if (xrandrEdid.length >= 128 && Arrays.equals(edid128, Arrays.copyOf(xrandrEdid, 128))) {
                     return Optional.of(entry.getKey());
@@ -180,6 +177,42 @@ public final class Xrandr {
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Finds the primary status for a display identified by its DRM connector ID and/or EDID, matching by
+     * {@code CONNECTOR_ID} first (Linux 6.5+) and falling back to EDID comparison.
+     *
+     * @param xrandrData  xrandr display data as returned by {@link #getDisplayData()}, which the caller is expected to
+     *                    share among the displays it is naming rather than querying per display
+     * @param connectorId the DRM connector ID ({@code -1} if not available)
+     * @param edid        the EDID byte array from DRM sysfs
+     * @return {@code true} if the matched xrandr output is marked as primary, {@code false} otherwise
+     */
+    public static boolean findPrimaryStatus(Map<String, Triplet<Integer, byte[], Boolean>> xrandrData, int connectorId,
+            byte[] edid) {
+        if (xrandrData.isEmpty()) {
+            return false;
+        }
+        // First try matching by CONNECTOR_ID (Linux 6.5+)
+        if (connectorId >= 0) {
+            for (Triplet<Integer, byte[], Boolean> triplet : xrandrData.values()) {
+                if (triplet.getA() == connectorId) {
+                    return triplet.getC();
+                }
+            }
+        }
+        // Fallback: match by first 128 bytes of EDID
+        if (edid.length >= 128) {
+            byte[] edid128 = Arrays.copyOf(edid, 128);
+            for (Triplet<Integer, byte[], Boolean> triplet : xrandrData.values()) {
+                byte[] xrandrEdid = triplet.getB();
+                if (xrandrEdid.length >= 128 && Arrays.equals(edid128, Arrays.copyOf(xrandrEdid, 128))) {
+                    return triplet.getC();
+                }
+            }
+        }
+        return false;
     }
 
     private static List<String> runXrandr() {

--- a/oshi-common/src/test/java/oshi/hardware/common/AbstractDisplayTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/AbstractDisplayTest.java
@@ -82,4 +82,11 @@ class AbstractDisplayTest {
         };
         assertThat(display.getOutputName().isPresent(), is(false));
     }
+
+    @Test
+    void testDefaultIsPrimaryIsFalse() {
+        AbstractDisplay display = new AbstractDisplay(new byte[128]) {
+        };
+        assertThat(display.isPrimary(), is(false));
+    }
 }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/unix/UnixDisplayTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/unix/UnixDisplayTest.java
@@ -19,7 +19,6 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 import oshi.hardware.Display;
-import oshi.util.tuples.Pair;
 import oshi.util.tuples.Triplet;
 
 /**
@@ -40,7 +39,7 @@ class UnixDisplayTest {
     @Test
     void testBatchSharesOneXrandrQuery() {
         AtomicInteger queries = new AtomicInteger();
-        Supplier<Map<String, Pair<Integer, byte[]>>> countingQuery = () -> {
+        Supplier<Map<String, Triplet<Integer, byte[], Boolean>>> countingQuery = () -> {
             queries.incrementAndGet();
             return xrandrData();
         };
@@ -57,13 +56,38 @@ class UnixDisplayTest {
     }
 
     @Test
-    void testBatchQueryIsNotRunUntilOutputNameIsRequested() {
+    void testBatchQueryIsRunOnceForPrimaryStatus() {
         AtomicInteger queries = new AtomicInteger();
         UnixDisplay.getDisplays(drmData(), () -> {
             queries.incrementAndGet();
             return xrandrData();
         });
-        assertThat(queries.get(), is(0));
+        // Primary status is computed eagerly during display construction
+        assertThat(queries.get(), is(1));
+    }
+
+    @Test
+    void testPrimaryStatusFromXrandr() {
+        List<Display> displays = UnixDisplay.getDisplays(drmData(), () -> xrandrData());
+        assertThat(displays.size(), is(2));
+        // DP-2 is marked primary in xrandr data
+        assertThat(displays.get(0).isPrimary(), is(true));
+        // HDMI-1 is not marked primary
+        assertThat(displays.get(1).isPrimary(), is(false));
+    }
+
+    @Test
+    void testPrimaryStatusDefaultsToFalse() {
+        // When xrandr data is empty (e.g., Wayland), all displays are non-primary
+        AtomicInteger queries = new AtomicInteger();
+        Supplier<Map<String, Triplet<Integer, byte[], Boolean>>> emptyQuery = () -> {
+            queries.incrementAndGet();
+            return new LinkedHashMap<>();
+        };
+        List<Display> displays = UnixDisplay.getDisplays(drmData(), emptyQuery);
+        assertThat(displays.size(), is(2));
+        assertThat(displays.get(0).isPrimary(), is(false));
+        assertThat(displays.get(1).isPrimary(), is(false));
     }
 
     // Two displays as DRM sysfs reports them: connector name, connector ID, EDID
@@ -75,10 +99,10 @@ class UnixDisplayTest {
     }
 
     // The same two displays as xrandr names them, matched to the DRM data by connector ID
-    private static Map<String, Pair<Integer, byte[]>> xrandrData() {
-        Map<String, Pair<Integer, byte[]>> data = new LinkedHashMap<>();
-        data.put("DP-2", new Pair<>(96, edid((byte) 0x01)));
-        data.put("HDMI-1", new Pair<>(80, edid((byte) 0x02)));
+    private static Map<String, Triplet<Integer, byte[], Boolean>> xrandrData() {
+        Map<String, Triplet<Integer, byte[], Boolean>> data = new LinkedHashMap<>();
+        data.put("DP-2", new Triplet<>(96, edid((byte) 0x01), true));
+        data.put("HDMI-1", new Triplet<>(80, edid((byte) 0x02), false));
         return data;
     }
 

--- a/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
+++ b/oshi-common/src/test/java/oshi/util/driver/unix/XrandrTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import oshi.util.tuples.Pair;
+import oshi.util.tuples.Triplet;
 
 class XrandrTest {
 
@@ -150,36 +150,38 @@ class XrandrTest {
 
     @Test
     void testGetDisplayDataSingleWithConnectorId() {
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrWithConnectorId());
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrWithConnectorId());
         assertThat(data.size(), is(1));
         assertThat(data.containsKey("DP2"), is(true));
-        Pair<Integer, byte[]> pair = data.get("DP2");
-        assertNotNull(pair);
-        assertThat(pair.getA(), is(96));
-        assertThat(pair.getB().length, is(128));
-        assertThat(pair.getB()[0], is((byte) 0x00));
-        assertThat(pair.getB()[1], is((byte) 0xFF));
+        Triplet<Integer, byte[], Boolean> triplet = data.get("DP2");
+        assertNotNull(triplet);
+        assertThat(triplet.getA(), is(96));
+        assertThat(triplet.getB().length, is(128));
+        assertThat(triplet.getB()[0], is((byte) 0x00));
+        assertThat(triplet.getB()[1], is((byte) 0xFF));
+        assertThat(triplet.getC(), is(true)); // DP2 is marked primary
     }
 
     @Test
     void testGetDisplayDataWithoutConnectorId() {
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrWithEdid());
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrWithEdid());
         assertThat(data.size(), is(1));
         assertThat(data.containsKey("HDMI-1"), is(true));
-        Pair<Integer, byte[]> pair = data.get("HDMI-1");
-        assertNotNull(pair);
-        assertThat(pair.getA(), is(-1));
-        assertThat(pair.getB().length, is(128));
+        Triplet<Integer, byte[], Boolean> triplet = data.get("HDMI-1");
+        assertNotNull(triplet);
+        assertThat(triplet.getA(), is(-1));
+        assertThat(triplet.getB().length, is(128));
+        assertThat(triplet.getC(), is(true)); // HDMI-1 is marked primary
     }
 
     @Test
     void testGetDisplayDataTwoDisplays() {
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
         assertThat(data.size(), is(2));
         assertThat(data.containsKey("DP2"), is(true));
         assertThat(data.containsKey("HDMI1"), is(true));
-        Pair<Integer, byte[]> dp2 = data.get("DP2");
-        Pair<Integer, byte[]> hdmi1 = data.get("HDMI1");
+        Triplet<Integer, byte[], Boolean> dp2 = data.get("DP2");
+        Triplet<Integer, byte[], Boolean> hdmi1 = data.get("HDMI1");
         assertNotNull(dp2);
         assertNotNull(hdmi1);
         // DP2 has CONNECTOR_ID, HDMI1 does not
@@ -188,6 +190,9 @@ class XrandrTest {
         // Both have valid EDIDs
         assertThat(dp2.getB().length, is(128));
         assertThat(hdmi1.getB().length, is(128));
+        // DP2 is primary, HDMI1 is not
+        assertThat(dp2.getC(), is(true));
+        assertThat(hdmi1.getC(), is(false));
     }
 
     @Test
@@ -197,20 +202,22 @@ class XrandrTest {
 
     @Test
     void testGetDisplayDataDisconnectedSkipped() {
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
         // DP1 is disconnected and has no EDID, should not appear
         assertThat(data.containsKey("DP1"), is(false));
     }
 
     @Test
     void testGetDisplayDataDisconnectedDoesNotLeakState() {
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrDisconnectedWithConnectorId());
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrDisconnectedWithConnectorId());
         assertThat(data.size(), is(1));
         assertThat(data.containsKey("eDP"), is(true));
-        Pair<Integer, byte[]> edp = data.get("eDP");
+        Triplet<Integer, byte[], Boolean> edp = data.get("eDP");
         assertNotNull(edp);
         // eDP's own CONNECTOR_ID is 51, not 70 or 80 from the disconnected outputs
         assertThat(edp.getA(), is(51));
+        // eDP is primary
+        assertThat(edp.getC(), is(true));
         // Disconnected outputs should not appear
         assertThat(data.containsKey("DP-1"), is(false));
         assertThat(data.containsKey("HDMI-A-1"), is(false));
@@ -233,41 +240,43 @@ class XrandrTest {
     @Test
     void testGetDisplayDataLegacyEdidDataProperty() {
         // X.Org Server through 1.6 published the driver-side atom EDID_DATA
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrWithEdidProperty("EDID_DATA:"));
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrWithEdidProperty("EDID_DATA:"));
         assertThat(data.size(), is(1));
-        Pair<Integer, byte[]> pair = data.get("HDMI-1");
-        assertNotNull(pair);
-        assertThat(pair.getB().length, is(128));
+        Triplet<Integer, byte[], Boolean> triplet = data.get("HDMI-1");
+        assertNotNull(triplet);
+        assertThat(triplet.getB().length, is(128));
+        assertThat(triplet.getC(), is(true)); // HDMI-1 is marked primary
     }
 
     @Test
     void testGetDisplayDataLegacyRandrEdidProperty() {
         // randrproto before 1.3 named the conventional property RANDR_EDID
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrWithEdidProperty("RANDR_EDID:"));
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrWithEdidProperty("RANDR_EDID:"));
         assertThat(data.size(), is(1));
-        Pair<Integer, byte[]> pair = data.get("HDMI-1");
-        assertNotNull(pair);
-        assertThat(pair.getB().length, is(128));
+        Triplet<Integer, byte[], Boolean> triplet = data.get("HDMI-1");
+        assertNotNull(triplet);
+        assertThat(triplet.getB().length, is(128));
+        assertThat(triplet.getC(), is(true)); // HDMI-1 is marked primary
     }
 
     @Test
     void testGetDisplayDataIgnoresOtherEdidNamedProperties() {
         // A property whose name merely contains EDID must not start an EDID block
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrWithEdidProperty("EDID_HASH:"));
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrWithEdidProperty("EDID_HASH:"));
         assertThat(data.isEmpty(), is(true));
     }
 
     @Test
     void testFindOutputNameByConnectorId() {
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
         // A connector ID match wins even though the EDID passed here belongs to no display
         assertThat(Xrandr.findOutputName(data, 96, new byte[0]), is(Optional.of("DP2")));
     }
 
     @Test
     void testFindOutputNameByEdid() {
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
-        Pair<Integer, byte[]> hdmi1 = data.get("HDMI1");
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        Triplet<Integer, byte[], Boolean> hdmi1 = data.get("HDMI1");
         assertNotNull(hdmi1);
         // HDMI1 has no connector ID in xrandr, so only the EDID can identify it
         assertThat(Xrandr.findOutputName(data, -1, hdmi1.getB()), is(Optional.of("HDMI1")));
@@ -275,15 +284,15 @@ class XrandrTest {
 
     @Test
     void testFindOutputNameFallsBackToEdidWhenConnectorIdIsUnmatched() {
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
-        Pair<Integer, byte[]> dp2 = data.get("DP2");
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        Triplet<Integer, byte[], Boolean> dp2 = data.get("DP2");
         assertNotNull(dp2);
         assertThat(Xrandr.findOutputName(data, 1234, dp2.getB()), is(Optional.of("DP2")));
     }
 
     @Test
     void testFindOutputNameNoMatch() {
-        Map<String, Pair<Integer, byte[]>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
         byte[] unknownEdid = new byte[128];
         Arrays.fill(unknownEdid, (byte) 0x5A);
         assertThat(Xrandr.findOutputName(data, 1234, unknownEdid).isPresent(), is(false));
@@ -292,6 +301,36 @@ class XrandrTest {
     @Test
     void testFindOutputNameEmptyData() {
         assertThat(Xrandr.findOutputName(Collections.emptyMap(), 96, new byte[128]).isPresent(), is(false));
+    }
+
+    @Test
+    void testFindPrimaryStatusByConnectorId() {
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        // A connector ID match returns the primary status
+        assertThat(Xrandr.findPrimaryStatus(data, 96, new byte[0]), is(true)); // DP2 is primary
+        assertThat(Xrandr.findPrimaryStatus(data, 80, new byte[0]), is(false)); // HDMI1 is not primary
+    }
+
+    @Test
+    void testFindPrimaryStatusByEdid() {
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        Triplet<Integer, byte[], Boolean> hdmi1 = data.get("HDMI1");
+        assertNotNull(hdmi1);
+        // HDMI1 has no connector ID in xrandr, so only the EDID can identify it
+        assertThat(Xrandr.findPrimaryStatus(data, -1, hdmi1.getB()), is(false)); // HDMI1 is not primary
+    }
+
+    @Test
+    void testFindPrimaryStatusNoMatch() {
+        Map<String, Triplet<Integer, byte[], Boolean>> data = Xrandr.getDisplayData(createXrandrTwoDisplays());
+        byte[] unknownEdid = new byte[128];
+        Arrays.fill(unknownEdid, (byte) 0x5A);
+        assertThat(Xrandr.findPrimaryStatus(data, 1234, unknownEdid), is(false));
+    }
+
+    @Test
+    void testFindPrimaryStatusEmptyData() {
+        assertThat(Xrandr.findPrimaryStatus(Collections.emptyMap(), 96, new byte[128]), is(false));
     }
 
     @Nested

--- a/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/CoreGraphicsFunctions.java
+++ b/oshi-core-ffm/src/main/java/oshi/ffm/platform/mac/CoreGraphicsFunctions.java
@@ -70,6 +70,24 @@ public final class CoreGraphicsFunctions extends MacForeignFunctions {
         return (int) CGDisplayIsBuiltin.invokeExact(display);
     }
 
+    // boolean CGDisplayIsMain(CGDirectDisplayID display);
+
+    private static final MethodHandle CGDisplayIsMain = LINKER
+            .downcallHandle(CORE_GRAPHICS.findOrThrow("CGDisplayIsMain"), FunctionDescriptor.of(JAVA_INT, JAVA_INT));
+
+    public static int CGDisplayIsMain(int display) throws Throwable {
+        return (int) CGDisplayIsMain.invokeExact(display);
+    }
+
+    // uint32_t CGDisplayVendorNumber(CGDirectDisplayID display);
+
+    private static final MethodHandle CGDisplayVendorNumber = LINKER.downcallHandle(
+            CORE_GRAPHICS.findOrThrow("CGDisplayVendorNumber"), FunctionDescriptor.of(JAVA_INT, JAVA_INT));
+
+    public static int CGDisplayVendorNumber(int display) throws Throwable {
+        return (int) CGDisplayVendorNumber.invokeExact(display);
+    }
+
     // uint32_t CGDisplayModelNumber(CGDirectDisplayID display);
 
     private static final MethodHandle CGDisplayModelNumber = LINKER.downcallHandle(
@@ -98,5 +116,14 @@ public final class CoreGraphicsFunctions extends MacForeignFunctions {
 
     public static MemorySegment CGDisplayScreenSize(SegmentAllocator allocator, int display) throws Throwable {
         return (MemorySegment) CGDisplayScreenSize.invokeExact(allocator, display);
+    }
+
+    // CGDirectDisplayID CGMainDisplayID();
+
+    private static final MethodHandle CGMainDisplayID = LINKER.downcallHandle(CORE_GRAPHICS.findOrThrow("CGMainDisplayID"),
+            FunctionDescriptor.of(JAVA_INT));
+
+    public static int CGMainDisplayID() throws Throwable {
+        return (int) CGMainDisplayID.invokeExact();
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/mac/MacDisplayFFM.java
@@ -43,20 +43,50 @@ final class MacDisplayFFM extends AbstractDisplay {
     private static final Logger LOG = LoggerFactory.getLogger(MacDisplayFFM.class);
 
     private final String devicePort;
+    private final boolean primary;
+
+    /**
+     * Value object holding the CoreGraphics main display identity for correlating IOKit-enumerated external displays.
+     */
+    private static final class MainDisplayIdentity {
+        private final boolean valid;
+        private final boolean ambiguous;
+        private final int vendor;
+        private final int product;
+        private final int serial;
+
+        MainDisplayIdentity(boolean valid, boolean ambiguous, int vendor, int product, int serial) {
+            this.valid = valid;
+            this.ambiguous = ambiguous;
+            this.vendor = vendor;
+            this.product = product;
+            this.serial = serial;
+        }
+    }
 
     MacDisplayFFM(byte[] edid) {
-        this(edid, Constants.UNKNOWN);
+        this(edid, Constants.UNKNOWN, false);
     }
 
     MacDisplayFFM(byte[] edid, String devicePort) {
+        this(edid, devicePort, false);
+    }
+
+    MacDisplayFFM(byte[] edid, String devicePort, boolean primary) {
         super(edid);
         this.devicePort = devicePort;
+        this.primary = primary;
         LOG.debug("Initialized MacDisplayFFM");
     }
 
     MacDisplayFFM(DisplayInfo displayInfo, String devicePort) {
+        this(displayInfo, devicePort, false);
+    }
+
+    MacDisplayFFM(DisplayInfo displayInfo, String devicePort, boolean primary) {
         super(displayInfo);
         this.devicePort = devicePort;
+        this.primary = primary;
         LOG.debug("Initialized MacDisplayFFM (synthetic)");
     }
 
@@ -65,20 +95,52 @@ final class MacDisplayFFM extends AbstractDisplay {
         return this.devicePort;
     }
 
+    @Override
+    public boolean isPrimary() {
+        return this.primary;
+    }
+
     public static List<Display> getDisplays() {
+        int mainDisplayId = ExceptionUtil.getIntOrDefault(() -> CoreGraphicsFunctions.CGMainDisplayID(), -1, LOG,
+                "Failed to get main display ID");
+        MainDisplayIdentity mainIdentity = getMainDisplayIdentity(mainDisplayId);
         List<Display> displays = new ArrayList<>();
         // Intel: real EDID exposed under IODisplayConnect (returns nothing on Apple Silicon). No port name available.
-        displays.addAll(getDisplaysFromService("IODisplayConnect", "IODisplayEDID", "IOService", null));
+        displays.addAll(getDisplaysFromService("IODisplayConnect", "IODisplayEDID", "IOService", null, mainIdentity));
         // Apple Silicon external monitors: same stripped EDID as Intel path, plus the port from TransportDescription.
         displays.addAll(
-                getDisplaysFromService("IOPortTransportStateDisplayPort", "EDID", null, "TransportDescription"));
+                getDisplaysFromService("IOPortTransportStateDisplayPort", "EDID", null, "TransportDescription",
+                        mainIdentity));
         // Apple Silicon built-in panel: no real EDID exposed, synthesize from DisplayAttributes.
-        displays.addAll(getAppleSiliconBuiltInDisplay());
+        displays.addAll(getAppleSiliconBuiltInDisplay(mainDisplayId));
         return displays;
     }
 
+    /**
+     * Gets the CoreGraphics main display identity for correlating IOKit-enumerated external displays.
+     *
+     * @param mainDisplayId The CGDirectDisplayID of the main display, or -1 if unavailable
+     * @return A MainDisplayIdentity object containing the main display's vendor/product/serial and validity/ambiguity
+     *         flags
+     */
+    private static MainDisplayIdentity getMainDisplayIdentity(int mainDisplayId) {
+        if (mainDisplayId < 0) {
+            return new MainDisplayIdentity(false, false, 0, 0, 0);
+        }
+        try {
+            int vendor = CoreGraphicsFunctions.CGDisplayVendorNumber(mainDisplayId);
+            int product = CoreGraphicsFunctions.CGDisplayModelNumber(mainDisplayId);
+            int serial = CoreGraphicsFunctions.CGDisplaySerialNumber(mainDisplayId);
+            boolean ambiguous = countDisplaysWithIdentity(vendor, product, serial) > 1;
+            return new MainDisplayIdentity(true, ambiguous, vendor, product, serial);
+        } catch (Throwable t) {
+            LOG.debug("Failed to get main display identity", t);
+            return new MainDisplayIdentity(false, false, 0, 0, 0);
+        }
+    }
+
     private static List<Display> getDisplaysFromService(String serviceName, String edidKeyName,
-            @Nullable String childEntryName, @Nullable String portKeyName) {
+            @Nullable String childEntryName, @Nullable String portKeyName, MainDisplayIdentity mainIdentity) {
         List<Display> displays = new ArrayList<>();
         IOIterator serviceIterator = IOKitUtilFFM.getMatchingServices(serviceName);
         if (serviceIterator == null) {
@@ -104,7 +166,14 @@ final class MacDisplayFFM extends AbstractDisplay {
                                             : propertySource.getStringProperty(portKeyName);
                                     String devicePort = ParseUtil
                                             .getStringValueOrUnknown(ParseUtil.getStringBefore(transport, '/'));
-                                    displays.add(new MacDisplayFFM(bytes, devicePort));
+                                    // Correlate EDID identity with the CoreGraphics main display identity.
+                                    boolean primary = false;
+                                    if (mainIdentity.valid && !mainIdentity.ambiguous) {
+                                        primary = EdidUtil.getVendorNumber(bytes) == mainIdentity.vendor
+                                                && EdidUtil.getProductNumber(bytes) == mainIdentity.product
+                                                && EdidUtil.getSerialNumber(bytes) == mainIdentity.serial;
+                                    }
+                                    displays.add(new MacDisplayFFM(bytes, devicePort, primary));
                                 }
                             }
                         }
@@ -126,9 +195,10 @@ final class MacDisplayFFM extends AbstractDisplay {
      * {@code IOPortTransportStateDisplayPort} with their real EDID); only the built-in panel, which has no physical
      * EDID EPROM, is synthesized from {@code DisplayAttributes}.
      *
+     * @param mainDisplayId the CGDirectDisplayID of the main display, or -1 if unavailable
      * @return A list containing the built-in display, or empty if not found
      */
-    private static List<Display> getAppleSiliconBuiltInDisplay() {
+    private static List<Display> getAppleSiliconBuiltInDisplay(int mainDisplayId) {
         List<Display> displays = new ArrayList<>();
         IOIterator iter = IOKitUtilFFM.getMatchingServices("IOMobileFramebuffer");
         if (iter == null) {
@@ -140,7 +210,7 @@ final class MacDisplayFFM extends AbstractDisplay {
             IORegistryEntry fb = iter.next();
             while (fb != null) {
                 try (IORegistryEntry current = fb) {
-                    addBuiltInDisplay(current, cfExternal, cfAttrs, displays);
+                    addBuiltInDisplay(current, cfExternal, cfAttrs, displays, mainDisplayId);
                 }
                 fb = iter.next();
             }
@@ -151,7 +221,7 @@ final class MacDisplayFFM extends AbstractDisplay {
     // Synthesizes a display for the built-in panel from its DisplayAttributes dictionary. External framebuffer nodes
     // (marked with "external" = true) are skipped, as are idle pipes with no DisplayAttributes.
     private static void addBuiltInDisplay(IORegistryEntry fb, CFStringRef cfExternal, CFStringRef cfAttrs,
-            List<Display> displays) {
+            List<Display> displays, int mainDisplayId) {
         // Skip external monitors — they are already enumerated via IOPortTransportStateDisplayPort.
         MemorySegment externalRaw = fb.createCFProperty(cfExternal.segment());
         if (externalRaw != null && !externalRaw.equals(MemorySegment.NULL)) {
@@ -180,7 +250,16 @@ final class MacDisplayFFM extends AbstractDisplay {
         try (CFDictionaryRef attrs = new CFDictionaryRef(attrsRaw)) {
             DisplayInfo info = synthesize(fb, attrs, devicePort);
             if (info != null) {
-                displays.add(new MacDisplayFFM(info, devicePort));
+                int builtInId = findBuiltInDisplayId();
+                boolean primary = false;
+                if (builtInId >= 0) {
+                    try {
+                        primary = CoreGraphicsFunctions.CGDisplayIsMain(builtInId) != 0;
+                    } catch (Throwable t) {
+                        LOG.debug("Failed to query CGDisplayIsMain for built-in display", t);
+                    }
+                }
+                displays.add(new MacDisplayFFM(info, devicePort, primary));
             }
         }
     }
@@ -312,5 +391,35 @@ final class MacDisplayFFM extends AbstractDisplay {
             }
         }
         return null;
+    }
+
+    // Counts how many active CoreGraphics displays share the given (vendor, product, serial) identity.
+    private static int countDisplaysWithIdentity(int vendor, int product, int serial) {
+        return ExceptionUtil.getIntOrDefault(() -> {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment countSeg = arena.allocate(ValueLayout.JAVA_INT);
+                if (CoreGraphicsFunctions.CGGetActiveDisplayList(0, MemorySegment.NULL, countSeg) != 0) {
+                    return 0;
+                }
+                int count = countSeg.get(ValueLayout.JAVA_INT, 0);
+                if (count == 0) {
+                    return 0;
+                }
+                MemorySegment idsSeg = arena.allocate(ValueLayout.JAVA_INT, count);
+                if (CoreGraphicsFunctions.CGGetActiveDisplayList(count, idsSeg, countSeg) != 0) {
+                    return 0;
+                }
+                int matches = 0;
+                for (int i = 0; i < count; i++) {
+                    int id = idsSeg.getAtIndex(ValueLayout.JAVA_INT, i);
+                    if (CoreGraphicsFunctions.CGDisplayVendorNumber(id) == vendor
+                            && CoreGraphicsFunctions.CGDisplayModelNumber(id) == product
+                            && CoreGraphicsFunctions.CGDisplaySerialNumber(id) == serial) {
+                        matches++;
+                    }
+                }
+                return matches;
+            }
+        }, 0, LOG, "Failed to count displays with identity");
     }
 }

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsDisplayFFM.java
@@ -15,9 +15,11 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -55,20 +57,45 @@ final class WindowsDisplayFFM extends AbstractDisplay {
     private static final int QDC_ATTEMPTS = 3;
 
     private final String devicePort;
+    private final boolean primary;
+
+    /**
+     * Value object holding the results of a CCD display configuration query: the connector-name map and the set of
+     * normalized monitor device paths that belong to the Windows primary display (source mode position 0,0).
+     */
+    private static final class DisplayConfig {
+        private final Map<String, String> portByPath;
+        private final Set<String> primaryPaths;
+
+        DisplayConfig(Map<String, String> portByPath, Set<String> primaryPaths) {
+            this.portByPath = portByPath;
+            this.primaryPaths = primaryPaths;
+        }
+    }
 
     WindowsDisplayFFM(byte[] edid) {
-        this(edid, Constants.UNKNOWN);
+        this(edid, Constants.UNKNOWN, false);
     }
 
     WindowsDisplayFFM(byte[] edid, String devicePort) {
+        this(edid, devicePort, false);
+    }
+
+    WindowsDisplayFFM(byte[] edid, String devicePort, boolean primary) {
         super(edid);
         this.devicePort = devicePort;
+        this.primary = primary;
         LOG.debug("Initialized WindowsDisplayFFM");
     }
 
     @Override
     public String getDevicePort() {
         return this.devicePort;
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return this.primary;
     }
 
     /**
@@ -83,8 +110,8 @@ final class WindowsDisplayFFM extends AbstractDisplay {
             MemorySegment guidSeg = arena.allocate(16);
             guidSeg.copyFrom(MemorySegment.ofArray(GUID_DEVINTERFACE_MONITOR));
 
-            // Map every active connector's device interface path to its connector name.
-            Map<String, String> portByPath = queryConnectorPorts(arena);
+            // Query the CCD display configuration for connector names and primary display identity.
+            DisplayConfig config = queryDisplayConfig(arena);
 
             Optional<MemorySegment> hDevInfoOpt = SetupApiFFM.SetupDiGetClassDevs(guidSeg,
                     SetupApiFFM.DIGCF_PRESENT | SetupApiFFM.DIGCF_DEVICEINTERFACE);
@@ -112,10 +139,14 @@ final class WindowsDisplayFFM extends AbstractDisplay {
                     }
                     // wrapped only to release the native handle on close
                     try (var _ = NativeHandle.of(key, Advapi32FFM::RegCloseKey)) {
-                        byte @Nullable [] edid = queryEdidFromKey(key, edidName, arena);
+                        byte[] edid = queryEdidFromKey(key, edidName, arena);
                         if (edid != null) {
-                            String port = lookupPort(hDevInfo, devInfoData, guidSeg, did, portByPath, arena);
-                            displays.add(new WindowsDisplayFFM(edid, port));
+                            String path = getDeviceInterfacePath(hDevInfo, devInfoData, guidSeg, did, arena);
+                            String normalizedPath = path != null ? DisplayConnector.normalizePath(path)
+                                    : Constants.UNKNOWN;
+                            String port = config.portByPath.getOrDefault(normalizedPath, Constants.UNKNOWN);
+                            boolean primary = config.primaryPaths.contains(normalizedPath);
+                            displays.add(new WindowsDisplayFFM(edid, port, primary));
                         }
                     }
                 }
@@ -146,53 +177,50 @@ final class WindowsDisplayFFM extends AbstractDisplay {
         }, null, LOG, "Failed to read EDID from registry");
     }
 
-    // Resolves the connector name for the current device by fetching its device interface path and looking it up in the
-    // CCD-derived map. Returns the sentinel if the interface or path cannot be obtained.
-    private static String lookupPort(MemorySegment hDevInfo, MemorySegment devInfoData, MemorySegment guidSeg,
-            MemorySegment did, Map<String, String> portByPath, Arena arena) {
+    // Obtains the device interface path for the current device: enumerates the monitor interface, then reads the path.
+    // Returns null if the interface or path cannot be obtained.
+    private static @Nullable String getDeviceInterfacePath(MemorySegment hDevInfo, MemorySegment devInfoData,
+            MemorySegment guidSeg, MemorySegment did, Arena arena) {
         did.fill((byte) 0);
         did.set(JAVA_INT, 0, (int) SP_DEVICE_INTERFACE_DATA.byteSize());
         if (SetupApiFFM.SetupDiEnumDeviceInterfaces(hDevInfo, devInfoData, guidSeg, 0, did) != 1) {
-            return Constants.UNKNOWN;
+            return null;
         }
         int size = SetupApiFFM.SetupDiGetDeviceInterfaceDetailSize(hDevInfo, did, arena);
         if (size <= 0) {
-            return Constants.UNKNOWN;
+            return null;
         }
-        Optional<String> path = SetupApiFFM.SetupDiGetDeviceInterfaceDetail(hDevInfo, did, size, arena);
-        if (!path.isPresent()) {
-            return Constants.UNKNOWN;
-        }
-        return portByPath.getOrDefault(DisplayConnector.normalizePath(path.get()), Constants.UNKNOWN);
+        return SetupApiFFM.SetupDiGetDeviceInterfaceDetail(hDevInfo, did, size, arena).orElse(null);
     }
 
-    // Builds a map from normalized monitor device interface path to connector name, from the CCD active paths. A
-    // topology change between sizing and querying the buffers makes QueryDisplayConfig fail with
+    // Builds a DisplayConfig from the CCD active paths, containing both the connector-name map and the set of primary
+    // device paths. A topology change between sizing and querying the buffers makes QueryDisplayConfig fail with
     // ERROR_INSUFFICIENT_BUFFER, which is retryable by re-sizing.
-    private static Map<String, String> queryConnectorPorts(Arena arena) {
+    private static DisplayConfig queryDisplayConfig(Arena arena) {
         for (int attempt = 0; attempt < QDC_ATTEMPTS; attempt++) {
-            Map<String, String> map = queryConnectorPortsOnce(arena);
-            if (map != null) {
-                return map;
+            DisplayConfig config = queryDisplayConfigOnce(arena);
+            if (config != null) {
+                return config;
             }
         }
         LOG.debug("Display configuration kept changing; unable to map connectors.");
-        return new HashMap<>();
+        return new DisplayConfig(new HashMap<>(), new HashSet<>());
     }
 
     // Returns null if the buffers were too small and the caller should re-size and retry.
-    private static @Nullable Map<String, String> queryConnectorPortsOnce(Arena arena) {
-        Map<String, String> map = new HashMap<>();
+    private static @Nullable DisplayConfig queryDisplayConfigOnce(Arena arena) {
+        Map<String, String> portMap = new HashMap<>();
+        Set<String> primaryPaths = new HashSet<>();
         MemorySegment numPaths = arena.allocate(JAVA_INT);
         MemorySegment numModes = arena.allocate(JAVA_INT);
         if (User32FFM.GetDisplayConfigBufferSizes(DisplayConnector.QDC_ONLY_ACTIVE_PATHS, numPaths,
                 numModes) != ERROR_SUCCESS) {
-            return map;
+            return new DisplayConfig(portMap, primaryPaths);
         }
         int pathCount = numPaths.get(JAVA_INT, 0);
         int modeCount = numModes.get(JAVA_INT, 0);
         if (pathCount <= 0) {
-            return map;
+            return new DisplayConfig(portMap, primaryPaths);
         }
         MemorySegment paths = arena.allocate((long) pathCount * DisplayConnector.PATH_INFO_SIZE);
         MemorySegment modes = arena.allocate(Math.max(1L, (long) modeCount * DisplayConnector.MODE_INFO_SIZE));
@@ -202,9 +230,10 @@ final class WindowsDisplayFFM extends AbstractDisplay {
             return null;
         }
         if (rc != ERROR_SUCCESS) {
-            return map;
+            return new DisplayConfig(portMap, primaryPaths);
         }
         int actualPaths = numPaths.get(JAVA_INT, 0);
+        int actualModes = numModes.get(JAVA_INT, 0);
         for (int i = 0; i < actualPaths; i++) {
             long base = (long) i * DisplayConnector.PATH_INFO_SIZE;
             int flags = paths.get(JAVA_INT, base + DisplayConnector.PATH_FLAGS_OFFSET);
@@ -213,13 +242,34 @@ final class WindowsDisplayFFM extends AbstractDisplay {
             }
             long adapterId = paths.get(JAVA_LONG_UNALIGNED, base + DisplayConnector.PATH_TARGET_ADAPTER_ID_OFFSET);
             int targetId = paths.get(JAVA_INT, base + DisplayConnector.PATH_TARGET_ID_OFFSET);
-            addConnector(map, arena, adapterId, targetId);
+            // Check whether this path's source mode is at desktop position (0, 0), which Windows
+            // defines as the primary display.
+            boolean primaryPath = isSourceAtOrigin(paths, base, modes, actualModes);
+            addConnector(portMap, primaryPaths, arena, adapterId, targetId, primaryPath);
         }
-        return map;
+        return new DisplayConfig(portMap, primaryPaths);
     }
 
-    // Fetches one target's DISPLAYCONFIG_TARGET_DEVICE_NAME and records its device path -> connector name.
-    private static void addConnector(Map<String, String> map, Arena arena, long adapterId, int targetId) {
+    // Returns true if the source mode for the given path has desktop position (0, 0).
+    private static boolean isSourceAtOrigin(MemorySegment paths, long pathBase, MemorySegment modes, int modeCount) {
+        int modeIdx = paths.get(JAVA_INT, pathBase + DisplayConnector.PATH_SOURCE_MODE_IDX_OFFSET);
+        if (modeIdx < 0 || modeIdx >= modeCount) {
+            return false;
+        }
+        long modeBase = (long) modeIdx * DisplayConnector.MODE_INFO_SIZE;
+        int infoType = modes.get(JAVA_INT, modeBase + DisplayConnector.MODE_INFO_TYPE_OFFSET);
+        if (infoType != DisplayConnector.MODE_INFO_TYPE_SOURCE) {
+            return false;
+        }
+        int posX = modes.get(JAVA_INT, modeBase + DisplayConnector.SOURCE_MODE_POSITION_X_OFFSET);
+        int posY = modes.get(JAVA_INT, modeBase + DisplayConnector.SOURCE_MODE_POSITION_Y_OFFSET);
+        return posX == 0 && posY == 0;
+    }
+
+    // Fetches one target's DISPLAYCONFIG_TARGET_DEVICE_NAME and records its device path -> connector name. If
+    // primaryPath is true, the normalized device path is also added to the primary set.
+    private static void addConnector(Map<String, String> portMap, Set<String> primaryPaths, Arena arena, long adapterId,
+            int targetId, boolean primaryPath) {
         MemorySegment tdn = arena.allocate(DisplayConnector.TARGET_DEVICE_NAME_SIZE);
         tdn.set(JAVA_INT, 0, DisplayConnector.DEVICE_INFO_GET_TARGET_NAME);
         tdn.set(JAVA_INT, DisplayConnector.TDN_HEADER_SIZE_OFFSET, DisplayConnector.TARGET_DEVICE_NAME_SIZE);
@@ -233,7 +283,10 @@ final class WindowsDisplayFFM extends AbstractDisplay {
         String path = readWideString(tdn.asSlice(DisplayConnector.TDN_MONITOR_DEVICE_PATH_OFFSET));
         String key = DisplayConnector.normalizePath(path);
         if (!Constants.UNKNOWN.equals(key)) {
-            map.put(key, DisplayConnector.connectorName(outputTechnology, connectorInstance));
+            portMap.put(key, DisplayConnector.connectorName(outputTechnology, connectorInstance));
+            if (primaryPath) {
+                primaryPaths.add(key);
+            }
         }
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/mac/MacDisplayJNA.java
@@ -53,6 +53,26 @@ final class MacDisplayJNA extends AbstractDisplay {
     private static final CFIndex K_CF_NUMBER_SINT64 = new CFIndex(4);
 
     private final String devicePort;
+    private final boolean primary;
+
+    /**
+     * Value object holding the CoreGraphics main display identity for correlating IOKit-enumerated external displays.
+     */
+    private static final class MainDisplayIdentity {
+        private final boolean valid;
+        private final boolean ambiguous;
+        private final int vendor;
+        private final int product;
+        private final int serial;
+
+        MainDisplayIdentity(boolean valid, boolean ambiguous, int vendor, int product, int serial) {
+            this.valid = valid;
+            this.ambiguous = ambiguous;
+            this.vendor = vendor;
+            this.product = product;
+            this.serial = serial;
+        }
+    }
 
     /**
      * Constructor for MacDisplayJNA from a real EDID byte array.
@@ -60,7 +80,7 @@ final class MacDisplayJNA extends AbstractDisplay {
      * @param edid a byte array representing a display EDID
      */
     MacDisplayJNA(byte[] edid) {
-        this(edid, Constants.UNKNOWN);
+        this(edid, Constants.UNKNOWN, false);
     }
 
     /**
@@ -70,8 +90,20 @@ final class MacDisplayJNA extends AbstractDisplay {
      * @param devicePort the device port this display is attached to
      */
     MacDisplayJNA(byte[] edid, String devicePort) {
+        this(edid, devicePort, false);
+    }
+
+    /**
+     * Constructor for MacDisplayJNA from a real EDID byte array with a device port and primary status.
+     *
+     * @param edid       a byte array representing a display EDID
+     * @param devicePort the device port this display is attached to
+     * @param primary    whether this display is the primary display
+     */
+    MacDisplayJNA(byte[] edid, String devicePort, boolean primary) {
         super(edid);
         this.devicePort = devicePort;
+        this.primary = primary;
         LOG.debug("Initialized MacDisplayJNA");
     }
 
@@ -83,8 +115,20 @@ final class MacDisplayJNA extends AbstractDisplay {
      * @param devicePort  the device port this display is attached to
      */
     MacDisplayJNA(DisplayInfo displayInfo, String devicePort) {
+        this(displayInfo, devicePort, false);
+    }
+
+    /**
+     * Constructor for MacDisplayJNA from a synthetic {@link DisplayInfo} with primary status.
+     *
+     * @param displayInfo the synthesized display info
+     * @param devicePort  the device port this display is attached to
+     * @param primary     whether this display is the primary display
+     */
+    MacDisplayJNA(DisplayInfo displayInfo, String devicePort, boolean primary) {
         super(displayInfo);
         this.devicePort = devicePort;
+        this.primary = primary;
         LOG.debug("Initialized MacDisplayJNA (synthetic)");
     }
 
@@ -93,21 +137,57 @@ final class MacDisplayJNA extends AbstractDisplay {
         return this.devicePort;
     }
 
+    @Override
+    public boolean isPrimary() {
+        return this.primary;
+    }
+
     /**
      * Gets Display Information
      *
      * @return An array of Display objects representing monitors, etc.
      */
     public static List<Display> getDisplays() {
+        // Get the main display ID from CoreGraphics
+        int mainDisplayId = ExceptionUtil.getIntOrDefault(CoreGraphics.INSTANCE::CGMainDisplayID, -1, LOG,
+                "Failed to get main display ID");
+        // Identity of the CoreGraphics main display for correlating IOKit-enumerated external displays.
+        MainDisplayIdentity mainIdentity = getMainDisplayIdentity(mainDisplayId);
+
         List<Display> displays = new ArrayList<>();
         // Intel: real EDID exposed under IODisplayConnect (returns nothing on Apple Silicon). No port name available.
-        displays.addAll(getDisplaysFromService("IODisplayConnect", "IODisplayEDID", "IOService", null));
+        displays.addAll(getDisplaysFromService("IODisplayConnect", "IODisplayEDID", "IOService", null, mainIdentity));
         // Apple Silicon external monitors: same stripped EDID as Intel path, plus the port from TransportDescription.
         displays.addAll(
-                getDisplaysFromService("IOPortTransportStateDisplayPort", "EDID", null, "TransportDescription"));
+                getDisplaysFromService("IOPortTransportStateDisplayPort", "EDID", null, "TransportDescription",
+                        mainIdentity));
         // Apple Silicon built-in panel: no real EDID exposed, synthesize from DisplayAttributes.
-        displays.addAll(getAppleSiliconBuiltInDisplay());
+        displays.addAll(getAppleSiliconBuiltInDisplay(mainDisplayId));
         return displays;
+    }
+
+    /**
+     * Gets the CoreGraphics main display identity for correlating IOKit-enumerated external displays.
+     *
+     * @param mainDisplayId The CGDirectDisplayID of the main display, or -1 if unavailable
+     * @return A MainDisplayIdentity object containing the main display's vendor/product/serial and validity/ambiguity
+     *         flags
+     */
+    private static MainDisplayIdentity getMainDisplayIdentity(int mainDisplayId) {
+        if (mainDisplayId < 0) {
+            return new MainDisplayIdentity(false, false, 0, 0, 0);
+        }
+        try {
+            CoreGraphics cg = CoreGraphics.INSTANCE;
+            int vendor = cg.CGDisplayVendorNumber(mainDisplayId);
+            int product = cg.CGDisplayModelNumber(mainDisplayId);
+            int serial = cg.CGDisplaySerialNumber(mainDisplayId);
+            boolean ambiguous = countDisplaysWithIdentity(cg, vendor, product, serial) > 1;
+            return new MainDisplayIdentity(true, ambiguous, vendor, product, serial);
+        } catch (Exception e) {
+            LOG.debug("Failed to get main display identity", e);
+            return new MainDisplayIdentity(false, false, 0, 0, 0);
+        }
     }
 
     /**
@@ -118,10 +198,11 @@ final class MacDisplayJNA extends AbstractDisplay {
      * @param childEntryName The name of the child entry to search in, or null to search directly in the service
      * @param portKeyName    The key name for the port property (e.g. {@code TransportDescription}), or null if the
      *                       service does not expose one
+     * @param mainIdentity   The CoreGraphics main display identity for correlation
      * @return List of Display objects found using this service
      */
     private static List<Display> getDisplaysFromService(String serviceName, String edidKeyName,
-            @Nullable String childEntryName, @Nullable String portKeyName) {
+            @Nullable String childEntryName, @Nullable String portKeyName, MainDisplayIdentity mainIdentity) {
         List<Display> displays = new ArrayList<>();
 
         IOIterator serviceIterator = IOKitUtil.getMatchingServices(serviceName);
@@ -150,7 +231,15 @@ final class MacDisplayJNA extends AbstractDisplay {
                                             : propertySource.getStringProperty(portKeyName);
                                     String devicePort = ParseUtil
                                             .getStringValueOrUnknown(ParseUtil.getStringBefore(transport, '/'));
-                                    displays.add(new MacDisplayJNA(p.getByteArray(0, length), devicePort));
+                                    byte[] edidBytes = p.getByteArray(0, length);
+                                    // Correlate EDID identity with the CoreGraphics main display identity.
+                                    boolean primary = false;
+                                    if (mainIdentity.valid && !mainIdentity.ambiguous) {
+                                        primary = EdidUtil.getVendorNumber(edidBytes) == mainIdentity.vendor
+                                                && EdidUtil.getProductNumber(edidBytes) == mainIdentity.product
+                                                && EdidUtil.getSerialNumber(edidBytes) == mainIdentity.serial;
+                                    }
+                                    displays.add(new MacDisplayJNA(edidBytes, devicePort, primary));
                                 }
                             } finally {
                                 edid.release();
@@ -178,9 +267,10 @@ final class MacDisplayJNA extends AbstractDisplay {
      * already enumerated via {@code IOPortTransportStateDisplayPort} with their real EDID); only the built-in panel,
      * which has no physical EDID EPROM, is synthesized from {@code DisplayAttributes}.
      *
+     * @param mainDisplayId The CGDirectDisplayID of the main display, or -1 if unavailable
      * @return A list containing the built-in display, or empty if not found
      */
-    private static List<Display> getAppleSiliconBuiltInDisplay() {
+    private static List<Display> getAppleSiliconBuiltInDisplay(int mainDisplayId) {
         List<Display> displays = new ArrayList<>();
         IOIterator iter = IOKitUtil.getMatchingServices("IOMobileFramebuffer");
         if (iter == null) {
@@ -192,7 +282,7 @@ final class MacDisplayJNA extends AbstractDisplay {
             IORegistryEntry fb = iter.next();
             while (fb != null) {
                 try {
-                    addBuiltInDisplay(fb, cfExternal, cfAttrs, displays);
+                    addBuiltInDisplay(fb, cfExternal, cfAttrs, displays, mainDisplayId);
                 } finally {
                     fb.release();
                 }
@@ -209,7 +299,7 @@ final class MacDisplayJNA extends AbstractDisplay {
     // Synthesizes a display for the built-in panel from its DisplayAttributes dictionary. External framebuffer nodes
     // (marked with "external" = true) are skipped, as are idle pipes with no DisplayAttributes.
     private static void addBuiltInDisplay(IORegistryEntry fb, CFStringRef cfExternal, CFStringRef cfAttrs,
-            List<Display> displays) {
+            List<Display> displays, int mainDisplayId) {
         // Skip external monitors — they are already enumerated via IOPortTransportStateDisplayPort.
         CFTypeRef externalRef = fb.createCFProperty(cfExternal);
         if (externalRef != null) {
@@ -242,7 +332,16 @@ final class MacDisplayJNA extends AbstractDisplay {
         try {
             DisplayInfo info = synthesize(fb, new CFDictionaryRef(attrsRaw.getPointer()), devicePort);
             if (info != null) {
-                displays.add(new MacDisplayJNA(info, devicePort));
+                int builtInId = findBuiltInDisplayId();
+                boolean primary = false;
+                if (builtInId >= 0) {
+                    try {
+                        primary = CoreGraphics.INSTANCE.CGDisplayIsMain(builtInId) != 0;
+                    } catch (Exception e) {
+                        LOG.debug("Failed to query CGDisplayIsMain for built-in display", e);
+                    }
+                }
+                displays.add(new MacDisplayJNA(info, devicePort, primary));
             }
         } finally {
             attrsRaw.release();
@@ -368,5 +467,25 @@ final class MacDisplayJNA extends AbstractDisplay {
             cfKey.release();
         }
         return null;
+    }
+
+    // Counts how many active CoreGraphics displays share the given (vendor, product, serial) identity.
+    private static int countDisplaysWithIdentity(CoreGraphics cg, int vendor, int product, int serial) {
+        IntByReference count = new IntByReference();
+        if (cg.CGGetActiveDisplayList(0, null, count) != 0 || count.getValue() == 0) {
+            return 0;
+        }
+        int[] displayIds = new int[count.getValue()];
+        if (cg.CGGetActiveDisplayList(displayIds.length, displayIds, count) != 0) {
+            return 0;
+        }
+        int matches = 0;
+        for (int id : displayIds) {
+            if (cg.CGDisplayVendorNumber(id) == vendor && cg.CGDisplayModelNumber(id) == product
+                    && cg.CGDisplaySerialNumber(id) == serial) {
+                matches++;
+            }
+        }
+        return matches;
     }
 }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsDisplayJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsDisplayJNA.java
@@ -6,8 +6,10 @@ package oshi.hardware.platform.windows;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -56,6 +58,21 @@ final class WindowsDisplayJNA extends AbstractDisplay {
     private static final int QDC_ATTEMPTS = 3;
 
     private final String devicePort;
+    private final boolean primary;
+
+    /**
+     * Value object holding the results of a CCD display configuration query: the connector-name map and the set of
+     * normalized monitor device paths that belong to the Windows primary display (source mode position 0,0).
+     */
+    private static final class DisplayConfig {
+        private final Map<String, String> portByPath;
+        private final Set<String> primaryPaths;
+
+        DisplayConfig(Map<String, String> portByPath, Set<String> primaryPaths) {
+            this.portByPath = portByPath;
+            this.primaryPaths = primaryPaths;
+        }
+    }
 
     /**
      * Constructor for WindowsDisplay.
@@ -63,7 +80,7 @@ final class WindowsDisplayJNA extends AbstractDisplay {
      * @param edid a byte array representing a display EDID
      */
     WindowsDisplayJNA(byte[] edid) {
-        this(edid, Constants.UNKNOWN);
+        this(edid, Constants.UNKNOWN, false);
     }
 
     /**
@@ -73,14 +90,31 @@ final class WindowsDisplayJNA extends AbstractDisplay {
      * @param devicePort the connector this display is attached to
      */
     WindowsDisplayJNA(byte[] edid, String devicePort) {
+        this(edid, devicePort, false);
+    }
+
+    /**
+     * Constructor for WindowsDisplay with a device port and primary status.
+     *
+     * @param edid       a byte array representing a display EDID
+     * @param devicePort the connector this display is attached to
+     * @param primary    whether this display is the primary display
+     */
+    WindowsDisplayJNA(byte[] edid, String devicePort, boolean primary) {
         super(edid);
         this.devicePort = devicePort;
+        this.primary = primary;
         LOG.debug("Initialized WindowsDisplay");
     }
 
     @Override
     public String getDevicePort() {
         return this.devicePort;
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return this.primary;
     }
 
     /**
@@ -91,8 +125,8 @@ final class WindowsDisplayJNA extends AbstractDisplay {
     public static List<Display> getDisplays() {
         List<Display> displays = new ArrayList<>();
 
-        // Map every active connector's device interface path to its connector name (e.g. "HDMI", "DisplayPort-1").
-        Map<String, String> portByPath = queryConnectorPorts();
+        // Query the CCD display configuration for connector names and primary display identity.
+        DisplayConfig config = queryDisplayConfig();
 
         HANDLE hDevInfo = SU.SetupDiGetClassDevs(GUID_DEVINTERFACE_MONITOR, null, null,
                 SetupApi.DIGCF_PRESENT | SetupApi.DIGCF_DEVICEINTERFACE);
@@ -114,8 +148,12 @@ final class WindowsDisplayJNA extends AbstractDisplay {
                                 edid = new byte[lpcbData.getValue()];
                                 if (ADV.RegQueryValueEx(key, "EDID", 0, pType, edid,
                                         lpcbData) == WinError.ERROR_SUCCESS) {
-                                    String port = lookupPort(hDevInfo, info, deviceInterfaceData, portByPath);
-                                    displays.add(new WindowsDisplayJNA(edid, port));
+                                    String path = getDeviceInterfacePath(hDevInfo, deviceInterfaceData, info);
+                                    String normalizedPath = path != null ? DisplayConnector.normalizePath(path)
+                                            : Constants.UNKNOWN;
+                                    String port = config.portByPath.getOrDefault(normalizedPath, Constants.UNKNOWN);
+                                    boolean primary = config.primaryPaths.contains(normalizedPath);
+                                    displays.add(new WindowsDisplayJNA(edid, port, primary));
                                 }
                             }
                         }
@@ -130,23 +168,19 @@ final class WindowsDisplayJNA extends AbstractDisplay {
         return displays;
     }
 
-    // Resolves the connector name for the current device by fetching its device interface path and looking it up in the
-    // CCD-derived map. Returns the sentinel if the interface or path cannot be obtained.
-    private static String lookupPort(HANDLE hDevInfo, CloseableSpDevinfoData info,
-            CloseableSpDeviceInterfaceData deviceInterfaceData, Map<String, String> portByPath) {
+    // Obtains the device interface path for the current device: enumerates the monitor interface, then reads the path.
+    // Returns null if the interface or path cannot be obtained.
+    private static @Nullable String getDeviceInterfacePath(HANDLE hDevInfo,
+            CloseableSpDeviceInterfaceData deviceInterfaceData, CloseableSpDevinfoData info) {
         if (!SU.SetupDiEnumDeviceInterfaces(hDevInfo, info.getPointer(), GUID_DEVINTERFACE_MONITOR, 0,
                 deviceInterfaceData)) {
-            return Constants.UNKNOWN;
+            return null;
         }
-        String path = getDeviceInterfacePath(hDevInfo, deviceInterfaceData);
-        if (path == null) {
-            return Constants.UNKNOWN;
-        }
-        return portByPath.getOrDefault(DisplayConnector.normalizePath(path), Constants.UNKNOWN);
+        return getDeviceInterfaceDetail(hDevInfo, deviceInterfaceData);
     }
 
     // Two-call SetupDiGetDeviceInterfaceDetail: first for the required size, then to read the device path.
-    private static @Nullable String getDeviceInterfacePath(HANDLE hDevInfo,
+    private static @Nullable String getDeviceInterfaceDetail(HANDLE hDevInfo,
             CloseableSpDeviceInterfaceData deviceInterfaceData) {
         try (CloseableIntByReference requiredSize = new CloseableIntByReference()) {
             SU.SetupDiGetDeviceInterfaceDetail(hDevInfo, deviceInterfaceData, null, 0, requiredSize, null);
@@ -166,34 +200,35 @@ final class WindowsDisplayJNA extends AbstractDisplay {
         return null;
     }
 
-    // Builds a map from normalized monitor device interface path to connector name, from the CCD active paths. A
-    // topology change between sizing and querying the buffers makes QueryDisplayConfig fail with
+    // Builds a DisplayConfig from the CCD active paths, containing both the connector-name map and the set of primary
+    // device paths. A topology change between sizing and querying the buffers makes QueryDisplayConfig fail with
     // ERROR_INSUFFICIENT_BUFFER, which is retryable by re-sizing.
-    private static Map<String, String> queryConnectorPorts() {
+    private static DisplayConfig queryDisplayConfig() {
         User32 u32 = User32.INSTANCE;
         for (int attempt = 0; attempt < QDC_ATTEMPTS; attempt++) {
-            Map<String, String> map = queryConnectorPortsOnce(u32);
-            if (map != null) {
-                return map;
+            DisplayConfig config = queryDisplayConfigOnce(u32);
+            if (config != null) {
+                return config;
             }
         }
         LOG.debug("Display configuration kept changing; unable to map connectors.");
-        return new HashMap<>();
+        return new DisplayConfig(new HashMap<>(), new HashSet<>());
     }
 
     // Returns null if the buffers were too small and the caller should re-size and retry.
-    private static @Nullable Map<String, String> queryConnectorPortsOnce(User32 u32) {
-        Map<String, String> map = new HashMap<>();
+    private static @Nullable DisplayConfig queryDisplayConfigOnce(User32 u32) {
+        Map<String, String> portMap = new HashMap<>();
+        Set<String> primaryPaths = new HashSet<>();
         try (CloseableIntByReference numPaths = new CloseableIntByReference();
                 CloseableIntByReference numModes = new CloseableIntByReference()) {
             if (u32.GetDisplayConfigBufferSizes(DisplayConnector.QDC_ONLY_ACTIVE_PATHS, numPaths,
                     numModes) != WinError.ERROR_SUCCESS) {
-                return map;
+                return new DisplayConfig(portMap, primaryPaths);
             }
             int pathCount = numPaths.getValue();
             int modeCount = numModes.getValue();
             if (pathCount <= 0) {
-                return map;
+                return new DisplayConfig(portMap, primaryPaths);
             }
             try (Memory paths = new Memory((long) pathCount * DisplayConnector.PATH_INFO_SIZE);
                     Memory modes = new Memory(Math.max(1L, (long) modeCount * DisplayConnector.MODE_INFO_SIZE))) {
@@ -205,9 +240,10 @@ final class WindowsDisplayJNA extends AbstractDisplay {
                     return null;
                 }
                 if (rc != WinError.ERROR_SUCCESS) {
-                    return map;
+                    return new DisplayConfig(portMap, primaryPaths);
                 }
                 int actualPaths = numPaths.getValue();
+                int actualModes = numModes.getValue();
                 for (int i = 0; i < actualPaths; i++) {
                     long base = (long) i * DisplayConnector.PATH_INFO_SIZE;
                     int flags = paths.getInt(base + DisplayConnector.PATH_FLAGS_OFFSET);
@@ -216,15 +252,36 @@ final class WindowsDisplayJNA extends AbstractDisplay {
                     }
                     long adapterId = paths.getLong(base + DisplayConnector.PATH_TARGET_ADAPTER_ID_OFFSET);
                     int targetId = paths.getInt(base + DisplayConnector.PATH_TARGET_ID_OFFSET);
-                    addConnector(map, u32, adapterId, targetId);
+                    // Check whether this path's source mode is at desktop position (0, 0), which Windows
+                    // defines as the primary display.
+                    boolean primaryPath = isSourceAtOrigin(paths, base, modes, actualModes);
+                    addConnector(portMap, primaryPaths, u32, adapterId, targetId, primaryPath);
                 }
             }
         }
-        return map;
+        return new DisplayConfig(portMap, primaryPaths);
     }
 
-    // Fetches one target's DISPLAYCONFIG_TARGET_DEVICE_NAME and records its device path -> connector name.
-    private static void addConnector(Map<String, String> map, User32 u32, long adapterId, int targetId) {
+    // Returns true if the source mode for the given path has desktop position (0, 0).
+    private static boolean isSourceAtOrigin(Memory paths, long pathBase, Memory modes, int modeCount) {
+        int modeIdx = paths.getInt(pathBase + DisplayConnector.PATH_SOURCE_MODE_IDX_OFFSET);
+        if (modeIdx < 0 || modeIdx >= modeCount) {
+            return false;
+        }
+        long modeBase = (long) modeIdx * DisplayConnector.MODE_INFO_SIZE;
+        int infoType = modes.getInt(modeBase + DisplayConnector.MODE_INFO_TYPE_OFFSET);
+        if (infoType != DisplayConnector.MODE_INFO_TYPE_SOURCE) {
+            return false;
+        }
+        int posX = modes.getInt(modeBase + DisplayConnector.SOURCE_MODE_POSITION_X_OFFSET);
+        int posY = modes.getInt(modeBase + DisplayConnector.SOURCE_MODE_POSITION_Y_OFFSET);
+        return posX == 0 && posY == 0;
+    }
+
+    // Fetches one target's DISPLAYCONFIG_TARGET_DEVICE_NAME and records its device path -> connector name. If
+    // primaryPath is true, the normalized device path is also added to the primary set.
+    private static void addConnector(Map<String, String> portMap, Set<String> primaryPaths, User32 u32, long adapterId,
+            int targetId, boolean primaryPath) {
         try (Memory tdn = new Memory(DisplayConnector.TARGET_DEVICE_NAME_SIZE)) {
             tdn.clear();
             tdn.setInt(0, DisplayConnector.DEVICE_INFO_GET_TARGET_NAME);
@@ -239,7 +296,10 @@ final class WindowsDisplayJNA extends AbstractDisplay {
             String key = DisplayConnector
                     .normalizePath(tdn.getWideString(DisplayConnector.TDN_MONITOR_DEVICE_PATH_OFFSET));
             if (!Constants.UNKNOWN.equals(key)) {
-                map.put(key, DisplayConnector.connectorName(outputTechnology, connectorInstance));
+                portMap.put(key, DisplayConnector.connectorName(outputTechnology, connectorInstance));
+                if (primaryPath) {
+                    primaryPaths.add(key);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds a new default method to the Display interface to determine whether a display is the primary display, as defined by the underlying platform.

**Linux**

On systems running an X server, the primary display is determined using the output marked as primary by xrandr.

If the display corresponds to the xrandr primary output, isPrimary() returns true; otherwise, it returns false.

On systems where an X server is not available, isPrimary() defaults to false, since there is no consistent way to determine the primary display from DRM alone.

**macOS**

On macOS, CoreGraphics is used as the authoritative source for determining the main display.

External displays are enumerated through IOKit, so the IOKit display must first be correlated with its corresponding CoreGraphics display. This is done by comparing the display’s numeric manufacturer/vendor ID, product ID, and serial number obtained from its EDID with the values returned by:

* CGDisplayVendorNumber
* CGDisplayModelNumber
* CGDisplaySerialNumber

If these values match the display identified by CoreGraphics as the main display, isPrimary() returns true.

Correlating IOKit and CoreGraphics displays using these identifiers is an established approach because CGDisplayIOServicePort, which previously provided a more direct mapping, is deprecated:

https://stackoverflow.com/questions/20025868/cgdisplayioserviceport-is-deprecated-in-os-x-10-9-how-to-replace

For the Apple Silicon built-in display, where the CGDirectDisplayID can already be identified directly, CGDisplayIsMain is used instead of EDID correlation.

Ambiguity handling: If multiple active displays have the same vendor, product, and serial-number combination, the mapping cannot be determined reliably. In this case, the displays are treated as ambiguous and isPrimary() returns false rather than potentially marking the wrong display as primary.

**Windows**

On Windows, the primary display is determined using the CCD (QueryDisplayConfig) topology.

Windows defines the primary desktop source as the source whose desktop position is (0, 0), as demonstrated in Microsoft’s CCD example:

https://learn.microsoft.com/en-us/windows-hardware/drivers/display/ccd-example-code

The correlation flow is:

QueryDisplayConfig
→ find the active source whose desktop position is (0, 0)
→ obtain its monitorDevicePath
→ normalize the path
→ match it against the monitor device interface path obtained through SetupAPI
→ mark the corresponding WindowsDisplay as primary

This allows the primary status to be associated with the same physical monitor already being enumerated through SetupAPI, without requiring EDID-based correlation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added primary-display detection across Windows, macOS, and Unix systems.
  * Added `isPrimary()` to identify whether a display is the system’s primary display.
  * Improved display identification using vendor, product, serial, connector, and position data.
  * Added EDID accessors for vendor, product, and serial numbers.

* **Bug Fixes**
  * Displays now reliably report primary status, defaulting to false when unavailable.
  * Improved handling of ambiguous or incomplete display information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->