### PR TITLE
Fix the Windows hardware monitor voltage query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#3723](https://github.com/oshi/oshi/pull/3723): Windows `Sensors` reads CPU temperature, fan speed and voltage from the `ROOT\LibreHardwareMonitor` WMI namespace when the LibreHardwareMonitor application is running, in addition to the `ROOT\OpenHardwareMonitor` namespace it already read. Users running the maintained LibreHardwareMonitor previously got its GPU metrics but no CPU sensor data - [@dbwiddis](https://github.com/dbwiddis).
 * [#3727](https://github.com/oshi/oshi/pull/3727): The `oshi.os.windows.ohm.disabled` and `oshi.os.windows.lhm.disabled` configuration properties skip the Open Hardware Monitor and Libre Hardware Monitor WMI namespaces, which OSHI otherwise queries on each sensor read until one returns data. The latter also covers GPU metrics - [@dbwiddis](https://github.com/dbwiddis).
+* [#3730](https://github.com/oshi/oshi/pull/3730): `Sensors.getCpuVoltage()` on Windows reports the voltage published by Open Hardware Monitor or LibreHardwareMonitor. The query asked the WMI `Hardware` class to filter on a `SensorType` property that class does not have, so it could never match and the value always came from a lower-priority source - [@dbwiddis](https://github.com/dbwiddis).
 
 # 7.6.0 (2026-08-23), 7.6.1 (2026-09-01)
 

--- a/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsSensors.java
+++ b/oshi-common/src/main/java/oshi/hardware/common/platform/windows/WindowsSensors.java
@@ -51,6 +51,11 @@ public abstract class WindowsSensors extends AbstractSensors {
     /** Libre Hardware Monitor's {@code HardwareType} value for a processor, which OHM spells {@code CPU}. */
     private static final String LHM_CPU = "Cpu";
 
+    /** {@code SensorType} values. Both monitors publish the same names, in WMI and through the jar alike. */
+    private static final String TEMPERATURE = "Temperature";
+    private static final String FAN = "Fan";
+    private static final String VOLTAGE = "Voltage";
+
     /**
      * Whether the optional {@code jLibreHardwareMonitor} dependency is on the class path. Declaring that dependency is
      * how a user opts in to it, and the class path does not change while OSHI is running, so it is tested once here
@@ -96,8 +101,8 @@ public abstract class WindowsSensors extends AbstractSensors {
         if (HardwareMonitorDisabled.isWmiDisabled(namespace)) {
             return 0;
         }
-        WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, "Hardware", cpuTypeName,
-                "Temperature", false);
+        WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, OhmHardware.HARDWARE, cpuTypeName,
+                TEMPERATURE);
         if (ohmSensors != null && ohmSensors.getResultCount() > 0) {
             double sum = 0;
             for (int i = 0; i < ohmSensors.getResultCount(); i++) {
@@ -109,7 +114,7 @@ public abstract class WindowsSensors extends AbstractSensors {
     }
 
     private static double getTempFromLhmJar() {
-        return getAverageValueFromLhmJar("CPU", "Temperature",
+        return getAverageValueFromLhmJar("CPU", TEMPERATURE,
                 (name, value) -> !name.contains("Max") && !name.contains("Average") && value > 0);
     }
 
@@ -159,8 +164,8 @@ public abstract class WindowsSensors extends AbstractSensors {
         if (HardwareMonitorDisabled.isWmiDisabled(namespace)) {
             return new int[0];
         }
-        WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, "Hardware", cpuTypeName, "Fan",
-                false);
+        WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, OhmHardware.HARDWARE, cpuTypeName,
+                FAN);
         if (ohmSensors != null && ohmSensors.getResultCount() > 0) {
             int[] fanSpeeds = new int[ohmSensors.getResultCount()];
             for (int i = 0; i < ohmSensors.getResultCount(); i++) {
@@ -172,7 +177,7 @@ public abstract class WindowsSensors extends AbstractSensors {
     }
 
     private static int[] getFansFromLhmJar() {
-        List<?> sensors = queryLhmJarSensors("SuperIO", "Fan");
+        List<?> sensors = queryLhmJarSensors("SuperIO", FAN);
         if (sensors == null || sensors.isEmpty()) {
             return new int[0];
         }
@@ -220,12 +225,12 @@ public abstract class WindowsSensors extends AbstractSensors {
     @Override
     public double queryCpuVoltage() {
         // Attempt to fetch value from Open Hardware Monitor if it is running
-        double volts = getVoltsFromMonitorWmi(OhmHardware.OHM_NAMESPACE);
+        double volts = getVoltsFromMonitorWmi(OhmHardware.OHM_NAMESPACE, OHM_CPU);
         if (volts > 0d) {
             return volts;
         }
         // Then Libre Hardware Monitor, the maintained successor, which publishes the same schema
-        volts = getVoltsFromMonitorWmi(LhmSensor.LHM_NAMESPACE);
+        volts = getVoltsFromMonitorWmi(LhmSensor.LHM_NAMESPACE, LHM_CPU);
         if (volts > 0d) {
             return volts;
         }
@@ -238,12 +243,15 @@ public abstract class WindowsSensors extends AbstractSensors {
         return getVoltsFromWMI();
     }
 
-    private double getVoltsFromMonitorWmi(String namespace) {
+    private double getVoltsFromMonitorWmi(String namespace, String cpuTypeName) {
         if (HardwareMonitorDisabled.isWmiDisabled(namespace)) {
             return 0d;
         }
-        WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, "Sensor", "Voltage", "Voltage",
-                true);
+        // The processor's voltage sensors, reached the same way as its temperature and fan sensors. This asked the
+        // Hardware class for SensorType="Voltage" until 2026-09; that class has no SensorType property, so the query
+        // could never match and this tier always fell through to the jar or to plain WMI.
+        WmiResult<ValueProperty> ohmSensors = queryHardwareMonitorSensor(namespace, OhmHardware.HARDWARE, cpuTypeName,
+                VOLTAGE);
         if (ohmSensors != null && ohmSensors.getResultCount() > 0) {
             return WmiUtil.getFloat(ohmSensors, ValueProperty.VALUE, 0);
         }
@@ -251,7 +259,7 @@ public abstract class WindowsSensors extends AbstractSensors {
     }
 
     private static double getVoltsFromLhmJar() {
-        return getAverageValueFromLhmJar("SuperIO", "Voltage",
+        return getAverageValueFromLhmJar("SuperIO", VOLTAGE,
                 (name, value) -> name.toLowerCase(Locale.ROOT).contains("vcore") && value > 0);
     }
 
@@ -283,23 +291,13 @@ public abstract class WindowsSensors extends AbstractSensors {
     }
 
     /**
-     * Selects the CPU hardware identifier from an Open Hardware Monitor identifier result. When {@code searchCpu} is
-     * set, the first identifier containing {@code cpu} is used; otherwise (or if none match) the first identifier is
-     * returned.
+     * Selects the hardware identifier to read sensors from. The query which produced the result already filtered on
+     * {@code HardwareType}, so the first identifier is the one wanted.
      *
-     * @param ohmHardware the OHM hardware identifier result
-     * @param searchCpu   whether to search for an identifier containing {@code cpu}
+     * @param ohmHardware the hardware identifier result
      * @return the selected identifier (possibly empty)
      */
-    protected static String selectOhmCpuIdentifier(WmiResult<IdentifierProperty> ohmHardware, boolean searchCpu) {
-        if (searchCpu) {
-            for (int i = 0; i < ohmHardware.getResultCount(); i++) {
-                String id = WmiUtil.getString(ohmHardware, IdentifierProperty.IDENTIFIER, i);
-                if (id.toLowerCase(Locale.ROOT).contains("cpu")) {
-                    return id;
-                }
-            }
-        }
+    protected static String selectOhmCpuIdentifier(WmiResult<IdentifierProperty> ohmHardware) {
         return WmiUtil.getString(ohmHardware, IdentifierProperty.IDENTIFIER, 0);
     }
 
@@ -370,14 +368,13 @@ public abstract class WindowsSensors extends AbstractSensors {
      * Hardware Monitor publish the same schema under their own namespaces, so the namespace selects which is queried.
      *
      * @param namespace   the WMI namespace, either {@link OhmHardware#OHM_NAMESPACE} or {@link LhmSensor#LHM_NAMESPACE}
-     * @param typeToQuery the hardware type to query
+     * @param typeToQuery the class whose {@code Type} column is filtered, {@link OhmHardware#HARDWARE}
      * @param typeName    the hardware type name, which differs between the two monitors
      * @param sensorType  the sensor type
-     * @param searchCpu   whether to search for a {@code cpu} identifier (vs. using the first)
      * @return the sensor values, or {@code null} if unavailable
      */
     protected abstract @Nullable WmiResult<ValueProperty> queryHardwareMonitorSensor(String namespace,
-            String typeToQuery, String typeName, String sensorType, boolean searchCpu);
+            String typeToQuery, String typeName, String sensorType);
 
     /**
      * Queries the current temperature from WMI {@code MSAcpi_ThermalZoneTemperature}.

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsSensorsDisabledTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsSensorsDisabledTest.java
@@ -97,7 +97,7 @@ class WindowsSensorsDisabledTest {
 
         @Override
         protected @Nullable WmiResult<ValueProperty> queryHardwareMonitorSensor(String namespace, String typeToQuery,
-                String typeName, String sensorType, boolean searchCpu) {
+                String typeName, String sensorType) {
             namespaces.add(namespace);
             return null;
         }

--- a/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsSensorsQueryTest.java
+++ b/oshi-common/src/test/java/oshi/hardware/common/platform/windows/WindowsSensorsQueryTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 The OSHI Project Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package oshi.hardware.common.platform.windows;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import oshi.driver.common.windows.wmi.MSAcpiThermalZoneTemperature.TemperatureProperty;
+import oshi.driver.common.windows.wmi.OhmHardware;
+import oshi.driver.common.windows.wmi.OhmSensor.ValueProperty;
+import oshi.driver.common.windows.wmi.Win32Fan.SpeedProperty;
+import oshi.driver.common.windows.wmi.Win32Processor.VoltProperty;
+import oshi.driver.common.windows.wmi.WmiResult;
+
+/**
+ * Tests what each sensor read asks the hardware monitors for.
+ * <p>
+ * Every sensor is reached the same way: filter the {@code Hardware} class on {@code HardwareType} to find the
+ * processor, then read that identifier's sensors of the wanted type. Voltage instead asked for
+ * {@code SensorType="Voltage"} on a class that has no such property, so it could never match; these assertions pin the
+ * shape of all three queries so that cannot recur.
+ */
+class WindowsSensorsQueryTest {
+
+    @Test
+    void testTemperatureQueriesTheProcessorsTemperatureSensors() {
+        RecordingSensors sensors = new RecordingSensors();
+        sensors.queryCpuTemperature();
+        assertThat("Both monitors queried for the processor's temperature", sensors.queries,
+                contains("Hardware/CPU/Temperature", "Hardware/Cpu/Temperature"));
+    }
+
+    @Test
+    void testFanSpeedQueriesTheProcessorsFanSensors() {
+        RecordingSensors sensors = new RecordingSensors();
+        sensors.queryFanSpeeds();
+        assertThat("Both monitors queried for the processor's fans", sensors.queries,
+                contains("Hardware/CPU/Fan", "Hardware/Cpu/Fan"));
+    }
+
+    @Test
+    void testVoltageQueriesTheProcessorsVoltageSensors() {
+        RecordingSensors sensors = new RecordingSensors();
+        sensors.queryCpuVoltage();
+        assertThat("Both monitors queried for the processor's voltage", sensors.queries,
+                contains("Hardware/CPU/Voltage", "Hardware/Cpu/Voltage"));
+    }
+
+    @Test
+    void testQueriesFilterTheHardwareClass() {
+        RecordingSensors sensors = new RecordingSensors();
+        sensors.queryCpuTemperature();
+        sensors.queryFanSpeeds();
+        sensors.queryCpuVoltage();
+        for (String query : sensors.queries) {
+            String typeToQuery = query.substring(0, query.indexOf('/'));
+            assertThat("A sensor query filters the Hardware class, which is the class carrying HardwareType",
+                    typeToQuery, is(OhmHardware.HARDWARE));
+        }
+    }
+
+    /** Records the query each tier makes as {@code typeToQuery/typeName/sensorType}, and returns no results. */
+    private static final class RecordingSensors extends WindowsSensors {
+        private final List<String> queries = new ArrayList<>();
+
+        @Override
+        protected @Nullable WmiResult<ValueProperty> queryHardwareMonitorSensor(String namespace, String typeToQuery,
+                String typeName, String sensorType) {
+            queries.add(typeToQuery + '/' + typeName + '/' + sensorType);
+            return null;
+        }
+
+        @Override
+        protected WmiResult<TemperatureProperty> queryWmiTemperature() {
+            return WmiResult.empty();
+        }
+
+        @Override
+        protected WmiResult<SpeedProperty> queryWmiFanSpeed() {
+            return WmiResult.empty();
+        }
+
+        @Override
+        protected WmiResult<VoltProperty> queryWmiVoltage() {
+            return WmiResult.empty();
+        }
+    }
+}

--- a/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsSensorsFFM.java
+++ b/oshi-core-ffm/src/main/java/oshi/hardware/platform/windows/WindowsSensorsFFM.java
@@ -37,9 +37,9 @@ final class WindowsSensorsFFM extends WindowsSensors {
 
     @Override
     protected @Nullable WmiResult<ValueProperty> queryHardwareMonitorSensor(String namespace, String typeToQuery,
-            String typeName, String sensorType, boolean searchCpu) {
+            String typeName, String sensorType) {
         return getHardwareMonitorSensors(namespace, typeToQuery, typeName, sensorType, (h, hwIdentifiers) -> {
-            String cpuIdentifier = selectOhmCpuIdentifier(hwIdentifiers, searchCpu);
+            String cpuIdentifier = selectOhmCpuIdentifier(hwIdentifiers);
             if (!cpuIdentifier.isEmpty()) {
                 return OhmSensor.querySensorValue(h, namespace, cpuIdentifier, sensorType);
             }

--- a/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensorsJNA.java
+++ b/oshi-core/src/main/java/oshi/hardware/platform/windows/WindowsSensorsJNA.java
@@ -38,9 +38,9 @@ final class WindowsSensorsJNA extends WindowsSensors {
 
     @Override
     protected @Nullable WmiResult<ValueProperty> queryHardwareMonitorSensor(String namespace, String typeToQuery,
-            String typeName, String sensorType, boolean searchCpu) {
+            String typeName, String sensorType) {
         return getHardwareMonitorSensors(namespace, typeToQuery, typeName, sensorType, (h, hwIdentifiers) -> {
-            String cpuIdentifier = selectOhmCpuIdentifier(hwIdentifiers, searchCpu);
+            String cpuIdentifier = selectOhmCpuIdentifier(hwIdentifiers);
             if (!cpuIdentifier.isEmpty()) {
                 return OhmSensor.querySensorValue(h, namespace, cpuIdentifier, sensorType);
             }


### PR DESCRIPTION
## The bug

`Sensors.getCpuVoltage()` asked the WMI `Hardware` class to filter on `SensorType`:

```java
queryHardwareMonitorSensor(namespace, "Sensor", "Voltage", "Voltage", true);
// -> Hardware WHERE SensorType="Voltage"
```

That class carries `HardwareType`, `Identifier`, `InstanceId`, `Name` and `Parent`. There is no `SensorType` on it, so the query could never match, and both the Open Hardware Monitor and LibreHardwareMonitor tiers always fell through to the jLibreHardwareMonitor jar or to `Win32_Processor`'s coarse `VoltageCaps` bits. It predates #3723 and applies to both namespaces equally.

## The fix

Reach the voltage sensors the way temperature and fan speed already do: filter `Hardware` on `HardwareType` to find the processor, then read that identifier's sensors of the wanted type. The voltage call now differs from the temperature one only in the sensor type it asks for.

That makes `searchCpu` unreachable — every caller now filters to CPU hardware, so the first identifier is always the right one — so it goes, along with the identifier scan it guarded, from the seam and both twins.

## Testing

`WindowsSensorsQueryTest` pins the shape of all three queries. It is a real regression test, not a restatement: restoring the old call fails two of its cases with

```
Expected: iterable containing ["Hardware/CPU/Voltage", "Hardware/Cpu/Voltage"]
     but: item 0: was "Sensor/Voltage/Voltage"
```

**What is not verified:** neither WMI tier can be exercised in CI, since both need the monitoring application running as Administrator. The query is now well-formed against the published schema, but no reading has been observed from it — this ships on the same evidence basis as the tiers it sits beside.

Also in here, since it is the same file and the same lines: the sensor type names become constants, which is Sonar's S1192 on `WindowsSensors`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows CPU voltage readings when Open Hardware Monitor or LibreHardwareMonitor is installed.
  - CPU voltage values now correctly use the voltage sensor data provided by supported hardware-monitoring tools.

- **Documentation**
  - Added a changelog entry for the upcoming 7.6.2 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->