### PR TITLE
Read CPU sensors from the LibreHardwareMonitor WMI namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 7.6.2 (in progress)
 
-* Your contribution here!
+##### Bug Fixes and Improvements
+
+* [#3723](https://github.com/oshi/oshi/pull/3723): Windows `Sensors` reads CPU temperature, fan speed and voltage from the `ROOT\LibreHardwareMonitor` WMI namespace when the LibreHardwareMonitor application is running, in addition to the `ROOT\OpenHardwareMonitor` namespace it already read. Users running the maintained LibreHardwareMonitor previously got its GPU metrics but no CPU sensor data - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.6.0 (2026-08-23), 7.6.1 (2026-09-01)
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -136,20 +136,44 @@ The FFM implementation (`oshi-core-ffm`) supports the same platforms as the JNA 
 
 ## How can I get reliable sensor information on Windows?
 
-Windows sensor information is unreliable via the supported Windows API.  OSHI includes an optional dependency on [jLibreHardwareMonitor](https://github.com/pandalxb/jLibreHardwareMonitor) which gives much more reliable sensor data, but is not included transitively due to its single-OS relevance and MPL 2.0-licensed binary DLLs. To include it, define the dependency in your own project.  You can do so using Maven:
+Windows sensor information is unreliable via the supported Windows API. There are two ways to get better data,
+and OSHI will use whichever is available.
 
-```
+### Option 1: run a hardware monitoring application
+
+If [LibreHardwareMonitor](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor) or the older
+[OpenHardwareMonitor](https://openhardwaremonitor.org/) is running **as Administrator** with WMI publishing enabled,
+OSHI reads its published data directly. No extra dependency is needed. LibreHardwareMonitor is the maintained one and
+additionally provides GPU temperature, power, clocks, fan, utilization and memory.
+
+### Option 2: the optional jLibreHardwareMonitor dependency
+
+[jLibreHardwareMonitor](https://github.com/pandalxb/jLibreHardwareMonitor) ships the monitoring libraries itself, so no
+application has to be running. It is not included transitively, due to its single-OS relevance and MPL 2.0-licensed
+binary DLLs. To include it, define the dependency in your own project **with an explicit version** — OSHI publishes no
+BOM and manages only the JNA artifacts, so a version-less declaration will not resolve. Using Maven:
+
+```xml
 <dependency>
     <groupId>io.github.pandalxb</groupId>
     <artifactId>jLibreHardwareMonitor</artifactId>
+    <version>1.0.6</version>
 </dependency>
 ```
 
 Or Gradle:
 
+```groovy
+implementation("io.github.pandalxb:jLibreHardwareMonitor:1.0.6")
 ```
-implementation("io.github.pandalxb:jLibreHardwareMonitor")
-```
+
+Your JVM must run **as Administrator**, as the underlying library loads a kernel driver for most sensors.
+
+Note one known limitation: this dependency reaches the monitoring libraries through a PowerShell session, and on
+Windows Server 2019 / Windows 10 1809-era hosts whose console handle is not a real screen buffer — a CI build agent,
+for example — PowerShell writes an error banner into the output being parsed, so no sensor data is returned and the
+dependency logs at ERROR. OSHI falls back to plain WMI in that case. See
+[issue #3707](https://github.com/oshi/oshi/issues/3707) for the details and current status.
 
 ## How do I resolve `Pdh call failed with error code 0xC0000BB8` issues?
 
@@ -338,7 +362,7 @@ However, some specific features require elevated permissions to access. Rather t
 
 **Windows:**
 - Process command lines and environment variables for processes owned by other users (requires `SeDebugPrivilege` or Administrator)
-- Sensor data (temperature, fan speeds) via [jLibreHardwareMonitor](https://github.com/oshi/jLibreHardwareMonitor)
+- Sensor data (temperature, fan speeds) via a hardware monitoring application or the optional [jLibreHardwareMonitor](https://github.com/pandalxb/jLibreHardwareMonitor) dependency
 
 **macOS:**
 - TCP/UDP connection details (without elevation, connection data is limited)

--- a/oshi-benchmark/src/test/java/oshi/comparison/WmiComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/WmiComparisonTest.java
@@ -424,12 +424,14 @@ class WmiComparisonTest {
         boolean jnaComInit = jnaHandler.initCOM();
         boolean ffmComInit = ffmHandler.initCOM();
         try {
-            WmiResult<ValueProperty> jna = OhmSensor.querySensorValue(jnaHandler, null, null);
-            WmiResult<ValueProperty> ffm = OhmSensor.querySensorValue(ffmHandler, null, null);
+            WmiResult<ValueProperty> jna = OhmSensor.querySensorValue(jnaHandler, OhmSensor.OHM_NAMESPACE, null, null);
+            WmiResult<ValueProperty> ffm = OhmSensor.querySensorValue(ffmHandler, OhmSensor.OHM_NAMESPACE, null, null);
             assertThat(ffm.getResultCount()).as("OhmSensor count").isEqualTo(jna.getResultCount());
 
-            WmiResult<IdentifierProperty> jnaHw = OhmHardware.queryHwIdentifier(jnaHandler, null, null);
-            WmiResult<IdentifierProperty> ffmHw = OhmHardware.queryHwIdentifier(ffmHandler, null, null);
+            WmiResult<IdentifierProperty> jnaHw = OhmHardware.queryHwIdentifier(jnaHandler, OhmHardware.OHM_NAMESPACE,
+                    null, null);
+            WmiResult<IdentifierProperty> ffmHw = OhmHardware.queryHwIdentifier(ffmHandler, OhmHardware.OHM_NAMESPACE,
+                    null, null);
             assertThat(ffmHw.getResultCount()).as("OhmHardware count").isEqualTo(jnaHw.getResultCount());
         } finally {
             if (ffmComInit) {

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/OhmHardware.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/OhmHardware.java
@@ -7,7 +7,14 @@ package oshi.driver.common.windows.wmi;
 import oshi.annotation.concurrent.ThreadSafe;
 
 /**
- * Constants, property enum, and WHERE clause builder for Open Hardware Monitor WMI Hardware data.
+ * Constants, property enum, and WHERE clause builder for hardware-monitor WMI Hardware data.
+ * <p>
+ * Open Hardware Monitor and Libre Hardware Monitor publish the same {@code Hardware} schema, each under its own
+ * namespace, so the namespace argument selects which monitor is queried. Their {@code HardwareType} values differ: LHM
+ * renames OHM's {@code Mainboard} to {@code Motherboard}, {@code RAM} to {@code Memory}, and {@code HDD} to
+ * {@code Storage}.
+ *
+ * @see LhmSensor#LHM_NAMESPACE
  */
 @ThreadSafe
 public class OhmHardware {
@@ -53,13 +60,14 @@ public class OhmHardware {
      * Queries the hardware identifiers for a monitored type.
      *
      * @param h           An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @param namespace   the WMI namespace to query, either {@link #OHM_NAMESPACE} or {@link LhmSensor#LHM_NAMESPACE}
      * @param typeToQuery which type to filter based on
      * @param typeName    the name of the type
      * @return WmiResult of hardware identifier properties.
      */
-    public static WmiResult<IdentifierProperty> queryHwIdentifier(WmiQueryExecutor h, String typeToQuery,
-            String typeName) {
-        WmiQuery<IdentifierProperty> hwIdentifierQuery = new WmiQuery<>(OHM_NAMESPACE,
+    public static WmiResult<IdentifierProperty> queryHwIdentifier(WmiQueryExecutor h, String namespace,
+            String typeToQuery, String typeName) {
+        WmiQuery<IdentifierProperty> hwIdentifierQuery = new WmiQuery<>(namespace,
                 buildHardwareWmiClassNameWithWhere(typeToQuery, typeName), IdentifierProperty.class);
         return h.queryWMI(hwIdentifierQuery, false);
     }

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/OhmSensor.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/OhmSensor.java
@@ -54,12 +54,14 @@ public class OhmSensor {
      * Queries the sensor value of a hardware identifier and sensor type.
      *
      * @param h          An instantiated {@link WmiQueryExecutor}. User should have already initialized COM.
+     * @param namespace  the WMI namespace to query, either {@link #OHM_NAMESPACE} or {@link LhmSensor#LHM_NAMESPACE}
      * @param identifier The identifier whose value to query.
      * @param sensorType The type of sensor to query.
      * @return The sensor value.
      */
-    public static WmiResult<ValueProperty> querySensorValue(WmiQueryExecutor h, String identifier, String sensorType) {
-        WmiQuery<ValueProperty> ohmSensorQuery = new WmiQuery<>(OHM_NAMESPACE,
+    public static WmiResult<ValueProperty> querySensorValue(WmiQueryExecutor h, String namespace, String identifier,
+            String sensorType) {
+        WmiQuery<ValueProperty> ohmSensorQuery = new WmiQuery<>(namespace,
                 buildSensorWmiClassNameWithWhere(identifier, sensorType), ValueProperty.class);
         return h.queryWMI(ohmSensorQuery, false);
     }

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsSensors.java
@@ -15,7 +15,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.wmi.LhmSensor;
 import oshi.driver.common.windows.wmi.MSAcpiThermalZoneTemperature.TemperatureProperty;
+import oshi.driver.common.windows.wmi.OhmHardware;
 import oshi.driver.common.windows.wmi.OhmHardware.IdentifierProperty;
 import oshi.driver.common.windows.wmi.OhmSensor.ValueProperty;
 import oshi.driver.common.windows.wmi.Win32Fan.SpeedProperty;
@@ -40,11 +42,22 @@ public abstract class WindowsSensors extends AbstractSensors {
 
     private static final String JLIBREHARDWAREMONITOR_PACKAGE = "io.github.pandalxb.jlibrehardwaremonitor";
 
+    /** Open Hardware Monitor's {@code HardwareType} value for a processor. */
+    private static final String OHM_CPU = "CPU";
+
+    /** Libre Hardware Monitor's {@code HardwareType} value for a processor, which OHM spells {@code CPU}. */
+    private static final String LHM_CPU = "Cpu";
+
     @Override
     public double queryCpuTemperature() {
         // Attempt to fetch value from Open Hardware Monitor if it is running, as it will give the most accurate results
         // and the time to query (or attempt) is trivial
-        double tempC = getTempFromOHM();
+        double tempC = getTempFromMonitorWmi(OhmHardware.OHM_NAMESPACE, OHM_CPU);
+        if (tempC > 0d) {
+            return tempC;
+        }
+        // Then Libre Hardware Monitor, the maintained successor, which publishes the same schema
+        tempC = getTempFromMonitorWmi(LhmSensor.LHM_NAMESPACE, LHM_CPU);
         if (tempC > 0d) {
             return tempC;
         }
@@ -57,8 +70,9 @@ public abstract class WindowsSensors extends AbstractSensors {
         return getTempFromWMI();
     }
 
-    private double getTempFromOHM() {
-        WmiResult<ValueProperty> ohmSensors = queryOhmCpuSensor("Hardware", "CPU", "Temperature", false);
+    private double getTempFromMonitorWmi(String namespace, String cpuTypeName) {
+        WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, "Hardware", cpuTypeName,
+                "Temperature", false);
         if (ohmSensors != null && ohmSensors.getResultCount() > 0) {
             double sum = 0;
             for (int i = 0; i < ohmSensors.getResultCount(); i++) {
@@ -93,7 +107,12 @@ public abstract class WindowsSensors extends AbstractSensors {
     @Override
     public int[] queryFanSpeeds() {
         // Attempt to fetch value from Open Hardware Monitor if it is running
-        int[] fanSpeeds = getFansFromOHM();
+        int[] fanSpeeds = getFansFromMonitorWmi(OhmHardware.OHM_NAMESPACE, OHM_CPU);
+        if (fanSpeeds.length > 0) {
+            return fanSpeeds;
+        }
+        // Then Libre Hardware Monitor, the maintained successor, which publishes the same schema
+        fanSpeeds = getFansFromMonitorWmi(LhmSensor.LHM_NAMESPACE, LHM_CPU);
         if (fanSpeeds.length > 0) {
             return fanSpeeds;
         }
@@ -111,8 +130,9 @@ public abstract class WindowsSensors extends AbstractSensors {
         return new int[0];
     }
 
-    private int[] getFansFromOHM() {
-        WmiResult<ValueProperty> ohmSensors = queryOhmCpuSensor("Hardware", "CPU", "Fan", false);
+    private int[] getFansFromMonitorWmi(String namespace, String cpuTypeName) {
+        WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, "Hardware", cpuTypeName, "Fan",
+                false);
         if (ohmSensors != null && ohmSensors.getResultCount() > 0) {
             int[] fanSpeeds = new int[ohmSensors.getResultCount()];
             for (int i = 0; i < ohmSensors.getResultCount(); i++) {
@@ -172,7 +192,12 @@ public abstract class WindowsSensors extends AbstractSensors {
     @Override
     public double queryCpuVoltage() {
         // Attempt to fetch value from Open Hardware Monitor if it is running
-        double volts = getVoltsFromOHM();
+        double volts = getVoltsFromMonitorWmi(OhmHardware.OHM_NAMESPACE);
+        if (volts > 0d) {
+            return volts;
+        }
+        // Then Libre Hardware Monitor, the maintained successor, which publishes the same schema
+        volts = getVoltsFromMonitorWmi(LhmSensor.LHM_NAMESPACE);
         if (volts > 0d) {
             return volts;
         }
@@ -185,8 +210,9 @@ public abstract class WindowsSensors extends AbstractSensors {
         return getVoltsFromWMI();
     }
 
-    private double getVoltsFromOHM() {
-        WmiResult<ValueProperty> ohmSensors = queryOhmCpuSensor("Sensor", "Voltage", "Voltage", true);
+    private double getVoltsFromMonitorWmi(String namespace) {
+        WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, "Sensor", "Voltage", "Voltage",
+                true);
         if (ohmSensors != null && ohmSensors.getResultCount() > 0) {
             return WmiUtil.getFloat(ohmSensors, ValueProperty.VALUE, 0);
         }
@@ -306,16 +332,18 @@ public abstract class WindowsSensors extends AbstractSensors {
     }
 
     /**
-     * Queries an Open Hardware Monitor CPU sensor via the backend-specific WMI handler.
+     * Queries a hardware-monitor CPU sensor via the backend-specific WMI handler. Open Hardware Monitor and Libre
+     * Hardware Monitor publish the same schema under their own namespaces, so the namespace selects which is queried.
      *
-     * @param typeToQuery the OHM hardware type to query
-     * @param typeName    the OHM hardware type name
+     * @param namespace   the WMI namespace, either {@link OhmHardware#OHM_NAMESPACE} or {@link LhmSensor#LHM_NAMESPACE}
+     * @param typeToQuery the hardware type to query
+     * @param typeName    the hardware type name, which differs between the two monitors
      * @param sensorType  the sensor type
      * @param searchCpu   whether to search for a {@code cpu} identifier (vs. using the first)
      * @return the sensor values, or {@code null} if unavailable
      */
-    protected abstract @Nullable WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName,
-            String sensorType, boolean searchCpu);
+    protected abstract @Nullable WmiResult<ValueProperty> queryHardwareMonitorSensor(String namespace,
+            String typeToQuery, String typeName, String sensorType, boolean searchCpu);
 
     /**
      * Queries the current temperature from WMI {@code MSAcpi_ThermalZoneTemperature}.

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsSensorsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsSensorsFFM.java
@@ -36,29 +36,30 @@ final class WindowsSensorsFFM extends WindowsSensors {
     private static final Logger LOG = LoggerFactory.getLogger(WindowsSensorsFFM.class);
 
     @Override
-    protected @Nullable WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName,
-            String sensorType, boolean searchCpu) {
-        return getOhmSensors(typeToQuery, typeName, sensorType, (h, ohmHardware) -> {
-            String cpuIdentifier = selectOhmCpuIdentifier(ohmHardware, searchCpu);
+    protected @Nullable WmiResult<ValueProperty> queryHardwareMonitorSensor(String namespace, String typeToQuery,
+            String typeName, String sensorType, boolean searchCpu) {
+        return getHardwareMonitorSensors(namespace, typeToQuery, typeName, sensorType, (h, hwIdentifiers) -> {
+            String cpuIdentifier = selectOhmCpuIdentifier(hwIdentifiers, searchCpu);
             if (!cpuIdentifier.isEmpty()) {
-                return OhmSensor.querySensorValue(h, cpuIdentifier, sensorType);
+                return OhmSensor.querySensorValue(h, namespace, cpuIdentifier, sensorType);
             }
             return null;
         });
     }
 
-    private static @Nullable WmiResult<ValueProperty> getOhmSensors(String typeToQuery, String typeName,
-            String sensorType,
+    private static @Nullable WmiResult<ValueProperty> getHardwareMonitorSensors(String namespace, String typeToQuery,
+            String typeName, String sensorType,
             BiFunction<WmiQueryHandlerFFM, WmiResult<IdentifierProperty>, WmiResult<ValueProperty>> querySensorFunction) {
         WmiQueryHandlerFFM h = Objects.requireNonNull(WmiQueryHandlerFFM.createInstance());
         boolean comInit = false;
-        WmiResult<ValueProperty> ohmSensors = null;
+        WmiResult<ValueProperty> sensors = null;
         try {
             comInit = h.initCOM();
-            WmiResult<IdentifierProperty> ohmHardware = OhmHardware.queryHwIdentifier(h, typeToQuery, typeName);
-            if (ohmHardware.getResultCount() > 0) {
-                LOG.debug("Found {} data in Open Hardware Monitor", sensorType);
-                ohmSensors = querySensorFunction.apply(h, ohmHardware);
+            WmiResult<IdentifierProperty> hwIdentifiers = OhmHardware.queryHwIdentifier(h, namespace, typeToQuery,
+                    typeName);
+            if (hwIdentifiers.getResultCount() > 0) {
+                LOG.debug("Found {} data in {}", sensorType, namespace);
+                sensors = querySensorFunction.apply(h, hwIdentifiers);
             }
         } catch (FfmComException e) {
             LOG.warn(COM_EXCEPTION_MSG, e);
@@ -67,7 +68,7 @@ final class WindowsSensorsFFM extends WindowsSensors {
                 h.unInitCOM();
             }
         }
-        return ohmSensors;
+        return sensors;
     }
 
     @Override

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensorsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensorsJNA.java
@@ -37,29 +37,30 @@ final class WindowsSensorsJNA extends WindowsSensors {
     private static final Logger LOG = LoggerFactory.getLogger(WindowsSensorsJNA.class);
 
     @Override
-    protected @Nullable WmiResult<ValueProperty> queryOhmCpuSensor(String typeToQuery, String typeName,
-            String sensorType, boolean searchCpu) {
-        return getOhmSensors(typeToQuery, typeName, sensorType, (h, ohmHardware) -> {
-            String cpuIdentifier = selectOhmCpuIdentifier(ohmHardware, searchCpu);
+    protected @Nullable WmiResult<ValueProperty> queryHardwareMonitorSensor(String namespace, String typeToQuery,
+            String typeName, String sensorType, boolean searchCpu) {
+        return getHardwareMonitorSensors(namespace, typeToQuery, typeName, sensorType, (h, hwIdentifiers) -> {
+            String cpuIdentifier = selectOhmCpuIdentifier(hwIdentifiers, searchCpu);
             if (!cpuIdentifier.isEmpty()) {
-                return OhmSensor.querySensorValue(h, cpuIdentifier, sensorType);
+                return OhmSensor.querySensorValue(h, namespace, cpuIdentifier, sensorType);
             }
             return null;
         });
     }
 
-    private static @Nullable WmiResult<ValueProperty> getOhmSensors(String typeToQuery, String typeName,
-            String sensorType,
+    private static @Nullable WmiResult<ValueProperty> getHardwareMonitorSensors(String namespace, String typeToQuery,
+            String typeName, String sensorType,
             BiFunction<WmiQueryHandler, WmiResult<IdentifierProperty>, WmiResult<ValueProperty>> querySensorFunction) {
         WmiQueryHandler h = Objects.requireNonNull(WmiQueryHandler.createInstance());
         boolean comInit = false;
-        WmiResult<ValueProperty> ohmSensors = null;
+        WmiResult<ValueProperty> sensors = null;
         try {
             comInit = h.initCOM();
-            WmiResult<IdentifierProperty> ohmHardware = OhmHardware.queryHwIdentifier(h, typeToQuery, typeName);
-            if (ohmHardware.getResultCount() > 0) {
-                LOG.debug("Found {} data in Open Hardware Monitor", sensorType);
-                ohmSensors = querySensorFunction.apply(h, ohmHardware);
+            WmiResult<IdentifierProperty> hwIdentifiers = OhmHardware.queryHwIdentifier(h, namespace, typeToQuery,
+                    typeName);
+            if (hwIdentifiers.getResultCount() > 0) {
+                LOG.debug("Found {} data in {}", sensorType, namespace);
+                sensors = querySensorFunction.apply(h, hwIdentifiers);
             }
         } catch (COMException e) {
             LOG.warn(COM_EXCEPTION_MSG, e);
@@ -68,7 +69,7 @@ final class WindowsSensorsJNA extends WindowsSensors {
                 h.unInitCOM();
             }
         }
-        return ohmSensors;
+        return sensors;
     }
 
     @Override


### PR DESCRIPTION
`WindowsSensors` tier 1 reads only `ROOT\OpenHardwareMonitor`, so a user running the modern, maintained **LibreHardwareMonitor** application gets its GPU metrics (through `LhmSensor`, already wired up for `WindowsGpuStats` and `WindowsGraphicsCard`) but **no CPU temperature, fan speed or voltage**. This closes that gap.

Noted as a standing gap in #3707, and worth doing independently of anything upstream there.

### Approach

LHM and OHM publish the **same** `Hardware` and `Sensor` schema, each under its own namespace — `Hardware WHERE <X>Type = "<Y>"` and `Sensor WHERE Parent = "..." AND SensorType = "..."` are byte-for-byte the same query shape in both drivers today. So rather than adding a parallel LHM path, `OhmHardware.queryHwIdentifier` and `OhmSensor.querySensorValue` take the namespace to query, and the twins' helper threads it through.

The point of doing it this way is that **no new logic is duplicated across the JNA and FFM implementations**. Both twins changed only by renames plus one added parameter; nothing was copied.

Where the monitors genuinely differ is the `HardwareType` spelling, so the CPU value is a named constant per namespace (`"CPU"` for OHM, `"Cpu"` for LHM). LHM also renames OHM's `Mainboard` to `Motherboard`, `RAM` to `Memory` and `HDD` to `Storage`; only the CPU value is needed here, but the difference is recorded in the `OhmHardware` javadoc so the next person does not have to rediscover it. Those mappings come from jLibreHardwareMonitor's own alias table, not from guesswork.

Tier order is now OHM WMI, **LHM WMI**, the jLibreHardwareMonitor jar, then plain WMI. The new tier sits alongside the other application-based path, since both cost almost nothing when the application is not running.

### Naming

`OhmHardware` and `OhmSensor` now serve both monitors, which their names no longer quite reflect. I documented that in the class javadoc rather than renaming, since a rename would also touch the GPU path. Happy to do the rename as a follow-up if preferred — these are in `oshi.driver`, outside the semver-guaranteed API.

### Testing

Full gate green on `oshi-common`, `oshi-core` and `oshi-core-ffm`: spotless, checkstyle, install, forbiddenapis, javadoc, and 1766 tests passing.

**Neither WMI tier can be exercised in CI**, as both require the corresponding application running as Administrator. This ships on structural equivalence to the existing, working OHM tier rather than on a live run — the same evidence basis tier 1 has always had. Verification on a machine with LibreHardwareMonitor installed would be welcome.

### Also in this PR

Documentation, which needs no release to be useful:

- `FAQ.md` restructured around the two ways to get better Windows sensor data — run a monitoring application, or add the optional dependency — now that the application path covers CPU sensors.
- The dependency snippets gain the explicit `<version>` they need. OSHI publishes no BOM and manages only the JNA artifacts, so the version-less snippet that was there could not resolve.
- A link pointing at a nonexistent `oshi/jLibreHardwareMonitor` repository is corrected to `pandalxb/jLibreHardwareMonitor`.
- The console-related limitation from #3707 is documented, with its corrected scope.

### Not addressed here

`getVoltsFromMonitorWmi` passes `"Sensor"`/`"Voltage"`, which builds `Hardware WHERE SensorType = "Voltage"` — but the `Hardware` class has no `SensorType` property, so that query looks like it can never match. It predates this change and now applies to both namespaces equally. Left alone deliberately; it wants its own investigation on a machine that can run these applications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Windows sensor detection now reads CPU temperature, fan speed, and voltage from both Open Hardware Monitor and Libre Hardware Monitor when either application is running.
  - Sensor queries can fall back between supported hardware-monitoring sources for more reliable results.

- **Documentation**
  - Updated Windows sensor guidance with setup requirements, permissions information, dependency version details, and known platform limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->