### PR TITLE
Import org.jspecify.annotations optionally in oshi-core and oshi-core-ffm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 7.6.1 (in progress)
 
-* Your contribution here!
+##### Bug Fixes and Improvements
+
+* [#3710](https://github.com/oshi/oshi/pull/3710): Fix the bnd imports for `oshi-core` and `oshi-core-ffm` to make the JSpecify annotations optional, so both bundles resolve in an OSGi container without JSpecify - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.6.0 (2026-08-23)
 

--- a/oshi-common/pom.xml
+++ b/oshi-common/pom.xml
@@ -49,16 +49,8 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-                <configuration>
-                    <bnd><![CDATA[Export-Package: oshi.*;-noimport:=true
-                    Import-Package: io.github.pandalxb.jlibrehardwaremonitor.*;resolution:=optional, org.jspecify.annotations;resolution:=optional, ${osgi.slf4j.import.packages}, *
-                    Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
-                    -snapshot: SNAPSHOT]]></bnd>
-                </configuration>
-            </plugin>
+            <!-- No bnd override: the parent's default instruction (Export-Package: oshi.*) already
+            describes this module exactly. -->
             <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>

--- a/oshi-core-ffm/pom.xml
+++ b/oshi-core-ffm/pom.xml
@@ -100,7 +100,7 @@
                 <artifactId>bnd-maven-plugin</artifactId>
                 <configuration>
                     <bnd><![CDATA[Export-Package: oshi.ffm.*,!oshi.driver.common.*,!oshi.driver.unix.bsd.*,!oshi.driver.unix.freebsd.disk.*,!oshi.driver.unix.solaris.disk.*,oshi.driver.*,oshi.hardware.platform.*,!oshi.software.common.*,oshi.software.os.linux.*,oshi.software.os.mac.*,oshi.software.os.unix.*,oshi.software.os.windows.*;-noimport:=true
-                    Import-Package: ${osgi.slf4j.import.packages}, *
+                    Import-Package: ${osgi.jspecify.import.packages}, ${osgi.slf4j.import.packages}, *
                     Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                     -snapshot: SNAPSHOT
                     -fixupmessages: "The default package"]]></bnd>

--- a/oshi-core/pom.xml
+++ b/oshi-core/pom.xml
@@ -151,7 +151,7 @@
                 <artifactId>bnd-maven-plugin</artifactId>
                 <configuration>
                     <bnd><![CDATA[Export-Package: oshi,oshi.jna.*,!oshi.driver.common.*,!oshi.driver.unix.bsd.*,!oshi.driver.unix.freebsd.disk.*,!oshi.driver.unix.solaris.disk.*,oshi.driver.*,oshi.hardware.platform.*,!oshi.software.common.*,oshi.software.os.linux.*,oshi.software.os.mac.*,oshi.software.os.unix.*,oshi.software.os.windows.*,oshi.util.gpu.*,oshi.util.platform.*;-noimport:=true
-                    Import-Package: ${osgi.slf4j.import.packages}, *
+                    Import-Package: ${osgi.jspecify.import.packages}, ${osgi.slf4j.import.packages}, *
                     Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                     -snapshot: SNAPSHOT]]></bnd>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,14 @@
         <jna.version>5.19.1</jna.version>
         <slf4j.version>2.0.18</slf4j.version>
         <osgi.slf4j.import.packages>org.slf4j;version="[1.7,3.0)"</osgi.slf4j.import.packages>
+        <!-- Optional OSGi imports, one property per <optional> Maven dependency. A module's bnd
+        Import-Package instruction replaces the parent's wholesale rather than adding to it, so every
+        module that overrides it has to restate each of these; spelling them out inline is what let
+        oshi-core and oshi-core-ffm hard-require org.jspecify.annotations through 7.6.0 (#3708). List
+        only the ones a given bundle actually references — bnd warns on an instruction that matches
+        nothing. -->
+        <osgi.jspecify.import.packages>org.jspecify.annotations;resolution:=optional</osgi.jspecify.import.packages>
+        <osgi.jlhm.import.packages>io.github.pandalxb.jlibrehardwaremonitor.*;resolution:=optional</osgi.jlhm.import.packages>
         <junit.version>6.1.3</junit.version>
         <!-- JUnit parallel-execution config; overridable per CI run (see OpenIndiana). -->
         <junit.parallel.executor-service>WORKER_THREAD_POOL</junit.parallel.executor-service>
@@ -387,7 +395,7 @@
                     <version>${bnd-maven-plugin.version}</version>
                     <configuration>
                         <bnd><![CDATA[Export-Package: oshi.*;-noimport:=true
-                        Import-Package: io.github.pandalxb.jlibrehardwaremonitor.*;resolution:=optional, ${osgi.slf4j.import.packages}, *
+                        Import-Package: ${osgi.jlhm.import.packages}, ${osgi.jspecify.import.packages}, ${osgi.slf4j.import.packages}, *
                         Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
                         -snapshot: SNAPSHOT]]></bnd>
                     </configuration>


### PR DESCRIPTION
Fixes #3708.

## The bug

`jspecify` is declared `<optional>` in `oshi-common`, `oshi-core` and `oshi-core-ffm` alike, so no consumer gets it transitively. But only `oshi-common`'s bnd instruction carried the matching `resolution:=optional` on the OSGi `Import-Package`. `oshi-core` and `oshi-core-ffm` each override the parent's `Import-Package` wholesale rather than adding to it, and neither restated the directive — so both bundles shipped a *mandatory* import of a package nobody is required to provide.

Verified against the 7.6.1-SNAPSHOT manifests before this change:

```
# oshi-common — correct
org.jspecify.annotations;version="[1.0,2)";resolution:=optional

# oshi-core, oshi-core-ffm — mandatory
org.jspecify.annotations;version="[1.0,2)"
```

Which is what @MrEasy hit:

```
Bundle 'mvn:com.github.oshi/oshi-core/7.6.0', referenced from feature 'ext-oshi'
imports package 'org.jspecify.annotations' but no export found.
```

`oshi-core-ffm` had the same defect; `oshi-metrics`, `oshi-demo` and `oshi-benchmark` skip bnd entirely and `oshi-dist` is a zip, so those three are the only bundles.

## The fix

Rather than paste the directive into two more places, hoist the optional imports into properties next to the existing `osgi.slf4j.import.packages`, so an overriding module restates a *reference* instead of a copy. Each bundle lists only what it actually references — jLibreHardwareMonitor is reached from `oshi-common` alone, and bnd warns on an `Import-Package` instruction that matches nothing, which is why there are two properties and not one.

With them in place `oshi-common`'s override became character-for-character the inherited default, so it is deleted.

## Verification

Diffed the generated `META-INF/MANIFEST.MF` of all three bundles before and after. The **only** semantic change in the reactor is `resolution:=optional` appearing on `org.jspecify.annotations` in `oshi-core` and `oshi-core-ffm`; `oshi-common`'s manifest is byte-identical apart from the build timestamp, confirming the override removal is a no-op.

`./mvnw clean spotless:apply sortpom:sort checkstyle:check install` passes with 0 test failures across the four test modules and no bnd warnings.

Not verified: actual resolution inside an OSGi container. The manifest header is now identical in form to the `oshi-common` one that already works for the reporter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OSGi bundle compatibility by supporting optional JSpecify annotation and hardware-monitoring package imports.
  * Updated core and FFM bundles to recognize these optional integrations without requiring them at runtime.

* **Documentation**
  * Added release notes for version 7.6.1 describing the updated optional OSGi imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->