### PR TITLE
Fix the CI path filters that silently skip platform coverage

### DIFF
--- a/.github/workflows/appveyor-dispatch.yaml
+++ b/.github/workflows/appveyor-dispatch.yaml
@@ -1,0 +1,43 @@
+# Force an AppVeyor build for a pull request by adding the `full-coverage` label.
+#
+# AppVeyor is the only Windows Server 2019 runner and it is path-filtered (see the skip_commits
+# block in appveyor.yml), so a change it skips has no Windows Server coverage at all. Commits
+# filtering does not apply to builds started through the API, so this is the escape hatch for a
+# change whose Windows relevance the filter cannot see.
+#
+# The label is the same one pr.yaml uses to force the Unix VM jobs on, so one label means "run the
+# long jobs regardless of what changed" across both CI systems.
+#
+# This needs an APPVEYOR_TOKEN repository secret, from https://ci.appveyor.com/api-keys. Without it
+# the job fails with a message saying so rather than appearing to succeed.
+#
+# pull_request_target, not pull_request, because secrets are not available to pull_request runs from
+# a fork, which is where every contributor pull request comes from. It is safe here for the reason
+# that makes pull_request_target dangerous elsewhere: this workflow never checks out the pull
+# request's code, and only reads its number.
+name: AppVeyor on demand
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions: {}
+
+jobs:
+  appveyor:
+    if: github.event.label.name == 'full-coverage'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start an AppVeyor build for this pull request
+        env:
+          APPVEYOR_TOKEN: ${{ secrets.APPVEYOR_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$APPVEYOR_TOKEN" ]; then
+            echo "::error::APPVEYOR_TOKEN secret is not set. Add it from https://ci.appveyor.com/api-keys."
+            exit 1
+          fi
+          curl -sS --fail-with-body -X POST https://ci.appveyor.com/api/builds \
+            -H "Authorization: Bearer $APPVEYOR_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"accountName\":\"dbwiddis\",\"projectSlug\":\"oshi\",\"pullRequestId\":$PR_NUMBER}"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,50 +34,36 @@ jobs:
     outputs:
       unix: ${{ steps.filter.outputs.unix }}
     steps:
+      # Skip the Unix VM jobs only when EVERY changed file is provably irrelevant to them: another
+      # platform's implementation tree, documentation, or CI configuration. Anything else runs them,
+      # including shared code and paths that do not exist yet.
+      #
+      # The include list this replaces looked for a `unix/` path segment plus the build inputs, which
+      # missed everything Unix depends on without saying "unix" in its path: oshi.properties carries
+      # the filesystem exclude lists for AIX, FreeBSD, DragonFly, OpenBSD and Solaris, and every Unix
+      # driver calls shared code such as ParseUtil. PR #3727 changed oshi.properties and all six Unix
+      # jobs reported "skipping".
+      #
+      # predicate-quantifier: some-with-excludes makes a file count when it matches at least one
+      # pattern and no negated one, so `**` minus the exclusions below is the whole rule, and the
+      # filter is true when at least one changed file survives it. No checkout is needed: on a
+      # pull_request event the action reads the file list from the API, which is what
+      # `pull-requests: read` above is for.
       - name: Detect Unix-relevant changes
         id: filter
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if ! CHANGED=$(gh pr view "${{ github.event.pull_request.number }}" \
-              --repo "${{ github.repository }}" --json files --jq '.files[].path'); then
-            # Fail safe: if the file list can't be read, run the Unix jobs rather than
-            # silently skip them and drop coverage.
-            echo "Could not read changed files; defaulting to running the Unix jobs"
-            echo "unix=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Changed files:"; echo "$CHANGED"
-          # Skip the Unix VM jobs only when EVERY changed file is provably irrelevant to them:
-          # another platform's implementation tree, documentation, or CI configuration. Anything
-          # else runs them, including shared code and paths that do not exist yet.
-          #
-          # The include list this replaces looked for a `unix/` path segment plus the build inputs,
-          # which missed everything Unix depends on without saying "unix" in its path: oshi.properties
-          # carries the filesystem exclude lists for AIX, FreeBSD, DragonFly, OpenBSD and Solaris, and
-          # every Unix driver calls shared code such as ParseUtil. PR #3727 changed oshi.properties
-          # and all six Unix jobs reported "skipping".
-          #
-          # Written as a case over shell globs rather than a grep pipeline. `grep -v ... | grep -q .`
-          # is wrong here: the reader exits on its first line, the writer takes SIGPIPE, and this
-          # step runs under bash -eo pipefail, so the pipeline reports 141. Inside `if` that reads as
-          # false, silently skipping the Unix jobs for a pull request that does touch relevant files.
-          # It is a race with the file count, so it would have passed review and failed later, on a
-          # large pull request. (`grep -qv` is no better: BSD grep ignores -v when setting -q's exit
-          # status, so it is correct only on the runner's GNU grep.)
-          #
-          # The jobs still report as skipped rather than vanishing, which keeps a skip visible on the
-          # pull request.
-          UNIX=false
-          while IFS= read -r FILE; do
-            [ -n "$FILE" ] || continue
-            case "$FILE" in
-              *.md|.github/*|.circleci/*|appveyor.yml|src/site/*) ;;
-              mac/*|*/mac/*|windows/*|*/windows/*) ;;
-              *) UNIX=true; break ;;
-            esac
-          done <<< "$CHANGED"
-          echo "unix=$UNIX" >> "$GITHUB_OUTPUT"
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            unix:
+              - '**'
+              - '!**/*.md'
+              - '!.github/**'
+              - '!.circleci/**'
+              - '!appveyor.yml'
+              - '!src/site/**'
+              - '!**/mac/**'
+              - '!**/windows/**'
 
   # Static analysis, split into parallel jobs so no single job's sequential Maven
   # invocations dominate the critical path.
@@ -225,9 +211,14 @@ jobs:
     needs: changes
     permissions:
       contents: read
+    # !cancelled() rather than a bare success dependency, so a failed detection step runs these
+    # instead of silently skipping them: an unreadable file list must not read as "nothing relevant
+    # changed". `result != 'skipped'` keeps that from also running them when the changes job itself
+    # was skipped, on an unrelated label. Neither runs when the workflow is cancelled.
     if: >-
-      needs.changes.outputs.unix == 'true' ||
-      contains(github.event.pull_request.labels.*.name, 'full-coverage')
+      !cancelled() && needs.changes.result != 'skipped' &&
+      (needs.changes.outputs.unix != 'false' ||
+      contains(github.event.pull_request.labels.*.name, 'full-coverage'))
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -265,9 +256,14 @@ jobs:
     needs: changes
     permissions:
       contents: read
+    # !cancelled() rather than a bare success dependency, so a failed detection step runs these
+    # instead of silently skipping them: an unreadable file list must not read as "nothing relevant
+    # changed". `result != 'skipped'` keeps that from also running them when the changes job itself
+    # was skipped, on an unrelated label. Neither runs when the workflow is cancelled.
     if: >-
-      needs.changes.outputs.unix == 'true' ||
-      contains(github.event.pull_request.labels.*.name, 'full-coverage')
+      !cancelled() && needs.changes.result != 'skipped' &&
+      (needs.changes.outputs.unix != 'false' ||
+      contains(github.event.pull_request.labels.*.name, 'full-coverage'))
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -310,9 +306,14 @@ jobs:
     needs: changes
     permissions:
       contents: read
+    # !cancelled() rather than a bare success dependency, so a failed detection step runs these
+    # instead of silently skipping them: an unreadable file list must not read as "nothing relevant
+    # changed". `result != 'skipped'` keeps that from also running them when the changes job itself
+    # was skipped, on an unrelated label. Neither runs when the workflow is cancelled.
     if: >-
-      needs.changes.outputs.unix == 'true' ||
-      contains(github.event.pull_request.labels.*.name, 'full-coverage')
+      !cancelled() && needs.changes.result != 'skipped' &&
+      (needs.changes.outputs.unix != 'false' ||
+      contains(github.event.pull_request.labels.*.name, 'full-coverage'))
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,18 +58,26 @@ jobs:
           # every Unix driver calls shared code such as ParseUtil. PR #3727 changed oshi.properties
           # and all six Unix jobs reported "skipping".
           #
-          # grep -v prints the lines that do NOT match, so a non-empty result means something
-          # relevant changed. The jobs still report as skipped rather than vanishing, which is what
-          # keeps a skip visible on the pull request.
+          # Written as a case over shell globs rather than a grep pipeline. `grep -v ... | grep -q .`
+          # is wrong here: the reader exits on its first line, the writer takes SIGPIPE, and this
+          # step runs under bash -eo pipefail, so the pipeline reports 141. Inside `if` that reads as
+          # false, silently skipping the Unix jobs for a pull request that does touch relevant files.
+          # It is a race with the file count, so it would have passed review and failed later, on a
+          # large pull request. (`grep -qv` is no better: BSD grep ignores -v when setting -q's exit
+          # status, so it is correct only on the runner's GNU grep.)
           #
-          # `grep -v ... | grep -q .` rather than `grep -qv ...`: BSD grep ignores -v when setting
-          # -q's exit status, so the single-command form is correct on the GNU grep this runner has
-          # and silently inverted for anyone testing it on macOS.
-          if echo "$CHANGED" | grep -vE '\.md$|(^|/)(mac|windows)/|^\.github/|^\.circleci/|^appveyor\.yml$|^src/site/' | grep -q .; then
-            echo "unix=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "unix=false" >> "$GITHUB_OUTPUT"
-          fi
+          # The jobs still report as skipped rather than vanishing, which keeps a skip visible on the
+          # pull request.
+          UNIX=false
+          while IFS= read -r FILE; do
+            [ -n "$FILE" ] || continue
+            case "$FILE" in
+              *.md|.github/*|.circleci/*|appveyor.yml|src/site/*) ;;
+              mac/*|*/mac/*|windows/*|*/windows/*) ;;
+              *) UNIX=true; break ;;
+            esac
+          done <<< "$CHANGED"
+          echo "unix=$UNIX" >> "$GITHUB_OUTPUT"
 
   # Static analysis, split into parallel jobs so no single job's sequential Maven
   # invocations dominate the critical path.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -47,10 +47,24 @@ jobs:
             exit 0
           fi
           echo "Changed files:"; echo "$CHANGED"
-          # Run the Unix VM jobs when Unix-platform code (any `unix/` path segment across
-          # oshi-common/oshi-core: hardware, software, driver, util, ffm, jna) or build
-          # infrastructure (any pom.xml, the Maven wrapper) changes.
-          if echo "$CHANGED" | grep -qE '(^|/)unix/|(^|/)pom\.xml$|^\.mvn/|^mvnw'; then
+          # Skip the Unix VM jobs only when EVERY changed file is provably irrelevant to them:
+          # another platform's implementation tree, documentation, or CI configuration. Anything
+          # else runs them, including shared code and paths that do not exist yet.
+          #
+          # The include list this replaces looked for a `unix/` path segment plus the build inputs,
+          # which missed everything Unix depends on without saying "unix" in its path: oshi.properties
+          # carries the filesystem exclude lists for AIX, FreeBSD, DragonFly, OpenBSD and Solaris, and
+          # every Unix driver calls shared code such as ParseUtil. PR #3727 changed oshi.properties
+          # and all six Unix jobs reported "skipping".
+          #
+          # grep -v prints the lines that do NOT match, so a non-empty result means something
+          # relevant changed. The jobs still report as skipped rather than vanishing, which is what
+          # keeps a skip visible on the pull request.
+          #
+          # `grep -v ... | grep -q .` rather than `grep -qv ...`: BSD grep ignores -v when setting
+          # -q's exit status, so the single-command form is correct on the GNU grep this runner has
+          # and silently inverted for anyone testing it on macOS.
+          if echo "$CHANGED" | grep -vE '\.md$|(^|/)(mac|windows)/|^\.github/|^\.circleci/|^appveyor\.yml$|^src/site/' | grep -q .; then
             echo "unix=true" >> "$GITHUB_OUTPUT"
           else
             echo "unix=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,8 @@ jobs:
   # The nested-VM Unix coverage jobs (freebsd/openbsd/openindiana) are gated on this
   # so an unrelated PR doesn't spin up slow VMs. Generic shared source is covered by
   # the always-on ubuntu/mac/windows jobs, Codecov carryforward, and the authoritative
-  # master run. A `full-coverage` label overrides the gate to force the VM jobs on.
+  # master run. A `full-coverage` label overrides the gate to force the VM jobs on; the same label
+  # starts an AppVeyor build, which is path-filtered in the same spirit (see appveyor-dispatch.yaml).
   changes:
     # On a `labeled` event only proceed for the full-coverage label, so adding an
     # unrelated label doesn't re-run CI. opened/synchronize/reopened always run.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,29 @@ branches:
     - master
     - debug
 
-only_commits:
+# Skip a build only when EVERY file in the head commit is provably irrelevant to Windows: another
+# platform's implementation tree, documentation, or another CI system's configuration. Anything else
+# runs, including shared code, build inputs and paths that do not exist yet.
+#
+# This is deliberately an exclusion list. The include list it replaces ('**/windows/**',
+# '**/common/**', '**/util/**') was written in 2020, when oshi-core was the only module holding code
+# and `common` could only mean one source tree. Across five modules those are Java package names
+# that appear everywhere, so the list both over-matched (63% of runs came from non-Windows code) and
+# silently missed real Windows changes: the three Windows comparison tests, oshi.properties, every
+# pom.xml, and the oshi-demo Windows classes. A miss is invisible - AppVeyor is not a required
+# check, so a skipped build leaves no status at all and the pull request still reads as green.
+#
+# Note that AppVeyor evaluates these against the HEAD COMMIT of a push, not the whole pull request.
+skip_commits:
   files:
-    - '**/windows/**'
-    - '**/common/**'
-    - '**/util/**'
+    - '**/*.md'
+    - '**/mac/**'
+    - '**/linux/**'
+    - '**/unix/**'
+    - '**/nativefree/**'
+    - '.github/**'
+    - '.circleci/**'
+    - 'src/site/**'
 
 environment:
   TERM: dumb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,5 +35,8 @@ install:
 build_script:
   - appveyor-retry ./mvnw -B -DskipTests=true clean package
 
+# -Paggregate-coverage turns off oshi-benchmark's own maven.test.skip, which otherwise suppresses
+# test *compilation*, so the oshi.comparison tests are neither built nor run. Three of them
+# (WMI, perfmon, registry) exercise Windows-only code paths and have no other Windows runner.
 test_script:
-  - ./mvnw -B test
+  - ./mvnw -B test -Paggregate-coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,8 +53,12 @@ install:
 build_script:
   - appveyor-retry ./mvnw -B -DskipTests=true clean package
 
-# -Paggregate-coverage turns off oshi-benchmark's own maven.test.skip, which otherwise suppresses
+# -Pnative-comparison turns off oshi-benchmark's own maven.test.skip, which otherwise suppresses
 # test *compilation*, so the oshi.comparison tests are neither built nor run. Three of them
 # (WMI, perfmon, registry) exercise Windows-only code paths and have no other Windows runner.
+#
+# Not -Paggregate-coverage, which would enable the same tests: nothing here uploads to Codecov, and
+# the GitHub-hosted windows job already owns that flag, so the aggregate report would be built and
+# discarded. If an upload is ever added, decide which flag it carries first.
 test_script:
-  - ./mvnw -B test -Paggregate-coverage
+  - ./mvnw -B test -Pnative-comparison

--- a/oshi-benchmark/src/test/java/oshi/comparison/ComparisonAssertions.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/ComparisonAssertions.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Shared assertion helpers for JNA vs FFM comparison tests.
  */
-final class ComparisonAssertions {
+public final class ComparisonAssertions {
 
     private ComparisonAssertions() {
     }
@@ -22,7 +22,7 @@ final class ComparisonAssertions {
      * @param ratio       the maximum allowed deviation (0.0–1.0)
      * @param description a label for assertion failure messages
      */
-    static void assertWithinRatio(long actual, long expected, double ratio, String description) {
+    public static void assertWithinRatio(long actual, long expected, double ratio, String description) {
         assertWithinRatio((double) actual, (double) expected, ratio, description);
     }
 
@@ -34,7 +34,7 @@ final class ComparisonAssertions {
      * @param ratio       the maximum allowed deviation (0.0–1.0)
      * @param description a label for assertion failure messages
      */
-    static void assertWithinRatio(double actual, double expected, double ratio, String description) {
+    public static void assertWithinRatio(double actual, double expected, double ratio, String description) {
         // Sensors that aren't available on a platform return NaN from both implementations (e.g. CPU temperature on a
         // FreeBSD VM without the coretemp kld module). Treat that as "equal: both are 'no data'" since NaN arithmetic
         // would otherwise make the ratio comparison fail.

--- a/oshi-benchmark/src/test/java/oshi/comparison/windows/PerfmonComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/windows/PerfmonComparisonTest.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.comparison;
+package oshi.comparison.windows;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static oshi.comparison.ComparisonAssertions.assertWithinRatio;

--- a/oshi-benchmark/src/test/java/oshi/comparison/windows/RegistryComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/windows/RegistryComparisonTest.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.comparison;
+package oshi.comparison.windows;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;

--- a/oshi-benchmark/src/test/java/oshi/comparison/windows/WmiComparisonTest.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/windows/WmiComparisonTest.java
@@ -2,7 +2,7 @@
  * Copyright 2026 The OSHI Project Contributors
  * SPDX-License-Identifier: MIT
  */
-package oshi.comparison;
+package oshi.comparison.windows;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static oshi.comparison.ComparisonAssertions.assertWithinRatio;

--- a/oshi-benchmark/src/test/java/oshi/comparison/windows/package-info.java
+++ b/oshi-benchmark/src/test/java/oshi/comparison/windows/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Comparison tests for the Windows-only query mechanisms: WMI, performance counters, and the registry. They live in
+ * their own package so that CI path filters keyed on a {@code windows} path segment select them.
+ */
+package oshi.comparison.windows;


### PR DESCRIPTION
## Why

The path filters were written in 2020, in `699858f753`, when `oshi-core` was the only module holding code and `**/common/**` could only mean one source tree. Across five modules `common` and `util` are Java package names that appear everywhere, so the filters now both over-match and under-match — and they are written as include lists, which fail toward *not running*. A skipped AppVeyor build leaves no status at all on a check that is not required, so the pull request still reads `CLEAN`. The failure mode always points toward "merge it".

Measured over `git ls-files`:

* AppVeyor's filter matched **858 of 1373** source files, of which only **312** were Windows paths — **63% of its runs came from non-Windows code** — while missing the three Windows comparison tests, `oshi.properties`, **every `pom.xml`** (`390ee7f5e5`, the compiler-plugin bump, carries no AppVeyor status), and the `oshi-demo` Windows classes.
* `pr.yaml`'s `unix` gate missed `oshi.properties`, which carries the filesystem exclude lists for AIX, FreeBSD, DragonFly, OpenBSD and Solaris, and shared code such as `ParseUtil` that every Unix driver calls. #3727 changed `oshi.properties` and all six Unix jobs reported `skipping`.

## What changed

1. **Move the Windows comparison tests to `oshi.comparison.windows`.** `Wmi`, `Perfmon` and `RegistryComparisonTest` are Windows-only but sat where no filter selects them; this is how a commit whose comparison tests did not compile reached CI green. They now match a `windows` path segment by construction rather than by growing a list.
2. **Run AppVeyor's tests under `-Pnative-comparison`.** `oshi-benchmark` sets `maven.test.skip` in its own pom, which suppresses test *compilation*, so a bare `mvn test` builds none of the `oshi.comparison` sources — AppVeyor reported success while building the very commit whose comparison tests did not compile. Not `-Paggregate-coverage`, which enables the same tests: AppVeyor uploads nothing to Codecov and the GitHub-hosted windows job already owns that flag, so the aggregate report would be built and discarded.
3. **Invert both filters into exclusion lists.** A build is skipped only when *every* changed file is provably irrelevant to that platform: another platform's implementation tree, documentation, or another CI system's config. Shared code, build inputs, and paths that do not exist yet all run.
4. **Let the existing `full-coverage` label force an AppVeyor build.** Commits filtering does not apply to API-started builds, so this is the escape hatch when the filter cannot see a change's Windows relevance. It reuses pr.yaml's label rather than adding a second one, so one label means "run the long jobs whatever changed" across both systems.

Filtering stays on the long-running jobs only — the point is not waiting on an OpenIndiana VM to review a macOS change. The GitHub-hosted Linux, macOS and Windows jobs keep running unconditionally, and CircleCI, cfarm and the full Unix suite keep their post-merge role.

## Notes

* The `APPVEYOR_TOKEN` repository secret commit 4 needs **has been added**, so nothing is outstanding. (The job fails with an explicit message if it is ever missing, rather than appearing to succeed.)
* It uses `pull_request_target` because secrets are unavailable to `pull_request` runs from a fork, which is where every contributor PR comes from. Safe here for the reason that trigger is usually dangerous: the workflow never checks out the PR's code and reads only its number.
* The Unix gate has no shell in it: it is `dorny/paths-filter`, SHA-pinned, with `predicate-quantifier: some-with-excludes` so the rule reads as `**` minus the irrelevant paths. It got there via two shell bugs worth recording, because both were in the plumbing rather than the rule and both failed toward *skipping* the jobs — `grep -qv`, which BSD grep evaluates differently from GNU grep, and then a `grep -v | grep -q .` pipeline that reports 141 on SIGPIPE under `pipefail` and so reads as false (reproduced on the first attempt over 1552 paths). The VM jobs gate on `!cancelled() && needs.changes.result != 'skipped'`, which keeps the fail-safe the shell version had: a failed detection runs them rather than silently skipping them.
* This PR is itself a test of item 3. AppVeyor builds it, because `appveyor.yml` is not in its own skip list — a change to the CI config now exercises that config. The Unix jobs also run, because the move touches `ComparisonAssertions`, a shared test helper outside any platform tree; only a change confined to `**/windows/**`, docs and CI config would skip them. Both are the fail-safe direction: unrecognized paths run.

No CHANGELOG entry: nothing user-visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-demand AppVeyor builds triggered by applying the `full-coverage` pull request label.

* **Bug Fixes**
  * Improved change detection and Unix coverage job handling for more reliable CI results.
  * Expanded Windows coverage builds to run WMI, performance counter, and registry comparison tests.

* **Tests**
  * Organized Windows comparison tests to improve CI selection and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

