### PR TITLE
Add config switches for the Windows hardware monitor WMI namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Bug Fixes and Improvements
 
 * [#3723](https://github.com/oshi/oshi/pull/3723): Windows `Sensors` reads CPU temperature, fan speed and voltage from the `ROOT\LibreHardwareMonitor` WMI namespace when the LibreHardwareMonitor application is running, in addition to the `ROOT\OpenHardwareMonitor` namespace it already read. Users running the maintained LibreHardwareMonitor previously got its GPU metrics but no CPU sensor data - [@dbwiddis](https://github.com/dbwiddis).
+* [#3727](https://github.com/oshi/oshi/pull/3727): The `oshi.os.windows.ohm.disabled` and `oshi.os.windows.lhm.disabled` configuration properties skip the Open Hardware Monitor and Libre Hardware Monitor WMI namespaces, which OSHI otherwise queries on every sensor read. The latter also covers GPU metrics - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.6.0 (2026-08-23), 7.6.1 (2026-09-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ##### Bug Fixes and Improvements
 
 * [#3723](https://github.com/oshi/oshi/pull/3723): Windows `Sensors` reads CPU temperature, fan speed and voltage from the `ROOT\LibreHardwareMonitor` WMI namespace when the LibreHardwareMonitor application is running, in addition to the `ROOT\OpenHardwareMonitor` namespace it already read. Users running the maintained LibreHardwareMonitor previously got its GPU metrics but no CPU sensor data - [@dbwiddis](https://github.com/dbwiddis).
-* [#3727](https://github.com/oshi/oshi/pull/3727): The `oshi.os.windows.ohm.disabled` and `oshi.os.windows.lhm.disabled` configuration properties skip the Open Hardware Monitor and Libre Hardware Monitor WMI namespaces, which OSHI otherwise queries on every sensor read. The latter also covers GPU metrics - [@dbwiddis](https://github.com/dbwiddis).
+* [#3727](https://github.com/oshi/oshi/pull/3727): The `oshi.os.windows.ohm.disabled` and `oshi.os.windows.lhm.disabled` configuration properties skip the Open Hardware Monitor and Libre Hardware Monitor WMI namespaces, which OSHI otherwise queries on each sensor read until one returns data. The latter also covers GPU metrics - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.6.0 (2026-08-23), 7.6.1 (2026-09-01)
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -177,9 +177,9 @@ dependency logs at ERROR. OSHI falls back to plain WMI in that case. See
 
 ### Turning off the sources you do not use
 
-Either application can be started or stopped at any time, so OSHI queries both WMI namespaces on every sensor read and
-simply gets no results when the application is not running. If you know you do not run one of them, say so up front and
-OSHI will not attempt the query:
+Either application can be started or stopped at any time, so OSHI queries their namespaces on each sensor read, in the
+order below, until one returns data, and gets no results when neither is running. If you know you do not run one of
+them, say so up front and OSHI will not attempt the query:
 
 | Property | Skips |
 |---|---|

--- a/FAQ.md
+++ b/FAQ.md
@@ -175,6 +175,21 @@ for example — PowerShell writes an error banner into the output being parsed, 
 dependency logs at ERROR. OSHI falls back to plain WMI in that case. See
 [issue #3707](https://github.com/oshi/oshi/issues/3707) for the details and current status.
 
+### Turning off the sources you do not use
+
+Either application can be started or stopped at any time, so OSHI queries both WMI namespaces on every sensor read and
+simply gets no results when the application is not running. If you know you do not run one of them, say so up front and
+OSHI will not attempt the query:
+
+| Property | Skips |
+|---|---|
+| `oshi.os.windows.ohm.disabled` | The `ROOT\OpenHardwareMonitor` namespace |
+| `oshi.os.windows.lhm.disabled` | The `ROOT\LibreHardwareMonitor` namespace, for GPU metrics as well as sensors |
+
+Both default to `false`. The jLibreHardwareMonitor dependency needs no such switch: it is not transitive, so declaring
+it is itself the decision to use it, and OSHI checks once whether it is on the class path. If the PowerShell limitation
+above affects you, remove the dependency.
+
 ## How do I resolve `Pdh call failed with error code 0xC0000BB8` issues?
 
 OSHI (and many other programs) rely on the English Performance Counter indices in the registry. These are located at `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\009\Counter`. Sometimes when configuring localized Windows installations, these values become corrupt or are missing.

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/HardwareMonitorDisabled.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/HardwareMonitorDisabled.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.wmi;
+
+import oshi.annotation.concurrent.ThreadSafe;
+import oshi.util.GlobalConfig;
+
+/**
+ * Tests whether the Open Hardware Monitor and Libre Hardware Monitor sources of sensor data are disabled by
+ * configuration.
+ * <p>
+ * Either application publishes its data only while it is running, and a user may start or stop it at any time, so OSHI
+ * queries for it on every read rather than caching its availability. These switches let a user who does not run one of
+ * them say so up front, so the query is never attempted. They are read on each call for the same reason the queries
+ * are: configuration may be changed before the first query is made.
+ *
+ * @see GlobalConfig#OSHI_OS_WINDOWS_OHM_DISABLED
+ * @see GlobalConfig#OSHI_OS_WINDOWS_LHM_DISABLED
+ */
+@ThreadSafe
+public final class HardwareMonitorDisabled {
+
+    private HardwareMonitorDisabled() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Tests whether queries to a hardware monitor's WMI namespace are disabled.
+     *
+     * @param namespace the WMI namespace, either {@link OhmHardware#OHM_NAMESPACE} or {@link LhmSensor#LHM_NAMESPACE}
+     * @return {@code true} if the namespace should not be queried, {@code false} otherwise, including for any other
+     *         namespace
+     */
+    public static boolean isWmiDisabled(String namespace) {
+        if (OhmHardware.OHM_NAMESPACE.equals(namespace)) {
+            return GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED, false);
+        }
+        if (LhmSensor.LHM_NAMESPACE.equals(namespace)) {
+            return GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED, false);
+        }
+        return false;
+    }
+}

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/LhmSensor.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/LhmSensor.java
@@ -88,9 +88,12 @@ public class LhmSensor {
      * @param h          An instantiated {@link WmiQueryExecutor}.
      * @param parent     the LHM hardware identifier (e.g. {@code /gpu-nvidia/0})
      * @param sensorType the sensor type string (e.g. {@code "Load"}, {@code "SmallData"})
-     * @return WMI result containing NAME, VALUE, and PARENT columns
+     * @return WMI result containing NAME, VALUE, and PARENT columns, or an empty result if LHM queries are disabled
      */
     public static WmiResult<LhmSensorProperty> querySensors(WmiQueryExecutor h, String parent, String sensorType) {
+        if (HardwareMonitorDisabled.isWmiDisabled(LHM_NAMESPACE)) {
+            return WmiResult.empty();
+        }
         WmiQuery<LhmSensorProperty> query = new WmiQuery<>(LHM_NAMESPACE,
                 buildSensorWmiClassNameWithWhere(parent, sensorType), LhmSensorProperty.class);
         return h.queryWMI(query);
@@ -100,9 +103,13 @@ public class LhmSensor {
      * Queries all GPU hardware entries from LHM to discover parent identifiers.
      *
      * @param h An instantiated {@link WmiQueryExecutor}.
-     * @return WMI result with IDENTIFIER and NAME columns for all GPU hardware entries
+     * @return WMI result with IDENTIFIER and NAME columns for all GPU hardware entries, or an empty result if LHM
+     *         queries are disabled
      */
     public static WmiResult<LhmHardwareProperty> queryGpuHardware(WmiQueryExecutor h) {
+        if (HardwareMonitorDisabled.isWmiDisabled(LHM_NAMESPACE)) {
+            return WmiResult.empty();
+        }
         WmiQuery<LhmHardwareProperty> query = new WmiQuery<>(LHM_NAMESPACE, buildGpuHardwareWmiClassName(),
                 LhmHardwareProperty.class);
         return h.queryWMI(query);

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiConstants.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiConstants.java
@@ -13,6 +13,8 @@ public final class WmiConstants {
     }
 
     // CIM types (from Wbemcli.h)
+    /** CIM type for an absent value. */
+    public static final int CIM_EMPTY = 0;
     /** CIM type for signed 32-bit integer. */
     public static final int CIM_SINT32 = 3;
     /** CIM type for 32-bit real. */
@@ -33,6 +35,8 @@ public final class WmiConstants {
     public static final int CIM_REFERENCE = 102;
 
     // Variant types (from OAIdl.h)
+    /** Variant type for an absent value. */
+    public static final int VT_EMPTY = 0;
     /** Variant type for 32-bit integer. */
     public static final int VT_I4 = 3;
     /** Variant type for 32-bit real. */

--- a/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiResult.java
+++ b/oshi-common/src/main/java/oshi/driver/common/windows/wmi/WmiResult.java
@@ -14,6 +14,36 @@ import org.jspecify.annotations.Nullable;
 public interface WmiResult<T extends Enum<T>> {
 
     /**
+     * Returns a result with no rows, for a query which was not executed.
+     *
+     * @param <T> the enum type representing the queried properties
+     * @return an empty result
+     */
+    static <T extends Enum<T>> WmiResult<T> empty() {
+        return new WmiResult<T>() {
+            @Override
+            public int getResultCount() {
+                return 0;
+            }
+
+            @Override
+            public @Nullable Object getValue(T property, int index) {
+                return null;
+            }
+
+            @Override
+            public int getVtType(T property) {
+                return WmiConstants.VT_EMPTY;
+            }
+
+            @Override
+            public int getCIMType(T property) {
+                return WmiConstants.CIM_EMPTY;
+            }
+        };
+    }
+
+    /**
      * Gets the number of results in this result set.
      *
      * @return the result count

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsSensors.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import oshi.annotation.concurrent.ThreadSafe;
+import oshi.driver.common.windows.wmi.HardwareMonitorDisabled;
 import oshi.driver.common.windows.wmi.LhmSensor;
 import oshi.driver.common.windows.wmi.MSAcpiThermalZoneTemperature.TemperatureProperty;
 import oshi.driver.common.windows.wmi.OhmHardware;
@@ -27,9 +28,11 @@ import oshi.driver.common.windows.wmi.WmiUtil;
 import oshi.hardware.common.AbstractSensors;
 
 /**
- * Abstract base shared by the Windows Sensors implementations (JNA and FFM). Holds the Open Hardware Monitor / Libre
- * Hardware Monitor / WMI fallback orchestration, the reflection-based Libre Hardware Monitor queries (which are
- * backend-agnostic), and the WMI/OHM result processing. The native driver queries are provided by the subclasses.
+ * Abstract base shared by the Windows Sensors implementations (JNA and FFM). Holds the orchestration of the sensor
+ * sources, which are tried in order: the Open Hardware Monitor and Libre Hardware Monitor WMI namespaces, published by
+ * either application while it runs; the optional {@code jLibreHardwareMonitor} dependency, which reads the monitoring
+ * libraries itself through reflection and needs no application running; and finally plain WMI. The reflection and
+ * result processing are backend-agnostic; the native driver queries are provided by the subclasses.
  */
 @ThreadSafe
 public abstract class WindowsSensors extends AbstractSensors {
@@ -48,6 +51,25 @@ public abstract class WindowsSensors extends AbstractSensors {
     /** Libre Hardware Monitor's {@code HardwareType} value for a processor, which OHM spells {@code CPU}. */
     private static final String LHM_CPU = "Cpu";
 
+    /**
+     * Whether the optional {@code jLibreHardwareMonitor} dependency is on the class path. Declaring that dependency is
+     * how a user opts in to it, and the class path does not change while OSHI is running, so it is tested once here
+     * rather than on every sensor read.
+     */
+    private static final boolean LHM_JAR_PRESENT = isLhmJarPresent();
+
+    private static boolean isLhmJarPresent() {
+        try {
+            // Test for the class without initializing it; the reflection below initializes it when first used
+            Class.forName(JLIBREHARDWAREMONITOR_PACKAGE + ".config.ComputerConfig", false,
+                    WindowsSensors.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            LOG.debug("jLibreHardwareMonitor is not on the class path. Sensor data will come from other sources.");
+            return false;
+        }
+    }
+
     @Override
     public double queryCpuTemperature() {
         // Attempt to fetch value from Open Hardware Monitor if it is running, as it will give the most accurate results
@@ -62,7 +84,7 @@ public abstract class WindowsSensors extends AbstractSensors {
             return tempC;
         }
         // Fetch value from LibreHardwareMonitorLib.dll / OpenHardwareMonitorLib.dll without applications running
-        tempC = getTempFromLHM();
+        tempC = getTempFromLhmJar();
         if (tempC > 0d) {
             return tempC;
         }
@@ -71,6 +93,9 @@ public abstract class WindowsSensors extends AbstractSensors {
     }
 
     private double getTempFromMonitorWmi(String namespace, String cpuTypeName) {
+        if (HardwareMonitorDisabled.isWmiDisabled(namespace)) {
+            return 0;
+        }
         WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, "Hardware", cpuTypeName,
                 "Temperature", false);
         if (ohmSensors != null && ohmSensors.getResultCount() > 0) {
@@ -83,8 +108,8 @@ public abstract class WindowsSensors extends AbstractSensors {
         return 0;
     }
 
-    private static double getTempFromLHM() {
-        return getAverageValueFromLHM("CPU", "Temperature",
+    private static double getTempFromLhmJar() {
+        return getAverageValueFromLhmJar("CPU", "Temperature",
                 (name, value) -> !name.contains("Max") && !name.contains("Average") && value > 0);
     }
 
@@ -117,7 +142,7 @@ public abstract class WindowsSensors extends AbstractSensors {
             return fanSpeeds;
         }
         // Fetch value from LibreHardwareMonitorLib.dll / OpenHardwareMonitorLib.dll without applications running
-        fanSpeeds = getFansFromLHM();
+        fanSpeeds = getFansFromLhmJar();
         if (fanSpeeds.length > 0) {
             return fanSpeeds;
         }
@@ -131,6 +156,9 @@ public abstract class WindowsSensors extends AbstractSensors {
     }
 
     private int[] getFansFromMonitorWmi(String namespace, String cpuTypeName) {
+        if (HardwareMonitorDisabled.isWmiDisabled(namespace)) {
+            return new int[0];
+        }
         WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, "Hardware", cpuTypeName, "Fan",
                 false);
         if (ohmSensors != null && ohmSensors.getResultCount() > 0) {
@@ -143,8 +171,8 @@ public abstract class WindowsSensors extends AbstractSensors {
         return new int[0];
     }
 
-    private static int[] getFansFromLHM() {
-        List<?> sensors = getLhmSensors("SuperIO", "Fan");
+    private static int[] getFansFromLhmJar() {
+        List<?> sensors = queryLhmJarSensors("SuperIO", "Fan");
         if (sensors == null || sensors.isEmpty()) {
             return new int[0];
         }
@@ -202,7 +230,7 @@ public abstract class WindowsSensors extends AbstractSensors {
             return volts;
         }
         // Fetch value from LibreHardwareMonitorLib.dll / OpenHardwareMonitorLib.dll without applications running
-        volts = getVoltsFromLHM();
+        volts = getVoltsFromLhmJar();
         if (volts > 0d) {
             return volts;
         }
@@ -211,6 +239,9 @@ public abstract class WindowsSensors extends AbstractSensors {
     }
 
     private double getVoltsFromMonitorWmi(String namespace) {
+        if (HardwareMonitorDisabled.isWmiDisabled(namespace)) {
+            return 0d;
+        }
         WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, "Sensor", "Voltage", "Voltage",
                 true);
         if (ohmSensors != null && ohmSensors.getResultCount() > 0) {
@@ -219,8 +250,8 @@ public abstract class WindowsSensors extends AbstractSensors {
         return 0d;
     }
 
-    private static double getVoltsFromLHM() {
-        return getAverageValueFromLHM("SuperIO", "Voltage",
+    private static double getVoltsFromLhmJar() {
+        return getAverageValueFromLhmJar("SuperIO", "Voltage",
                 (name, value) -> name.toLowerCase(Locale.ROOT).contains("vcore") && value > 0);
     }
 
@@ -272,9 +303,9 @@ public abstract class WindowsSensors extends AbstractSensors {
         return WmiUtil.getString(ohmHardware, IdentifierProperty.IDENTIFIER, 0);
     }
 
-    private static double getAverageValueFromLHM(String hardwareType, String sensorType,
+    private static double getAverageValueFromLhmJar(String hardwareType, String sensorType,
             BiPredicate<String, Double> sensorValidFunction) {
-        List<?> sensors = getLhmSensors(hardwareType, sensorType);
+        List<?> sensors = queryLhmJarSensors(hardwareType, sensorType);
         if (sensors == null || sensors.isEmpty()) {
             return 0;
         }
@@ -302,7 +333,10 @@ public abstract class WindowsSensors extends AbstractSensors {
         return 0;
     }
 
-    private static List<?> getLhmSensors(String hardwareType, String sensorType) {
+    private static List<?> queryLhmJarSensors(String hardwareType, String sensorType) {
+        if (!LHM_JAR_PRESENT) {
+            return Collections.emptyList();
+        }
         try {
             Class<?> computerConfigClass = Class.forName(JLIBREHARDWAREMONITOR_PACKAGE + ".config.ComputerConfig");
             Class<?> libreHardwareManagerClass = Class

--- a/oshi-common/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-common/src/main/java/oshi/util/GlobalConfig.java
@@ -281,9 +281,9 @@ public final class GlobalConfig {
     public static final String OSHI_OS_WINDOWS_OHM_DISABLED = "oshi.os.windows.ohm.disabled";
     /**
      * Whether queries to the Libre Hardware Monitor WMI namespace ({@code ROOT\LibreHardwareMonitor}) are disabled.
-     * OSHI queries that namespace on every sensor read and for GPU metrics, as the application may be started or
-     * stopped while OSHI is running. Set this to {@code true} to skip those queries entirely on a system where Libre
-     * Hardware Monitor is known not to be used. Default is {@code false}.
+     * OSHI queries that namespace for GPU metrics, and on any sensor read which Open Hardware Monitor did not satisfy,
+     * as the application may be started or stopped while OSHI is running. Set this to {@code true} to skip those
+     * queries entirely on a system where Libre Hardware Monitor is known not to be used. Default is {@code false}.
      *
      * @see #OSHI_OS_WINDOWS_OHM_DISABLED
      */

--- a/oshi-common/src/main/java/oshi/util/GlobalConfig.java
+++ b/oshi-common/src/main/java/oshi/util/GlobalConfig.java
@@ -271,6 +271,25 @@ public final class GlobalConfig {
     public static final String OSHI_OS_WINDOWS_PERF_DISABLE_ALL_ON_FAILURE = "oshi.os.windows.perf.disable.all.on.failure";
 
     /**
+     * Whether queries to the Open Hardware Monitor WMI namespace ({@code ROOT\OpenHardwareMonitor}) are disabled. OSHI
+     * queries that namespace on every sensor read, as the application may be started or stopped while OSHI is running.
+     * Set this to {@code true} to skip those queries entirely on a system where Open Hardware Monitor is known not to
+     * be used. Default is {@code false}.
+     *
+     * @see #OSHI_OS_WINDOWS_LHM_DISABLED
+     */
+    public static final String OSHI_OS_WINDOWS_OHM_DISABLED = "oshi.os.windows.ohm.disabled";
+    /**
+     * Whether queries to the Libre Hardware Monitor WMI namespace ({@code ROOT\LibreHardwareMonitor}) are disabled.
+     * OSHI queries that namespace on every sensor read and for GPU metrics, as the application may be started or
+     * stopped while OSHI is running. Set this to {@code true} to skip those queries entirely on a system where Libre
+     * Hardware Monitor is known not to be used. Default is {@code false}.
+     *
+     * @see #OSHI_OS_WINDOWS_OHM_DISABLED
+     */
+    public static final String OSHI_OS_WINDOWS_LHM_DISABLED = "oshi.os.windows.lhm.disabled";
+
+    /**
      * Whether to use the Posix-standard {@code who} command for session information instead of native code. The native
      * implementation ({@code getutxent}) is not thread safe; while OSHI synchronizes its own access, other OS code may
      * access the same data structures. The command-line variant may use reentrant code on some platforms. Default is

--- a/oshi-common/src/main/resources/oshi.properties
+++ b/oshi-common/src/main/resources/oshi.properties
@@ -123,6 +123,23 @@ oshi.os.windows.perfdisk.disabled=
 # Assume any performance counter failure means all counters will fail and revert to WMI backup
 oshi.os.windows.perf.disable.all.on.failure=false
 
+# Whether to skip querying the Open Hardware Monitor and Libre Hardware Monitor
+# applications for sensor data.
+#
+# Either application publishes sensor data to its own WMI namespace while it is
+# running as Administrator. Because a user may start or stop them at any time,
+# OSHI queries the namespaces on every sensor read and simply gets no results
+# when the application is not running. Setting these to true lets a user who
+# does not run one of them say so up front, so OSHI never attempts the query.
+#
+# Open Hardware Monitor is the older of the two; its namespace supplies CPU
+# temperature, fan speeds, and voltage.
+oshi.os.windows.ohm.disabled=false
+#
+# Libre Hardware Monitor is the maintained successor; its namespace supplies the
+# same sensor data as well as GPU metrics and GPU hardware identification.
+oshi.os.windows.lhm.disabled=false
+
 # Whether to use the Legacy Processor performance counters for System CPU ticks instead of
 # Processor Information (since Windows 7). These counters are not processor-group aware
 # and may give incorrect results on systems with more than 64 logical processors. Normally on

--- a/oshi-common/src/main/resources/oshi.properties
+++ b/oshi-common/src/main/resources/oshi.properties
@@ -128,9 +128,10 @@ oshi.os.windows.perf.disable.all.on.failure=false
 #
 # Either application publishes sensor data to its own WMI namespace while it is
 # running as Administrator. Because a user may start or stop them at any time,
-# OSHI queries the namespaces on every sensor read and simply gets no results
-# when the application is not running. Setting these to true lets a user who
-# does not run one of them say so up front, so OSHI never attempts the query.
+# OSHI queries the namespaces on each sensor read, Open Hardware Monitor first
+# and Libre Hardware Monitor only if that returned nothing, and gets no results
+# when neither is running. Setting these to true lets a user who does not run
+# one of them say so up front, so OSHI never attempts the query.
 #
 # Open Hardware Monitor is the older of the two; its namespace supplies CPU
 # temperature, fan speeds, and voltage.

--- a/oshi-common/src/test/java/oshi/driver/common/windows/wmi/HardwareMonitorDisabledTest.java
+++ b/oshi-common/src/test/java/oshi/driver/common/windows/wmi/HardwareMonitorDisabledTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.driver.common.windows.wmi;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import oshi.driver.common.windows.wmi.LhmSensor.LhmHardwareProperty;
+import oshi.driver.common.windows.wmi.LhmSensor.LhmSensorProperty;
+import oshi.util.GlobalConfig;
+
+/**
+ * Tests the configuration switches which suppress hardware monitor queries. The switches are global state, so these
+ * tests must not run alongside any other test which reads or writes the configuration.
+ */
+@Isolated
+class HardwareMonitorDisabledTest {
+
+    private static final String OTHER_NAMESPACE = "ROOT\\CIMV2";
+
+    private final @Nullable String ohmConfig = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED);
+    private final @Nullable String lhmConfig = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED);
+
+    @AfterEach
+    void restoreConfig() {
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED, ohmConfig);
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED, lhmConfig);
+    }
+
+    @Test
+    void testEnabledByDefault() {
+        assertThat("OHM enabled by default", HardwareMonitorDisabled.isWmiDisabled(OhmHardware.OHM_NAMESPACE),
+                is(false));
+        assertThat("LHM enabled by default", HardwareMonitorDisabled.isWmiDisabled(LhmSensor.LHM_NAMESPACE), is(false));
+    }
+
+    @Test
+    void testSwitchesAreIndependent() {
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED, true);
+        assertThat("OHM disabled", HardwareMonitorDisabled.isWmiDisabled(OhmHardware.OHM_NAMESPACE), is(true));
+        assertThat("LHM unaffected", HardwareMonitorDisabled.isWmiDisabled(LhmSensor.LHM_NAMESPACE), is(false));
+
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED, false);
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED, true);
+        assertThat("LHM disabled", HardwareMonitorDisabled.isWmiDisabled(LhmSensor.LHM_NAMESPACE), is(true));
+        assertThat("OHM unaffected", HardwareMonitorDisabled.isWmiDisabled(OhmHardware.OHM_NAMESPACE), is(false));
+    }
+
+    @Test
+    void testOtherNamespaceUnaffected() {
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED, true);
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED, true);
+        assertThat("Unrelated namespace still queried", HardwareMonitorDisabled.isWmiDisabled(OTHER_NAMESPACE),
+                is(false));
+    }
+
+    @Test
+    void testDisabledLhmSkipsQueries() {
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED, true);
+        CountingExecutor executor = new CountingExecutor();
+
+        WmiResult<LhmSensorProperty> sensors = LhmSensor.querySensors(executor, "/gpu-nvidia/0", "Load");
+        assertThat("No sensor rows", sensors.getResultCount(), is(0));
+        WmiResult<LhmHardwareProperty> hardware = LhmSensor.queryGpuHardware(executor);
+        assertThat("No hardware rows", hardware.getResultCount(), is(0));
+        assertThat("WMI not queried", executor.queries, is(0));
+    }
+
+    @Test
+    void testEnabledLhmQueries() {
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED, false);
+        CountingExecutor executor = new CountingExecutor();
+
+        LhmSensor.querySensors(executor, "/gpu-nvidia/0", "Load");
+        LhmSensor.queryGpuHardware(executor);
+        assertThat("WMI queried once per call", executor.queries, is(2));
+    }
+
+    /** A {@link WmiQueryExecutor} which counts queries and returns no rows. */
+    private static final class CountingExecutor implements WmiQueryExecutor {
+        private int queries;
+
+        @Override
+        public <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query) {
+            queries++;
+            return WmiResult.empty();
+        }
+
+        @Override
+        public <T extends Enum<T>> WmiResult<T> queryWMI(WmiQuery<T> query, boolean initCom) {
+            return queryWMI(query);
+        }
+    }
+}

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsSensorsDisabledTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsSensorsDisabledTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import oshi.driver.common.windows.wmi.LhmSensor;
+import oshi.driver.common.windows.wmi.MSAcpiThermalZoneTemperature.TemperatureProperty;
+import oshi.driver.common.windows.wmi.OhmHardware;
+import oshi.driver.common.windows.wmi.OhmSensor.ValueProperty;
+import oshi.driver.common.windows.wmi.Win32Fan.SpeedProperty;
+import oshi.driver.common.windows.wmi.Win32Processor.VoltProperty;
+import oshi.driver.common.windows.wmi.WmiResult;
+import oshi.util.GlobalConfig;
+
+/**
+ * Tests that the hardware monitor configuration switches suppress the sensor tiers which use them. The switches are
+ * global state, so these tests must not run alongside any other test which reads or writes the configuration.
+ */
+@Isolated
+class WindowsSensorsDisabledTest {
+
+    private final @Nullable String ohmConfig = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED);
+    private final @Nullable String lhmConfig = GlobalConfig.get(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED);
+
+    @AfterEach
+    void restoreConfig() {
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED, ohmConfig);
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED, lhmConfig);
+    }
+
+    @Test
+    void testBothMonitorsQueriedByDefault() {
+        RecordingSensors sensors = new RecordingSensors();
+        sensors.queryCpuTemperature();
+        assertThat("Both namespaces queried for temperature", sensors.namespaces,
+                contains(OhmHardware.OHM_NAMESPACE, LhmSensor.LHM_NAMESPACE));
+
+        sensors.namespaces.clear();
+        sensors.queryFanSpeeds();
+        assertThat("Both namespaces queried for fan speed", sensors.namespaces,
+                contains(OhmHardware.OHM_NAMESPACE, LhmSensor.LHM_NAMESPACE));
+
+        sensors.namespaces.clear();
+        sensors.queryCpuVoltage();
+        assertThat("Both namespaces queried for voltage", sensors.namespaces,
+                contains(OhmHardware.OHM_NAMESPACE, LhmSensor.LHM_NAMESPACE));
+    }
+
+    @Test
+    void testDisablingOneMonitorLeavesTheOther() {
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED, true);
+        RecordingSensors sensors = new RecordingSensors();
+        sensors.queryCpuTemperature();
+        sensors.queryFanSpeeds();
+        sensors.queryCpuVoltage();
+        assertThat("Only LHM queried", sensors.namespaces,
+                contains(LhmSensor.LHM_NAMESPACE, LhmSensor.LHM_NAMESPACE, LhmSensor.LHM_NAMESPACE));
+
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED, false);
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED, true);
+        sensors.namespaces.clear();
+        sensors.queryCpuTemperature();
+        sensors.queryFanSpeeds();
+        sensors.queryCpuVoltage();
+        assertThat("Only OHM queried", sensors.namespaces,
+                contains(OhmHardware.OHM_NAMESPACE, OhmHardware.OHM_NAMESPACE, OhmHardware.OHM_NAMESPACE));
+    }
+
+    @Test
+    void testDisablingBothMonitorsSkipsAllQueries() {
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_OHM_DISABLED, true);
+        GlobalConfig.set(GlobalConfig.OSHI_OS_WINDOWS_LHM_DISABLED, true);
+        RecordingSensors sensors = new RecordingSensors();
+        sensors.queryCpuTemperature();
+        sensors.queryFanSpeeds();
+        sensors.queryCpuVoltage();
+        assertThat("No monitor queried", sensors.namespaces, is(empty()));
+    }
+
+    /** Records the namespaces queried and returns no results from any source. */
+    private static final class RecordingSensors extends WindowsSensors {
+        private final List<String> namespaces = new ArrayList<>();
+
+        @Override
+        protected @Nullable WmiResult<ValueProperty> queryHardwareMonitorSensor(String namespace, String typeToQuery,
+                String typeName, String sensorType, boolean searchCpu) {
+            namespaces.add(namespace);
+            return null;
+        }
+
+        @Override
+        protected WmiResult<TemperatureProperty> queryWmiTemperature() {
+            return WmiResult.empty();
+        }
+
+        @Override
+        protected WmiResult<SpeedProperty> queryWmiFanSpeed() {
+            return WmiResult.empty();
+        }
+
+        @Override
+        protected WmiResult<VoltProperty> queryWmiVoltage() {
+            return WmiResult.empty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Open Hardware Monitor and Libre Hardware Monitor publish sensor data to their own WMI namespaces only while they are running, and a user may start or stop either at any time. OSHI therefore queries both on every sensor read and simply gets no results when neither is running. There is currently no way for a user who runs neither, or only one, to say so.

This adds two properties, in the spirit of the existing `perfos`/`perfproc`/`perfdisk` switches:

| Property | Skips |
|---|---|
| `oshi.os.windows.ohm.disabled` | The `ROOT\OpenHardwareMonitor` namespace |
| `oshi.os.windows.lhm.disabled` | The `ROOT\LibreHardwareMonitor` namespace, GPU metrics as well as sensors |

Both default to `false`, preserving today's behavior, and both are read on each call rather than latched, so they can be set before the first query and so the runtime probing they suppress stays runtime probing.

## Where the guards sit

Everything is in `oshi-common`, so both backends inherit it and cannot diverge:

* `HardwareMonitorDisabled` (new) is the one home for the reads, keyed on the namespace constant so any other namespace is unaffected.
* `WindowsSensors` guards the two monitor tiers in its three `*FromMonitorWmi` methods. That is ahead of the point where each backend creates a `WmiQueryHandler` and initializes COM, so a disabled monitor costs nothing at all.
* `LhmSensor.querySensors`/`queryGpuHardware` are the choke point both backends delegate to, which is what gives the LHM switch its reach beyond sensors. `queryGpuHardware` returning empty leaves the graphics card LHM parent map empty, which is already the "skip LHM" sentinel `WindowsGpuStats` checks, so GPU metrics fall through to NVML/ADL/PDH with no change in either twin.
* `WmiResult.empty()` (new) supplies the no-row result a skipped query returns.

## The jLibreHardwareMonitor dependency deliberately gets no switch

It is optional and not transitive, so declaring it is already the affirmative decision to use it, and removing it is the way to opt out. A configuration property would only duplicate that.

Its presence is now tested once at class initialization, the way udev loading is handled, instead of on every read. Previously a user without the dependency — nearly everyone — drove a `Class.forName` failure and caught `ClassNotFoundException` on each of the three sensor reads. The probe passes `initialize=false`, so checking presence does not run the library's static initializers; only real use does. The inner `ClassNotFoundException` catch stays, since the probe proves only that `ComputerConfig` resolves.

The private methods reading that dependency are renamed to `*LhmJar*`: "LHM" previously named both the jar and the WMI namespace within the same class.

## Testing

Two new test classes in `oshi-common`, which run on every platform: one covers the switches and proves the executor is never touched when LHM is off, the other records which namespaces each sensor read actually queries. Both carry `@Isolated`, as they mutate global configuration and the suite runs concurrently.

Neither WMI namespace can be exercised in CI, since both need the application running as Administrator, so the guards ship on the same evidence basis as the tiers they guard.

Verified with the full gate on JDK 26: `clean spotless:apply sortpom:sort checkstyle:check install forbiddenapis:check javadoc:javadoc -Paggregate-coverage`, plus `-Perror-prone` for NullAway. All green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows configuration options to disable Open Hardware Monitor and Libre Hardware Monitor sensor queries.
  * Disabling Libre Hardware Monitor also skips related GPU sensor queries.
  * Sensor reads return empty results when a configured monitor is disabled.
  * Windows sensor sources are queried in order, stopping when a source returns data.

* **Documentation**
  * Updated the changelog and FAQ with hardware-monitor configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->